### PR TITLE
Use adaptor instead of storeOp to fix 'failed to legalize'

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -207,7 +207,7 @@ struct MaterializeFlowDispatchTensorStoreOp final
     RankedTensorType paddedType = newTargetType.asRankedTensorType();
 
     Location loc = storeOp.getLoc();
-    SmallVector<Value> dynamicResultSizes{storeOp->getOperands()};
+    SmallVector<Value> dynamicResultSizes{adaptor.getOperands()};
     Value empty =
         rewriter.create<tensor::EmptyOp>(loc, paddedType, dynamicResultSizes);
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -28,6 +28,8 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 
+#define DEBUG_TYPE "iree-codegen-materialize-encoding"
+
 namespace mlir::iree_compiler {
 
 using IREE::Codegen::MaterializeEncodingInfo;
@@ -859,6 +861,26 @@ void populateMaterializeEncodingPatterns(
       [&typeConverter](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
         auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
             subspanOp.getResult().getType());
+        // For types that are not `TensorExt::DispatchTensorType` mark as legal.
+        if (!resultType)
+          return true;
+        return resultType == typeConverter.convertType(resultType);
+      });
+  target.addIllegalOp<IREE::Encoding::SetEncodingOp,
+                      IREE::Encoding::UnsetEncodingOp>();
+  target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorStoreOp>(
+      [&typeConverter](IREE::TensorExt::DispatchTensorStoreOp storeOp) {
+        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+            storeOp.getTargetType());
+        // For types that are not `TensorExt::DispatchTensorType` mark as legal.
+        if (!resultType)
+          return true;
+        return resultType == typeConverter.convertType(resultType);
+      });
+  target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorLoadOp>(
+      [&typeConverter](IREE::TensorExt::DispatchTensorLoadOp loadOp) {
+        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+            loadOp.getSourceType());
         // For types that are not `TensorExt::DispatchTensorType` mark as legal.
         if (!resultType)
           return true;

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -385,3 +385,32 @@ func.func @materialize_pad_encoding_on_partial_dynamic_shape() {
 // CHECK-SAME:      !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2080xf32>>
 // CHECK:         iree_tensor_ext.dispatch.tensor.load %[[A]], offsets = [0, 0], sizes = [%{{.+}}, 2048], strides = [1, 1]
 // CHECK-SAME:      !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2080xf32>>{%{{.+}}} -> tensor<?x2048xf32>
+
+// -----
+
+#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+#pipeline_layout1 = #hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+func.func @materialize_pad_encoding_dynamic_load_store() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i64
+  %1 = arith.index_castui %0 : i64 to index
+  %2 = util.assume.int %1<umin = 0, umax = 9007199254740991> : index
+  %3 = hal.interface.constant.load layout(#pipeline_layout1) ordinal(0) : i32
+  %4 = arith.index_castui %3 : i32 to index
+  %5 = hal.interface.binding.subspan layout(#pipeline_layout1) binding(0) alignment(64) offset(%4) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%2}
+  %6 = hal.interface.binding.subspan layout(#pipeline_layout1) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #encoding>>{%2}
+  %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%2, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%2} -> tensor<?x2048xf16>
+  %8 = iree_encoding.set_encoding %7 : tensor<?x2048xf16> -> tensor<?x2048xf16, #iree_encoding.pad_encoding_layout<[0, ?]>>
+  iree_tensor_ext.dispatch.tensor.store %8, %6, offsets = [0, 0], sizes = [%2, 2048], strides = [1, 1] : tensor<?x2048xf16, #iree_encoding.pad_encoding_layout<[0, ?]>> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #encoding>>{%2}
+  return
+}
+// CHECK-LABEL: @materialize_pad_encoding_dynamic_load_store
+// CHECK:         %[[A:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+// CHECK-SAME:                  !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%{{.+}}}
+// CHECK:         %[[B:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+// CHECK-SAME:                  !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2080xf16>>{%{{.+}}}
+// CHECK:         %[[LD:.+]] = iree_tensor_ext.dispatch.tensor.load %[[A]], offsets = [0, 0], sizes = [%{{.+}}, 2048], strides = [1, 1]
+// CHECK-SAME:                  !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%{{.+}}} -> tensor<?x2048xf16>
+// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[LD]], %[[B]], offsets = [0, 0], sizes = [%{{.+}}, 2048], strides = [1, 1]
+// CHECK-SAME:                  tensor<?x2048xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2080xf16>>{%{{.+}}}


### PR DESCRIPTION
Stacked on top of: https://github.com/iree-org/iree/pull/20969

Fixes a conversion error caused by using the store operation itself instead of the adaptor:
```
within split at .../materialize_encoding_into_padding.mlir:437 offset :16:8: error: failed to legalize unresolved materialization from ('!iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2080xf16>>') to ('!iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>') that remained live after conversion
  %4 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect)
       ^
within split at .../materialize_encoding_into_padding.mlir:437 offset :16:8: note: see current operation: %8 = "builtin.unrealized_conversion_cast"(%7) : (!iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2080xf16>>) -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>
within split at .../materialize_encoding_into_padding.mlir:437 offset :21:3: note: see existing live user here: %11 = "tensor.empty"(%10, %8, %3, %3) : (tensor<?x2048xf16, #iree_encoding.pad_encoding_layout<[0, ?]>>, !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>>>, index, index) -> tensor<?x2080xf16>
  iree_tensor_ext.dispatch.tensor.store %6, %4, offsets = [0, 0], sizes = [%9, 2048], strides = [1, 1]
  ^
within split at .../materialize_encoding_into_padding.mlir:437 offset :7:1: error: 'func.func' op materialization failed
func.func @set_encoding_and_store_with_unresolved_encodings() {
```