### PR TITLE
[HAL] set shared usage bits

### DIFF
--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -75,6 +75,24 @@ public:
                                             configAttr, executableTargetAttrs);
   }
 
+  LogicalResult
+  setSharedUsageBits(const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+                     IREE::HAL::BufferUsageBitfield &bufferUsage) const override {
+    for (auto targetAttr : targets) {
+      // if the target is metal, we dont need to add any usage bits
+      if (targetAttr.getDeviceID().getValue() == "metal") {
+        continue;
+      }
+      // if the target is local, we need to add the mapping persistent usage bit
+      if (targetAttr.getDeviceID().getValue() == "local") {
+        bufferUsage = bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
+      }
+      // interop with other targets is not supported yet
+      return failure();
+    }
+    return success();
+  }
+
 private:
   const MetalSPIRVOptions &options;
 };

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -82,14 +82,14 @@ public:
       // If the target is metal (self), we dont need to add any usage bits.
       if (targetAttr.getDeviceID().getValue() == "metal") {
         continue;
-      }
-      // For local interop, we need to add the mapping persistent usage bit.
-      if (targetAttr.getDeviceID().getValue() == "local") {
+      } else if (targetAttr.getDeviceID().getValue() == "local") {
+        // For local interop, we need to add the mapping persistent usage bit.
         bufferUsage =
             bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
+      } else {
+        // Interop with other targets is not supported yet.
+        return failure();
       }
-      // Interop with other targets is not supported yet.
-      return failure();
     }
     return success();
   }

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -79,16 +79,16 @@ public:
       const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
       IREE::HAL::BufferUsageBitfield &bufferUsage) const override {
     for (auto targetAttr : targets) {
-      // if the target is metal, we dont need to add any usage bits
+      // If the target is metal (self), we dont need to add any usage bits.
       if (targetAttr.getDeviceID().getValue() == "metal") {
         continue;
       }
-      // if the target is local, we need to add the mapping persistent usage bit
+      // For local interop, we need to add the mapping persistent usage bit.
       if (targetAttr.getDeviceID().getValue() == "local") {
         bufferUsage =
             bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
       }
-      // interop with other targets is not supported yet
+      // Interop with other targets is not supported yet.
       return failure();
     }
     return success();

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -75,9 +75,9 @@ public:
                                             configAttr, executableTargetAttrs);
   }
 
-  LogicalResult
-  setSharedUsageBits(const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
-                     IREE::HAL::BufferUsageBitfield &bufferUsage) const override {
+  LogicalResult setSharedUsageBits(
+      const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+      IREE::HAL::BufferUsageBitfield &bufferUsage) const override {
     for (auto targetAttr : targets) {
       // if the target is metal, we dont need to add any usage bits
       if (targetAttr.getDeviceID().getValue() == "metal") {
@@ -85,7 +85,8 @@ public:
       }
       // if the target is local, we need to add the mapping persistent usage bit
       if (targetAttr.getDeviceID().getValue() == "local") {
-        bufferUsage = bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
+        bufferUsage =
+            bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
       }
       // interop with other targets is not supported yet
       return failure();

--- a/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
+++ b/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
@@ -15,8 +15,10 @@ package(
 iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
-        ["smoketest.mlir"],
-        ["heterogeneous_interop.mlir"],
+        [
+            "smoketest.mlir",
+            "heterogeneous_interop.mlir",
+        ],
         include = ["*.mlir"],
     ),
     cfg = "//compiler:lit.cfg.py",

--- a/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
+++ b/compiler/plugins/target/MetalSPIRV/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         ["smoketest.mlir"],
+        ["heterogeneous_interop.mlir"],
         include = ["*.mlir"],
     ),
     cfg = "//compiler:lit.cfg.py",

--- a/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
+++ b/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "smoketest.mlir"
+    "heterogeneous_interop.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
+++ b/compiler/plugins/target/MetalSPIRV/test/CMakeLists.txt
@@ -14,8 +14,8 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "smoketest.mlir"
     "heterogeneous_interop.mlir"
+    "smoketest.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/plugins/target/MetalSPIRV/test/heterogeneous_interop.mlir
+++ b/compiler/plugins/target/MetalSPIRV/test/heterogeneous_interop.mlir
@@ -1,24 +1,30 @@
-// RUN: iree-compile --compile-from=stream --compile-to=hal %s | FileCheck %s
+// RUN: iree-opt --iree-hal-transformation-pipeline --split-input-file --verify-diagnostics %s | FileCheck %s
 
 module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
-  util.global private @device_a = #hal.device.target<"local", [#hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>, ukernels = "none"}>]> : !hal.device
-  util.global private @device_b = #hal.device.target<"metal", [#hal.executable.target<"metal-spirv", "metal-msl-fb", {iree.gpu.target = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <compute =  fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [], subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768, max_workgroup_counts = [65535, 65535, 65535]>>}>]> : !hal.device
-  util.func public @multi_device_mul(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "async func @multi_device_mul(%input0: tensor<4xf32> {iree.abi.affinity = #hal.device.promise<@device_a>}) -> (%output0: tensor<4xf32> {iree.abi.affinity = #hal.device.promise<@device_a>})", iree.abi.model = "coarse-fences"}} {
-    %c0 = arith.constant 0 : index
+  util.global private @device_a = #hal.device.target<"local"> : !hal.device
+  util.global private @device_b = #hal.device.target<"metal"> : !hal.device
+  util.func public @multi_device_mul() -> !stream.resource<external> {
     %c16 = arith.constant 16 : index
-    %c4 = arith.constant 4 : index
-    %element_type_f32 = hal.element_type<f32> : i32
-    %dense_row_major = hal.encoding_type<dense_row_major> : i32
-    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%c4]) type(%element_type_f32) encoding(%dense_row_major)
-    %0 = stream.tensor.import on(#hal.device.affinity<@device_a>) %arg0 : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%c16}
-    %1 = stream.timepoint.import on(#hal.device.affinity<@device_a>) %arg1 : (!hal.fence) => !stream.timepoint
-    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.optimal<[#hal.device.affinity<@device_a>, #hal.device.affinity<@device_b>]>) await(%1) => !stream.resource<external>{%c16} => !stream.timepoint
-    stream.timepoint.chain_external on(#hal.device.affinity<@device_a>) %result_timepoint => (%arg2 : !hal.fence)
-    %5 = stream.tensor.export on(#hal.device.affinity<@device_a>) %result : tensor<4xf32> in !stream.resource<external>{%c16} -> !hal.buffer_view
-    util.return %5 : !hal.buffer_view
+    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.optimal<[#hal.device.affinity<@device_a>, #hal.device.affinity<@device_b>]>) : !stream.resource<external>{%c16} => !stream.timepoint
+    util.return %result : !stream.resource<external>
   }
 }
+
 // Check that for local interop we have a mapping persistent buffer flags.
-// CHECK: util.func public @multi_device_mul(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
 // CHECK: hal.device.queue.alloca
 // CHECK-SAME: MappingPersistent
+
+// -----
+
+// Check that we fail if we try to share allocations with incompatible devices.
+module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
+  util.global private @device_a = #hal.device.target<"local"> : !hal.device
+  util.global private @device_b = #hal.device.target<"metal"> : !hal.device
+  util.global private @device_c = #hal.device.target<"vulkan"> : !hal.device
+  util.func public @multi_device_mul() -> !stream.resource<external> {
+    %c16 = arith.constant 16 : index
+    // expected-error @+1 {{failed to legalize operation 'stream.resource.alloca' that was explicitly marked illegal}}
+    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.optimal<[#hal.device.affinity<@device_a>, #hal.device.affinity<@device_b>, #hal.device.affinity<@device_c>]>) : !stream.resource<external>{%c16} => !stream.timepoint
+    util.return %result : !stream.resource<external>
+  }
+}

--- a/compiler/plugins/target/MetalSPIRV/test/heterogeneous_interop.mlir
+++ b/compiler/plugins/target/MetalSPIRV/test/heterogeneous_interop.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-compile --compile-from=stream --compile-to=hal %s | FileCheck %s
+
+module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
+  util.global private @device_a = #hal.device.target<"local", [#hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>, ukernels = "none"}>]> : !hal.device
+  util.global private @device_b = #hal.device.target<"metal", [#hal.executable.target<"metal-spirv", "metal-msl-fb", {iree.gpu.target = #iree_gpu.target<arch = "apple", features = "spirv:v1.3,cap:Shader", wgp = <compute =  fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [], subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 32768, max_workgroup_counts = [65535, 65535, 65535]>>}>]> : !hal.device
+  util.func public @multi_device_mul(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "async func @multi_device_mul(%input0: tensor<4xf32> {iree.abi.affinity = #hal.device.promise<@device_a>}) -> (%output0: tensor<4xf32> {iree.abi.affinity = #hal.device.promise<@device_a>})", iree.abi.model = "coarse-fences"}} {
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index
+    %c4 = arith.constant 4 : index
+    %element_type_f32 = hal.element_type<f32> : i32
+    %dense_row_major = hal.encoding_type<dense_row_major> : i32
+    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%c4]) type(%element_type_f32) encoding(%dense_row_major)
+    %0 = stream.tensor.import on(#hal.device.affinity<@device_a>) %arg0 : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%c16}
+    %1 = stream.timepoint.import on(#hal.device.affinity<@device_a>) %arg1 : (!hal.fence) => !stream.timepoint
+    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.optimal<[#hal.device.affinity<@device_a>, #hal.device.affinity<@device_b>]>) await(%1) => !stream.resource<external>{%c16} => !stream.timepoint
+    stream.timepoint.chain_external on(#hal.device.affinity<@device_a>) %result_timepoint => (%arg2 : !hal.fence)
+    %5 = stream.tensor.export on(#hal.device.affinity<@device_a>) %result : tensor<4xf32> in !stream.resource<external>{%c16} -> !hal.buffer_view
+    util.return %5 : !hal.buffer_view
+  }
+}
+// Check that for local interop we have a mapping persistent buffer flags.
+// CHECK: util.func public @multi_device_mul(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
+// CHECK: hal.device.queue.alloca
+// CHECK-SAME: MappingPersistent

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
@@ -219,14 +219,16 @@ void DeviceAnalysis::gatherAllDeviceTargets(
 void DeviceAnalysis::gatherDeviceAffinityTargets(
     IREE::Stream::AffinityAttr affinityAttr, Operation *fromOp,
     SetVector<IREE::HAL::DeviceTargetAttr> &resultSet) {
-  // We currently only know how to handle HAL device affinities.
-  // We could support other ones via an interface but instead we just fall back
-  // to default logic if no affinity or an unknown one is found.
+  // If we have a device optimal attr, we need to gather the targets for each
+  // of the affinities.
   if (auto optimalAttr =
           mlir::dyn_cast_or_null<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
     for (auto affinity : optimalAttr.getAffinities()) {
       gatherDeviceAffinityTargets(affinity, fromOp, resultSet);
     }
+  // We currently only know how to handle HAL device affinities.
+  // We could support other ones via an interface but instead we just fall back
+  // to default logic if no affinity or an unknown one is found.
   } else if (auto deviceAffinityAttr =
                  dyn_cast_if_present<IREE::HAL::DeviceAffinityAttr>(
                      affinityAttr)) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
@@ -226,9 +226,9 @@ void DeviceAnalysis::gatherDeviceAffinityTargets(
     for (auto affinity : optimalAttr.getAffinities()) {
       gatherDeviceAffinityTargets(affinity, fromOp, resultSet);
     }
-  // We currently only know how to handle HAL device affinities.
-  // We could support other ones via an interface but instead we just fall back
-  // to default logic if no affinity or an unknown one is found.
+    // We currently only know how to handle HAL device affinities.
+    // We could support other ones via an interface but instead we just fall
+    // back to default logic if no affinity or an unknown one is found.
   } else if (auto deviceAffinityAttr =
                  dyn_cast_if_present<IREE::HAL::DeviceAffinityAttr>(
                      affinityAttr)) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.cpp
@@ -222,12 +222,14 @@ void DeviceAnalysis::gatherDeviceAffinityTargets(
   // We currently only know how to handle HAL device affinities.
   // We could support other ones via an interface but instead we just fall back
   // to default logic if no affinity or an unknown one is found.
-  if (auto optimalAttr = mlir::dyn_cast_or_null<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
+  if (auto optimalAttr =
+          mlir::dyn_cast_or_null<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
     for (auto affinity : optimalAttr.getAffinities()) {
       gatherDeviceAffinityTargets(affinity, fromOp, resultSet);
     }
-  } else if( auto deviceAffinityAttr =
-                 dyn_cast_if_present<IREE::HAL::DeviceAffinityAttr>(affinityAttr)) {
+  } else if (auto deviceAffinityAttr =
+                 dyn_cast_if_present<IREE::HAL::DeviceAffinityAttr>(
+                     affinityAttr)) {
     gatherDeviceTargets(deviceAffinityAttr.getDevice(), fromOp, resultSet);
   } else {
     gatherLegacyDeviceTargetAttrs(fromOp, resultSet);

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -102,10 +102,8 @@ trySetSharedUsageBits(Operation *op,
       StringRef deviceID = targetAttr.getDeviceID().getValue();
       std::shared_ptr<IREE::HAL::TargetDevice> targetDevice =
           targetRegistry.getTargetDevice(deviceID);
-      if (!targetDevice) {
-        return failure();
-      }
-      if (failed(targetDevice->setSharedUsageBits(targetAttrs, bufferUsage))) {
+      if (!targetDevice ||
+          failed(targetDevice->setSharedUsageBits(targetAttrs, bufferUsage))) {
         return failure();
       }
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -83,22 +83,22 @@ struct ContextResolveOpPattern
   }
 };
 
-// try to add usage bits for allocations that are used on multiple devices
+// Try to add usage bits for allocations that are used on multiple devices.
 LogicalResult
 trySetSharedUsageBits(Operation *op,
                       IREE::HAL::BufferUsageBitfield &bufferUsage,
                       const IREE::HAL::TargetRegistry &targetRegistry,
                       IREE::HAL::DeviceAnalysis &deviceAnalysis) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
-  // if its no device.optimal attr we dont need to do anything
+  // If its no device.optimal attr we dont need to do anything.
   if (auto optimalAttr =
           dyn_cast_if_present<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
-    // use the DeviceAnalysis to get all DeviceTargetAttrs for the operation
+    // Use the DeviceAnalysis to get all DeviceTargetAttrs for the operation.
     SetVector<IREE::HAL::DeviceTargetAttr> targetAttrs;
     deviceAnalysis.gatherDeviceAffinityTargets(affinityAttr, op, targetAttrs);
     for (auto targetAttr : targetAttrs) {
-      // use the registry to get the the instance of the TargetDevice
-      // and let it add the usage bits.
+      // Use the registry to get the instance of the TargetDevice and let it
+      // add the usage bits.
       StringRef deviceID = targetAttr.getDeviceID().getValue();
       std::shared_ptr<IREE::HAL::TargetDevice> targetDevice =
           targetRegistry.getTargetDevice(deviceID);
@@ -134,7 +134,7 @@ struct ResourceAllocOpPattern
       return failure();
     }
 
-    // try to add usage bits for allocations that are used on multiple devices.
+    // Try to add usage bits for allocations that are used on multiple devices.
     if (failed(trySetSharedUsageBits(allocOp, bufferUsage, targetRegistry,
                                      deviceAnalysis))) {
       return failure();
@@ -180,7 +180,7 @@ struct ResourceAllocaOpPattern
       return failure();
     }
 
-    // try to add usage bits for allocations that are used on multiple devices.
+    // Try to add usage bits for allocations that are used on multiple devices.
     if (failed(trySetSharedUsageBits(allocaOp, bufferUsage, targetRegistry,
                                      deviceAnalysis))) {
       return failure();

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -105,7 +105,9 @@ trySetSharedUsageBits(Operation *op,
       if (!targetDevice) {
         return failure();
       }
-      return targetDevice->setSharedUsageBits(targetAttrs, bufferUsage);
+      if (failed(targetDevice->setSharedUsageBits(targetAttrs, bufferUsage))) {
+        return failure();
+      }
     }
   }
   return success();

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_HAL_CONVERSION_STREAMTOHAL_PATTERNS_H_
 #define IREE_COMPILER_DIALECT_HAL_CONVERSION_STREAMTOHAL_PATTERNS_H_
 
+#include "iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -16,7 +17,9 @@ namespace mlir::iree_compiler {
 void populateStreamToHALPatterns(MLIRContext *context,
                                  ConversionTarget &conversionTarget,
                                  TypeConverter &typeConverter,
-                                 RewritePatternSet &patterns);
+                                 RewritePatternSet &patterns,
+                                 IREE::HAL::DeviceAnalysis& deviceAnalysis,
+                                 const IREE::HAL::TargetRegistry &targetRegistry);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.h
@@ -14,12 +14,11 @@
 namespace mlir::iree_compiler {
 
 // Populates conversion patterns for stream->HAL.
-void populateStreamToHALPatterns(MLIRContext *context,
-                                 ConversionTarget &conversionTarget,
-                                 TypeConverter &typeConverter,
-                                 RewritePatternSet &patterns,
-                                 IREE::HAL::DeviceAnalysis& deviceAnalysis,
-                                 const IREE::HAL::TargetRegistry &targetRegistry);
+void populateStreamToHALPatterns(
+    MLIRContext *context, ConversionTarget &conversionTarget,
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    IREE::HAL::DeviceAnalysis &deviceAnalysis,
+    const IREE::HAL::TargetRegistry &targetRegistry);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
@@ -115,7 +115,7 @@ LogicalResult LocalDevice::setSharedUsageBits(
     const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
     IREE::HAL::BufferUsageBitfield &bufferUsage) const {
   for (auto targetAttr : targets) {
-    // if the target is not local (self), we need to add the mapping persistent
+    // If the target is not local (self), we need to add the mapping persistent
     // usage bit.
     if (targetAttr.getDeviceID().getValue() != "local") {
       bufferUsage =

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
@@ -111,4 +111,18 @@ Value LocalDevice::buildDeviceTargetMatch(
       loc, device, "local*", targetAttr.getExecutableTargets(), builder);
 }
 
+LogicalResult LocalDevice::setSharedUsageBits(
+    const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+    IREE::HAL::BufferUsageBitfield &bufferUsage) const {
+  for (auto targetAttr : targets) {
+    // if the target is not local (self), we need to add the mapping persistent
+    // usage bit.
+    if (targetAttr.getDeviceID().getValue() != "local") {
+      bufferUsage =
+          bufferUsage | IREE::HAL::BufferUsageBitfield::MappingPersistent;
+    }
+  }
+  return success();
+}
+
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
@@ -40,6 +40,9 @@ public:
   Value buildDeviceTargetMatch(Location loc, Value device,
                                IREE::HAL::DeviceTargetAttr targetAttr,
                                OpBuilder &builder) const override;
+  LogicalResult
+  setSharedUsageBits(const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+                     IREE::HAL::BufferUsageBitfield &bufferUsage) const override;
 
 private:
   const Options options;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
@@ -40,9 +40,9 @@ public:
   Value buildDeviceTargetMatch(Location loc, Value device,
                                IREE::HAL::DeviceTargetAttr targetAttr,
                                OpBuilder &builder) const override;
-  LogicalResult
-  setSharedUsageBits(const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
-                     IREE::HAL::BufferUsageBitfield &bufferUsage) const override;
+  LogicalResult setSharedUsageBits(
+      const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+      IREE::HAL::BufferUsageBitfield &bufferUsage) const override;
 
 private:
   const Options options;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h
@@ -40,6 +40,7 @@ public:
   Value buildDeviceTargetMatch(Location loc, Value device,
                                IREE::HAL::DeviceTargetAttr targetAttr,
                                OpBuilder &builder) const override;
+
   LogicalResult setSharedUsageBits(
       const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
       IREE::HAL::BufferUsageBitfield &bufferUsage) const override;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
@@ -22,7 +22,7 @@ Value TargetDevice::buildDeviceTargetMatch(
 LogicalResult TargetDevice::setSharedUsageBits(
     const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
     IREE::HAL::BufferUsageBitfield &bufferUsage) const {
-      return failure();
+  return failure();
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
@@ -19,4 +19,10 @@ Value TargetDevice::buildDeviceTargetMatch(
       builder);
 }
 
+LogicalResult TargetDevice::setSharedUsageBits(
+    const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+    IREE::HAL::BufferUsageBitfield &bufferUsage) const {
+      return failure();
+}
+
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.cpp
@@ -22,6 +22,7 @@ Value TargetDevice::buildDeviceTargetMatch(
 LogicalResult TargetDevice::setSharedUsageBits(
     const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
     IREE::HAL::BufferUsageBitfield &bufferUsage) const {
+  // If the TargetDevice does not implement this function, default to failure.
   return failure();
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetDevice.h
@@ -8,7 +8,6 @@
 #define IREE_COMPILER_DIALECT_HAL_TARGET_TARGETDEVICE_H_
 
 #include <optional>
-#include <string>
 
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -43,6 +42,11 @@ public:
   virtual Value buildDeviceTargetMatch(Location loc, Value device,
                                        IREE::HAL::DeviceTargetAttr targetAttr,
                                        OpBuilder &builder) const;
+
+  // Sets the shared usage bits for the given device set.
+  virtual LogicalResult
+  setSharedUsageBits(const SetVector<IREE::HAL::DeviceTargetAttr> &targets,
+                     IREE::HAL::BufferUsageBitfield &bufferUsage) const;
 
   // TODO(benvanik): pipeline registration for specialization of host code at
   // various stages.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
@@ -60,7 +60,8 @@ static void stripExportRegions(ModuleOp moduleOp) {
 
 struct ConvertToHALPass
     : public IREE::HAL::impl::ConvertToHALPassBase<ConvertToHALPass> {
-  using IREE::HAL::impl::ConvertToHALPassBase<ConvertToHALPass>::ConvertToHALPassBase;
+  using IREE::HAL::impl::ConvertToHALPassBase<
+      ConvertToHALPass>::ConvertToHALPassBase;
 
   void runOnOperation() override {
     auto *context = &getContext();
@@ -92,7 +93,8 @@ struct ConvertToHALPass
       return signalPassFailure();
     }
     populateStreamToHALPatterns(context, conversionTarget, typeConverter,
-                                patterns, deviceAnalysis, *targetRegistry.value);
+                                patterns, deviceAnalysis,
+                                *targetRegistry.value);
 
     // Gather all HAL dialect conversion patterns from custom dialects.
     // These will perform the tensor->buffer mapping for their ops.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -455,7 +455,7 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   //----------------------------------------------------------------------------
 
   // Convert supported input dialects (std, stream, etc) into the HAL dialect.
-  passManager.addPass(IREE::HAL::createConvertToHALPass());
+  passManager.addPass(IREE::HAL::createConvertToHALPass({targetRegistry}));
 
   // If memoization is disabled then inline any regions that were created during
   // conversion.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -26,6 +26,13 @@ def ConvertToHALPass :
     so that the information required to marshal buffers and operands to the
     device is available for conversion.
   }];
+  let options = [
+    Option<
+      "targetRegistry", "target-registry",
+      "llvm::cl::TargetRegistryRef", "",
+      "Target registry containing the list of available devices and backends."
+    >,
+  ];
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::func::FuncDialect",


### PR DESCRIPTION
draft implementation for https://github.com/iree-org/iree/issues/20856

This probably needs a lot of improvement in the design, I hope I can get some feedback here.

In general there are still a couple of open questions for me:

1. When to set the usage bits (should it be part of the stream-conversion or happen after it?)
2. How to use the topology information? This currently does not and only relies on the information provided by the TargetDevices. However, it feels like setting the usage bits should be dependent on the topology.

So to improve this I could imagine setting the buffer bits based on the topology information + usage information of the hal.device.optimal. However, this would require the topology information to always be available. While so far I understood it more as something (optional) that could be set at the higher level of the stack to enable optimizations (like eliding transfers) but should not be required to exist. However, this assumption could also be wrong on my side.

What I could also imagine as a plausible solution is to have an additional pass that runs before the stream-conversion that would query the devices for some default topology information (if it is not already set by the user). So have something like TargetDevice::getTopologyLinks() which would then replace the TargetDevice::setSharedUsageBits.

This would also have the benefit of removing the dependence of the TargetRegistry and DeviceAnalysis from the stream-conversion which I (sadly) introduced here.