### PR TITLE
Adding IREE::HAL::AnnotateTargetDevicesPass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/Attributes/DeviceTargetPVS.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/Attributes/DeviceTargetPVS.cpp
@@ -229,6 +229,13 @@ void DeviceTargetValuePVS::updateFromDefiningOp(Value value, OpResult result,
         newState ^= truePVS.getState();
         newState ^= falsePVS.getState();
       })
+      .Case([&](IREE::HAL::AllocatorSelectOp op) {
+        for (auto device : op.getDevices()) {
+          auto &operandPVS = solver.getElementFor<DeviceTargetValuePVS>(
+              *this, Position::forValue(device), DFX::Resolution::REQUIRED);
+          newState ^= operandPVS.getState();
+        }
+      })
       .Case([&](IREE::Util::OptimizationBarrierOp op) {
         auto &sourcePVS = solver.getElementFor<DeviceTargetValuePVS>(
             *this, Position::forValue(op.getOperand(0)),

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceSet.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceSet.cpp
@@ -26,7 +26,7 @@ DeviceSet::DeviceSet(ArrayRef<IREE::HAL::DeviceTargetAttr> targetAttrs) {
 }
 
 DeviceSet::DeviceSet(const DenseSet<IREE::HAL::DeviceTargetAttr> &targetAttrs)
-    : targetAttrs(targetAttrs) {}
+    : targetAttrs(targetAttrs.begin(), targetAttrs.end()) {}
 
 DeviceSet::~DeviceSet() = default;
 
@@ -44,7 +44,7 @@ DeviceSet::getExecutableTargets() const {
 
 template <typename AttrT>
 static std::optional<typename AttrT::ValueType> joinConfigAttrs(
-    const DenseSet<IREE::HAL::DeviceTargetAttr> &targetAttrs, StringRef name,
+    const SetVector<IREE::HAL::DeviceTargetAttr> &targetAttrs, StringRef name,
     std::function<typename AttrT::ValueType(typename AttrT::ValueType,
                                             typename AttrT::ValueType)>
         join) {
@@ -71,12 +71,12 @@ static std::optional<typename AttrT::ValueType> joinConfigAttrs(
 
 template <typename AttrT>
 static std::optional<StaticRange<typename AttrT::ValueType>>
-joinConfigStaticRanges(const DenseSet<IREE::HAL::DeviceTargetAttr> &targetAttrs,
-                       StringRef name,
-                       std::function<StaticRange<typename AttrT::ValueType>(
-                           StaticRange<typename AttrT::ValueType>,
-                           StaticRange<typename AttrT::ValueType>)>
-                           join) {
+joinConfigStaticRanges(
+    const SetVector<IREE::HAL::DeviceTargetAttr> &targetAttrs, StringRef name,
+    std::function<StaticRange<typename AttrT::ValueType>(
+        StaticRange<typename AttrT::ValueType>,
+        StaticRange<typename AttrT::ValueType>)>
+        join) {
   if (targetAttrs.empty()) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceSet.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/DeviceSet.h
@@ -10,7 +10,6 @@
 #include <optional>
 
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
-#include "llvm/ADT/DenseSet.h"
 #include "mlir/Support/LLVM.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
@@ -23,6 +22,14 @@ public:
   explicit DeviceSet(ArrayRef<IREE::HAL::DeviceTargetAttr> targetAttrs);
   explicit DeviceSet(const DenseSet<IREE::HAL::DeviceTargetAttr> &targetAttrs);
   ~DeviceSet();
+
+  // Returns true if the set is empty (analysis failed or was incomplete).
+  bool empty() const { return targetAttrs.empty(); }
+
+  // Returns the unordered list of device targets.
+  ArrayRef<IREE::HAL::DeviceTargetAttr> getValues() const {
+    return targetAttrs.getArrayRef();
+  }
 
   // Returns zero or more executable targets that may be used by any device.
   std::optional<SmallVector<IREE::HAL::ExecutableTargetAttr>>
@@ -50,7 +57,7 @@ public:
   std::optional<StaticRange<APInt>> getConfigAttrRange(StringRef name) const;
 
 private:
-  DenseSet<IREE::HAL::DeviceTargetAttr> targetAttrs;
+  SetVector<IREE::HAL::DeviceTargetAttr> targetAttrs;
 };
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AnnotateTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AnnotateTargetDevices.cpp
@@ -1,0 +1,133 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+#define GEN_PASS_DEF_ANNOTATETARGETDEVICESPASS
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// --iree-hal-annotate-target-devices
+//===----------------------------------------------------------------------===//
+
+// Sorts |attrs| in lexigraphical order.
+// We have to do this as the PVS elements we source from are unsorted.
+static void sortAttributes(SmallVectorImpl<Attribute> &attrs) {
+  if (attrs.size() <= 1) {
+    return;
+  }
+  llvm::stable_sort(attrs, [](Attribute lhs, Attribute rhs) {
+    std::string lhsStr;
+    llvm::raw_string_ostream lhsStream(lhsStr);
+    lhs.print(lhsStream);
+    std::string rhsStr;
+    llvm::raw_string_ostream rhsStream(rhsStr);
+    rhs.print(rhsStream);
+    return lhsStr < rhsStr;
+  });
+}
+
+static ArrayAttr
+getDeviceSetAttr(MLIRContext *context,
+                 std::optional<IREE::HAL::DeviceSet> deviceSet) {
+  if (!deviceSet.has_value() || deviceSet->empty()) {
+    return ArrayAttr::get(context, {});
+  }
+  SmallVector<Attribute> targetAttrs;
+  llvm::append_range(targetAttrs, deviceSet->getValues());
+  sortAttributes(targetAttrs);
+  return ArrayAttr::get(context, targetAttrs);
+}
+
+static void annotateGlobalOp(IREE::Util::GlobalOpInterface globalOp,
+                             DeviceAnalysis &deviceAnalysis) {
+  if (isa<IREE::HAL::DeviceType>(globalOp.getGlobalType())) {
+    globalOp->setAttr(
+        "hal.device.targets",
+        getDeviceSetAttr(globalOp.getContext(),
+                         deviceAnalysis.lookupDeviceTargets(globalOp)));
+  }
+}
+
+static void annotateOperandsAndResults(Operation *op,
+                                       DeviceAnalysis &deviceAnalysis) {
+  SmallVector<Attribute> operandAttrs;
+  for (auto operand : op->getOperands()) {
+    if (isa<IREE::HAL::DeviceType>(operand.getType())) {
+      operandAttrs.push_back(getDeviceSetAttr(
+          op->getContext(), deviceAnalysis.lookupDeviceTargets(operand)));
+    }
+  }
+  SmallVector<Attribute> resultAttrs;
+  for (auto result : op->getResults()) {
+    if (isa<IREE::HAL::DeviceType>(result.getType())) {
+      resultAttrs.push_back(getDeviceSetAttr(
+          op->getContext(), deviceAnalysis.lookupDeviceTargets(result)));
+    }
+  }
+  if (!operandAttrs.empty()) {
+    op->setAttr("hal.device.targets.operands",
+                ArrayAttr::get(op->getContext(), operandAttrs));
+  }
+  if (!resultAttrs.empty()) {
+    op->setAttr("hal.device.targets.results",
+                ArrayAttr::get(op->getContext(), resultAttrs));
+  }
+}
+
+static void annotateFuncOp(FunctionOpInterface funcOp,
+                           DeviceAnalysis &deviceAnalysis) {
+  if (funcOp.empty())
+    return;
+  for (auto arg : funcOp.front().getArguments()) {
+    if (isa<IREE::HAL::DeviceType>(arg.getType())) {
+      funcOp.setArgAttr(
+          arg.getArgNumber(), "hal.device.targets",
+          getDeviceSetAttr(funcOp.getContext(),
+                           deviceAnalysis.lookupDeviceTargets(arg)));
+    }
+  }
+  funcOp.walk(
+      [&](Operation *op) { annotateOperandsAndResults(op, deviceAnalysis); });
+}
+
+struct AnnotateTargetDevicesPass
+    : public IREE::HAL::impl::AnnotateTargetDevicesPassBase<
+          AnnotateTargetDevicesPass> {
+  void runOnOperation() override {
+    // Run device analysis on the whole module.
+    DeviceAnalysis deviceAnalysis(getOperation());
+    if (failed(deviceAnalysis.run())) {
+      return signalPassFailure();
+    }
+
+    // Annotate all ops with derived affinities.
+    for (auto &op : getOperation().getOps()) {
+      if (op.hasTrait<OpTrait::IREE::Util::ObjectLike>())
+        continue;
+      if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
+        annotateGlobalOp(globalOp, deviceAnalysis);
+      } else if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {
+        annotateFuncOp(funcOp, deviceAnalysis);
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -20,6 +20,7 @@ package(
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
+        "AnnotateTargetDevices.cpp",
         "AssignLegacyTargetDevices.cpp",
         "AssignTargetDevices.cpp",
         "CaptureExecutableSources.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "AnnotateTargetDevices.cpp"
     "AssignLegacyTargetDevices.cpp"
     "AssignTargetDevices.cpp"
     "CaptureExecutableSources.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -639,6 +639,16 @@ def ElideRedundantCommandsPass :
 // Benchmarking and debugging utilities
 //===----------------------------------------------------------------------===//
 
+def AnnotateTargetDevicesPass :
+    Pass<"iree-hal-annotate-target-devices", "mlir::ModuleOp"> {
+  let summary = "Annotates device values with their analyzed potential target devices.";
+  let description = [{
+    Uses data flow analysis to identify potential targets for `!hal.device`
+    values. This can be used to diagnose device analysis issues and otherwise
+    does not impact compilation.
+  }];
+}
+
 def CaptureExecutableSourcesPass :
     Pass<"iree-hal-capture-executable-sources", "mlir::ModuleOp"> {
   let summary = "Captures individual hal.executable.variant source listings and embeds them in the IR.";

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "annotate_target_devices.mlir",
             "assign_legacy_target_devices.mlir",
             "assign_target_devices.mlir",
             "capture_executable_sources.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "annotate_target_devices.mlir"
     "assign_legacy_target_devices.mlir"
     "assign_target_devices.mlir"
     "capture_executable_sources.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/annotate_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/annotate_target_devices.mlir
@@ -1,0 +1,139 @@
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --iree-hal-annotate-target-devices %s | FileCheck %s
+
+// CHECK: util.global private @unspecified_ordinal
+// CHECK-SAME: hal.device.targets = []
+util.global private @unspecified_ordinal = #hal.device.ordinal<0> : !hal.device
+util.func private @unspecified_ordinal_load() -> !hal.device {
+  // CHECK: util.global.load
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[]]
+  %device = util.global.load immutable @unspecified_ordinal : !hal.device
+  util.return %device : !hal.device
+}
+
+// -----
+
+// CHECK: util.global private @target_device
+// CHECK-SAME-LITERAL: hal.device.targets = [#hal.device.target<"device">
+util.global private @target_device = #hal.device.target<"device"> : !hal.device
+util.func private @target_device_load() -> !hal.device {
+  // CHECK: util.global.load
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device"> : !hal.device]]
+  %device = util.global.load immutable @target_device : !hal.device
+  util.return %device : !hal.device
+}
+
+// -----
+
+// Tests that fallbacks get propagated (this is not a real use of fallbacks,
+// but tests the indirection works).
+
+// CHECK: util.global private @required_device
+// CHECK-SAME: hal.device.targets = [#hal.device.target<"required"> : !hal.device]
+util.global private @required_device = #hal.device.target<"required"> : !hal.device
+// CHECK: util.global private @optional_device
+// CHECK-SAME-LITERAL: hal.device.targets = [#hal.device.target<"required"> : !hal.device]
+util.global private @optional_device = #hal.device.fallback<@required_device> : !hal.device
+util.func private @optional_device_load() -> !hal.device {
+  // CHECK: util.global.load
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"required"> : !hal.device]]
+  %device = util.global.load immutable @optional_device : !hal.device
+  util.return %device : !hal.device
+}
+
+// -----
+
+// CHECK: util.global private @selected_device
+// CHECK-SAME-LITERAL: hal.device.targets = [[#hal.device.target<"a"> : !hal.device, #hal.device.target<"b"> : !hal.device]]
+util.global private @selected_device = #hal.device.select<[
+  #hal.device.target<"a"> : !hal.device,
+  #hal.device.target<"b"> : !hal.device
+]> : !hal.device
+util.func private @selected_device_load() -> !hal.device {
+  // CHECK: util.global.load
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"a"> : !hal.device, #hal.device.target<"b"> : !hal.device]]
+  %device = util.global.load immutable @selected_device : !hal.device
+  util.return %device : !hal.device
+}
+
+// -----
+
+// Tests that both potential sets are propagated across select ops.
+
+util.global private @device_a = #hal.device.target<"device_a"> : !hal.device
+util.global private @device_b = #hal.device.target<"device_b"> : !hal.device
+util.func private @arith_select(%cond: i1) -> !hal.device {
+  %device_a = util.global.load immutable @device_a : !hal.device
+  %device_b = util.global.load immutable @device_b : !hal.device
+  // CHECK: arith.select
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device], [#hal.device.target<"device_b"> : !hal.device]]
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]
+  %select = arith.select %cond, %device_a, %device_b : !hal.device
+  util.return %select : !hal.device
+}
+
+// -----
+
+// Tests that both potential sets are propagated across allocator select ops.
+
+util.global private @device_a = #hal.device.target<"device_a"> : !hal.device
+util.global private @device_b = #hal.device.target<"device_b"> : !hal.device
+util.func private @allocator_select() -> !hal.device {
+  %device_a = util.global.load immutable @device_a : !hal.device
+  %affinity_a = arith.constant 100 : i64
+  %device_b = util.global.load immutable @device_b : !hal.device
+  %affinity_b = arith.constant 101 : i64
+  %type = arith.constant 2 : i32
+  %usage = arith.constant 3 : i32
+  // CHECK: hal.allocator.select
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device], [#hal.device.target<"device_b"> : !hal.device]]
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]}
+  %device, %queue_affinity = hal.allocator.select
+      from([
+        (%device_a, %affinity_a : !hal.device, i64),
+        (%device_b, %affinity_b : !hal.device, i64)
+      ])
+      type(%type) usage(%usage) : !hal.device, i64
+  util.return %device : !hal.device
+}
+
+// -----
+
+// Tests that device analysis tracks across function calls.
+
+util.global private @device_a = #hal.device.target<"device_a"> : !hal.device
+util.global private @device_b = #hal.device.target<"device_b"> : !hal.device
+// CHECK: util.func private @caller
+util.func private @caller() -> !hal.device {
+  %device_a = util.global.load immutable @device_a : !hal.device
+  // CHECK: util.call @callee_a
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device]]
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device_a"> : !hal.device]]
+  %call_a = util.call @callee_a(%device_a) : (!hal.device) -> !hal.device
+  // CHECK: util.call @callee_ab
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device]]
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]
+  %call_ab = util.call @callee_ab(%call_a) : (!hal.device) -> !hal.device
+  // CHECK: util.return
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]
+  util.return %call_ab : !hal.device
+}
+// CHECK: util.func private @callee_a
+// CHECK-SAME-LITERAL: !hal.device {hal.device.targets = [#hal.device.target<"device_a"> : !hal.device]}
+util.func private @callee_a(%device: !hal.device) -> !hal.device {
+  // CHECK: util.return
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device]]
+  util.return %device : !hal.device
+}
+// CHECK: util.func private @callee_ab
+// CHECK-SAME-LITERAL: !hal.device {hal.device.targets = [#hal.device.target<"device_a"> : !hal.device]}
+util.func private @callee_ab(%device_a: !hal.device) -> !hal.device {
+  %cond = arith.constant true
+  %device_b = util.global.load immutable @device_b : !hal.device
+  // CHECK: arith.select
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device], [#hal.device.target<"device_b"> : !hal.device]]
+  // CHECK-SAME-LITERAL: hal.device.targets.results = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]
+  %device_ab = arith.select %cond, %device_a, %device_b : !hal.device
+  // CHECK: util.return
+  // CHECK-SAME-LITERAL: hal.device.targets.operands = [[#hal.device.target<"device_a"> : !hal.device, #hal.device.target<"device_b"> : !hal.device]]
+  util.return %device_ab : !hal.device
+}


### PR DESCRIPTION
This is similar to the Stream AnnotateAffinitiesPass but for DeviceAnalysis and puts attributes on various `!hal.device` SSA values for inspection. The new test verifies the analysis works for a few common cases.