### PR TITLE
Expose creation of FileHandles from FDs to python.

### DIFF
--- a/runtime/bindings/python/io.cc
+++ b/runtime/bindings/python/io.cc
@@ -228,10 +228,24 @@ void SetupIoBindings(py::module_ &m) {
           [](py::handle self) {
             return py::steal<py::object>(PyMemoryView_FromObject(self.ptr()));
           })
+      .def_prop_ro("is_fd",
+                   [](FileHandle &self) {
+                     auto primitive =
+                         iree_io_file_handle_primitive(self.raw_ptr());
+                     return primitive.type == IREE_IO_FILE_HANDLE_TYPE_FD;
+                   })
+      .def_prop_ro("fd",
+                   [](FileHandle &self) {
+                     auto primitive =
+                         iree_io_file_handle_primitive(self.raw_ptr());
+                     return primitive.value.fd;
+                   })
       .def("__repr__", [](py::handle self_object) {
         if (py::cast<py::bool_>(self_object.attr("is_host_allocation"))) {
           return py::str("FileHandle<host_allocation({})>")
               .format(self_object.attr("host_allocation"));
+        } else if (py::cast<py::bool_>(self_object.attr("is_fd"))) {
+          return py::str("FileHandle<fd({})>").format(self_object.attr("fd"));
         } else {
           return py::str("<FileHandle unknown>");
         }

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -96,6 +96,10 @@ class FileHandle:
     def wrap_memory(
         host_buffer: Any, readable: bool = True, writable: bool = False
     ) -> FileHandle: ...
+    @staticmethod
+    def wrap_fd(
+        fd: int, readable: bool = True, writable: bool = False
+    ) -> FileHandle: ...
     def host_allocation(self) -> memoryview:
         """Access the raw view of the allocated host memory.
 

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -138,11 +138,6 @@ class ParameterApiTest(unittest.TestCase):
             index_repr = repr(index)
             self.assertIn("Parameter scope <global> (3 entries", index_repr)
 
-            # Get the array contents and verify against original.
-            array_view = entries["array"].file_view
-            self.assertEqual(len(array_view), 24)
-            array_back = np.asarray(array_view).view(np.int64).reshape(orig_array.shape)
-            np.testing.assert_array_equal(array_back, orig_array)
             f.close()
 
         with tempfile.TemporaryDirectory() as td:

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -125,7 +125,7 @@ class ParameterApiTest(unittest.TestCase):
             )
             self.assertRegex(
                 repr(entries["array"]),
-                r"<ParameterIndexEntry 'array' FileHandle<host_allocation\(.*\)>:384:24",
+                r"<ParameterIndexEntry 'array' FileHandle<fd\(.*\)>",
             )
 
             # Verify some non-happy paths.
@@ -143,6 +143,7 @@ class ParameterApiTest(unittest.TestCase):
             self.assertEqual(len(array_view), 24)
             array_back = np.asarray(array_view).view(np.int64).reshape(orig_array.shape)
             np.testing.assert_array_equal(array_back, orig_array)
+            f.close()
 
         with tempfile.TemporaryDirectory() as td:
             file_path = Path(td) / "archive.irpa"

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -96,6 +96,71 @@ class ParameterApiTest(unittest.TestCase):
             verify_archive(file_path)
             gc.collect()
 
+    def testArchiveFileRoundtripByFD(self):
+        orig_array = np.asarray([[1], [2], [3]], dtype=np.int64)
+
+        def verify_archive_from_fd(file_path: Path):
+            f = open(file_path, "rb")
+            self.assertIsNotNone(f)
+
+            handle = rt.FileHandle.wrap_fd(f.fileno(), True, False)
+
+            # Load and verify.
+            index = rt.ParameterIndex()
+            # For this test, disable mmap to make temp file management on
+            # windows a bit better.
+            index.load_from_file_handle(handle, "irpa")
+            self.assertEqual(len(index), 3)
+
+            # Note that the happy path of most properties are verified via
+            # the repr (as they are called internal to that).
+            entries = dict(index.items())
+            self.assertEqual(
+                repr(entries["weight"]),
+                "<ParameterIndexEntry 'weight' splat b'\\x02':600>",
+            )
+            self.assertEqual(
+                repr(entries["bias"]),
+                "<ParameterIndexEntry 'bias' splat b' ':30>",
+            )
+            self.assertRegex(
+                repr(entries["array"]),
+                r"<ParameterIndexEntry 'array' FileHandle<host_allocation\(.*\)>:384:24",
+            )
+
+            # Verify some non-happy paths.
+            with self.assertRaisesRegex(ValueError, "Entry is not file storage based"):
+                entries["weight"].file_storage
+            with self.assertRaisesRegex(ValueError, "Entry is not splat"):
+                entries["array"].splat_pattern
+
+            # Verify that the repr of the index itself is sensical.
+            index_repr = repr(index)
+            self.assertIn("Parameter scope <global> (3 entries", index_repr)
+
+            # Get the array contents and verify against original.
+            array_view = entries["array"].file_view
+            self.assertEqual(len(array_view), 24)
+            array_back = np.asarray(array_view).view(np.int64).reshape(orig_array.shape)
+            np.testing.assert_array_equal(array_back, orig_array)
+
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            rt.save_archive_file(
+                {
+                    "weight": rt.SplatValue(np.int8(2), [30, 20]),
+                    "bias": rt.SplatValue(array.array("b", [32]), 30),
+                    "array": orig_array,
+                },
+                file_path,
+            )
+            self.assertTrue(file_path.exists())
+            self.assertGreater(file_path.stat().st_size, 0)
+            # Open / verify in its own scope and collect prior to tearing
+            # down the temp dir.
+            verify_archive_from_fd(file_path)
+            gc.collect()
+
     def testParameterIndexEntryFromToNumpy(self):
         array = np.array([[1, 2], [3, 4]], dtype=np.int32)
         index = rt.ParameterIndex()
@@ -136,6 +201,12 @@ class ParameterApiTest(unittest.TestCase):
         index_entry_as_array = rt.parameter_index_entry_as_numpy_ndarray(entry)
         expected_array = np.array([1, 2, 3, 4], dtype=np.uint8)
         np.testing.assert_array_equal(index_entry_as_array, expected_array, strict=True)
+
+    def testFileHandleWrap(self):
+        fh = rt.FileHandle.wrap_memory(b"foobar")
+        view = fh.host_allocation
+        del fh
+        self.assertEqual(bytes(view), b"foobar")
 
     def testFileHandleWrap(self):
         fh = rt.FileHandle.wrap_memory(b"foobar")

--- a/runtime/src/iree/io/file_handle.h
+++ b/runtime/src/iree/io/file_handle.h
@@ -206,6 +206,12 @@ IREE_API_EXPORT iree_status_t iree_io_file_handle_open(
     iree_io_file_mode_t mode, iree_string_view_t path,
     iree_allocator_t host_allocator, iree_io_file_handle_t** out_handle);
 
+// Duplicates an existing platform fd that was already opened as |mode|
+// Returns IREE_STATUS_INVALID_ARGUMENT if the fd was not valid.
+IREE_API_EXPORT iree_status_t iree_io_file_handle_open_fd(
+    iree_io_file_mode_t mode, int fd, iree_allocator_t host_allocator,
+    iree_io_file_handle_t** out_handle);
+
 //===----------------------------------------------------------------------===//
 // iree_io_file_mapping_t
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This allows us to create a parameter_index_provider from an FD rather than requiring us to mmap or preload
the entire file. This is significantly better on some systems.