### PR TITLE
Add note about GPU time synchronization

### DIFF
--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -402,6 +402,20 @@ sudo sh -c "ulimit -n <bigNum> && <myTracyInstrumentedProgram>"
 
 ---
 
+### :octicons-clock-fill-16: GPU timeline drift
+
+On some platforms, the GPU timeline and CPU timeline may drift relative to each
+other. In some cases this is a result of network time synchronization. To ensure
+accurate timing, disable network time synchronization. On Ubuntu and some other
+linux platforms, that can be done with the following command, which will disable
+time sync until the next boot:
+
+```shell
+sudo systmectl stop systemd-timesyncd
+# When done, resume the sync:
+sudo systemctl start systemd-timesyncd
+```
+
 ## :octicons-log-16: Appendix
 
 ### Building Tracy from source


### PR DESCRIPTION
In experiments with shortfin, this prevents the kernel launches from appearing before they are enqueued.