### PR TITLE
[NFC] Refresh the interface names for Encoding dialect and data-tiling specifics.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -26,7 +26,7 @@ using IREE::Codegen::MaterializeEncodingInfo;
 using IREE::Encoding::PadEncodingLayoutAttr;
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
-    IREE::Encoding::LayoutAttrInterface layoutAttr)
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr)
     : layoutAttr(layoutAttr) {
   addConversion([](IntegerType intType) { return intType; });
   addConversion([](IndexType indexType) { return indexType; });

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -23,9 +23,9 @@ namespace mlir::iree_compiler {
 class MaterializeEncodingTypeConverter : public TypeConverter {
 public:
   MaterializeEncodingTypeConverter(
-      IREE::Encoding::LayoutAttrInterface layoutAttr);
+      IREE::Encoding::LayoutMaterializerAttr layoutAttr);
 
-  const IREE::Encoding::LayoutAttrInterface &getLayoutAttr() const {
+  const IREE::Encoding::LayoutMaterializerAttr &getLayoutAttr() const {
     return layoutAttr;
   }
 
@@ -60,7 +60,7 @@ public:
       SmallVectorImpl<OpFoldResult> &newStrides) const;
 
 private:
-  const IREE::Encoding::LayoutAttrInterface layoutAttr;
+  const IREE::Encoding::LayoutMaterializerAttr layoutAttr;
 };
 
 /// Conversion target to use for for materializing the encoding.

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -92,8 +92,8 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
             ? targetConfig.getAs<IREE::Encoding::LayoutMaterializerAttr>(
                   IREE::Encoding::kEncodingResolverAttrName)
             : nullptr;
-    auto resolverAttr = llvm::dyn_cast_or_null<
-        IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr);
+    auto resolverAttr =
+        llvm::dyn_cast_or_null<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
 
     IREE::Encoding::LayoutMaterializerAttr layoutAttrWithTargetInfo =
         layoutAttr && resolverAttr

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -64,11 +64,11 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     }
 
     auto getTestTargetOrNopLayout =
-        [&]() -> IREE::Encoding::LayoutAttrInterface {
+        [&]() -> IREE::Encoding::LayoutMaterializerAttr {
       if (testCLGPUTarget) {
         LDBG("Select GPUEncodingLayoutAttr attribute as the layout attribute. "
              "(testCLGPUTarget)");
-        return cast<IREE::Encoding::LayoutAttrInterface>(
+        return cast<IREE::Encoding::LayoutMaterializerAttr>(
             IREE::GPU::GPUEncodingLayoutAttr::get(
                 ctx,
                 DictionaryAttr::get(ctx, NamedAttribute(kGPUTargetAttrName,
@@ -76,7 +76,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
       }
       LDBG("Select EncodingNopLayoutAttr attribute as the layout "
            "attribute (Encoding resolver unknown or unsupported).");
-      return cast<IREE::Encoding::LayoutAttrInterface>(
+      return cast<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Codegen::EncodingNopLayoutAttr::get(ctx));
     };
 
@@ -87,20 +87,21 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     // If the layoutAttr was not found, or if it does not implement the layout
     // resolver interface, fall back to the resolver for getCLGPUTarget. If
     // there is also no test target set, fall back to the nop layout.
-    IREE::Encoding::LayoutAttrInterface layoutAttr =
-        targetConfig ? targetConfig.getAs<IREE::Encoding::LayoutAttrInterface>(
-                           IREE::Encoding::kEncodingResolverAttrName)
-                     : nullptr;
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr =
+        targetConfig
+            ? targetConfig.getAs<IREE::Encoding::LayoutMaterializerAttr>(
+                  IREE::Encoding::kEncodingResolverAttrName)
+            : nullptr;
     auto resolverAttr = llvm::dyn_cast_or_null<
         IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr);
 
-    IREE::Encoding::LayoutAttrInterface layoutAttrWithTargetInfo =
+    IREE::Encoding::LayoutMaterializerAttr layoutAttrWithTargetInfo =
         layoutAttr && resolverAttr
-            ? cast<IREE::Encoding::LayoutAttrInterface>(
+            ? cast<IREE::Encoding::LayoutMaterializerAttr>(
                   resolverAttr.cloneWithSimplifiedConfig(targetConfig))
             : getTestTargetOrNopLayout();
 
-    LDBG("Selected LayoutAttrInterface with target configuration: "
+    LDBG("Selected Encoding::LayoutMaterializerAttr with target configuration: "
          << layoutAttrWithTargetInfo);
 
     MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -37,7 +37,7 @@ struct MaterializeEncodingIntoNopPass final
     FunctionOpInterface operation = getOperation();
 
     RewritePatternSet materializeEncodingPattern(context);
-    auto layoutAttr = cast<IREE::Encoding::LayoutAttrInterface>(
+    auto layoutAttr = cast<IREE::Encoding::LayoutMaterializerAttr>(
         IREE::Codegen::EncodingNopLayoutAttr::get(context));
     MaterializeEncodingTypeConverter typeConverter(layoutAttr);
     MaterializeEncodingConversionTarget target(*context);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -55,8 +55,7 @@ static PadEncodingLayoutAttr getPadLayout(Attribute layoutAttr,
     return dyn_cast<PadEncodingLayoutAttr>(*layouts.begin());
   }
   Attribute resolvedEncoding =
-      cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr)
-          .getLayout(type);
+      cast<IREE::Encoding::LayoutResolverAttr>(layoutAttr).getLayout(type);
   LLVM_DEBUG({
     llvm::dbgs() << "Unresolved type: " << type << "\n";
     llvm::dbgs() << "layoutAttr: " << layoutAttr << "\n";
@@ -303,8 +302,7 @@ struct MaterializeEncodingIntoPaddingPass final
         targetConfig.contains(IREE::Encoding::kEncodingResolverAttrName)) {
       layoutAttr = targetConfig.getAs<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Encoding::kEncodingResolverAttrName);
-      auto resolverAttr =
-          cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr);
+      auto resolverAttr = cast<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
       layoutAttr = cast<IREE::Encoding::LayoutMaterializerAttr>(
           resolverAttr.cloneWithSimplifiedConfig(targetConfig));
     } else {

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -88,7 +88,7 @@ static RankedTensorType getPaddedType(Attribute layoutAttr,
 struct MaterializePadEncodingTypeConverter final
     : MaterializeEncodingTypeConverter {
   MaterializePadEncodingTypeConverter(
-      IREE::Encoding::LayoutAttrInterface layoutAttr)
+      IREE::Encoding::LayoutMaterializerAttr layoutAttr)
       : MaterializeEncodingTypeConverter(layoutAttr) {
     addConversion([](RankedTensorType type) -> std::optional<RankedTensorType> {
       // The type converter is designed for `pad_encoding_layout` encoding
@@ -298,17 +298,17 @@ struct MaterializeEncodingIntoPaddingPass final
     // access the target info during materialization.
     //
     // Otherwise, fall back to the nop layout.
-    IREE::Encoding::LayoutAttrInterface layoutAttr;
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr;
     if (targetConfig &&
         targetConfig.contains(IREE::Encoding::kEncodingResolverAttrName)) {
-      layoutAttr = targetConfig.getAs<IREE::Encoding::LayoutAttrInterface>(
+      layoutAttr = targetConfig.getAs<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Encoding::kEncodingResolverAttrName);
       auto resolverAttr =
           cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr);
-      layoutAttr = cast<IREE::Encoding::LayoutAttrInterface>(
+      layoutAttr = cast<IREE::Encoding::LayoutMaterializerAttr>(
           resolverAttr.cloneWithSimplifiedConfig(targetConfig));
     } else {
-      layoutAttr = cast<IREE::Encoding::LayoutAttrInterface>(
+      layoutAttr = cast<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Codegen::EncodingNopLayoutAttr::get(context));
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -839,7 +839,8 @@ public:
     auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
         this->getTypeConverter());
 
-    IREE::Encoding::LayoutAttrInterface layoutAttr = converter->getLayoutAttr();
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr =
+        converter->getLayoutAttr();
     SmallVector<Type> convertedResTypes;
     for (auto init : op.getDpsInits()) {
       convertedResTypes.push_back(converter->convertType(init.getType()));

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -22,9 +22,8 @@ def IREECPU_CPUEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
-    Codegen::PackedLayoutAttrInterface, etc. They are implemented through
-    external model mechanism See the implementation in
-    compiler/Codegen/ExternalInterfaces/*.
+    Codegen::PackedLayoutAttr, etc. They are implemented through external model
+    mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
@@ -42,9 +41,8 @@ def IREECPU_VMVXEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
-    Codegen::PackedLayoutAttrInterface, etc. They are implemented through
-    external model mechanism See the implementation in
-    compiler/Codegen/ExternalInterfaces/*.
+    Codegen::PackedLayoutAttr, etc. They are implemented through external model
+    mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -21,7 +21,7 @@ def IREECPU_CPUEncodingLayoutAttr :
   let summary = [{The encoding layout attribute for CPU backends.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding
-    serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
+    serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
     Codegen::PackedLayoutAttr, etc. They are implemented through external model
     mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
@@ -40,7 +40,7 @@ def IREECPU_VMVXEncodingLayoutAttr :
   let summary = [{The encoding layout attribute for VMVX backend.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding
-    serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
+    serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
     Codegen::PackedLayoutAttr, etc. They are implemented through external model
     mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -22,7 +22,7 @@ def IREECPU_CPUEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
-    Codegen::PackedLayoutAttr, etc. They are implemented through external model
+    Codegen::PackedLayoutMaterializerAttr, etc. They are implemented through external model
     mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 
@@ -41,7 +41,7 @@ def IREECPU_VMVXEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
-    Codegen::PackedLayoutAttr, etc. They are implemented through external model
+    Codegen::PackedLayoutMaterializerAttr, etc. They are implemented through external model
     mechanism See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -129,8 +129,8 @@ def IREECodegen_LoweringConfigAttrInterface :
   ];
 }
 
-def IREECodegen_PackedLayoutAttrInterface :
-  AttrInterface<"PackedLayoutAttrInterface"> {
+def IREECodegen_PackedLayoutAttr :
+  AttrInterface<"PackedLayoutAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   let description = [{
     An interface that collects a set of methods for packed encoding materialization.

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -129,8 +129,8 @@ def IREECodegen_LoweringConfigAttrInterface :
   ];
 }
 
-def IREECodegen_PackedLayoutAttr :
-  AttrInterface<"PackedLayoutAttr"> {
+def IREECodegen_PackedLayoutMaterializerAttr :
+  AttrInterface<"PackedLayoutMaterializerAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   let description = [{
     An interface that collects a set of methods for packed encoding materialization.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -320,10 +320,10 @@ def IREEGPU_GPUEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
-    Codegen::PackedLayoutAttrInterface, etc. They should be implemented
-    through external model mechanism because we do not want to relocate
-    domain-specific logic to the dialect implementation, and we can have better
-    code structure. See the implementation in
+    Codegen::PackedLayoutAttr, etc. They should be implemented through external
+    model mechanism because we do not want to relocate domain-specific logic to
+    the dialect implementation, and we can have better code structure. See the
+    implementation in
     compiler/Codegen/ExternalInterfaces/*.
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -347,7 +347,7 @@ def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
   let description = [{
     Describes padding preferences for a given GPU target.
     This attribute can implement any encoding interface for data-tiling,
-    e.g., Encoding::EncodingLayoutResolverAttrInterface, etc. They should be
+    e.g., Encoding::LayoutResolverAttr, etc. They should be
     implemented through external model mechanism because we do not want to
     relocate domain-specific logic to the dialect implementation, and we can
     have better code structure. See the implementation in

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -320,7 +320,7 @@ def IREEGPU_GPUEncodingLayoutAttr :
   let description = [{
     This attribute can implement any layout interface methods for encoding
     serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
-    Codegen::PackedLayoutAttr, etc. They should be implemented through external
+    Codegen::PackedLayoutMaterializerAttr, etc. They should be implemented through external
     model mechanism because we do not want to relocate domain-specific logic to
     the dialect implementation, and we can have better code structure. See the
     implementation in compiler/Codegen/ExternalInterfaces/*.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -323,8 +323,7 @@ def IREEGPU_GPUEncodingLayoutAttr :
     Codegen::PackedLayoutAttr, etc. They should be implemented through external
     model mechanism because we do not want to relocate domain-specific logic to
     the dialect implementation, and we can have better code structure. See the
-    implementation in
-    compiler/Codegen/ExternalInterfaces/*.
+    implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
@@ -347,11 +346,10 @@ def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
   let description = [{
     Describes padding preferences for a given GPU target.
     This attribute can implement any encoding interface for data-tiling,
-    e.g., Encoding::LayoutResolverAttr, etc. They should be
-    implemented through external model mechanism because we do not want to
-    relocate domain-specific logic to the dialect implementation, and we can
-    have better code structure. See the implementation in
-    compiler/Codegen/ExternalInterfaces/*.
+    e.g., Encoding::LayoutResolverAttr, etc. They should be implemented through
+    external model mechanism because we do not want to relocate domain-specific
+    logic to the dialect implementation, and we can have better code structure.
+    See the implementation in compiler/Codegen/ExternalInterfaces/*.
   }];
 
   let parameters = (ins

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -319,7 +319,7 @@ def IREEGPU_GPUEncodingLayoutAttr :
   let summary = [{The encoding layout attribute for GPU backend.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding
-    serialization and or materialization, e.g., Encoding::LayoutAttrInterface,
+    serialization and or materialization, e.g., Encoding::LayoutMaterializerAttr,
     Codegen::PackedLayoutAttr, etc. They should be implemented through external
     model mechanism because we do not want to relocate domain-specific logic to
     the dialect implementation, and we can have better code structure. See the

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -9,7 +9,7 @@
 // backend:
 //
 // - IREE::Encoding::EncodingLayoutResolverAttrInterface
-// - IREE::Encoding::SerializableEncodingAttrInterface
+// - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
 // - IREE::Codegen::PackedLayoutAttr
 //
@@ -652,9 +652,9 @@ struct CPUHostEncodingLayoutResolverAttrInterface final
   }
 };
 
-struct CPUHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
-          CPUHostSerializableEncodingAttrInterface, CPUEncodingLayoutAttr> {
+struct CPUHostSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<CPUHostSerializableAttr,
+                                                      CPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
@@ -787,9 +787,9 @@ struct VMVXHostEncodingLayoutResolverAttrInterface final
   }
 };
 
-struct VMVXHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
-          VMVXHostSerializableEncodingAttrInterface, VMVXEncodingLayoutAttr> {
+struct VMVXHostSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<VMVXHostSerializableAttr,
+                                                      VMVXEncodingLayoutAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
                                     ValueRange dynamicDims) const {
@@ -801,19 +801,19 @@ struct VMVXHostSerializableEncodingAttrInterface final
 } // namespace
 
 void registerCPUEncodingExternalModels(DialectRegistry &registry) {
-  registry.addExtension(
-      +[](MLIRContext *ctx, IREE::CPU::IREECPUDialect *dialect) {
-        IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
-            CPUDeviceEncodingPackedLayoutAttr,
-            CPUDeviceEncodingLayoutMaterializerAttr,
-            CPUHostEncodingLayoutResolverAttrInterface,
-            CPUHostSerializableEncodingAttrInterface>(*ctx);
-        IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
-            VMVXDeviceEncodingPackedLayoutAttr,
-            VMVXDeviceEncodingLayoutMaterializerAttr,
-            VMVXHostEncodingLayoutResolverAttrInterface,
-            VMVXHostSerializableEncodingAttrInterface>(*ctx);
-      });
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::CPU::IREECPUDialect *dialect) {
+    IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
+        CPUDeviceEncodingPackedLayoutAttr,
+        CPUDeviceEncodingLayoutMaterializerAttr,
+        CPUHostEncodingLayoutResolverAttrInterface, CPUHostSerializableAttr>(
+        *ctx);
+    IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
+        VMVXDeviceEncodingPackedLayoutAttr,
+        VMVXDeviceEncodingLayoutMaterializerAttr,
+        VMVXHostEncodingLayoutResolverAttrInterface, VMVXHostSerializableAttr>(
+        *ctx);
+  });
 }
 
 } // namespace mlir::iree_compiler::IREE::CPU

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -562,9 +562,9 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
   return {};
 }
 
-struct CPUDeviceEncodingPackedLayoutAttr
-    : public DevicePackedLayoutAttrExternalModelBase<
-          CPUDeviceEncodingPackedLayoutAttr, CPUEncodingLayoutAttr> {
+struct CPUEncodingPackedLayoutAttr
+    : public PackedLayoutAttrExternalModelBase<CPUEncodingPackedLayoutAttr,
+                                               CPUEncodingLayoutAttr> {
 
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<CPUEncodingLayoutAttr>(attr).getConfiguration();
@@ -612,9 +612,9 @@ struct CPUDeviceEncodingPackedLayoutAttr
   }
 };
 
-struct CPUDeviceEncodingLayoutMaterializerAttr final
-    : public DeviceEncodingLayoutMaterializerAttrExternalModelBase<
-          CPUDeviceEncodingLayoutMaterializerAttr, CPUEncodingLayoutAttr> {
+struct CPUEncodingLayoutMaterializerAttr final
+    : public EncodingLayoutMaterializerAttrExternalModelBase<
+          CPUEncodingLayoutMaterializerAttr, CPUEncodingLayoutAttr> {
 
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
@@ -632,9 +632,9 @@ struct CPUDeviceEncodingLayoutMaterializerAttr final
   }
 };
 
-struct CPUHostLayoutResolverAttr final
-    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
-          CPUHostLayoutResolverAttr, CPUEncodingLayoutAttr> {
+struct CPULayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<CPULayoutResolverAttr,
+                                                        CPUEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -652,8 +652,8 @@ struct CPUHostLayoutResolverAttr final
   }
 };
 
-struct CPUHostSerializableAttr final
-    : IREE::Encoding::SerializableAttr::ExternalModel<CPUHostSerializableAttr,
+struct CPUSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<CPUSerializableAttr,
                                                       CPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
@@ -698,9 +698,9 @@ enumerateVMVXMatmulTiles(linalg::ContractionDimensions cDims,
   };
 }
 
-struct VMVXDeviceEncodingPackedLayoutAttr final
-    : DevicePackedLayoutAttrExternalModelBase<
-          VMVXDeviceEncodingPackedLayoutAttr, VMVXEncodingLayoutAttr> {
+struct VMVXEncodingPackedLayoutAttr final
+    : PackedLayoutAttrExternalModelBase<VMVXEncodingPackedLayoutAttr,
+                                        VMVXEncodingLayoutAttr> {
 
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<VMVXEncodingLayoutAttr>(attr).getConfiguration();
@@ -748,9 +748,9 @@ struct VMVXDeviceEncodingPackedLayoutAttr final
   }
 };
 
-struct VMVXDeviceEncodingLayoutMaterializerAttr final
-    : DeviceEncodingLayoutMaterializerAttrExternalModelBase<
-          VMVXDeviceEncodingLayoutMaterializerAttr, VMVXEncodingLayoutAttr> {
+struct VMVXEncodingLayoutMaterializerAttr final
+    : EncodingLayoutMaterializerAttrExternalModelBase<
+          VMVXEncodingLayoutMaterializerAttr, VMVXEncodingLayoutAttr> {
 
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
@@ -768,9 +768,9 @@ struct VMVXDeviceEncodingLayoutMaterializerAttr final
   }
 };
 
-struct VMVXHostLayoutResolverAttr final
+struct VMVXLayoutResolverAttr final
     : IREE::Encoding::LayoutResolverAttr::ExternalModel<
-          VMVXHostLayoutResolverAttr, VMVXEncodingLayoutAttr> {
+          VMVXLayoutResolverAttr, VMVXEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -787,8 +787,8 @@ struct VMVXHostLayoutResolverAttr final
   }
 };
 
-struct VMVXHostSerializableAttr final
-    : IREE::Encoding::SerializableAttr::ExternalModel<VMVXHostSerializableAttr,
+struct VMVXSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<VMVXSerializableAttr,
                                                       VMVXEncodingLayoutAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
@@ -804,13 +804,11 @@ void registerCPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::CPU::IREECPUDialect *dialect) {
         IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
-            CPUDeviceEncodingPackedLayoutAttr,
-            CPUDeviceEncodingLayoutMaterializerAttr, CPUHostLayoutResolverAttr,
-            CPUHostSerializableAttr>(*ctx);
+            CPUEncodingPackedLayoutAttr, CPUEncodingLayoutMaterializerAttr,
+            CPULayoutResolverAttr, CPUSerializableAttr>(*ctx);
         IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
-            VMVXDeviceEncodingPackedLayoutAttr,
-            VMVXDeviceEncodingLayoutMaterializerAttr,
-            VMVXHostLayoutResolverAttr, VMVXHostSerializableAttr>(*ctx);
+            VMVXEncodingPackedLayoutAttr, VMVXEncodingLayoutMaterializerAttr,
+            VMVXLayoutResolverAttr, VMVXSerializableAttr>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -8,7 +8,7 @@
 // This file implements the following interfaces for CPU backends and the VMVX
 // backend:
 //
-// - IREE::Encoding::EncodingLayoutResolverAttrInterface
+// - IREE::Encoding::LayoutResolverAttr
 // - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
 // - IREE::Codegen::PackedLayoutAttr
@@ -632,9 +632,9 @@ struct CPUDeviceEncodingLayoutMaterializerAttr final
   }
 };
 
-struct CPUHostEncodingLayoutResolverAttrInterface final
-    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
-          CPUHostEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
+struct CPUHostLayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          CPUHostLayoutResolverAttr, CPUEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -768,9 +768,9 @@ struct VMVXDeviceEncodingLayoutMaterializerAttr final
   }
 };
 
-struct VMVXHostEncodingLayoutResolverAttrInterface final
-    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
-          VMVXHostEncodingLayoutResolverAttrInterface, VMVXEncodingLayoutAttr> {
+struct VMVXHostLayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          VMVXHostLayoutResolverAttr, VMVXEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -801,19 +801,17 @@ struct VMVXHostSerializableAttr final
 } // namespace
 
 void registerCPUEncodingExternalModels(DialectRegistry &registry) {
-  registry.addExtension(+[](MLIRContext *ctx,
-                            IREE::CPU::IREECPUDialect *dialect) {
-    IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
-        CPUDeviceEncodingPackedLayoutAttr,
-        CPUDeviceEncodingLayoutMaterializerAttr,
-        CPUHostEncodingLayoutResolverAttrInterface, CPUHostSerializableAttr>(
-        *ctx);
-    IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
-        VMVXDeviceEncodingPackedLayoutAttr,
-        VMVXDeviceEncodingLayoutMaterializerAttr,
-        VMVXHostEncodingLayoutResolverAttrInterface, VMVXHostSerializableAttr>(
-        *ctx);
-  });
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::CPU::IREECPUDialect *dialect) {
+        IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
+            CPUDeviceEncodingPackedLayoutAttr,
+            CPUDeviceEncodingLayoutMaterializerAttr, CPUHostLayoutResolverAttr,
+            CPUHostSerializableAttr>(*ctx);
+        IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
+            VMVXDeviceEncodingPackedLayoutAttr,
+            VMVXDeviceEncodingLayoutMaterializerAttr,
+            VMVXHostLayoutResolverAttr, VMVXHostSerializableAttr>(*ctx);
+      });
 }
 
 } // namespace mlir::iree_compiler::IREE::CPU

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -11,7 +11,7 @@
 // - IREE::Encoding::LayoutResolverAttr
 // - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
-// - IREE::Codegen::PackedLayoutAttr
+// - IREE::Codegen::PackedLayoutMaterializerAttr
 //
 // In these backends, we transpose narrow-N into narrow-M
 // for a combination of reasons:
@@ -278,7 +278,7 @@ FailureOr<Operation *> lowerContractionOpWithEncoding(
 
   MaterializeEncodingInfo encodingInfo = {};
   if (auto packedLayoutAttr =
-          dyn_cast<IREE::Codegen::PackedLayoutAttr>(layoutAttr)) {
+          dyn_cast<IREE::Codegen::PackedLayoutMaterializerAttr>(layoutAttr)) {
     encodingInfo = packedLayoutAttr.getEncodingInfo(
         cast<RankedTensorType>(linalgOp->getResultTypes()[0]));
   }
@@ -562,9 +562,9 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
   return {};
 }
 
-struct CPUEncodingPackedLayoutAttr
-    : public PackedLayoutAttrExternalModelBase<CPUEncodingPackedLayoutAttr,
-                                               CPUEncodingLayoutAttr> {
+struct CPUEncodingPackedLayoutMaterializerAttr
+    : public PackedLayoutMaterializerAttrExternalModelBase<
+          CPUEncodingPackedLayoutMaterializerAttr, CPUEncodingLayoutAttr> {
 
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<CPUEncodingLayoutAttr>(attr).getConfiguration();
@@ -698,9 +698,9 @@ enumerateVMVXMatmulTiles(linalg::ContractionDimensions cDims,
   };
 }
 
-struct VMVXEncodingPackedLayoutAttr final
-    : PackedLayoutAttrExternalModelBase<VMVXEncodingPackedLayoutAttr,
-                                        VMVXEncodingLayoutAttr> {
+struct VMVXEncodingPackedLayoutMaterializerAttr final
+    : PackedLayoutMaterializerAttrExternalModelBase<
+          VMVXEncodingPackedLayoutMaterializerAttr, VMVXEncodingLayoutAttr> {
 
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<VMVXEncodingLayoutAttr>(attr).getConfiguration();
@@ -804,11 +804,13 @@ void registerCPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::CPU::IREECPUDialect *dialect) {
         IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
-            CPUEncodingPackedLayoutAttr, CPUEncodingLayoutMaterializerAttr,
-            CPULayoutResolverAttr, CPUSerializableAttr>(*ctx);
+            CPUEncodingPackedLayoutMaterializerAttr,
+            CPUEncodingLayoutMaterializerAttr, CPULayoutResolverAttr,
+            CPUSerializableAttr>(*ctx);
         IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
-            VMVXEncodingPackedLayoutAttr, VMVXEncodingLayoutMaterializerAttr,
-            VMVXLayoutResolverAttr, VMVXSerializableAttr>(*ctx);
+            VMVXEncodingPackedLayoutMaterializerAttr,
+            VMVXEncodingLayoutMaterializerAttr, VMVXLayoutResolverAttr,
+            VMVXSerializableAttr>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
@@ -15,9 +15,9 @@ namespace mlir::iree_compiler::IREE::Codegen {
 
 using IREE::TensorExt::DispatchTensorType;
 
-struct EncodingNopDeviceLayoutMaterializerAttr final
+struct EncodingNopLayoutMaterializerAttr final
     : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
-          EncodingNopDeviceLayoutMaterializerAttr, EncodingNopLayoutAttr> {
+          EncodingNopLayoutMaterializerAttr, EncodingNopLayoutAttr> {
   Type convertType(Attribute attr, Type type) const {
     return TypeSwitch<Type, Type>(type)
         .Case<RankedTensorType>([&](auto rankedTensorType) {
@@ -63,9 +63,9 @@ struct EncodingNopDeviceLayoutMaterializerAttr final
   }
 };
 
-struct EncodingNopHostLayoutResolverAttr final
+struct EncodingNopLayoutResolverAttr final
     : IREE::Encoding::LayoutResolverAttr::ExternalModel<
-          EncodingNopHostLayoutResolverAttr, EncodingNopLayoutAttr> {
+          EncodingNopLayoutResolverAttr, EncodingNopLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     return attr;
@@ -77,12 +77,12 @@ struct EncodingNopHostLayoutResolverAttr final
 };
 
 void registerCodegenExternalModels(DialectRegistry &registry) {
-  registry.addExtension(
-      +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
-        EncodingNopLayoutAttr::attachInterface<
-            EncodingNopHostLayoutResolverAttr,
-            EncodingNopDeviceLayoutMaterializerAttr>(*ctx);
-      });
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::Codegen::IREECodegenDialect *dialect) {
+    EncodingNopLayoutAttr::attachInterface<EncodingNopLayoutResolverAttr,
+                                           EncodingNopLayoutMaterializerAttr>(
+        *ctx);
+  });
 }
 
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
@@ -63,10 +63,9 @@ struct EncodingNopDeviceLayoutMaterializerAttr final
   }
 };
 
-struct EncodingNopHostEncodingLayoutResolverAttrInterface final
-    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
-          EncodingNopHostEncodingLayoutResolverAttrInterface,
-          EncodingNopLayoutAttr> {
+struct EncodingNopHostLayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          EncodingNopHostLayoutResolverAttr, EncodingNopLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     return attr;
@@ -81,7 +80,7 @@ void registerCodegenExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
         EncodingNopLayoutAttr::attachInterface<
-            EncodingNopHostEncodingLayoutResolverAttrInterface,
+            EncodingNopHostLayoutResolverAttr,
             EncodingNopDeviceLayoutMaterializerAttr>(*ctx);
       });
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
@@ -15,9 +15,9 @@ namespace mlir::iree_compiler::IREE::Codegen {
 
 using IREE::TensorExt::DispatchTensorType;
 
-struct EncodingNopDeviceLayoutAttrInterface final
-    : IREE::Encoding::LayoutAttrInterface::ExternalModel<
-          EncodingNopDeviceLayoutAttrInterface, EncodingNopLayoutAttr> {
+struct EncodingNopDeviceLayoutMaterializerAttr final
+    : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
+          EncodingNopDeviceLayoutMaterializerAttr, EncodingNopLayoutAttr> {
   Type convertType(Attribute attr, Type type) const {
     return TypeSwitch<Type, Type>(type)
         .Case<RankedTensorType>([&](auto rankedTensorType) {
@@ -82,7 +82,7 @@ void registerCodegenExternalModels(DialectRegistry &registry) {
       +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
         EncodingNopLayoutAttr::attachInterface<
             EncodingNopHostEncodingLayoutResolverAttrInterface,
-            EncodingNopDeviceLayoutAttrInterface>(*ctx);
+            EncodingNopDeviceLayoutMaterializerAttr>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -9,7 +9,7 @@
 //
 // - IREE::Encoding::EncodingLayoutResolverAttrInterface
 // - IREE::Encoding::SerializableEncodingAttrInterface
-// - IREE::Encoding::LayoutAttrInterface
+// - IREE::Encoding::LayoutMaterializerAttr
 // - IREE::Encoding::PackedLayoutAttr
 //
 // Different from CPU backends, we do not transpose narrow-N to narrow-M for a
@@ -359,9 +359,9 @@ struct GPUDeviceEncodingPackedLayoutAttr
   }
 };
 
-struct GPUDeviceEncodingLayoutAttrInterface
-    : public DeviceEncodingLayoutAttrInterfaceExternalModelBase<
-          GPUDeviceEncodingLayoutAttrInterface, GPUEncodingLayoutAttr> {
+struct GPUDeviceEncodingLayoutMaterializerAttr
+    : public DeviceEncodingLayoutMaterializerAttrExternalModelBase<
+          GPUDeviceEncodingLayoutMaterializerAttr, GPUEncodingLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
@@ -416,9 +416,9 @@ struct GPUHostEncodingLayoutResolverAttrInterface final
   }
 };
 
-struct GPUPadDeviceEncodingLayoutAttrInterface final
-    : IREE::Encoding::LayoutAttrInterface::ExternalModel<
-          GPUPadDeviceEncodingLayoutAttrInterface, GPUPadLayoutAttr> {
+struct GPUPadDeviceEncodingLayoutMaterializerAttr final
+    : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
+          GPUPadDeviceEncodingLayoutMaterializerAttr, GPUPadLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
@@ -535,11 +535,11 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
       +[](MLIRContext *ctx, IREE::GPU::IREEGPUDialect *dialect) {
         IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
             GPUDeviceEncodingPackedLayoutAttr,
-            GPUDeviceEncodingLayoutAttrInterface,
+            GPUDeviceEncodingLayoutMaterializerAttr,
             GPUHostEncodingLayoutResolverAttrInterface,
             GPUHostSerializableEncodingAttrInterface>(*ctx);
         IREE::GPU::GPUPadLayoutAttr::attachInterface<
-            GPUPadDeviceEncodingLayoutAttrInterface,
+            GPUPadDeviceEncodingLayoutMaterializerAttr,
             GPUPadEncodingLayoutResolverAttrInterface>(*ctx);
       });
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -10,7 +10,7 @@
 // - IREE::Encoding::LayoutResolverAttr
 // - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
-// - IREE::Encoding::PackedLayoutAttr
+// - IREE::Codegen::PackedLayoutAttr
 //
 // Different from CPU backends, we do not transpose narrow-N to narrow-M for a
 // combination of reasons:

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -10,7 +10,7 @@
 // - IREE::Encoding::EncodingLayoutResolverAttrInterface
 // - IREE::Encoding::SerializableEncodingAttrInterface
 // - IREE::Encoding::LayoutAttrInterface
-// - IREE::Encoding::PackedLayoutAttrInterface
+// - IREE::Encoding::PackedLayoutAttr
 //
 // Different from CPU backends, we do not transpose narrow-N to narrow-M for a
 // combination of reasons:
@@ -307,9 +307,9 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   return mmaOp;
 }
 
-struct GPUDeviceEncodingPackedLayoutAttrInterface
+struct GPUDeviceEncodingPackedLayoutAttr
     : public DevicePackedLayoutAttrExternalModelBase<
-          GPUDeviceEncodingPackedLayoutAttrInterface, GPUEncodingLayoutAttr> {
+          GPUDeviceEncodingPackedLayoutAttr, GPUEncodingLayoutAttr> {
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<GPUEncodingLayoutAttr>(attr).getConfiguration();
   }
@@ -534,7 +534,7 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::GPU::IREEGPUDialect *dialect) {
         IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
-            GPUDeviceEncodingPackedLayoutAttrInterface,
+            GPUDeviceEncodingPackedLayoutAttr,
             GPUDeviceEncodingLayoutAttrInterface,
             GPUHostEncodingLayoutResolverAttrInterface,
             GPUHostSerializableEncodingAttrInterface>(*ctx);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -7,7 +7,7 @@
 //
 // This file implements the following interfaces for GPU backends:
 //
-// - IREE::Encoding::EncodingLayoutResolverAttrInterface
+// - IREE::Encoding::LayoutResolverAttr
 // - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
 // - IREE::Encoding::PackedLayoutAttr
@@ -392,9 +392,9 @@ struct GPUHostSerializableAttr final
   }
 };
 
-struct GPUHostEncodingLayoutResolverAttrInterface final
-    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
-          GPUHostEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
+struct GPUHostLayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          GPUHostLayoutResolverAttr, GPUEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -426,9 +426,9 @@ struct GPUPadDeviceEncodingLayoutMaterializerAttr final
   }
 };
 
-struct GPUPadEncodingLayoutResolverAttrInterface final
-    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
-          GPUPadEncodingLayoutResolverAttrInterface, GPUPadLayoutAttr> {
+struct GPUPadLayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          GPUPadLayoutResolverAttr, GPUPadLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -531,17 +531,16 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
 } // namespace
 
 void registerGPUEncodingExternalModels(DialectRegistry &registry) {
-  registry.addExtension(
-      +[](MLIRContext *ctx, IREE::GPU::IREEGPUDialect *dialect) {
-        IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
-            GPUDeviceEncodingPackedLayoutAttr,
-            GPUDeviceEncodingLayoutMaterializerAttr,
-            GPUHostEncodingLayoutResolverAttrInterface,
-            GPUHostSerializableAttr>(*ctx);
-        IREE::GPU::GPUPadLayoutAttr::attachInterface<
-            GPUPadDeviceEncodingLayoutMaterializerAttr,
-            GPUPadEncodingLayoutResolverAttrInterface>(*ctx);
-      });
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::GPU::IREEGPUDialect *dialect) {
+    IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
+        GPUDeviceEncodingPackedLayoutAttr,
+        GPUDeviceEncodingLayoutMaterializerAttr, GPUHostLayoutResolverAttr,
+        GPUHostSerializableAttr>(*ctx);
+    IREE::GPU::GPUPadLayoutAttr::attachInterface<
+        GPUPadDeviceEncodingLayoutMaterializerAttr, GPUPadLayoutResolverAttr>(
+        *ctx);
+  });
 }
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -10,7 +10,7 @@
 // - IREE::Encoding::LayoutResolverAttr
 // - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
-// - IREE::Codegen::PackedLayoutAttr
+// - IREE::Codegen::PackedLayoutMaterializerAttr
 //
 // Different from CPU backends, we do not transpose narrow-N to narrow-M for a
 // combination of reasons:
@@ -307,9 +307,9 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   return mmaOp;
 }
 
-struct GPUEncodingPackedLayoutAttr
-    : public PackedLayoutAttrExternalModelBase<GPUEncodingPackedLayoutAttr,
-                                               GPUEncodingLayoutAttr> {
+struct GPUEncodingPackedLayoutMaterializerAttr
+    : public PackedLayoutMaterializerAttrExternalModelBase<
+          GPUEncodingPackedLayoutMaterializerAttr, GPUEncodingLayoutAttr> {
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<GPUEncodingLayoutAttr>(attr).getConfiguration();
   }
@@ -534,8 +534,9 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx,
                             IREE::GPU::IREEGPUDialect *dialect) {
     IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
-        GPUEncodingPackedLayoutAttr, GPUEncodingLayoutMaterializerAttr,
-        GPULayoutResolverAttr, GPUSerializableAttr>(*ctx);
+        GPUEncodingPackedLayoutMaterializerAttr,
+        GPUEncodingLayoutMaterializerAttr, GPULayoutResolverAttr,
+        GPUSerializableAttr>(*ctx);
     IREE::GPU::GPUPadLayoutAttr::attachInterface<
         GPUPadEncodingLayoutMaterializerAttr, GPUPadLayoutResolverAttr>(*ctx);
   });

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -307,9 +307,9 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   return mmaOp;
 }
 
-struct GPUDeviceEncodingPackedLayoutAttr
-    : public DevicePackedLayoutAttrExternalModelBase<
-          GPUDeviceEncodingPackedLayoutAttr, GPUEncodingLayoutAttr> {
+struct GPUEncodingPackedLayoutAttr
+    : public PackedLayoutAttrExternalModelBase<GPUEncodingPackedLayoutAttr,
+                                               GPUEncodingLayoutAttr> {
   DictionaryAttr getConfiguration(Attribute attr) const {
     return cast<GPUEncodingLayoutAttr>(attr).getConfiguration();
   }
@@ -359,9 +359,9 @@ struct GPUDeviceEncodingPackedLayoutAttr
   }
 };
 
-struct GPUDeviceEncodingLayoutMaterializerAttr
-    : public DeviceEncodingLayoutMaterializerAttrExternalModelBase<
-          GPUDeviceEncodingLayoutMaterializerAttr, GPUEncodingLayoutAttr> {
+struct GPUEncodingLayoutMaterializerAttr
+    : public EncodingLayoutMaterializerAttrExternalModelBase<
+          GPUEncodingLayoutMaterializerAttr, GPUEncodingLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
@@ -380,8 +380,8 @@ struct GPUDeviceEncodingLayoutMaterializerAttr
   }
 };
 
-struct GPUHostSerializableAttr final
-    : IREE::Encoding::SerializableAttr::ExternalModel<GPUHostSerializableAttr,
+struct GPUSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<GPUSerializableAttr,
                                                       GPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
@@ -392,9 +392,9 @@ struct GPUHostSerializableAttr final
   }
 };
 
-struct GPUHostLayoutResolverAttr final
-    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
-          GPUHostLayoutResolverAttr, GPUEncodingLayoutAttr> {
+struct GPULayoutResolverAttr final
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<GPULayoutResolverAttr,
+                                                        GPUEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -416,9 +416,9 @@ struct GPUHostLayoutResolverAttr final
   }
 };
 
-struct GPUPadDeviceEncodingLayoutMaterializerAttr final
+struct GPUPadEncodingLayoutMaterializerAttr final
     : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
-          GPUPadDeviceEncodingLayoutMaterializerAttr, GPUPadLayoutAttr> {
+          GPUPadEncodingLayoutMaterializerAttr, GPUPadLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
@@ -534,12 +534,10 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx,
                             IREE::GPU::IREEGPUDialect *dialect) {
     IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
-        GPUDeviceEncodingPackedLayoutAttr,
-        GPUDeviceEncodingLayoutMaterializerAttr, GPUHostLayoutResolverAttr,
-        GPUHostSerializableAttr>(*ctx);
+        GPUEncodingPackedLayoutAttr, GPUEncodingLayoutMaterializerAttr,
+        GPULayoutResolverAttr, GPUSerializableAttr>(*ctx);
     IREE::GPU::GPUPadLayoutAttr::attachInterface<
-        GPUPadDeviceEncodingLayoutMaterializerAttr, GPUPadLayoutResolverAttr>(
-        *ctx);
+        GPUPadEncodingLayoutMaterializerAttr, GPUPadLayoutResolverAttr>(*ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -8,7 +8,7 @@
 // This file implements the following interfaces for GPU backends:
 //
 // - IREE::Encoding::EncodingLayoutResolverAttrInterface
-// - IREE::Encoding::SerializableEncodingAttrInterface
+// - IREE::Encoding::SerializableAttr
 // - IREE::Encoding::LayoutMaterializerAttr
 // - IREE::Encoding::PackedLayoutAttr
 //
@@ -380,9 +380,9 @@ struct GPUDeviceEncodingLayoutMaterializerAttr
   }
 };
 
-struct GPUHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
-          GPUHostSerializableEncodingAttrInterface, GPUEncodingLayoutAttr> {
+struct GPUHostSerializableAttr final
+    : IREE::Encoding::SerializableAttr::ExternalModel<GPUHostSerializableAttr,
+                                                      GPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
@@ -537,7 +537,7 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
             GPUDeviceEncodingPackedLayoutAttr,
             GPUDeviceEncodingLayoutMaterializerAttr,
             GPUHostEncodingLayoutResolverAttrInterface,
-            GPUHostSerializableEncodingAttrInterface>(*ctx);
+            GPUHostSerializableAttr>(*ctx);
         IREE::GPU::GPUPadLayoutAttr::attachInterface<
             GPUPadDeviceEncodingLayoutMaterializerAttr,
             GPUPadEncodingLayoutResolverAttrInterface>(*ctx);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -25,7 +25,7 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
                                             OpBuilder &builder,
                                             RankedTensorType type,
                                             ValueRange dynamicDims) {
-  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttrInterface>(attr);
+  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttr>(attr);
   MaterializeEncodingInfo encodingInfo = deviceLayoutAttr.getEncodingInfo(type);
   SmallVector<int64_t> paddedShape(type.getShape());
   SmallVector<Value> paddedDynamicDims(dynamicDims.begin(), dynamicDims.end());
@@ -96,7 +96,7 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
 DictionaryAttr getPackedLayoutImpl(Attribute attr, RankedTensorType type,
                                    bool addEncodingAttr) {
   MLIRContext *ctx = attr.getContext();
-  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttrInterface>(attr);
+  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttr>(attr);
   const MaterializeEncodingInfo info = deviceLayoutAttr.getEncodingInfo(type);
   Attribute encodingInfoAttr =
       IREE::Codegen::serializeEncodingInfo(attr.getContext(), info);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -25,7 +25,8 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
                                             OpBuilder &builder,
                                             RankedTensorType type,
                                             ValueRange dynamicDims) {
-  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttr>(attr);
+  auto deviceLayoutAttr =
+      cast<IREE::Codegen::PackedLayoutMaterializerAttr>(attr);
   MaterializeEncodingInfo encodingInfo = deviceLayoutAttr.getEncodingInfo(type);
   SmallVector<int64_t> paddedShape(type.getShape());
   SmallVector<Value> paddedDynamicDims(dynamicDims.begin(), dynamicDims.end());
@@ -96,7 +97,8 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
 DictionaryAttr getPackedLayoutImpl(Attribute attr, RankedTensorType type,
                                    bool addEncodingAttr) {
   MLIRContext *ctx = attr.getContext();
-  auto deviceLayoutAttr = cast<IREE::Codegen::PackedLayoutAttr>(attr);
+  auto deviceLayoutAttr =
+      cast<IREE::Codegen::PackedLayoutMaterializerAttr>(attr);
   const MaterializeEncodingInfo info = deviceLayoutAttr.getEncodingInfo(type);
   Attribute encodingInfoAttr =
       IREE::Codegen::serializeEncodingInfo(attr.getContext(), info);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -27,15 +27,16 @@ static const char kEncodingInfoAttrName[] = "encoding_info";
 // reduce the duplicated implementations before. To inherit it, it requires the
 // derived class to implement the `getConfiguration` method and the
 // `getEncodingInfoImpl` method.
-template <typename EncodingPackedLayoutAttr, typename EncodingLayoutAttr>
-struct PackedLayoutAttrExternalModelBase
-    : public IREE::Codegen::PackedLayoutAttr::ExternalModel<
-          EncodingPackedLayoutAttr, EncodingLayoutAttr> {
+template <typename EncodingPackedLayoutMaterializerAttr,
+          typename EncodingLayoutAttr>
+struct PackedLayoutMaterializerAttrExternalModelBase
+    : public IREE::Codegen::PackedLayoutMaterializerAttr::ExternalModel<
+          EncodingPackedLayoutMaterializerAttr, EncodingLayoutAttr> {
 public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(Attribute attr, RankedTensorType type) const {
-    const EncodingPackedLayoutAttr *impl =
-        static_cast<const EncodingPackedLayoutAttr *>(this);
+    const EncodingPackedLayoutMaterializerAttr *impl =
+        static_cast<const EncodingPackedLayoutMaterializerAttr *>(this);
     // If the layout is already resolved, use it directly.
     if (auto config = impl->getConfiguration(attr)) {
       if (auto namedAttr = config.getNamed(kEncodingInfoAttrName)) {
@@ -140,7 +141,7 @@ public:
 
 /// Calculates the storage size in bytes for the given `type` with a packed
 /// layout encoding `attr`. Requirement: `attr` must implement
-/// IREE::Codegen::PackedLayoutAttr.
+/// IREE::Codegen::PackedLayoutMaterializerAttr.
 Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
                                             OpBuilder &builder,
                                             RankedTensorType type,
@@ -154,7 +155,8 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
 /// `addEncodingAttr` is mainly for VMVX ukernel path because the ukernel ops
 /// lowering requires all the information. There are no direct mappings from
 /// layouts to ukernels.
-/// Requirement: `attr` must implement IREE::Codegen::PackedLayoutAttr.
+/// Requirement: `attr` must implement
+/// IREE::Codegen::PackedLayoutMaterializerAttr.
 DictionaryAttr getPackedLayoutImpl(Attribute attr, RankedTensorType type,
                                    bool addEncodingAttr = false);
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -27,15 +27,15 @@ static const char kEncodingInfoAttrName[] = "encoding_info";
 // reduce the duplicated implementations before. To inherit it, it requires the
 // derived class to implement the `getConfiguration` method and the
 // `getEncodingInfoImpl` method.
-template <typename DeviceEncodingPackedLayoutAttr, typename EncodingLayoutAttr>
-struct DevicePackedLayoutAttrExternalModelBase
+template <typename EncodingPackedLayoutAttr, typename EncodingLayoutAttr>
+struct PackedLayoutAttrExternalModelBase
     : public IREE::Codegen::PackedLayoutAttr::ExternalModel<
-          DeviceEncodingPackedLayoutAttr, EncodingLayoutAttr> {
+          EncodingPackedLayoutAttr, EncodingLayoutAttr> {
 public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(Attribute attr, RankedTensorType type) const {
-    const DeviceEncodingPackedLayoutAttr *impl =
-        static_cast<const DeviceEncodingPackedLayoutAttr *>(this);
+    const EncodingPackedLayoutAttr *impl =
+        static_cast<const EncodingPackedLayoutAttr *>(this);
     // If the layout is already resolved, use it directly.
     if (auto config = impl->getConfiguration(attr)) {
       if (auto namedAttr = config.getNamed(kEncodingInfoAttrName)) {
@@ -50,11 +50,10 @@ public:
   }
 };
 
-template <typename DeviceEncodingLayoutMaterializerAttr,
-          typename EncodingLayoutAttr>
-struct DeviceEncodingLayoutMaterializerAttrExternalModelBase
+template <typename EncodingLayoutMaterializerAttr, typename EncodingLayoutAttr>
+struct EncodingLayoutMaterializerAttrExternalModelBase
     : public IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
-          DeviceEncodingLayoutMaterializerAttr, EncodingLayoutAttr> {
+          EncodingLayoutMaterializerAttr, EncodingLayoutAttr> {
 public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(EncodingLayoutAttr layoutAttr, RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -50,16 +50,16 @@ public:
   }
 };
 
-template <typename DeviceEncodingLayoutAttrInterface,
+template <typename DeviceEncodingLayoutMaterializerAttr,
           typename EncodingLayoutAttr>
-struct DeviceEncodingLayoutAttrInterfaceExternalModelBase
-    : public IREE::Encoding::LayoutAttrInterface::ExternalModel<
-          DeviceEncodingLayoutAttrInterface, EncodingLayoutAttr> {
+struct DeviceEncodingLayoutMaterializerAttrExternalModelBase
+    : public IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
+          DeviceEncodingLayoutMaterializerAttr, EncodingLayoutAttr> {
 public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(EncodingLayoutAttr layoutAttr, RankedTensorType type) const {
     return getEncodingInfoFromLayout(
-        type, cast<IREE::Encoding::LayoutAttrInterface>(layoutAttr));
+        type, cast<IREE::Encoding::LayoutMaterializerAttr>(layoutAttr));
   }
 
   Type convertType(Attribute attr, Type type) const {
@@ -116,7 +116,7 @@ public:
       ArrayRef<OpFoldResult> strides, SmallVectorImpl<OpFoldResult> &newOffsets,
       SmallVectorImpl<OpFoldResult> &newSizes,
       SmallVectorImpl<OpFoldResult> &newStrides) const {
-    auto layoutAttr = cast<IREE::Encoding::LayoutAttrInterface>(attr);
+    auto layoutAttr = cast<IREE::Encoding::LayoutMaterializerAttr>(attr);
     // Only handle cases where the slice spans the whole
     // `!iree_tensor_ext.dispatch.tensor` type.
     // TODO(jornt): Enable partial slices.

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -27,16 +27,15 @@ static const char kEncodingInfoAttrName[] = "encoding_info";
 // reduce the duplicated implementations before. To inherit it, it requires the
 // derived class to implement the `getConfiguration` method and the
 // `getEncodingInfoImpl` method.
-template <typename DeviceEncodingPackedLayoutAttrInterface,
-          typename EncodingLayoutAttr>
+template <typename DeviceEncodingPackedLayoutAttr, typename EncodingLayoutAttr>
 struct DevicePackedLayoutAttrExternalModelBase
-    : public IREE::Codegen::PackedLayoutAttrInterface::ExternalModel<
-          DeviceEncodingPackedLayoutAttrInterface, EncodingLayoutAttr> {
+    : public IREE::Codegen::PackedLayoutAttr::ExternalModel<
+          DeviceEncodingPackedLayoutAttr, EncodingLayoutAttr> {
 public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(Attribute attr, RankedTensorType type) const {
-    const DeviceEncodingPackedLayoutAttrInterface *impl =
-        static_cast<const DeviceEncodingPackedLayoutAttrInterface *>(this);
+    const DeviceEncodingPackedLayoutAttr *impl =
+        static_cast<const DeviceEncodingPackedLayoutAttr *>(this);
     // If the layout is already resolved, use it directly.
     if (auto config = impl->getConfiguration(attr)) {
       if (auto namedAttr = config.getNamed(kEncodingInfoAttrName)) {
@@ -142,7 +141,7 @@ public:
 
 /// Calculates the storage size in bytes for the given `type` with a packed
 /// layout encoding `attr`. Requirement: `attr` must implement
-/// IREE::Codegen::PackedLayoutAttrInterface.
+/// IREE::Codegen::PackedLayoutAttr.
 Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
                                             OpBuilder &builder,
                                             RankedTensorType type,
@@ -156,7 +155,7 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
 /// `addEncodingAttr` is mainly for VMVX ukernel path because the ukernel ops
 /// lowering requires all the information. There are no direct mappings from
 /// layouts to ukernels.
-/// Requirement: `attr` must implement IREE::Codegen::PackedLayoutAttrInterface.
+/// Requirement: `attr` must implement IREE::Codegen::PackedLayoutAttr.
 DictionaryAttr getPackedLayoutImpl(Attribute attr, RankedTensorType type,
                                    bool addEncodingAttr = false);
 

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -24,8 +24,7 @@ getEncodingInfoFromType(RankedTensorType type) {
   }
   ArrayRef<Attribute> layouts = layoutAttr.getLayouts().getValue();
   assert(layouts.size() == 1 && "only single layout is supported");
-  if (auto layout =
-          dyn_cast<IREE::Codegen::PackedLayoutAttrInterface>(layouts[0])) {
+  if (auto layout = dyn_cast<IREE::Codegen::PackedLayoutAttr>(layouts[0])) {
     return layout.getEncodingInfo(type);
   }
   return std::nullopt;
@@ -41,7 +40,7 @@ getEncodingInfoFromLayout(RankedTensorType type,
     return maybeEncodingInfo.value();
   }
   if (auto packedLayoutAttr =
-          dyn_cast<IREE::Codegen::PackedLayoutAttrInterface>(layoutAttr)) {
+          dyn_cast<IREE::Codegen::PackedLayoutAttr>(layoutAttr)) {
     return packedLayoutAttr.getEncodingInfo(type);
   }
   return IREE::Codegen::MaterializeEncodingInfo{};

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -24,7 +24,8 @@ getEncodingInfoFromType(RankedTensorType type) {
   }
   ArrayRef<Attribute> layouts = layoutAttr.getLayouts().getValue();
   assert(layouts.size() == 1 && "only single layout is supported");
-  if (auto layout = dyn_cast<IREE::Codegen::PackedLayoutAttr>(layouts[0])) {
+  if (auto layout =
+          dyn_cast<IREE::Codegen::PackedLayoutMaterializerAttr>(layouts[0])) {
     return layout.getEncodingInfo(type);
   }
   return std::nullopt;
@@ -40,7 +41,7 @@ getEncodingInfoFromLayout(RankedTensorType type,
     return maybeEncodingInfo.value();
   }
   if (auto packedLayoutAttr =
-          dyn_cast<IREE::Codegen::PackedLayoutAttr>(layoutAttr)) {
+          dyn_cast<IREE::Codegen::PackedLayoutMaterializerAttr>(layoutAttr)) {
     return packedLayoutAttr.getEncodingInfo(type);
   }
   return IREE::Codegen::MaterializeEncodingInfo{};

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -32,7 +32,7 @@ getEncodingInfoFromType(RankedTensorType type) {
 
 IREE::Codegen::MaterializeEncodingInfo
 getEncodingInfoFromLayout(RankedTensorType type,
-                          IREE::Encoding::LayoutAttrInterface layoutAttr) {
+                          IREE::Encoding::LayoutMaterializerAttr layoutAttr) {
   // If the layout is present in the encoding, use it directly. It means that
   // the layout is already resolved and some information could be dropped during
   // the lowering. Thus, we prioritize the resolved layout.
@@ -48,7 +48,7 @@ getEncodingInfoFromLayout(RankedTensorType type,
 
 FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
     OpBuilder &rewriter, Location loc, RankedTensorType tensorType,
-    IREE::Encoding::LayoutAttrInterface layoutAttr,
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr,
     const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo) {
   ArrayRef<int64_t> staticTileSizes = materializeEncodingInfo.innerTileSizes;
   if (!ShapedType::isDynamicShape(staticTileSizes)) {
@@ -83,7 +83,7 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
 FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensorImpl(
     OpBuilder &builder, Location loc,
     IREE::TensorExt::DispatchTensorType dispatchTensorType,
-    ValueRange dynamicDims, IREE::Encoding::LayoutAttrInterface layoutAttr,
+    ValueRange dynamicDims, IREE::Encoding::LayoutMaterializerAttr layoutAttr,
     IREE::Codegen::MaterializeEncodingInfo encodingInfo) {
   auto boundTensorType =
       llvm::dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.h
@@ -22,12 +22,12 @@ namespace mlir::iree_compiler {
 /// otherwise.
 IREE::Codegen::MaterializeEncodingInfo
 getEncodingInfoFromLayout(RankedTensorType type,
-                          IREE::Encoding::LayoutAttrInterface layoutAttr);
+                          IREE::Encoding::LayoutMaterializerAttr layoutAttr);
 
 /// Returns the inner tile sizes to be used for the given tensor type.
 FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
     OpBuilder &rewriter, Location loc, RankedTensorType tensorType,
-    IREE::Encoding::LayoutAttrInterface layoutAttr,
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr,
     const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo);
 
 /// Returns the materialized packed and swizzled shape for a
@@ -37,7 +37,7 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
 FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensorImpl(
     OpBuilder &builder, Location loc,
     IREE::TensorExt::DispatchTensorType dispatchTensorType,
-    ValueRange dynamicDims, IREE::Encoding::LayoutAttrInterface layoutAttr,
+    ValueRange dynamicDims, IREE::Encoding::LayoutMaterializerAttr layoutAttr,
     IREE::Codegen::MaterializeEncodingInfo encodingInfo);
 
 /// Applies an returns a tile-swizzling permutation to a packed shape.

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -58,10 +58,9 @@ LayoutAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
   if (layouts.empty()) {
     return emitError() << "expected non-empty layouts";
   }
-  if (!llvm::all_of(layouts,
-                    llvm::IsaPred<SerializableEncodingAttrInterface>)) {
+  if (!llvm::all_of(layouts, llvm::IsaPred<SerializableAttr>)) {
     return emitError() << "expected all the layout attributes to implement "
-                          "SerializableEncodingAttrInterface";
+                          "SerializableAttr";
   }
   return success();
 }
@@ -69,7 +68,7 @@ LayoutAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
 bool LayoutAttr::isSerialized() const { return true; }
 
 bool LayoutAttr::isIdentityLayout() const {
-  auto layouts = getLayouts().getAsRange<SerializableEncodingAttrInterface>();
+  auto layouts = getLayouts().getAsRange<SerializableAttr>();
   return llvm::all_of(layouts,
                       [](auto attr) { return attr.isIdentityLayout(); });
 }
@@ -79,8 +78,7 @@ Value LayoutAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
                                               ValueRange dynamicDims) const {
   ArrayAttr layoutsAttr = getLayouts();
   Value res;
-  for (auto attr :
-       layoutsAttr.getAsRange<SerializableEncodingAttrInterface>()) {
+  for (auto attr : layoutsAttr.getAsRange<SerializableAttr>()) {
     Value requestedSize =
         attr.calculateStorageSizeInBytes(loc, builder, type, dynamicDims);
     if (!res) {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -274,7 +274,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
       backend, usually for better cache behavior.
     Negative values for padding is illegal.
 
-    This attribute implements `Encoding::SerializedEncodingLayoutResolverAttrInterface`,
+    This attribute implements `Encoding::SerializedLayoutResolverAttr`,
     to provide a hook for tensor sizeof lowering. The implementation of this
     interface is backend-agnostic, but the emission of the pad encoding attribute
     itself can be target- or domain-specific.
@@ -303,7 +303,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
 
 def IdentityEncodingAttr :
     IREEEncoding_Attr<"IdentityEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_LayoutResolverAttr, [
         "cloneWithSimplifiedConfig",
         "getLayout",
       ]>
@@ -324,7 +324,7 @@ def IdentityEncodingAttr :
 
 def UnsupportedEncodingAttr :
     IREEEncoding_Attr<"UnsupportedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_LayoutResolverAttr, [
         "cloneWithSimplifiedConfig",
         "getLayout",
       ]>
@@ -381,7 +381,7 @@ def UnknownEncodingAttr : IREEEncoding_Attr<"UnknownEncoding"> {
 
 def UnspecializedEncodingAttr :
     IREEEncoding_Attr<"UnspecializedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_LayoutResolverAttr, [
         "cloneWithSimplifiedConfig",
         "getLayout",
       ]>
@@ -393,7 +393,7 @@ def UnspecializedEncodingAttr :
 
   let description = [{
     This attribute indicates this is an unspecialized encoding. It implements
-    very basic interface methods of EncodingLayoutResolverAttrInterface that
+    very basic interface methods of LayoutResolverAttr that
     returns the SpecializedEncodingAttr with the same seed as serialized layout
     in encoding specialization. Different seed values indicate different layouts.
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -47,7 +47,7 @@ def EncodingOpTypeAttr:
 
 def LayoutAttr :
     IREEEncoding_Attr<"Layout", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "isIdentityLayout",
         "calculateStorageSizeInBytes",
@@ -62,7 +62,7 @@ def LayoutAttr :
     array because a device could have multiple target layouts.
 
     It has a verifier that will ensure that all the attributes in layouts
-    implement SerializableEncodingAttrInterface.
+    implement SerializableAttr.
   }];
 
   let parameters = (ins
@@ -99,7 +99,7 @@ def PackedStorageAttr : IREEEncoding_Attr<"PackedStorage"> {
 
 def EncodingAttr :
     IREEEncoding_Attr<"Encoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "cloneWithLayouts",
       ]>,
@@ -189,7 +189,7 @@ def EncodingAttr :
 //===---------------------------------------------------------------------===//
 
 def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "cloneWithLayouts",
       ]>,
@@ -250,7 +250,7 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
 //===---------------------------------------------------------------------===//
 
 def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "calculateStorageSizeInBytes",
         "cloneWithLayouts",
         "isIdentityLayout",
@@ -346,7 +346,7 @@ def UnsupportedEncodingAttr :
 
 def TestingEncodingAttr :
     IREEEncoding_Attr<"TestingEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "cloneWithLayouts",
       ]>
@@ -406,7 +406,7 @@ def UnspecializedEncodingAttr :
 
 def SpecializedEncodingAttr :
     IREEEncoding_Attr<"SpecializedEncoding", [
-      IREEEncoding_SerializableEncodingAttrInterface
+      IREEEncoding_SerializableAttr
     ]> {
   let mnemonic = "specialized_encoding";
   let assemblyFormat = "`<` $seed (`,` $type^)? `>`";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -14,8 +14,8 @@ include "mlir/IR/BuiltinAttributeInterfaces.td"
 // Attribute Interfaces
 //===----------------------------------------------------------------------===//
 
-def IREEEncoding_EncodingLayoutResolverAttrInterface :
-  AttrInterface<"EncodingLayoutResolverAttrInterface"> {
+def IREEEncoding_LayoutResolverAttr :
+  AttrInterface<"LayoutResolverAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
     Interface used to query layout information needed to materialize encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -207,8 +207,8 @@ def IREEEncoding_SerializableEncodingAttrInterface :
   }];
 }
 
-def IREEEncoding_LayoutAttrInterface :
-  AttrInterface<"LayoutAttrInterface"> {
+def IREEEncoding_LayoutMaterializerAttr :
+  AttrInterface<"LayoutMaterializerAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
     An interface that collects a set of methods for encoding materialization.

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -55,7 +55,7 @@ def IREEEncoding_EncodingLayoutResolverAttrInterface :
       /*desc=*/[{
         Returns the an attribute implementing the  which is either common format
         or wrapped by an attribute that implements the
-        `SerializableEncodingAttrInterface` interface.
+        `SerializableAttr` interface.
         If it is in common format (e.g., a regular tensor type), we can easily
         calculate the storage size. Otherwise, we will need a hook from
         external, and the hook can come from an attribute that implements the
@@ -76,8 +76,8 @@ def IREEEncoding_EncodingLayoutResolverAttrInterface :
   ];
 }
 
-def IREEEncoding_SerializableEncodingAttrInterface :
-  AttrInterface<"SerializableEncodingAttrInterface"> {
+def IREEEncoding_SerializableAttr :
+  AttrInterface<"SerializableAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
     Interface for encoding attributes that can be attached on a tensor type. An
@@ -161,12 +161,12 @@ def IREEEncoding_SerializableEncodingAttrInterface :
       /*retTy=*/"bool",
       /*methodName=*/"isCompatibleWith",
       /*args=*/(ins
-        "IREE::Encoding::SerializableEncodingAttrInterface":$other
+        "IREE::Encoding::SerializableAttr":$other
       ),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         auto attr =
-          llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>($_attr);
+          llvm::dyn_cast_or_null<SerializableAttr>($_attr);
         if (!attr) {
           return false;
         }
@@ -201,7 +201,7 @@ def IREEEncoding_SerializableEncodingAttrInterface :
 
   let extraClassDeclaration = [{
     /// Returns true if they are the same attribute. Otherwise, returns true if
-    /// both attributes implement SerializableEncodingAttrInterface interface
+    /// both attributes implement SerializableAttr interface
     /// and they are compatible with each other.
     static bool areCompatible(Attribute lhs, Attribute rhs);
   }];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -30,8 +30,7 @@ LogicalResult SetEncodingOp::verify() {
     return emitOpError(
         "source of set_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<SerializableEncodingAttrInterface>(
-          getResultType().getEncoding())) {
+  if (!isa_and_nonnull<SerializableAttr>(getResultType().getEncoding())) {
     return emitOpError(
         "result of set_encoding op expected to have a valid tensor encoding");
   }
@@ -64,8 +63,7 @@ LogicalResult UnsetEncodingOp::verify() {
     return emitOpError(
         "result of unset_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<SerializableEncodingAttrInterface>(
-          getSourceType().getEncoding())) {
+  if (!isa_and_nonnull<SerializableAttr>(getSourceType().getEncoding())) {
     return emitOpError(
         "source of unset_encoding op expected to have a valid tensor encoding");
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -29,9 +29,8 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
   let summary = [{Perform pack and pad operation on source.}];
   let description = [{
     Operation to assign an encoding to a tensor. The operation does not change
-    the rank or extent of a tensor. Instead it adds an
-    LayoutResolverAttr attribute to the tensor type to
-    represent a change in layout.
+    the rank or extent of a tensor. Instead it adds an LayoutResolverAttr
+    attribute to the tensor type to represent a change in layout.
   }];
 
   let arguments = (ins AnyRankedTensor:$source);
@@ -62,8 +61,8 @@ def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
   ]> {
   let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
-    Operation to convert an tensor with LayoutResolverAttr
-    encoding that represents its data layout into a tensor with default layout
+    Operation to convert an tensor with LayoutResolverAttr encoding that
+    represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
   }];
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -29,7 +29,7 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
   let summary = [{Perform pack and pad operation on source.}];
   let description = [{
     Operation to assign an encoding to a tensor. The operation does not change
-    the rank or extent of a tensor. Instead it adds an LayoutResolverAttr
+    the rank or extent of a tensor. Instead it adds a LayoutResolverAttr
     attribute to the tensor type to represent a change in layout.
   }];
 
@@ -61,7 +61,7 @@ def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
   ]> {
   let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
-    Operation to convert an tensor with LayoutResolverAttr encoding that
+    Operation to convert a tensor with LayoutResolverAttr encoding that
     represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
   }];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -30,7 +30,7 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
   let description = [{
     Operation to assign an encoding to a tensor. The operation does not change
     the rank or extent of a tensor. Instead it adds an
-    EncodingLayoutResolverAttrInterface attribute to the tensor type to
+    LayoutResolverAttr attribute to the tensor type to
     represent a change in layout.
   }];
 
@@ -62,7 +62,7 @@ def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
   ]> {
   let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
-    Operation to convert an tensor with EncodingLayoutResolverAttrInterface
+    Operation to convert an tensor with LayoutResolverAttr
     encoding that represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
   }];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -17,15 +17,12 @@
 namespace mlir::iree_compiler::IREE::Encoding {
 
 // static
-bool SerializableEncodingAttrInterface::areCompatible(Attribute lhs,
-                                                      Attribute rhs) {
+bool SerializableAttr::areCompatible(Attribute lhs, Attribute rhs) {
   if (lhs == rhs) {
     return true;
   }
-  auto lhsEncoding =
-      llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>(lhs);
-  auto rhsEncoding =
-      llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>(rhs);
+  auto lhsEncoding = llvm::dyn_cast_or_null<SerializableAttr>(lhs);
+  auto rhsEncoding = llvm::dyn_cast_or_null<SerializableAttr>(rhs);
   if (!lhsEncoding || !rhsEncoding) {
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -180,7 +180,7 @@ func.func @illegal_layout_encoding_without_any_layout(%arg0: tensor<?x?xf32, #en
 
 // -----
 
-// expected-error @+1 {{expected all the layout attributes to implement SerializableEncodingAttrInterface}}
+// expected-error @+1 {{expected all the layout attributes to implement SerializableAttr}}
 #encoding = #iree_encoding.layout<[#iree_encoding.unknown_encoding]>
 func.func @illegal_layout_encoding_with_invalid_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
@@ -33,11 +33,11 @@ TEST_F(EncodingAttrsTest, EncodingAttr) {
   MLIRContext *ctx = getContext();
   Builder builder(ctx);
   SmallVector<Type> elemTypes(3, builder.getF32Type());
-  auto attr = cast<SerializableEncodingAttrInterface>(EncodingAttr::get(
+  auto attr = cast<SerializableAttr>(EncodingAttr::get(
       ctx, /*operandIndex=*/0, EncodingOpType::matmul, elemTypes));
   EXPECT_FALSE(attr.isIdentityLayout());
 
-  attr = cast<SerializableEncodingAttrInterface>(attr.cloneWithLayouts(
+  attr = cast<SerializableAttr>(attr.cloneWithLayouts(
       PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
@@ -45,11 +45,10 @@ TEST_F(EncodingAttrsTest, EncodingAttr) {
 TEST_F(EncodingAttrsTest, MatulKAttr) {
   MLIRContext *ctx = getContext();
   Builder builder(ctx);
-  auto attr = cast<SerializableEncodingAttrInterface>(
-      MatmulKAttr::get(ctx, /*k_dims=*/{1}));
+  auto attr = cast<SerializableAttr>(MatmulKAttr::get(ctx, /*k_dims=*/{1}));
   EXPECT_FALSE(attr.isIdentityLayout());
 
-  attr = cast<SerializableEncodingAttrInterface>(attr.cloneWithLayouts(
+  attr = cast<SerializableAttr>(attr.cloneWithLayouts(
       PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
@@ -58,13 +57,11 @@ TEST_F(EncodingAttrsTest, PadEncodingLayoutAttr) {
   MLIRContext *ctx = getContext();
   auto zeroPaddingAttr =
       PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2);
-  EXPECT_TRUE(cast<SerializableEncodingAttrInterface>(zeroPaddingAttr)
-                  .isIdentityLayout());
+  EXPECT_TRUE(cast<SerializableAttr>(zeroPaddingAttr).isIdentityLayout());
 
   SmallVector<int64_t> paddings = {4, 2};
   auto nonZeroPaddingAttr = PadEncodingLayoutAttr::get(ctx, paddings);
-  EXPECT_FALSE(cast<SerializableEncodingAttrInterface>(nonZeroPaddingAttr)
-                   .isIdentityLayout());
+  EXPECT_FALSE(cast<SerializableAttr>(nonZeroPaddingAttr).isIdentityLayout());
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
@@ -14,10 +14,8 @@
 
 namespace mlir::iree_compiler::IREE::Encoding {
 
-SerializableEncodingAttrInterface
-getSerializableEncodingAttrInterface(RankedTensorType type) {
-  return dyn_cast_or_null<SerializableEncodingAttrInterface>(
-      type.getEncoding());
+SerializableAttr getSerializableAttr(RankedTensorType type) {
+  return dyn_cast_or_null<SerializableAttr>(type.getEncoding());
 }
 
 EncodingAttr getEncodingAttr(RankedTensorType type) {

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -14,9 +14,8 @@
 namespace mlir::iree_compiler::IREE::Encoding {
 
 /// Returns the encoding attribute from the type if there is an encoding that
-/// implements SerializableEncodingAttrInterface. Otherwise, returns null.
-SerializableEncodingAttrInterface
-getSerializableEncodingAttrInterface(RankedTensorType type);
+/// implements SerializableAttr. Otherwise, returns null.
+SerializableAttr getSerializableAttr(RankedTensorType type);
 
 /// Returns the encoding attribute from the type if there is an encoding.
 /// Otherwise, returns null.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -124,11 +124,11 @@ class HALAffinityAnalysisDialectInterface
 public:
   using AffinityAnalysisDialectInterface::AffinityAnalysisDialectInterface;
 
-  // Returns a function that gathers the corresponding
-  // LayoutResolverAttr attributes for each
-  // (IREE::Stream::Affinity, Operation) query. The attribute is extracted from
-  // the `encoding` field in the HAL::ExecutableTargetAttr configuration. If the
-  // `encoding` is not present, IdentityEncodingAttr is returned.
+  // Returns a function that gathers the corresponding LayoutResolverAttr
+  // attributes for each (IREE::Stream::Affinity, Operation) query. The
+  // attribute is extracted from the `encoding` field in the
+  // HAL::ExecutableTargetAttr configuration. If the `encoding` is not present,
+  // IdentityEncodingAttr is returned.
   IREE::Stream::ResolveLayoutAttrFn
   makeLayoutAttrResolver(ModuleOp moduleOp) const {
     return [=](ArrayRef<IREE::Stream::AffinityAndOpPair> batchQueries,

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -125,7 +125,7 @@ public:
   using AffinityAnalysisDialectInterface::AffinityAnalysisDialectInterface;
 
   // Returns a function that gathers the corresponding
-  // EncodingLayoutResolverAttrInterface attributes for each
+  // LayoutResolverAttr attributes for each
   // (IREE::Stream::Affinity, Operation) query. The attribute is extracted from
   // the `encoding` field in the HAL::ExecutableTargetAttr configuration. If the
   // `encoding` is not present, IdentityEncodingAttr is returned.
@@ -163,7 +163,7 @@ public:
           }
           auto encodingLayoutAttr =
               targetAttr.getConfiguration()
-                  .getAs<IREE::Encoding::EncodingLayoutResolverAttrInterface>(
+                  .getAs<IREE::Encoding::LayoutResolverAttr>(
                       IREE::Encoding::kEncodingResolverAttrName);
           if (!encodingLayoutAttr) {
             layoutAttrs[key].insert(getDefaultAttr());

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -1471,8 +1471,8 @@ OpFoldResult TensorEncodeOp::fold(FoldAdaptor adaptor) {
     if (!type.getEncoding()) {
       return true;
     }
-    IREE::Encoding::SerializableEncodingAttrInterface attr =
-        IREE::Encoding::getSerializableEncodingAttrInterface(type);
+    IREE::Encoding::SerializableAttr attr =
+        IREE::Encoding::getSerializableAttr(type);
     if (!attr) {
       return false;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1954,7 +1954,7 @@ LogicalResult TensorCloneOp::verify() {
   // information.
   auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
   auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
-  if (!IREE::Encoding::SerializableEncodingAttrInterface::areCompatible(
+  if (!IREE::Encoding::SerializableAttr::areCompatible(
           sourceEncoding.getEncoding(), resultEncoding.getEncoding())) {
     return op.emitOpError() << "clones changing tensor encoding from "
                             << sourceEncoding.getEncoding() << " to "

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -52,8 +52,7 @@ static LogicalResult checkEncoding(Operation *op, RankedTensorType encodingType,
     return success();
   }
 
-  auto serializableEncoding =
-      IREE::Encoding::getSerializableEncodingAttrInterface(encodingType);
+  auto serializableEncoding = IREE::Encoding::getSerializableAttr(encodingType);
   if (serializableEncoding && !serializableEncoding.isSerialized()) {
     return rewriter.notifyMatchFailure(op, [=](Diagnostic &d) {
       d << "unsupported (unserialized) tensor encoding: " << encodingType;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -542,7 +542,7 @@ def SpecializeEncodingsPass :
     - The binding types have to implement IREE::Encoding::EncodingTypeInterface,
       so it can updates the types without accessing any other dialects.
     - All the encodings attached on the types have to implement
-      SerializableEncodingAttrInterface. Because the pass updates the encodings
+      SerializableAttr. Because the pass updates the encodings
       using interfaces.
   }];
   let dependentDialects = [

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -542,8 +542,7 @@ def SpecializeEncodingsPass :
     - The binding types have to implement IREE::Encoding::EncodingTypeInterface,
       so it can updates the types without accessing any other dialects.
     - All the encodings attached on the types have to implement
-      SerializableAttr. Because the pass updates the encodings
-      using interfaces.
+      SerializableAttr. Because the pass updates the encodings using interfaces.
   }];
   let dependentDialects = [
     "IREE::Encoding::IREEEncodingDialect"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -86,11 +86,9 @@ static bool isRecognizedEncodingType(Type type) {
 /// There are requirements to get the resolved layouts. Otherwise, the encodings
 /// are dropped.
 ///   - All attributes in the `layoutResolvers` must implement
-///     LayoutResolverAttr. Otherwise, there is no way to query
-///     layouts.
-///   - The encoding on the type must implement
-///     SerializableAttr. Otherwise, there is no way to update
-///     encodings.
+///     LayoutResolverAttr. Otherwise, there is no way to query layouts.
+///   - The encoding on the type must implement SerializableAttr. Otherwise,
+///     there is no way to update encodings.
 static Type getTypeWithResolvedEncodingLayouts(
     Type type, const SetVector<Attribute> &layoutResolvers) {
   if (!isRecognizedEncodingType(type)) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -86,7 +86,7 @@ static bool isRecognizedEncodingType(Type type) {
 /// There are requirements to get the resolved layouts. Otherwise, the encodings
 /// are dropped.
 ///   - All attributes in the `layoutResolvers` must implement
-///     EncodingLayoutResolverAttrInterface. Otherwise, there is no way to query
+///     LayoutResolverAttr. Otherwise, there is no way to query
 ///     layouts.
 ///   - The encoding on the type must implement
 ///     SerializableAttr. Otherwise, there is no way to update
@@ -101,15 +101,13 @@ static Type getTypeWithResolvedEncodingLayouts(
   if (encodingAttr.isSerialized()) {
     return type;
   }
-  if (!llvm::all_of(
-          layoutResolvers,
-          llvm::IsaPred<IREE::Encoding::EncodingLayoutResolverAttrInterface>)) {
+  if (!llvm::all_of(layoutResolvers,
+                    llvm::IsaPred<IREE::Encoding::LayoutResolverAttr>)) {
     return rankedTensorType.dropEncoding();
   }
   SmallVector<Attribute> layouts;
   for (auto attr : layoutResolvers) {
-    auto encodingLayoutAttr =
-        cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(attr);
+    auto encodingLayoutAttr = cast<IREE::Encoding::LayoutResolverAttr>(attr);
     Attribute layout = encodingLayoutAttr.getLayout(rankedTensorType);
     if (!layout) {
       return nullptr;

--- a/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
@@ -91,7 +91,7 @@ Value calculateStorageElementCountInBytes(Location loc,
                                           ValueRange dynamicDims,
                                           OpBuilder &builder) {
   if (auto serializableEncodingAttr =
-          IREE::Encoding::getSerializableEncodingAttrInterface(shapedType)) {
+          IREE::Encoding::getSerializableAttr(shapedType)) {
     return serializableEncodingAttr.calculateStorageSizeInBytes(
         loc, builder, shapedType, dynamicDims);
   }


### PR DESCRIPTION
The IREE team has been developing the encodings and data-tiling specifics for a while. Now we have better pictures about the layering and the naming. The revision updates the interface names, which removes the redundant words and provides more descriptive names.

The attributes and interfaces are already defined within encoding namespace/dialect.  There is a hidden convention that we prefer fully specify type name in IREE core dialects. Because it is easier to do large scale replacements, avoids conflicts with MLIR upstream types, and makes it easier to port passes between dialects. In this context, Encoding is redundant in attribute names and interface names.

- `EncodingLayoutResolverAttrInterface` -> `LayoutResolverAttr`.
- `SerializableEncodingAttrInterface` -> `SerializableAttr`.
- `LayoutAttrInterface` -> `LayoutMaterializerAttr`.
- `PackedLayoutAttrInterface` -> `PackedLayoutMaterializerAttr `.

The Host/Device words are removed from the interface implementation because they were introduced for having a clear line between host and device. We have better abstraction now, and they are no longer needed.

It is a step towards https://github.com/iree-org/iree/issues/20742