### PR TITLE
[NFC][LinalgExt] Remove duplicate logic from ReshapeFusion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -15,7 +15,8 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 // Populate functions.
 //===----------------------------------------------------------------------===//
 
-/// Fold expand_shape ops with their producers (only `AttentionOp` supported)
+/// Fold expand_shape ops with their producers and collapse_shape ops with
+/// consumers.
 void populateFoldReshapeOpsByExpansionPatterns(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFoldingReshapes);


### PR DESCRIPTION
Merges logic to propagate reshapes for attention, gather, and scatter + removes the now dead code.