### PR TITLE
Adding dummy AMDGPU device library.

### DIFF
--- a/build_tools/bazel/iree_amdgpu_binary.bzl
+++ b/build_tools/bazel/iree_amdgpu_binary.bzl
@@ -1,0 +1,168 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Rules for compiling with clang to produce AMDGPU libraries."""
+
+def iree_amdgpu_binary(
+        name,
+        target,
+        arch,
+        srcs,
+        internal_hdrs = [],
+        copts = [],
+        linkopts = [],
+        **kwargs):
+    """Builds an LLVM shared library for AMDGPU from input files via clang.
+
+    Args:
+        name: Name of the target.
+        target: LLVM `-target` flag.
+        arch: LLVM `-march` flag.
+        srcs: source files to pass to clang.
+        internal_hdrs: all headers transitively included by the source files.
+                       Unlike typical Bazel `hdrs`, these are not exposed as
+                       interface headers. This would normally be part of `srcs`,
+                       but separating it was easier for `bazel_to_cmake`, as
+                       CMake does not need this, and making this explicitly
+                       Bazel-only allows using `filegroup` on the Bazel side.
+        copts: additional flags to pass to clang.
+        linkopts: additional flags to pass to lld.
+        **kwargs: any additional attributes to pass to the underlying rules.
+    """
+
+    clang_tool = "@llvm-project//clang:clang"
+    link_tool = "@llvm-project//llvm:llvm-link"
+    lld_tool = "@llvm-project//lld:lld"
+    builtin_headers_dep = "@llvm-project//clang:builtin_headers_gen"
+    builtin_headers_path = "external/llvm-project/clang/staging/include/"
+
+    base_copts = [
+        # C configuration.
+        "-x c",
+        "-std=c23",
+        "-Xclang -finclude-default-header",
+        "-nogpulib",
+        "-fno-short-wchar",
+
+        # Target architecture/machine.
+        "-target %s" % (target),
+        "-march=%s" % (arch),
+        "-fgpu-rdc",  # NOTE: may not be required for all targets
+
+        # Header paths for builtins and our own includes.
+        "-isystem $(BINDIR)/%s" % builtin_headers_path,
+        "-I$(BINDIR)/runtime/src",
+        "-Iruntime/src",
+
+        # Avoid warnings about things we do that are not compatible across
+        # compilers but are fine because we're only ever compiling with clang.
+        "-Wno-gnu-pointer-arith",
+
+        # Optimized.
+        "-fno-ident",
+        "-fvisibility=hidden",
+        "-O3",
+
+        # Object file only in bitcode format.
+        "-c",
+        "-emit-llvm",
+    ]
+
+    bitcode_files = []
+
+    for src in srcs:
+        bitcode_out = "%s_%s.bc" % (name, src)
+        bitcode_files.append(bitcode_out)
+        native.genrule(
+            name = "gen_%s" % (bitcode_out),
+            srcs = [src, builtin_headers_dep] + internal_hdrs,
+            outs = [bitcode_out],
+            cmd = " && ".join([
+                " ".join([
+                    "$(location %s)" % (clang_tool),
+                    " ".join(base_copts + copts),
+                    "-o $(location %s)" % (bitcode_out),
+                    "$(location %s)" % (src),
+                ]),
+            ]),
+            tools = [clang_tool],
+            message = "Compiling %s to %s..." % (src, bitcode_out),
+            output_to_bindir = 1,
+            **kwargs
+        )
+
+    archive_out = "%s.a" % (name)
+    native.genrule(
+        name = "archive_%s" % (name),
+        srcs = bitcode_files,
+        outs = [archive_out],
+        cmd = " && ".join([
+            " ".join([
+                "$(location %s)" % (link_tool),
+                " ".join(["$(locations %s)" % (src) for src in bitcode_files]),
+                "-o $(location %s)" % (archive_out),
+            ]),
+        ]),
+        tools = [link_tool],
+        message = "Archiving bitcode libraries %s to %s..." % (bitcode_files, archive_out),
+        output_to_bindir = 1,
+        **kwargs
+    )
+
+    link_out = "%s.bc" % (name)
+    native.genrule(
+        name = "link_%s" % (name),
+        srcs = [archive_out],
+        outs = [link_out],
+        cmd = " && ".join([
+            " ".join([
+                "$(location %s)" % (link_tool),
+                "-internalize",
+                "-only-needed",
+                "$(locations %s)" % (archive_out),
+                "-o $(location %s)" % (link_out),
+            ]),
+        ]),
+        tools = [link_tool],
+        message = "Linking bitcode library %s to %s..." % (name, link_out),
+        output_to_bindir = 1,
+        **kwargs
+    )
+
+    base_linkopts = [
+        "-m elf64_amdgpu",
+        "--build-id=none",
+        "--no-undefined",
+        "-shared",
+        "-plugin-opt=mcpu=%s" % (arch),
+        "-plugin-opt=O3",
+        "--lto-CGO3",
+        "--no-whole-archive",
+        "--gc-sections",
+        "--strip-debug",
+        "--discard-all",
+        "--discard-locals",
+    ]
+
+    out = "%s.so" % (name)
+    native.genrule(
+        name = name,
+        srcs = [link_out],
+        outs = [out],
+        cmd = " && ".join([
+            " ".join([
+                "$(location %s)" % (lld_tool),
+                "-flavor gnu",
+                " ".join(base_linkopts + linkopts),
+                "$(location %s)" % (link_out),
+                "-o $(location %s)" % (out),
+            ]),
+        ]),
+        tools = [lld_tool],
+        message = "Generating OpenCL binary %s to %s..." % (name, out),
+        output_to_bindir = 1,
+        **kwargs
+    )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -591,6 +591,31 @@ class BuildFileFunctions(object):
             f")\n\n"
         )
 
+    def iree_amdgpu_binary(
+        self, name, target, arch, srcs, internal_hdrs=[], copts=[], linkopts=[]
+    ):
+        name_block = self._convert_string_arg_block("NAME", name, quote=False)
+        target_block = self._convert_string_arg_block("TARGET", target, quote=False)
+        arch_block = self._convert_string_arg_block("ARCH", arch, quote=False)
+        hdrs_block = self._convert_srcs_block(internal_hdrs, block_name="INTERNAL_HDRS")
+        srcs_block = self._convert_srcs_block(srcs)
+        copts_block = self._convert_string_list_block("COPTS", copts, sort=False)
+        linkopts_block = self._convert_string_list_block(
+            "LINKOPTS", linkopts, sort=False
+        )
+
+        self._converter.body += (
+            f"iree_amdgpu_binary(\n"
+            f"{name_block}"
+            f"{target_block}"
+            f"{arch_block}"
+            f"{hdrs_block}"
+            f"{srcs_block}"
+            f"{copts_block}"
+            f"{linkopts_block}"
+            f")\n\n"
+        )
+
     def iree_cuda_bitcode_library(
         self, name, cuda_arch, srcs, internal_hdrs=None, copts=None
     ):

--- a/build_tools/cmake/iree_amdgpu_binary.cmake
+++ b/build_tools/cmake/iree_amdgpu_binary.cmake
@@ -1,0 +1,168 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(CMakeParseArguments)
+
+# Builds an LLVM shared library for AMDGPU from input files via clang.
+#
+# Parameters:
+# NAME: Name of the target.
+# OUT: Output file name.
+# TARGET: LLVM `-target` flag.
+# ARCH: LLVM `-march` flag.
+# SRCS: source files to pass to clang.
+# INTERNAL_HDRS: all headers transitively included by the source files.
+#                Unlike typical Bazel `hdrs`, these are not exposed as
+#                interface headers. This would normally be part of `srcs`,
+#                but separating it was easier for `bazel_to_cmake`, as
+#                CMake does not need this, and making this explicitly
+#                Bazel-only allows using `filegroup` on the Bazel side.
+# COPTS: additional flags to pass to clang.
+# LINKOPTS: additional flags to pass to lld.
+function(iree_amdgpu_binary)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;OUT;TARGET;ARCH"
+    "SRCS;INTERNAL_HDRS;COPTS;LINKOPTS"
+    ${ARGN}
+  )
+
+  iree_package_name(_PACKAGE_NAME)
+
+  if(DEFINED _RULE_OUT)
+    set(_OUT "${_RULE_OUT}")
+  else()
+    set(_OUT "${_RULE_NAME}.so")
+  endif()
+
+  set(_COPTS
+    # C configuration.
+    "-x" "c"
+    "-Xclang" "-finclude-default-header"
+    "-std=c23"
+    "-nogpulib"
+    "-fno-short-wchar"
+
+    # Target architecture/machine.
+    "-target" "${_RULE_TARGET}"
+    "-march=${_RULE_ARCH}"
+    "-fgpu-rdc"  # NOTE: may not be required for all targets
+
+    # Header paths for builtins and our own includes.
+    "-isystem" "${IREE_CLANG_BUILTIN_HEADERS_PATH}"
+    "-I${IREE_SOURCE_DIR}/runtime/src"
+    "-I${IREE_BINARY_DIR}/runtime/src"
+
+    # Avoid warnings about things we do that are not compatible across compilers
+    # but are fine because we're only ever compiling with clang.
+    "-Wno-gnu-pointer-arith"
+
+    # Optimized.
+    "-fno-ident"
+    "-fvisibility=hidden"
+    "-O3"
+
+    # Object file only in bitcode format.
+    "-c"
+    "-emit-llvm"
+  )
+
+  set(_BITCODE_FILES)
+  foreach(_SRC ${_RULE_SRCS})
+    get_filename_component(_BITCODE_SRC_PATH "${_SRC}" REALPATH)
+    string(REGEX REPLACE "[.]c$" ".bc" _BITCODE_FILE ${_SRC})
+    list(APPEND _BITCODE_FILES ${_BITCODE_FILE})
+    add_custom_command(
+      OUTPUT
+        "${_BITCODE_FILE}"
+      COMMAND
+        "${IREE_CLANG_BINARY}"
+        ${_COPTS}
+        "${_BITCODE_SRC_PATH}"
+        "-o"
+        "${_BITCODE_FILE}"
+      DEPENDS
+        "${IREE_CLANG_BINARY}"
+        "${_BITCODE_SRC_PATH}"
+        "${_RULE_INTERNAL_HDRS}"
+      MAIN_DEPENDENCY
+        "${_BITCODE_SRC_PATH}"
+      COMMENT
+        "Compiling ${_SRC} to ${_BITCODE_FILE}"
+      VERBATIM
+    )
+  endforeach()
+
+  set(_ARCHIVE_FILE "${_RULE_NAME}.a")
+  add_custom_command(
+    OUTPUT
+      ${_ARCHIVE_FILE}
+    COMMAND
+      ${IREE_LLVM_LINK_BINARY}
+      ${_BITCODE_FILES}
+      "-o"
+      "${_ARCHIVE_FILE}"
+    DEPENDS
+      ${IREE_LLVM_LINK_BINARY}
+      ${_BITCODE_FILES}
+    COMMENT
+      "Archiving bitcode to ${_ARCHIVE_FILE}"
+    VERBATIM
+  )
+
+  set(_LINKED_FILE "${_RULE_NAME}.bc")
+  add_custom_command(
+    OUTPUT
+      ${_LINKED_FILE}
+    COMMAND
+      ${IREE_LLVM_LINK_BINARY}
+      "-internalize"
+      "-only-needed"
+      "${_ARCHIVE_FILE}"
+      "-o" "${_LINKED_FILE}"
+    DEPENDS
+      "${IREE_LLVM_LINK_BINARY}"
+      "${_ARCHIVE_FILE}"
+    COMMENT
+      "Linking bitcode to ${_LINKED_FILE}"
+    VERBATIM
+  )
+
+  add_custom_command(
+    OUTPUT
+      "${_OUT}"
+    COMMAND
+      ${IREE_LLD_BINARY}
+      "-flavor" "gnu"
+      "-m" "elf64_amdgpu"
+      "--build-id=none"
+      "--no-undefined"
+      "-shared"
+      "-plugin-opt=mcpu=${_RULE_ARCH}"
+      "-plugin-opt=O3"
+      "--lto-CGO3"
+      "--no-whole-archive"
+      "--gc-sections"
+      "--strip-debug"
+      "--discard-all"
+      "--discard-locals"
+      "${_LINKED_FILE}"
+      "-o" "${_OUT}"
+    DEPENDS
+      "${_LINKED_FILE}"
+      "${IREE_LLD_TARGET}"
+    COMMENT
+      "Compiling binary to ${_OUT}"
+    VERBATIM
+  )
+
+  # Only add iree_${NAME} as custom target doesn't support aliasing to
+  # iree::${NAME}.
+  add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}"
+    DEPENDS "${_OUT}"
+  )
+endfunction()

--- a/runtime/src/iree/hal/drivers/amdgpu/device/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/BUILD.bazel
@@ -1,0 +1,74 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:iree_amdgpu_binary.bzl", "iree_amdgpu_binary")
+load("//build_tools/embed_data:build_defs.bzl", "iree_c_embed_data")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+#===------------------------------------------------------------------------===#
+# Common sources
+#===------------------------------------------------------------------------===#
+
+BITCODE_SRCS = glob([
+    "*.c",
+    "support/*.c",
+])
+
+BITCODE_HDRS = glob([
+    "*.h",
+    "support/*.h",
+])
+
+#===------------------------------------------------------------------------===#
+# Exported Headers
+#===------------------------------------------------------------------------===#
+
+iree_runtime_cc_library(
+    name = "headers",
+    hdrs = BITCODE_HDRS,
+)
+
+#===------------------------------------------------------------------------===#
+# Architecture-specific Binaries
+#===------------------------------------------------------------------------===#
+# NOTE: the naming here matches what HSA_ISA_INFO_NAME returns so that we can
+# match them at runtime without having to load and reflect each code object.
+
+# TODO(benvanik): when TheRock stabilizes its naming convention we'll want to
+# copy that and make it configurable. See:
+# https://github.com/ROCm/TheRock/blob/main/cmake/therock_amdgpu_targets.cmake
+# Matching their family naming scheme would allow us to directly source from
+# their command line arguments. How best to map this to bazel I don't know, so
+# for now we include a hand-picked set that people using bazel request.
+
+iree_amdgpu_binary(
+    name = "amdgcn-amd-amdhsa--gfx1100",
+    srcs = BITCODE_SRCS,
+    arch = "gfx1100",
+    internal_hdrs = BITCODE_HDRS,
+    target = "amdgcn-amd-amdhsa",
+)
+
+#===------------------------------------------------------------------------===#
+# Embedded Binary Table
+#===------------------------------------------------------------------------===#
+
+iree_c_embed_data(
+    name = "binaries",
+    srcs = [
+        ":amdgcn-amd-amdhsa--gfx1100.so",
+    ],
+    c_file_output = "binaries.c",
+    flatten = True,
+    h_file_output = "binaries.h",
+    identifier = "iree_hal_amdgpu_device_binaries",
+)

--- a/runtime/src/iree/hal/drivers/amdgpu/device/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/CMakeLists.txt
@@ -1,0 +1,85 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#===------------------------------------------------------------------------===#
+# Common Sources
+#===------------------------------------------------------------------------===#
+
+set(_BITCODE_SRCS
+  "dummy.c"
+)
+
+set(_BITCODE_HDRS
+  "kernel_tables.h"
+  "kernels.h"
+  "support/common.h"
+  "support/kernel_args.h"
+)
+
+#===------------------------------------------------------------------------===#
+# Exported Headers
+#===------------------------------------------------------------------------===#
+
+iree_cc_library(
+  NAME
+    headers
+  HDRS
+    "${_BITCODE_HDRS}"
+  PUBLIC
+)
+
+#===------------------------------------------------------------------------===#
+# Architecture-specific Binaries
+#===------------------------------------------------------------------------===#
+# NOTE: the naming here matches what HSA_ISA_INFO_NAME returns so that we can
+# match them at runtime without having to load and reflect each code object.
+
+# TODO(benvanik): when TheRock stabilizes its naming convention we'll want to
+# copy that and make it configurable. See:
+# https://github.com/ROCm/TheRock/blob/main/cmake/therock_amdgpu_targets.cmake
+# Matching their family naming scheme would allow us to directly source from
+# their command line arguments.
+
+set(IREE_HAL_AMDGPU_DEVICE_LIBRARY_TARGETS
+    "gfx942;gfx1100"
+    CACHE STRING
+    "Bundled device library architectures included in the runtime binary.")
+
+set(_ARCH_BINARIES)
+foreach(_ARCH ${IREE_HAL_AMDGPU_DEVICE_LIBRARY_TARGETS})
+  iree_amdgpu_binary(
+    NAME
+      amdgcn-amd-amdhsa--${_ARCH}
+    TARGET
+      amdgcn-amd-amdhsa
+    ARCH
+      ${_ARCH}
+    SRCS
+      "${_BITCODE_SRCS}"
+    INTERNAL_HDRS
+      "${_BITCODE_HDRS}"
+  )
+  list(APPEND _ARCH_BINARIES "amdgcn-amd-amdhsa--${_ARCH}.so")
+endforeach()
+
+#===------------------------------------------------------------------------===#
+# Embedded Binary Table
+#===------------------------------------------------------------------------===#
+
+iree_c_embed_data(
+  NAME
+    binaries
+  SRCS
+    "${_ARCH_BINARIES}"
+  C_FILE_OUTPUT
+    "binaries.c"
+  H_FILE_OUTPUT
+    "binaries.h"
+  IDENTIFIER
+    "iree_hal_amdgpu_device_binaries"
+  FLATTEN
+  PUBLIC
+)

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dummy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dummy.c
@@ -1,0 +1,14 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/device/support/common.h"
+
+// Temporary file just to get things building.
+IREE_AMDGPU_ATTRIBUTE_KERNEL void iree_hal_amdgpu_device_buffer_fill_x1(
+    void* IREE_AMDGPU_RESTRICT target_ptr, const uint64_t length,
+    const uint8_t pattern) {
+  // Placeholder.
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/device/kernel_tables.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/kernel_tables.h
@@ -1,0 +1,59 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// Blits (buffer.h)
+//===----------------------------------------------------------------------===//
+
+// NOTE: these workgroup sizes are guesses and need to be changed.
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_fill_x1, 32, 1, 1)
+#if 0
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_fill_x2, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_fill_x4, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_fill_x8, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_copy_x1, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_copy_x2, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_copy_x4, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_copy_x8, 32, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_buffer_copy_x64, 32, 1, 1)
+#endif
+
+//===----------------------------------------------------------------------===//
+// Command buffers (command_buffer.h)
+//===----------------------------------------------------------------------===//
+
+// NOTE: these workgroup sizes are guesses and need to be changed.
+#if 0
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_cmd_block_issue, 1, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(
+    iree_hal_amdgpu_device_cmd_dispatch_indirect_update, 1, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_cmd_branch, 1, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_cmd_return, 1, 1, 1)
+#endif
+
+//===----------------------------------------------------------------------===//
+// Scheduling (scheduler.h)
+//===----------------------------------------------------------------------===//
+
+// NOTE: these workgroup sizes are guesses and need to be changed.
+#if 0
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_queue_scheduler_initialize,
+                              1, 1, 1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_queue_scheduler_tick, 1, 1,
+                              1)
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_queue_retire_entry, 1, 1,
+                              1)
+#endif
+
+//===----------------------------------------------------------------------===//
+// Tracing (tracing.h)
+//===----------------------------------------------------------------------===//
+
+#if 0
+// NOTE: these workgroup sizes are guesses and need to be changed.
+IREE_HAL_AMDGPU_DEVICE_KERNEL(iree_hal_amdgpu_device_trace_buffer_initialize,
+                              32, 1, 1)
+#endif

--- a/runtime/src/iree/hal/drivers/amdgpu/device/kernels.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/kernels.h
@@ -1,0 +1,28 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_DEVICE_KERNELS_H_
+#define IREE_HAL_DRIVERS_AMDGPU_DEVICE_KERNELS_H_
+
+#include "iree/hal/drivers/amdgpu/device/support/common.h"
+#include "iree/hal/drivers/amdgpu/device/support/kernel_args.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_kernels_t
+//===----------------------------------------------------------------------===//
+
+// Opaque handles used to launch builtin kernels.
+// Stored on the command buffer as they are constant for the lifetime of the
+// program and we may have command buffers opt into different DMA modes.
+typedef struct iree_hal_amdgpu_device_kernels_t {
+#define IREE_HAL_AMDGPU_DEVICE_KERNEL(name, workgroup_size_x,             \
+                                      workgroup_size_y, workgroup_size_z) \
+  iree_hal_amdgpu_device_kernel_args_t name;
+#include "iree/hal/drivers/amdgpu/device/kernel_tables.h"
+#undef IREE_HAL_AMDGPU_DEVICE_KERNEL
+} iree_hal_amdgpu_device_kernels_t;
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_DEVICE_KERNELS_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/device/support/common.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/support/common.h
@@ -1,0 +1,355 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// NOTE: builtins are defined in the LLVM AMDGPU device library that is linked
+// into the device runtime. We need to redefine them as externs here as they are
+// not defined in any accessible headers.
+//
+// Sources:
+// https://github.com/ROCm/rocMLIR/blob/develop/external/llvm-project/amd/device-libs/README.md
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_COMMON_H_
+#define IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_COMMON_H_
+
+//===----------------------------------------------------------------------===//
+// Compiler Configuration
+//===----------------------------------------------------------------------===//
+
+#if defined(__AMDGPU__)
+#define IREE_AMDGPU_TARGET_DEVICE 1
+#else
+#define IREE_AMDGPU_TARGET_HOST 1
+#endif  // __AMDGPU__
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+typedef char int8_t;
+typedef unsigned char uint8_t;
+typedef short int16_t;
+typedef unsigned short uint16_t;
+typedef int int32_t;
+typedef unsigned int uint32_t;
+typedef long int64_t;
+typedef unsigned long uint64_t;
+
+typedef int64_t ssize_t;
+typedef uint64_t size_t;
+typedef int64_t intptr_t;
+typedef uint64_t uintptr_t;
+
+#define UINT64_MAX 0xFFFFFFFFFFFFFFFFull
+
+#define NULL ((void*)0)
+
+#else
+
+// NOTE: minimal support for including headers in host code is provided to make
+// sharing enums/structures possible; no code is expected to compile.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "iree/base/internal/atomics.h"
+#include "iree/base/internal/threading.h"
+#include "third_party/hsa-runtime-headers/include/hsa/hsa.h"  // IWYU pragma: export
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+//===----------------------------------------------------------------------===//
+// Attributes
+//===----------------------------------------------------------------------===//
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+#define IREE_AMDGPU_RESTRICT __restrict__
+#define IREE_AMDGPU_ALIGNAS(x) __attribute__((aligned(x)))
+
+#define IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#define IREE_AMDGPU_ATTRIBUTE_SINGLE_WORK_ITEM
+#define IREE_AMDGPU_ATTRIBUTE_PACKED __attribute__((__packed__))
+
+#define IREE_AMDGPU_ATTRIBUTE_KERNEL \
+  [[clang::amdgpu_kernel, gnu::visibility("protected")]]
+
+#define IREE_AMDGPU_LIKELY(x) (__builtin_expect(!!(x), 1))
+#define IREE_AMDGPU_UNLIKELY(x) (__builtin_expect(!!(x), 0))
+
+#define IREE_AMDGPU_GUARDED_BY(mutex)
+
+#else
+
+#define IREE_AMDGPU_RESTRICT IREE_RESTRICT
+#define IREE_AMDGPU_ALIGNAS(x) iree_alignas(x)
+
+#define IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE IREE_ATTRIBUTE_ALWAYS_INLINE
+#define IREE_AMDGPU_ATTRIBUTE_SINGLE_WORK_ITEM
+#define IREE_AMDGPU_ATTRIBUTE_PACKED IREE_ATTRIBUTE_PACKED
+
+#define IREE_AMDGPU_LIKELY(x) IREE_LIKELY(x)
+#define IREE_AMDGPU_UNLIKELY(x) IREE_UNLIKELY(x)
+
+#define IREE_AMDGPU_GUARDED_BY(mutex)
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+// Indicates a pointer is on the device. Used as annotations in host code.
+#if !defined(IREE_AMDGPU_DEVICE_PTR)
+#define IREE_AMDGPU_DEVICE_PTR
+#endif  // IREE_AMDGPU_DEVICE_PTR
+
+//===----------------------------------------------------------------------===//
+// Alignment / Math
+//===----------------------------------------------------------------------===//
+
+#define IREE_AMDGPU_ARRAYSIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
+#define IREE_AMDGPU_MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define IREE_AMDGPU_MAX(a, b) (((a) > (b)) ? (a) : (b))
+
+#define IREE_AMDGPU_CEIL_DIV(lhs, rhs) (((lhs) + (rhs) - 1) / (rhs))
+
+static inline IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE size_t
+iree_amdgpu_align(size_t value, size_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+// Returns true if any bit from |rhs| is set in |lhs|.
+#define IREE_AMDGPU_ANY_BIT_SET(lhs, rhs) (((lhs) & (rhs)) != 0)
+// Returns true iff all bits from |rhs| are set in |lhs|.
+#define IREE_AMDGPU_ALL_BITS_SET(lhs, rhs) (((lhs) & (rhs)) == (rhs))
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+// Returns the number of leading zeros in a 64-bit bitfield.
+// Returns -1 if no bits are set.
+// Commonly used in HIP as `__lastbit_u32_u64`.
+//
+// Examples:
+//  0x0000000000000000 = -1
+//  0x0000000000000001 =  0
+//  0x0000000000000010 =  4
+//  0xFFFFFFFFFFFFFFFF = -1
+#define IREE_AMDGPU_LASTBIT_U64(v) ((v) == 0 ? -1 : __builtin_ctzl(v))
+
+#else
+
+#define IREE_AMDGPU_LASTBIT_U64(v) \
+  ((v) == 0 ? -1 : iree_math_count_trailing_zeros_u64(v))
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+//===----------------------------------------------------------------------===//
+// OpenCL-like Scoped Atomics
+//===----------------------------------------------------------------------===//
+
+#define iree_amdgpu_destructive_interference_size 64
+#define iree_amdgpu_constructive_interference_size 64
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+typedef uint32_t iree_amdgpu_memory_order_t;
+#define iree_amdgpu_memory_order_relaxed __ATOMIC_RELAXED
+#define iree_amdgpu_memory_order_acquire __ATOMIC_ACQUIRE
+#define iree_amdgpu_memory_order_release __ATOMIC_RELEASE
+#define iree_amdgpu_memory_order_acq_rel __ATOMIC_ACQ_REL
+#define iree_amdgpu_memory_order_seq_cst __ATOMIC_SEQ_CST
+
+#define iree_amdgpu_memory_scope_work_item __MEMORY_SCOPE_SINGLE
+#define iree_amdgpu_memory_scope_sub_group __MEMORY_SCOPE_WVFRNT
+#define iree_amdgpu_memory_scope_work_group __MEMORY_SCOPE_WRKGRP
+#if defined(__MEMORY_SCOPE_DEVICE) && defined(__MEMORY_SCOPE_SYSTEM)
+#define iree_amdgpu_memory_scope_device __MEMORY_SCOPE_DEVICE
+#define iree_amdgpu_memory_scope_system __MEMORY_SCOPE_SYSTEM
+#else
+#define iree_amdgpu_memory_scope_device 0
+#define iree_amdgpu_memory_scope_system 0
+#endif  // __MEMORY_SCOPE_DEVICE / __MEMORY_SCOPE_SYSTEM
+
+#define IREE_AMDGPU_SCOPED_ATOMIC_INIT(object, value) *(object) = (value)
+
+typedef /*_Atomic*/ int32_t iree_amdgpu_scoped_atomic_int32_t;
+typedef /*_Atomic*/ int64_t iree_amdgpu_scoped_atomic_int64_t;
+typedef /*_Atomic*/ uint32_t iree_amdgpu_scoped_atomic_uint32_t;
+typedef /*_Atomic*/ uint64_t iree_amdgpu_scoped_atomic_uint64_t;
+
+#define iree_amdgpu_scoped_atomic_load(object, memory_order, memory_scope) \
+  __scoped_atomic_load_n((object), (memory_order), (memory_scope))
+#define iree_amdgpu_scoped_atomic_store(object, desired, memory_order, \
+                                        memory_scope)                  \
+  __scoped_atomic_store_n((object), (desired), (memory_order), (memory_scope))
+
+#define iree_amdgpu_scoped_atomic_fetch_add(object, operand, memory_order, \
+                                            memory_scope)                  \
+  __scoped_atomic_fetch_add((object), (operand), (memory_order), (memory_scope))
+#define iree_amdgpu_scoped_atomic_fetch_sub(object, operand, memory_order, \
+                                            memory_scope)                  \
+  __scoped_atomic_fetch_sub((object), (operand), (memory_order), (memory_scope))
+#define iree_amdgpu_scoped_atomic_fetch_and(object, operand, memory_order, \
+                                            memory_scope)                  \
+  __scoped_atomic_fetch_and((object), (operand), (memory_order), (memory_scope))
+#define iree_amdgpu_scoped_atomic_fetch_or(object, operand, memory_order, \
+                                           memory_scope)                  \
+  __scoped_atomic_fetch_or((object), (operand), (memory_order), (memory_scope))
+#define iree_amdgpu_scoped_atomic_fetch_xor(object, operand, memory_order, \
+                                            memory_scope)                  \
+  __scoped_atomic_fetch_xor((object), (operand), (memory_order), (memory_scope))
+
+#define iree_amdgpu_scoped_atomic_exchange(object, desired, memory_order, \
+                                           memory_scope)                  \
+  __scoped_atomic_exchange_n((object), (desired), (memory_order),         \
+                             (memory_scope))
+
+#define iree_amdgpu_scoped_atomic_compare_exchange_weak(                    \
+    object, expected, desired, memory_order_success, memory_order_fail,     \
+    memory_scope)                                                           \
+  __scoped_atomic_compare_exchange_n((object), (expected), (desired),       \
+                                     /*weak=*/true, (memory_order_success), \
+                                     (memory_order_fail), (memory_scope))
+#define iree_amdgpu_scoped_atomic_compare_exchange_strong(                   \
+    object, expected, desired, memory_order_success, memory_order_fail,      \
+    memory_scope)                                                            \
+  __scoped_atomic_compare_exchange_n((object), (expected), (desired),        \
+                                     /*weak=*/false, (memory_order_success), \
+                                     (memory_order_fail), (memory_scope))
+
+#else
+
+typedef uint32_t iree_amdgpu_memory_order_t;
+#define iree_amdgpu_memory_order_relaxed iree_memory_order_relaxed
+#define iree_amdgpu_memory_order_acquire iree_memory_order_acquire
+#define iree_amdgpu_memory_order_release iree_memory_order_release
+#define iree_amdgpu_memory_order_acq_rel iree_memory_order_acq_rel
+#define iree_amdgpu_memory_order_seq_cst iree_memory_order_seq_cst
+
+#define iree_amdgpu_memory_scope_work_item 0
+#define iree_amdgpu_memory_scope_sub_group 0
+#define iree_amdgpu_memory_scope_work_group 0
+#define iree_amdgpu_memory_scope_device 0
+#define iree_amdgpu_memory_scope_system 0
+
+#define IREE_AMDGPU_SCOPED_ATOMIC_INIT(object, value) \
+  *(object) = IREE_ATOMIC_VAR_INIT(value)
+
+typedef iree_atomic_int32_t iree_amdgpu_scoped_atomic_int32_t;
+typedef iree_atomic_int64_t iree_amdgpu_scoped_atomic_int64_t;
+typedef iree_atomic_uint32_t iree_amdgpu_scoped_atomic_uint32_t;
+typedef iree_atomic_uint64_t iree_amdgpu_scoped_atomic_uint64_t;
+
+#define iree_amdgpu_scoped_atomic_load(object, memory_order, memory_scope) \
+  iree_atomic_load((object), (memory_order))
+#define iree_amdgpu_scoped_atomic_store(object, desired, memory_order, \
+                                        memory_scope)                  \
+  iree_atomic_store((object), (desired), (memory_order))
+
+#define iree_amdgpu_scoped_atomic_fetch_add(object, operand, memory_order, \
+                                            memory_scope)                  \
+  iree_atomic_fetch_add((object), (operand), (memory_order))
+#define iree_amdgpu_scoped_atomic_fetch_sub(object, operand, memory_order, \
+                                            memory_scope)                  \
+  iree_atomic_fetch_sub((object), (operand), (memory_order))
+#define iree_amdgpu_scoped_atomic_fetch_and(object, operand, memory_order, \
+                                            memory_scope)                  \
+  iree_atomic_fetch_and((object), (operand), (memory_order))
+#define iree_amdgpu_scoped_atomic_fetch_or(object, operand, memory_order, \
+                                           memory_scope)                  \
+  iree_atomic_fetch_or((object), (operand), (memory_order))
+#define iree_amdgpu_scoped_atomic_fetch_xor(object, operand, memory_order, \
+                                            memory_scope)                  \
+  iree_atomic_fetch_xor((object), (operand), (memory_order))
+
+#define iree_amdgpu_scoped_atomic_exchange(object, desired, memory_order, \
+                                           memory_scope)                  \
+  iree_atomic_exchange((object), (desired), (memory_order))
+
+#define iree_amdgpu_scoped_atomic_compare_exchange_weak(                \
+    object, expected, desired, memory_order_success, memory_order_fail, \
+    memory_scope)                                                       \
+  iree_atomic_compare_exchange_weak((object), (expected), (desired),    \
+                                    (memory_order_success),             \
+                                    (memory_order_fail))
+#define iree_amdgpu_scoped_atomic_compare_exchange_strong(              \
+    object, expected, desired, memory_order_success, memory_order_fail, \
+    memory_scope)                                                       \
+  iree_atomic_compare_exchange_strong((object), (expected), (desired),  \
+                                      (memory_order_success),           \
+                                      (memory_order_fail))
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+//===----------------------------------------------------------------------===//
+// Timing
+//===----------------------------------------------------------------------===//
+
+// Tick in the agent domain.
+// This can be converted to the system domain for correlation across agents and
+// the host with hsa_amd_profiling_convert_tick_to_system_domain.
+typedef uint64_t iree_amdgpu_device_tick_t;
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+// Returns a tick in the agent domain.
+// This can be converted to the system domain for correlation across agents and
+// the host with hsa_amd_profiling_convert_tick_to_system_domain. The value is
+// the same as that placed into signal start_ts/end_ts by the command processor.
+#define iree_amdgpu_device_timestamp __builtin_readsteadycounter
+
+// Sleeps the current thread for some "short" amount of time.
+// This maps to the S_SLEEP instruction that varies on different architectures
+// in how long it can delay execution. The behavior cannot be mapped to wall
+// time as it suspends for 64*arg + 1-64 clocks but archs have different limits,
+// clock speed can vary over the course of execution, etc. This is mostly only
+// useful as a "yield for a few instructions to stop hammering a memory
+// location" primitive.
+static inline IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE void iree_amdgpu_yield(void) {
+  __builtin_amdgcn_s_sleep(1);
+}
+
+#else
+
+static inline IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE void iree_amdgpu_yield(void) {
+  iree_thread_yield();
+}
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+//===----------------------------------------------------------------------===//
+// Memory Utilities
+//===----------------------------------------------------------------------===//
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+// TODO(benvanik): use memcpy builtin - these should all be small.
+//
+// NOTE: doing a memcpy in a single thread is totally not how one should use a
+// GPU, but meh. Nearly all tracing usage is with literals we pass as pointers
+// and this is really only used by log messages that may be snprintf'ed.
+static inline IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE void iree_amdgpu_memcpy(
+    void* IREE_AMDGPU_RESTRICT dst, const void* IREE_AMDGPU_RESTRICT src,
+    size_t length) {
+  for (size_t i = 0; i < length; ++i) {
+    ((char*)dst)[i] = ((const char*)src)[i];
+  }
+}
+
+// TODO(benvanik): use memset builtin - these should all be small.
+//
+// NOTE: doing a memset in a single thread is totally not how one should use a
+// GPU - this should only be used when debugging.
+static inline IREE_AMDGPU_ATTRIBUTE_ALWAYS_INLINE void iree_amdgpu_memset(
+    void* IREE_AMDGPU_RESTRICT dst, char value, size_t length) {
+  for (size_t i = 0; i < length; ++i) {
+    ((char*)dst)[i] = value;
+  }
+}
+
+#else
+
+#define iree_amdgpu_memcpy memcpy
+#define iree_amdgpu_memset memset
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_COMMON_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/device/support/kernel_args.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/support/kernel_args.h
@@ -1,0 +1,56 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_KERNEL_ARGS_H_
+#define IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_KERNEL_ARGS_H_
+
+#include "iree/hal/drivers/amdgpu/device/support/common.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_kernel_args_t
+//===----------------------------------------------------------------------===//
+
+// Kernel arguments used for fixed-size kernels.
+// This must match what the kernel was compiled to support.
+typedef struct iree_hal_amdgpu_device_kernel_args_t {
+  // Opaque handle to the kernel object to execute.
+  uint64_t kernel_object;
+  // Dispatch setup parameters. Used to configure kernel dispatch parameters
+  // such as the number of dimensions in the grid. The parameters are
+  // described by hsa_kernel_dispatch_packet_setup_t.
+  uint16_t setup;
+  // XYZ dimensions of work-group, in work-items. Must be greater than 0.
+  // If the grid has fewer than 3 dimensions the unused must be 1.
+  uint16_t workgroup_size[3];
+  // Size in bytes of private memory allocation request (per work-item).
+  uint32_t private_segment_size;
+  // Size in bytes of group memory allocation request (per work-group). Must
+  // not be less than the sum of the group memory used by the kernel (and the
+  // functions it calls directly or indirectly) and the dynamically allocated
+  // group segment variables.
+  uint32_t group_segment_size;
+  // Size of kernarg segment memory that is required to hold the values of the
+  // kernel arguments, in bytes. Must be a multiple of 16.
+  uint16_t kernarg_size;
+  // Alignment (in bytes) of the buffer used to pass arguments to the kernel,
+  // which is the maximum of 16 and the maximum alignment of any of the kernel
+  // arguments.
+  uint16_t kernarg_alignment;
+  // Allocated source location in host memory. Inaccessible and only here to
+  // feed back to the host for trace processing.
+  uint64_t trace_src_loc;
+  // Total number of 4-byte constants used by the dispatch (if a HAL dispatch).
+  uint16_t constant_count;
+  // Total number of bindings used by the dispatch (if a HAL dispatch).
+  uint16_t binding_count;
+  uint32_t reserved;
+} iree_hal_amdgpu_device_kernel_args_t;
+static_assert(
+    sizeof(iree_hal_amdgpu_device_kernel_args_t) <= 64,
+    "keep hot kernel arg structure in as few cache lines as possible; every "
+    "dispatch issued must access this information and it is likely uncached");
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_DEVICE_SUPPORT_KERNEL_ARGS_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.c
@@ -1,0 +1,227 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/base/internal/math.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): move to iree/base/internal/math.h? Also used in device-side
+// library (which we can't use runtime headers in, so we need copies somewhere).
+//
+// https://en.wikipedia.org/wiki/Find_first_set
+#define IREE_HAL_AMDGPU_FFS_U64(v) \
+  ((v) == 0 ? -1 : iree_math_count_trailing_zeros_u64(v))
+
+// Returns a word with the bit at |bit_offset| set.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_MASK(0)   = 0b00..001
+//   _BIT_OFFSET_TO_WORD_MASK(1)   = 0b00..010
+//   _BIT_OFFSET_TO_WORD_MASK(2)   = 0b00..100
+#define _BIT_OFFSET_TO_WORD_MASK(bit_offset) \
+  (1ull << ((bit_offset) % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD))
+
+// Returns a word index in the bitmap containing the bit at |bit_offset|.
+//
+// Examples:
+//   _BIT_OFFSET_TO_WORD_INDEX(0)   = 0
+//   _BIT_OFFSET_TO_WORD_INDEX(64)  = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(127) = 1
+//   _BIT_OFFSET_TO_WORD_INDEX(128) = 2
+#define _BIT_OFFSET_TO_WORD_INDEX(bit_offset) \
+  ((bit_offset) / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns a word mask that includes all valid bits after |bit_offset|.
+//
+// Examples:
+//   _BIT_PREFIX_WORD_MASK(0) = 0b11..111
+//   _BIT_PREFIX_WORD_MASK(1) = 0b11..110
+//   _BIT_PREFIX_WORD_MASK(2) = 0b11..100
+//   _BIT_PREFIX_WORD_MASK(3) = 0b11..000
+#define _BIT_PREFIX_WORD_MASK(bit_offset) \
+  (~0ull << ((bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Returns a word mask that includes all valid bits up to |bit_offset|.
+//
+// Examples:
+//   _BIT_SUFFIX_WORD_MASK(0) = 0b00..000
+//   _BIT_SUFFIX_WORD_MASK(1) = 0b00..001
+//   _BIT_SUFFIX_WORD_MASK(2) = 0b00..011
+//   _BIT_SUFFIX_WORD_MASK(3) = 0b00..111
+#define _BIT_SUFFIX_WORD_MASK(bit_offset) \
+  (~0ull >> (-(bit_offset) & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)))
+
+// Scan full words first and handle any remaining bits after.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap) {
+  iree_host_size_t i = 0;
+  for (i = 0; i < bitmap.bit_count / IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+       ++i) {
+    if (bitmap.words[i]) return false;
+  }
+  if (bitmap.bit_count % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD) {
+    if (bitmap.words[i] & _BIT_SUFFIX_WORD_MASK(bitmap.bit_count)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index) {
+  return 1ull & (bitmap.words[_BIT_OFFSET_TO_WORD_INDEX(bit_index)] >>
+                 (bit_index & (IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD - 1)));
+}
+
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr |= word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Set from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr |= word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Set the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr |= word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0xFF, word_count * sizeof(uint64_t));
+}
+
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index) {
+  const uint64_t word_mask = _BIT_OFFSET_TO_WORD_MASK(bit_index);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  *word_ptr &= ~word_mask;
+}
+
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length) {
+  const iree_host_size_t bit_end = bit_index + bit_length;
+
+  // Reset from the start of the span to the last full word.
+  int64_t bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD -
+                      (bit_index % IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD);
+  uint64_t* word_ptr = bitmap.words + _BIT_OFFSET_TO_WORD_INDEX(bit_index);
+  uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_index);
+  while ((int64_t)bit_length - bit_chunk >= 0) {
+    *word_ptr &= ~word_mask;
+    word_mask = ~0ull;
+    bit_length -= bit_chunk;
+    bit_chunk = IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD;
+    ++word_ptr;
+  }
+
+  // Reset the suffix bits in the last word (if any).
+  if (bit_length > 0) {
+    word_mask &= _BIT_SUFFIX_WORD_MASK(bit_end);
+    *word_ptr &= ~word_mask;
+  }
+}
+
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap) {
+  const iree_host_size_t word_count =
+      iree_hal_amdgpu_bitmap_calculate_words(bitmap.bit_count);
+  memset(bitmap.words, 0x00, word_count * sizeof(uint64_t));
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_set_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = words[word_index] & word_mask; !word; word = words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words,
+                                                  bitmap.bit_count, bit_offset);
+}
+
+static iree_host_size_t iree_hal_amdgpu_bitmap_find_next_unset_bit(
+    const uint64_t* words, iree_host_size_t bit_count,
+    iree_host_size_t bit_offset) {
+  if (IREE_UNLIKELY(bit_offset >= bit_count)) return bit_count;
+  const uint64_t word_mask = _BIT_PREFIX_WORD_MASK(bit_offset);
+  iree_host_size_t word_index = _BIT_OFFSET_TO_WORD_INDEX(bit_offset);
+  uint64_t word = 0;
+  for (word = ~words[word_index] & word_mask; !word;
+       word = ~words[word_index]) {
+    if ((word_index + 1) * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD >= bit_count) {
+      return bit_count;  // hit end without finding anything
+    }
+    ++word_index;
+  }
+  return iree_min(word_index * IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD +
+                      IREE_HAL_AMDGPU_FFS_U64(word),
+                  bit_count);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset) {
+  return iree_hal_amdgpu_bitmap_find_next_unset_bit(
+      bitmap.words, bitmap.bit_count, bit_offset);
+}
+
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length) {
+  iree_host_size_t bit_index = 0;
+  do {
+    bit_index = iree_hal_amdgpu_bitmap_find_next_unset_bit(
+        bitmap.words, bitmap.bit_count, bit_offset);
+    const iree_host_size_t bit_end = bit_index + bit_length;
+    if (bit_end > bitmap.bit_count) return bitmap.bit_count;
+    const iree_host_size_t next_index =
+        iree_hal_amdgpu_bitmap_find_next_set_bit(bitmap.words, bit_end,
+                                                 bit_index);
+    if (next_index < bit_end) {
+      bit_offset = next_index + 1;
+      continue;  // resume from next set bit (as we know there's nothing before)
+    } else {
+      break;  // found
+    }
+  } while (true);
+  return iree_min(bit_index, bitmap.bit_count);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap.h
@@ -1,0 +1,104 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_bitmap_t
+//===----------------------------------------------------------------------===//
+
+// Bits per word of bitmap data.
+#define IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD (sizeof(uint64_t) * 8)
+
+// Reference to a bitmap stored in 64-bit words.
+// This is a fat pointer to the storage and does not store anything itself.
+// Intended for small counts (~dozens to hundreds).
+//
+// Bits outside of the bit count range may be modified by operations and their
+// contents should be treated as undefined.
+//
+// We could reduce this or specialize to a single pointer by packing the bit
+// count in the upper byte of the pointer given that most usage is <= 64 bits.
+// Today this type generally only lives on the stack or in registers so we don't
+// bother as shifting around would be more expensive.
+typedef struct iree_hal_amdgpu_bitmap_t {
+  iree_host_size_t bit_count;
+  uint64_t* words;
+} iree_hal_amdgpu_bitmap_t;
+
+// Calculates the total number of words required to store |bit_count| bits.
+#define iree_hal_amdgpu_bitmap_calculate_words(bit_count) \
+  iree_host_size_ceil_div(bit_count, IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD)
+
+// Returns true if no bits are set in the bitmap.
+bool iree_hal_amdgpu_bitmap_empty(iree_hal_amdgpu_bitmap_t bitmap);
+
+// TODO(benvanik): iree_hal_amdgpu_bitmap_count (popcnt loop with masking).
+
+// Returns true if the bit at |bit_index| is 1.
+// Expects |bit_index| to be in bounds.
+bool iree_hal_amdgpu_bitmap_test(iree_hal_amdgpu_bitmap_t bitmap,
+                                 iree_host_size_t bit_index);
+
+// Sets the bit at |bit_index| to 1.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_set(iree_hal_amdgpu_bitmap_t bitmap,
+                                iree_host_size_t bit_index);
+
+// Sets all bits between |bit_index| and |bit_index| + |bitmap_length| to 1.
+// Expects the entire range to be in bounds.
+void iree_hal_amdgpu_bitmap_set_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                     iree_host_size_t bit_index,
+                                     iree_host_size_t bit_length);
+
+// Sets all bits in the bitmap to 1.
+void iree_hal_amdgpu_bitmap_set_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Resets the bit at |bit_index| to 0.
+// Expects |bit_index| to be in bounds.
+void iree_hal_amdgpu_bitmap_reset(iree_hal_amdgpu_bitmap_t bitmap,
+                                  iree_host_size_t bit_index);
+
+// Resets all bits between |bit_index| and |bit_index| + |bitmap_length| to 0.
+void iree_hal_amdgpu_bitmap_reset_span(iree_hal_amdgpu_bitmap_t bitmap,
+                                       iree_host_size_t bit_index,
+                                       iree_host_size_t bit_length);
+
+// Resets all bits in the bitmap to 0.
+void iree_hal_amdgpu_bitmap_reset_all(iree_hal_amdgpu_bitmap_t bitmap);
+
+// Finds the first set bit (value 1) starting from |bit_offset|.
+// Returns the bitmap size if no set bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_set(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first unset bit (value 0) starting from |bit_offset|.
+// Returns the bitmap size if no unset bit is found.
+// Expects |bit_offset| to be in bounds or 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset);
+
+// Finds the first contiguous |bit_length| span of unset bits (value 0) starting
+// from |bit_offset|.
+// Returns the bitmap size if no span of unset bits is found.
+// Expects the entire range to be in bounds or |bit_offset|/|bit_length| as 0.
+iree_host_size_t iree_hal_amdgpu_bitmap_find_first_unset_span(
+    iree_hal_amdgpu_bitmap_t bitmap, iree_host_size_t bit_offset,
+    iree_host_size_t bit_length);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BITMAP_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/bitmap_test.cc
@@ -1,0 +1,447 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+TEST(BitmapTest, CalculateWords) {
+  static_assert(IREE_HAL_AMDGPU_BITMAP_BITS_PER_WORD == 64,
+                "assumes 64-bit words");
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(1), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(63), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(64), 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_calculate_words(65), 2);
+}
+
+// Tests that a NULL storage pointer is allowed (as we shouldn't touch it).
+TEST(BitmapTest, Empty) {
+  iree_hal_amdgpu_bitmap_t bitmap = {0, NULL};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);           // no-op
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);         // no-op
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 0);    // no-op
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 0);  // no-op
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 0, 0), 0);
+}
+
+TEST(BitmapTest, Test) {
+  uint64_t words[] = {
+      0ull | 0b1010,
+      0ull | 0b1,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 1));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 3));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 0));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+}
+
+TEST(BitmapTest, Set63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Set64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Set65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Set73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, SetPreserve) {
+  uint64_t words[] = {
+      0ull | (1ull << 2),
+      0ull | (1ull << 3),
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  iree_hal_amdgpu_bitmap_set(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b101ull);
+  EXPECT_EQ(words[1], 0b1010ull);
+}
+
+TEST(BitmapTest, SetSpanPrefix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSuffix) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetSpanSplit) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0b1ull << 63);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, SetAll) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_set_all(bitmap);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0x0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, Reset0) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset63) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  iree_hal_amdgpu_bitmap_set(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 63);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 63));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0ull);
+}
+
+TEST(BitmapTest, Reset64) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  iree_hal_amdgpu_bitmap_set(bitmap, 64);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull);
+}
+
+TEST(BitmapTest, Reset65) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  iree_hal_amdgpu_bitmap_set(bitmap, 65);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 65));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 0b10ull);
+}
+
+TEST(BitmapTest, Reset73) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  iree_hal_amdgpu_bitmap_set(bitmap, 73);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 73));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1], 1ull << (73 - 64));
+}
+
+TEST(BitmapTest, ResetPreserve) {
+  uint64_t words[] = {
+      0b101ull,
+      0b1010ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  iree_hal_amdgpu_bitmap_reset(bitmap, 0);
+  iree_hal_amdgpu_bitmap_reset(bitmap, 64 + 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 0));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 2));
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 1));
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_test(bitmap, 64 + 3));
+  EXPECT_EQ(words[0], 0b100ull);
+  EXPECT_EQ(words[1], 0b1000ull);
+}
+
+TEST(BitmapTest, ResetSpanPrefix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, 64 + 10 - 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1000000000ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSuffix) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 64 + 10 - 1, 1);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b0111111111ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanSplit) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 63, 2);
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], ~(0b1ull << 63));
+  EXPECT_EQ(words[1] & 0b1111111111ull,
+            0b1111111110ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetSpanAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, 0, bitmap.bit_count);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, ResetAll) {
+  uint64_t words[] = {
+      ~0ull,
+      ~0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(words[0], 0ull);
+  EXPECT_EQ(words[1] & 0b1111111111ull, 0ull);  // note tail bits are undefined
+}
+
+TEST(BitmapTest, FindEmpty) {
+  uint64_t words[] = {
+      0ull,
+      0ull,
+  };
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 0), 0);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, 10), 10);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 10,
+                                                         bitmap.bit_count - 10),
+            10);
+}
+
+TEST(BitmapTest, Find0) {
+  uint64_t words[] = {
+      0ull | 0b1,
+      0ull,
+  };
+  const int bit_index = 0;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find63) {
+  uint64_t words[] = {
+      0ull | (1ull << 63),
+      0ull,
+  };
+  const int bit_index = 63;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find64) {
+  uint64_t words[] = {
+      0ull,
+      0ull | 0b1,
+  };
+  const int bit_index = 64;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find67) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 3),
+  };
+  const int bit_index = 64 + 3;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_FALSE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bit_index + 1);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(
+                bitmap, bit_index, bitmap.bit_count - bit_index - 1),
+            bit_index + 1);
+}
+
+TEST(BitmapTest, Find73) {
+  uint64_t words[] = {
+      0ull,
+      0ull | (0b1 << 10),
+  };
+  const int bit_index = 64 + 10;
+  iree_hal_amdgpu_bitmap_t bitmap = {64 + 10, words};
+  EXPECT_TRUE(iree_hal_amdgpu_bitmap_empty(bitmap));
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_set(bitmap, 0), bit_index);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset(bitmap, bit_index),
+            bitmap.bit_count);
+  EXPECT_EQ(iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, bit_index, 0),
+            bitmap.bit_count);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
@@ -1,0 +1,604 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/block_pool.h"
+
+#include "iree/hal/drivers/amdgpu/util/bitmap.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_pool_t
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_hal_amdgpu_block_pool_grow(
+    iree_hal_amdgpu_block_pool_t* block_pool);
+
+iree_status_t iree_hal_amdgpu_block_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_block_pool_options_t options, hsa_agent_t agent,
+    hsa_amd_memory_pool_t memory_pool, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_block_pool_t* out_block_pool) {
+  IREE_ASSERT_ARGUMENT(out_block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, options.block_size);
+
+  memset(out_block_pool, 0, sizeof(*out_block_pool));
+
+  if (!options.block_size ||
+      !iree_device_size_is_power_of_two(options.block_size)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                             "block size must be a power-of-two; got %" PRIdsz,
+                             options.block_size));
+  }
+
+  out_block_pool->libhsa = libhsa;
+  out_block_pool->host_allocator = host_allocator;
+  out_block_pool->agent = agent;
+  out_block_pool->memory_pool = memory_pool;
+  out_block_pool->block_size = options.block_size;
+
+  // Query the memory pool for its allocation granularity.
+  // This is not the minimum allocation size
+  // (HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE) but the recommended size
+  // to prevent internal fragmentation. We will always make allocations of this
+  // size and then suballocate the block size.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_memory_pool_get_info(
+          IREE_LIBHSA(libhsa), memory_pool,
+          HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+          &alloc_rec_granule),
+      "querying HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE to "
+      "determine blocks/allocation");
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, alloc_rec_granule);
+
+  // If no min block count was provided we pick one as either the number that
+  // will fit into the recommended allocation granule.
+  const iree_host_size_t min_blocks_per_allocation =
+      options.min_blocks_per_allocation
+          ? options.min_blocks_per_allocation
+          : iree_host_size_ceil_div(alloc_rec_granule, options.block_size);
+
+  // Always allocate aligned to the recommended granularity.
+  // This may lead to more blocks than the user requested but the extra memory
+  // would likely be unused anyway (or used poorly).
+  const iree_device_size_t allocation_size = iree_device_align(
+      options.block_size * min_blocks_per_allocation, alloc_rec_granule);
+  out_block_pool->blocks_per_allocation =
+      (iree_host_size_t)(allocation_size / options.block_size);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_block_pool->blocks_per_allocation);
+
+  iree_slim_mutex_initialize(&out_block_pool->mutex);
+  iree_slim_mutex_lock(&out_block_pool->mutex);
+
+  // Preallocate as many allocations as required to hold the requested initial
+  // block count.
+  iree_status_t status = iree_ok_status();
+  iree_host_size_t initial_allocation_count = iree_host_size_ceil_div(
+      options.initial_capacity, out_block_pool->blocks_per_allocation);
+  for (iree_host_size_t i = 0; i < initial_allocation_count; ++i) {
+    status = iree_hal_amdgpu_block_pool_grow(out_block_pool);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  iree_slim_mutex_unlock(&out_block_pool->mutex);
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_block_pool_deinitialize(out_block_pool);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_block_pool_deinitialize(
+    iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Should have freed everything so we can just trim the pool to drop all
+  // blocks.
+  iree_hal_amdgpu_block_pool_trim(block_pool);
+  IREE_ASSERT(!block_pool->allocations_head,
+              "must have freed all blocks prior to deallocating the pool");
+
+  iree_slim_mutex_deinitialize(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Grows the block pool by one block allocation and links all of the blocks
+// contained into the block pool free list.
+//
+// Must be called with the pool lock held.
+static iree_status_t iree_hal_amdgpu_block_pool_grow(
+    iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate device memory. This may fail if resources are exhausted.
+  IREE_AMDGPU_DEVICE_PTR uint8_t* base_ptr = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_memory_pool_allocate(
+          IREE_LIBHSA(block_pool->libhsa), block_pool->memory_pool,
+          block_pool->blocks_per_allocation * block_pool->block_size,
+          HSA_AMD_MEMORY_POOL_STANDARD_FLAG, (void**)&base_ptr),
+      "growing block pool with one block of %" PRIdsz " bytes",
+      block_pool->block_size * block_pool->blocks_per_allocation);
+
+  // Allocate host memory container for the allocation.
+  iree_hal_amdgpu_block_allocation_t* block_allocation = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      block_pool->host_allocator,
+      sizeof(*block_allocation) + block_pool->blocks_per_allocation *
+                                      sizeof(block_allocation->blocks[0]),
+      (void**)&block_allocation);
+  if (iree_status_is_ok(status)) {
+    block_allocation->next = block_pool->allocations_head;
+    block_allocation->base_ptr = base_ptr;
+    block_allocation->used_count = 0;
+    block_pool->allocations_head = block_allocation;
+
+    // Setup all blocks to point at their relevant memory.
+    // We append to the block pool free list as we go.
+    for (iree_host_size_t i = 0; i < block_pool->blocks_per_allocation; ++i) {
+      iree_hal_amdgpu_block_t* block = &block_allocation->blocks[i];
+      block->ptr = base_ptr + i * block_pool->block_size;
+      block->allocation = block_allocation;
+      block->next = block_pool->free_blocks_head;
+      block_pool->free_blocks_head = block;
+    }
+  } else {
+    IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_free(
+        IREE_LIBHSA(block_pool->libhsa), base_ptr));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_block_pool_trim(iree_hal_amdgpu_block_pool_t* block_pool) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: we could steal the whole list and free it outside of the lock but we
+  // actually want to prevent anyone else from growing the pool until we've
+  // completed - otherwise a sequence of trim+alloc could cause higher peak
+  // usage.
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Preprocess the block free list to remove all blocks whose allocation has
+  // no used blocks. This is so that the walk over the allocation list can free
+  // the host memory that contains the blocks below.
+  //
+  // This isn't great but compared to the cost of calling into HSA to deallocate
+  // the device memory this is nothing. Trims only happen when latency is not
+  // important.
+  iree_hal_amdgpu_block_t* free_block = block_pool->free_blocks_head;
+  iree_hal_amdgpu_block_t* prev_free_block = NULL;
+  while (free_block) {
+    iree_hal_amdgpu_block_t* next_free_block = free_block->next;
+    if (free_block->allocation->used_count == 0) {
+      // Allocation will be freed below - unlink.
+      if (free_block == block_pool->free_blocks_head) {
+        block_pool->free_blocks_head = next_free_block;
+        if (prev_free_block) prev_free_block->next = next_free_block;
+      } else {
+        prev_free_block->next = next_free_block;
+      }
+    } else {
+      // Allocation still has uses - keep the block in the list.
+      prev_free_block = free_block;
+    }
+    free_block = next_free_block;
+  }
+
+  // Walk each allocation and free it if it has no outstanding blocks allocated.
+  // Note that we already cleaned up the free block list above.
+  iree_hal_amdgpu_block_allocation_t* allocation = block_pool->allocations_head;
+  iree_hal_amdgpu_block_allocation_t* prev_allocation = NULL;
+  while (allocation) {
+    iree_hal_amdgpu_block_allocation_t* next_allocation = allocation->next;
+    if (allocation->used_count == 0) {
+      // No blocks outstanding - can free and remove from the allocation list.
+      IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_free(
+          IREE_LIBHSA(block_pool->libhsa), allocation->base_ptr));
+      if (allocation == block_pool->allocations_head) {
+        block_pool->allocations_head = next_allocation;
+        if (prev_allocation) prev_allocation->next = next_allocation;
+      } else {
+        prev_allocation->next = next_allocation;
+      }
+      iree_allocator_free(block_pool->host_allocator, allocation);
+    } else {
+      // Skip as blocks still outstanding.
+      prev_allocation = allocation;
+    }
+    allocation = next_allocation;
+  }
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_amdgpu_block_pool_acquire(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t** out_block) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  IREE_ASSERT_ARGUMENT(out_block);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_block = NULL;
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // If there are no free blocks available grow the pool by one block allocation
+  // (which may allocate multiple blocks worth of memory).
+  if (!block_pool->free_blocks_head) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_amdgpu_block_pool_grow(block_pool));
+  }
+
+  // Slice off the next free block.
+  iree_hal_amdgpu_block_t* block = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block->next;
+  block->next = NULL;  // user may use this
+  block->prev = NULL;
+  memset(block->user_data, 0, sizeof(block->user_data));
+  ++block->allocation->used_count;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  *out_block = block;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_block_pool_release(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_hal_amdgpu_block_t* block) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  if (!block) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Return the block to the pool free list and update the allocation tracking.
+  block->next = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block;
+  --block->allocation->used_count;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_hal_amdgpu_block_pool_release_list(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t* block_head) {
+  IREE_ASSERT_ARGUMENT(block_pool);
+  if (!block_head) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&block_pool->mutex);
+
+  // Return the blocks to the pool free list and update the allocation tracking.
+  // Note that each block has allocation tracking that needs to be adjusted.
+  iree_hal_amdgpu_block_t* block = block_head;
+  iree_hal_amdgpu_block_t* block_tail = block;
+  do {
+    block_tail = block;
+    --block->allocation->used_count;
+    block = block->next;
+  } while (block);
+
+  // Prepend the list to the block pool free list.
+  // The provided list is already linked so we just need to swap it in.
+  // If we didn't have the per-block work we could do this without scanning the
+  // list by taking a tail block as an argument (the caller may already have
+  // it).
+  block_tail->next = block_pool->free_blocks_head;
+  block_pool->free_blocks_head = block_tail;
+
+  iree_slim_mutex_unlock(&block_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_arena_t
+//===----------------------------------------------------------------------===//
+
+void iree_hal_amdgpu_block_arena_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_arena_t* out_arena) {
+  memset(out_arena, 0, sizeof(*out_arena));
+  out_arena->block_pool = block_pool;
+}
+
+void iree_hal_amdgpu_block_arena_deinitialize(
+    iree_hal_amdgpu_block_arena_t* arena) {
+  iree_hal_amdgpu_block_arena_reset(arena);
+}
+
+void iree_hal_amdgpu_block_arena_reset(iree_hal_amdgpu_block_arena_t* arena) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (arena->block_head != NULL) {
+    iree_hal_amdgpu_block_pool_release_list(arena->block_pool,
+                                            arena->block_head);
+    arena->block_head = NULL;
+    arena->block_tail = NULL;
+  }
+
+  arena->total_allocation_size = 0;
+  arena->used_allocation_size = 0;
+  arena->block_bytes_remaining = 0;
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_hal_amdgpu_block_t* iree_hal_amdgpu_block_arena_release_blocks(
+    iree_hal_amdgpu_block_arena_t* arena) {
+  iree_hal_amdgpu_block_t* block_head = arena->block_head;
+  arena->block_head = NULL;
+  arena->block_tail = NULL;
+  arena->total_allocation_size = 0;
+  arena->used_allocation_size = 0;
+  arena->block_bytes_remaining = 0;
+  return block_head;
+}
+
+iree_status_t iree_hal_amdgpu_block_arena_allocate(
+    iree_hal_amdgpu_block_arena_t* arena, iree_device_size_t byte_length,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr) {
+  *out_ptr = NULL;
+
+  iree_hal_amdgpu_block_pool_t* block_pool = arena->block_pool;
+
+  // Pad length allocated so that each pointer bump is always ending at an
+  // aligned address and the next allocation will start aligned.
+  iree_device_size_t aligned_length =
+      iree_device_align(byte_length, iree_hal_amdgpu_max_align_t);
+
+  // Check to see if the current block (if any) has space - if not, get another.
+  if (arena->block_head == NULL ||
+      arena->block_bytes_remaining < aligned_length) {
+    IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_amdgpu_allocate_grow");
+    iree_hal_amdgpu_block_t* block = NULL;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_amdgpu_block_pool_acquire(arena->block_pool, &block));
+    block->next = NULL;
+    if (arena->block_tail) {
+      arena->block_tail->next = block;
+    } else {
+      arena->block_head = block;
+    }
+    arena->block_tail = block;
+    arena->total_allocation_size += block_pool->block_size;
+    arena->block_bytes_remaining = block_pool->block_size;
+    IREE_TRACE_ZONE_END(z0);
+  }
+
+  // Slice out the allocation from the current block.
+  IREE_AMDGPU_DEVICE_PTR void* ptr =
+      (uint8_t*)arena->block_tail->ptr - arena->block_bytes_remaining;
+  arena->block_bytes_remaining -= aligned_length;
+  arena->used_allocation_size += aligned_length;
+  *out_ptr = ptr;
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_allocator_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_block_allocator_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_host_size_t min_page_size,
+    iree_hal_amdgpu_block_allocator_t* out_allocator) {
+  // Verify preconditions.
+  if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(min_page_size))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "min_page_size of %" PRIhsz
+                            " bytes must be a power-of-two",
+                            min_page_size);
+  } else if (IREE_UNLIKELY(block_pool->block_size < min_page_size)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "min_page_size of %" PRIhsz
+        " bytes must fit within the pooled block size of %" PRIhsz " bytes",
+        min_page_size, block_pool->block_size);
+  }
+
+  // We limit our page count to how many bits we have in the usage bitmap.
+  // We may use fewer bits if the granularity is large and the blocks are small.
+  const iree_host_size_t max_page_count =
+      IREE_HAL_AMDGPU_BLOCK_USER_DATA_SIZE * 8;
+  const iree_host_size_t page_size =
+      iree_max(min_page_size, block_pool->block_size / max_page_count);
+  const iree_host_size_t page_count = block_pool->block_size / page_size;
+
+  out_allocator->page_size = page_size;
+  out_allocator->page_count = page_count;
+  out_allocator->block_pool = block_pool;
+
+  iree_slim_mutex_initialize(&out_allocator->mutex);
+  out_allocator->block_head = NULL;
+  out_allocator->block_tail = NULL;
+
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_block_allocator_deinitialize(
+    iree_hal_amdgpu_block_allocator_t* allocator) {
+  if (!allocator) return;
+
+  IREE_ASSERT_EQ(allocator->block_head, NULL);
+  IREE_ASSERT_EQ(allocator->block_tail, NULL);
+
+  iree_slim_mutex_deinitialize(&allocator->mutex);
+
+  memset(allocator, 0, sizeof(*allocator));
+}
+
+static iree_status_t iree_hal_amdgpu_block_allocator_allocate_with_lock(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t page_count,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token) {
+  // Scan the block list for sufficient contiguous free pages. The blocks are
+  // roughly sorted with blocks that have free pages first and we rely on the
+  // total block count being small to make this linear scan ok. We will need to
+  // bucket by longest span or some other "real" allocator things if this ends
+  // up not being enough.
+  iree_hal_amdgpu_block_t* block = allocator->block_head;
+  while (block) {
+    const iree_hal_amdgpu_bitmap_t bitmap = {
+        .bit_count = allocator->page_count,
+        .words = &block->user_data[0],
+    };
+    const iree_host_size_t page_index =
+        iree_hal_amdgpu_bitmap_find_first_unset_span(bitmap, 0, page_count);
+    if (page_index == bitmap.bit_count) {
+      // No span of sufficient size found - try the next block with free pages.
+      block = block->next;
+      continue;
+    }
+    // Span of pages found. Reserve and return the allocation.
+    iree_hal_amdgpu_bitmap_set_span(bitmap, page_index, page_count);
+    *out_ptr = (uint8_t*)block->ptr + page_index * allocator->page_size;
+    out_token->page_count = (uint64_t)page_count;
+    out_token->block = (uint64_t)block;
+    return iree_ok_status();
+  }
+
+  // Acquire a new block from the block pool.
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_block_pool_acquire(allocator->block_pool, &block));
+
+  // Reset the bitmap as the contents are undefined.
+  const iree_hal_amdgpu_bitmap_t bitmap = {
+      .bit_count = allocator->page_count,
+      .words = &block->user_data[0],
+  };
+  iree_hal_amdgpu_bitmap_reset_all(bitmap);
+
+  // Link the block into the list.
+  // If it is full to start (page_count == pages per block) we move it to the
+  // end of the list so it's not scanned.
+  if (page_count == allocator->page_count) {
+    block->next = NULL;
+    block->prev = allocator->block_tail;
+    if (allocator->block_tail) {
+      allocator->block_tail->next = block;
+    } else {
+      allocator->block_head = block;
+    }
+    allocator->block_tail = block;
+  } else {
+    block->next = allocator->block_head;
+    block->prev = NULL;
+    if (allocator->block_head) {
+      allocator->block_head->prev = block;
+    } else {
+      allocator->block_tail = block;
+    }
+    allocator->block_head = block;
+  }
+
+  // Reserve the the entire page range starting at index 0.
+  const iree_host_size_t page_index = 0;
+  iree_hal_amdgpu_bitmap_set_span(bitmap, page_index, page_count);
+  *out_ptr = (uint8_t*)block->ptr + page_index * allocator->page_size;
+  out_token->page_count = (uint64_t)page_count;
+  out_token->block = (uint64_t)block;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_block_allocator_allocate(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t size,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token) {
+  // Round up the allocation size to the next page size.
+  const iree_host_size_t page_count =
+      iree_host_size_ceil_div(size, allocator->page_size);
+
+  // If the allocation exceeds the page count of a block we cannot allocate it.
+  // We could send these off to an oversized dedicated allocation pool but the
+  // usage of this today shouldn't hit that. Everything should be on the fast
+  // path and dedicated allocations for high-frequency transient allocations are
+  // the slowest of paths.
+  if (page_count > allocator->page_count) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "page count %" PRIhsz " for an allocation of %" PRIhsz
+        " bytes exceeds block page capacity of %u x %u byte blocks",
+        page_count, size, allocator->page_count, allocator->page_size);
+  }
+
+  iree_slim_mutex_lock(&allocator->mutex);
+  iree_status_t status = iree_hal_amdgpu_block_allocator_allocate_with_lock(
+      allocator, page_count, out_ptr, out_token);
+  iree_slim_mutex_unlock(&allocator->mutex);
+  return status;
+}
+
+static void iree_hal_amdgpu_block_allocator_free_with_lock(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token) {
+  iree_hal_amdgpu_block_t* block =
+      (iree_hal_amdgpu_block_t*)(((int64_t)token.block << 8) >> 8);
+
+  // Calculate and clear the page bits corresponding to the allocated range.
+  const uint64_t byte_offset = (uint64_t)ptr - (uint64_t)block->ptr;
+  const iree_host_size_t page_index = byte_offset / allocator->page_size;
+  const iree_hal_amdgpu_bitmap_t bitmap = {
+      .bit_count = allocator->page_count,
+      .words = &block->user_data[0],
+  };
+  iree_hal_amdgpu_bitmap_reset_span(bitmap, page_index, token.page_count);
+
+  // We do two things: moving the block to the head of list so it's found in
+  // scans and returning the block to the block pool if it has no more
+  // allocations outstanding. In both cases we unlink it from the block list.
+  if (block->next) {
+    block->next->prev = block->prev;
+  } else {
+    allocator->block_tail = block->prev;
+  }
+  if (block->prev) {
+    block->prev->next = block->next;
+  } else {
+    allocator->block_head = block->next;
+  }
+  block->prev = block->next = NULL;
+
+  // If the block has no more remaining allocations outstanding it can be
+  // returned to the block pool after we unlink it.
+  if (iree_hal_amdgpu_bitmap_empty(bitmap)) {
+    iree_hal_amdgpu_block_pool_release(allocator->block_pool, block);
+    return;
+  }
+
+  // Move the block to the head of the list as we now know it has free pages.
+  // When allocations are made in predictable patterns (most are) this ensures
+  // the next set of allocations will find pages they are looking for early in
+  // their scan. Or not - there's pathological cases where it'll just create
+  // a ton of fragmentation.
+  if (allocator->block_head) {
+    allocator->block_head->prev = block;
+  } else {
+    allocator->block_tail = block;
+  }
+  block->next = allocator->block_head;
+  allocator->block_head = block;
+}
+
+void iree_hal_amdgpu_block_allocator_free(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token) {
+  if (!ptr) return;
+  iree_slim_mutex_lock(&allocator->mutex);
+  iree_hal_amdgpu_block_allocator_free_with_lock(allocator, ptr, token);
+  iree_slim_mutex_unlock(&allocator->mutex);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
@@ -1,0 +1,354 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Allocation and Transfer Utilities
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): verify that 16 is enough - there are some rules for kernarg
+// alignment we may need to respect. Things seem to work but that may be by
+// chance and out of spec.
+#define iree_hal_amdgpu_max_align_t 16
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_pool_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_block_t iree_hal_amdgpu_block_t;
+typedef struct iree_hal_amdgpu_block_allocation_t
+    iree_hal_amdgpu_block_allocation_t;
+typedef struct iree_hal_amdgpu_block_pool_t iree_hal_amdgpu_block_pool_t;
+
+// Options for configuring a block pool.
+typedef struct iree_hal_amdgpu_block_pool_options_t {
+  // Size in bytes of the device block. Must be a power of two.
+  iree_device_size_t block_size;
+  // Blocks per device allocation made.
+  // This trades off potential underutilized allocations with the number of
+  // allocations made. May be rounded up to meet device requirements.
+  // If 0 then as many blocks as fit within a single recommended device
+  // allocation will be used.
+  iree_host_size_t min_blocks_per_allocation;
+  // Initial capacity of the pool in blocks.
+  // At least this number of blocks will be allocated during pool
+  // initialization, possibly split into multiple block pool allocations.
+  iree_host_size_t initial_capacity;
+} iree_hal_amdgpu_block_pool_options_t;
+
+// A block in the block pool.
+// This is a suballocation of an iree_hal_amdgpu_block_allocation_t device
+// allocation.
+typedef struct iree_hal_amdgpu_block_t {
+  // Device pointer to the allocated block.
+  IREE_AMDGPU_DEVICE_PTR void* ptr;
+  // Parent allocation of the block.
+  // This could be derived from the block pointer if we placed the parent
+  // iree_hal_amdgpu_block_allocation_t at a fixed address (if we ever need
+  // another user_data field).
+  iree_hal_amdgpu_block_allocation_t* allocation;
+  // Next block in a user-defined block list. May be used for any purpose.
+  // Initially NULL on blocks acquired from the pool. Note that this may
+  // reference blocks in another allocation or even pool.
+  iree_hal_amdgpu_block_t* next;
+  // Previous block in a user-defined block list. May be used for any purpose.
+  // Initially NULL on blocks acquired from the pool. Note that this may
+  // reference blocks in another allocation or even pool.
+  iree_hal_amdgpu_block_t* prev;
+  // Arbitrary user data valid while the block is held by the user.
+  // This can be used to sequester small amounts of metadata for tracking.
+  // Initially 0 on blocks acquired from the pool. No cleanup is performed upon
+  // release.
+  uint64_t user_data[4];
+} iree_hal_amdgpu_block_t;
+static_assert(sizeof(iree_hal_amdgpu_block_t) == 64,
+              "keep blocks cache line sized");
+
+// Size of the user data field in a block in bytes.
+#define IREE_HAL_AMDGPU_BLOCK_USER_DATA_SIZE \
+  sizeof(((iree_hal_amdgpu_block_t*)NULL)->user_data)
+
+// A single device allocation containing one or more blocks.
+typedef struct iree_hal_amdgpu_block_allocation_t {
+  // Next in the linked list of allocations managed by the block pool.
+  iree_hal_amdgpu_block_allocation_t* next;
+  // Base pointer of the device allocation.
+  IREE_AMDGPU_DEVICE_PTR void* base_ptr;
+  // Number of used blocks in the allocation outstanding.
+  iree_host_size_t used_count;
+  // Contiguously allocated blocks within the allocation.
+  iree_alignas(64) iree_hal_amdgpu_block_t blocks[/*blocks_per_allocation*/];
+} iree_hal_amdgpu_block_allocation_t;
+
+// A shared pool of equal-sized blocks in device agent memory.
+// Tries to make as few device allocations as possible and of the granularity
+// requested by the driver (or larger). Device memory is not touched by the host
+// as part of management and the memory may not even be host accessible.
+//
+// This uses a linked data structure to allow growth without reallocation (user
+// workloads are unpredictable). The savings from pooling blocks by not having
+// to call into HSA is many orders of magnitude greater than the cost of some
+// linked-list pointer walks. Since users of the block pool almost always need a
+// linked list to store the block in their own lists (iovecs, etc) we expose
+// those as part of the internal tracking structure we need for managing free
+// lists.
+//
+// Thread-safe; may be used by multiple queues on the same physical device with
+// independent host threads.
+typedef struct iree_hal_amdgpu_block_pool_t {
+  // HSA API handle. Unowned and must be kept live by parent.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  // Host allocator used for block lists.
+  iree_allocator_t host_allocator;
+  // Agent the block pool is managing blocks on.
+  hsa_agent_t agent;
+  // Memory pool blocks are allocated from.
+  hsa_amd_memory_pool_t memory_pool;
+  // Size in bytes of a block on device.
+  iree_device_size_t block_size;
+  // Number of blocks in a single device allocation.
+  iree_device_size_t blocks_per_allocation;
+  // Mutex managing the block pool resources.
+  iree_slim_mutex_t mutex;
+  // Linked list of allocations managed by the pool.
+  // Newly allocated blocks are inserted at the head of the list.
+  iree_hal_amdgpu_block_allocation_t* allocations_head IREE_GUARDED_BY(mutex);
+  // Linked list of free blocks in the pool.
+  // The first block in the list is usually the last block released.
+  iree_hal_amdgpu_block_t* free_blocks_head IREE_GUARDED_BY(mutex);
+} iree_hal_amdgpu_block_pool_t;
+
+// Initializes the block pool to allocate from the given |agent| |memory_pool|.
+// Each block will have the same block size and multiple blocks may be allocated
+// at the same time to hit the pool allocation granularity.
+//
+// If an initial block capacity is provided the block pool will make its initial
+// growth allocation to have the given number of blocks available for use prior
+// to returning.
+//
+// A reference to |libhsa| will be kept by the block pool in order to allocate
+// and free memory and must remain live.
+iree_status_t iree_hal_amdgpu_block_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_block_pool_options_t options, hsa_agent_t agent,
+    hsa_amd_memory_pool_t memory_pool, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_block_pool_t* out_block_pool);
+
+// Deinitializes the block pool and releases all resources back to the device.
+// Any outstanding block pointers will become invalid.
+void iree_hal_amdgpu_block_pool_deinitialize(
+    iree_hal_amdgpu_block_pool_t* block_pool);
+
+// Trims the block pool by releasing all allocations that have no outstanding
+// blocks allocated. Does not compact allocations to reduce fragmentation.
+void iree_hal_amdgpu_block_pool_trim(iree_hal_amdgpu_block_pool_t* block_pool);
+
+// Acquires a block from the |block_pool|, growing the pool if needed.
+iree_status_t iree_hal_amdgpu_block_pool_acquire(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t** out_block);
+
+// Releases a block back to the pool.
+// The block must have been acquired from |block_pool|.
+void iree_hal_amdgpu_block_pool_release(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_hal_amdgpu_block_t* block);
+
+// Releases a linked list of blocks back to the pool.
+// All blocks must have been acquired from |block_pool|.
+void iree_hal_amdgpu_block_pool_release_list(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_t* block_head);
+
+// Block pools for device memory blocks of various sizes.
+// The pools may be configured differently for their usage based on who owns
+// them but generally follow the same bucketing strategy.
+typedef struct iree_hal_amdgpu_block_pools_t {
+  // Used for small allocations of around ~4-32KB.
+  iree_hal_amdgpu_block_pool_t small;
+  // Used for large page-sized allocations of around ~64kB-512KB.
+  iree_hal_amdgpu_block_pool_t large;
+  // Any larger should (probably) be dedicated allocations.
+} iree_hal_amdgpu_block_pools_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_arena_t
+//===----------------------------------------------------------------------===//
+
+// A lightweight bump-pointer arena allocator using a shared block pool.
+// As allocations are made from the arena and block capacity is exhausted new
+// blocks will be acquired from the pool. Upon being reset all blocks will be
+// released back to the pool for reuse by either the same arena in the future or
+// other arenas sharing the same pool.
+//
+// The size of each allocated block used by the arena is inherited from the
+// block pool. Allocations from the arena can not exceed the block size.
+//
+// Thread-compatible; the shared block pool is thread-safe and may be used by
+// arenas on multiple threads but each arena must only be used by a single
+// thread at a time.
+typedef struct iree_hal_amdgpu_block_arena_t {
+  // Fixed-size block pool used to acquire new blocks for the arena.
+  iree_hal_amdgpu_block_pool_t* block_pool;
+  // Total bytes allocated to the arena from the block pool.
+  iree_device_size_t total_allocation_size;
+  // Total bytes allocated from the arena; the utilization of the arena can be
+  // checked with `used_allocation_size / total_allocation_size`.
+  iree_device_size_t used_allocation_size;
+  // Linked list of allocated blocks maintained so that reset can release them.
+  // Newly allocated blocks are appended to the list such that block_tail is
+  // always the most recently allocated block.
+  iree_hal_amdgpu_block_t* block_head;
+  iree_hal_amdgpu_block_t* block_tail;
+  // The number of bytes remaining in the block pointed to by block_head.
+  iree_device_size_t block_bytes_remaining;
+} iree_hal_amdgpu_block_arena_t;
+
+// Initializes an arena that will use |block_pool| for allocating blocks as
+// needed from device memory.
+void iree_hal_amdgpu_block_arena_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool,
+    iree_hal_amdgpu_block_arena_t* out_arena);
+
+// Deinitializes the arena and returns allocated blocks to the parent pool.
+void iree_hal_amdgpu_block_arena_deinitialize(
+    iree_hal_amdgpu_block_arena_t* arena);
+
+// Resets the entire arena and returns allocated blocks to the parent pool.
+void iree_hal_amdgpu_block_arena_reset(iree_hal_amdgpu_block_arena_t* arena);
+
+// Releases ownership of the allocated blocks and returns them as a FIFO linked
+// list. The arena will be reset and ready to allocate new blocks.
+iree_hal_amdgpu_block_t* iree_hal_amdgpu_block_arena_release_blocks(
+    iree_hal_amdgpu_block_arena_t* arena);
+
+// Allocates |byte_length| contiguous bytes from the arena.
+// The returned bytes will have undefined contents and must be initialized by
+// the caller.
+iree_status_t iree_hal_amdgpu_block_arena_allocate(
+    iree_hal_amdgpu_block_arena_t* arena, iree_device_size_t byte_length,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_block_allocator_t
+//===----------------------------------------------------------------------===//
+
+// Opaque token handed out with allocations used to quickly free the allocation.
+typedef union iree_hal_amdgpu_block_token_t {
+  uint64_t bits;
+  struct {
+    // Number of pages the allocation occupies in the block.
+    uint64_t page_count : 8;
+    // iree_hal_amdgpu_block_t pointer; we only need the lower 7 bytes to
+    // represent blocks. The block is aligned and we could steal some lower bits
+    // if we wanted to allow a larger page_count.
+    uint64_t block : 56;
+  };
+} iree_hal_amdgpu_block_token_t;
+static_assert(sizeof(iree_hal_amdgpu_block_token_t) == sizeof(uint64_t),
+              "must match reserved space in the device library");
+
+// A block suballocator intended for relatively small allocations (~256 bytes to
+// ~4096 bytes) made at average frequency (~once per queue submission).
+//
+// Each block acquired from the block pool is divided into 256 fixed size pages.
+// This allows for a bitmap of used pages to be stored inline in the metadata of
+// the block the pages are present in. It also allows for O(1) deallocation at
+// the cost of O(block count) allocation. This is achieved by providing a token
+// with each allocation that contains the block pointer packed with the page
+// count of the allocation (knowing it is always <= 256) avoiding the need to
+// either touch the device-side memory or allocate additional host-side
+// metadata. The memory overhead of each allocation rounds to zero as the token
+// is stored in the data structures of the client code requesting the allocation
+// and each block already has 256 bits of host-local user data storage available
+// for use.
+//
+// The downside of this implementation is that it can suffer from internal
+// fragmentation. If exclusively 129 page allocations are made nearly half of
+// all acquired block storage will be wasted. That's (hopefully) rare for the
+// intended usage which is either ~64-128 byte allocations (most scheduler queue
+// entries) or ~1024-4096 byte allocations (execution entries with binding
+// tables). If fragmentation becomes an issue we can bucket the free list by
+// number of contiguous pages free and reduce the scan cost.
+//
+// The allocator uses the user_data[] field in iree_hal_amdgpu_block_t to store
+// the page occupancy bitmap. Though fixed today we could extend it to allow
+// for larger bitmaps when block sizes are much greater than page size. It's
+// expected that users will route requests to a block pool corresponding to
+// their size class so as to avoid overallocation/under-utilization: allocating
+// 1 byte from the large block pool would acquire an entire large block that
+// would be nearly entirely unused if we didn't do that first-level filtering.
+//
+// Thread-safe; allocate/free are guarded within the allocator and the
+// underlying block pool is also thread-safe.
+typedef struct iree_hal_amdgpu_block_allocator_t {
+  // Power-of-two calculated allocation granularity in bytes. All allocations
+  // are padded to this size.
+  uint32_t page_size;
+  // Power-of-two number of pages within each block.
+  uint32_t page_count;
+  // Block pool with fixed-size blocks that the allocator uses for storage.
+  iree_hal_amdgpu_block_pool_t* block_pool;
+  // Guards access to the block lists and block bitmaps.
+  iree_slim_mutex_t mutex;
+  // Doubly linked list of blocks. Roughly sorted with blocks that have free
+  // space near the front.
+  iree_hal_amdgpu_block_t* block_head IREE_GUARDED_BY(mutex);
+  iree_hal_amdgpu_block_t* block_tail IREE_GUARDED_BY(mutex);
+} iree_hal_amdgpu_block_allocator_t;
+
+// Initializes a new allocator that acquires its memory from the given
+// |block_pool| and with a fixed power-of-two allocation |min_page_size|.
+// Allocations will be padded to the granularity.
+iree_status_t iree_hal_amdgpu_block_allocator_initialize(
+    iree_hal_amdgpu_block_pool_t* block_pool, iree_host_size_t min_page_size,
+    iree_hal_amdgpu_block_allocator_t* out_allocator);
+
+// Deinitializes the allocator and frees all blocks back to the block pool.
+// Requires that all outstanding allocations have been freed.
+void iree_hal_amdgpu_block_allocator_deinitialize(
+    iree_hal_amdgpu_block_allocator_t* allocator);
+
+// Allocates a range of memory with iree_hal_amdgpu_max_align_t alignment.
+// |out_ptr| will point to the device address of the allocation (which may not
+// be host accessible) and |out_token| is opaque allocation-specific metadata
+// that must be passed to iree_hal_amdgpu_block_allocator_free.
+iree_status_t iree_hal_amdgpu_block_allocator_allocate(
+    iree_hal_amdgpu_block_allocator_t* allocator, iree_host_size_t size,
+    IREE_AMDGPU_DEVICE_PTR void** out_ptr,
+    iree_hal_amdgpu_block_token_t* out_token);
+
+// Frees an allocated |ptr| with associated metadata |token|.
+// The corresponding pages will be marked as free within the parent block and
+// if the block has no more used pages it will be returned to the pool.
+void iree_hal_amdgpu_block_allocator_free(
+    iree_hal_amdgpu_block_allocator_t* allocator,
+    IREE_AMDGPU_DEVICE_PTR void* ptr, iree_hal_amdgpu_block_token_t token);
+
+// Block allocators for device memory blocks of various sizes.
+// The allocators are configured to use the block pools in
+// iree_hal_amdgpu_block_pools_t.
+typedef struct iree_hal_amdgpu_block_allocators_t {
+  // Used for small allocations of around ~64B-256B.
+  iree_hal_amdgpu_block_allocator_t small;
+  // Used for large allocations of around ~4096B-256KB.
+  iree_hal_amdgpu_block_allocator_t large;
+} iree_hal_amdgpu_block_allocators_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BLOCK_POOL_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool_test.cc
@@ -1,0 +1,214 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/block_pool.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct BlockPoolTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+TEST_F(BlockPoolTest, LifetimeEmpty) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/1 * 1024,
+      /*.initial_capacity=*/0,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Acquire a block. This will grow the pool as we started empty.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+
+  // Acquire another block. It should have a unique address (to ensure we didn't
+  // return the same block).
+  iree_hal_amdgpu_block_t* block1 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block1));
+  EXPECT_NE(block1->ptr, nullptr);
+  EXPECT_NE(block1->ptr, block0->ptr);
+  EXPECT_EQ(block1->next, nullptr);
+
+  // Release the first block back to the pool followed by the second.
+  // This ensures we support arbitrary ordering.
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block1);
+
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+TEST_F(BlockPoolTest, LifetimeInitial) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/1 * 1024,
+      /*.initial_capacity=*/32,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Acquire and release block. This should not grow the pool as we initialized
+  // it above.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+// Allocates a few blocks to force some growth, frees some, trims, and tries to
+// grow again. We have to use the reported blocks_per_allocation as the pool
+// will always round up what we specify.
+TEST_F(BlockPoolTest, Trimming) {
+  IREE_TRACE_SCOPE();
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  iree_hal_amdgpu_block_pool_options_t options = {
+      /*.block_size=*/256 * 1024,
+      /*.initial_capacity=*/0,
+  };
+  iree_hal_amdgpu_block_pool_t block_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_initialize(
+      &libhsa, options, gpu_agent, memory_pool, host_allocator, &block_pool));
+
+  // Since the exact counts are device dependent we have to dynamically manage
+  // our working set. We try to hit a certain number of batches.
+  // Note that to ensure we get new blocks we allocate everything and then
+  // selectively release resources.
+  //
+  // batches[0] = fully allocated
+  // batches[1] = all but one allocated
+  // batches[2] = only one allocated
+  struct batch_t {
+    std::vector<iree_hal_amdgpu_block_t*> blocks;
+  };
+  batch_t batches[4] = {};
+  for (iree_host_size_t batch = 0; batch < IREE_ARRAYSIZE(batches); ++batch) {
+    for (iree_host_size_t i = 0; i < block_pool.blocks_per_allocation; ++i) {
+      iree_hal_amdgpu_block_t* block = NULL;
+      IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block));
+      batches[batch].blocks.push_back(block);
+    }
+  }
+  {
+    // batches[0] = fully allocated, don't release anything.
+  }
+  {
+    // batches[1] = all but one allocated - release only the last.
+    iree_hal_amdgpu_block_t* block = batches[1].blocks.back();
+    batches[1].blocks.pop_back();
+    iree_hal_amdgpu_block_pool_release(&block_pool, block);
+  }
+  {
+    // batches[2] = only one allocated - release all but the first.
+    for (iree_host_size_t i = 0; i < batches[2].blocks.size() - 1; ++i) {
+      iree_hal_amdgpu_block_t* block = batches[2].blocks.back();
+      batches[2].blocks.pop_back();
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+  {
+    // batches[3] = none allocated - release all.
+    while (!batches[3].blocks.empty()) {
+      iree_hal_amdgpu_block_t* block = batches[3].blocks.back();
+      batches[3].blocks.pop_back();
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+
+  // Trim now - we should only drop one allocation for batches[3] that has
+  // no live blocks.
+  iree_hal_amdgpu_block_pool_trim(&block_pool);
+
+  // Acquire a new block - should use something we have in the pool. This is
+  // something that would trigger ASAN if we freed something bad.
+  iree_hal_amdgpu_block_t* block0 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block0));
+  EXPECT_NE(block0->ptr, nullptr);
+  EXPECT_EQ(block0->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block0);
+
+  // Drop all of batches[2] and try trimming again.
+  for (auto* block : batches[2].blocks) {
+    iree_hal_amdgpu_block_pool_release(&block_pool, block);
+  }
+  batches[2].blocks.clear();
+  iree_hal_amdgpu_block_pool_trim(&block_pool);
+
+  // Another test block.
+  iree_hal_amdgpu_block_t* block1 = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_block_pool_acquire(&block_pool, &block1));
+  EXPECT_NE(block1->ptr, nullptr);
+  EXPECT_EQ(block1->next, nullptr);
+  iree_hal_amdgpu_block_pool_release(&block_pool, block1);
+
+  // Release all remaining blocks.
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(batches); ++i) {
+    for (auto* block : batches[i].blocks) {
+      iree_hal_amdgpu_block_pool_release(&block_pool, block);
+    }
+  }
+
+  // Implicitly trims.
+  iree_hal_amdgpu_block_pool_deinitialize(&block_pool);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/device_library.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/device_library.c
@@ -1,0 +1,459 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/device_library.h"
+
+#include "iree/hal/drivers/amdgpu/device/binaries.h"
+#include "iree/hal/drivers/amdgpu/device/kernels.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_library_t
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_file_toc_append_names_to_builder(
+    const iree_file_toc_t* file_toc, size_t file_count,
+    iree_string_builder_t* builder) {
+  for (iree_host_size_t i = 0; i < file_count; ++i) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, ", "));
+    }
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_cstring(builder, file_toc[i].name));
+  }
+  return iree_ok_status();
+}
+
+typedef struct iree_hal_amdgpu_agent_available_isas_t {
+  iree_host_size_t count;
+  hsa_isa_t values[32];
+} iree_hal_amdgpu_agent_available_isas_t;
+
+static hsa_status_t iree_hal_amdgpu_iterate_agent_isa(hsa_isa_t isa,
+                                                      void* user_data) {
+  iree_hal_amdgpu_agent_available_isas_t* isas =
+      (iree_hal_amdgpu_agent_available_isas_t*)user_data;
+  if (isas->count >= IREE_ARRAYSIZE(isas->values)) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  isas->values[isas->count++] = isa;
+  return HSA_STATUS_SUCCESS;
+}
+
+static iree_status_t iree_hal_amdgpu_agent_available_isas_append_to_builder(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_agent_available_isas_t* isas,
+    iree_string_builder_t* builder) {
+  for (iree_host_size_t i = 0; i < isas->count; ++i) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, ", "));
+    }
+    uint32_t isa_name_length = 0;
+    IREE_RETURN_IF_ERROR(
+        iree_hsa_isa_get_info_alt(IREE_LIBHSA(libhsa), isas->values[i],
+                                  HSA_ISA_INFO_NAME_LENGTH, &isa_name_length));
+    char* isa_name = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_inline(builder, isa_name_length, &isa_name));
+    IREE_RETURN_IF_ERROR(iree_hsa_isa_get_info_alt(
+        IREE_LIBHSA(libhsa), isas->values[i], HSA_ISA_INFO_NAME, isa_name));
+  }
+  return iree_ok_status();
+}
+
+// Selects a device library binary file that supports the ISA of the provided
+// |agent|.
+static iree_status_t iree_hal_amdgpu_device_library_select_file(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    iree_allocator_t host_allocator, hsa_isa_t* out_isa,
+    const iree_file_toc_t** out_file_toc) {
+  IREE_ASSERT_ARGUMENT(out_isa);
+  IREE_ASSERT_ARGUMENT(out_file_toc);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_isa = (hsa_isa_t){0};
+  *out_file_toc = NULL;
+
+  // Query all available ISAs supported by the agent.
+  // This list is ordered by descending priority.
+  iree_hal_amdgpu_agent_available_isas_t available_isas;
+  memset(&available_isas, 0, sizeof(available_isas));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_agent_iterate_isas(IREE_LIBHSA(libhsa), agent,
+                                      iree_hal_amdgpu_iterate_agent_isa,
+                                      &available_isas));
+
+  // For each ISA in decreasing priority try to find a binary that matches.
+  // The binaries are named the same as HSA uses for the ISA name with the .so
+  // suffix.
+  hsa_isa_t best_isa = {0};
+  const iree_file_toc_t* best_file_toc = NULL;
+  for (iree_host_size_t i = 0; i < available_isas.count && !best_file_toc;
+       ++i) {
+    // Get the ISA name - it'll be something like `amdgcn-amd-amdhsa--gfx1100`
+    // for some reason.
+    hsa_isa_t isa = available_isas.values[i];
+    uint32_t isa_name_length = 0;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_hsa_isa_get_info_alt(IREE_LIBHSA(libhsa), isa,
+                                  HSA_ISA_INFO_NAME_LENGTH, &isa_name_length));
+    char* isa_name_buffer = iree_alloca(isa_name_length);
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hsa_isa_get_info_alt(IREE_LIBHSA(libhsa), isa,
+                                      HSA_ISA_INFO_NAME, isa_name_buffer));
+    iree_string_view_t isa_name =
+        iree_make_string_view(isa_name_buffer, isa_name_length - 1);
+    for (iree_host_size_t j = 0; j < iree_hal_amdgpu_device_binaries_size();
+         ++j) {
+      const iree_file_toc_t* file_toc =
+          &iree_hal_amdgpu_device_binaries_create()[j];
+      if (iree_string_view_starts_with(IREE_SV(file_toc->name), isa_name)) {
+        best_isa = isa;
+        best_file_toc = file_toc;
+        break;
+      }
+    }
+  }
+
+  // If we found a matching file return that for loading. It _should_ work but
+  // is not guaranteed.
+  iree_status_t status = iree_ok_status();
+  if (best_file_toc) {
+    *out_isa = best_isa;
+    *out_file_toc = best_file_toc;
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, best_file_toc->name);
+  } else {
+    // Failures get nice errors with available/supported ISAs listed out.
+    status = iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                              "no device library binary found that matches one "
+                              "of the supported ISAs");
+#if IREE_STATUS_MODE >= 2
+    iree_string_builder_t builder;
+    iree_string_builder_initialize(host_allocator, &builder);
+    IREE_IGNORE_ERROR(iree_string_builder_append_string(
+        &builder, IREE_SV("available in runtime build: [")));
+    IREE_IGNORE_ERROR(iree_file_toc_append_names_to_builder(
+        iree_hal_amdgpu_device_binaries_create(),
+        iree_hal_amdgpu_device_binaries_size(), &builder));
+    IREE_IGNORE_ERROR(iree_string_builder_append_string(
+        &builder, IREE_SV("], supported by agent: [")));
+    IREE_IGNORE_ERROR(iree_hal_amdgpu_agent_available_isas_append_to_builder(
+        libhsa, &available_isas, &builder));
+    IREE_IGNORE_ERROR(
+        iree_string_builder_append_string(&builder, IREE_SV("]")));
+    status = iree_status_annotate_f(status, "%.*s",
+                                    (int)iree_string_builder_size(&builder),
+                                    iree_string_builder_buffer(&builder));
+    iree_string_builder_deinitialize(&builder);
+#endif  // IREE_STATUS_MODE >= 2
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_device_library_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_device_library_t* out_library) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_library);
+
+  if (IREE_UNLIKELY(topology->gpu_agent_count == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "topology must have at least one GPU agent");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  memset(out_library, 0, sizeof(*out_library));
+  out_library->libhsa = libhsa;
+
+  // Select (or try to) the binary file for the leading GPU agent.
+  // Today we require a single device ISA for all devices as heterogeneous
+  // multi-device HAL usage is expected for different devices.
+  hsa_isa_t isa = {0};
+  const iree_file_toc_t* file_toc = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_amdgpu_device_library_select_file(
+          libhsa, topology->gpu_agents[0], host_allocator, &isa, &file_toc));
+
+  // TODO(benvanik): figure out what options we could pass? Documentation is ...
+  // lacking. These may have only been used for HSAIL anyway.
+  const char* options = NULL;
+
+  // Bind a code object reader to the memory sourced from our rodata.
+  hsa_code_object_reader_t code_object_reader;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_code_object_reader_create_from_memory(
+              IREE_LIBHSA(libhsa), file_toc->data, file_toc->size,
+              &code_object_reader));
+
+  // Create the executable that will hold all of the loaded code objects.
+  // TODO(benvanik): pass profile/rounding mode from queried info.
+  iree_status_t status =
+      iree_hsa_executable_create_alt(IREE_LIBHSA(libhsa), HSA_PROFILE_FULL,
+                                     HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
+                                     options, &out_library->executable);
+
+  // Load the code object for each agent.
+  // Note that we could save off the loaded_code_object per-agent here but then
+  // we'd need big fixed storage or dynamically allocated storage - instead we
+  // take the hit of doing the n^2 resolve because it's only done once per
+  // HAL device initialization. Everything that needs the information from the
+  // loaded_code_objects caches the results.
+  if (iree_status_is_ok(status)) {
+    for (iree_host_size_t i = 0; i < topology->gpu_agent_count; ++i) {
+      status = iree_hsa_executable_load_agent_code_object(
+          IREE_LIBHSA(libhsa), out_library->executable, topology->gpu_agents[i],
+          code_object_reader, options, NULL);
+      if (!iree_status_is_ok(status)) break;
+    }
+  }
+
+  // Freeze the executable now that loading has completed. Most queries require
+  // that the executable be frozen.
+  if (iree_status_is_ok(status)) {
+    status = iree_hsa_executable_freeze(IREE_LIBHSA(libhsa),
+                                        out_library->executable, options);
+  }
+
+  // Release the reader now that the executable has been fully loaded.
+  IREE_IGNORE_ERROR(iree_hsa_code_object_reader_destroy(IREE_LIBHSA(libhsa),
+                                                        code_object_reader));
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_device_library_deinitialize(out_library);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_device_library_deinitialize(
+    iree_hal_amdgpu_device_library_t* library) {
+  IREE_ASSERT_ARGUMENT(library);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (library->executable.handle) {
+    IREE_IGNORE_ERROR(iree_hsa_executable_destroy(IREE_LIBHSA(library->libhsa),
+                                                  library->executable));
+  }
+
+  memset(library, 0, sizeof(*library));
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+typedef struct iree_hal_amdgpu_find_loaded_code_object_state_t {
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  hsa_agent_t agent;
+  hsa_loaded_code_object_t loaded_code_object;
+} iree_hal_amdgpu_find_loaded_code_object_state_t;
+static hsa_status_t iree_hal_amdgpu_iterate_loaded_code_object(
+    hsa_executable_t executable, hsa_loaded_code_object_t loaded_code_object,
+    void* user_data) {
+  iree_hal_amdgpu_find_loaded_code_object_state_t* find_state =
+      (iree_hal_amdgpu_find_loaded_code_object_state_t*)user_data;
+  hsa_agent_t agent = {0};
+  hsa_status_t hsa_status =
+      find_state->libhsa->amd_loader
+          .hsa_ven_amd_loader_loaded_code_object_get_info(
+              loaded_code_object,
+              HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_AGENT, &agent);
+  if (hsa_status != HSA_STATUS_SUCCESS) return hsa_status;
+  if (agent.handle == find_state->agent.handle) {
+    find_state->loaded_code_object = loaded_code_object;
+    return HSA_STATUS_INFO_BREAK;  // found
+  }
+  return HSA_STATUS_SUCCESS;  // continue
+}
+
+// Finds the loaded code object in |executable| for the given |agent|.
+static iree_status_t iree_hal_amdgpu_find_loaded_code_object(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
+    hsa_agent_t agent, hsa_loaded_code_object_t* out_loaded_code_object) {
+  // Iterate over the code objects and find the first that matches the agent.
+  iree_hal_amdgpu_find_loaded_code_object_state_t find_state = {
+      .libhsa = libhsa,
+      .agent = agent,
+      .loaded_code_object = {0},
+  };
+  hsa_status_t hsa_status =
+      libhsa->amd_loader
+          .hsa_ven_amd_loader_executable_iterate_loaded_code_objects(
+              executable, iree_hal_amdgpu_iterate_loaded_code_object,
+              &find_state);
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    // None found.
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "no loaded code object found for the given agent");
+  } else if (hsa_status != HSA_STATUS_INFO_BREAK) {
+    // Error during iteration.
+    return iree_status_from_hsa_status(
+        __FILE__, __LINE__, hsa_status,
+        "hsa_ven_amd_loader_executable_iterate_loaded_code_objects",
+        "iterating loaded code objects");
+  }
+  *out_loaded_code_object = find_state.loaded_code_object;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_device_library_populate_agent_code_range(
+    const iree_hal_amdgpu_device_library_t* library, hsa_agent_t device_agent,
+    iree_hal_amdgpu_code_range_t* out_range) {
+  IREE_ASSERT_ARGUMENT(library);
+  IREE_ASSERT_ARGUMENT(out_range);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_range, 0, sizeof(*out_range));
+
+  const iree_hal_amdgpu_libhsa_t* libhsa = library->libhsa;
+
+  // Lookup the loaded code object for the given device agent.
+  // Each agent has its own copy and the virtual address ranges will differ for
+  // each.
+  hsa_loaded_code_object_t loaded_code_object = {0};
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_amdgpu_find_loaded_code_object(
+              libhsa, library->executable, device_agent, &loaded_code_object));
+
+  hsa_status_t hsa_status = HSA_STATUS_SUCCESS;
+
+  // Query the requested information.
+  iree_hal_amdgpu_code_range_t range = {0};
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    hsa_status =
+        libhsa->amd_loader.hsa_ven_amd_loader_loaded_code_object_get_info(
+            loaded_code_object,
+            HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_BASE,
+            &range.device_ptr);
+  }
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    hsa_status = libhsa->amd_loader.hsa_ven_amd_loader_query_host_address(
+        (void*)range.device_ptr, (const void**)&range.host_ptr);
+  }
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    hsa_status =
+        libhsa->amd_loader.hsa_ven_amd_loader_loaded_code_object_get_info(
+            loaded_code_object,
+            HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_SIZE, &range.size);
+  }
+
+  iree_status_t status = iree_ok_status();
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    *out_range = range;
+  } else {
+    status = iree_status_from_hsa_status(
+        __FILE__, __LINE__, hsa_status,
+        "hsa_ven_amd_loader_loaded_code_object_get_info",
+        "querying code object info");
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_hal_amdgpu_device_library_populate_kernel_args(
+    const iree_hal_amdgpu_device_library_t* library, hsa_agent_t device_agent,
+    const char* symbol_name, uint16_t workgroup_size_x,
+    uint16_t workgroup_size_y, uint16_t workgroup_size_z,
+    iree_hal_amdgpu_device_kernel_args_t* out_kernel_args) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, symbol_name);
+
+  const iree_hal_amdgpu_libhsa_t* libhsa = library->libhsa;
+
+  // Lookup the symbol. The `.kd` suffix is required and should have been passed
+  // by the caller.
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_executable_get_symbol_by_name(IREE_LIBHSA(libhsa),
+                                             library->executable, symbol_name,
+                                             &device_agent, &symbol),
+      "resolving `%s`", symbol_name);
+
+  // All of our kernels assume 3 dimensions.
+  out_kernel_args->setup = 3 << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
+
+  // TODO(benvanik): embed this as a custom section or attributes that we could
+  // somehow query? For now we hardcode and take directly. This may be fine as
+  // we aren't doing anything but blits and probably don't need to tightly
+  // optimize workgroup size across architectures. Unfortunately the
+  // `reqd_work_group_size` attribute is exactly what we want but clang only
+  // allows it on OpenCL kernels (not C ones). Reading it is a PITA (need to
+  // crack open the ELF, find the AMDGPU notes section, and decode the msgpack)
+  // so unless we absolutely need it alternatives (like extracting from shared
+  // headers as part of a build step) may be better.
+  out_kernel_args->workgroup_size[0] = workgroup_size_x;
+  out_kernel_args->workgroup_size[1] = workgroup_size_y;
+  out_kernel_args->workgroup_size[2] = workgroup_size_z;
+
+  // The object pointer is used in dispatch packets from either the host or
+  // device.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_executable_symbol_get_info(
+          IREE_LIBHSA(libhsa), symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT,
+          &out_kernel_args->kernel_object));
+
+  // Segment size information used to populate dispatch packets and reserve
+  // space.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_executable_symbol_get_info(
+              IREE_LIBHSA(libhsa), symbol,
+              HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
+              &out_kernel_args->private_segment_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_executable_symbol_get_info(
+              IREE_LIBHSA(libhsa), symbol,
+              HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE,
+              &out_kernel_args->group_segment_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_executable_symbol_get_info(
+              IREE_LIBHSA(libhsa), symbol,
+              HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_KERNARG_SEGMENT_SIZE,
+              &out_kernel_args->kernarg_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_executable_symbol_get_info(
+              IREE_LIBHSA(libhsa), symbol,
+              HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_KERNARG_SEGMENT_ALIGNMENT,
+              &out_kernel_args->kernarg_alignment));
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+  // TODO(benvanik): intern an export_loc? We don't have a Tracy API for this
+  // yet and our option is to leak the value unconditionally.
+  out_kernel_args->trace_src_loc = 0;
+#else
+  out_kernel_args->trace_src_loc = 0;
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_device_library_populate_agent_kernels(
+    const iree_hal_amdgpu_device_library_t* library, hsa_agent_t device_agent,
+    iree_hal_amdgpu_device_kernels_t* out_kernels) {
+  IREE_ASSERT_ARGUMENT(library);
+  IREE_ASSERT_ARGUMENT(out_kernels);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  memset(out_kernels, 0, sizeof(*out_kernels));
+
+#define IREE_HAL_AMDGPU_DEVICE_KERNEL(name, workgroup_size_x,             \
+                                      workgroup_size_y, workgroup_size_z) \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                      \
+      z0,                                                                 \
+      iree_hal_amdgpu_device_library_populate_kernel_args(                \
+          library, device_agent, #name ".kd", workgroup_size_x,           \
+          workgroup_size_y, workgroup_size_z, &out_kernels->name),        \
+      #name);
+#include "iree/hal/drivers/amdgpu/device/kernel_tables.h"
+#undef IREE_HAL_AMDGPU_DEVICE_KERNEL
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/device_library.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/device_library.h
@@ -1,0 +1,80 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_DEVICE_LIBRARY_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_DEVICE_LIBRARY_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_device_kernels_t
+    iree_hal_amdgpu_device_kernels_t;
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_library_t
+//===----------------------------------------------------------------------===//
+
+// Loaded device library executable.
+typedef struct iree_hal_amdgpu_device_library_t {
+  // Unowned libhsa handle. Must be retained by the owner.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  // Loaded and frozen executable for all GPU devices.
+  hsa_executable_t executable;
+} iree_hal_amdgpu_device_library_t;
+
+// Initializes |out_library| by loading the builtin device library for all of
+// the GPU devices in the provided topology.
+//
+// |libhsa| is captured by-reference and must remain valid for the lifetime of
+// the cache.
+iree_status_t iree_hal_amdgpu_device_library_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_device_library_t* out_library);
+
+// Deinitializes |library| and releases underlying executable resources.
+void iree_hal_amdgpu_device_library_deinitialize(
+    iree_hal_amdgpu_device_library_t* library);
+
+// Describes a loaded code range on a particular agent.
+typedef struct iree_hal_amdgpu_code_range_t {
+  // Base pointer in the loaded code in host memory.
+  // This represents the address of the same byte as the device_ptr.
+  const uint8_t* host_ptr;
+  // Base pointer in the loaded code in device memory (agent-specific).
+  // This represents the address of the same byte as the host_ptr.
+  uint64_t device_ptr;
+  // Size of the loaded code in bytes.
+  uint64_t size;
+} iree_hal_amdgpu_code_range_t;
+
+// Populates the host and device code |out_base| and |out_size| with the
+// information based on |device_agent|. Each device agent will have its own copy
+// of the code object and different virtual address ranges but _should_ share
+// the same host ranges.
+iree_status_t iree_hal_amdgpu_device_library_populate_agent_code_range(
+    const iree_hal_amdgpu_device_library_t* library, hsa_agent_t device_agent,
+    iree_hal_amdgpu_code_range_t* out_range);
+
+// Populates |out_kernels| with the information based on |device_agent|.
+// Each device agent will have its own unique kernel object pointers. Most other
+// information should be consistent across all other devices as they must be
+// homogeneous within the same HAL device context.
+iree_status_t iree_hal_amdgpu_device_library_populate_agent_kernels(
+    const iree_hal_amdgpu_device_library_t* library, hsa_agent_t device_agent,
+    iree_hal_amdgpu_device_kernels_t* out_kernels);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_DEVICE_LIBRARY_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/device_library_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/device_library_test.cc
@@ -1,0 +1,81 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/device_library.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/device/kernels.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct DeviceLibraryTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+TEST_F(DeviceLibraryTest, Load) {
+  IREE_TRACE_SCOPE();
+
+  iree_hal_amdgpu_device_library_t library;
+  IREE_ASSERT_OK(iree_hal_amdgpu_device_library_initialize(
+      &libhsa, &topology, host_allocator, &library));
+
+  for (iree_host_size_t i = 0; i < topology.gpu_agent_count; ++i) {
+    hsa_agent_t agent = topology.gpu_agents[i];
+
+    // Code range should be non-zero and somewhere in the process address space.
+    iree_hal_amdgpu_code_range_t code_range = {0};
+    IREE_ASSERT_OK(iree_hal_amdgpu_device_library_populate_agent_code_range(
+        &library, agent, &code_range));
+    ASSERT_NE(code_range.host_ptr, nullptr);
+    ASSERT_NE(code_range.device_ptr, 0);
+    ASSERT_NE(code_range.size, 0);
+
+    // Kernel information should be populated but we don't really care with what
+    // here as we aren't running anything.
+    iree_hal_amdgpu_device_kernels_t kernels;
+    IREE_ASSERT_OK(iree_hal_amdgpu_device_library_populate_agent_kernels(
+        &library, agent, &kernels));
+    const auto& any_args = kernels.iree_hal_amdgpu_device_buffer_fill_x1;
+    ASSERT_NE(any_args.kernel_object, 0);
+    ASSERT_NE(any_args.setup, 0);
+    ASSERT_NE(any_args.kernarg_size, 0);
+    ASSERT_NE(any_args.kernarg_alignment, 0);
+  }
+
+  iree_hal_amdgpu_device_library_deinitialize(&library);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -1,0 +1,293 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_find_global_memory_pool_state_t {
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  hsa_amd_memory_pool_global_flag_t match_flags;
+  hsa_amd_memory_pool_t best_pool;
+} iree_hal_amdgpu_find_global_memory_pool_state_t;
+static hsa_status_t iree_hal_amdgpu_find_global_memory_pool_iterator(
+    hsa_amd_memory_pool_t memory_pool, void* user_data) {
+  iree_hal_amdgpu_find_global_memory_pool_state_t* state =
+      (iree_hal_amdgpu_find_global_memory_pool_state_t*)user_data;
+
+  // Filter to the global segment only.
+  hsa_region_segment_t segment = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+      &segment));
+  if (segment != HSA_REGION_SEGMENT_GLOBAL) return HSA_STATUS_SUCCESS;
+
+  // Must be able to allocate. This should be true for any pool we query that
+  // matches the other flags. Workgroup-private pools won't have this set.
+  bool alloc_allowed = false;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed));
+  if (!alloc_allowed) return HSA_STATUS_SUCCESS;
+
+  // Match if flags are present.
+  hsa_region_global_flag_t global_flag = 0;
+  IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(state->libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &global_flag));
+  if (global_flag & state->match_flags) {
+    state->best_pool = memory_pool;
+    return HSA_STATUS_INFO_BREAK;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_pool, 0, sizeof(*out_pool));
+
+  iree_hal_amdgpu_find_global_memory_pool_state_t find_state = {
+      .libhsa = libhsa,
+      .match_flags = match_flags,
+      .best_pool = {0},
+  };
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_agent_iterate_memory_pools(
+              IREE_LIBHSA(libhsa), agent,
+              iree_hal_amdgpu_find_global_memory_pool_iterator, &find_state));
+  if (!find_state.best_pool.handle) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_NOT_FOUND,
+                             "no memory pool matching the required flags %u",
+                             match_flags));
+  }
+
+  *out_pool = find_state.best_pool;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED, out_pool);
+}
+
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_find_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_pool);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, min_capacity);
+  memset(out_ringbuffer, 0, sizeof(*out_ringbuffer));
+
+  // hsa_amd_vmem_handle_create wants values aligned to this value.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hsa_amd_memory_pool_get_info(
+              IREE_LIBHSA(libhsa), memory_pool,
+              HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+              &alloc_rec_granule));
+
+  // Round up capacity and alignment to the allocation granule.
+  const size_t alignment = alloc_rec_granule;
+  const size_t capacity = iree_device_align(min_capacity, alloc_rec_granule);
+  out_ringbuffer->capacity = capacity;
+
+  // Reserve the virtual address space for the 3x the capacity. We'll map the
+  // physical allocation into this address space.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_vmem_address_reserve_align(
+          IREE_LIBHSA(libhsa), &out_ringbuffer->va_base_ptr, capacity * 3,
+          /*address=*/0, alignment, /*flags=*/0),
+      "reserving ringbuffer capacity*3 (%" PRIdsz "*3=%" PRIdsz ")", capacity,
+      capacity * 3);
+  out_ringbuffer->ring_base_ptr =
+      (uint8_t*)out_ringbuffer->va_base_ptr + capacity;
+
+  // Allocate the physical memory for backing the ringbuffer.
+  iree_status_t status = iree_hsa_amd_vmem_handle_create(
+      IREE_LIBHSA(libhsa), memory_pool, capacity, MEMORY_TYPE_NONE,
+      /*flags=*/0, &out_ringbuffer->alloc_handle);
+
+  void* va_offsets[3] = {
+      (uint8_t*)out_ringbuffer->va_base_ptr + 0 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 1 * capacity,
+      (uint8_t*)out_ringbuffer->va_base_ptr + 2 * capacity,
+  };
+
+  // Map the physical allocation into the virtual address space 3 times
+  // (prev, base, next).
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_map(IREE_LIBHSA(libhsa), va_offsets[i], capacity, 0,
+                              out_ringbuffer->alloc_handle, /*flags=*/0);
+  }
+
+  // Enable access on requested devices (no access by default).
+  // Must be done per memory handle, not the entire VA.
+  for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < 3; ++i) {
+    status =
+        iree_hsa_amd_vmem_set_access(IREE_LIBHSA(libhsa), va_offsets[i],
+                                     capacity, access_descs, access_desc_count);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_vmem_ringbuffer_deinitialize(libhsa, out_ringbuffer);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate scratch for the access descriptors. Note that though we allocate
+  // for all agents we don't pass agents with HSA_ACCESS_PERMISSION_NONE as that
+  // actually causes HSA to allocate information about that agent.
+  // HSA_ACCESS_PERMISSION_NONE should only be used to _remove_ access that was
+  // previous granted.
+  iree_host_size_t access_desc_count = 0;
+  hsa_amd_memory_access_desc_t* access_descs =
+      (hsa_amd_memory_access_desc_t*)iree_alloca(
+          topology->all_agent_count * sizeof(hsa_amd_memory_access_desc_t));
+
+  // Populate the access list.
+  switch (access_mode) {
+    case IREE_HAL_AMDGPU_ACCESS_MODE_SHARED: {
+      // All devices get read/write access.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = HSA_ACCESS_PERMISSION_RW,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE: {
+      // Only the local agent can access the ringbuffer.
+      access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+          .agent_handle = local_agent,
+          .permissions = HSA_ACCESS_PERMISSION_RW,
+      };
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER: {
+      // Local agent gets read, all agents get write.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    case IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER: {
+      // Local agent gets write, all agents get read.
+      for (iree_host_size_t i = 0; i < topology->all_agent_count; ++i) {
+        hsa_agent_t agent = topology->all_agents[i];
+        hsa_access_permission_t permissions = HSA_ACCESS_PERMISSION_NONE;
+        if (agent.handle == local_agent.handle) {
+          permissions = HSA_ACCESS_PERMISSION_WO;
+        } else {
+          permissions = HSA_ACCESS_PERMISSION_RO;
+        }
+        access_descs[access_desc_count++] = (hsa_amd_memory_access_desc_t){
+            .agent_handle = topology->all_agents[i],
+            .permissions = permissions,
+        };
+      }
+    } break;
+    default: {
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                               "unhandled access mode"));
+    } break;
+  }
+
+  // Route to the explicit initializer.
+  iree_status_t status = iree_hal_amdgpu_vmem_ringbuffer_initialize(
+      libhsa, local_agent, memory_pool, min_capacity, access_desc_count,
+      access_descs, out_ringbuffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(ringbuffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Unmap physical allocation and release it.
+  if (ringbuffer->alloc_handle.handle) {
+    void* va_offsets[3] = {
+        (uint8_t*)ringbuffer->va_base_ptr + 0 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 1 * ringbuffer->capacity,
+        (uint8_t*)ringbuffer->va_base_ptr + 2 * ringbuffer->capacity,
+    };
+    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(va_offsets); ++i) {
+      IREE_IGNORE_ERROR(iree_hsa_amd_vmem_unmap(
+          IREE_LIBHSA(libhsa), va_offsets[i], ringbuffer->capacity));
+    }
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_handle_release(
+        IREE_LIBHSA(libhsa), ringbuffer->alloc_handle));
+  }
+
+  if (ringbuffer->va_base_ptr) {
+    IREE_IGNORE_ERROR(iree_hsa_amd_vmem_address_free(IREE_LIBHSA(libhsa),
+                                                     ringbuffer->va_base_ptr,
+                                                     ringbuffer->capacity * 3));
+  }
+
+  memset(ringbuffer, 0, sizeof(*ringbuffer));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -1,0 +1,133 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+// Semantically defines how a vmem allocation can be accessed.
+typedef enum iree_hal_amdgpu_vmem_access_mode_e {
+  // All agents may produce and consume the memory. Read/write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_SHARED = 0u,
+  // Memory is accessed exclusively by the agent it is allocated on.
+  // No other agent has access. Read/write for agent only.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE,
+  // Memory is consumed exclusively by the agent it is allocated on but may be
+  // produced from any agent. This is useful for mailboxes. Read for agent only
+  // and write for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_CONSUMER,
+  // Memory is produced exclusively by the agent it is allocated on but may be
+  // consumed from any agent. This is useful for outbound buffers. Write for
+  // agent only and read for all agents.
+  IREE_HAL_AMDGPU_ACCESS_MODE_EXCLUSIVE_PRODUCER,
+} iree_hal_amdgpu_vmem_access_mode_t;
+
+// Finds a global memory pool on the |agent| matching any of the specified
+// global flags.
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a coarse-grained memory pool on the |agent|.
+// The returned pool will support allocations and be
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_coarse_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+// Finds a fine-grained memory pool on the |agent|.
+// The returned pool will support allocations and be either
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED or
+// HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED.
+iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_t* out_pool);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+// An allocated ringbuffer using virtual memory mapping to present a contiguous
+// virtual address range that is backed by a single physical buffer but that
+// allows access before and after it.
+//
+// This presents as a ringbuffer that does not need any special logic for
+// wrapping from base offsets used when copying in memory. It follows the
+// approach documented in https://lo.calho.st/posts/black-magic-buffer/ and
+// https://www.mikeash.com/pyblog/friday-qa-2012-02-17-ring-buffers-and-mirrored-memory-part-ii.html
+// of virtual memory mapping the buffer multiple times, example code:
+// https://github.com/google/wuffs/blob/main/script/mmap-ring-buffer.c
+//
+// We use SVM to allocate the physical memory of the ringbuffer and then stitch
+// together 3 virtual memory ranges in one contiguous virtual allocation that
+// aliases the physical allocation. By treating the middle range as the base
+// buffer pointer we are then able to freely dereference both before and after
+// the base pointer by up to the ringbuffer size in length.
+//   physical: <ringbuffer size> --+------+------+
+//                                 v      v      v
+//                        virtual: [prev] [base] [next]
+//                                 ^      ^
+//                                 |      +-- ring_base_ptr
+//                                 +--------- va_base_ptr
+typedef struct iree_hal_amdgpu_vmem_ringbuffer_t {
+  // Capacity of the ringbuffer in bytes.
+  // May be larger than the requested size if adjusted to the minimum allocation
+  // granule.
+  iree_device_size_t capacity;
+  // Physical allocation of the pinned ringbuffer memory.
+  // This is sized to the requested capacity of the ringbuffer.
+  hsa_amd_vmem_alloc_handle_t alloc_handle;
+  // Base virtual address pointer of the ringbuffer. This is the start of the
+  // reserved address range.
+  IREE_AMDGPU_DEVICE_PTR void* va_base_ptr;
+  // Base virtual address pointer of the central ringbuffer contents.
+  IREE_AMDGPU_DEVICE_PTR void* ring_base_ptr;
+} iree_hal_amdgpu_vmem_ringbuffer_t;
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested |min_capacity| with at least 64 byte alignment.
+// |access_descs| will be used to setup accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    iree_host_size_t access_desc_count,
+    const hsa_amd_memory_access_desc_t* access_descs,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Initializes a ringbuffer by allocating the physical and virtual memory of at
+// least the requested power-of-two |min_capacity| with at least
+// least 64 byte alignment. |topology| and |access_mode| will be used to setup
+// accessibility.
+iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t local_agent,
+    hsa_amd_memory_pool_t memory_pool, iree_device_size_t min_capacity,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_vmem_access_mode_t access_mode,
+    iree_hal_amdgpu_vmem_ringbuffer_t* out_ringbuffer);
+
+// Deinitializes a ringbuffer and frees all physical and virtual allocations.
+void iree_hal_amdgpu_vmem_ringbuffer_deinitialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_amdgpu_vmem_ringbuffer_t* ringbuffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_VMEM_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct VMemTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Virtual Memory Utilities
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, FindCoarseGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  EXPECT_TRUE(iree_all_bits_set(
+      global_flags, HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED));
+}
+
+TEST_F(VMemTest, FindFineGlobalMemoryPool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.cpu_agent_count, 1);
+
+  hsa_amd_memory_pool_t gpu_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  EXPECT_NE(gpu_pool.handle, 0);
+
+  hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
+  IREE_ASSERT_OK(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(&libhsa), gpu_pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+      &global_flags));
+  // NOTE: the pool may have either flag set.
+  EXPECT_TRUE(iree_any_bit_set(
+      global_flags,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_vmem_ringbuffer_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(VMemTest, RingbufferLifetime) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  EXPECT_GE(ringbuffer.capacity, min_capacity);
+  EXPECT_EQ(ringbuffer.ring_base_ptr,
+            (uint8_t*)ringbuffer.va_base_ptr + ringbuffer.capacity);
+  EXPECT_TRUE(iree_device_size_has_alignment(
+      (iree_device_size_t)ringbuffer.ring_base_ptr, 64));
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+TEST_F(VMemTest, RingbufferWrap) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool;
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  // Fill entire range [0,capacity).
+  iree_device_size_t capacity_u32 = ringbuffer.capacity / sizeof(uint32_t);
+  uint32_t* ptr = (uint32_t*)ringbuffer.ring_base_ptr;
+  for (iree_device_size_t i = 0; i < capacity_u32; ++i) {
+    ptr[i] = (uint32_t)i;
+  }
+
+  // Compare some locations off the base to ensure wrapping is valid.
+  EXPECT_EQ(ptr[0], ptr[capacity_u32]);
+  EXPECT_EQ(ptr[-1], ptr[capacity_u32 - 1]);
+  EXPECT_EQ(ptr[1], ptr[capacity_u32 + 1]);
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu


### PR DESCRIPTION
This contains headers shared with the host runtime such that it can build but does not implement any logic. The build rules will likely change over time to support externally-provided ROCM/TheRock clangs so we don't need to build them as part of a runtime build, but currently does support the installed LLVM toolchain settings we already have (`IREE_CLANG_BINARY`/`IREE_LLD_BINARY`/etc).

Which targets we build the device library for and bundle is controlled with the `IREE_HAL_AMDGPU_DEVICE_LIBRARY_TARGETS` cmake flag. This matches LLVM/us/TheRocks naming - e.g. "gfx942;gfx1100" says to bundle a copy compiled for gfx942 and a copy compiled for gfx1100. The hope is that once TheRock stabilizes its family naming we can have an equivalent mapping such that documentation lines up: https://github.com/ROCm/TheRock/blob/main/cmake/therock_amdgpu_targets.cmake

Of note is that a single `iree_hal_amdgpu_device_library_t` instance will be loaded for use on all agents in the topology. The ISAs reported by each agent are used to select the bundled prebuilt device library - today all agent ISAs must match but we can lighten that restriction in the future if we wanted.

The only non-standard thing we do here is `iree_hal_amdgpu_device_library_populate_agent_code_range`, which is used to let us take device pointers to addresses in the device agent copy of the loaded object and map it back to the corresponding copy in host memory. This is used by tracing to let us embed source locations directly in the device library code that we can resolve and pass to tracy (which we don't want poking into device memory).

Sub-review for #20990. Not expected to pass CI.