### PR TITLE
Assign optimal affinities to allocations during ScheduleAllocation.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -24,10 +24,6 @@ namespace mlir::iree_compiler {
 
 Value lookupDeviceFor(Operation *op, OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
-  if (isa<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
-    llvm::report_fatal_error("#hal.device.optimal not supported on op type " +
-                             op->getName().getStringRef());
-  }
   auto resolveOp = builder.create<IREE::Stream::ContextResolveOp>(
       op->getLoc(),
       TypeRange{
@@ -40,10 +36,6 @@ Value lookupDeviceFor(Operation *op, OpBuilder &builder) {
 std::tuple<Value, Value> lookupDeviceAndQueueAffinityFor(Operation *op,
                                                          OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
-  if (isa<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
-    llvm::report_fatal_error("#hal.device.optimal not supported on op type " +
-                             op->getName().getStringRef());
-  }
   auto resolveOp = builder.create<IREE::Stream::ContextResolveOp>(
       op->getLoc(),
       TypeRange{
@@ -71,10 +63,6 @@ std::tuple<Value, Value> lookupDeviceAndQueueAffinityFor(
 
 Value lookupAllocatorFor(Operation *op, OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
-  if (isa<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
-    llvm::report_fatal_error("#hal.device.optimal not supported on op type " +
-                             op->getName().getStringRef());
-  }
   auto resolveOp = builder.create<IREE::Stream::ContextResolveOp>(
       op->getLoc(),
       TypeRange{

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/file_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/file_ops.mlir
@@ -15,6 +15,25 @@ util.func public @file_constant(%buffer: !util.buffer) {
 
 // -----
 
+// TODO(multi-device): emit policy ops to select the device. Today the first
+// affinity specified is chosen.
+
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+
+// CHECK-LABEL: @file_constant_optimal
+//  CHECK-SAME: (%[[BUFFER:.+]]: !util.buffer)
+util.func public @file_constant_optimal(%buffer: !util.buffer) {
+  %c0 = arith.constant 0 : index
+  %c1088 = arith.constant 1088 : index
+  // CHECK: %[[DEVICE:.+]] = util.global.load immutable @device_a
+  // CHECK: = hal.ex.file.from_memory device(%[[DEVICE]] : !hal.device) affinity(%c-1_i64) access(Read) buffer(%[[BUFFER]] : !util.buffer)[%c0 for %c1088] flags(%c0_i32) : !hal.file
+  %file = stream.file.constant on(#hal.device.optimal<[#hal.device.affinity<@device_a>, #hal.device.affinity<@device_b>]>) %buffer[%c0 for %c1088] : !util.buffer{%c1088} -> !stream.file
+  util.return
+}
+
+// -----
+
 util.global private @device : !hal.device
 
 // CHECK-LABEL: @file_read

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -918,17 +918,17 @@ IREE::Stream::AffinityAttr
 DeviceAffinityAttr::joinOR(IREE::Stream::AffinityAttr other) const {
   if (!other) {
     return *this;
+  } else if (isa<DeviceOptimalAttr>(other)) {
+    return other.joinOR(*this);
+  } else if (auto otherAffinityAttr =
+                 dyn_cast_if_present<DeviceAffinityAttr>(other)) {
+    if (otherAffinityAttr.getDevice() == getDevice()) {
+      return DeviceAffinityAttr::get(getContext(), getDevice(),
+                                     getQueueMask() |
+                                         otherAffinityAttr.getQueueMask());
+    }
   }
-  auto otherAffinityAttr = dyn_cast_if_present<DeviceAffinityAttr>(other);
-  if (!otherAffinityAttr) {
-    return nullptr; // invalid
-  }
-  if (otherAffinityAttr.getDevice() != getDevice()) {
-    return nullptr; // cannot join across devices (could select optimal, though)
-  }
-  return DeviceAffinityAttr::get(getContext(), getDevice(),
-                                 getQueueMask() |
-                                     otherAffinityAttr.getQueueMask());
+  return IREE::HAL::DeviceOptimalAttr::get(getContext(), {*this, other});
 }
 
 IREE::Stream::AffinityAttr
@@ -1041,17 +1041,17 @@ IREE::Stream::AffinityAttr
 DevicePromiseAttr::joinOR(IREE::Stream::AffinityAttr other) const {
   if (!other) {
     return *this;
+  } else if (isa<DeviceOptimalAttr>(other)) {
+    return other.joinOR(*this);
+  } else if (auto otherPromiseAttr =
+                 dyn_cast_if_present<DevicePromiseAttr>(other)) {
+    if (otherPromiseAttr.getDevice() == getDevice()) {
+      return DevicePromiseAttr::get(getContext(), getDevice(),
+                                    getQueueMask() |
+                                        otherPromiseAttr.getQueueMask());
+    }
   }
-  auto otherPromiseAttr = dyn_cast_if_present<DevicePromiseAttr>(other);
-  if (!otherPromiseAttr) {
-    return nullptr; // invalid
-  }
-  if (otherPromiseAttr.getDevice() != getDevice()) {
-    return nullptr; // cannot join across devices (could select optimal, though)
-  }
-  return DevicePromiseAttr::get(getContext(), getDevice(),
-                                getQueueMask() |
-                                    otherPromiseAttr.getQueueMask());
+  return IREE::HAL::DeviceOptimalAttr::get(getContext(), {*this, other});
 }
 
 IREE::Stream::AffinityAttr

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.h
@@ -96,6 +96,18 @@ public:
   bool tryLookupResourceUsageAffinity(
       Value value, SmallVectorImpl<IREE::Stream::AffinityAttr> &affinities);
 
+  // Populates all affinities a value has been pinned to, if any.
+  // Returns true if the value had pinned affinities.
+  bool tryLookupPinnedAffinities(
+      Value value, SmallVectorImpl<IREE::Stream::AffinityAttr> &affinities);
+
+  // Precomputed IR properties that can be queried within the solver.
+  // Static information that will not change based on analysis can be placed
+  // here to amortize the costs required to calculate it.
+  //
+  // Usage within an element initialize/update:
+  //   auto &queries = AffinityAnalysis::PrecomputedQueries::get(solver);
+  //   queries.whatever;
   struct PrecomputedQueries {
     // Values mapped to ops that pin their affinity, if any.
     // Omitted values are not pinned. Note that a single value may be pinned to

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -61,9 +61,10 @@ def Stream_AffinityAttr : AttrInterface<"AffinityAttr"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Returns an affinity describing the union with |other| constraints.
+        Returns an affinity describing the union with |other| constraints such
+        that the "optimal" affinity for the particular operation is selected.
         The returned affinity specifies that a particular operation may execute
-        on _either_ of the source affinities.
+        on _any_ of the source affinities.
       }],
       /*retTy=*/"IREE::Stream::AffinityAttr",
       /*methodName=*/"joinOR",
@@ -118,6 +119,12 @@ def Stream_AffinityAttr : AttrInterface<"AffinityAttr"> {
     // Returns true if |lhs| and |rhs| indicate that their operations can
     // execute together on the same execution queue.
     static bool canExecuteTogether(AffinityAttr lhs, AffinityAttr rhs);
+
+    // Returns an affinity representing the optimal affinity from the given set.
+    // The resulting affinity will have a single logical execution context
+    // resolved but doing so may be deferred until runtime.
+    // Returns nullptr if no optimal join is possible.
+    static AffinityAttr joinOR(ArrayRef<AffinityAttr> affinityAttrs);
   }];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -393,6 +393,21 @@ bool AffinityAttr::canExecuteTogether(AffinityAttr lhs, AffinityAttr rhs) {
   return lhs.isExecutableWith(rhs);
 }
 
+// static
+AffinityAttr AffinityAttr::joinOR(ArrayRef<AffinityAttr> affinityAttrs) {
+  if (affinityAttrs.empty()) {
+    return nullptr;
+  } else if (affinityAttrs.size() == 1) {
+    return affinityAttrs.front();
+  } else {
+    AffinityAttr resultAttr;
+    for (auto affinityAttr : affinityAttrs) {
+      resultAttr = resultAttr ? resultAttr.joinOR(affinityAttr) : affinityAttr;
+    }
+    return resultAttr;
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // #stream.partitioning_config
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Updates affinity analysis to better track operand/result usage independently from execution scope particularly with pinned ops. The improved tracking enables ScheduleAllocationPass to now join all potential affinities a result will be used on to produce the affinity for each allocation whether they are transients or constants/variables. By performing analysis at the point immediately prior to going from `stream.async.*` (with all optimizations/transfer elision/etc applied) to `stream.cmd.*` (where we can freely alias) we can produce the tightest usage affinities and segment each resource independently prior to packing.

Deallocations that can either be inserted directly during ScheduleAllocationPass or analyzed later during stream->hal lowering can reuse the joined affinities while the fallback case sets the prefer-origin flag indicating that the runtime should decide. The behavior at runtime will be the same for each but by preserving that information in the compiler for longer we can in the future set timepoint affinities more tightly (today we don't track them, but really should).

Example IR showing what this does today and what it can do once we elide transfers:
https://gist.github.com/benvanik/ecc9b37fb2b670ce1ed2fb0d7c694287

Fixes #20855.
