### PR TITLE
Precomputing pinned value affinities during analysis.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -62,6 +62,169 @@ static const std::string getAffinitySetAsStr(
 }
 
 //===----------------------------------------------------------------------===//
+// Precomputed IR properties
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): template this as a helper and move into common... though
+// hopefully it's rarely needed.
+class SidebandElement
+    : public DFX::StateWrapper<DFX::BooleanState, DFX::OperationElement> {
+public:
+  using BaseType = DFX::StateWrapper<DFX::BooleanState, DFX::OperationElement>;
+  SidebandElement(const Position &pos,
+                  AffinityAnalysis::PrecomputedQueries *precomputedQueries)
+      : BaseType(pos), precomputedQueries(precomputedQueries) {}
+
+  static SidebandElement &
+  createForPosition(const Position &pos, DFX::Solver &solver,
+                    AffinityAnalysis::PrecomputedQueries *precomputedQueries) {
+    return *(new (solver.getAllocator())
+                 SidebandElement(pos, precomputedQueries));
+  }
+
+  // Identity definitions.
+  const std::string getName() const override { return "SidebandElement"; }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  static const char ID;
+
+  const std::string getAsStr(AsmState &asmState) const override {
+    return "sideband";
+  }
+
+  const AffinityAnalysis::PrecomputedQueries &get() const {
+    return *precomputedQueries;
+  }
+
+private:
+  void initializeOperation(Operation *op, DFX::Solver &solver) override {
+    getState().setKnown(true);
+    indicateOptimisticFixpoint();
+  }
+  ChangeStatus updateOperation(Operation *op, DFX::Solver &solver) override {
+    return ChangeStatus::UNCHANGED;
+  }
+
+  AffinityAnalysis::PrecomputedQueries *precomputedQueries;
+};
+const char SidebandElement::ID = 0;
+
+// Populates value affinities for all operands and results of the affinity op
+// that pins affinity transitively (through tied ops).
+static void populatePinnedAffinities(
+    IREE::Stream::AffinityOpInterface affinityOp, Explorer &explorer,
+    AffinityAnalysis::PrecomputedQueries &precomputedQueries) {
+  assert(affinityOp.pinsValueAffinity() && "must pin affinity");
+  auto &pinnedAffinities = precomputedQueries.pinnedAffinities;
+  auto markPinned = [&](Value value) {
+    auto it = pinnedAffinities.find(value);
+    if (it == pinnedAffinities.end()) {
+      // First time this value has been pinned.
+      pinnedAffinities[value].insert(affinityOp);
+      return true; // continue searching
+    } else if (it->second.contains(affinityOp)) {
+      // Already pinned to this affinity.
+      return false; // stop searching
+    } else {
+      // Adding a new affinity.
+      it->second.insert(affinityOp);
+      return true; // continue searching
+    }
+  };
+  for (Value result : affinityOp->getResults()) {
+    if (!isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {
+      continue;
+    }
+    explorer.walkTransitiveUses(result, [&](OpOperand &operand) {
+      if (!isa<IREE::Stream::AffinityTypeInterface>(operand.get().getType())) {
+        // Type changed; stop tracking affinity.
+        return WalkResult::skip();
+      } else if (auto affinityOp =
+                     dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
+                         operand.getOwner())) {
+        // If the user _also_ pins affinity we need to stop. The overall
+        // population will eventually reach it and start pinning from there.
+        if (affinityOp.pinsValueAffinity()) {
+          return WalkResult::skip();
+        }
+      }
+      return markPinned(operand.get()) ? WalkResult::advance()
+                                       : WalkResult::skip();
+    });
+  }
+  for (Value operand : affinityOp->getOperands()) {
+    if (!isa<IREE::Stream::AffinityTypeInterface>(operand.getType())) {
+      continue;
+    }
+    explorer.walkDefiningOps(operand, [&](OpResult result) -> WalkResult {
+      if (result.getOwner() == affinityOp) {
+        return WalkResult::advance(); // starting point
+      }
+      if (!isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {
+        // Type changed; stop tracking affinity.
+        return WalkResult::skip();
+      } else if (auto affinityOp =
+                     dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
+                         result.getOwner())) {
+        // If the defining op _also_ pins affinity we need to stop. The overall
+        // population will eventually reach it and start pinning from there.
+        if (affinityOp.pinsValueAffinity()) {
+          return WalkResult::skip();
+        }
+      }
+      return markPinned(result) ? WalkResult::advance() : WalkResult::skip();
+    });
+  }
+}
+
+void AffinityAnalysis::PrecomputedQueries::compute(Explorer &explorer) {
+  explorer.forEachFunctionLikeOp([&](FunctionOpInterface funcOp) {
+    funcOp.walk([&](Operation *op) {
+      if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
+        if (affinityOp.pinsValueAffinity()) {
+          populatePinnedAffinities(affinityOp, explorer, *this);
+        }
+      }
+    });
+  });
+}
+
+void AffinityAnalysis::PrecomputedQueries::inject(DFX::Solver &solver) {
+  solver.registerElement(SidebandElement::createForPosition(
+      Position::forOperation(solver.getExplorer().getRootOp()), solver, this));
+}
+
+// static
+const AffinityAnalysis::PrecomputedQueries &
+AffinityAnalysis::PrecomputedQueries::get(DFX::Solver &solver) {
+  auto *sidebandElement = solver.lookupElementFor<SidebandElement>(
+      Position::forOperation(solver.getExplorer().getRootOp()));
+  assert(sidebandElement && "sideband element must have been registered before "
+                            "attempting to query it");
+  return sidebandElement->get();
+}
+
+void AffinityAnalysis::PrecomputedQueries::print(llvm::raw_ostream &os,
+                                                 AsmState &asmState) {
+  os << "[PrecomputedQueries] pinned affinities:\n";
+  for (auto it : pinnedAffinities) {
+    os << "  ";
+    it.first.printAsOperand(os, asmState);
+    os << ":\n";
+    llvm::interleave(
+        it.second, os,
+        [&](auto affinityOp) {
+          os << "    ";
+          affinityOp->print(llvm::dbgs(), asmState);
+        },
+        ",\n");
+    os << "\n";
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Analysis elements
 //===----------------------------------------------------------------------===//
 
@@ -100,8 +263,8 @@ private:
   void updateFromUse(Value value, OpOperand &operand, StateType &newState,
                      DFX::Solver &solver);
 
-  // Operations that the value is pinned to.
-  SetVector<Operation *> pinnedOps;
+  // Operations that the value is pinned to, if any.
+  SmallVector<IREE::Stream::AffinityOpInterface> pinnedOps;
 };
 const char ValueProducerAffinityPVS::ID = 0;
 
@@ -291,6 +454,18 @@ TraversalResult ValueConsumerAffinityPVS::updateFromUse(Value value,
   // Handle consumers that are not affinity aware - this should have any control
   // flow ops so that we can track values that flow through the program.
   return TypeSwitch<Operation *, TraversalResult>(operand.getOwner())
+      .Case([&](IREE::Stream::AsyncTransferOp op) {
+        if (auto targetAffinityAttr = op.getResultAffinityAttr()) {
+          LLVM_DEBUG({
+            llvm::dbgs() << "[ValueConsumerAffinityPVS] value ";
+            value.printAsOperand(llvm::dbgs(), solver.getAsmState());
+            llvm::dbgs() << " affinity unioning with transfer target "
+                         << "affinity as " << targetAffinityAttr << "\n";
+          });
+          newState.unionAssumed(targetAffinityAttr);
+        }
+        return TraversalResult::COMPLETE;
+      })
       .Case([&](mlir::arith::SelectOp op) {
         auto &resultPVS = solver.getElementFor<ValueConsumerAffinityPVS>(
             *this, Position::forValue(op.getResult()),
@@ -437,32 +612,11 @@ TraversalResult ValueConsumerAffinityPVS::updateFromUse(Value value,
 
 void ValueProducerAffinityPVS::initializeValue(Value value,
                                                DFX::Solver &solver) {
-  solver.getExplorer().walkDefiningOps(value, [&](OpResult result) {
-    if (!isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {
-      return WalkResult::skip();
-    }
-    if (auto affinityOp =
-            dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
-                result.getOwner())) {
-      if (affinityOp.pinsValueAffinity()) {
-        pinnedOps.insert(result.getOwner());
-      }
-    }
-    return WalkResult::advance();
-  });
-  solver.getExplorer().walkTransitiveUses(value, [&](OpOperand &operand) {
-    if (!isa<IREE::Stream::AffinityTypeInterface>(operand.get().getType())) {
-      return WalkResult::skip();
-    }
-    if (auto affinityOp =
-            dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
-                operand.getOwner())) {
-      if (affinityOp.pinsValueAffinity()) {
-        pinnedOps.insert(operand.getOwner());
-      }
-    }
-    return WalkResult::advance();
-  });
+  auto &precomputedQueries = AffinityAnalysis::PrecomputedQueries::get(solver);
+  auto it = precomputedQueries.pinnedAffinities.find(value);
+  if (it != precomputedQueries.pinnedAffinities.end()) {
+    pinnedOps = llvm::to_vector(it->second);
+  }
 }
 
 ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
@@ -545,7 +699,7 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
             LLVM_DEBUG({
               llvm::dbgs() << "[ValueProducerAffinityPVS] value ";
               value.printAsOperand(llvm::dbgs(), solver.getAsmState());
-              llvm::dbgs() << " affinity using assuming pinned affinity from ";
+              llvm::dbgs() << " affinity using pinned affinity from ";
               result.printAsOperand(llvm::dbgs(), solver.getAsmState());
               llvm::dbgs() << " as ";
               opPVS.print(llvm::dbgs(), solver.getAsmState());
@@ -603,6 +757,18 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
 
         // Special handling for specific ops.
         TypeSwitch<Operation *>(result.getOwner())
+            .Case([&](IREE::Stream::AsyncTransferOp op) {
+              if (auto sourceAffinityAttr = op.getSourceAffinityAttr()) {
+                LLVM_DEBUG({
+                  llvm::dbgs() << "[ValueProducerAffinityPVS] value ";
+                  value.printAsOperand(llvm::dbgs(), solver.getAsmState());
+                  llvm::dbgs()
+                      << " affinity unioning with transfer source affinity as "
+                      << sourceAffinityAttr << "\n";
+                });
+                newState.unionAssumed(sourceAffinityAttr);
+              }
+            })
             .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
               auto *globalInfo = solver.getExplorer().queryGlobalInfoFrom(
                   loadOp.getGlobalName(), loadOp);
@@ -634,6 +800,15 @@ ChangeStatus ValueProducerAffinityPVS::updateValue(Value value,
             .Default([&](auto op) {
               auto valuePVS = solver.getElementFor<ValueProducerAffinityPVS>(
                   *this, Position::forValue(result), DFX::Resolution::OPTIONAL);
+              LLVM_DEBUG({
+                llvm::dbgs() << "[ValueProducerAffinityPVS] value ";
+                value.printAsOperand(llvm::dbgs(), solver.getAsmState());
+                llvm::dbgs() << " affinity using generic producer affinity of ";
+                result.printAsOperand(llvm::dbgs(), solver.getAsmState());
+                llvm::dbgs() << " as ";
+                valuePVS.print(llvm::dbgs(), solver.getAsmState());
+                llvm::dbgs() << "\n";
+              });
               newState ^= valuePVS;
             });
         return WalkResult::advance();
@@ -891,12 +1066,14 @@ bool AffinityAnalysis::tryLookupGlobalAffinity(
     Operation *op, SmallVectorImpl<IREE::Stream::AffinityAttr> &affinities) {
   auto globalPVS =
       solver.lookupElementFor<GlobalAffinityPVS>(Position::forOperation(op));
-  if (!globalPVS || !globalPVS->isValidState() ||
-      globalPVS->isUndefContained()) {
+  if (!globalPVS) {
+    // Global was never analyzed (probably not an executable op); try to find a
+    // default.
+    return tryLookupDefaultAffinity(op, affinities);
+  } else if (!globalPVS->isValidState() || globalPVS->isUndefContained()) {
     // Analysis failed.
     return false;
-  }
-  if (globalPVS->getAssumedSet().empty()) {
+  } else if (globalPVS->getAssumedSet().empty()) {
     // Analysis completed but no affinity was specified; try to find a default.
     return tryLookupDefaultAffinity(op, affinities);
   }
@@ -923,11 +1100,14 @@ bool AffinityAnalysis::tryLookupExecutionAffinity(
     Operation *op, SmallVectorImpl<IREE::Stream::AffinityAttr> &affinities) {
   auto opPVS =
       solver.lookupElementFor<OpAffinityPVS>(Position::forOperation(op));
-  if (!opPVS || !opPVS->isValidState() || opPVS->isUndefContained()) {
+  if (!opPVS) {
+    // Op was never analyzed (probably not an executable op); try to find a
+    // default.
+    return tryLookupDefaultAffinity(op, affinities);
+  } else if (!opPVS->isValidState() || opPVS->isUndefContained()) {
     // Analysis failed.
     return false;
-  }
-  if (opPVS->getAssumedSet().empty()) {
+  } else if (opPVS->getAssumedSet().empty()) {
     // Analysis completed but no affinity was specified; try to find a default.
     return tryLookupDefaultAffinity(op, affinities);
   }
@@ -1052,7 +1232,8 @@ bool AffinityAnalysis::tryLookupResourceUsageAffinity(
       // it, but not be any more efficient as we'd have to do the sort twice. We
       // should probably change the functions to take a SetVectorImpl instead.
       for (auto affinity : consumerPVS->getAssumedSet()) {
-        if (!producerPVS->getAssumedSet().contains(affinity)) {
+        if (!producerPVS || !producerPVS->isValidState() ||
+            !producerPVS->getAssumedSet().contains(affinity)) {
           affinities.push_back(affinity);
         }
       }
@@ -1068,6 +1249,16 @@ bool AffinityAnalysis::tryLookupResourceUsageAffinity(
 }
 
 LogicalResult AffinityAnalysis::run() {
+  // An unfortunate full-module walk.
+  // We should try to do everything that we can before touching the solver in
+  // this walk and cache it on precomputedQueries.
+  precomputedQueries.compute(explorer);
+  LLVM_DEBUG(precomputedQueries.print(llvm::dbgs(), solver.getAsmState()));
+
+  // Inject sideband data into the solver. This allows our elements to lookup
+  // the data by querying on the root op.
+  precomputedQueries.inject(solver);
+
   // Initialize globals so that we can assign them affinity.
   explorer.forEachGlobal([&](const auto *globalInfo) {
     if (isa<IREE::Stream::AffinityTypeInterface>(
@@ -1108,7 +1299,10 @@ LogicalResult AffinityAnalysis::run() {
         }
       }
       if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-        solver.getOrCreateElementFor<OpAffinityPVS>(Position::forOperation(op));
+        if (affinityOp.requiresAffinity()) {
+          solver.getOrCreateElementFor<OpAffinityPVS>(
+              Position::forOperation(op));
+        }
       }
       for (auto result : op->getResults()) {
         if (isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -24,7 +24,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 
-#define DEBUG_TYPE "iree-util-dfx"
+#define DEBUG_TYPE "iree-stream-affinity-analysis"
 
 namespace mlir::iree_compiler::IREE::Stream {
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.h
@@ -96,10 +96,24 @@ public:
   bool tryLookupResourceUsageAffinity(
       Value value, SmallVectorImpl<IREE::Stream::AffinityAttr> &affinities);
 
+  struct PrecomputedQueries {
+    // Values mapped to ops that pin their affinity, if any.
+    // Omitted values are not pinned. Note that a single value may be pinned to
+    // multiple potential affinities.
+    DenseMap<Value, DenseSet<IREE::Stream::AffinityOpInterface>>
+        pinnedAffinities;
+
+    void compute(Explorer &explorer);
+    void inject(DFX::Solver &solver);
+    static const PrecomputedQueries &get(DFX::Solver &solver);
+    void print(llvm::raw_ostream &os, AsmState &asmState);
+  };
+
 private:
   Explorer explorer;
   llvm::BumpPtrAllocator allocator;
   DFX::Solver solver;
+  PrecomputedQueries precomputedQueries;
 };
 
 } // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -225,8 +225,8 @@ util.global private @device : !hal.device
 util.func public @tensorBarrierDispatch(%input: tensor<?x128xi8>, %dim0: index) -> tensor<?x128xi8> {
   // CHECK: %[[BARRIER:.+]] = stream.async.barrier on(#hal.device.affinity<@device>) %[[INPUT]] : !stream.resource<*>{%[[INPUT_SIZE]]}
   %barrier = flow.tensor.barrier %input : tensor<?x128xi8>{%dim0} on #hal.device.affinity<@device>
-  // CHECK: %[[RESULT_SIZE:.+]] = stream.tensor.sizeof tensor<?x128xi8>{%[[DIM0]]} : index
-  // CHECK: %[[RESULT:.+]] = stream.tensor.dispatch @ex::@entry(%[[BARRIER]])
+  // CHECK: %[[RESULT_SIZE:.+]] = stream.tensor.sizeof on(#hal.device.affinity<@device>)  tensor<?x128xi8>{%[[DIM0]]} : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.dispatch on(#hal.device.affinity<@device>)  @ex::@entry(%[[BARRIER]])
   %0 = flow.dispatch @ex::@entry(%barrier) : (tensor<?x128xi8>{%dim0}) -> tensor<?x128xi8>{%dim0}
   // CHECK: util.return %[[RESULT]], %[[RESULT_SIZE]]
   util.return %0 : tensor<?x128xi8>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_transfers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_transfers.mlir
@@ -49,7 +49,7 @@ util.func public @omittedSourceAffinity(%size: index) -> !stream.resource<*> {
   // CHECK: %[[SPLAT:.+]] = stream.async.splat
   %splat = stream.async.splat %c123_i32 : i32 -> !stream.resource<*>{%size}
   // CHECK-NOT: stream.async.transfer
-  // CHECK: %[[TRANSFER:.+]] = stream.async.clone %[[SPLAT]]
+  // CHECK: %[[TRANSFER:.+]] = stream.async.clone on(#hal.device.promise<@dev_a>) %[[SPLAT]]
   %transfer = stream.async.transfer %splat : !stream.resource<*>{%size} -> to(#hal.device.promise<@dev_a>) !stream.resource<*>{%size}
   // CHECK: util.return %[[TRANSFER]]
   util.return %transfer : !stream.resource<*>

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
@@ -83,6 +83,26 @@ public:
                                            /*forceUpdate=*/true);
   }
 
+  // Creates (if needed) an element and adds it to the solver.
+  // Use during initialization for elements that may recursively initialize
+  // themselves.
+  template <typename ElementT>
+  void cacheElementFor(Position pos) {
+    cacheElementFor<ElementT>(pos, /*queryingElement=*/nullptr,
+                              Resolution::NONE);
+  }
+
+  // Creates (if needed) an element and adds it to the solver.
+  // Use during initialization for elements that may recursively initialize
+  // themselves.
+  template <typename ElementT>
+  void cacheElementFor(Position pos, const AbstractElement *queryingElement,
+                       Resolution resolution) {
+    getOrCreateElementFor<ElementT>(pos, queryingElement, resolution,
+                                    /*forceUpdate=*/false,
+                                    /*updateAfterInit=*/false);
+  }
+
   // Returns the element of |ElementT| for |pos| and optionally adds a
   // dependency from |queryingElement| to the returned element with the given
   // |resolution|.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -876,6 +876,24 @@ def Util_TiedOpInterface : OpInterface<"TiedOpInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns the operand tied to the given result of the op or nullptr if
+        none.
+      }],
+      /*retTy=*/"mlir::OpOperand *",
+      /*methodName=*/"getTiedResultOpOperand",
+      /*args=*/(ins "Value":$result),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        auto resultIndex = cast<mlir::OpResult>(result).getResultNumber();
+        auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
+            .getTiedResultOperandIndex(resultIndex);
+        return operandIndex.has_value() ?
+            &$_op->getOpOperand(operandIndex.value()) :
+            nullptr;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Returns the operand index tied to the given result index, if any.
 
         Note that the index returned is into the full range of all operands of

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -89,6 +89,10 @@ struct FlowBarrierTargetAffinityAttrExternalModel
 
   bool requiresAffinity(Operation *op) const { return true; }
 
+  bool pinsValueAffinity(Operation *op) const {
+    return op->hasAttrOfType<IREE::Stream::AffinityAttr>("target");
+  }
+
   IREE::Stream::AffinityAttr getAffinityAttr(Operation *op) const {
     return op->getAttrOfType<IREE::Stream::AffinityAttr>("target");
   }


### PR DESCRIPTION
This along with a fix to Explorer actually skip skipped entries hopefully prevents n^2 walks through tied operands. Extra logging and a few utilities were added that were useful in getting this working. The primary affinity analysis test now runs with a low solver iteration limit and has a test that is expected to fail if it is exceeded (it failed prior to this PR).