### PR TITLE
[PJRT] Add simple level control to the logger in PJRT plugin

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/common/debugging.h
+++ b/integrations/pjrt/src/iree_pjrt/common/debugging.h
@@ -18,16 +18,28 @@ namespace iree::pjrt {
 
 //===----------------------------------------------------------------------===//
 // Logger
-// The plugin API currently does not have any logging facilities, but since
-// these are easier added later, we have a placeholder Logger that we thread
-// through. It can be extended later.
+// It currently contains two log levels: debug and error.
+// The sink can only be stderr for now, and log messages are prefixed with
+// [IREE-PJRT][YYYY-MM-DD HH:MM:SS][LEVEL].
 //===----------------------------------------------------------------------===//
 
 class Logger {
  public:
-  Logger() = default;
+  // NOTE: The log levels must be ordered by severity,
+  // with the most verbose level first.
+  enum Level { DEBUG, ERROR };
+
+  static std::optional<Level> LevelFromString(std::string_view level);
+  static std::string_view LevelToString(Level level);
+
+  Logger(Level level) : level_(level){};
   void debug(std::string_view message);
   void error(std::string_view message);
+
+ private:
+  void log(Level level, std::string_view message);
+
+  Level level_;
 };
 
 //===----------------------------------------------------------------------===//

--- a/integrations/pjrt/src/iree_pjrt/common/dylib_platform.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/dylib_platform.cc
@@ -75,8 +75,10 @@ iree_status_t DylibPlatform::SubclassInitialize() {
   // Fallback config to environment.
   config_vars().EnableEnvFallback("IREE_PJRT_");
 
-  // Just a vanilla logger for now.
-  logger_ = std::make_unique<Logger>();
+  auto log_level_str = config_vars().Lookup("LOG_LEVEL");
+  auto log_level =
+      log_level_str ? Logger::LevelFromString(*log_level_str) : std::nullopt;
+  logger_ = std::make_unique<Logger>(log_level.value_or(Logger::DEBUG));
 
   // Process once initialization of the compiler shared library.
   auto library_path = GetCompilerLibraryPath();


### PR DESCRIPTION
We made several changes to `iree::pjrt::Logger`:
- add `Logger::Level` to control the current log level, as well as convert between level enum value and string;
- print the local time in the prefix of log messages;
- new environment variable `IREE_PJRT_LOG_LEVEL` to control the current log level.

So after this patch we can set `IREE_PJRT_LOG_LEVEL=error` to ignore verbose debug logs.

ci-exactly: build_packages, test_pjrt