### PR TITLE
Adding `iree_hal_amdgpu_block_pool_t`.

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
@@ -1,0 +1,227 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/base/internal/math.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): move to iree/base/internal/math.h? Also used in device-side
+// library (which we can't use runtime headers in, so we need copies somewhere).
+//
+// https://en.wikipedia.org/wiki/Find_first_set
+#define IREE_HAL_AMDGPU_FFS_U64(v) \
+  ((v) == 0 ? -1 : iree_math_count_trailing_zeros_u64(v))
+
+// Returns a word with the bit at |bit_offset| set.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_MASK(0)   = 0b00..001
+//   _BIT_OFFSET_TO_WORD_MASK(1)   = 0b00..010
+//   _BIT_OFFSET_TO_WORD_MASK(2)   = 0b00..100
+#define _BIT_OFFSET_TO_WORD_MASK(bit_offset) \
+  (1ull << ((bit_offset) % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD))
+
+// Returns a word index in the bitmap containing the bit at |bit_offset|.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_INDEX(0)   = 0
+//   _BIT_OFFSET_TO_WORD_INDEX(64)  = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(127) = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(128) = 2
+#define _BIT_OFFSET_TO_WORD_INDEX(bit_offset) \
+  ((bit_offset) / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns a word mask that includes all valid bits after |bit_offset|.
+//
+// Examples:
+//   _BIT_PREFIX_WORD_MASK(0) = 0b11..111
+//   _BIT_PREFIX_WORD_MASK(1) = 0b11..110
+//   _BIT_PREFIX_WORD_MASK(2) = 0b11..100
+//   _BIT_PREFIX_WORD_MASK(3) = 0b11..000
+#define _BIT_PREFIX_WORD_MASK(bit_offset) \
+  (~0ull << ((bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Returns a word mask that includes all valid bits up to |bit_offset|.
+//
+// Examples:
+//   _BIT_SUFFIX_WORD_MASK(0) = 0b00..000
+//   _BIT_SUFFIX_WORD_MASK(1) = 0b00..001
+//   _BIT_SUFFIX_WORD_MASK(2) = 0b00..011
+//   _BIT_SUFFIX_WORD_MASK(3) = 0b00..111
+#define _BIT_SUFFIX_WORD_MASK(bit_offset) \
+  (~0ull >> (-(bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Scan full words first and handle any remaining bits after.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap) {
+  iree_host_size_t i = 0;
+  for (i = 0; i < bitmap.bit_count / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+       ++i) {
+    if (bitmap.words[i]) return false;
+  }
+  if (bitmap.bit_count % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD) {
+    if (bitmap.words[i] & _BIT_SUFFIX_WORD_MASK(bitmap.bit_count)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index) {
+  return 1ull & (bitmap.words[_BIT_OFFSET_TO_WORD_INDEX(bit_index)] >>
+                 (bit_index & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)));
+}
+
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr |= word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Set from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr |= word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Set the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr |= word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0xFF, word_count * sizeof(uint64_t));
+}
+
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr &= ~word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Reset from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr &= ~word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Reset the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr &= ~word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0x00, word_count * sizeof(uint64_t));
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_set_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = words[word_index] & word_mask; !word; word = words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words,
+                                                  bitmap.bit_count, bit_offset);
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_unset_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = ~words[word_index] & word_mask; !word;
+       word = ~words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_unset_bit(
+      bitmap.words, bitmap.bit_count, bit_offset);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length) {
+  iree_host_size_t bit_index = 0;
+  do {
+    bit_index = iree_hal_amdgpu_bitmap_find_next_unset_bit(
+        bitmap.words, bitmap.bit_count, bit_offset);
+    const iree_host_size_t bit_end = bit_index + bit_length;
+    if (bit_end > bitmap.bit_count) return bitmap.bit_count;
+    const iree_host_size_t next_index =
+        iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words, bit_end,
+                                                 bit_index);
+    if (next_index < bit_end) {
+      bit_offset = next_index + 1;
+      continue;  // resume from next set bit (as we know there's nothing before)
+    } else {
+      break;  // found
+    }
+  } while (true);
+  return iree_min(bit_index, bitmap.bit_count);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
@@ -1,0 +1,104 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// Bits per word of bitmap data.
+#define IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD (sizeof(uint64_t) * 8)
+
+// Reference to a bitmap stored in 64-bit words.
+// This is a fat pointer to the storage and does not store anything itself.
+// Intended for small counts (~dozens to hundreds).
+//
+// Bits outside of the bit count range may be modified by operations and their
+// contents should be treated as undefined.
+//
+// We could reduce this or specialize to a single pointer by packing the bit
+// count in the upper byte of the pointer given that most usage is <= 64 bits.
+// Today this type generally only lives on the stack or in registers so we don't
+// bother as shifting around would be more expensive.
+typedef struct iree_hal_amdgpu_bitmap_t {
+  iree_host_size_t bit_count;
+  uint64_t* words;
+} iree_hal_amdgpu_bitmap_t;
+
+// Calculates the total number of words required to store |bit_count| bits.
+#define iree_hal_amdgpu_bitmap_calculate_words(bit_count) \
+  iree_host_size_ceil_div(bit_count, IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns true if no bits are set in the bitmap.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap);
+
+// TODO(benvanik): iree_hal_amdgpu_bitmap_count (popcnt loop with masking).
+
+// Returns true if the bit at |bit_index| is 1.
+// Expects |bit_index| to be in bounds.
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index);
+
+// Sets the bit at |bit_index| to 1.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index);
+
+// Sets all bits between |bit_index| and |bit_index| + |bitmap_length| to 1.
+// Expects the entire range to be in bounds.
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length);
+
+// Sets all bits in the bitmap to 1.
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Resets the bit at |bit_index| to 0.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index);
+
+// Resets all bits between |bit_index| and |bit_index| + |bitmap_length| to 0.
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length);
+
+// Resets all bits in the bitmap to 0.
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Finds the first set bit (value 1) starting from |bit_offset|.
+// Returns the bitmap size if no set bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first unset bit (value 0) starting from |bit_offset|.
+// Returns the bitmap size if no unset bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first contiguous |bit_length| span of unset bits (value 0) starting
+// from |bit_offset|.
+// Returns the bitmap size if no span of unset bits is found.
+// Expects the entire range to be in bounds or |bit_offset|/|bit_length| as 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
@@ -1,0 +1,447 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+TEST(BitmapTest, CalculateWords) {
+  static_assert(IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD == 64,
+                "assumes 64-bit words");
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(1), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(63), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(64), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(65), 2);
+}
+
+// Tests that a NULL storage pointer is allowed (as we shouldn't touch it).
+TEST(BitmapTest, Empty) {
+  iree_hal_amdgpu_bitmap_t bitmap = {0, NULL};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);           // no-op
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);         // no-op
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 0);    // no-op
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 0);  // no-op
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 0, 0), 0);
+}
+
+TEST(BitmapTest, Test) {
+  uint64_t words[] = {
+      0ull | 0b1010,
+      0ull | 0b1,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 1));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 3));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 0));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+}
+
+TEST(BitmapTest, Set63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Set64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Set65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Set73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, SetPreserve) {
+  uint64_t words[] = {
+      0ull | (1ull << 2),
+      0ull | (1ull << 3),
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  iree_hal_amdgpu_bitmap_set(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b101ull);
+  EXPECT_EQ(words[1], 0b1010ull);
+}
+
+TEST(BitmapTest, SetSpanPrefix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSuffix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSplit) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetAll) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0x0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, Reset0) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Reset65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Reset73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, ResetPreserve) {
+  uint64_t words[] = {
+      0b101ull,
+      0b1010ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  iree_hal_amdgpu_bitmap_reset(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b100ull);
+  EXPECT_EQ(words[1], 0b1000ull);
+}
+
+TEST(BitmapTest, ResetSpanPrefix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSuffix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSplit) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~(0b1ull << 63));
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111110ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, bitmap.bit_count);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, FindEmpty) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 10), 10);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 10,
+                                                         bitmap.bit_count - 10),
+            10);
+}
+
+TEST(BitmapTest, Find0) {
+  uint64_t words[] = {
+      0ull | 0b1,
+      0ull,
+  };
+  const int bit_index = 0;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find63) {
+  uint64_t words[] = {
+      0ull | (1ull << 63),
+      0ull,
+  };
+  const int bit_index = 63;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find64) {
+  uint64_t words[] = {
+      0ull,
+      0ull | 0b1,
+  };
+  const int bit_index = 64;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find67) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 3),
+  };
+  const int bit_index = 64 + 3;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find73) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 10),
+  };
+  const int bit_index = 64 + 10;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, bit_index, 0),
+            bitmap.bit_count);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
@@ -1,0 +1,604 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/block_pool.h"
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_pool_t
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_hal_amdgpu_block_pool_grow(
+    iree_hal_amdgpu_block_pool_t* block_pool);
+
+iree_status_t iree_hal_amdgpu_block_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_block_pool_options_t options, hsa_agent_t agent,
+    hsa_amd_memory_pool_t memory_pool, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_block_pool_t* out_block_pool) {
+  IREE_ASSERT_ARGUMENT(out_block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, options.block_size);
+
+  memset(out_block_pool, 0, sizeof(*out_block_pool));
+
+  if (!options.block_size ||
+      !iree_device_size_is_power_of_two(options.block_size)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                             "block size must be a power-of-two; got %" PRIdsz,
+                             options.block_size));
+  }
+
+  out_block_pool->libhsa = libhsa;
+  out_block_pool->host_allocator = host_allocator;
+  out_block_pool->agent = agent;
+  out_block_pool->memory_pool = memory_pool;
+  out_block_pool->block_size = options.block_size;
+
+  // Query the memory pool for its allocation granularity.
+  // This is not the minimum allocation size
+  // (HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE) but the recommended size
+  // to prevent internal fragmentation. We will always make allocations of this
+  // size and then suballocate the block size.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_memory_pool_get_info(
+          IREE_LIBHSA(libhsa), memory_pool,
+          HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+          &alloc_rec_granule),
+      "querying HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE to "
+      "determine blocks/allocation");
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, alloc_rec_granule);
+
+  // If no min block count was provided we pick one as either the number that
+  // will fit into the recommended allocation granule.
+  const iree_host_size_t min_blocks_per_allocation =
+      options.min_blocks_per_allocation
+          ? options.min_blocks_per_allocation
+          : iree_host_size_ceil_div(alloc_rec_granule, options.block_size);
+
+  // Always allocate aligned to the recommended granularity.
+  // This may lead to more blocks than the user requested but the extra memory
+  // would likely be unused anyway (or used poorly).
+  const iree_device_size_t allocation_size = iree_device_align(
+      options.block_size * min_blocks_per_allocation, alloc_rec_granule);
+  out_block_pool->blocks_per_allocation =
+      (iree_host_size_t)(allocation_size / options.block_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_block_pool->blocks_per_allocation);
+
+  iree_slim_mutex_initialize(&out_block_pool->mutex);
+  iree_slim_mutex_lock(&out_block_pool->mutex);
+
+  // Preallocate as many allocations as required to hold the requested initial
+  // block count.
+  iree_status_t status = iree_ok_status();
+  iree_host_size_t initial_allocation_count = iree_host_size_ceil_div(
+      options.initial_capacity, out_block_pool->blocks_per_allocation);
+  for (iree_host_size_t i = 0; i < initial_allocation_count; ++i) {
+    status = iree_hal_amdgpu_block_pool_grow(out_block_pool);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  iree_slim_mutex_unlock(&out_block_pool->mutex);
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_block_pool_deinitialize(out_block_pool);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_block_pool_deinitialize(
+    iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Should have freed everything so we can just trim the pool to drop all
+  // blocks.
+  iree_hal_amdgpu_block_pool_trim(block_pool);
+  IREE_ASSERT(!block_pool->allocations_head,
+              "must have freed all blocks prior to deallocating the pool");
+
+  iree_slim_mutex_deinitialize(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Grows the block pool by one block allocation and links all of the blocks
+// contained into the block pool free list.
+//
+// Must be called with the pool lock held.
+static iree_status_t iree_hal_amdgpu_block_pool_grow(
+    iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate device memory. This may fail if resources are exhausted.
+  IREE_AMDGPU_DEVICE_PTR uint8_t* base_ptr = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_memory_pool_allocate(
+          IREE_LIBHSA(block_pool->libhsa), block_pool->memory_pool,
+          block_pool->blocks_per_allocation * block_pool->block_size,
+          HSA_AMD_MEMORY_POOL_STANDARD_FLAG, (void**)&base_ptr),
+      "growing block pool with one block of %" PRIdsz " bytes",
+      block_pool->block_size * block_pool->blocks_per_allocation);
+
+  // Allocate host memory container for the allocation.
+  iree_hal_amdgpu_block_allocation_t* block_allocation = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      block_pool->host_allocator,
+      sizeof(*block_allocation) + block_pool->blocks_per_allocation *
+                                      sizeof(block_allocation->blocks[0]),
+      (void**)&block_allocation);
+  if (iree_status_is_ok(status)) {
+    block_allocation->next = block_pool->allocations_head;
+    block_allocation->base_ptr = base_ptr;
+    block_allocation->used_count = 0;
+    block_pool->allocations_head = block_allocation;
+
+    // Setup all blocks to point at their relevant memory.
+    // We append to the block pool free list as we go.
+    for (iree_host_size_t i = 0; i < block_pool->blocks_per_allocation; ++i) {
+      iree_hal_amdgpu_block_t* block = &block_allocation->blocks[i];
+      block->ptr = base_ptr + i * block_pool->block_size;
+      block->allocation = block_allocation;
+      block->next = block_pool->free_blocks_head;
+      block_pool->free_blocks_head = block;
+    }
+  } else {
+    IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_free(
+        IREE_LIBHSA(block_pool->libhsa), base_ptr));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_block_pool_trim(iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: we could steal the whole list and free it outside of the lock but we
+  // actually want to prevent anyone else from growing the pool until we've
+  // completed - otherwise a sequence of trim+alloc could cause higher peak
+  // usage.
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Preprocess the block free list to remove all blocks whose allocation has
+  // no used blocks. This is so that the walk over the allocation list can free
+  // the host memory that contains the blocks below.
+  //
+  // This isn't great but compared to the cost of calling into HSA to deallocate
+  // the device memory this is nothing. Trims only happen when latency is not
+  // important.
+  iree_hal_amdgpu_block_t* free_block = block_pool->free_blocks_head;
+  iree_hal_amdgpu_block_t* prev_free_block = NULL;
+  while (free_block) {
+    iree_hal_amdgpu_block_t* next_free_block = free_block->next;
+    if (free_block->allocation->used_count == 0) {
+      // Allocation will be freed below - unlink.
+      if (free_block == block_pool->free_blocks_head) {
+        block_pool->free_blocks_head = next_free_block;
+        if (prev_free_block) prev_free_block->next = next_free_block;
+      } else {
+        prev_free_block->next = next_free_block;
+      }
+    } else {
+      // Allocation still has uses - keep the block in the list.
+      prev_free_block = free_block;
+    }
+    free_block = next_free_block;
+  }
+
+  // Walk each allocation and free it if it has no outstanding blocks allocated.
+  // Note that we already cleaned up the free block list above.
+  iree_hal_amdgpu_block_allocation_t* allocation = block_pool->allocations_head;
+  iree_hal_amdgpu_block_allocation_t* prev_allocation = NULL;
+  while (allocation) {
+    iree_hal_amdgpu_block_allocation_t* next_allocation = allocation->next;
+    if (allocation->used_count == 0) {
+      // No blocks outstanding - can free and remove from the allocation list.
+      IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_free(
+          IREE_LIBHSA(block_pool->libhsa), allocation->base_ptr));
+      if (allocation == block_pool->allocations_head) {
+        block_pool->allocations_head = next_allocation;
+        if (prev_allocation) prev_allocation->next = next_allocation;
+      } else {
+        prev_allocation->next = next_allocation;
+      }
+      iree_allocator_free(block_pool->host_allocator, allocation);
+    } else {
+      // Skip as blocks still outstanding.
+      prev_allocation = allocation;
+    }
+    allocation = next_allocation;
+  }
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_amdgpu_block_pool_acquire(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t** out_block) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_ASSERT_ARGUMENT(out_block);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_block = NULL;
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // If there are no free blocks available grow the pool by one block allocation
+  // (which may allocate multiple blocks worth of memory).
+  if (!block_pool->free_blocks_head) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_amdgpu_block_pool_grow(block_pool));
+  }
+
+  // Slice off the next free block.
+  iree_hal_amdgpu_block_t* block = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block->next;
+  block->next = NULL;  // user may use this
+  block->prev = NULL;
+  memset(block->user_data, 0, sizeof(block->user_data));
+  ++block->allocation->used_count;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  *out_block = block;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_block_pool_release(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_hal_amdgpu_block_t* block) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  if (!block) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Return the block to the pool free list and update the allocation tracking.
+  block->next = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block;
+  --block->allocation->used_count;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_hal_amdgpu_block_pool_release_list(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t* block_head) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  if (!block_head) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Return the blocks to the pool free list and update the allocation tracking.
+  // Note that each block has allocation tracking that needs to be adjusted.
+  iree_hal_amdgpu_block_t* block = block_head;
+  iree_hal_amdgpu_block_t* block_tail = block;
+  do {
+    block_tail = block;
+    --block->allocation->used_count;
+    block = block->next;
+  } while (block);
+
+  // Prepend the list to the block pool free list.
+  // The provided list is already linked so we just need to swap it in.
+  // If we didn't have the per-block work we could do this without scanning the
+  // list by taking a tail block as an argument (the caller may already have
+  // it).
+  block_tail->next = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block_tail;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_arena_t
+//===----------------------------------------------------------------------===//
+
+void iree_hal_amdgpu_block_arena_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_arena_t* out_arena) {
+  memset(out_arena, 0, sizeof(*out_arena));
+  out_arena->block_pool = block_pool;
+}
+
+void iree_hal_amdgpu_block_arena_deinitialize(
+    iree_hal_amdgpu_block_arena_t* arena) {
+  iree_hal_amdgpu_block_arena_reset(arena);
+}
+
+void iree_hal_amdgpu_block_arena_reset(iree_hal_amdgpu_block_arena_t* arena) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (arena->block_head != NULL) {
+    iree_hal_amdgpu_block_pool_release_list(arena->block_pool,
+                                            arena->block_head);
+    arena->block_head = NULL;
+    arena->block_tail = NULL;
+  }
+
+  arena->total_allocation_size = 0;
+  arena->used_allocation_size = 0;
+  arena->block_bytes_remaining = 0;
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_hal_amdgpu_block_t* iree_hal_amdgpu_block_arena_release_blocks(
+    iree_hal_amdgpu_block_arena_t* arena) {
+  iree_hal_amdgpu_block_t* block_head = arena->block_head;
+  arena->block_head = NULL;
+  arena->block_tail = NULL;
+  arena->total_allocation_size = 0;
+  arena->used_allocation_size = 0;
+  arena->block_bytes_remaining = 0;
+  return block_head;
+}
+
+iree_status_t iree_hal_amdgpu_block_arena_allocate(
+    iree_hal_amdgpu_block_arena_t* arena, iree_device_size_t byte_length,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr) {
+  *out_ptr = NULL;
+
+  iree_hal_amdgpu_block_pool_t* block_pool = arena->block_pool;
+
+  // Pad length allocated so that each pointer bump is always ending at an
+  // aligned address and the next allocation will start aligned.
+  iree_device_size_t aligned_length =
+      iree_device_align(byte_length, iree_hal_amdgpu_max_align_t);
+
+  // Check to see if the current block (if any) has space - if not, get another.
+  if (arena->block_head == NULL ||
+      arena->block_bytes_remaining < aligned_length) {
+    IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_amdgpu_allocate_grow");
+    iree_hal_amdgpu_block_t* block = NULL;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_amdgpu_block_pool_acquire(arena->block_pool, &block));
+    block->next = NULL;
+    if (arena->block_tail) {
+      arena->block_tail->next = block;
+    } else {
+      arena->block_head = block;
+    }
+    arena->block_tail = block;
+    arena->total_allocation_size += block_pool->block_size;
+    arena->block_bytes_remaining = block_pool->block_size;
+    IREE_TRACE_ZONE_END(z0);
+  }
+
+  // Slice out the allocation from the current block.
+  IREE_AMDGPU_DEVICE_PTR void* ptr =
+      (uint8_t*)arena->block_tail->ptr - arena->block_bytes_remaining;
+  arena->block_bytes_remaining -= aligned_length;
+  arena->used_allocation_size += aligned_length;
+  *out_ptr = ptr;
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_allocator_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_block_allocator_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_host_size_t min_page_size,
+    iree_hal_amdgpu_block_allocator_t* out_allocator) {
+  // Verify preconditions.
+  if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(min_page_size))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "min_page_size of %" PRIhsz
+                            " bytes must be a power-of-two",
+                            min_page_size);
+  } else if (IREE_UNLIKELY(block_pool->block_size < min_page_size)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "min_page_size of %" PRIhsz
+        " bytes must fit within the pooled block size of %" PRIhsz " bytes",
+        min_page_size, block_pool->block_size);
+  }
+
+  // We limit our page count to how many bits we have in the usage bitmap.
+  // We may use fewer bits if the granularity is large and the blocks are small.
+  const iree_host_size_t max_page_count =
+      IREE_HAL_AMDGPU_BLOCK_USER_DATA_SIZE * 8;
+  const iree_host_size_t page_size =
+      iree_max(min_page_size, block_pool->block_size / max_page_count);
+  const iree_host_size_t page_count = block_pool->block_size / page_size;
+
+  out_allocator->page_size = page_size;
+  out_allocator->page_count = page_count;
+  out_allocator->block_pool = block_pool;
+
+  iree_slim_mutex_initialize(&out_allocator->mutex);
+  out_allocator->block_head = NULL;
+  out_allocator->block_tail = NULL;
+
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_block_allocator_deinitialize(
+    iree_hal_amdgpu_block_allocator_t* allocator) {
+  if (!allocator) return;
+
+  IREE_ASSERT_EQ(allocator->block_head, NULL);
+  IREE_ASSERT_EQ(allocator->block_tail, NULL);
+
+  iree_slim_mutex_deinitialize(&allocator->mutex);
+
+  memset(allocator, 0, sizeof(*allocator));
+}
+
+static iree_status_t iree_hal_amdgpu_block_allocator_allocate_with_lock(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t page_count,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token) {
+  // Scan the block list for sufficient contiguous free pages. The blocks are
+  // roughly sorted with blocks that have free pages first and we rely on the
+  // total block count being small to make this linear scan ok. We will need to
+  // bucket by longest span or some other "real" allocator things if this ends
+  // up not being enough.
+  iree_hal_amdgpu_block_t* block = allocator->block_head;
+  while (block) {
+    const iree_hal_amdgpu_bitmap_t bitmap = {
+        .bit_count = allocator->page_count,
+        .words = &block->user_data[0],
+    };
+    const iree_host_size_t page_index =
+        iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 0, page_count);
+    if (page_index == bitmap.bit_count) {
+      // No span of sufficient size found - try the next block with free pages.
+      block = block->next;
+      continue;
+    }
+    // Span of pages found. Reserve and return the allocation.
+    iree_hal_amdgpu_bitmap_set_span(bitmap, page_index, page_count);
+    *out_ptr = (uint8_t*)block->ptr + page_index * allocator->page_size;
+    out_token->page_count = (uint64_t)page_count;
+    out_token->block = (uint64_t)block;
+    return iree_ok_status();
+  }
+
+  // Acquire a new block from the block pool.
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_block_pool_acquire(allocator->block_pool, &block));
+
+  // Reset the bitmap as the contents are undefined.
+  const iree_hal_amdgpu_bitmap_t bitmap = {
+      .bit_count = allocator->page_count,
+      .words = &block->user_data[0],
+  };
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);
+
+  // Link the block into the list.
+  // If it is full to start (page_count == pages per block) we move it to the
+  // end of the list so it's not scanned.
+  if (page_count == allocator->page_count) {
+    block->next = NULL;
+    block->prev = allocator->block_tail;
+    if (allocator->block_tail) {
+      allocator->block_tail->next = block;
+    } else {
+      allocator->block_head = block;
+    }
+    allocator->block_tail = block;
+  } else {
+    block->next = allocator->block_head;
+    block->prev = NULL;
+    if (allocator->block_head) {
+      allocator->block_head->prev = block;
+    } else {
+      allocator->block_tail = block;
+    }
+    allocator->block_head = block;
+  }
+
+  // Reserve the the entire page range starting at index 0.
+  const iree_host_size_t page_index = 0;
+  iree_hal_amdgpu_bitmap_set_span(bitmap, page_index, page_count);
+  *out_ptr = (uint8_t*)block->ptr + page_index * allocator->page_size;
+  out_token->page_count = (uint64_t)page_count;
+  out_token->block = (uint64_t)block;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_block_allocator_allocate(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t size,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token) {
+  // Round up the allocation size to the next page size.
+  const iree_host_size_t page_count =
+      iree_host_size_ceil_div(size, allocator->page_size);
+
+  // If the allocation exceeds the page count of a block we cannot allocate it.
+  // We could send these off to an oversized dedicated allocation pool but the
+  // usage of this today shouldn't hit that. Everything should be on the fast
+  // path and dedicated allocations for high-frequency transient allocations are
+  // the slowest of paths.
+  if (page_count > allocator->page_count) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "page count %" PRIhsz " for an allocation of %" PRIhsz
+        " bytes exceeds block page capacity of %u x %u byte blocks",
+        page_count, size, allocator->page_count, allocator->page_size);
+  }
+
+  iree_slim_mutex_lock(&allocator->mutex);
+  iree_status_t status = iree_hal_amdgpu_block_allocator_allocate_with_lock(
+      allocator, page_count, out_ptr, out_token);
+  iree_slim_mutex_unlock(&allocator->mutex);
+  return status;
+}
+
+static void iree_hal_amdgpu_block_allocator_free_with_lock(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token) {
+  iree_hal_amdgpu_block_t* block =
+      (iree_hal_amdgpu_block_t*)(((int64_t)token.block << 8) >> 8);
+
+  // Calculate and clear the page bits corresponding to the allocated range.
+  const uint64_t byte_offset = (uint64_t)ptr - (uint64_t)block->ptr;
+  const iree_host_size_t page_index = byte_offset / allocator->page_size;
+  const iree_hal_amdgpu_bitmap_t bitmap = {
+      .bit_count = allocator->page_count,
+      .words = &block->user_data[0],
+  };
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, page_index, token.page_count);
+
+  // We do two things: moving the block to the head of list so it's found in
+  // scans and returning the block to the block pool if it has no more
+  // allocations outstanding. In both cases we unlink it from the block list.
+  if (block->next) {
+    block->next->prev = block->prev;
+  } else {
+    allocator->block_tail = block->prev;
+  }
+  if (block->prev) {
+    block->prev->next = block->next;
+  } else {
+    allocator->block_head = block->next;
+  }
+  block->prev = block->next = NULL;
+
+  // If the block has no more remaining allocations outstanding it can be
+  // returned to the block pool after we unlink it.
+  if (iree_hal_amdgpu_bitmap_empty(bitmap)) {
+    iree_hal_amdgpu_block_pool_release(allocator->block_pool, block);
+    return;
+  }
+
+  // Move the block to the head of the list as we now know it has free pages.
+  // When allocations are made in predictable patterns (most are) this ensures
+  // the next set of allocations will find pages they are looking for early in
+  // their scan. Or not - there's pathological cases where it'll just create
+  // a ton of fragmentation.
+  if (allocator->block_head) {
+    allocator->block_head->prev = block;
+  } else {
+    allocator->block_tail = block;
+  }
+  block->next = allocator->block_head;
+  allocator->block_head = block;
+}
+
+void iree_hal_amdgpu_block_allocator_free(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token) {
+  if (!ptr) return;
+  iree_slim_mutex_lock(&allocator->mutex);
+  iree_hal_amdgpu_block_allocator_free_with_lock(allocator, ptr, token);
+  iree_slim_mutex_unlock(&allocator->mutex);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
@@ -1,0 +1,354 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Allocation and Transfer Utilities
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): verify that 16 is enough - there are some rules for kernarg
+// alignment we may need to respect. Things seem to work but that may be by
+// chance and out of spec.
+#define iree_hal_amdgpu_max_align_t 16
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_pool_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_block_t iree_hal_amdgpu_block_t;
+typedef struct iree_hal_amdgpu_block_allocation_t
+    iree_hal_amdgpu_block_allocation_t;
+typedef struct iree_hal_amdgpu_block_pool_t iree_hal_amdgpu_block_pool_t;
+
+// Options for configuring a block pool.
+typedef struct iree_hal_amdgpu_block_pool_options_t {
+  // Size in bytes of the device block. Must be a power of two.
+  iree_device_size_t block_size;
+  // Blocks per device allocation made.
+  // This trades off potential underutilized allocations with the number of
+  // allocations made. May be rounded up to meet device requirements.
+  // If 0 then as many blocks as fit within a single recommended device
+  // allocation will be used.
+  iree_host_size_t min_blocks_per_allocation;
+  // Initial capacity of the pool in blocks.
+  // At least this number of blocks will be allocated during pool
+  // initialization, possibly split into multiple block pool allocations.
+  iree_host_size_t initial_capacity;
+} iree_hal_amdgpu_block_pool_options_t;
+
+// A block in the block pool.
+// This is a suballocation of an iree_hal_amdgpu_block_allocation_t device
+// allocation.
+typedef struct iree_hal_amdgpu_block_t {
+  // Device pointer to the allocated block.
+  IREE_AMDGPU_DEVICE_PTR void* ptr;
+  // Parent allocation of the block.
+  // This could be derived from the block pointer if we placed the parent
+  // iree_hal_amdgpu_block_allocation_t at a fixed address (if we ever need
+  // another user_data field).
+  iree_hal_amdgpu_block_allocation_t* allocation;
+  // Next block in a user-defined block list. May be used for any purpose.
+  // Initially NULL on blocks acquired from the pool. Note that this may
+  // reference blocks in another allocation or even pool.
+  iree_hal_amdgpu_block_t* next;
+  // Previous block in a user-defined block list. May be used for any purpose.
+  // Initially NULL on blocks acquired from the pool. Note that this may
+  // reference blocks in another allocation or even pool.
+  iree_hal_amdgpu_block_t* prev;
+  // Arbitrary user data valid while the block is held by the user.
+  // This can be used to sequester small amounts of metadata for tracking.
+  // Initially 0 on blocks acquired from the pool. No cleanup is performed upon
+  // release.
+  uint64_t user_data[4];
+} iree_hal_amdgpu_block_t;
+static_assert(sizeof(iree_hal_amdgpu_block_t) == 64,
+              "keep blocks cache line sized");
+
+// Size of the user data field in a block in bytes.
+#define IREE_HAL_AMDGPU_BLOCK_USER_DATA_SIZE \
+  sizeof(((iree_hal_amdgpu_block_t*)NULL)->user_data)
+
+// A single device allocation containing one or more blocks.
+typedef struct iree_hal_amdgpu_block_allocation_t {
+  // Next in the linked list of allocations managed by the block pool.
+  iree_hal_amdgpu_block_allocation_t* next;
+  // Base pointer of the device allocation.
+  IREE_AMDGPU_DEVICE_PTR void* base_ptr;
+  // Number of used blocks in the allocation outstanding.
+  iree_host_size_t used_count;
+  // Contiguously allocated blocks within the allocation.
+  iree_alignas(64) iree_hal_amdgpu_block_t blocks[/*blocks_per_allocation*/];
+} iree_hal_amdgpu_block_allocation_t;
+
+// A shared pool of equal-sized blocks in device agent memory.
+// Tries to make as few device allocations as possible and of the granularity
+// requested by the driver (or larger). Device memory is not touched by the host
+// as part of management and the memory may not even be host accessible.
+//
+// This uses a linked data structure to allow growth without reallocation (user
+// workloads are unpredictable). The savings from pooling blocks by not having
+// to call into HSA is many orders of magnitude greater than the cost of some
+// linked-list pointer walks. Since users of the block pool almost always need a
+// linked list to store the block in their own lists (iovecs, etc) we expose
+// those as part of the internal tracking structure we need for managing free
+// lists.
+//
+// Thread-safe; may be used by multiple queues on the same physical device with
+// independent host threads.
+typedef struct iree_hal_amdgpu_block_pool_t {
+  // HSA API handle. Unowned and must be kept live by parent.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  // Host allocator used for block lists.
+  iree_allocator_t host_allocator;
+  // Agent the block pool is managing blocks on.
+  hsa_agent_t agent;
+  // Memory pool blocks are allocated from.
+  hsa_amd_memory_pool_t memory_pool;
+  // Size in bytes of a block on device.
+  iree_device_size_t block_size;
+  // Number of blocks in a single device allocation.
+  iree_device_size_t blocks_per_allocation;
+  // Mutex managing the block pool resources.
+  iree_slim_mutex_t mutex;
+  // Linked list of allocations managed by the pool.
+  // Newly allocated blocks are inserted at the head of the list.
+  iree_hal_amdgpu_block_allocation_t* allocations_head IREE_GUARDED_BY(mutex);
+  // Linked list of free blocks in the pool.
+  // The first block in the list is usually the last block released.
+  iree_hal_amdgpu_block_t* free_blocks_head IREE_GUARDED_BY(mutex);
+} iree_hal_amdgpu_block_pool_t;
+
+// Initializes the block pool to allocate from the given |agent| |memory_pool|.
+// Each block will have the same block size and multiple blocks may be allocated
+// at the same time to hit the pool allocation granularity.
+//
+// If an initial block capacity is provided the block pool will make its initial
+// growth allocation to have the given number of blocks available for use prior
+// to returning.
+//
+// A reference to |libhsa| will be kept by the block pool in order to allocate
+// and free memory and must remain live.
+iree_status_t iree_hal_amdgpu_block_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_block_pool_options_t options, hsa_agent_t agent,
+    hsa_amd_memory_pool_t memory_pool, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_block_pool_t* out_block_pool);
+
+// Deinitializes the block pool and releases all resources back to the device.
+// Any outstanding block pointers will become invalid.
+void iree_hal_amdgpu_block_pool_deinitialize(
+    iree_hal_amdgpu_block_pool_t* block_pool);
+
+// Trims the block pool by releasing all allocations that have no outstanding
+// blocks allocated. Does not compact allocations to reduce fragmentation.
+void iree_hal_amdgpu_block_pool_trim(iree_hal_amdgpu_block_pool_t* block_pool);
+
+// Acquires a block from the |block_pool|, growing the pool if needed.
+iree_status_t iree_hal_amdgpu_block_pool_acquire(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t** out_block);
+
+// Releases a block back to the pool.
+// The block must have been acquired from |block_pool|.
+void iree_hal_amdgpu_block_pool_release(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_hal_amdgpu_block_t* block);
+
+// Releases a linked list of blocks back to the pool.
+// All blocks must have been acquired from |block_pool|.
+void iree_hal_amdgpu_block_pool_release_list(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t* block_head);
+
+// Block pools for device memory blocks of various sizes.
+// The pools may be configured differently for their usage based on who owns
+// them but generally follow the same bucketing strategy.
+typedef struct iree_hal_amdgpu_block_pools_t {
+  // Used for small allocations of around ~4-32KB.
+  iree_hal_amdgpu_block_pool_t small;
+  // Used for large page-sized allocations of around ~64kB-512KB.
+  iree_hal_amdgpu_block_pool_t large;
+  // Any larger should (probably) be dedicated allocations.
+} iree_hal_amdgpu_block_pools_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_arena_t
+//===----------------------------------------------------------------------===//
+
+// A lightweight bump-pointer arena allocator using a shared block pool.
+// As allocations are made from the arena and block capacity is exhausted new
+// blocks will be acquired from the pool. Upon being reset all blocks will be
+// released back to the pool for reuse by either the same arena in the future or
+// other arenas sharing the same pool.
+//
+// The size of each allocated block used by the arena is inherited from the
+// block pool. Allocations from the arena can not exceed the block size.
+//
+// Thread-compatible; the shared block pool is thread-safe and may be used by
+// arenas on multiple threads but each arena must only be used by a single
+// thread at a time.
+typedef struct iree_hal_amdgpu_block_arena_t {
+  // Fixed-size block pool used to acquire new blocks for the arena.
+  iree_hal_amdgpu_block_pool_t* block_pool;
+  // Total bytes allocated to the arena from the block pool.
+  iree_device_size_t total_allocation_size;
+  // Total bytes allocated from the arena; the utilization of the arena can be
+  // checked with `used_allocation_size / total_allocation_size`.
+  iree_device_size_t used_allocation_size;
+  // Linked list of allocated blocks maintained so that reset can release them.
+  // Newly allocated blocks are appended to the list such that block_tail is
+  // always the most recently allocated block.
+  iree_hal_amdgpu_block_t* block_head;
+  iree_hal_amdgpu_block_t* block_tail;
+  // The number of bytes remaining in the block pointed to by block_head.
+  iree_device_size_t block_bytes_remaining;
+} iree_hal_amdgpu_block_arena_t;
+
+// Initializes an arena that will use |block_pool| for allocating blocks as
+// needed from device memory.
+void iree_hal_amdgpu_block_arena_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_arena_t* out_arena);
+
+// Deinitializes the arena and returns allocated blocks to the parent pool.
+void iree_hal_amdgpu_block_arena_deinitialize(
+    iree_hal_amdgpu_block_arena_t* arena);
+
+// Resets the entire arena and returns allocated blocks to the parent pool.
+void iree_hal_amdgpu_block_arena_reset(iree_hal_amdgpu_block_arena_t* arena);
+
+// Releases ownership of the allocated blocks and returns them as a FIFO linked
+// list. The arena will be reset and ready to allocate new blocks.
+iree_hal_amdgpu_block_t* iree_hal_amdgpu_block_arena_release_blocks(
+    iree_hal_amdgpu_block_arena_t* arena);
+
+// Allocates |byte_length| contiguous bytes from the arena.
+// The returned bytes will have undefined contents and must be initialized by
+// the caller.
+iree_status_t iree_hal_amdgpu_block_arena_allocate(
+    iree_hal_amdgpu_block_arena_t* arena, iree_device_size_t byte_length,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_allocator_t
+//===----------------------------------------------------------------------===//
+
+// Opaque token handed out with allocations used to quickly free the allocation.
+typedef union iree_hal_amdgpu_block_token_t {
+  uint64_t bits;
+  struct {
+    // Number of pages the allocation occupies in the block.
+    uint64_t page_count : 8;
+    // iree_hal_amdgpu_block_t pointer; we only need the lower 7 bytes to
+    // represent blocks. The block is aligned and we could steal some lower bits
+    // if we wanted to allow a larger page_count.
+    uint64_t block : 56;
+  };
+} iree_hal_amdgpu_block_token_t;
+static_assert(sizeof(iree_hal_amdgpu_block_token_t) == sizeof(uint64_t),
+              "must match reserved space in the device library");
+
+// A block suballocator intended for relatively small allocations (~256 bytes to
+// ~4096 bytes) made at average frequency (~once per queue submission).
+//
+// Each block acquired from the block pool is divided into 256 fixed size pages.
+// This allows for a bitmap of used pages to be stored inline in the metadata of
+// the block the pages are present in. It also allows for O(1) deallocation at
+// the cost of O(block count) allocation. This is achieved by providing a token
+// with each allocation that contains the block pointer packed with the page
+// count of the allocation (knowing it is always <= 256) avoiding the need to
+// either touch the device-side memory or allocate additional host-side
+// metadata. The memory overhead of each allocation rounds to zero as the token
+// is stored in the data structures of the client code requesting the allocation
+// and each block already has 256 bits of host-local user data storage available
+// for use.
+//
+// The downside of this implementation is that it can suffer from internal
+// fragmentation. If exclusively 129 page allocations are made nearly half of
+// all acquired block storage will be wasted. That's (hopefully) rare for the
+// intended usage which is either ~64-128 byte allocations (most scheduler queue
+// entries) or ~1024-4096 byte allocations (execution entries with binding
+// tables). If fragmentation becomes an issue we can bucket the free list by
+// number of contiguous pages free and reduce the scan cost.
+//
+// The allocator uses the user_data[] field in iree_hal_amdgpu_block_t to store
+// the page occupancy bitmap. Though fixed today we could extend it to allow
+// for larger bitmaps when block sizes are much greater than page size. It's
+// expected that users will route requests to a block pool corresponding to
+// their size class so as to avoid overallocation/under-utilization: allocating
+// 1 byte from the large block pool would acquire an entire large block that
+// would be nearly entirely unused if we didn't do that first-level filtering.
+//
+// Thread-safe; allocate/free are guarded within the allocator and the
+// underlying block pool is also thread-safe.
+typedef struct iree_hal_amdgpu_block_allocator_t {
+  // Power-of-two calculated allocation granularity in bytes. All allocations
+  // are padded to this size.
+  uint32_t page_size;
+  // Power-of-two number of pages within each block.
+  uint32_t page_count;
+  // Block pool with fixed-size blocks that the allocator uses for storage.
+  iree_hal_amdgpu_block_pool_t* block_pool;
+  // Guards access to the block lists and block bitmaps.
+  iree_slim_mutex_t mutex;
+  // Doubly linked list of blocks. Roughly sorted with blocks that have free
+  // space near the front.
+  iree_hal_amdgpu_block_t* block_head IREE_GUARDED_BY(mutex);
+  iree_hal_amdgpu_block_t* block_tail IREE_GUARDED_BY(mutex);
+} iree_hal_amdgpu_block_allocator_t;
+
+// Initializes a new allocator that acquires its memory from the given
+// |block_pool| and with a fixed power-of-two allocation |min_page_size|.
+// Allocations will be padded to the granularity.
+iree_status_t iree_hal_amdgpu_block_allocator_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_host_size_t min_page_size,
+    iree_hal_amdgpu_block_allocator_t* out_allocator);
+
+// Deinitializes the allocator and frees all blocks back to the block pool.
+// Requires that all outstanding allocations have been freed.
+void iree_hal_amdgpu_block_allocator_deinitialize(
+    iree_hal_amdgpu_block_allocator_t* allocator);
+
+// Allocates a range of memory with iree_hal_amdgpu_max_align_t alignment.
+// |out_ptr| will point to the device address of the allocation (which may not
+// be host accessible) and |out_token| is opaque allocation-specific metadata
+// that must be passed to iree_hal_amdgpu_block_allocator_free.
+iree_status_t iree_hal_amdgpu_block_allocator_allocate(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t size,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token);
+
+// Frees an allocated |ptr| with associated metadata |token|.
+// The corresponding pages will be marked as free within the parent block and
+// if the block has no more used pages it will be returned to the pool.
+void iree_hal_amdgpu_block_allocator_free(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token);
+
+// Block allocators for device memory blocks of various sizes.
+// The allocators are configured to use the block pools in
+// iree_hal_amdgpu_block_pools_t.
+typedef struct iree_hal_amdgpu_block_allocators_t {
+  // Used for small allocations of around ~64B-256B.
+  iree_hal_amdgpu_block_allocator_t small;
+  // Used for large allocations of around ~4096B-256KB.
+  iree_hal_amdgpu_block_allocator_t large;
+} iree_hal_amdgpu_block_allocators_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool_test.cc
@@ -1,0 +1,214 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/block_pool.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct BlockPoolTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+TEST_F(BlockPoolTest, LifetimeEmpty) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/1 * 1024,
+      /*.initial_capacity=*/0,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Acquire a block. This will grow the pool as we started empty.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+
+  // Acquire another block. It should have a unique address (to ensure we didn't
+  // return the same block).
+  iree_hal_amdgpu_block_t* block1 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block1));
+  EXPECT_NE(block1->ptr, nullptr);
+  EXPECT_NE(block1->ptr, block0->ptr);
+  EXPECT_EQ(block1->next, nullptr);
+
+  // Release the first block back to the pool followed by the second.
+  // This ensures we support arbitrary ordering.
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block1);
+
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+TEST_F(BlockPoolTest, LifetimeInitial) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/1 * 1024,
+      /*.initial_capacity=*/32,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Acquire and release block. This should not grow the pool as we initialized
+  // it above.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+// Allocates a few blocks to force some growth, frees some, trims, and tries to
+// grow again. We have to use the reported blocks_per_allocation as the pool
+// will always round up what we specify.
+TEST_F(BlockPoolTest, Trimming) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/256 * 1024,
+      /*.initial_capacity=*/0,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Since the exact counts are device dependent we have to dynamically manage
+  // our working set. We try to hit a certain number of batches.
+  // Note that to ensure we get new blocks we allocate everything and then
+  // selectively release resources.
+  //
+  // batches[0] = fully allocated
+  // batches[1] = all but one allocated
+  // batches[2] = only one allocated
+  struct batch_t {
+    std::vector<iree_hal_amdgpu_block_t*> blocks;
+  };
+  batch_t batches[4] = {};
+  for (iree_host_size_t batch = 0; batch < IREE_ARRAYSIZE(batches); ++batch) {
+    for (iree_host_size_t i = 0; i < block_pool.blocks_per_allocation; ++i) {
+      iree_hal_amdgpu_block_t* block = NULL;
+      IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block));
+      batches[batch].blocks.push_back(block);
+    }
+  }
+  {
+    // batches[0] = fully allocated, don't release anything.
+  }
+  {
+    // batches[1] = all but one allocated - release only the last.
+    iree_hal_amdgpu_block_t* block = batches[1].blocks.back();
+    batches[1].blocks.pop_back();
+    iree_hal_amdgpu_block_pool_release(&block_pool, block);
+  }
+  {
+    // batches[2] = only one allocated - release all but the first.
+    for (iree_host_size_t i = 0; i < batches[2].blocks.size() - 1; ++i) {
+      iree_hal_amdgpu_block_t* block = batches[2].blocks.back();
+      batches[2].blocks.pop_back();
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+  {
+    // batches[3] = none allocated - release all.
+    while (!batches[3].blocks.empty()) {
+      iree_hal_amdgpu_block_t* block = batches[3].blocks.back();
+      batches[3].blocks.pop_back();
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+
+  // Trim now - we should only drop one allocation for batches[3] that has
+  // no live blocks.
+  iree_hal_amdgpu_block_pool_trim(&block_pool);
+
+  // Acquire a new block - should use something we have in the pool. This is
+  // something that would trigger ASAN if we freed something bad.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+
+  // Drop all of batches[2] and try trimming again.
+  for (auto* block : batches[2].blocks) {
+    iree_hal_amdgpu_block_pool_release(&block_pool, block);
+  }
+  batches[2].blocks.clear();
+  iree_hal_amdgpu_block_pool_trim(&block_pool);
+
+  // Another test block.
+  iree_hal_amdgpu_block_t* block1 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block1));
+  EXPECT_NE(block1->ptr, nullptr);
+  EXPECT_EQ(block1->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block1);
+
+  // Release all remaining blocks.
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(batches); ++i) {
+    for (auto* block : batches[i].blocks) {
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+
+  // Implicitly trims.
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -1,0 +1,293 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_find_global_memory_pool_state_t {
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  hsa_amd_memory_pool_global_flag_t match_flags;
+  hsa_amd_memory_pool_t best_pool;
+} iree_hal_amdgpu_find_global_memory_pool_state_t;
+static hsa_status_t iree_hal_amdgpu_find_global_memory_pool_iterator(
+    hsa_amd_memory_pool_t memory_pool, void* user_data) {
+  iree_hal_amdgpu_find_global_memory_pool_state_t* state =
+      (iree_hal_amdgpu_find_global_memory_pool_state_t*)user_data;
+
+  // Filter to the global segment only.
+  hsa_region_segment_t segment = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+      &segment));
+  if (segment != HSA_REGION_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
+
+  // Must be able to allocate. This should be true for any pool we query that
+  // matches the other flags. Workgroup-private pools won't have this set.
+  bool alloc_allowed = false;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed));
+  if (!alloc_allowed) return HSA_STATUS_SUCCESS;
+
+  // Match if flags are present.
+  hsa_region_global_flag_t global_flag = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &global_flag));
+  if (global_flag & state->match_flags) {
+    state->best_pool = memory_pool;
+    return HSA_STATUS_INFO_BREAK;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_pool, 0, sizeof(*out_pool));
+
+  iree_hal_amdgpu_find_global_memory_pool_state_t find_state = {
+      .libhsa = libhsa,
+      .match_flags = match_flags,
+      .best_pool = {0},
+  };
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_agent_iterate_memory_pools(
+              IREE_LIBHSA(libhsa), agent,
+              iree_hal_amdgpu_find_global_memory_pool_iterator, &find_state));
+  if (!find_state.best_pool.handle) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_NOT_FOUND,
+                             "no memory pool matching the required flags %u",
+                             match_flags));
+  }
+
+  *out_pool = find_state.best_pool;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED, out_pool);
+}
+
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_pool);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, min_capacity);
+  memset(out_ringbuffer, 0, sizeof(*out_ringbuffer));
+
+  // hsa_amd_vmem_handle_create wants values aligned to this value.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_memory_pool_get_info(
+              IREE_LIBHSA(libhsa), memory_pool,
+              HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+              &alloc_rec_granule));
+
+  // Round up capacity and alignment to the allocation granule.
+  const size_t alignment = alloc_rec_granule;
+  const size_t capacity = iree_device_align(min_capacity, alloc_rec_granule);
+  out_ringbuffer->capacity = capacity;
+
+  // Reserve the virtual address space for the 3x the capacity. We'll map the
+  // physical allocation into this address space.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_vmem_address_reserve_align(
+          IREE_LIBHSA(libhsa), &out_ringbuffer->va_base_ptr, capacity * 3,
+          /*address=*/0, alignment, /*flags=*/0),
+      "reserving ringbuffer capacity*3 (%" PRIdsz "*3=%" PRIdsz ")", capacity,
+      capacity * 3);
+  out_ringbuffer->ring_base_ptr =
+      (uint8_t*)out_ringbuffer->va_base_ptr + capacity;
+
+  // Allocate the physical memory for backing the ringbuffer.
+  iree_status_t status = iree_hsa_amd_vmem_handle_create(
+      IREE_LIBHSA(libhsa), memory_pool, capacity, MEMORY_TYPE_NONE,
+      /*flags=*/0, &out_ringbuffer->alloc_handle);
+
+  void* va_offsets[3] = {
+      (uint8_t*)out_ringbuffer->va_base_ptr + 0 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 1 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 2 * capacity,
+  };
+
+  // Map the physical allocation into the virtual address space 3 times
+  // (prev, base, next).
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_map(IREE_LIBHSA(libhsa), va_offsets[i], capacity, 0,
+                              out_ringbuffer->alloc_handle, /*flags=*/0);
+  }
+
+  // Enable access on requested devices (no access by default).
+  // Must be done per memory handle, not the entire VA.
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_set_access(IREE_LIBHSA(libhsa), va_offsets[i],
+                                     capacity, access_descs, access_desc_count);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_vmem_ringbuffer_deinitialize(libhsa, out_ringbuffer);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate scratch for the access descriptors. Note that though we allocate
+  // for all agents we don't pass agents with HSA_ACCESS_PERMISSION_NONE as that
+  // actually causes HSA to allocate information about that agent.
+  // HSA_ACCESS_PERMISSION_NONE should only be used to _remove_ access that was
+  // previous granted.
+  iree_host_size_t access_desc_count = 0;
+  hsa_amd_memory_access_desc_t* access_descs =
+      (hsa_amd_memory_access_desc_t*)iree_alloca(
+          topology->all_agent_count * sizeof(hsa_amd_memory_access_desc_t));
+
+  // Populate the access list.
+  switch (access_mode) {
+    case IREE_HAL_AMDGPU_ACCESS_MODE_SHARED: {
+      // All devices get read/write access.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = HSA_ACCESS_PERMISSION_RW,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE: {
+      // Only the local agent can access the ringbuffer.
+      access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+          .agent_handle = local_agent,
+          .permissions = HSA_ACCESS_PERMISSION_RW,
+      };
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER: {
+      // Local agent gets read, all agents get write.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER: {
+      // Local agent gets write, all agents get read.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    default: {
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                               "unhandled access mode"));
+    } break;
+  }
+
+  // Route to the explicit initializer.
+  iree_status_t status = iree_hal_amdgpu_vmem_ringbuffer_initialize(
+      libhsa, local_agent, memory_pool, min_capacity, access_desc_count,
+      access_descs, out_ringbuffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Unmap physical allocation and release it.
+  if (ringbuffer->alloc_handle.handle) {
+    void* va_offsets[3] = {
+        (uint8_t*)ringbuffer->va_base_ptr + 0 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 1 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 2 * ringbuffer->capacity,
+    };
+    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(va_offsets); ++i) {
+      IREE_IGNORE_ERROR(iree_hsa_amd_vmem_unmap(
+          IREE_LIBHSA(libhsa), va_offsets[i], ringbuffer->capacity));
+    }
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_handle_release(
+        IREE_LIBHSA(libhsa), ringbuffer->alloc_handle));
+  }
+
+  if (ringbuffer->va_base_ptr) {
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_address_free(IREE_LIBHSA(libhsa),
+                                                     ringbuffer->va_base_ptr,
+                                                     ringbuffer->capacity * 3));
+  }
+
+  memset(ringbuffer, 0, sizeof(*ringbuffer));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -1,0 +1,133 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+// Semantically defines how a vmem allocation can be accessed.
+typedef enum iree_hal_amdgpu_vmem_access_mode_e {
+  // All agents may produce and consume the memory. Read/write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_SHARED = 0u,
+  // Memory is accessed exclusively by the agent it is allocated on.
+  // No other agent has access. Read/write for agent only.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE,
+  // Memory is consumed exclusively by the agent it is allocated on but may be
+  // produced from any agent. This is useful for mailboxes. Read for agent only
+  // and write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER,
+  // Memory is produced exclusively by the agent it is allocated on but may be
+  // consumed from any agent. This is useful for outbound buffers. Write for
+  // agent only and read for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER,
+} iree_hal_amdgpu_vmem_access_mode_t;
+
+// Finds a global memory pool on the |agent| matching any of the specified
+// global flags.
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a coarse-grained memory pool on the |agent|.
+// The returned pool will support allocations and be
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a fine-grained memory pool on the |agent|.
+// The returned pool will support allocations and be either
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED or
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+// An allocated ringbuffer using virtual memory mapping to present a contiguous
+// virtual address range that is backed by a single physical buffer but that
+// allows access before and after it.
+//
+// This presents as a ringbuffer that does not need any special logic for
+// wrapping from base offsets used when copying in memory. It follows the
+// approach documented in https://lo.calho.st/posts/black-magic-buffer/ and
+// https://www.mikeash.com/pyblog/friday-qa-2012-02-17-ring-buffers-and-mirrored-memory-part-ii.html
+// of virtual memory mapping the buffer multiple times, example code:
+// https://github.com/google/wuffs/blob/main/script/mmap-ring-buffer.c
+//
+// We use SVM to allocate the physical memory of the ringbuffer and then stitch
+// together 3 virtual memory ranges in one contiguous virtual allocation that
+// aliases the physical allocation. By treating the middle range as the base
+// buffer pointer we are then able to freely dereference both before and after
+// the base pointer by up to the ringbuffer size in length.
+//   physical: <ringbuffer size> --+------+------+
+//                                 v      v      v
+//                        virtual: [prev] [base] [next]
+//                                 ^      ^
+//                                 |      +-- ring_base_ptr
+//                                 +--------- va_base_ptr
+typedef struct iree_hal_amdgpu_vmem_ringbuffer_t {
+  // Capacity of the ringbuffer in bytes.
+  // May be larger than the requested size if adjusted to the minimum allocation
+  // granule.
+  iree_device_size_t capacity;
+  // Physical allocation of the pinned ringbuffer memory.
+  // This is sized to the requested capacity of the ringbuffer.
+  hsa_amd_vmem_alloc_handle_t alloc_handle;
+  // Base virtual address pointer of the ringbuffer. This is the start of the
+  // reserved address range.
+  IREE_AMDGPU_DEVICE_PTR void* va_base_ptr;
+  // Base virtual address pointer of the central ringbuffer contents.
+  IREE_AMDGPU_DEVICE_PTR void* ring_base_ptr;
+} iree_hal_amdgpu_vmem_ringbuffer_t;
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested |min_capacity| with at least 64 byte alignment.
+// |access_descs| will be used to setup accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested power-of-two |min_capacity| with at least
+// least 64 byte alignment. |topology| and |access_mode| will be used to setup
+// accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Deinitializes a ringbuffer and frees all physical and virtual allocations.
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct VMemTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, FindCoarseGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  EXPECT_TRUE(iree_all_bits_set(
+      global_flags, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED));
+}
+
+TEST_F(VMemTest, FindFineGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  // NOTE: the pool may have either flag set.
+  EXPECT_TRUE(iree_any_bit_set(
+      global_flags,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, RingbufferLifetime) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  EXPECT_GE(ringbuffer.capacity, min_capacity);
+  EXPECT_EQ(ringbuffer.ring_base_ptr,
+            (uint8_t*)ringbuffer.va_base_ptr + ringbuffer.capacity);
+  EXPECT_TRUE(iree_device_size_has_alignment(
+      (iree_device_size_t)ringbuffer.ring_base_ptr, 64));
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+TEST_F(VMemTest, RingbufferWrap) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  // Fill entire range [0,capacity).
+  iree_device_size_t capacity_u32 = ringbuffer.capacity / sizeof(uint32_t);
+  uint32_t* ptr = (uint32_t*)ringbuffer.ring_base_ptr;
+  for (iree_device_size_t i = 0; i < capacity_u32; ++i) {
+    ptr[i] = (uint32_t)i;
+  }
+
+  // Compare some locations off the base to ensure wrapping is valid.
+  EXPECT_EQ(ptr[0], ptr[capacity_u32]);
+  EXPECT_EQ(ptr[-1], ptr[capacity_u32 - 1]);
+  EXPECT_EQ(ptr[1], ptr[capacity_u32 + 1]);
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu


### PR DESCRIPTION
A dynamically growable pool of fixed-size blocks. All metadata is managed on the host external to the allocated blocks that are intended to be in non-local and potentially non-visible device memory. `iree_hal_amdgpu_block_arena_t` is a simple bump-pointer arena backed by blocks from a pool. `iree_hal_amdgpu_block_allocator_t` is a simple suballocator with malloc/free-like semantics and a special sidecar token used to avoid needing to access the block memory (which may be non-visible) or perform scans of the outstanding allocations.

Sub-review for #20990. Not expected to pass CI.