### PR TITLE
Fix 'failed to legalize' in padding materialization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -28,6 +28,8 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 
+#define DEBUG_TYPE "iree-codegen-materialize-encoding"
+
 namespace mlir::iree_compiler {
 
 using IREE::Codegen::MaterializeEncodingInfo;
@@ -859,6 +861,26 @@ void populateMaterializeEncodingPatterns(
       [&typeConverter](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
         auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
             subspanOp.getResult().getType());
+        // For types that are not `TensorExt::DispatchTensorType` mark as legal.
+        if (!resultType)
+          return true;
+        return resultType == typeConverter.convertType(resultType);
+      });
+  target.addIllegalOp<IREE::Encoding::SetEncodingOp,
+                      IREE::Encoding::UnsetEncodingOp>();
+  target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorStoreOp>(
+      [&typeConverter](IREE::TensorExt::DispatchTensorStoreOp storeOp) {
+        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+            storeOp.getTargetType());
+        // For types that are not `TensorExt::DispatchTensorType` mark as legal.
+        if (!resultType)
+          return true;
+        return resultType == typeConverter.convertType(resultType);
+      });
+  target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorLoadOp>(
+      [&typeConverter](IREE::TensorExt::DispatchTensorLoadOp loadOp) {
+        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+            loadOp.getSourceType());
         // For types that are not `TensorExt::DispatchTensorType` mark as legal.
         if (!resultType)
           return true;


### PR DESCRIPTION
Contains fixes to avoid conversion errors (as demonstrated by the added test):
- Adds `SetEncodingOp`, `UnsetEncodingOp` to the conversion target's illegal ops.
- Adds dynamic legality checks for `DispatchTensorStoreOp` and `DispatchTensorLoadOp`.

Without this we see following error:
```
error: failed to legalize unresolved materialization from ('!iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2080xf32>>') to ('!iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>') that remained live after conversion
  %10 = hal.interface.binding.subspan layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>{%9}
        ^
within split at .../materialize_encoding_into_padding.mlir:352 offset :11:9: note: see current operation: %8 = "builtin.unrealized_conversion_cast"(%7) : (!iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2080xf32>>) -> !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>
within split at .../materialize_encoding_into_padding.mlir:352 offset :13:9: note: see existing live user here: %8 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0], sizes = [%4, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>{%4} -> tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>
  %12 = iree_tensor_ext.dispatch.tensor.load %10, offsets = [0, 0], sizes = [%9, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>{%9} -> tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>
        ^
within split at .../materialize_encoding_into_padding.mlir:352 offset :3:1: error: 'func.func' op materialization failed
func.func @materialize_pad_encoding_on_partial_dynamic_shape() {
```