### PR TITLE
Remove restriction on IGEMM lowering for dilated convolutions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -143,6 +143,42 @@ util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4
 // CHECK:      util.return %[[MATMUL]] : tensor<1x7x7x16xf32>
 
 // -----
+
+util.func public @conv_dilated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x12x12x16xf32>) -> tensor<1x12x12x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1 : tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%arg2 : tensor<1x12x12x16xf32>) -> tensor<1x12x12x16xf32>
+  util.return %0 : tensor<1x12x12x16xf32>
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK:      util.func public @conv_dilated(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x12x12x16xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x12x12x36xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [2, 2] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0, 0] * [12, 1] k_offset = [0] * [1]
+// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x12x12x36xf32>) -> tensor<1x12x12x36xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x12x12x36xf32>, tensor<36x16xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x12x12x16xf32>) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<1x12x12x16xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<1x12x12x16xf32>
+
+// -----
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2 + d5, d3 + d6, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d5, d6, d1, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d1)>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -430,13 +430,6 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     return failure();
   }
 
-  // TODO: Support dilation.
-  if (!hasAllOneValues(convDims.dilations)) {
-    LDBG("[unimplemented] expected no dilations (expected dilations to all be "
-         "one).");
-    return failure();
-  }
-
   // TODO: Support pooling operations. For pooling ops, the input/output channel
   // size will be categorized as the additional batch dimension.
   if (convDims.outputChannel.empty() || convDims.inputChannel.empty()) {


### PR DESCRIPTION
The IGEMM works out of the box for the dilated convolutions by removing the previous guard condition. The output numerics are correct for forward convs. The performance can be improved from 475us to 195us with IGEMM for the following conv kernel.
```
convbfp16 -n 16 -c 144 -H 24 -W 16 -k 144 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 2 -j 2 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100
```