### PR TITLE
Restrict GPUAllocPrivateMemoryForDPSOps to pure tensor semantics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUAllocPrivateMemoryForDPSOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUAllocPrivateMemoryForDPSOps.cpp
@@ -56,6 +56,9 @@ void GPUAllocPrivateMemoryForDPSOpsPass::runOnOperation() {
   // dimensions).
   SmallVector<OpOperand *> worklist;
   funcOp.walk([&](DestinationStyleOpInterface dpsOp) {
+    if (!dpsOp.hasPureTensorSemantics()) {
+      return;
+    }
     for (int idx = 0; idx < dpsOp.getNumDpsInits(); ++idx) {
       OpOperand *value = dpsOp.getDpsInitOperand(idx);
       if (!dpsOp->getResult(idx).use_empty()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUAllocPrivateMemoryForDPSOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUAllocPrivateMemoryForDPSOps.cpp
@@ -61,7 +61,7 @@ void GPUAllocPrivateMemoryForDPSOpsPass::runOnOperation() {
     }
     for (int idx = 0; idx < dpsOp.getNumDpsInits(); ++idx) {
       OpOperand *value = dpsOp.getDpsInitOperand(idx);
-      if (!dpsOp->getResult(idx).use_empty()) {
+      if (!dpsOp.getTiedOpResult(value).use_empty()) {
         continue;
       }
       if (isAllocSizeTooBig(value->get().getType())) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_alloc_private_memory_for_dps_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_alloc_private_memory_for_dps_ops.mlir
@@ -42,3 +42,14 @@ func.func @used_result_not_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readon
   } -> tensor<1x10xf32>, tensor<1x10xi64>
   return %3#0, %3#1 : tensor<1x10xf32>, tensor<1x10xi64>
 }
+
+// -----
+
+// CHECK-LABEL: func @memref_semantics(
+//  CHECK-SAME:   %[[DEST:.+]]: memref<?x?xf32>
+//       CHECK:   linalg.fill {{.*}} outs(%[[DEST]]
+func.func @memref_semantics(%dest: memref<?x?xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  linalg.fill ins(%cst : f32) outs(%dest : memref<?x?xf32>)
+  return
+}


### PR DESCRIPTION
This recently introduced pass (https://github.com/iree-org/iree/pull/20793) has logic that seems to be assuming tensor semantics, as it assumes that the DPS op has as many results as it has DPS inits:
https://github.com/iree-org/iree/blob/ea7dfc142d2ed8b97d10186abb79a9b6aad52973/compiler/src/iree/compiler/Codegen/Common/GPU/GPUAllocPrivateMemoryForDPSOps.cpp#L59-L61

I experienced crashes in that `getResult(idx)` call with `idx` being out of bounds, that I traced to this assumption is defeated on buffer semantics where ops have `memref` DPS operands but no results, as in:

```
dpsOp = vector.transfer_write %x, %y .....  : vector<...>, memref<...>
```
