### PR TITLE
Adding bitmap data structure.

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
@@ -1,0 +1,227 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/base/internal/math.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): move to iree/base/internal/math.h? Also used in device-side
+// library (which we can't use runtime headers in, so we need copies somewhere).
+//
+// https://en.wikipedia.org/wiki/Find_first_set
+#define IREE_HAL_AMDGPU_FFS_U64(v) \
+  ((v) == 0 ? -1 : iree_math_count_trailing_zeros_u64(v))
+
+// Returns a word with the bit at |bit_offset| set.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_MASK(0)   = 0b00..001
+//   _BIT_OFFSET_TO_WORD_MASK(1)   = 0b00..010
+//   _BIT_OFFSET_TO_WORD_MASK(2)   = 0b00..100
+#define _BIT_OFFSET_TO_WORD_MASK(bit_offset) \
+  (1ull << ((bit_offset) % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD))
+
+// Returns a word index in the bitmap containing the bit at |bit_offset|.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_INDEX(0)   = 0
+//   _BIT_OFFSET_TO_WORD_INDEX(64)  = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(127) = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(128) = 2
+#define _BIT_OFFSET_TO_WORD_INDEX(bit_offset) \
+  ((bit_offset) / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns a word mask that includes all valid bits after |bit_offset|.
+//
+// Examples:
+//   _BIT_PREFIX_WORD_MASK(0) = 0b11..111
+//   _BIT_PREFIX_WORD_MASK(1) = 0b11..110
+//   _BIT_PREFIX_WORD_MASK(2) = 0b11..100
+//   _BIT_PREFIX_WORD_MASK(3) = 0b11..000
+#define _BIT_PREFIX_WORD_MASK(bit_offset) \
+  (~0ull << ((bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Returns a word mask that includes all valid bits up to |bit_offset|.
+//
+// Examples:
+//   _BIT_SUFFIX_WORD_MASK(0) = 0b00..000
+//   _BIT_SUFFIX_WORD_MASK(1) = 0b00..001
+//   _BIT_SUFFIX_WORD_MASK(2) = 0b00..011
+//   _BIT_SUFFIX_WORD_MASK(3) = 0b00..111
+#define _BIT_SUFFIX_WORD_MASK(bit_offset) \
+  (~0ull >> (-(bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Scan full words first and handle any remaining bits after.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap) {
+  iree_host_size_t i = 0;
+  for (i = 0; i < bitmap.bit_count / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+       ++i) {
+    if (bitmap.words[i]) return false;
+  }
+  if (bitmap.bit_count % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD) {
+    if (bitmap.words[i] & _BIT_SUFFIX_WORD_MASK(bitmap.bit_count)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index) {
+  return 1ull & (bitmap.words[_BIT_OFFSET_TO_WORD_INDEX(bit_index)] >>
+                 (bit_index & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)));
+}
+
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr |= word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Set from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr |= word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Set the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr |= word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0xFF, word_count * sizeof(uint64_t));
+}
+
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr &= ~word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Reset from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr &= ~word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Reset the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr &= ~word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0x00, word_count * sizeof(uint64_t));
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_set_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = words[word_index] & word_mask; !word; word = words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words,
+                                                  bitmap.bit_count, bit_offset);
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_unset_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = ~words[word_index] & word_mask; !word;
+       word = ~words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_unset_bit(
+      bitmap.words, bitmap.bit_count, bit_offset);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length) {
+  iree_host_size_t bit_index = 0;
+  do {
+    bit_index = iree_hal_amdgpu_bitmap_find_next_unset_bit(
+        bitmap.words, bitmap.bit_count, bit_offset);
+    const iree_host_size_t bit_end = bit_index + bit_length;
+    if (bit_end > bitmap.bit_count) return bitmap.bit_count;
+    const iree_host_size_t next_index =
+        iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words, bit_end,
+                                                 bit_index);
+    if (next_index < bit_end) {
+      bit_offset = next_index + 1;
+      continue;  // resume from next set bit (as we know there's nothing before)
+    } else {
+      break;  // found
+    }
+  } while (true);
+  return iree_min(bit_index, bitmap.bit_count);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
@@ -1,0 +1,104 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// Bits per word of bitmap data.
+#define IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD (sizeof(uint64_t) * 8)
+
+// Reference to a bitmap stored in 64-bit words.
+// This is a fat pointer to the storage and does not store anything itself.
+// Intended for small counts (~dozens to hundreds).
+//
+// Bits outside of the bit count range may be modified by operations and their
+// contents should be treated as undefined.
+//
+// We could reduce this or specialize to a single pointer by packing the bit
+// count in the upper byte of the pointer given that most usage is <= 64 bits.
+// Today this type generally only lives on the stack or in registers so we don't
+// bother as shifting around would be more expensive.
+typedef struct iree_hal_amdgpu_bitmap_t {
+  iree_host_size_t bit_count;
+  uint64_t* words;
+} iree_hal_amdgpu_bitmap_t;
+
+// Calculates the total number of words required to store |bit_count| bits.
+#define iree_hal_amdgpu_bitmap_calculate_words(bit_count) \
+  iree_host_size_ceil_div(bit_count, IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns true if no bits are set in the bitmap.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap);
+
+// TODO(benvanik): iree_hal_amdgpu_bitmap_count (popcnt loop with masking).
+
+// Returns true if the bit at |bit_index| is 1.
+// Expects |bit_index| to be in bounds.
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index);
+
+// Sets the bit at |bit_index| to 1.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index);
+
+// Sets all bits between |bit_index| and |bit_index| + |bitmap_length| to 1.
+// Expects the entire range to be in bounds.
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length);
+
+// Sets all bits in the bitmap to 1.
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Resets the bit at |bit_index| to 0.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index);
+
+// Resets all bits between |bit_index| and |bit_index| + |bitmap_length| to 0.
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length);
+
+// Resets all bits in the bitmap to 0.
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Finds the first set bit (value 1) starting from |bit_offset|.
+// Returns the bitmap size if no set bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first unset bit (value 0) starting from |bit_offset|.
+// Returns the bitmap size if no unset bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first contiguous |bit_length| span of unset bits (value 0) starting
+// from |bit_offset|.
+// Returns the bitmap size if no span of unset bits is found.
+// Expects the entire range to be in bounds or |bit_offset|/|bit_length| as 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
@@ -1,0 +1,447 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+TEST(BitmapTest, CalculateWords) {
+  static_assert(IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD == 64,
+                "assumes 64-bit words");
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(1), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(63), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(64), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(65), 2);
+}
+
+// Tests that a NULL storage pointer is allowed (as we shouldn't touch it).
+TEST(BitmapTest, Empty) {
+  iree_hal_amdgpu_bitmap_t bitmap = {0, NULL};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);           // no-op
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);         // no-op
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 0);    // no-op
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 0);  // no-op
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 0, 0), 0);
+}
+
+TEST(BitmapTest, Test) {
+  uint64_t words[] = {
+      0ull | 0b1010,
+      0ull | 0b1,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 1));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 3));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 0));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+}
+
+TEST(BitmapTest, Set63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Set64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Set65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Set73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, SetPreserve) {
+  uint64_t words[] = {
+      0ull | (1ull << 2),
+      0ull | (1ull << 3),
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  iree_hal_amdgpu_bitmap_set(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b101ull);
+  EXPECT_EQ(words[1], 0b1010ull);
+}
+
+TEST(BitmapTest, SetSpanPrefix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSuffix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSplit) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetAll) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0x0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, Reset0) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Reset65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Reset73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, ResetPreserve) {
+  uint64_t words[] = {
+      0b101ull,
+      0b1010ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  iree_hal_amdgpu_bitmap_reset(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b100ull);
+  EXPECT_EQ(words[1], 0b1000ull);
+}
+
+TEST(BitmapTest, ResetSpanPrefix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSuffix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSplit) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~(0b1ull << 63));
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111110ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, bitmap.bit_count);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, FindEmpty) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 10), 10);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 10,
+                                                         bitmap.bit_count - 10),
+            10);
+}
+
+TEST(BitmapTest, Find0) {
+  uint64_t words[] = {
+      0ull | 0b1,
+      0ull,
+  };
+  const int bit_index = 0;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find63) {
+  uint64_t words[] = {
+      0ull | (1ull << 63),
+      0ull,
+  };
+  const int bit_index = 63;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find64) {
+  uint64_t words[] = {
+      0ull,
+      0ull | 0b1,
+  };
+  const int bit_index = 64;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find67) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 3),
+  };
+  const int bit_index = 64 + 3;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find73) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 10),
+  };
+  const int bit_index = 64 + 10;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, bit_index, 0),
+            bitmap.bit_count);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -1,0 +1,293 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_find_global_memory_pool_state_t {
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  hsa_amd_memory_pool_global_flag_t match_flags;
+  hsa_amd_memory_pool_t best_pool;
+} iree_hal_amdgpu_find_global_memory_pool_state_t;
+static hsa_status_t iree_hal_amdgpu_find_global_memory_pool_iterator(
+    hsa_amd_memory_pool_t memory_pool, void* user_data) {
+  iree_hal_amdgpu_find_global_memory_pool_state_t* state =
+      (iree_hal_amdgpu_find_global_memory_pool_state_t*)user_data;
+
+  // Filter to the global segment only.
+  hsa_region_segment_t segment = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+      &segment));
+  if (segment != HSA_REGION_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
+
+  // Must be able to allocate. This should be true for any pool we query that
+  // matches the other flags. Workgroup-private pools won't have this set.
+  bool alloc_allowed = false;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed));
+  if (!alloc_allowed) return HSA_STATUS_SUCCESS;
+
+  // Match if flags are present.
+  hsa_region_global_flag_t global_flag = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &global_flag));
+  if (global_flag & state->match_flags) {
+    state->best_pool = memory_pool;
+    return HSA_STATUS_INFO_BREAK;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_pool, 0, sizeof(*out_pool));
+
+  iree_hal_amdgpu_find_global_memory_pool_state_t find_state = {
+      .libhsa = libhsa,
+      .match_flags = match_flags,
+      .best_pool = {0},
+  };
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_agent_iterate_memory_pools(
+              IREE_LIBHSA(libhsa), agent,
+              iree_hal_amdgpu_find_global_memory_pool_iterator, &find_state));
+  if (!find_state.best_pool.handle) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_NOT_FOUND,
+                             "no memory pool matching the required flags %u",
+                             match_flags));
+  }
+
+  *out_pool = find_state.best_pool;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED, out_pool);
+}
+
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_pool);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, min_capacity);
+  memset(out_ringbuffer, 0, sizeof(*out_ringbuffer));
+
+  // hsa_amd_vmem_handle_create wants values aligned to this value.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_memory_pool_get_info(
+              IREE_LIBHSA(libhsa), memory_pool,
+              HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+              &alloc_rec_granule));
+
+  // Round up capacity and alignment to the allocation granule.
+  const size_t alignment = alloc_rec_granule;
+  const size_t capacity = iree_device_align(min_capacity, alloc_rec_granule);
+  out_ringbuffer->capacity = capacity;
+
+  // Reserve the virtual address space for the 3x the capacity. We'll map the
+  // physical allocation into this address space.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_vmem_address_reserve_align(
+          IREE_LIBHSA(libhsa), &out_ringbuffer->va_base_ptr, capacity * 3,
+          /*address=*/0, alignment, /*flags=*/0),
+      "reserving ringbuffer capacity*3 (%" PRIdsz "*3=%" PRIdsz ")", capacity,
+      capacity * 3);
+  out_ringbuffer->ring_base_ptr =
+      (uint8_t*)out_ringbuffer->va_base_ptr + capacity;
+
+  // Allocate the physical memory for backing the ringbuffer.
+  iree_status_t status = iree_hsa_amd_vmem_handle_create(
+      IREE_LIBHSA(libhsa), memory_pool, capacity, MEMORY_TYPE_NONE,
+      /*flags=*/0, &out_ringbuffer->alloc_handle);
+
+  void* va_offsets[3] = {
+      (uint8_t*)out_ringbuffer->va_base_ptr + 0 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 1 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 2 * capacity,
+  };
+
+  // Map the physical allocation into the virtual address space 3 times
+  // (prev, base, next).
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_map(IREE_LIBHSA(libhsa), va_offsets[i], capacity, 0,
+                              out_ringbuffer->alloc_handle, /*flags=*/0);
+  }
+
+  // Enable access on requested devices (no access by default).
+  // Must be done per memory handle, not the entire VA.
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_set_access(IREE_LIBHSA(libhsa), va_offsets[i],
+                                     capacity, access_descs, access_desc_count);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_vmem_ringbuffer_deinitialize(libhsa, out_ringbuffer);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate scratch for the access descriptors. Note that though we allocate
+  // for all agents we don't pass agents with HSA_ACCESS_PERMISSION_NONE as that
+  // actually causes HSA to allocate information about that agent.
+  // HSA_ACCESS_PERMISSION_NONE should only be used to _remove_ access that was
+  // previous granted.
+  iree_host_size_t access_desc_count = 0;
+  hsa_amd_memory_access_desc_t* access_descs =
+      (hsa_amd_memory_access_desc_t*)iree_alloca(
+          topology->all_agent_count * sizeof(hsa_amd_memory_access_desc_t));
+
+  // Populate the access list.
+  switch (access_mode) {
+    case IREE_HAL_AMDGPU_ACCESS_MODE_SHARED: {
+      // All devices get read/write access.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = HSA_ACCESS_PERMISSION_RW,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE: {
+      // Only the local agent can access the ringbuffer.
+      access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+          .agent_handle = local_agent,
+          .permissions = HSA_ACCESS_PERMISSION_RW,
+      };
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER: {
+      // Local agent gets read, all agents get write.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER: {
+      // Local agent gets write, all agents get read.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    default: {
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                               "unhandled access mode"));
+    } break;
+  }
+
+  // Route to the explicit initializer.
+  iree_status_t status = iree_hal_amdgpu_vmem_ringbuffer_initialize(
+      libhsa, local_agent, memory_pool, min_capacity, access_desc_count,
+      access_descs, out_ringbuffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Unmap physical allocation and release it.
+  if (ringbuffer->alloc_handle.handle) {
+    void* va_offsets[3] = {
+        (uint8_t*)ringbuffer->va_base_ptr + 0 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 1 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 2 * ringbuffer->capacity,
+    };
+    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(va_offsets); ++i) {
+      IREE_IGNORE_ERROR(iree_hsa_amd_vmem_unmap(
+          IREE_LIBHSA(libhsa), va_offsets[i], ringbuffer->capacity));
+    }
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_handle_release(
+        IREE_LIBHSA(libhsa), ringbuffer->alloc_handle));
+  }
+
+  if (ringbuffer->va_base_ptr) {
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_address_free(IREE_LIBHSA(libhsa),
+                                                     ringbuffer->va_base_ptr,
+                                                     ringbuffer->capacity * 3));
+  }
+
+  memset(ringbuffer, 0, sizeof(*ringbuffer));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -1,0 +1,133 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+// Semantically defines how a vmem allocation can be accessed.
+typedef enum iree_hal_amdgpu_vmem_access_mode_e {
+  // All agents may produce and consume the memory. Read/write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_SHARED = 0u,
+  // Memory is accessed exclusively by the agent it is allocated on.
+  // No other agent has access. Read/write for agent only.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE,
+  // Memory is consumed exclusively by the agent it is allocated on but may be
+  // produced from any agent. This is useful for mailboxes. Read for agent only
+  // and write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER,
+  // Memory is produced exclusively by the agent it is allocated on but may be
+  // consumed from any agent. This is useful for outbound buffers. Write for
+  // agent only and read for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER,
+} iree_hal_amdgpu_vmem_access_mode_t;
+
+// Finds a global memory pool on the |agent| matching any of the specified
+// global flags.
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a coarse-grained memory pool on the |agent|.
+// The returned pool will support allocations and be
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a fine-grained memory pool on the |agent|.
+// The returned pool will support allocations and be either
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED or
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+// An allocated ringbuffer using virtual memory mapping to present a contiguous
+// virtual address range that is backed by a single physical buffer but that
+// allows access before and after it.
+//
+// This presents as a ringbuffer that does not need any special logic for
+// wrapping from base offsets used when copying in memory. It follows the
+// approach documented in https://lo.calho.st/posts/black-magic-buffer/ and
+// https://www.mikeash.com/pyblog/friday-qa-2012-02-17-ring-buffers-and-mirrored-memory-part-ii.html
+// of virtual memory mapping the buffer multiple times, example code:
+// https://github.com/google/wuffs/blob/main/script/mmap-ring-buffer.c
+//
+// We use SVM to allocate the physical memory of the ringbuffer and then stitch
+// together 3 virtual memory ranges in one contiguous virtual allocation that
+// aliases the physical allocation. By treating the middle range as the base
+// buffer pointer we are then able to freely dereference both before and after
+// the base pointer by up to the ringbuffer size in length.
+//   physical: <ringbuffer size> --+------+------+
+//                                 v      v      v
+//                        virtual: [prev] [base] [next]
+//                                 ^      ^
+//                                 |      +-- ring_base_ptr
+//                                 +--------- va_base_ptr
+typedef struct iree_hal_amdgpu_vmem_ringbuffer_t {
+  // Capacity of the ringbuffer in bytes.
+  // May be larger than the requested size if adjusted to the minimum allocation
+  // granule.
+  iree_device_size_t capacity;
+  // Physical allocation of the pinned ringbuffer memory.
+  // This is sized to the requested capacity of the ringbuffer.
+  hsa_amd_vmem_alloc_handle_t alloc_handle;
+  // Base virtual address pointer of the ringbuffer. This is the start of the
+  // reserved address range.
+  IREE_AMDGPU_DEVICE_PTR void* va_base_ptr;
+  // Base virtual address pointer of the central ringbuffer contents.
+  IREE_AMDGPU_DEVICE_PTR void* ring_base_ptr;
+} iree_hal_amdgpu_vmem_ringbuffer_t;
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested |min_capacity| with at least 64 byte alignment.
+// |access_descs| will be used to setup accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested power-of-two |min_capacity| with at least
+// least 64 byte alignment. |topology| and |access_mode| will be used to setup
+// accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Deinitializes a ringbuffer and frees all physical and virtual allocations.
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct VMemTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, FindCoarseGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  EXPECT_TRUE(iree_all_bits_set(
+      global_flags, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED));
+}
+
+TEST_F(VMemTest, FindFineGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  // NOTE: the pool may have either flag set.
+  EXPECT_TRUE(iree_any_bit_set(
+      global_flags,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, RingbufferLifetime) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  EXPECT_GE(ringbuffer.capacity, min_capacity);
+  EXPECT_EQ(ringbuffer.ring_base_ptr,
+            (uint8_t*)ringbuffer.va_base_ptr + ringbuffer.capacity);
+  EXPECT_TRUE(iree_device_size_has_alignment(
+      (iree_device_size_t)ringbuffer.ring_base_ptr, 64));
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+TEST_F(VMemTest, RingbufferWrap) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  // Fill entire range [0,capacity).
+  iree_device_size_t capacity_u32 = ringbuffer.capacity / sizeof(uint32_t);
+  uint32_t* ptr = (uint32_t*)ringbuffer.ring_base_ptr;
+  for (iree_device_size_t i = 0; i < capacity_u32; ++i) {
+    ptr[i] = (uint32_t)i;
+  }
+
+  // Compare some locations off the base to ensure wrapping is valid.
+  EXPECT_EQ(ptr[0], ptr[capacity_u32]);
+  EXPECT_EQ(ptr[-1], ptr[capacity_u32 - 1]);
+  EXPECT_EQ(ptr[1], ptr[capacity_u32 + 1]);
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu


### PR DESCRIPTION
Basic fat pointer-style bitmap (external storage, dynamic size) with some common operations used with allocators/pools. It's not AMDGPU-specific and if we want to use it elsewhere we can move it out to a common location.

Sub-review for #20990. Not expected to pass CI.