### PR TITLE
Release our buffer reference regardless of buffer_view success.

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -889,10 +889,12 @@ HalBufferView HalDevice::FromDLPackCapsule(py::object input_capsule) {
                                   IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
                                   iree_allocator_system(), &buffer_view);
 
-  if (!iree_status_is_ok(status)) {
-    iree_hal_buffer_release(imported_buffer);
-    CheckApiStatus(status, "Failed to create buffer view");
-  }
+  // If the buffer view was successfully created, remove our ref
+  // since the buffer view incremented it.
+  // If the buffer view failed, then remove our ref so we don't
+  // leak the buffer.
+  iree_hal_buffer_release(imported_buffer);
+  CheckApiStatus(status, "Failed to create buffer view");
 
   return HalBufferView::StealFromRawPtr(buffer_view);
 }


### PR DESCRIPTION
If we successfully created the buffer view, it holds a ref to the buffer, so we want to release our own. If we failed then we want to release the imported buffer anyway so we don't leak.