### PR TITLE
[Codegen][GPU][NFC] Remove dead MMA interface method

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -62,24 +62,6 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Returns the vector layout for the A/B/C matrix of the MMA operation:
-        ```
-          C += A * B
-        ```
-      }],
-      /*retTy=*/"::mlir::FailureOr<::std::tuple<"
-                  "::mlir::iree_compiler::IREE::VectorExt::VectorLayoutInterface, "
-                  "::mlir::iree_compiler::IREE::VectorExt::VectorLayoutInterface, "
-                  "::mlir::iree_compiler::IREE::VectorExt::VectorLayoutInterface>>",
-      /*methodName=*/"getContractionLayout",
-      /*args=*/(ins "::mlir::vector::ContractionOp":$contract),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return failure();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
         Returns the expected subgroup size of the MMA operation/intrinsic.
       }],
       /*retTy=*/"int64_t",


### PR DESCRIPTION
The getContractionLayout() method is not used anywhere and is not implemented by any MMA attributes - it's always defaulted to returning failure(). To simplify attribute generalization work, remove it.