### PR TITLE
[LinalgExt][NFC] Check for tensor semantics directly

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -660,9 +660,9 @@ struct RemoveUnusedSortOpResults
     auto results = sortOp.getResults();
     unsigned numRes = sortOp.getNumResults();
 
-    // # TODO(#20831): Implement a way to remove unused results when using
-    // buffer semantics.
-    if (numRes == 0) {
+    // # TODO(#20831): Add support for removing unused operands when the op has
+    // pure buffer semantics.
+    if (sortOp.hasPureBufferSemantics()) {
       return failure();
     }
 


### PR DESCRIPTION
Follow up on https://github.com/iree-org/iree/pull/20827, use a cleaner way to check for tensor semantics.

See https://github.com/iree-org/iree/pull/20827#discussion_r2092129307 for context.