### PR TITLE
Allow importing an external stream into HIP.

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1055,11 +1055,11 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id,
     for (auto it : params.value()) {
       param_strings.push_back(std::make_pair(py::cast<std::string>(it.first),
                                              py::cast<std::string>(it.second)));
-      passed_params.push_back(iree_string_pair_t{
-          .first = {.data = param_strings.back().first.c_str(),
-                    .size = param_strings.back().first.size()},
-          .second = {.data = param_strings.back().second.c_str(),
-                     .size = param_strings.back().second.size()}});
+      passed_params.push_back(
+          iree_string_pair_t{{param_strings.back().first.c_str(),
+                              param_strings.back().first.size()},
+                             {param_strings.back().second.c_str(),
+                              param_strings.back().second.size()}});
     }
   }
 

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <iterator>
 #include <optional>
+#include <utility>
 
 #include "./local_dlpack.h"
 #include "./numpy_interop.h"
@@ -1021,6 +1022,7 @@ HalDevice HalDriver::CreateDefaultDevice(std::optional<py::list> allocators) {
 }
 
 HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id,
+                                  std::optional<py::dict> params,
                                   std::optional<py::list> allocators) {
   // Since the device ids are supposed to be opaque, we need to verify
   // them by querying available devices.
@@ -1047,11 +1049,24 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id,
     throw std::invalid_argument(std::move(msg));
   }
 
-  std::vector<iree_string_pair_t> params;
+  std::vector<std::pair<std::string, std::string>> param_strings;
+  std::vector<iree_string_pair_t> passed_params;
+  if (params.has_value()) {
+    for (auto it : params.value()) {
+      param_strings.push_back(std::make_pair(py::cast<std::string>(it.first),
+                                             py::cast<std::string>(it.second)));
+      passed_params.push_back(iree_string_pair_t{
+          .first = {.data = param_strings.back().first.c_str(),
+                    .size = param_strings.back().first.size()},
+          .second = {.data = param_strings.back().second.c_str(),
+                     .size = param_strings.back().second.size()}});
+    }
+  }
+
   iree_hal_device_t* device;
   CheckApiStatus(iree_hal_driver_create_device_by_id(
-                     raw_ptr(), device_id, params.size(),
-                     (params.empty() ? nullptr : &params.front()),
+                     raw_ptr(), device_id, passed_params.size(),
+                     (passed_params.empty() ? nullptr : &passed_params.front()),
                      iree_allocator_system(), &device),
                  "Error creating default device");
   CheckApiStatus(ConfigureDevice(device, allocators),
@@ -1450,22 +1465,24 @@ void SetupHalBindings(nanobind::module_ m) {
       .def("create_default_device", &HalDriver::CreateDefaultDevice,
            py::keep_alive<0, 1>(), py::arg("allocators") = py::none())
       .def("create_device", &HalDriver::CreateDevice, py::keep_alive<0, 1>(),
-           py::arg("device_id"), py::arg("allocators") = py::none())
+           py::arg("device_id"), py::arg("params") = py::none(),
+           py::arg("allocators") = py::none())
       .def("create_device_by_uri", &HalDriver::CreateDeviceByURI,
            py::keep_alive<0, 1>(), py::arg("device_uri"),
            py::arg("allocators") = py::none())
       .def(
           "create_device",
           [](HalDriver& self, py::dict device_info,
+             std::optional<py::dict> params,
              std::optional<py::list> allocators) -> HalDevice {
             // Alias of create_device that takes a dict as returned from
             // query_available_devices for convenience.
             auto device_id =
                 py::cast<iree_hal_device_id_t>(device_info["device_id"]);
-            return self.CreateDevice(device_id, allocators);
+            return self.CreateDevice(device_id, params, allocators);
           },
           py::keep_alive<0, 1>(), py::arg("device_info"),
-          py::arg("allocators") = py::none())
+          py::arg("params") = py::none(), py::arg("allocators") = py::none())
       .def("query_available_devices", &HalDriver::QueryAvailableDevices)
       .def("dump_device_info",
            [](HalDriver& self, iree_hal_device_id_t device_id) {

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -174,6 +174,7 @@ class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
   py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice(std::optional<py::list> allocators);
   HalDevice CreateDevice(iree_hal_device_id_t device_id,
+                         std::optional<py::dict> params,
                          std::optional<py::list> allocators);
   HalDevice CreateDeviceByURI(std::string& device_uri,
                               std::optional<py::list> allocators);

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -273,11 +273,17 @@ class HalDriver:
     ) -> HalDevice: ...
     @overload
     def create_device(
-        self, device_id: int, allocators: Optional[list[HalAllocator]] = None
+        self,
+        device_id: int,
+        params: Optional[dict],
+        allocators: Optional[list[HalAllocator]] = None,
     ) -> HalDevice: ...
     @overload
     def create_device(
-        self, device_info: dict, allocators: Optional[list[HalAllocator]] = None
+        self,
+        device_info: dict,
+        params: Optional[dict],
+        allocators: Optional[list[HalAllocator]] = None,
     ) -> HalDevice: ...
     def create_device_by_uri(
         self, device_uri: str, allocators: Optional[list[HalAllocator]] = None

--- a/runtime/src/iree/hal/drivers/hip/api.h
+++ b/runtime/src/iree/hal/drivers/hip/api.h
@@ -109,6 +109,9 @@ typedef struct iree_hal_hip_device_params_t {
 
   // Enable async caching on the device.
   bool async_caching;
+
+  // External stream to use for the device.
+  uint64_t external_stream;
 } iree_hal_hip_device_params_t;
 
 // Initializes |out_params| to default values.

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -613,11 +613,11 @@ static void iree_hal_hip_device_destroy(iree_hal_device_t* base_device) {
     if (!device->uses_external_stream) {
       IREE_HIP_IGNORE_ERROR(
           symbols, hipStreamDestroy(device->devices[i].hip_dispatch_stream));
-    } else {
-      IREE_HIP_IGNORE_ERROR(
-          symbols,
-          hipStreamDestroy(device->devices[i].hip_async_memory_stream));
     }
+
+    IREE_HIP_IGNORE_ERROR(
+        symbols, hipStreamDestroy(device->devices[i].hip_async_memory_stream));
+
     // NOTE: This function return hipSuccess though doesn't release the
     // primaryCtx by design on HIP/HCC path.
     IREE_HIP_IGNORE_ERROR(

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1001,8 +1001,8 @@ iree_hal_hip_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
-void iree_hal_hip_async_buffer_release(void* user_data,
-                                       struct iree_hal_buffer_t* buffer) {
+static void iree_hal_hip_async_buffer_release(
+    void* user_data, struct iree_hal_buffer_t* buffer) {
   iree_hal_hip_device_t* device = (iree_hal_hip_device_t*)user_data;
   void* ptr = iree_hal_hip_buffer_device_pointer(buffer);
   if (ptr) {
@@ -1067,7 +1067,7 @@ static const iree_hal_resource_vtable_t
         .destroy = &iree_hal_hip_dispatch_completed_destroy,
 };
 
-iree_status_t iree_hal_hip_dispatch_completed_create(
+static iree_status_t iree_hal_hip_dispatch_completed_create(
     iree_allocator_t host_allocator,
     iree_hal_hip_dispatch_completed_data_t** out) {
   *out = NULL;
@@ -1082,7 +1082,7 @@ iree_status_t iree_hal_hip_dispatch_completed_create(
   return iree_ok_status();
 }
 
-bool iree_hal_hip_dispatch_is_completed(
+static bool iree_hal_hip_dispatch_is_completed(
     iree_hal_hip_dispatch_completed_data_t* data) {
   iree_slim_mutex_lock(&data->completed_mutex);
   bool ret = data->completed;
@@ -1090,7 +1090,7 @@ bool iree_hal_hip_dispatch_is_completed(
   return ret;
 }
 
-void iree_hal_hip_set_external_stream_data_completed(
+static void iree_hal_hip_set_external_stream_data_completed(
     iree_hal_hip_dispatch_completed_data_t* data) {
   iree_slim_mutex_lock(&data->completed_mutex);
   data->completed = true;
@@ -1098,7 +1098,7 @@ void iree_hal_hip_set_external_stream_data_completed(
   iree_notification_post(&data->notification, IREE_ALL_WAITERS);
 }
 
-void iree_hal_hip_wait_for_dispatch(
+static void iree_hal_hip_wait_for_dispatch(
     iree_hal_hip_dispatch_completed_data_t* data) {
   iree_notification_await(
       &data->notification,
@@ -1121,7 +1121,7 @@ typedef struct iree_hal_hip_semaphore_callback_data_t {
   iree_hal_hip_dispatch_completed_data_t* external_stream_dispatch_data;
 } iree_hal_hip_semaphore_callback_data_t;
 
-iree_host_size_t
+static iree_host_size_t
 iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
     iree_hal_semaphore_list_t wait_semaphore_list,
     iree_hal_semaphore_list_t signal_semaphore_list) {
@@ -1135,7 +1135,7 @@ iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
   return wait_semaphore_list_size + signal_semaphore_list_size;
 }
 
-iree_status_t iree_hal_hip_semaphore_callback_data_initialize(
+static iree_status_t iree_hal_hip_semaphore_callback_data_initialize(
     iree_allocator_t host_allocator, iree_hal_hip_device_t* device,
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_hip_dispatch_callback_t dispatch_fn,
@@ -1199,7 +1199,7 @@ iree_status_t iree_hal_hip_semaphore_callback_data_initialize(
   return iree_ok_status();
 }
 
-void iree_hal_hip_semaphore_callback_data_deinitialize(
+static void iree_hal_hip_semaphore_callback_data_deinitialize(
     iree_hal_hip_semaphore_callback_data_t* data) {
   iree_slim_mutex_deinitialize(&data->status_mutex);
   if (data->device->uses_external_stream) {

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -37,6 +37,7 @@
 
 #define IREE_HAL_DEVICE_TRANSFER_DEFAULT_BUFFER_SIZE (128 * 1024 * 1024)
 #define IREE_HAL_DEVICE_MAX_TRANSFER_DEFAULT_CHUNK_SIZE (64 * 1024 * 1024)
+#define IREE_HAL_DEVICE_INVALID_EXTERNAL_STREAM (0xFFFFFFFFFFFFFFFFul)
 
 //===----------------------------------------------------------------------===//
 // iree_hal_hip_device_t
@@ -74,6 +75,10 @@ typedef struct iree_hal_hip_device_t {
 
   // Device memory pools and allocators.
   bool supports_memory_pools;
+
+  // Device uses an external execution stream rather than a
+  // self-managed stream.
+  bool uses_external_stream;
 
   // Optional provider used for creating/configuring collective channels.
   iree_hal_channel_provider_t* channel_provider;
@@ -230,10 +235,11 @@ IREE_API_EXPORT void iree_hal_hip_device_params_initialize(
       IREE_HAL_DEVICE_MAX_TRANSFER_DEFAULT_CHUNK_SIZE;
   out_params->allow_inline_execution = false;
   out_params->async_caching = true;
+  out_params->external_stream = IREE_HAL_DEVICE_INVALID_EXTERNAL_STREAM;
 }
 
 static iree_status_t iree_hal_hip_device_check_params(
-    const iree_hal_hip_device_params_t* params) {
+    const iree_hal_hip_device_params_t* params, iree_host_size_t device_count) {
   if (params->arena_block_size < 4096) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "arena block size too small (< 4096 bytes)");
@@ -241,6 +247,13 @@ static iree_status_t iree_hal_hip_device_check_params(
   if (params->queue_count == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "at least one queue is required");
+  }
+  if (params->external_stream != IREE_HAL_DEVICE_INVALID_EXTERNAL_STREAM) {
+    if (device_count != 1) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "only one backing device supported when using external streams");
+    }
   }
   return iree_ok_status();
 }
@@ -470,8 +483,9 @@ iree_status_t iree_hal_hip_device_create(
       z0, iree_allocator_malloc(host_allocator, total_device_size,
                                 (void**)&device));
   device->device_count = device_count;
-
-  iree_status_t status = iree_hal_hip_device_check_params(params);
+  device->uses_external_stream =
+      params->external_stream != IREE_HAL_DEVICE_INVALID_EXTERNAL_STREAM;
+  iree_status_t status = iree_hal_hip_device_check_params(params, device_count);
 
   // Initialize each device.
   for (iree_host_size_t i = 0; i < device_count && iree_status_is_ok(status);
@@ -490,10 +504,15 @@ iree_status_t iree_hal_hip_device_create(
 
     // Create the default dispatch stream for the device.
     if (iree_status_is_ok(status)) {
-      status = IREE_HIP_CALL_TO_STATUS(
-          symbols,
-          hipStreamCreateWithFlags(&device->devices[i].hip_dispatch_stream,
-                                   hipStreamNonBlocking));
+      if (device->uses_external_stream) {
+        device->devices[i].hip_dispatch_stream =
+            (hipStream_t)(params->external_stream);
+      } else {
+        status = IREE_HIP_CALL_TO_STATUS(
+            symbols,
+            hipStreamCreateWithFlags(&device->devices[i].hip_dispatch_stream,
+                                     hipStreamNonBlocking));
+      }
     }
     if (iree_status_is_ok(status)) {
       status = IREE_HIP_CALL_TO_STATUS(
@@ -591,10 +610,14 @@ static void iree_hal_hip_device_destroy(iree_hal_device_t* base_device) {
   if (device->host_event_pool) iree_event_pool_free(device->host_event_pool);
 
   for (iree_host_size_t i = 0; i < device->device_count; ++i) {
-    IREE_HIP_IGNORE_ERROR(
-        symbols, hipStreamDestroy(device->devices[i].hip_dispatch_stream));
-    IREE_HIP_IGNORE_ERROR(
-        symbols, hipStreamDestroy(device->devices[i].hip_async_memory_stream));
+    if (!device->uses_external_stream) {
+      IREE_HIP_IGNORE_ERROR(
+          symbols, hipStreamDestroy(device->devices[i].hip_dispatch_stream));
+    } else {
+      IREE_HIP_IGNORE_ERROR(
+          symbols,
+          hipStreamDestroy(device->devices[i].hip_async_memory_stream));
+    }
     // NOTE: This function return hipSuccess though doesn't release the
     // primaryCtx by design on HIP/HCC path.
     IREE_HIP_IGNORE_ERROR(
@@ -1024,6 +1047,65 @@ static iree_status_t iree_hal_hip_device_prepare_async_alloc(
   return status;
 }
 
+typedef struct iree_hal_hip_dispatch_completed_data_t {
+  iree_hal_resource_t resource;
+  iree_notification_t notification;
+  iree_slim_mutex_t completed_mutex;
+  bool completed;
+} iree_hal_hip_dispatch_completed_data_t;
+
+static void iree_hal_hip_dispatch_completed_destroy(
+    iree_hal_resource_t* resource) {
+  iree_hal_hip_dispatch_completed_data_t* data =
+      (iree_hal_hip_dispatch_completed_data_t*)resource;
+  iree_slim_mutex_deinitialize(&data->completed_mutex);
+  iree_notification_deinitialize(&data->notification);
+}
+
+static const iree_hal_resource_vtable_t
+    iree_hal_hip_dispatch_completed_data_vtable_t = {
+        .destroy = &iree_hal_hip_dispatch_completed_destroy,
+};
+
+iree_status_t iree_hal_hip_dispatch_completed_create(
+    iree_allocator_t host_allocator,
+    iree_hal_hip_dispatch_completed_data_t** out) {
+  *out = NULL;
+
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, sizeof(**out), (void**)out));
+
+  iree_slim_mutex_initialize(&(*out)->completed_mutex);
+  iree_notification_initialize(&(*out)->notification);
+  iree_hal_resource_initialize(&iree_hal_hip_dispatch_completed_data_vtable_t,
+                               &(*out)->resource);
+  return iree_ok_status();
+}
+
+bool iree_hal_hip_dispatch_is_completed(
+    iree_hal_hip_dispatch_completed_data_t* data) {
+  iree_slim_mutex_lock(&data->completed_mutex);
+  bool ret = data->completed;
+  iree_slim_mutex_unlock(&data->completed_mutex);
+  return ret;
+}
+
+void iree_hal_hip_set_external_stream_data_completed(
+    iree_hal_hip_dispatch_completed_data_t* data) {
+  iree_slim_mutex_lock(&data->completed_mutex);
+  data->completed = true;
+  iree_slim_mutex_unlock(&data->completed_mutex);
+  iree_notification_post(&data->notification, IREE_ALL_WAITERS);
+}
+
+void iree_hal_hip_wait_for_dispatch(
+    iree_hal_hip_dispatch_completed_data_t* data) {
+  iree_notification_await(
+      &data->notification,
+      (iree_condition_fn_t)iree_hal_hip_dispatch_is_completed, data,
+      iree_infinite_timeout());
+}
+
 typedef struct iree_hal_hip_semaphore_callback_data_t {
   iree_allocator_t host_allocator;
   iree_atomic_int64_t wait_semaphore_count;
@@ -1034,6 +1116,9 @@ typedef struct iree_hal_hip_semaphore_callback_data_t {
   iree_hal_semaphore_list_t signal_semaphore_list;
   iree_slim_mutex_t status_mutex;
   iree_status_t status;
+  // This is null unless we are running with an extenal stream,
+  // at which point this is valid.
+  iree_hal_hip_dispatch_completed_data_t* external_stream_dispatch_data;
 } iree_hal_hip_semaphore_callback_data_t;
 
 iree_host_size_t
@@ -1050,7 +1135,7 @@ iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
   return wait_semaphore_list_size + signal_semaphore_list_size;
 }
 
-void iree_hal_hip_semaphore_callback_data_initialize(
+iree_status_t iree_hal_hip_semaphore_callback_data_initialize(
     iree_allocator_t host_allocator, iree_hal_hip_device_t* device,
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_hip_dispatch_callback_t dispatch_fn,
@@ -1058,6 +1143,11 @@ void iree_hal_hip_semaphore_callback_data_initialize(
     iree_hal_semaphore_list_t signal_semaphore_list,
     void* additional_data_offset,
     iree_hal_hip_semaphore_callback_data_t* data) {
+  if (device->uses_external_stream) {
+    IREE_RETURN_IF_ERROR(iree_hal_hip_dispatch_completed_create(
+        host_allocator, &data->external_stream_dispatch_data));
+  }
+
   data->host_allocator = host_allocator;
   iree_atomic_store(&data->wait_semaphore_count, wait_semaphore_list.count,
                     iree_memory_order_relaxed);
@@ -1106,11 +1196,15 @@ void iree_hal_hip_semaphore_callback_data_initialize(
 
   iree_slim_mutex_initialize(&data->status_mutex);
   data->status = iree_ok_status();
+  return iree_ok_status();
 }
 
 void iree_hal_hip_semaphore_callback_data_deinitialize(
     iree_hal_hip_semaphore_callback_data_t* data) {
   iree_slim_mutex_deinitialize(&data->status_mutex);
+  if (data->device->uses_external_stream) {
+    iree_hal_resource_release(data->external_stream_dispatch_data);
+  }
   for (iree_host_size_t i = 0; i < data->wait_semaphore_list.count; ++i) {
     iree_hal_resource_release(data->wait_semaphore_list.semaphores[i]);
   }
@@ -1435,6 +1529,11 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
   }
   IREE_TRACE_ZONE_END(z3);
 
+  if (device->uses_external_stream) {
+    iree_hal_hip_set_external_stream_data_completed(
+        data->base.external_stream_dispatch_data);
+  }
+
   const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
   if (iree_status_is_ok(status)) {
     // Data may get deleted any time after adding it to the cleanup,
@@ -1480,20 +1579,22 @@ static iree_status_t iree_hal_hip_device_make_buffer_callback_data(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, total_callback_size,
                                 (void**)&callback_data));
-  iree_hal_hip_semaphore_callback_data_initialize(
+  iree_status_t status = iree_hal_hip_semaphore_callback_data_initialize(
       host_allocator, device, queue_affinity,
       &iree_hal_hip_device_perform_buffer_operation_now, wait_semaphore_list,
       signal_semaphore_list,
       (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
       &callback_data->base);
 
-  callback_data->buffer = buffer;
-  iree_hal_buffer_retain(buffer);
-  callback_data->type = type;
+  if (iree_status_is_ok(status)) {
+    callback_data->buffer = buffer;
+    iree_hal_buffer_retain(buffer);
+    callback_data->type = type;
+  }
 
   *out_data = callback_data;
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 // TODO: implement multiple streams; today we only have one and queue_affinity
@@ -1531,12 +1632,20 @@ static iree_status_t iree_hal_hip_device_queue_alloca(
 
     iree_hal_hip_device_semaphore_buffer_operation_callback_data_t*
         callback_data = NULL;
+    iree_hal_hip_dispatch_completed_data_t* external_stream_data = NULL;
+
     if (iree_status_is_ok(status)) {
       status = iree_hal_hip_device_make_buffer_callback_data(
           device, device->host_allocator, queue_affinity, wait_semaphore_list,
           signal_semaphore_list, buffer,
           IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_ALLOC, &callback_data);
+      if (device->uses_external_stream) {
+        external_stream_data =
+            callback_data->base.external_stream_dispatch_data;
+        iree_hal_resource_retain(external_stream_data);
+      }
     }
+
     if (iree_status_is_ok(status) && wait_semaphore_list.count == 0) {
       status = iree_hal_hip_dispatch_thread_add_dispatch(
           device->devices[device_ordinal].dispatch_thread,
@@ -1569,6 +1678,13 @@ static iree_status_t iree_hal_hip_device_queue_alloca(
         iree_hal_hip_buffer_set_allocation_empty(buffer);
         iree_hal_resource_release(&buffer->resource);
       }
+    }
+
+    if (device->uses_external_stream) {
+      if (iree_status_is_ok(status)) {
+        iree_hal_hip_wait_for_dispatch(external_stream_data);
+      }
+      iree_hal_resource_release(external_stream_data);
     }
 
     IREE_TRACE_ZONE_END(z0);
@@ -1633,6 +1749,11 @@ static iree_status_t iree_hal_hip_device_queue_dealloca(
         device, device->host_allocator, queue_affinity, wait_semaphore_list,
         signal_semaphore_list, buffer,
         IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC, &callback_data);
+    iree_hal_hip_dispatch_completed_data_t* external_stream_data = NULL;
+    if (device->uses_external_stream) {
+      external_stream_data = callback_data->base.external_stream_dispatch_data;
+      iree_hal_resource_retain(external_stream_data);
+    }
 
     if (iree_status_is_ok(status) && wait_semaphore_list.count == 0) {
       status = iree_hal_hip_dispatch_thread_add_dispatch(
@@ -1658,6 +1779,13 @@ static iree_status_t iree_hal_hip_device_queue_dealloca(
             signal_semaphore_list.semaphores[i],
             signal_semaphore_list.payload_values[i]);
       }
+    }
+
+    if (device->uses_external_stream) {
+      if (iree_status_is_ok(status)) {
+        iree_hal_hip_wait_for_dispatch(external_stream_data);
+      }
+      iree_hal_resource_release(external_stream_data);
     }
 
     IREE_TRACE_ZONE_END(z0);
@@ -1984,6 +2112,11 @@ static iree_status_t iree_hal_hip_device_perform_queue_read_now(
     }
   }
 
+  if (device->uses_external_stream) {
+    iree_hal_hip_set_external_stream_data_completed(
+        data->base.external_stream_dispatch_data);
+  }
+
   if (!iree_status_is_ok(status)) {
     for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
          ++i) {
@@ -2030,33 +2163,34 @@ static iree_status_t iree_hal_hip_device_make_queue_read_callback_data(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, total_callback_size,
                                 (void**)&callback_data));
-  iree_hal_hip_semaphore_callback_data_initialize(
+  iree_status_t status = iree_hal_hip_semaphore_callback_data_initialize(
       host_allocator, device, queue_affinity,
       &iree_hal_hip_device_perform_queue_read_now, wait_semaphore_list,
       signal_semaphore_list,
       (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
       &callback_data->base);
 
-  uint64_t* chunk_base =
-      (void*)((uint8_t*)callback_data + sizeof(*callback_data) +
-              additional_data_for_base);
-  iree_hal_command_buffer_t** command_buffer_base =
-      (iree_hal_command_buffer_t**)((uint8_t*)chunk_base +
-                                    sizeof(*callback_data->read_chunk_sizes) *
-                                        chunk_count);
-  callback_data->source_file = source_file;
-  callback_data->source_offset = source_offset;
-  callback_data->target_buffer = target_buffer;
-  iree_hal_resource_retain(target_buffer);
-  iree_hal_file_retain(source_file);
-  callback_data->target_offset = target_offset;
-  callback_data->length = length;
-  callback_data->flags = flags;
-  callback_data->read_chunks_completed = 0;
-  callback_data->num_read_chunks = chunk_count;
-  callback_data->read_chunk_sizes = chunk_base;
-  callback_data->command_buffers = command_buffer_base;
-
+  if (iree_status_is_ok(status)) {
+    uint64_t* chunk_base =
+        (void*)((uint8_t*)callback_data + sizeof(*callback_data) +
+                additional_data_for_base);
+    iree_hal_command_buffer_t** command_buffer_base =
+        (iree_hal_command_buffer_t**)((uint8_t*)chunk_base +
+                                      sizeof(*callback_data->read_chunk_sizes) *
+                                          chunk_count);
+    callback_data->source_file = source_file;
+    callback_data->source_offset = source_offset;
+    callback_data->target_buffer = target_buffer;
+    iree_hal_resource_retain(target_buffer);
+    iree_hal_file_retain(source_file);
+    callback_data->target_offset = target_offset;
+    callback_data->length = length;
+    callback_data->flags = flags;
+    callback_data->read_chunks_completed = 0;
+    callback_data->num_read_chunks = chunk_count;
+    callback_data->read_chunk_sizes = chunk_base;
+    callback_data->command_buffers = command_buffer_base;
+  }
   *out_data = callback_data;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -2085,6 +2219,12 @@ static iree_status_t iree_hal_hip_device_queue_read(
       signal_semaphore_list, source_file, source_offset, target_buffer,
       target_offset, length, flags, &callback_data);
 
+  iree_hal_hip_dispatch_completed_data_t* external_stream_data = NULL;
+  if (device->uses_external_stream) {
+    external_stream_data = callback_data->base.external_stream_dispatch_data;
+    iree_hal_resource_retain(external_stream_data);
+  }
+
   if (iree_status_is_ok(status) && wait_semaphore_list.count == 0) {
     status = iree_hal_hip_dispatch_thread_add_dispatch(
         device->devices[device_ordinal].dispatch_thread,
@@ -2108,6 +2248,13 @@ static iree_status_t iree_hal_hip_device_queue_read(
           signal_semaphore_list.semaphores[i],
           signal_semaphore_list.payload_values[i]);
     }
+  }
+
+  if (device->uses_external_stream) {
+    if (iree_status_is_ok(status)) {
+      iree_hal_hip_wait_for_dispatch(external_stream_data);
+    }
+    iree_hal_resource_release(external_stream_data);
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -2308,6 +2455,11 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
 
   IREE_TRACE_ZONE_END(z1);
 
+  if (device->uses_external_stream) {
+    iree_hal_hip_set_external_stream_data_completed(
+        data->base.external_stream_dispatch_data);
+  }
+
   // Store symbols, because the cleanup may trigger off-thread
   // before it returns.
   const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
@@ -2362,18 +2514,19 @@ static iree_status_t iree_hal_hip_device_make_callback_data(
       z0, iree_allocator_malloc(host_allocator, total_callback_size,
                                 (void**)&callback_data));
 
-  iree_hal_hip_semaphore_callback_data_initialize(
+  iree_status_t status = iree_hal_hip_semaphore_callback_data_initialize(
       host_allocator, device, queue_affinity, &iree_hal_hip_device_execute_now,
       wait_semaphore_list, signal_semaphore_list,
       (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
       &callback_data->base);
 
-  // Copy the execution resources for later access.
-  callback_data->command_buffer = command_buffer;
-
   // Retain all command buffers and semaphores.
-  iree_status_t status =
-      iree_hal_resource_set_allocate(block_pool, &callback_data->resource_set);
+  if (iree_status_is_ok(status)) {
+    // Copy the execution resources for later access.
+    callback_data->command_buffer = command_buffer;
+    status = iree_hal_resource_set_allocate(block_pool,
+                                            &callback_data->resource_set);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_resource_set_insert(callback_data->resource_set,
                                           wait_semaphore_list.count,
@@ -2389,20 +2542,22 @@ static iree_status_t iree_hal_hip_device_make_callback_data(
                                           &command_buffer);
   }
 
-  callback_data->binding_table = binding_table;
-  iree_hal_buffer_binding_t* binding_element_ptr =
-      (iree_hal_buffer_binding_t*)((uint8_t*)callback_data +
-                                   sizeof(*callback_data) +
-                                   additional_data_for_base);
-  callback_data->binding_table.bindings = binding_element_ptr;
-  memcpy(binding_element_ptr, binding_table.bindings,
-         sizeof(*binding_element_ptr) * binding_table.count);
-  status = iree_hal_resource_set_insert_strided(
-      callback_data->resource_set, binding_table.count,
-      callback_data->binding_table.bindings,
-      offsetof(iree_hal_buffer_binding_t, buffer),
-      sizeof(iree_hal_buffer_binding_t));
+  if (iree_status_is_ok(status)) {
+    callback_data->binding_table = binding_table;
+    iree_hal_buffer_binding_t* binding_element_ptr =
+        (iree_hal_buffer_binding_t*)((uint8_t*)callback_data +
+                                     sizeof(*callback_data) +
+                                     additional_data_for_base);
+    callback_data->binding_table.bindings = binding_element_ptr;
+    memcpy(binding_element_ptr, binding_table.bindings,
+           sizeof(*binding_element_ptr) * binding_table.count);
 
+    status = iree_hal_resource_set_insert_strided(
+        callback_data->resource_set, binding_table.count,
+        callback_data->binding_table.bindings,
+        offsetof(iree_hal_buffer_binding_t, buffer),
+        sizeof(iree_hal_buffer_binding_t));
+  }
   *out_data = callback_data;
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -2437,25 +2592,27 @@ static iree_status_t iree_hal_hip_device_queue_execute(
       device, device->host_allocator, &device->block_pool, queue_affinity,
       wait_semaphore_list, signal_semaphore_list, command_buffer, binding_table,
       &callback_data);
+  iree_hal_hip_dispatch_completed_data_t* external_stream_data = NULL;
+  if (device->uses_external_stream) {
+    external_stream_data = callback_data->base.external_stream_dispatch_data;
+    iree_hal_resource_retain(external_stream_data);
+  }
 
   if (iree_status_is_ok(status)) {
     if (wait_semaphore_list.count == 0) {
       status = iree_hal_hip_dispatch_thread_add_dispatch(
           device->devices[device_ordinal].dispatch_thread,
           &iree_hal_hip_device_execute_now, callback_data);
-      IREE_TRACE_ZONE_END(z0);
-      return status;
-    }
-  }
-
-  if (iree_status_is_ok(status)) {
-    for (iree_host_size_t i = 0; i < wait_semaphore_list.count; ++i) {
-      status = iree_status_join(
-          status, iree_hal_hip_semaphore_notify_work(
-                      wait_semaphore_list.semaphores[i],
-                      wait_semaphore_list.payload_values[i],
-                      device->devices[device_ordinal].device_event_pool,
-                      &iree_hal_hip_device_semaphore_callback, callback_data));
+    } else {
+      for (iree_host_size_t i = 0; i < wait_semaphore_list.count; ++i) {
+        status = iree_status_join(
+            status,
+            iree_hal_hip_semaphore_notify_work(
+                wait_semaphore_list.semaphores[i],
+                wait_semaphore_list.payload_values[i],
+                device->devices[device_ordinal].device_event_pool,
+                &iree_hal_hip_device_semaphore_callback, callback_data));
+      }
     }
   } else {
     iree_hal_hip_device_destroy_callback_data(callback_data);
@@ -2467,6 +2624,13 @@ static iree_status_t iree_hal_hip_device_queue_execute(
           signal_semaphore_list.semaphores[i],
           signal_semaphore_list.payload_values[i]);
     }
+  }
+
+  if (device->uses_external_stream) {
+    if (iree_status_is_ok(status)) {
+      iree_hal_hip_wait_for_dispatch(external_stream_data);
+    }
+    iree_hal_resource_release(external_stream_data);
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -347,6 +347,9 @@ static iree_status_t iree_hal_hip_driver_select_default_device(
   return status;
 }
 
+static const iree_string_view_t key_hip_external_stream =
+    iree_string_view_literal("hip_external_stream");
+
 static iree_status_t iree_hal_hip_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_host_size_t param_count, const iree_string_pair_t* params,
@@ -371,9 +374,23 @@ static iree_status_t iree_hal_hip_driver_create_device_by_id(
 
   iree_string_view_t device_name = iree_make_cstring_view("hip");
 
+  iree_hal_hip_device_params_t device_params = driver->device_params;
+  uint64_t luvalue;
+  for (iree_host_size_t i = 0; i < param_count; ++i) {
+    if (iree_string_view_equal(params[i].key, key_hip_external_stream)) {
+      if (!iree_string_view_atoi_uint64(params[i].value, &luvalue)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'hip_external_stream' expected to be uint Got: '%.*s'",
+            (int)params[i].value.size, params[i].value.data);
+      }
+      device_params.external_stream = luvalue;
+    }
+  }
+
   // Attempt to create the device now.
   iree_status_t status = iree_hal_hip_device_create(
-      base_driver, device_name, &driver->device_params, &driver->hip_symbols,
+      base_driver, device_name, &device_params, &driver->hip_symbols,
       &driver->nccl_symbols, 1, &device, host_allocator, out_device);
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -375,13 +375,13 @@ static iree_status_t iree_hal_hip_driver_create_device_by_id(
   iree_string_view_t device_name = iree_make_cstring_view("hip");
 
   iree_hal_hip_device_params_t device_params = driver->device_params;
-  uint64_t luvalue;
   for (iree_host_size_t i = 0; i < param_count; ++i) {
     if (iree_string_view_equal(params[i].key, key_hip_external_stream)) {
+      uint64_t luvalue = 0;
       if (!iree_string_view_atoi_uint64(params[i].value, &luvalue)) {
         return iree_make_status(
             IREE_STATUS_FAILED_PRECONDITION,
-            "Option 'hip_external_stream' expected to be uint Got: '%.*s'",
+            "option 'hip_external_stream' expected to be uint64, Got: '%.*s'",
             (int)params[i].value.size, params[i].value.data);
       }
       device_params.external_stream = luvalue;


### PR DESCRIPTION
This is for cases where we want a very tight integration with an external application using HIP. This allows us to share a stream withan external application. This forces dispatches to be serialized with the main thread so we aren't submitting to the stream while someone else is as well.