### PR TITLE
[NFC] Fix test issues on Windows.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
@@ -118,10 +118,12 @@ distributeLinalgCopyToThreads(RewriterBase &rewriter, linalg::CopyOp copy,
   };
 
   // Build a for loop skeleton:
-  scf::ForOp forOp = rewriter.create<scf::ForOp>(
-      loc, /*lb=*/rewriter.create<arith::ConstantIndexOp>(loc, 0),
-      /*ub=*/rewriter.create<arith::ConstantIndexOp>(loc, numCopiesPerThread),
-      /*steps=*/rewriter.create<arith::ConstantIndexOp>(loc, 1));
+  auto lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  auto upperBound =
+      rewriter.create<arith::ConstantIndexOp>(loc, numCopiesPerThread);
+  auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  scf::ForOp forOp =
+      rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
 
   auto delinearizeIndex = [&](Value index, ArrayRef<int64_t> shape) {
     return rewriter.create<affine::AffineDelinearizeIndexOp>(loc, index, shape)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_global_loads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_global_loads.mlir
@@ -21,12 +21,12 @@ func.func @matmul_copy_16x64xi8(%src: memref<16x64xi8>, %dest : memref<16x64xi8,
 // CHECK-SAME: %[[SRC:.*]]: memref<16x64xi8>
 // CHECK-SAME: %[[DEST:.*]]: memref<16x64xi8, #gpu.address_space<workgroup>>
 
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C4:.*]] = arith.constant 4 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C4]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (1, 4, 64, 4)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (16, 64)
@@ -51,12 +51,12 @@ func.func @matmul_copy_64x16xi8(%src: memref<64x16xi8>, %dest: memref<64x16xi8, 
 // CHECK-SAME: %[[SRC:.*]]: memref<64x16xi8>
 // CHECK-SAME: %[[DEST:.*]]: memref<64x16xi8, #gpu.address_space<workgroup>>
 
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C4:.*]] = arith.constant 4 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C4]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (1, 4, 64, 4)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (64, 16)
@@ -89,12 +89,12 @@ func.func @matmul_copy_32x64xi16(%src: memref<32x64xi16>, %dest: memref<32x64xi1
 // CHECK-LABEL: func.func @matmul_copy_32x64xi16
 // CHECK-SAME: %[[SRC:.*]]: memref<32x64xi16>
 // CHECK-SAME: %[[DEST:.*]]: memref<32x64xi16, #gpu.address_space<workgroup>>
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[C16:.*]] = arith.constant 16 : index
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C16:.*]] = arith.constant 16 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C16]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (2, 16, 32, 2)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (32, 64)
@@ -128,12 +128,12 @@ func.func @matmul_copy_32x128xi16(%src: memref<32x128xi16>, %dest: memref<32x128
 // CHECK-SAME: %[[SRC:.*]]: memref<32x128xi16>
 // CHECK-SAME: %[[DEST:.*]]: memref<32x128xi16, #gpu.address_space<workgroup>>
 
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[C32:.*]] = arith.constant 32 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C32]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (2, 32, 32, 2)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (32, 128)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_global_loads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_global_loads.mlir
@@ -21,12 +21,12 @@ func.func @matmul_copy_16x64xi8(%src: memref<16x64xi8>, %dest : memref<16x64xi8,
 // CHECK-SAME: %[[SRC:.*]]: memref<16x64xi8>
 // CHECK-SAME: %[[DEST:.*]]: memref<16x64xi8, #gpu.address_space<workgroup>>
 
-// CHECK: %[[C1:.*]] = arith.constant 1 : index
-// CHECK: %[[C4:.*]] = arith.constant 4 : index
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK: %[[LID:.*]] = gpu.lane_id
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C4]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (1, 4, 64, 4)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (16, 64)
@@ -51,12 +51,12 @@ func.func @matmul_copy_64x16xi8(%src: memref<64x16xi8>, %dest: memref<64x16xi8, 
 // CHECK-SAME: %[[SRC:.*]]: memref<64x16xi8>
 // CHECK-SAME: %[[DEST:.*]]: memref<64x16xi8, #gpu.address_space<workgroup>>
 
-// CHECK: %[[C1:.*]] = arith.constant 1 : index
-// CHECK: %[[C4:.*]] = arith.constant 4 : index
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK: %[[LID:.*]] = gpu.lane_id
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C4]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (1, 4, 64, 4)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (64, 16)
@@ -89,12 +89,12 @@ func.func @matmul_copy_32x64xi16(%src: memref<32x64xi16>, %dest: memref<32x64xi1
 // CHECK-LABEL: func.func @matmul_copy_32x64xi16
 // CHECK-SAME: %[[SRC:.*]]: memref<32x64xi16>
 // CHECK-SAME: %[[DEST:.*]]: memref<32x64xi16, #gpu.address_space<workgroup>>
-// CHECK: %[[C1:.*]] = arith.constant 1 : index
-// CHECK: %[[C16:.*]] = arith.constant 16 : index
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK: %[[LID:.*]] = gpu.lane_id
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C16:.*]] = arith.constant 16 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C16]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (2, 16, 32, 2)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (32, 64)
@@ -128,12 +128,12 @@ func.func @matmul_copy_32x128xi16(%src: memref<32x128xi16>, %dest: memref<32x128
 // CHECK-SAME: %[[SRC:.*]]: memref<32x128xi16>
 // CHECK-SAME: %[[DEST:.*]]: memref<32x128xi16, #gpu.address_space<workgroup>>
 
-// CHECK: %[[C1:.*]] = arith.constant 1 : index
-// CHECK: %[[C32:.*]] = arith.constant 32 : index
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
-// CHECK: %[[SGID:.*]] = gpu.subgroup_id
-// CHECK: %[[LID:.*]] = gpu.lane_id
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[BUFFER:.*]] = amdgpu.fat_raw_buffer_cast %[[SRC]]
+// CHECK-DAG: %[[SGID:.*]] = gpu.subgroup_id
+// CHECK-DAG: %[[LID:.*]] = gpu.lane_id
 // CHECK: scf.for %[[ARG0:.*]] = %[[C0]] to %[[C32]] step %[[C1]] {
 // CHECK:   %[[GATHER_ADDR:.*]] = affine.linearize_index disjoint [%[[SGID]], %[[ARG0]], %[[LID]], %[[C0]]] by (2, 32, 32, 2)
 // CHECK:   %[[DELI_GATHER:.*]]:2 = affine.delinearize_index %[[GATHER_ADDR]] into (32, 128)


### PR DESCRIPTION
Evaluation order changes with msvc compiler, so use CHECK-DAG instead of CHECK.