### PR TITLE
Adding virtual memory utilities and iree_hal_amdgpu_vmem_ringbuffer_t.

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -1,0 +1,293 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_find_global_memory_pool_state_t {
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  hsa_amd_memory_pool_global_flag_t match_flags;
+  hsa_amd_memory_pool_t best_pool;
+} iree_hal_amdgpu_find_global_memory_pool_state_t;
+static hsa_status_t iree_hal_amdgpu_find_global_memory_pool_iterator(
+    hsa_amd_memory_pool_t memory_pool, void* user_data) {
+  iree_hal_amdgpu_find_global_memory_pool_state_t* state =
+      (iree_hal_amdgpu_find_global_memory_pool_state_t*)user_data;
+
+  // Filter to the global segment only.
+  hsa_region_segment_t segment = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+      &segment));
+  if (segment != HSA_REGION_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
+
+  // Must be able to allocate. This should be true for any pool we query that
+  // matches the other flags. Workgroup-private pools won't have this set.
+  bool alloc_allowed = false;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed));
+  if (!alloc_allowed) return HSA_STATUS_SUCCESS;
+
+  // Match if flags are present.
+  hsa_region_global_flag_t global_flag = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &global_flag));
+  if (global_flag & state->match_flags) {
+    state->best_pool = memory_pool;
+    return HSA_STATUS_INFO_BREAK;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_pool, 0, sizeof(*out_pool));
+
+  iree_hal_amdgpu_find_global_memory_pool_state_t find_state = {
+      .libhsa = libhsa,
+      .match_flags = match_flags,
+      .best_pool = {0},
+  };
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_agent_iterate_memory_pools(
+              IREE_LIBHSA(libhsa), agent,
+              iree_hal_amdgpu_find_global_memory_pool_iterator, &find_state));
+  if (!find_state.best_pool.handle) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_NOT_FOUND,
+                             "no memory pool matching the required flags %u",
+                             match_flags));
+  }
+
+  *out_pool = find_state.best_pool;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED, out_pool);
+}
+
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_pool);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, min_capacity);
+  memset(out_ringbuffer, 0, sizeof(*out_ringbuffer));
+
+  // hsa_amd_vmem_handle_create wants values aligned to this value.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_memory_pool_get_info(
+              IREE_LIBHSA(libhsa), memory_pool,
+              HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+              &alloc_rec_granule));
+
+  // Round up capacity and alignment to the allocation granule.
+  const size_t alignment = alloc_rec_granule;
+  const size_t capacity = iree_device_align(min_capacity, alloc_rec_granule);
+  out_ringbuffer->capacity = capacity;
+
+  // Reserve the virtual address space for the 3x the capacity. We'll map the
+  // physical allocation into this address space.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_vmem_address_reserve_align(
+          IREE_LIBHSA(libhsa), &out_ringbuffer->va_base_ptr, capacity * 3,
+          /*address=*/0, alignment, /*flags=*/0),
+      "reserving ringbuffer capacity*3 (%" PRIdsz "*3=%" PRIdsz ")", capacity,
+      capacity * 3);
+  out_ringbuffer->ring_base_ptr =
+      (uint8_t*)out_ringbuffer->va_base_ptr + capacity;
+
+  // Allocate the physical memory for backing the ringbuffer.
+  iree_status_t status = iree_hsa_amd_vmem_handle_create(
+      IREE_LIBHSA(libhsa), memory_pool, capacity, MEMORY_TYPE_NONE,
+      /*flags=*/0, &out_ringbuffer->alloc_handle);
+
+  void* va_offsets[3] = {
+      (uint8_t*)out_ringbuffer->va_base_ptr + 0 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 1 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 2 * capacity,
+  };
+
+  // Map the physical allocation into the virtual address space 3 times
+  // (prev, base, next).
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_map(IREE_LIBHSA(libhsa), va_offsets[i], capacity, 0,
+                              out_ringbuffer->alloc_handle, /*flags=*/0);
+  }
+
+  // Enable access on requested devices (no access by default).
+  // Must be done per memory handle, not the entire VA.
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_set_access(IREE_LIBHSA(libhsa), va_offsets[i],
+                                     capacity, access_descs, access_desc_count);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_vmem_ringbuffer_deinitialize(libhsa, out_ringbuffer);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate scratch for the access descriptors. Note that though we allocate
+  // for all agents we don't pass agents with HSA_ACCESS_PERMISSION_NONE as that
+  // actually causes HSA to allocate information about that agent.
+  // HSA_ACCESS_PERMISSION_NONE should only be used to _remove_ access that was
+  // previous granted.
+  iree_host_size_t access_desc_count = 0;
+  hsa_amd_memory_access_desc_t* access_descs =
+      (hsa_amd_memory_access_desc_t*)iree_alloca(
+          topology->all_agent_count * sizeof(hsa_amd_memory_access_desc_t));
+
+  // Populate the access list.
+  switch (access_mode) {
+    case IREE_HAL_AMDGPU_ACCESS_MODE_SHARED: {
+      // All devices get read/write access.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = HSA_ACCESS_PERMISSION_RW,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE: {
+      // Only the local agent can access the ringbuffer.
+      access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+          .agent_handle = local_agent,
+          .permissions = HSA_ACCESS_PERMISSION_RW,
+      };
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER: {
+      // Local agent gets read, all agents get write.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER: {
+      // Local agent gets write, all agents get read.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    default: {
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                               "unhandled access mode"));
+    } break;
+  }
+
+  // Route to the explicit initializer.
+  iree_status_t status = iree_hal_amdgpu_vmem_ringbuffer_initialize(
+      libhsa, local_agent, memory_pool, min_capacity, access_desc_count,
+      access_descs, out_ringbuffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Unmap physical allocation and release it.
+  if (ringbuffer->alloc_handle.handle) {
+    void* va_offsets[3] = {
+        (uint8_t*)ringbuffer->va_base_ptr + 0 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 1 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 2 * ringbuffer->capacity,
+    };
+    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(va_offsets); ++i) {
+      IREE_IGNORE_ERROR(iree_hsa_amd_vmem_unmap(
+          IREE_LIBHSA(libhsa), va_offsets[i], ringbuffer->capacity));
+    }
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_handle_release(
+        IREE_LIBHSA(libhsa), ringbuffer->alloc_handle));
+  }
+
+  if (ringbuffer->va_base_ptr) {
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_address_free(IREE_LIBHSA(libhsa),
+                                                     ringbuffer->va_base_ptr,
+                                                     ringbuffer->capacity * 3));
+  }
+
+  memset(ringbuffer, 0, sizeof(*ringbuffer));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -1,0 +1,133 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+// Semantically defines how a vmem allocation can be accessed.
+typedef enum iree_hal_amdgpu_vmem_access_mode_e {
+  // All agents may produce and consume the memory. Read/write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_SHARED = 0u,
+  // Memory is accessed exclusively by the agent it is allocated on.
+  // No other agent has access. Read/write for agent only.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE,
+  // Memory is consumed exclusively by the agent it is allocated on but may be
+  // produced from any agent. This is useful for mailboxes. Read for agent only
+  // and write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER,
+  // Memory is produced exclusively by the agent it is allocated on but may be
+  // consumed from any agent. This is useful for outbound buffers. Write for
+  // agent only and read for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER,
+} iree_hal_amdgpu_vmem_access_mode_t;
+
+// Finds a global memory pool on the |agent| matching any of the specified
+// global flags.
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a coarse-grained memory pool on the |agent|.
+// The returned pool will support allocations and be
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a fine-grained memory pool on the |agent|.
+// The returned pool will support allocations and be either
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED or
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+// An allocated ringbuffer using virtual memory mapping to present a contiguous
+// virtual address range that is backed by a single physical buffer but that
+// allows access before and after it.
+//
+// This presents as a ringbuffer that does not need any special logic for
+// wrapping from base offsets used when copying in memory. It follows the
+// approach documented in https://lo.calho.st/posts/black-magic-buffer/ and
+// https://www.mikeash.com/pyblog/friday-qa-2012-02-17-ring-buffers-and-mirrored-memory-part-ii.html
+// of virtual memory mapping the buffer multiple times, example code:
+// https://github.com/google/wuffs/blob/main/script/mmap-ring-buffer.c
+//
+// We use SVM to allocate the physical memory of the ringbuffer and then stitch
+// together 3 virtual memory ranges in one contiguous virtual allocation that
+// aliases the physical allocation. By treating the middle range as the base
+// buffer pointer we are then able to freely dereference both before and after
+// the base pointer by up to the ringbuffer size in length.
+//   physical: <ringbuffer size> --+------+------+
+//                                 v      v      v
+//                        virtual: [prev] [base] [next]
+//                                 ^      ^
+//                                 |      +-- ring_base_ptr
+//                                 +--------- va_base_ptr
+typedef struct iree_hal_amdgpu_vmem_ringbuffer_t {
+  // Capacity of the ringbuffer in bytes.
+  // May be larger than the requested size if adjusted to the minimum allocation
+  // granule.
+  iree_device_size_t capacity;
+  // Physical allocation of the pinned ringbuffer memory.
+  // This is sized to the requested capacity of the ringbuffer.
+  hsa_amd_vmem_alloc_handle_t alloc_handle;
+  // Base virtual address pointer of the ringbuffer. This is the start of the
+  // reserved address range.
+  IREE_AMDGPU_DEVICE_PTR void* va_base_ptr;
+  // Base virtual address pointer of the central ringbuffer contents.
+  IREE_AMDGPU_DEVICE_PTR void* ring_base_ptr;
+} iree_hal_amdgpu_vmem_ringbuffer_t;
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested |min_capacity| with at least 64 byte alignment.
+// |access_descs| will be used to setup accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested power-of-two |min_capacity| with at least
+// least 64 byte alignment. |topology| and |access_mode| will be used to setup
+// accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Deinitializes a ringbuffer and frees all physical and virtual allocations.
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct VMemTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, FindCoarseGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  EXPECT_TRUE(iree_all_bits_set(
+      global_flags, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED));
+}
+
+TEST_F(VMemTest, FindFineGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  // NOTE: the pool may have either flag set.
+  EXPECT_TRUE(iree_any_bit_set(
+      global_flags,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, RingbufferLifetime) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  EXPECT_GE(ringbuffer.capacity, min_capacity);
+  EXPECT_EQ(ringbuffer.ring_base_ptr,
+            (uint8_t*)ringbuffer.va_base_ptr + ringbuffer.capacity);
+  EXPECT_TRUE(iree_device_size_has_alignment(
+      (iree_device_size_t)ringbuffer.ring_base_ptr, 64));
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+TEST_F(VMemTest, RingbufferWrap) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  // Fill entire range [0,capacity).
+  iree_device_size_t capacity_u32 = ringbuffer.capacity / sizeof(uint32_t);
+  uint32_t* ptr = (uint32_t*)ringbuffer.ring_base_ptr;
+  for (iree_device_size_t i = 0; i < capacity_u32; ++i) {
+    ptr[i] = (uint32_t)i;
+  }
+
+  // Compare some locations off the base to ensure wrapping is valid.
+  EXPECT_EQ(ptr[0], ptr[capacity_u32]);
+  EXPECT_EQ(ptr[-1], ptr[capacity_u32 - 1]);
+  EXPECT_EQ(ptr[1], ptr[capacity_u32 + 1]);
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu


### PR DESCRIPTION
Factors out the memory pool iteration that a lot of code ends up needing and with the callback usually ends up fairly messy. The ringbuffer is described in the comments and provides an implementation of https://lo.calho.st/posts/black-magic-buffer/ / https://www.mikeash.com/pyblog/friday-qa-2012-02-17-ring-buffers-and-mirrored-memory-part-ii.html using SVM.

Sub-review for #20990. Not expected to pass CI.