### PR TITLE
Refresh the uses of memref.assume_alignment in lit tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute.mlir
@@ -14,11 +14,8 @@ func.func @add_tensor() attributes {translation_info = #translation} {
   %c64 = arith.constant 64 : index
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %0, 64 : memref<233x1024xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %1, 64 : memref<233x1024xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %2, 64 : memref<233x1024xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %3 = affine.apply #map()[%workgroup_id_x]
@@ -63,11 +60,8 @@ func.func @add_tensor_lane_id() attributes {translation_info = #translation} {
   %c64 = arith.constant 64 : index
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %0, 64 : memref<233x1024xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %1, 64 : memref<233x1024xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<233x1024xf32>
-  memref.assume_alignment %2, 64 : memref<233x1024xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %3 = affine.apply #map()[%workgroup_id_x]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pipeline.mlir
@@ -20,11 +20,8 @@ func.func @_matmul_f16_f16_dispatch_0_fill_3456x1024() {
   %4 = memref.alloc() : memref<4x32x40xf16, 3>
   %5 = memref.alloc() : memref<4x32x40xf16, 3>
   %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<3456x2048xf16>
-  memref.assume_alignment %6, 64 : memref<3456x2048xf16>
   %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2048x1024xf16>
-  memref.assume_alignment %7, 64 : memref<2048x1024xf16>
   %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<3456x1024xf16>
-  memref.assume_alignment %8, 64 : memref<3456x1024xf16>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %9 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 16 + s2 * 32 + s0 floordiv 4)>()[%1, %2, %3]
@@ -83,11 +80,8 @@ func.func @nvidia_tenscore_schedule_f16() {
   %alloc_1 = memref.alloc() : memref<3x128x32xf16, #gpu.address_space<workgroup>>
   %alloc_2 = memref.alloc() : memref<3x32x256xf16, #gpu.address_space<workgroup>>
   %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<512x1280xf16>
-  memref.assume_alignment %3, 64 : memref<512x1280xf16>
   %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<1280x1280xf16>
-  memref.assume_alignment %4, 64 : memref<1280x1280xf16>
   %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<512x1280xf16>
-  memref.assume_alignment %5, 64 : memref<512x1280xf16>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %6:32 = scf.for %arg0 = %c0 to %c1280 step %c32 iter_args(%arg1 = %cst, %arg2 = %cst, %arg3 = %cst, %arg4 = %cst, %arg5 = %cst, %arg6 = %cst, %arg7 = %cst, %arg8 = %cst, %arg9 = %cst, %arg10 = %cst, %arg11 = %cst, %arg12 = %cst, %arg13 = %cst, %arg14 = %cst, %arg15 = %cst, %arg16 = %cst, %arg17 = %cst, %arg18 = %cst, %arg19 = %cst, %arg20 = %cst, %arg21 = %cst, %arg22 = %cst, %arg23 = %cst, %arg24 = %cst, %arg25 = %cst, %arg26 = %cst, %arg27 = %cst, %arg28 = %cst, %arg29 = %cst, %arg30 = %cst, %arg31 = %cst, %arg32 = %cst) -> (vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>) {
@@ -535,11 +529,8 @@ func.func @nvidia_tenscore_schedule_f32() {
   %alloc_2 = memref.alloc() : memref<3x128x32xf32, #gpu.address_space<workgroup>>
   %alloc_3 = memref.alloc() : memref<3x32x128xf32, #gpu.address_space<workgroup>>
   %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf32>
-  memref.assume_alignment %3, 64 : memref<256x256xf32>
   %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<256x256xf32>
-  memref.assume_alignment %4, 64 : memref<256x256xf32>
   %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<256x256xf32>
-  memref.assume_alignment %5, 64 : memref<256x256xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %6 = affine.apply affine_map<()[s0, s1, s2, s3] -> (s1 * 8 + s2 * 16 + s3 * 128 + s0 floordiv 8)>()[%0, %1, %2, %workgroup_id_y]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -244,11 +244,8 @@ module {
     %cst_1 = arith.constant 0.000000e+00 : f16
     %thread_id_x = gpu.thread_id  x
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<1x4096xf16, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %0, 64 : memref<1x4096xf16, #hal.descriptor_type<storage_buffer>>
     %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<32000x4096xf16, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %1, 64 : memref<32000x4096xf16, #hal.descriptor_type<storage_buffer>>
     %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<1x32000xf16, #hal.descriptor_type<storage_buffer>>
-    memref.assume_alignment %2, 64 : memref<1x32000xf16, #hal.descriptor_type<storage_buffer>>
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %3 = affine.apply #map()[%workgroup_id_x]
     %4 = scf.for %arg0 = %c0 to %c4096 step %c512 iter_args(%arg1 = %cst) -> (vector<4x512xf16>) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -107,7 +107,6 @@ func.func @already_bufferized() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %0, 64 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>
   %alloc = memref.alloc() : memref<1001xf32>
   linalg.fill ins(%cst : f32) outs(%alloc : memref<1001xf32>)
   linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["reduction"]} ins(%alloc : memref<1001xf32>) outs(%0 : memref<1001xf32, #hal.descriptor_type<storage_buffer>>) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/canonicalize_early_bufferization_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/canonicalize_early_bufferization_ops.mlir
@@ -118,9 +118,7 @@ func.func @fold_dynamic_reshape_load() {
   %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
   %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
   %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>{%0, %1}
-  memref.assume_alignment %4, 1 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>
   %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>{%2, %3}
-  memref.assume_alignment %5, 1 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>
   %6 = iree_codegen.load_from_buffer %4 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>> -> tensor<?x?xf32>
   %collapsed = tensor.collapse_shape %6 [[0, 1]] : tensor<?x?xf32> into tensor<?xf32>
   %expanded = tensor.expand_shape %collapsed [[0, 1]] output_shape [%2, %3] : tensor<?xf32> into tensor<?x?xf32>
@@ -153,9 +151,7 @@ func.func @fold_dynamic_reshape_store() {
   %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
   %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
   %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>{%0, %1}
-  memref.assume_alignment %4, 1 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>
   %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>{%2, %3}
-  memref.assume_alignment %5, 1 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>>
   %6 = iree_codegen.load_from_buffer %4 : memref<?x?xf32, #hal.descriptor_type<storage_buffer>> -> tensor<?x?xf32>
   %barrier = util.optimization_barrier %6 : tensor<?x?xf32>
   %collapsed = tensor.collapse_shape %barrier [[0, 1]] : tensor<?x?xf32> into tensor<?xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_to_uint16_buffers.mlir
@@ -74,11 +74,8 @@ func.func @mmt4d_bf16xbf16xf32() {
   %c64 = arith.constant 64 : index
   %c128 = arith.constant 128 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<1x3x8x1xbf16>
-  memref.assume_alignment %0, 64 : memref<1x3x8x1xbf16>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c64) flags(ReadOnly) : memref<1x3x8x1xbf16, strided<[24, 8, 1, 1], offset: 32>>
-  memref.assume_alignment %1, 64 : memref<1x3x8x1xbf16, strided<[24, 8, 1, 1], offset: 32>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c128) : memref<1x1x8x8xf32, strided<[64, 64, 8, 1], offset: 32>>
-  memref.assume_alignment %2, 64 : memref<1x1x8x8xf32, strided<[64, 64, 8, 1], offset: 32>>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/hoist_unrolled_vector_extract_insert_slice.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/hoist_unrolled_vector_extract_insert_slice.mlir
@@ -12,11 +12,8 @@ func.func @hoist_unrolled_vector_for_mma() {
   %c64 = arith.constant 64 : index
   %c2048 = arith.constant 2048 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<3456x2048xf16>
-  memref.assume_alignment %0, 64 : memref<3456x2048xf16>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<2048x1024xf16>
-  memref.assume_alignment %1, 64 : memref<2048x1024xf16>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<3456x1024xf32>
-  memref.assume_alignment %2, 64 : memref<3456x1024xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %3 = gpu.thread_id  x
   %4 = gpu.thread_id  y

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -276,7 +276,6 @@ func.func @early_bufferized_copy_cst_ops() {
   %cst = arith.constant dense<0> : tensor<2x3xi32>
   %0 = bufferization.to_buffer %cst : tensor<2x3xi32> to memref<2x3xi32, affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s1 + s0 + d1 * s2)>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2x5xi32>
-  memref.assume_alignment %1, 64 : memref<2x5xi32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2x5xi32>>
   %3 = memref.subview %1[%c0, %c2] [2, 3] [%c1, %c1] : memref<2x5xi32> to memref<2x3xi32, affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s1 + s0 + d1 * s2)>>
   linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<2x3xi32, affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s1 + s0 + d1 * s2)>>) outs(%3 : memref<2x3xi32, affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s1 + s0 + d1 * s2)>>) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_dead_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_dead_allocs.mlir
@@ -24,7 +24,7 @@ func.func @alloc_keep(%arg0: index, %arg1: index) -> memref<?x?xf32> {
 ]>
 func.func @cleanup_only_assume_alignment_uses() {
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<42xf32>
-  memref.assume_alignment %0, 64 : memref<42xf32>
+  %1 = memref.assume_alignment %0, 64 : memref<42xf32>
   return
 }
 // CHECK-LABEL: func.func @cleanup_only_assume_alignment_uses()

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -1713,9 +1713,7 @@ hal.executable private @no_compute {
         %8 = iree_tensor_ext.dispatch.workload.ordinal %3, 3 : index
         %9 = iree_tensor_ext.dispatch.workload.ordinal %4, 4 : index
         %10 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<?x?x?xf32>{%5, %6, %7}
-        memref.assume_alignment %10, 64 : memref<?x?x?xf32>
         %11 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<1x?x?xf32>{%8, %9}
-        memref.assume_alignment %11, 64 : memref<1x?x?xf32>
         return
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -262,8 +262,8 @@ func.func @matmul_interchange(%0 : tensor<?x?xf32>,
 // -----
 
 func.func @no_compute(%arg0 : memref<?x?x?xf32>, %arg1 : memref<?x?x?xf32>) {
-  memref.assume_alignment %arg0, 64 : memref<?x?x?xf32>
-  memref.assume_alignment %arg1, 64 : memref<?x?x?xf32>
+  util.optimization_barrier %arg0 : memref<?x?x?xf32>
+  util.optimization_barrier %arg1 : memref<?x?x?xf32>
   return
 }
 // CHECK-LABEL: @no_compute(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
@@ -18,11 +18,8 @@ func.func @mmt4d_kernel_dispatch() attributes {hal.executable.target = #target} 
   %c128 = arith.constant 128 : index
   %c64 = arith.constant 64 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<1x2x8x4xi8>
-  memref.assume_alignment %0, 64 : memref<1x2x8x4xi8>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c64) : memref<1x2x8x4xi8>
-  memref.assume_alignment %1, 64 : memref<1x2x8x4xi8>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c128) : memref<1x1x8x8xi32>
-  memref.assume_alignment %2, 64 : memref<1x1x8x8xi32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -146,11 +146,11 @@ func.func @batch_matmul_dynamic() attributes {hal.executable.target = #executabl
 func.func @check_buffer_ops_vectorization() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x1024xi32>
-  memref.assume_alignment %0, 64 : memref<128x1024xi32>
+  %assume_align_0 = memref.assume_alignment %0, 64 : memref<128x1024xi32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128x1536xi32>
-  memref.assume_alignment %1, 64 : memref<128x1536xi32>
-  %subview = memref.subview %1[0, 0] [128, 1024] [1, 1] : memref<128x1536xi32> to memref<128x1024xi32, #map>
-  linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<128x1024xi32>) outs(%subview : memref<128x1024xi32, #map>) {
+  %assum_align_1 = memref.assume_alignment %1, 64 : memref<128x1536xi32>
+  %subview = memref.subview %assum_align_1[0, 0] [128, 1024] [1, 1] : memref<128x1536xi32> to memref<128x1024xi32, #map>
+  linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%assum_align_0 : memref<128x1024xi32>) outs(%subview : memref<128x1024xi32, #map>) {
   ^bb0(%in: i32, %out: i32):
     linalg.yield %in : i32
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -148,9 +148,9 @@ func.func @check_buffer_ops_vectorization() attributes {hal.executable.target = 
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x1024xi32>
   %assume_align_0 = memref.assume_alignment %0, 64 : memref<128x1024xi32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128x1536xi32>
-  %assum_align_1 = memref.assume_alignment %1, 64 : memref<128x1536xi32>
-  %subview = memref.subview %assum_align_1[0, 0] [128, 1024] [1, 1] : memref<128x1536xi32> to memref<128x1024xi32, #map>
-  linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%assum_align_0 : memref<128x1024xi32>) outs(%subview : memref<128x1024xi32, #map>) {
+  %assume_align_1 = memref.assume_alignment %1, 64 : memref<128x1536xi32>
+  %subview = memref.subview %assume_align_1[0, 0] [128, 1024] [1, 1] : memref<128x1536xi32> to memref<128x1024xi32, #map>
+  linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%assume_align_0 : memref<128x1024xi32>) outs(%subview : memref<128x1024xi32, #map>) {
   ^bb0(%in: i32, %out: i32):
     linalg.yield %in : i32
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
@@ -18,13 +18,9 @@ func.func @matmul_391x384x384_f32() {
   %cst_1 = arith.constant dense<6.000000e+00> : vector<8x32xf32>
   %alloca = memref.alloca() {alignment = 64 : i64} : memref<8x32xf32>
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<391x384xf32>
-  memref.assume_alignment %0, 64 : memref<391x384xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<384x384xf32>
-  memref.assume_alignment %1, 64 : memref<384x384xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : memref<384xf32>
-  memref.assume_alignment %2, 64 : memref<384xf32>
   %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : memref<391x384xf32>
-  memref.assume_alignment %3, 64 : memref<391x384xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_y]
@@ -99,13 +95,9 @@ func.func @matmul_scalar_loads() {
   %cst_1 = arith.constant dense<6.000000e+00> : vector<8x32xf32>
   %alloca = memref.alloca() {alignment = 64 : i64} : memref<8x32xf32>
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<391x384xf32>
-  memref.assume_alignment %0, 64 : memref<391x384xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<384x384xf32>
-  memref.assume_alignment %1, 64 : memref<384x384xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : memref<384xf32>
-  memref.assume_alignment %2, 64 : memref<384xf32>
   %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : memref<391x384xf32>
-  memref.assume_alignment %3, 64 : memref<391x384xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_y]
@@ -180,11 +172,8 @@ func.func @gather_strided_memref() {
   %c4 = arith.constant 4 : index
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<2592000x3xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %0, 64 : memref<2592000x3xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<518400xi32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %1, 64 : memref<518400xi32, #hal.descriptor_type<storage_buffer>>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<518400xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %2, 64 : memref<518400xf32, #hal.descriptor_type<storage_buffer>>
   %subview = memref.subview %0[0, 0] [2592000, 1] [1, 1] : memref<2592000x3xf32, #hal.descriptor_type<storage_buffer>> to memref<2592000xf32, strided<[3]>, #hal.descriptor_type<storage_buffer>>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %3 = affine.apply affine_map<()[s0] -> (s0 * 4096)>()[%workgroup_id_x]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -138,13 +138,9 @@ module {
     %c0 = arith.constant 0 : index
     %thread_id_x = gpu.thread_id  x upper_bound 64
     %0 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<131072x192xf16, #gpu.address_space<global>>
-    memref.assume_alignment %0, 64 : memref<131072x192xf16, #gpu.address_space<global>>
     %1 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<131072x192xf16, #gpu.address_space<global>>
-    memref.assume_alignment %1, 64 : memref<131072x192xf16, #gpu.address_space<global>>
     %2 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : memref<402653184xi8, #gpu.address_space<global>>
-    memref.assume_alignment %2, 64 : memref<402653184xi8, #gpu.address_space<global>>
     %3 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(4) alignment(64) offset(%c0) flags(Indirect) : memref<131072x192x32xf16, #gpu.address_space<global>>
-    memref.assume_alignment %3, 64 : memref<131072x192x32xf16, #gpu.address_space<global>>
     %4 = arith.divui %thread_id_x, %c4 : index
     %5 = arith.remui %thread_id_x, %c4 : index
     %6 = arith.muli %5, %c8 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -87,11 +87,8 @@ func.func @batch_matmul_func() attributes {translation_info = #translation} {
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(32) offset(%c0) : memref<4x32x1024xf32>
-  memref.assume_alignment %0, 32 : memref<4x32x1024xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(32) offset(%c0) : memref<4x1024x64xf32>
-  memref.assume_alignment %1, 32 : memref<4x1024x64xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(32) offset(%c0) : memref<4x32x64xf32>
-  memref.assume_alignment %2, 32 : memref<4x32x64xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -265,11 +262,8 @@ module {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f32
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<1x64x56x56xf32>
-    memref.assume_alignment %0, 64 : memref<1x64x56x56xf32>
     %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c41664) : memref<64x64x1x1xf32>
-    memref.assume_alignment %1, 64 : memref<64x64x1x1xf32>
     %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c802816) : memref<1x64x56x56xf32>
-    memref.assume_alignment %2, 64 : memref<1x64x56x56xf32>
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %workgroup_count_x = hal.interface.workgroup.count[0] : index
     %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -152,11 +152,8 @@ func.func @illegal() attributes {translation_info = #translation} {
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(32) offset(%c0) : memref<4x32x1024xf32>
-  memref.assume_alignment %0, 32 : memref<4x32x1024xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(32) offset(%c0) : memref<4x1024x64xf32>
-  memref.assume_alignment %1, 32 : memref<4x1024x64xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(32) offset(%c0) : memref<4x32x64xf32>
-  memref.assume_alignment %2, 32 : memref<4x32x64xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
@@ -21,7 +21,6 @@ module {
 }
 
 //   CHECK-LABEL:  func.func @sort1D
-//         CHECK:      memref.assume_alignment
 //         CHECK:      amdgpu.fat_raw_buffer_cast
 
 // -----
@@ -45,7 +44,6 @@ module {
 }
 
 //   CHECK-LABEL:  func.func @sort2D_static_shape
-//         CHECK:      memref.assume_alignment
 //         CHECK:      amdgpu.fat_raw_buffer_cast
 //         CHECK:      scf.forall
 //         CHECK:        memref.subview
@@ -77,7 +75,6 @@ module {
 }
 
 //   CHECK-LABEL:  func.func @sort3D_dynamic_shape
-//         CHECK:      memref.assume_alignment
 //         CHECK:      amdgpu.fat_raw_buffer_cast
 //         CHECK:      scf.forall
 //         CHECK:       scf.for

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
@@ -14,7 +14,6 @@ func.func @reduce_dispatch_0() attributes {translation_info = #translation_info}
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32>
-  memref.assume_alignment %0, 64 : memref<128xf32>
   %1 = gpu.thread_id  x
   %2 = arith.cmpi ult, %1, %c1 : index
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
@@ -12,7 +12,6 @@ module {
     %c8 = arith.constant 8 : index
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xf16>
-    memref.assume_alignment %0, 64 : memref<2xf16>
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %subview = memref.subview %0[%workgroup_id_x] [1] [1] : memref<2xf16> to memref<1xf16, strided<[1], offset: ?>>
     scf.forall (%arg0) in (%c250) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
@@ -20,11 +20,8 @@ func.func @matmul_pipelining() {
   %4 = memref.alloc() : memref<4x32x40xf16, 3>
   %5 = memref.alloc() : memref<4x32x40xf16, 3>
   %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<3456x2048xf16>
-  memref.assume_alignment %6, 64 : memref<3456x2048xf16>
   %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2048x1024xf16>
-  memref.assume_alignment %7, 64 : memref<2048x1024xf16>
   %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<3456x1024xf16>
-  memref.assume_alignment %8, 64 : memref<3456x1024xf16>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %9 = affine.apply affine_map<()[s0, s1, s2] -> (s1 * 16 + s2 * 32 + s0 floordiv 4)>()[%1, %2, %3]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -16,11 +16,8 @@ func.func @matmul() {
   %c32 = arith.constant 32 : index
   %cst_0 = arith.constant 0.000000e+00 : f32
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %0, 64 : memref<32x32xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %1, 64 : memref<32x32xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %2, 64 : memref<32x32xf32>
   %3 = gpu.thread_id  x
   %4 = gpu.thread_id  y
   %5 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%4]
@@ -95,11 +92,8 @@ func.func @gathered_matmul() {
   %cst_1 = arith.constant dense<[0, 1, 2, 3]> : vector<4xindex>
   %cst_2 = arith.constant dense<1> : vector<4x4xindex>
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %0, 64 : memref<32x32xf32>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %1, 64 : memref<32x32xf32>
   %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : memref<32x32xf32>
-  memref.assume_alignment %2, 64 : memref<32x32xf32>
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
   %3 = gpu.thread_id  x
   %4 = gpu.thread_id  y

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -15,7 +15,6 @@ hal.executable private @static_3d_sort  {
       func.func @static_3d_sort() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>>
-        memref.assume_alignment %0, 64 : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %1 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
@@ -25,7 +25,7 @@ util.func @verify_invalid_non_identity_map(%buffer: memref<4xf32, #map>, %idx: i
 // CHECK-LABEL: @assume_alignment
 util.func @assume_alignment(%buffer: memref<?xf32>) {
   // CHECK-NOT: assume_alignment
-  memref.assume_alignment %buffer, 64 : memref<?xf32>
+  %assume_align = memref.assume_alignment %buffer, 64 : memref<?xf32>
   util.return
 }
 


### PR DESCRIPTION
Few tests are updated to use the result of `memref.assume_alignment` because they care about the ops.

Many `memref.assume_alignment` ops are removed from many lit tests because they do not need them. They don't use them at their pass scope.

There are two tests not changed because of recent regression. I'll revisit it if I come back to the issue. For now, leave them as what they are:
- SPIRV/test/tile_and_promote_cooperative_matrix.mlir
- SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir

This is a follow-up to https://github.com/iree-org/iree/commit/cbb753630d2bcadadb1dd4613df7267cd22fc9a4