### PR TITLE
[LinalgExt] Add argmax op with rountrip and invalid mlir test

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -948,9 +948,9 @@ LogicalResult ArgmaxOp::verify() {
   if (failed(verifyCompatibleShape(outputValueType, outputIndexType))) {
     return op->emitOpError("output indices/values shape must match. ")
            << "Output value shape: "
-           << llvm::interleaved_array(outputValueType.getShape(), ", ")
+           << llvm::interleaved_array(outputValueType.getShape())
            << ", output index shape: "
-           << llvm::interleaved_array(outputIndexType.getShape(), ", ");
+           << llvm::interleaved_array(outputIndexType.getShape());
   }
 
   SmallVector<int64_t> expectedShape;
@@ -961,9 +961,9 @@ LogicalResult ArgmaxOp::verify() {
   if (!llvm::equal(expectedShape, outputValueType.getShape())) {
     return op->emitOpError("output shape must match input shape with reduction "
                            "dimension removed. ")
-           << "Expected: " << llvm::interleaved_array(expectedShape, ", ")
+           << "Expected: " << llvm::interleaved_array(expectedShape)
            << ", but got: "
-           << llvm::interleaved_array(outputValueType.getShape(), ", ");
+           << llvm::interleaved_array(outputValueType.getShape());
   }
 
   return success();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -946,15 +947,10 @@ LogicalResult ArgmaxOp::verify() {
 
   if (failed(verifyCompatibleShape(outputValueType, outputIndexType))) {
     return op->emitOpError("output indices/values shape must match. ")
-           << "Output value shape: ["
-           << llvm::join(map_range(outputValueType.getShape(),
-                                   [](int64_t d) { return std::to_string(d); }),
-                         ", ")
-           << "]" << ", output index shape: ["
-           << llvm::join(map_range(outputIndexType.getShape(),
-                                   [](int64_t d) { return std::to_string(d); }),
-                         ", ")
-           << "]";
+           << "Output value shape: "
+           << llvm::interleaved_array(outputValueType.getShape(), ", ")
+           << ", output index shape: "
+           << llvm::interleaved_array(outputIndexType.getShape(), ", ");
   }
 
   SmallVector<int64_t> expectedShape;
@@ -965,15 +961,9 @@ LogicalResult ArgmaxOp::verify() {
   if (!llvm::equal(expectedShape, outputValueType.getShape())) {
     return op->emitOpError("output shape must match input shape with reduction "
                            "dimension removed. ")
-           << "Expected: ["
-           << llvm::join(map_range(expectedShape,
-                                   [](int64_t d) { return std::to_string(d); }),
-                         ", ")
-           << "]" << ", but got: ["
-           << llvm::join(map_range(outputValueType.getShape(),
-                                   [](int64_t d) { return std::to_string(d); }),
-                         ", ")
-           << "]";
+           << "Expected: " << llvm::interleaved_array(expectedShape, ", ")
+           << ", but got: "
+           << llvm::interleaved_array(outputValueType.getShape(), ", ");
   }
 
   return success();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -708,7 +708,15 @@ let assemblyFormat = [{
     }
 
     ShapedType getInputType() {
-      return llvm::cast<ShapedType>(getInputValue().getType());
+      return cast<ShapedType>(getInputValue().getType());
+    }
+
+    ShapedType getOutputValueType() {
+      return cast<ShapedType>(outputValue().getType());
+    }
+
+    ShapedType getOutputIndexType() {
+      return cast<ShapedType>(outputIndex().getType());
     }
 
     int64_t getInputRank() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -668,6 +668,60 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   }];
 }
 
+def IREELinalgExt_ArgmaxOp : IREELinalgExt_Op<"argmax", [
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
+]> {
+  let summary = "Argmax reduction op.";
+  let description = [{
+    An argmax op that reduces along a given dimension, returning the max value and its index.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyShaped>:$inputs,
+    Variadic<AnyShaped>:$outputs,
+    I64Attr:$dimension
+  );
+
+  let results = (outs
+    Variadic<AnyRankedTensor>:$results
+  );
+
+let assemblyFormat = [{
+    attr-dict
+    `dimension` `(` $dimension `)`
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`:` type($results)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value getInputValue() {
+      return getDpsInputOperand(0)->get();
+    }
+
+    Value outputValue() {
+      return getDpsInitOperand(0)->get();
+    }
+
+    Value outputIndex() {
+      return getDpsInitOperand(1)->get();
+    }
+
+    ShapedType getInputType() {
+      return llvm::cast<ShapedType>(getInputValue().getType());
+    }
+
+    int64_t getInputRank() {
+      return getInputType().getRank();
+    }
+
+    // For DPS interface.
+    MutableOperandRange getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Attention
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -568,6 +568,111 @@ func.func @map_scatter_wrong_num_yielded_values(
 
 // -----
 
+func.func @argmax_invalid_too_many_inputs(
+    %input_val: tensor<2x10xf32>,
+    %input_extra: tensor<2x10xf32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{expected exactly one input operand (values)}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val, %input_extra : tensor<2x10xf32>, tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>)
+    : tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_missing_output(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{expected two output operands (value and index)}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val : tensor<2xf32>)
+    : tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_dim(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
+  // expected-error@+1 {{reduction dimension exceeds input rank}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(2)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>)
+    : tensor<2xf32>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_type_mismatch(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<2xf16>,
+    %out_idx: tensor<2xi32>) -> (tensor<2xf16>, tensor<2xi32>) {
+  // expected-error@+1 {{input and output value element types must match}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2xf16>, tensor<2xi32>)
+    : tensor<2xf16>, tensor<2xi32>
+  return %0#0, %0#1 : tensor<2xf16>, tensor<2xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_output_shape_mismatch(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<2xf32>,
+    %out_idx: tensor<10xi32>) -> (tensor<2xf32>, tensor<10xi32>) {
+  // expected-error@+1 {{output indices/values shape must match}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2xf32>, tensor<10xi32>)
+    : tensor<2xf32>, tensor<10xi32>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<10xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_output_shape_wrong_reduction(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<1xf32>,
+    %out_idx: tensor<1xi32>) -> (tensor<1xf32>, tensor<1xi32>) {
+  // expected-error@+1 {{output shape must match input shape with reduction dimension removed}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<1xf32>, tensor<1xi32>)
+    : tensor<1xf32>, tensor<1xi32>
+  return %0#0, %0#1 : tensor<1xf32>, tensor<1xi32>
+}
+
+// -----
+
+func.func @argmax_invalid_output_same_as_input(
+    %input_val: tensor<2x10xf32>,
+    %out_val: tensor<2x10xf32>,
+    %out_idx: tensor<2x10xi32>) -> (tensor<2x10xf32>, tensor<2x10xi32>) {
+  // expected-error@+1 {{output shape must match input shape with reduction dimension removed}}
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input_val : tensor<2x10xf32>)
+    outs(%out_val, %out_idx : tensor<2x10xf32>, tensor<2x10xi32>)
+    : tensor<2x10xf32>, tensor<2x10xi32>
+  return %0#0, %0#1 : tensor<2x10xf32>, tensor<2x10xi32>
+}
+
+// -----
+
 func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
   // expected-error@+1 {{expected one or two input operands}}
   %0:2 = iree_linalg_ext.topk

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -573,7 +573,7 @@ func.func @argmax_invalid_too_many_inputs(
     %input_extra: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{expected exactly one input operand (values)}}
+  // expected-error@+1 {{expected exactly one input operand (values), but got 2}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val, %input_extra : tensor<2x10xf32>, tensor<2x10xf32>)
@@ -587,7 +587,7 @@ func.func @argmax_invalid_too_many_inputs(
 func.func @argmax_invalid_missing_output(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{expected two output operands (value and index)}}
+  // expected-error@+1 {{expected two output operands (value and index), but got 1}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
@@ -602,7 +602,7 @@ func.func @argmax_invalid_dim(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
-  // expected-error@+1 {{reduction dimension exceeds input rank}}
+  // expected-error@+1 {{reduction dimension exceeds or equals input rank. got dimension: 2, but input rank is: 2}}
   %0:2 = iree_linalg_ext.argmax
     dimension(2)
     ins(%input_val : tensor<2x10xf32>)
@@ -617,7 +617,7 @@ func.func @argmax_invalid_type_mismatch(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf16>,
     %out_idx: tensor<2xi32>) -> (tensor<2xf16>, tensor<2xi32>) {
-  // expected-error@+1 {{input and output value element types must match}}
+  // expected-error@+1 {{input and output value element types must match. Input type: 'f32', output value type: 'f16'}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
@@ -632,7 +632,7 @@ func.func @argmax_invalid_output_shape_mismatch(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<10xi32>) -> (tensor<2xf32>, tensor<10xi32>) {
-  // expected-error@+1 {{output indices/values shape must match}}
+  // expected-error@+1 {{output indices/values shape must match. Output value shape: [2], output index shape: [10]}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
@@ -647,7 +647,7 @@ func.func @argmax_invalid_output_shape_wrong_reduction(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<1xf32>,
     %out_idx: tensor<1xi32>) -> (tensor<1xf32>, tensor<1xi32>) {
-  // expected-error@+1 {{output shape must match input shape with reduction dimension removed}}
+  // expected-error@+1 {{output shape must match input shape with reduction dimension removed. Expected: [2], but got: [1]}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
@@ -662,7 +662,7 @@ func.func @argmax_invalid_output_same_as_input(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2x10xf32>,
     %out_idx: tensor<2x10xi32>) -> (tensor<2x10xf32>, tensor<2x10xi32>) {
-  // expected-error@+1 {{output shape must match input shape with reduction dimension removed}}
+  // expected-error@+1 {{output shape must match input shape with reduction dimension removed. Expected: [2], but got: [2, 10]}}
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -833,6 +833,79 @@ func.func @map_scatter_memref_static(
 
 // -----
 
+func.func @argmax_static(
+    %input : tensor<2x6xf32>,
+    %outv : tensor<2xf32>, %outi : tensor<2xindex>
+) -> (tensor<2xf32>, tensor<2xindex>) {
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input : tensor<2x6xf32>)
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>)
+    : tensor<2xf32>, tensor<2xindex>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
+}
+
+// CHECK-LABEL: func.func @argmax_static(
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<2x6xf32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xindex>
+//      CHECK:   %[[VAL:.+]]:2 = iree_linalg_ext.argmax
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]] : tensor<2x6xf32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xindex>)
+// CHECK-SAME:     : tensor<2xf32>, tensor<2xindex>
+//      CHECK:   return %[[VAL]]#0, %[[VAL]]#1 : tensor<2xf32>, tensor<2xindex>
+
+// -----
+
+func.func @argmax_dynamic(
+    %input : tensor<?x?xf32>,
+    %outv : tensor<?xf32>, %outi : tensor<?xindex>
+) -> (tensor<?xf32>, tensor<?xindex>) {
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input : tensor<?x?xf32>)
+    outs(%outv, %outi : tensor<?xf32>, tensor<?xindex>)
+    : tensor<?xf32>, tensor<?xindex>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?xindex>
+}
+
+// CHECK-LABEL: func.func @argmax_dynamic(
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<?xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<?xindex>
+//      CHECK:   %[[VAL:.+]]:2 = iree_linalg_ext.argmax
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]] : tensor<?x?xf32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<?xf32>, tensor<?xindex>)
+// CHECK-SAME:     : tensor<?xf32>, tensor<?xindex>
+//      CHECK:   return %[[VAL]]#0, %[[VAL]]#1 : tensor<?xf32>, tensor<?xindex>
+
+// -----
+
+func.func @argmax_static_memref(
+    %input : memref<2x6xf32>,
+    %outv : memref<2xf32>, %outi : memref<2xindex>
+) {
+  iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input : memref<2x6xf32>)
+    outs(%outv, %outi : memref<2xf32>, memref<2xindex>)
+  return
+}
+
+
+// CHECK-LABEL: func.func @argmax_static_memref(
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: memref<2x6xf32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: memref<2xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: memref<2xindex>
+// CHECK:   iree_linalg_ext.argmax
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]] : memref<2x6xf32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : memref<2xf32>, memref<2xindex>)
+
+// -----
+
 func.func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
     -> (tensor<1024xf32>, tensor<1024xf32>) {
   %cst1 = arith.constant 1 : index


### PR DESCRIPTION
This PR introduces the `iree_linalg_ext.argmax` operation and defines its verifier along with corresponding roundtrip and invalid tests (`roundtrip.mlir` and `invalid.mlir`).

Support for argmax will be added incrementally across multiple PRs:
- Add the iree_linalg_ext.argmax op definition and verification logic, along with roundtrip and invalid IR tests (this PR)
- Add tiling support 
- Add convert_to_loops lowering support 
- Add e2e support with other changes in compiler/Codegen/Interfaces (also split-k and ukernel)
 

