### PR TITLE
[flow] fix(CloneProducersIntoWorkgroups): Add LinalgOp Init Check

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -791,3 +791,25 @@ util.func public @dont_clone_gather_like(%arg0: tensor<4x1x4xi64>, %arg1: tensor
 //       CHECK:      %[[ATTENTION:.+]] = iree_linalg_ext.attention
 //       CHECK:        ins({{.*}}, %[[DISPATCHK]], %[[DISPATCHV]]
 //       CHECK:      flow.return %[[ATTENTION]]
+
+// -----
+
+util.func public @matmul_with_bias_consant(%arg0: tensor<2x3xf32>, %arg1: tensor<3x2xf32>) -> tensor<2x2xf32> {
+  %0 = arith.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>
+  %2 = flow.dispatch.region -> (tensor<2x2xf32>) {
+    %3 = linalg.matmul
+            indexing_maps = [
+                affine_map<(m, n, k) -> (m, k)>,
+                affine_map<(m, n, k) -> (k, n)>,
+                affine_map<(m, n, k) -> (m, n)>]
+            ins(%arg0, %arg1 : tensor<2x3xf32>,tensor<3x2xf32>)
+            outs(%0: tensor<2x2xf32>) -> tensor<2x2xf32>
+    flow.return %3 : tensor<2x2xf32>
+  }
+  util.return %2 : tensor<2x2xf32>
+}
+// CHECK-LABEL: util.func public @matmul_with_bias_consant
+//       CHECK: %[[BIAS:.+]] = arith.constant
+//       CHECK: %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
+//       CHECK:   flow.return %[[MATMUL]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -1027,7 +1027,7 @@ util.func public @extract_slice(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : 
 
 // -----
 
-util.func public @inline_cst(%arg0 : tensor<4x32xi32>) -> tensor<32xi32> {
+util.func public @do_not_inline_cst(%arg0 : tensor<4x32xi32>) -> tensor<32xi32> {
   %cst = arith.constant dense<0> : tensor<32xi32>
   %0 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>],
@@ -1039,20 +1039,72 @@ util.func public @inline_cst(%arg0 : tensor<4x32xi32>) -> tensor<32xi32> {
       } -> tensor<32xi32>
   util.return %0 : tensor<32xi32>
 }
-//      CHECK: util.func public @inline_cst(%[[ARG0:.+]]: tensor<4x32xi32>)
+// CHECK-LABEL: util.func public @do_not_inline_cst
+// CHECK-SAME:      (%[[ARG0:.+]]: tensor<4x32xi32>)
+//      CHECK:   %[[CST:.+]] = arith.constant dense<0> : tensor<32xi32>
 //      CHECK:   flow.dispatch.workgroups
-// CHECK-SAME:     (%[[ARG0]])
-//      CHECK:     %[[CST:.+]] = arith.constant dense<0> : tensor<32xi32>
+// CHECK-SAME:     (%[[ARG0]], %[[CST]])
 
 // -----
 
-util.func public @inline_cst2(%arg0 : tensor<4x2xi32>) -> tensor<2xi32> {
+util.func public @inline_cst(%arg0 : tensor<4x32xi32>) -> tensor<32xi32> {
+  %cst = arith.constant dense<0> : tensor<32xi32>
+  %empty = tensor.empty() : tensor<32xi32>
+  %0 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d1)>,
+        affine_map<(d0, d1) -> (d1)>
+      ],
+      iterator_types = ["reduction", "parallel"]}
+      ins(%arg0, %cst : tensor<4x32xi32>, tensor<32xi32>) outs(%empty : tensor<32xi32>) {
+      ^bb0(%arg1 : i32, %arg2 : i32, %arg3: i32) :
+        %1 = arith.addi %arg1, %arg2 : i32
+        linalg.yield %1 : i32
+      } -> tensor<32xi32>
+  util.return %0 : tensor<32xi32>
+}
+// CHECK-LABEL: util.func public @inline_cst
+// CHECK-SAME:      (%[[ARG0:.+]]: tensor<4x32xi32>)
+//      CHECK:   flow.dispatch.workgroups
+// CHECK-SAME:     (%[[ARG0]])
+//      CHECK:   %[[CST:.+]] = arith.constant dense<0> : tensor<32xi32>
+
+
+// -----
+
+util.func public @do_not_inline_cst2(%arg0 : tensor<4x2xi32>) -> tensor<2xi32> {
   %cst = arith.constant dense<[21, 42]> : tensor<2xi32>
   %0 = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>],
       iterator_types = ["reduction", "parallel"]}
       ins(%arg0 : tensor<4x2xi32>) outs(%cst : tensor<2xi32>) {
       ^bb0(%arg1 : i32, %arg2 : i32) :
+        %1 = arith.addi %arg1, %arg2 : i32
+        linalg.yield %1 : i32
+      } -> tensor<2xi32>
+  util.return %0 : tensor<2xi32>
+}
+// CHECK-LABEL: util.func public @do_not_inline_cst2(
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<4x2xi32>)
+//       CHECK:     %[[CST:.+]] = arith.constant dense<[21, 42]> : tensor<2xi32>
+//       CHECK:   flow.dispatch.workgroups
+//  CHECK-SAME:     (%[[ARG0]], %[[CST]])
+
+// -----
+
+util.func public @inline_cst2(%arg0 : tensor<4x2xi32>) -> tensor<2xi32> {
+  %cst = arith.constant dense<[21, 42]> : tensor<2xi32>
+  %empty = tensor.empty() : tensor<2xi32>
+  %0 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d1)>,
+        affine_map<(d0, d1) -> (d1)>
+      ],
+      iterator_types = ["reduction", "parallel"]}
+      ins(%arg0, %cst : tensor<4x2xi32>, tensor<2xi32>) outs(%empty : tensor<2xi32>) {
+      ^bb0(%arg1 : i32, %arg2 : i32, %arg3 : i32) :
         %1 = arith.addi %arg1, %arg2 : i32
         linalg.yield %1 : i32
       } -> tensor<2xi32>


### PR DESCRIPTION
The issue that triggers the failure is:

```
module {
  util.func public @main(%arg0: tensor<1x1xf32>) -> tensor<1x9xf32> {
    %cst = arith.constant dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x9xf32>
    %cst_0 = arith.constant dense<[[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00, 3.000000e+00, 3.000000e+00, 4.000000e+00, 4.000000e+00, 5.000000e+00]]> : tensor<1x9xf32>
    %0 = linalg.matmul ins(%arg0, %cst : tensor<1x1xf32>, tensor<1x9xf32>) outs(%cst_0 : tensor<1x9xf32>) -> tensor<1x9xf32>
    util.return %0 : tensor<1x9xf32>
  }
}
```

Command to reproduce: 
```
iree-compile --iree-input-type=auto --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=llvm-cpu --mlir-print-debuginfo --mlir-print
-op-on-diagnostic=false --iree-llvmcpu-target-cpu-features=host --iree-llvmcpu-target-triple=x86_64-linux-gnu --iree-input-type=auto --iree-opt-data-tiling=true --iree-llvmcpu-enable-ukernels=all --iree-preprocessing-pass-
pipeline="builtin.module(util.func(iree-preprocessing-convert-conv2d-to-img2col))" repro.mlir
```

Because of the size, we generate two mmt4d kernel calls that get wrapped in a workgroup. The workgroup verification check will then find the ForAll op that contains the MMT4D operation and check if there are any global loads.

Because the constant was cloned into the workgroup and it is on the output of the linalg operation, it was marked with the storage_buffer attribute and triggers the failure.

The following change prevents output tensors from being cloned into the workgroup even if they are quite small as they are deemed writable and by definition of Destinantion Style Passing are an output of the function not an input so it should not be optimized into the loop.