### PR TITLE
Remove reference to linalg op tests in iree-test-suites.

### DIFF
--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -409,18 +409,6 @@ repository.
 * Keeping tests out of tree forces them to use public project APIs and allows
   the core project to keep its infrastructure simpler.
 
-#### linalg operator tests
-
-Tests for operators in the MLIR linalg dialect like `matmul`, and `convolution`
-are being migrated from folders like
-[`tests/e2e/matmul/`](https://github.com/iree-org/iree/tree/main/tests/e2e/matmul)
-in the
-[iree-org/iree](https://github.com/iree-org/iree) repository to
-[`linalg_ops/`](https://github.com/iree-org/iree-test-suites/tree/main/linalg_ops)
-in the
-[iree-org/iree-test-suites](https://github.com/iree-org/iree-test-suites)
-repository.
-
 #### :simple-onnx: ONNX operator tests
 
 Tests for individual ONNX operators are included at


### PR DESCRIPTION
See https://github.com/iree-org/iree-test-suites/pull/100, which deletes the linalg ops tests from https://github.com/iree-org/iree-test-suites.

This test suite was never fully migrated, the version in IREE has continued development, and the tests in iree-test-suites started failing on March 27 without being fixed: https://github.com/iree-org/iree-test-suites/actions/workflows/test_linalg_ops.yml.

We could restart the migration work later, but right now this is just costing CI resources and code complexity.