### PR TITLE
[Codegen][GPU] Creating FissionTransferOpsInControlFlow to assist convolution prefetching

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -118,6 +118,7 @@ iree_compiler_cc_library(
         "EraseDeadAllocAndStores.cpp",
         "EraseHALDescriptorTypeFromMemRef.cpp",
         "ExtractAddressComputation.cpp",
+        "FissionTransferOpsInControlFlow.cpp",
         "FlattenMemRefSubspanPass.cpp",
         "FlattenMemRefs.cpp",
         "FoldAffineMinInDistributedLoops.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -108,6 +108,7 @@ iree_cc_library(
     "EraseDeadAllocAndStores.cpp"
     "EraseHALDescriptorTypeFromMemRef.cpp"
     "ExtractAddressComputation.cpp"
+    "FissionTransferOpsInControlFlow.cpp"
     "FlattenMemRefSubspanPass.cpp"
     "FlattenMemRefs.cpp"
     "FoldAffineMinInDistributedLoops.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -1,0 +1,267 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-fission-transfer-ops-in-control-flow"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_FISSIONTRANSFEROPSINCONTROLFLOWPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+static void replaceOperand(Operation *op, Value oldVal, Value newVal) {
+  for (auto &operand : op->getOpOperands()) {
+    if (operand.get() == oldVal) {
+      operand.set(newVal);
+    }
+  }
+}
+
+static SetVector<Operation *>
+collectBackwardSliceInControlFlow(Operation *op, Operation *parentOp) {
+  BackwardSliceOptions options;
+  options.inclusive = false;
+  options.filter = [&](Operation *op) { return parentOp == op->getParentOp(); };
+  SetVector<Operation *> slice;
+  getBackwardSlice(op, &slice, options);
+  return slice;
+}
+
+static void cloneSliceIntoLoop(IRRewriter &rewriter,
+                               SetVector<Operation *> &slice,
+                               scf::ForOp &newLoop, IRMapping &mapping) {
+  for (Operation *op : slice) {
+    rewriter.clone(*op, mapping);
+  }
+}
+
+static scf::ForOp createNewLoop(IRRewriter &rewriter, scf::ForOp forOp,
+                                Location loc) {
+  return rewriter.create<scf::ForOp>(loc, forOp.getLowerBound(),
+                                     forOp.getUpperBound(), forOp.getStep(),
+                                     forOp.getRegionIterArgs());
+}
+
+static memref::AllocaOp createAlloca(IRRewriter &rewriter,
+                                     vector::TransferReadOp readOp,
+                                     scf::ForOp forOp) {
+  // %alloca_size = (%upper_bound - %lower_bound) / %step
+  auto loc = forOp.getLoc();
+  auto allocaSize = rewriter.create<arith::CeilDivUIOp>(
+      loc,
+      rewriter.create<arith::SubIOp>(loc, forOp.getUpperBound(),
+                                     forOp.getLowerBound()),
+      forOp.getStep());
+
+  auto vectorType = cast<VectorType>(readOp.getVectorType());
+  SmallVector<int64_t> memrefShape(vectorType.getShape());
+  memrefShape.insert(memrefShape.begin(), ShapedType::kDynamic);
+  auto privateAddrSpaceAttr = gpu::AddressSpaceAttr::get(
+      rewriter.getContext(), gpu::GPUDialect::getPrivateAddressSpace());
+  auto memrefType = MemRefType::get(memrefShape, vectorType.getElementType(),
+                                    AffineMap{}, privateAddrSpaceAttr);
+
+  return rewriter.create<memref::AllocaOp>(loc, memrefType,
+                                           ValueRange{allocaSize});
+}
+
+static void setupReadLoop(IRRewriter &rewriter, vector::TransferReadOp readOp,
+                          scf::ForOp forOp, memref::AllocaOp alloca) {
+  scf::ForOp readLoop = createNewLoop(rewriter, forOp, readOp.getLoc());
+  rewriter.setInsertionPointToStart(readLoop.getBody());
+
+  IRMapping readMapping;
+  readMapping.map(forOp.getInductionVar(), readLoop.getInductionVar());
+  SetVector<Operation *> readSlice =
+      collectBackwardSliceInControlFlow(readOp, forOp);
+  cloneSliceIntoLoop(rewriter, readSlice, readLoop, readMapping);
+
+  Operation *lastRead = rewriter.clone(*readOp, readMapping);
+
+  // %read_index = (%loop_index - %loop_lower_bound) / %loop_step
+  auto readLoopIndex = rewriter.create<arith::DivUIOp>(
+      readOp.getLoc(),
+      rewriter.create<arith::SubIOp>(readOp.getLoc(),
+                                     readLoop.getInductionVar(),
+                                     readLoop.getLowerBound()),
+      readLoop.getStep());
+
+  SmallVector<Value> readLoopIndices = {readLoopIndex};
+  auto readOpIndicesSize = readOp.getIndices().size();
+  auto constantZero =
+      rewriter.create<arith::ConstantIndexOp>(readOp.getLoc(), 0);
+  auto zeroIndices = SmallVector<Value>(readOpIndicesSize, constantZero);
+  readLoopIndices.insert(readLoopIndices.end(), zeroIndices.begin(),
+                         zeroIndices.end());
+
+  rewriter.create<vector::TransferWriteOp>(
+      readOp.getLoc(), lastRead->getResult(0), alloca, readLoopIndices);
+
+  LDBG("Read loop: \n" << readLoop << "\n");
+  rewriter.setInsertionPointAfter(readLoop.getOperation());
+}
+
+static void setupWriteLoop(IRRewriter &rewriter, vector::TransferReadOp readOp,
+                           vector::TransferWriteOp writeOp, scf::ForOp forOp,
+                           memref::AllocaOp alloca) {
+  scf::ForOp writeLoop = createNewLoop(rewriter, forOp, writeOp.getLoc());
+  rewriter.setInsertionPointToStart(writeLoop.getBody());
+
+  // %write_index = (%loop_index - %loop_lower_bound) / %loop_step
+  auto writeLoopIndex = rewriter.create<arith::DivUIOp>(
+      writeOp.getLoc(),
+      rewriter.create<arith::SubIOp>(writeOp.getLoc(),
+                                     writeLoop.getInductionVar(),
+                                     writeLoop.getLowerBound()),
+      writeLoop.getStep());
+
+  SmallVector<Value> writeLoopIndices = {writeLoopIndex};
+  auto zeroIndicesSize = writeOp.getIndices().size();
+  auto constantZero =
+      rewriter.create<arith::ConstantIndexOp>(readOp.getLoc(), 0);
+  SmallVector<Value> zeroIndices(zeroIndicesSize, constantZero);
+  writeLoopIndices.insert(writeLoopIndices.end(), zeroIndices.begin(),
+                          zeroIndices.end());
+
+  vector::TransferReadOp newReadOp = rewriter.create<vector::TransferReadOp>(
+      writeOp.getLoc(), writeOp.getVectorType(), alloca, writeLoopIndices);
+
+  IRMapping writeMapping;
+  writeMapping.map(forOp.getInductionVar(), writeLoop.getInductionVar());
+  SetVector<Operation *> writeSlice =
+      collectBackwardSliceInControlFlow(writeOp, forOp);
+  cloneSliceIntoLoop(rewriter, writeSlice, writeLoop, writeMapping);
+
+  rewriter.clone(*writeOp, writeMapping);
+  for (auto &op : writeLoop.getBody()->getOperations()) {
+    replaceOperand(&op, writeMapping.lookup(readOp.getResult()), newReadOp);
+  }
+
+  LDBG("Write loop: \n" << writeLoop << "\n");
+}
+
+/// Splits transfer read and write operations from a control flow Operation
+/// (forOp) into separate loops.
+///
+/// For example, given a loop with transfer read and write operations:
+///   scf.for %i = 0 to 10 {
+///     %read = vector.transfer_read ...
+///     vector.transfer_write %read ...
+///   }
+///
+/// This function will transform it into:
+///   %alloca = memref.alloca ...  // Alloca for intermediate results
+///   scf.for %i = 0 to 10 {
+///     %read = vector.transfer_read ...
+///     vector.transfer_write %read %alloca
+///   }
+///   scf.for %j = 0 to 10 {
+///     %read = vector.transfer_read %alloca
+///     vector.transfer_write %read ...
+///   }
+static void splitTransferOpsFromControlFlow(IRRewriter &rewriter,
+                                            vector::TransferReadOp readOp,
+                                            vector::TransferWriteOp writeOp,
+                                            scf::ForOp forOp) {
+  LDBG("Splitting transfer ops from control flow: \n"
+       << "For Op: " << forOp << "\n");
+
+  rewriter.setInsertionPoint(forOp);
+  memref::AllocaOp alloca = createAlloca(rewriter, readOp, forOp);
+
+  setupReadLoop(rewriter, readOp, forOp, alloca);
+  setupWriteLoop(rewriter, readOp, writeOp, forOp, alloca);
+
+  rewriter.eraseOp(forOp);
+}
+
+static bool isLegal(vector::TransferReadOp readOp,
+                    vector::TransferWriteOp writeOp, scf::ForOp forOp) {
+  if (readOp->getParentOp() != forOp || writeOp->getParentOp() != forOp) {
+    return false;
+  }
+  if (!hasGlobalMemoryAddressSpace(
+          cast<MemRefType>(readOp.getBase().getType()))) {
+    return false;
+  }
+  if (hasGlobalMemoryAddressSpace(
+          cast<MemRefType>(writeOp.getBase().getType()))) {
+    return false;
+  }
+  return true;
+}
+
+namespace {
+struct FissionTarget {
+  scf::ForOp parent;
+  vector::TransferReadOp readOp;
+  vector::TransferWriteOp writeOp;
+};
+} // namespace
+
+static FailureOr<FissionTarget> populateFissionTarget(scf::ForOp forOp) {
+  // Fission Loop always has a transfer_write as the last operation.
+  auto lastOp = forOp.getBody()->getTerminator()->getPrevNode();
+  if (!isa<vector::TransferWriteOp>(lastOp)) {
+    return failure();
+  }
+
+  vector::TransferWriteOp writeOp = cast<vector::TransferWriteOp>(lastOp);
+  SetVector<Operation *> writeSlice =
+      collectBackwardSliceInControlFlow(writeOp, forOp.getOperation());
+  for (Operation *op : writeSlice) {
+    if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
+      if (!isLegal(readOp, writeOp, forOp)) {
+        continue;
+      }
+
+      FissionTarget fissionTarget = {forOp, readOp, writeOp};
+      return fissionTarget;
+    }
+  }
+  return failure();
+}
+
+struct FissionTransferOpsInControlFlowPass final
+    : impl::FissionTransferOpsInControlFlowPassBase<
+          FissionTransferOpsInControlFlowPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+    IRRewriter rewriter(funcOp.getContext());
+
+    SmallVector<scf::ForOp> loops;
+    funcOp.walk([&loops](scf::ForOp forOp) { loops.push_back(forOp); });
+
+    SmallVector<FissionTarget> fissionTargets;
+    for (scf::ForOp forOp : loops) {
+      auto result = populateFissionTarget(forOp);
+      if (failed(result)) {
+        continue;
+      }
+      fissionTargets.push_back(result.value());
+    }
+
+    for (const FissionTarget &target : fissionTargets) {
+      splitTransferOpsFromControlFlow(rewriter, target.readOp, target.writeOp,
+                                      target.parent);
+    }
+  }
+};
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -39,7 +39,10 @@ collectBackwardSliceInControlFlow(Operation *op, Operation *parentOp) {
   options.inclusive = false;
   options.filter = [&](Operation *op) { return parentOp == op->getParentOp(); };
   SetVector<Operation *> slice;
-  getBackwardSlice(op, &slice, options);
+  LogicalResult result = getBackwardSlice(op, &slice, options);
+  if (failed(result)) {
+    return {};
+  }
   return slice;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -349,6 +349,14 @@ def ExtractAddressComputationPass : Pass<"iree-codegen-extract-address-computati
   ];
 }
 
+def FissionTransferOpsInControlFlowPass : InterfacePass<"iree-codegen-fission-transfer-ops-in-control-flow", "mlir::FunctionOpInterface"> {
+  let summary =
+      "Fission transfer read and write ops in control flow to allow prefetching.";
+  let dependentDialects = [
+      "memref::MemRefDialect"
+  ];
+}
+
 def FlattenMemRefSubspanPass : Pass<"iree-codegen-flatten-memref-subspan", "ModuleOp"> {
   let summary =
       "Flatten n-D MemRef subspan ops to 1-D ones and fold byte offsets";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -50,6 +50,7 @@ iree_lit_test_suite(
             "emulate_narrow_type.mlir",
             "erase_hal_descriptor_type.mlir",
             "extract_address_computation.mlir",
+            "fission_transfer_ops_control_flow.mlir",
             "flatten_memref_subspan.mlir",
             "fold_affine_min_in_distributed_loops.mlir",
             "fold_affine_min_of_block_id.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "erase_dead_alloc_and_stores.mlir"
     "erase_hal_descriptor_type.mlir"
     "extract_address_computation.mlir"
+    "fission_transfer_ops_control_flow.mlir"
     "flatten_memref_subspan.mlir"
     "fold_affine_min_in_distributed_loops.mlir"
     "fold_affine_min_of_block_id.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/fission_transfer_ops_control_flow.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fission_transfer_ops_control_flow.mlir
@@ -1,0 +1,84 @@
+// RUN: iree-opt --split-input-file -pass-pipeline="builtin.module(func.func(iree-codegen-fission-transfer-ops-in-control-flow),cse,canonicalize)" %s | FileCheck %s
+
+// CHECK-LABEL: @fission_global_read_to_private_write
+// CHECK-SAME: %[[ARG0:.*]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME: %[[ARG1:.*]]: index
+// CHECK-SAME: %[[ARG2:.*]]: i1
+// CHECK-SAME: %[[ARG3:.*]]: vector<1x1x1x8xbf16>
+// CHECK-SAME: %[[ARG4:.*]]: memref<1x1x1x8xbf16, #gpu.address_space<private>>
+func.func @fission_global_read_to_private_write(%arg0: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %arg1: index, %arg2: i1, %arg3: vector<1x1x1x8xbf16>, %arg4: memref<1x1x1x8xbf16, #gpu.address_space<private>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : bf16
+  scf.for %arg5 = %c0 to %arg1 step %c1 {
+    %read = vector.transfer_read %arg0[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
+    %select = arith.select %arg2, %read, %arg3 : vector<1x1x1x8xbf16>
+    vector.transfer_write %select, %arg4[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x8xbf16>, memref<1x1x1x8xbf16, #gpu.address_space<private>>
+  }
+  return
+}
+// CHECK: %[[ALLOCA:.*]] = memref.alloca(%[[ARG1]])
+// CHECK: scf.for %[[ITER:.*]] = %c0 to %[[ARG1]] step %c1 {
+// CHECK:   %[[read:.*]] = vector.transfer_read %arg0[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]}
+// CHECK:   vector.transfer_write %[[read]], %[[ALLOCA]][%[[ITER]], %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]}
+// CHECK: }
+// CHECK: scf.for %[[ITER:.*]] = %c0 to %[[ARG1]] step %c1 {
+// CHECK:   %[[read:.*]] = vector.transfer_read %[[ALLOCA]][%[[ITER]], %c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]}
+// CHECK:   %[[select:.*]] = arith.select %[[ARG2]], %[[read]], %[[ARG3]]
+// CHECK:   vector.transfer_write %[[select]], %arg4[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]}
+// CHECK: }
+
+// -----
+
+// CHECK-LABEL: @fission_global_read_to_workgroup_write
+// CHECK-SAME: %[[ARG0:.*]]: index
+// CHECK-SAME: %[[ARG1:.*]]: memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME: %[[ARG2:.*]]: memref<1x4xf32, #gpu.address_space<workgroup>>
+func.func @fission_global_read_to_workgroup_write(%arg0: index, %arg1: memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>, %arg2: memref<1x4xf32, #gpu.address_space<workgroup>>) {
+  %c0 = arith.constant 0 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  scf.for %arg5 = %arg0 to %c16 step %c128 {
+    %58 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<1x4xf32>
+    vector.transfer_write %58, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<1x4xf32>, memref<1x4xf32, #gpu.address_space<workgroup>>
+  }
+  return
+}
+// CHECK: %[[SUB:.*]] = arith.subi %c16, %[[ARG0]]
+// CHECK: %[[DIV:.*]] = arith.ceildivui %[[SUB]], %c128
+// CHECK: %[[ALLOCA:.*]] = memref.alloca(%[[DIV]])
+// CHECK: scf.for %[[ITER:.*]] = %[[ARG0]] to %c16 step %c128 {
+// CHECK:   %[[READ:.*]] = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]}
+// CHECK:   %[[SUB:.*]] = arith.subi %[[ITER]], %[[ARG0]]
+// CHECK:   %[[DIV:.*]] = arith.divui %[[SUB]], %c128
+// CHECK:   vector.transfer_write %[[READ]], %[[ALLOCA]][%[[DIV]], %c0, %c0] {in_bounds = [true, true]}
+// CHECK: }
+// CHECK: scf.for %[[ITER:.*]] = %[[ARG0]] to %c16 step %c128 {
+// CHECK:   %[[SUB:.*]] = arith.subi %[[ITER]], %[[ARG0]]
+// CHECK:   %[[DIV:.*]] = arith.divui %[[SUB]], %c128
+// CHECK:   %[[READ:.*]] = vector.transfer_read %[[ALLOCA]][%[[DIV]], %c0, %c0], %cst {in_bounds = [true, true]}
+// CHECK:   vector.transfer_write %[[READ]], %arg2[%c0, %c0] {in_bounds = [true, true]}
+// CHECK: }
+
+// -----
+
+// CHECK-LABEL: @no_fission_global_read_to_global_write
+// CHECK-SAME: %[[ARG0:.*]]: memref<1x?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME: %[[ARG1:.*]]: memref<1x?x?xf32, #gpu.address_space<global>>
+// CHECK-SAME: %[[ARG2:.*]]: index
+func.func @no_fission_global_read_to_global_write(%arg0: memref<1x?x?xf32, #amdgpu.address_space<fat_raw_buffer>>, %arg1: memref<1x?x?xf32, #gpu.address_space<global>>, %arg2: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  scf.for %arg3 = %c0 to %arg2 step %c1 {
+    %read = vector.transfer_read %arg0[%arg3, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x?x?xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x4xf32>
+    vector.transfer_write %read, %arg1[%arg3, %c0, %c0] {in_bounds = [true, true, true]} : vector<1x1x4xf32>, memref<1x?x?xf32, #gpu.address_space<global>>
+  }
+  return
+}
+// CHECK: scf.for %[[ITER:.*]] = %c0 to %[[ARG2]] step %c1 {
+// CHECK:   %[[READ:.*]] = vector.transfer_read
+// CHECK:   vector.transfer_write %[[READ]], %arg1[%[[ITER]], %c0, %c0] {in_bounds = [true, true, true]}
+// CHECK: }
+// CHECK-NOT: scf.for

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -548,6 +548,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
   }
   if (pipelineOptions.prefetchSharedMemory) {
+    funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
     funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
     funcPassManager.addPass(createRemoveSingleIterationLoopPass());
     funcPassManager.addPass(createLLVMGPUPrefetchSharedMemoryPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1172,14 +1172,13 @@ hal.executable public @main {
 //   CHECK-DAG:   memref.alloc() : memref<1x16x6xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<1x16x66xf32, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (12, 37, 10) {
-//       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c145 step %c1 {{.*}} -> (vector<1x1x1x4x1xf32>)
+//       CHECK:     scf.for %[[IV:.+]] = %c0 to %c144 step %c1 {{.*}} -> (vector<1x1x1x4x1xf32>)
 //       CHECK:       gpu.barrier
 //   CHECK-DAG:       vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
 //   CHECK-DAG:       vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
 // CHECK-COUNT-1:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 4 : i32, m = 16 : i32, n = 16 : i32
 //       CHECK:       scf.yield
-//       CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x4x1xf32> to vector<4xf32>
-//       CHECK:     vector.transfer_write %[[LOOP_T]]
+//       CHECK:     vector.transfer_write {{.*}} #gpu.address_space<workgroup>>
 //       CHECK:     scf.for {{.*}} {
 //       CHECK:       memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
 //       CHECK:    }


### PR DESCRIPTION
This pass allows dependent transfer read and write ops to split as individual targets for shared memory prefetch to happen. This is especially helpful in padded convolutions where control flow exists in middle of the K-loop.

In very generic terms, given a loop with transfer read and write operations:

```cpp
scf.for %i = 0 to 10 {
  %read = vector.transfer_read ...
  vector.transfer_write %read ...
}
```
This pass will transform it into:
```cpp
%alloca = memref.alloca ...  // Alloca for intermediate results
scf.for %i = 0 to 10 {
  %read = vector.transfer_read ...
  vector.transfer_write %read %alloca
}
scf.for %j = 0 to 10 {
  %read = vector.transfer_read %alloca
  vector.transfer_write %read ...
}
```