### PR TITLE
Properly order multiple emplaced dispatch results.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -143,6 +143,9 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp,
   // Convert the op to be fully emplaced (all results are tied allocas).
   // We may immediately replace some of these with transfer targets and that's
   // a waste of IR but we won't know exactly which ones we'll replace until we
+  // are processing the results (as some values may be used by multiple operands
+  // _and_ tied to multiple results, and that may only happen after we start
+  // emplacing things).
   OpBuilder builder(dispatchOp);
   Value zeroOffset = indexSet.get(0);
   for (auto [resultIndex, result] : llvm::enumerate(dispatchOp.getResults())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -32,6 +33,15 @@ namespace {
 //===----------------------------------------------------------------------===//
 // Emplacement
 //===----------------------------------------------------------------------===//
+
+// Returns true if |tiedOp| has any tied operands.
+static bool hasTiedOperands(IREE::Util::TiedOpInterface tiedOp) {
+  SmallVector<int64_t> tiedResultOperands;
+  tiedOp.getAllTiedOperands(tiedResultOperands);
+  return llvm::any_of(tiedResultOperands, [](int64_t index) {
+    return index != IREE::Util::TiedOpInterface::kUntiedIndex;
+  });
+}
 
 static void
 replaceUsesAndTransfer(Value oldValue, Value newValue,
@@ -54,74 +64,125 @@ replaceUsesAndTransfer(Value oldValue, Value newValue,
   oldValue.replaceAllUsesWith(transferValue);
 }
 
-// TODO(#14566): multiple results with sparse ties don't work due to
-// implicit operand/result ordering on the dispatch ops. Flow and stream
-// dispatch ops and the executable entry points need to be reworked to
-// remove the implicit ordering. For now we only emplace results until the
-// first we can't then bail and leave them out-of-place.
-static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
-  bool didChange = false;
-  // Collect the Update ops and their corresponding resultIndex.
-  SmallVector<std::tuple<IREE::Stream::AsyncUpdateOp, int>> updateOpDataVec;
+static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp,
+                                 IndexSet &indexSet) {
+  [[maybe_unused]] OpPrintingFlags printingFlags;
+  LLVM_DEBUG(printingFlags = OpPrintingFlags()
+                                 .elideLargeElementsAttrs()
+                                 .assumeVerified()
+                                 .skipRegions());
+
+  // If the op has tied operands we have to bail; the dispatch binding mapping
+  // is currently implicit and we can't tell where we should be inserting new
+  // operands as we tie them. The dispatch op would need to store which bindings
+  // in the target executable relate to which operand/result explicitly (and it
+  // really should!) for us to handle that. We'd then change from appending new
+  // operands to inserting at the appropriate location below.
+  if (hasTiedOperands(dispatchOp)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "  ! skipping dispatch, op already has tied operands\n");
+    return false;
+  }
+
+  // Collect the update ops and their corresponding resultIndex.
+  SmallVector<std::tuple<IREE::Stream::AsyncUpdateOp, int>> updateResultOps;
   for (auto [resultIndex, result] : llvm::enumerate(dispatchOp.getResults())) {
     // Ignore results with multiple users. We could potentially place these but
     // that makes tracking much more complicated.
     if (!result.hasOneUse()) {
-      // TODO(#14566): continue if sparse emplacement on multiple results.
-      break;
+      LLVM_DEBUG({
+        llvm::dbgs() << "  ! skipping result #" << resultIndex
+                     << " of dispatch ";
+        result.printAsOperand(llvm::dbgs(), printingFlags);
+        llvm::dbgs() << ": has multiple uses\n";
+      });
+      continue;
     }
-    // Ignore already-tied operands.
-    // TODO(benvanik): update tied range if we want to place into a superset?
-    auto operandIndex = dispatchOp.getTiedResultOperandIndex(resultIndex);
-    if (operandIndex.has_value()) {
-      // TODO(#14566): continue if sparse emplacement on multiple results.
-      break;
-    }
-
-    // Find potential update to place the dispatch result into.
     Operation *userOp = *result.user_begin();
+
+    // Check if the user is an update op we can merge.
     auto updateOp = dyn_cast_or_null<IREE::Stream::AsyncUpdateOp>(userOp);
-    if (!updateOp)
-      break;
-    if (updateOp.getUpdate() != result) {
-      // TODO(#14566): continue if sparse emplacement on multiple results.
-      break;
+    if (!updateOp || updateOp.getUpdate() != result) {
+      continue; // not relevant
     }
 
     // Currently only allow exactly matching affinities.
     // TODO(multi-device): memory compatibility - if compatible then allow.
     if (updateOp.getAffinityAttr() != dispatchOp.getAffinityAttr()) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "  ! unable to emplace result #" << resultIndex
+                     << " of dispatch ";
+        result.printAsOperand(llvm::dbgs(), printingFlags);
+        llvm::dbgs() << " into ";
+        updateOp.print(llvm::dbgs(), printingFlags);
+        llvm::dbgs() << ": affinities do not match\n";
+        llvm::dbgs() << "    dispatch affinity: "
+                     << dispatchOp.getAffinityAttr() << "\n";
+        llvm::dbgs() << "    update affinity: " << updateOp.getAffinityAttr()
+                     << "\n";
+      });
       continue;
     }
-    updateOpDataVec.emplace_back(updateOp, resultIndex);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "  + emplacing result #" << resultIndex
+                   << " of dispatch ";
+      result.printAsOperand(llvm::dbgs(), printingFlags);
+      llvm::dbgs() << " into ";
+      updateOp.print(llvm::dbgs(), printingFlags);
+      llvm::dbgs() << "\n";
+    });
+
+    updateResultOps.emplace_back(updateOp, resultIndex);
   }
+  if (updateResultOps.empty()) {
+    // No potential updates found, early exit.
+    return false;
+  }
+
+  // Convert the op to be fully emplaced (all results are tied allocas).
+  // We may immediately replace some of these with transfer targets and that's
+  // a waste of IR but we won't know exactly which ones we'll replace until we
+  OpBuilder builder(dispatchOp);
+  Value zeroOffset = indexSet.get(0);
+  for (auto [resultIndex, result] : llvm::enumerate(dispatchOp.getResults())) {
+    Value resultSize = dispatchOp.getResultSize(resultIndex);
+
+    // TODO(multi-device): possibly perform analysis to pick an affinity based
+    // on usage. Today we assume the resource affinity matches the execution op.
+    auto allocaOp = builder.create<IREE::Stream::AsyncAllocaOp>(
+        dispatchOp.getLoc(), result.getType(), resultSize,
+        dispatchOp.getAffinityAttr());
+
+    auto operandIndex = dispatchOp.getResourceOperands().size();
+    dispatchOp.getResourceOperandsMutable().append(allocaOp.getResult());
+    dispatchOp.getResourceOperandSizesMutable().append(resultSize);
+    dispatchOp.getResourceOperandOffsetsMutable().append(zeroOffset);
+    dispatchOp.getResourceOperandEndsMutable().append(resultSize);
+    dispatchOp.getResourceOperandLengthsMutable().append(resultSize);
+    dispatchOp.setTiedResultOperandIndex(resultIndex, operandIndex);
+  }
+
   // Sort the update ops in block order so that we dont accidentally move them
   // above the dispatch op in the next section which will cause a dominance
   // issue.
-  llvm::sort(updateOpDataVec, [&](const auto &a, const auto &b) {
+  llvm::sort(updateResultOps, [&](const auto &a, const auto &b) {
     return std::get<0>(a)->isBeforeInBlock(std::get<0>(b));
   });
-  for (auto updateOpData : updateOpDataVec) {
-    int resultIndex;
-    IREE::Stream::AsyncUpdateOp updateOp;
-    std::tie(updateOp, resultIndex) = updateOpData;
+
+  // Try to prepare each candidate for use by the dispatch. If we can't then
+  // we skip the particular emplacement.
+  bool didChange = false;
+  for (auto [updateOp, resultIndex] : updateResultOps) {
     Value targetResource = updateOp.getTarget();
     if (targetResource.getDefiningOp() == dispatchOp) {
       // NOTE: we may have already replaced the update target with one of our
       // results - if so we need to find the operand to capture tied to that
       // new result instead of our own new result (which would make a cycle).
       targetResource = dispatchOp.getTiedResultOperand(targetResource);
+    } else if (!targetResource) {
+      continue;
     }
-    if (!targetResource) {
-      // TODO(#14566): continue if sparse emplacement on multiple results.
-      break;
-    }
-    Value targetResourceSize = updateOp.getTargetSize();
-    Value targetOffset = updateOp.getTargetOffset();
-    Value targetEnd = updateOp.getTargetEnd();
-    Value targetLength = updateOp.getUpdateSize();
-    Value targetResult = updateOp.getResult();
-    Value targetResultSize = updateOp.getTargetSize();
 
     // Try to move all SSA values required into the appropriate place.
     // TODO(benvanik): undo this if there's a failure (or record/roll-back).
@@ -133,33 +194,80 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
                                            dispatchOp) ||
         !IREE::Util::tryMoveProducerBefore(updateOp.getTargetEnd(),
                                            dispatchOp) ||
-        !IREE::Util::tryMoveProducerBefore(updateOp.getTarget(), dispatchOp)) {
+        !IREE::Util::tryMoveProducerBefore(targetResource, dispatchOp)) {
       // Failed to move while keeping valid SSA dominance.
-      // TODO(#14566): continue if sparse emplacement on multiple results.
-      break;
+      LLVM_DEBUG({
+        llvm::dbgs() << "  ! failed to move producers from update ";
+        updateOp.print(llvm::dbgs(), printingFlags);
+        llvm::dbgs() << " before dispatch with result #" << resultIndex << "\n";
+      });
+      continue;
     }
 
-    // Add operand and tie the result.
-    auto operandIndex = dispatchOp.getResourceOperands().size();
-    dispatchOp.getResourceOperandsMutable().append(targetResource);
-    dispatchOp.getResourceOperandSizesMutable().append(targetResourceSize);
-    dispatchOp.getResourceOperandOffsetsMutable().append(targetOffset);
-    dispatchOp.getResourceOperandEndsMutable().append(targetEnd);
-    dispatchOp.getResourceOperandLengthsMutable().append(targetLength);
-    dispatchOp.setTiedResultOperandIndex(resultIndex, operandIndex);
+    Value targetResourceSize = updateOp.getTargetSize();
+    Value targetOffset = updateOp.getTargetOffset();
+    Value targetEnd = updateOp.getTargetEnd();
+    Value targetLength = updateOp.getUpdateSize();
+    Value targetResult = updateOp.getResult();
+    Value targetResultSize = updateOp.getTargetSize();
 
-    // Update result size (requires this dance as [] is a no-op!).
-    SmallVector<Value> resultSizes = dispatchOp.getResultSizes();
-    resultSizes[resultIndex] = targetResultSize;
-    dispatchOp.getResultSizesMutable().assign(resultSizes);
+    // The dispatch operands are mixed types but all resource-related lists are
+    // only for resources. operandIndex is in the mixed domain and we have to
+    // calculate the corresponding resource domain index.
+    auto operandIndex = dispatchOp.getTiedResultOperandIndex(resultIndex);
+    assert(operandIndex.has_value() && "should have been tied above");
+    unsigned resourceIndex = 0;
+    for (unsigned i = 0; i < *operandIndex; ++i) {
+      resourceIndex += isa<IREE::Stream::ResourceType>(
+                           dispatchOp.getResourceOperands()[i].getType())
+                           ? 1
+                           : 0;
+    }
+
+    // Replace the operand with the target range.
+    Value previousResource = dispatchOp.getResourceOperands()[*operandIndex];
+    dispatchOp.getResourceOperandsMutable()
+        .slice(*operandIndex, 1)
+        .assign(targetResource);
+    dispatchOp.getResourceOperandSizesMutable()
+        .slice(resourceIndex, 1)
+        .assign(targetResourceSize);
+    dispatchOp.getResourceOperandOffsetsMutable()
+        .slice(resourceIndex, 1)
+        .assign(targetOffset);
+    dispatchOp.getResourceOperandEndsMutable()
+        .slice(resourceIndex, 1)
+        .assign(targetEnd);
+    dispatchOp.getResourceOperandLengthsMutable()
+        .slice(resourceIndex, 1)
+        .assign(targetLength);
+    dispatchOp.getResultSizesMutable()
+        .slice(resultIndex, 1)
+        .assign(targetResultSize);
 
     // Replace users with the result of the dispatch op.
+    LLVM_DEBUG({
+      llvm::dbgs() << "  * replacing uses of ";
+      targetResult.printAsOperand(llvm::dbgs(), printingFlags);
+      llvm::dbgs() << " with update source ";
+      updateOp.print(llvm::dbgs(), printingFlags);
+      llvm::dbgs() << "\n";
+    });
     replaceUsesAndTransfer(targetResult, updateOp.getUpdate(),
                            dispatchOp.getAffinityAttr());
     updateOp->erase();
 
+    // If the previously captured resource is no longer used then delete it.
+    // This cleans up some of the allocas we speculatively add above.
+    if (previousResource.use_empty()) {
+      if (auto *definingOp = previousResource.getDefiningOp()) {
+        definingOp->erase();
+      }
+    }
+
     didChange = true;
   }
+
   return didChange;
 }
 
@@ -168,16 +276,17 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
 static bool emplaceAllocationsInRegion(Region &region) {
   bool didChange = false;
   for (auto &block : region.getBlocks()) {
+    IndexSet indexSet(region.getLoc(), OpBuilder::atBlockBegin(&block));
     for (auto &op : block) {
-      if (!op.hasTrait<OpTrait::IREE::Stream::AsyncPhaseOp>())
-        continue;
-      // TODO(benvanik): support placement for more ops e.g. copies/collectives.
-      didChange = TypeSwitch<Operation *, bool>(&op)
-                      // TODO(#11249): support in-place collective ops.
-                      .Case<IREE::Stream::AsyncDispatchOp>(
-                          [&](auto op) { return tryEmplaceDispatchOp(op); })
-                      .Default(false) ||
-                  didChange;
+      if (op.hasTrait<OpTrait::IREE::Stream::AsyncPhaseOp>()) {
+        didChange = TypeSwitch<Operation *, bool>(&op)
+                        // TODO(#11249): support in-place collective ops.
+                        .Case<IREE::Stream::AsyncDispatchOp>([&](auto op) {
+                          return tryEmplaceDispatchOp(op, indexSet);
+                        })
+                        .Default(false) ||
+                    didChange;
+      }
     }
   }
   return didChange;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -229,6 +229,7 @@ def EmplaceAllocationsPass :
     tensor concatenation.
   }];
   let dependentDialects = [
+    "mlir::arith::ArithDialect",
     "IREE::Stream::StreamDialect",
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-emplace-allocations))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-emplace-allocations,cse))' %s | FileCheck %s
 
 // Tests that a dispatch result is placed into the target of an update.
 
@@ -11,10 +11,14 @@ util.func public @emplaceDispatch(
     // CHECK-SAME: %[[TARGET:arg[0-9]+]]: !stream.resource<*>, %[[TARGET_SIZE:arg[0-9]+]]: index
     %target: !stream.resource<*>, %target_size: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index
+  // CHECK-DAG: %[[UNIFORM0:.+]] = arith.constant 123
+  %uniform0 = arith.constant 123 : i32
+  // CHECK-DAG: %[[UNIFORM1:.+]] = arith.constant 456
+  %uniform1 = arith.constant 456 : i32
   // CHECK: %[[UPDATE_END:.+]] = arith.addi %[[UPDATE_OFFSET]], %[[UPDATE_SIZE]]
-  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch(%[[INPUT]][{{.+}}], %[[TARGET]][%[[UPDATE_OFFSET]] to %[[UPDATE_END]] for %[[UPDATE_SIZE]]]) :
-  // CHECK-SAME: (!stream.resource<*>{%[[INPUT_SIZE]]}, !stream.resource<*>{%[[TARGET_SIZE]]}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
-  %update = stream.async.dispatch @ex::@dispatch(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch(%[[UNIFORM0]], %[[INPUT]][%c0 to %[[INPUT_SIZE]] for %[[INPUT_SIZE]]], %[[UNIFORM1]], %[[TARGET]][%[[UPDATE_OFFSET]] to %[[UPDATE_END]] for %[[UPDATE_SIZE]]]) :
+  // CHECK-SAME: (i32, !stream.resource<*>{%[[INPUT_SIZE]]}, i32, !stream.resource<*>{%[[TARGET_SIZE]]}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
+  %update = stream.async.dispatch @ex::@dispatch(%uniform0, %input[%c0 to %input_size for %input_size], %uniform1) : (i32, !stream.resource<*>{%input_size}, i32) -> !stream.resource<*>{%update_size}
   // NOTE: this gets hoisted above the dispatch.
   %update_end = arith.addi %update_offset, %update_size : index
   // CHECK-NOT: stream.async.update
@@ -61,7 +65,7 @@ util.func public @emplaceDispatchSequence(
   %c98304 = arith.constant 98304 : index
   %c147456 = arith.constant 147456 : index
   %c196608 = arith.constant 196608 : index
-  // CHECK: %[[TARGET:.+]] = stream.async.alloca
+  // CHECK: %[[TARGET:.+]] = stream.async.alloca : !stream.resource<*>{%[[TARGET_SIZE]]}
   // CHECK: %[[TARGET0:.+]] = stream.async.dispatch @ex::@dispatch0({{.+}}, %[[TARGET]][%c0 to %c49152 for %[[UPDATE_SIZE]]]) : ({{.+}}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
   %update0 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
   // CHECK: %[[TARGET1:.+]] = stream.async.dispatch @ex::@dispatch1({{.+}}, %[[TARGET0]][%c49152 to %c98304 for %[[UPDATE_SIZE]]]) : ({{.+}}) -> %[[TARGET0]]{%[[TARGET_SIZE]]}
@@ -86,6 +90,36 @@ util.func public @emplaceDispatchSequence(
 
 // -----
 
+// Tests that emplacement propagation through tied results is stopped by
+// hazards. Here the %temp0 in-place operation on %update0 stops the placement
+// of %update1 into %target0.
+
+// CHECK-LABEL: @dontEmplaceDispatchWithTiedResults
+func.func @dontEmplaceDispatchWithTiedResults(
+    // CHECK-SAME: %[[INPUT:arg[0-9]+]]: !stream.resource<*>, %[[INPUT_SIZE:arg[0-9]+]]: index,
+    %input: !stream.resource<*>, %input_size: index,
+    // CHECK-SAME: %[[UPDATE_SIZE:arg[0-9]+]]: index, %[[TARGET_SIZE:arg[0-9]+]]: index
+    %update_size: index, %target_size: index) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  %c49152 = arith.constant 49152 : index
+  %c98304 = arith.constant 98304 : index
+  // CHECK: stream.async.dispatch @ex::@dispatch0
+  %update0 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
+  // CHECK: stream.async.dispatch @ex::@dispatch1
+  %temp0 = stream.async.dispatch @ex::@dispatch1(%update0[%c0 to %update_size for %update_size]) : (!stream.resource<*>{%update_size}) -> %update0{%update_size}
+  // CHECK: stream.async.dispatch @ex::@dispatch2
+  %update1 = stream.async.dispatch @ex::@dispatch2(%temp0[%c0 to %update_size for %update_size], %update0[%c0 to %update_size for %update_size]) : (!stream.resource<*>{%update_size}, !stream.resource<*>{%update_size}) -> %temp0{%update_size}
+  // CHECK: stream.async.alloca
+  %target = stream.async.alloca : !stream.resource<*>{%target_size}
+  // CHECK: stream.async.update
+  %target0 = stream.async.update %update0, %target[%c0 to %c49152] : !stream.resource<*>{%update_size} -> %target as !stream.resource<*>{%target_size}
+  // CHECK: stream.async.update
+  %target1 = stream.async.update %update1, %target0[%c49152 to %c98304] : !stream.resource<*>{%update_size} -> %target0 as !stream.resource<*>{%target_size}
+  return %target1 : !stream.resource<*>
+}
+
+// -----
+
 // Tests a concat-like sequence that has some inter-dependencies - these
 // dependencies shouldn't stop us from emplacing.
 
@@ -100,10 +134,12 @@ util.func public @emplaceMultiResultDispatchSequence(
   %c98304 = arith.constant 98304 : index
   %c147456 = arith.constant 147456 : index
   %c196608 = arith.constant 196608 : index
-  // CHECK: %[[TARGET:.+]] = stream.async.alloca
+  // CHECK: %[[TARGET:.+]] = stream.async.alloca : !stream.resource<*>{%[[TARGET_SIZE]]}
   // CHECK: %[[TARGET0:.+]] = stream.async.dispatch @ex::@dispatch0({{.+}}, %[[TARGET]][%c0 to %c49152 for %[[UPDATE_SIZE]]]) : ({{.+}}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
   %update0 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
-  // CHECK: %[[TARGET1_TEMP:.+]]:2 = stream.async.dispatch @ex::@dispatch1({{.+}}, %[[TARGET0]][%c49152 to %c98304 for %[[UPDATE_SIZE]]]) : ({{.+}}) -> (%[[TARGET0]]{%[[TARGET_SIZE]]}, !stream.resource<*>{%[[INPUT_SIZE]]})
+  // The second result gets allocated even though it's not emplaced due to how the pass works.
+  // CHECK: %[[WRITE1_ALLOCA:.+]] = stream.async.alloca : !stream.resource<*>{%[[INPUT_SIZE]]}
+  // CHECK: %[[TARGET1_TEMP:.+]]:2 = stream.async.dispatch @ex::@dispatch1({{.+}}, %[[TARGET0]][%c49152 to %c98304 for %[[UPDATE_SIZE]]], %[[WRITE1_ALLOCA]][%c0 to %[[INPUT_SIZE]] for %[[INPUT_SIZE]]]) : ({{.+}}) -> (%[[TARGET0]]{%[[TARGET_SIZE]]}, %[[WRITE1_ALLOCA]]{%[[INPUT_SIZE]]})
   %update1_temp:2 = stream.async.dispatch @ex::@dispatch1(%input[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> (!stream.resource<*>{%update_size}, !stream.resource<*>{%input_size})
   // CHECK: %[[TARGET2:.+]] = stream.async.dispatch @ex::@dispatch2({{.+}}, %[[TARGET1_TEMP]]#0[%c98304 to %c147456 for %[[UPDATE_SIZE]]]) : ({{.+}}) -> %[[TARGET1_TEMP]]#0{%[[TARGET_SIZE]]}
   %update2 = stream.async.dispatch @ex::@dispatch2(%update1_temp#1[%c0 to %input_size for %input_size]) : (!stream.resource<*>{%input_size}) -> !stream.resource<*>{%update_size}
@@ -156,7 +192,8 @@ util.func public @emplaceMultiResultDispatchInto(
 
 // -----
 
-// Test that multiple results with the last result updated first get placed correctly
+// Test that multiple results inserted out of order get tied back to a dispatch
+// consistently.
 
 // CHECK-LABEL: @emplaceMultiResultDispatchIntoSwapped
 util.func public @emplaceMultiResultDispatchIntoSwapped(
@@ -169,7 +206,7 @@ util.func public @emplaceMultiResultDispatchIntoSwapped(
   %c64 = arith.constant 64 : index
   // CHECK: %[[TARGET:.+]] = stream.async.alloca
   // CHECK: %[[DISPATCH:.+]]:2 = stream.async.dispatch @ex::@dispatch0
-  // CHECK-SAME: ({{.+}}, %[[TARGET]][%c0 to %c32 for %[[UPDATE_SIZE]]], %[[TARGET]][%c32 to %c64 for %[[UPDATE_SIZE]]]) :
+  // CHECK-SAME: ({{.+}}, %[[TARGET]][%c32 to %c64 for %[[UPDATE_SIZE]]], %[[TARGET]][%c0 to %c32 for %[[UPDATE_SIZE]]]) :
   // CHECK-SAME: ({{.+}}) -> (%[[TARGET]]{%[[TARGET_SIZE]]}, %[[TARGET]]{%[[TARGET_SIZE]]})
   %update:2 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) :
       (!stream.resource<*>{%input_size}) -> (!stream.resource<*>{%update_size}, !stream.resource<*>{%update_size})
@@ -185,15 +222,11 @@ util.func public @emplaceMultiResultDispatchIntoSwapped(
 
 // -----
 
-// TODO(#14566): multiple results with sparse ties don't work due to implicit
-// operand/result ordering on the dispatch ops. Flow and stream dispatch ops and
-// the executable entry points need to be reworked to remove the implicit
-// ordering. For now we only emplace results until the first we can't then bail
-// and leave them out-of-place. This test should place the first but not the
-// third as the second isn't placed.
+// Tests that we handle sparse emplacement (some results emplaced, some not).
+// If any result is emplaced all results get upgraded to tied allocas.
 
-// CHECK-LABEL: @dontEmplaceSparseMultiResult
-util.func public @dontEmplaceSparseMultiResult(
+// CHECK-LABEL: @emplaceSparseMultiResult
+util.func public @emplaceSparseMultiResult(
     // CHECK-SAME: %[[INPUT:arg[0-9]+]]: !stream.resource<*>, %[[INPUT_SIZE:arg[0-9]+]]: index,
     %input: !stream.resource<*>, %input_size: index,
     // CHECK-SAME: %[[UPDATE_SIZE:arg[0-9]+]]: index, %[[TARGET_SIZE:arg[0-9]+]]: index
@@ -201,19 +234,20 @@ util.func public @dontEmplaceSparseMultiResult(
   %c0 = arith.constant 0 : index
   %c32 = arith.constant 32 : index
   %c64 = arith.constant 64 : index
-  // CHECK: %[[TARGET:.+]] = stream.async.alloca
+  // CHECK-DAG: %[[UNEMPLACED:.+]] = stream.async.alloca : !stream.resource<*>{%[[UPDATE_SIZE]]}
+  // CHECK-DAG: %[[TARGET:.+]] = stream.async.alloca : !stream.resource<*>{%[[TARGET_SIZE]]}
   // CHECK: %[[DISPATCH:.+]]:3 = stream.async.dispatch @ex::@dispatch0
-  // CHECK-SAME: ({{.+}}, %[[TARGET]][%c0 to %c32 for %[[UPDATE_SIZE]]]) :
-  // CHECK-SAME: ({{.+}}) -> (%[[TARGET]]{%[[TARGET_SIZE]]}, !stream.resource<*>{%[[UPDATE_SIZE]]}, !stream.resource<*>{%[[UPDATE_SIZE]]})
+  // CHECK-SAME: (%[[INPUT]][%c0 to %[[INPUT_SIZE]] for %[[INPUT_SIZE]]], %[[TARGET]][%c0 to %c32 for %[[UPDATE_SIZE]]], %[[UNEMPLACED]][%c0 to %[[UPDATE_SIZE]] for %[[UPDATE_SIZE]]], %[[TARGET]][%c32 to %c64 for %[[UPDATE_SIZE]]]) :
+  // CHECK-SAME: ({{.+}}) -> (%[[TARGET]]{%[[TARGET_SIZE]]}, %[[UNEMPLACED]]{%[[UPDATE_SIZE]]}, %[[TARGET]]{%[[TARGET_SIZE]]})
   %update:3 = stream.async.dispatch @ex::@dispatch0(%input[%c0 to %input_size for %input_size]) :
       (!stream.resource<*>{%input_size}) -> (!stream.resource<*>{%update_size}, !stream.resource<*>{%update_size}, !stream.resource<*>{%update_size})
   // CHECK-NOT: stream.async.alloca
   %target = stream.async.alloca : !stream.resource<*>{%target_size}
   // CHECK-NOT: stream.async.update
   %target0 = stream.async.update %update#0, %target[%c0 to %c32] : !stream.resource<*>{%update_size} -> %target as !stream.resource<*>{%target_size}
-  // CHECK: %[[TARGET1:.+]] = stream.async.update %[[DISPATCH]]#2, %[[DISPATCH]]#0[%c32 to %c64]
+  // CHECK-NOT: stream.async.update
   %target1 = stream.async.update %update#2, %target0[%c32 to %c64] : !stream.resource<*>{%update_size} -> %target0 as !stream.resource<*>{%target_size}
-  // CHECK: util.return %[[TARGET1]]
+  // CHECK: util.return %[[DISPATCH]]#2
   util.return %target1 : !stream.resource<*>
 }
 


### PR DESCRIPTION
#18321 introduced a fix for one issue that caused another: the tied operands added for each result must be in the original result order, but the code was sorting by the order the update ops were present in the block instead. This reworks the pass a bit to support multiple emplace-able results as well as sparsely emplaced results (which prior to this would cause the op to not be emplaced at all). This pass still needs a full rewrite - this is just a quick fix to the correctness issue that was introduced.
The major change here is that all results get turned into tied results from alloca ops and then are selectively replaced by target resource/ranges when possible. This does result in some extra tied operands that don't need to be which is not great for IR size but should result in the same kind of output programs. To fix this all properly an explicit separation of stream bindings between read only, read write, and write only is needed and that is a much larger task.

Fixes #20819.