### PR TITLE
Adding skeleton AMDGPU buffer handle and handle pool.

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -18,10 +18,10 @@ iree_runtime_cc_library(
     srcs = [
         # "allocator.c",
         # "allocator.h",
-        # "buffer.c",
-        # "buffer.h",
-        # "buffer_pool.c",
-        # "buffer_pool.h",
+        "buffer.c",
+        "buffer.h",
+        "buffer_pool.c",
+        "buffer_pool.h",
         "channel.c",
         "channel.h",
         # "command_buffer.c",
@@ -71,5 +71,61 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/schemas:amdgpu_executable_def_c_fbs",
         "//runtime/src/iree/schemas:executable_debug_info_c_fbs",
+    ],
+)
+
+# Provided for tests and tools that may reach in.
+# These headers are not part of the public API and should not be depended on.
+iree_runtime_cc_library(
+    name = "headers",
+    hdrs = [
+        # "allocator.h",
+        "buffer.h",
+        "buffer_pool.h",
+        "channel.h",
+        # "command_buffer.h",
+        "driver.h",
+        "event.h",
+        "executable.h",
+        "executable_cache.h",
+        # "host_worker.h",
+        "logical_device.h",
+        "physical_device.h",
+        # "queue.h",
+        # "semaphore.h",
+        # "semaphore_pool.h",
+        "system.h",
+        # "trace_buffer.h",
+    ],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu/device:binaries",
+        "//runtime/src/iree/hal/drivers/amdgpu/device:headers",
+        "//runtime/src/iree/hal/drivers/amdgpu/util",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:topology",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "buffer_pool_test",
+    srcs = ["buffer_pool_test.cc"],
+    tags = [
+        "driver=amdgpu",
+        "nodocker",
+    ],
+    deps = [
+        ":amdgpu",
+        ":headers",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal/drivers/amdgpu/device:headers",
+        "//runtime/src/iree/hal/drivers/amdgpu/util",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:topology",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -16,6 +16,10 @@ iree_cc_library(
   HDRS
     "api.h"
   SRCS
+    "buffer.c"
+    "buffer.h"
+    "buffer_pool.c"
+    "buffer_pool.h"
     "channel.c"
     "channel.h"
     "driver.c"
@@ -50,6 +54,53 @@ iree_cc_library(
     iree::schemas::amdgpu_executable_def_c_fbs
     iree::schemas::executable_debug_info_c_fbs
   PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    headers
+  HDRS
+    "buffer.h"
+    "buffer_pool.h"
+    "channel.h"
+    "driver.h"
+    "event.h"
+    "executable.h"
+    "executable_cache.h"
+    "logical_device.h"
+    "physical_device.h"
+    "system.h"
+  DEPS
+    iree::base
+    iree::base::internal
+    iree::base::internal::arena
+    iree::hal
+    iree::hal::drivers::amdgpu::device::binaries
+    iree::hal::drivers::amdgpu::device::headers
+    iree::hal::drivers::amdgpu::util
+    iree::hal::drivers::amdgpu::util::libhsa
+    iree::hal::drivers::amdgpu::util::topology
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    buffer_pool_test
+  SRCS
+    "buffer_pool_test.cc"
+  DEPS
+    ::amdgpu
+    ::headers
+    iree::base
+    iree::hal::drivers::amdgpu::device::headers
+    iree::hal::drivers::amdgpu::util
+    iree::hal::drivers::amdgpu::util::libhsa
+    iree::hal::drivers::amdgpu::util::topology
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "driver=amdgpu"
+    "nodocker"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.c
@@ -1,0 +1,334 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/buffer.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_external_buffer_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_external_buffer_t {
+  iree_hal_buffer_t base;
+  iree_allocator_t host_allocator;
+  iree_hal_buffer_release_callback_t release_callback;
+  uint64_t device_ptr;
+} iree_hal_amdgpu_external_buffer_t;
+
+static const iree_hal_buffer_vtable_t iree_hal_amdgpu_external_buffer_vtable;
+
+static iree_hal_amdgpu_external_buffer_t* iree_hal_amdgpu_external_buffer_cast(
+    iree_hal_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_amdgpu_external_buffer_vtable);
+  return (iree_hal_amdgpu_external_buffer_t*)base_value;
+}
+
+static const iree_hal_amdgpu_external_buffer_t*
+iree_hal_amdgpu_external_buffer_const_cast(
+    const iree_hal_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_amdgpu_external_buffer_vtable);
+  return (const iree_hal_amdgpu_external_buffer_t*)base_value;
+}
+
+iree_status_t iree_hal_amdgpu_external_buffer_wrap(
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_device_size_t byte_offset, iree_device_size_t byte_length,
+    uint64_t device_ptr, iree_hal_buffer_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(device_ptr);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_amdgpu_external_buffer_t* buffer = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer));
+  iree_hal_buffer_initialize(
+      placement, &buffer->base, allocation_size, byte_offset, byte_length,
+      memory_type, allowed_access, allowed_usage,
+      &iree_hal_amdgpu_external_buffer_vtable, &buffer->base);
+  buffer->host_allocator = host_allocator;
+  buffer->release_callback = release_callback;
+  buffer->device_ptr = device_ptr;
+
+  *out_buffer = &buffer->base;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static void iree_hal_amdgpu_external_buffer_destroy(
+    iree_hal_buffer_t* base_buffer) {
+  iree_hal_amdgpu_external_buffer_t* buffer =
+      iree_hal_amdgpu_external_buffer_cast(base_buffer);
+  iree_allocator_t host_allocator = buffer->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Optionally call a release callback when the buffer is destroyed. Not all
+  // implementations may require this but it's cheap and provides additional
+  // flexibility.
+  if (buffer->release_callback.fn) {
+    buffer->release_callback.fn(buffer->release_callback.user_data,
+                                base_buffer);
+  }
+
+  iree_allocator_free(host_allocator, buffer);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_amdgpu_external_buffer_map_range(
+    iree_hal_buffer_t* base_buffer, iree_hal_mapping_mode_t mapping_mode,
+    iree_hal_memory_access_t memory_access,
+    iree_device_size_t local_byte_offset, iree_device_size_t local_byte_length,
+    iree_hal_buffer_mapping_t* mapping) {
+  iree_hal_amdgpu_external_buffer_t* buffer =
+      iree_hal_amdgpu_external_buffer_cast(base_buffer);
+
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_memory_type(
+      iree_hal_buffer_memory_type(base_buffer),
+      IREE_HAL_MEMORY_TYPE_HOST_VISIBLE));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
+      iree_hal_buffer_allowed_usage(base_buffer),
+      mapping_mode == IREE_HAL_MAPPING_MODE_PERSISTENT
+          ? IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT
+          : IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED));
+
+  mapping->contents = iree_make_byte_span(
+      (IREE_AMDGPU_DEVICE_PTR void*)buffer->device_ptr, local_byte_length);
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_external_buffer_unmap_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length, iree_hal_buffer_mapping_t* mapping) {
+  // Nothing to do today (though maybe we may want to flush?).
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_external_buffer_invalidate_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  // TODO(benvanik): anything we need to do to invalidate?
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_external_buffer_flush_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  // TODO(benvanik): anything we need to do to flush?
+  return iree_ok_status();
+}
+
+static const iree_hal_buffer_vtable_t iree_hal_amdgpu_external_buffer_vtable = {
+    .recycle = iree_hal_buffer_recycle,
+    .destroy = iree_hal_amdgpu_external_buffer_destroy,
+    .map_range = iree_hal_amdgpu_external_buffer_map_range,
+    .unmap_range = iree_hal_amdgpu_external_buffer_unmap_range,
+    .invalidate_range = iree_hal_amdgpu_external_buffer_invalidate_range,
+    .flush_range = iree_hal_amdgpu_external_buffer_flush_range,
+};
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_transient_buffer_t
+//===----------------------------------------------------------------------===//
+
+static const iree_hal_buffer_vtable_t iree_hal_amdgpu_transient_buffer_vtable;
+
+void iree_hal_amdgpu_transient_buffer_initialize(
+    iree_hal_buffer_placement_t placement,
+    iree_hal_amdgpu_device_allocation_handle_t* handle,
+    iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_amdgpu_transient_buffer_t* out_buffer) {
+  IREE_ASSERT_ARGUMENT(handle);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+
+  memset(out_buffer, 0, sizeof(*out_buffer));
+
+  // Transient buffers *are* asynchronous buffers.
+  placement.flags |= IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS;
+
+  iree_hal_buffer_initialize(
+      placement, &out_buffer->base,
+      /*allocation_size=*/0,
+      /*byte_offset=*/0, /*byte_length=*/0, /*memory_type=*/0,
+      /*allowed_access=*/0, /*allowed_usage=*/0,
+      &iree_hal_amdgpu_transient_buffer_vtable, &out_buffer->base);
+  out_buffer->handle = handle;
+  out_buffer->release_callback = release_callback;
+}
+
+void iree_hal_amdgpu_transient_buffer_deinitialize(
+    iree_hal_amdgpu_transient_buffer_t* buffer) {
+  // No-op.
+}
+
+static iree_hal_amdgpu_transient_buffer_t*
+iree_hal_amdgpu_transient_buffer_cast(iree_hal_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_amdgpu_transient_buffer_vtable);
+  return (iree_hal_amdgpu_transient_buffer_t*)base_value;
+}
+
+static const iree_hal_amdgpu_transient_buffer_t*
+iree_hal_amdgpu_transient_buffer_const_cast(
+    const iree_hal_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_amdgpu_transient_buffer_vtable);
+  return (const iree_hal_amdgpu_transient_buffer_t*)base_value;
+}
+
+// Returns true if |buffer| is an iree_hal_amdgpu_transient_buffer_t.
+static bool iree_hal_amdgpu_transient_buffer_isa(iree_hal_buffer_t* buffer) {
+  return iree_hal_resource_is(buffer, &iree_hal_amdgpu_transient_buffer_vtable);
+}
+
+static void iree_hal_amdgpu_transient_buffer_recycle(
+    iree_hal_buffer_t* base_buffer) {
+  if (IREE_UNLIKELY(!base_buffer)) return;
+  iree_hal_amdgpu_transient_buffer_t* buffer =
+      iree_hal_amdgpu_transient_buffer_cast(base_buffer);
+  IREE_ASSERT(buffer->release_callback.fn);
+  if (buffer->release_callback.fn) {
+    buffer->release_callback.fn(buffer->release_callback.user_data,
+                                base_buffer);
+  }
+}
+
+void iree_hal_amdgpu_transient_buffer_reset(
+    iree_hal_amdgpu_transient_buffer_t* buffer,
+    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_device_size_t byte_offset, iree_device_size_t byte_length) {
+  buffer->base.memory_type = memory_type;
+  buffer->base.allowed_access = allowed_access;
+  buffer->base.allowed_usage = allowed_usage;
+  buffer->base.allocation_size = allocation_size;
+  buffer->base.byte_offset = byte_offset;
+  buffer->base.byte_length = byte_length;
+}
+
+// Returns the device pointer from the allocation handle if it is currently
+// allocated. This may read from device memory and is only valid when the buffer
+// is allocated and the completion signals have propagated (ordering the
+// writes).
+static iree_status_t iree_hal_amdgpu_transient_buffer_ptr(
+    iree_hal_amdgpu_transient_buffer_t* buffer, void** out_ptr) {
+  static_assert(sizeof(void*) == sizeof(iree_atomic_uint64_t),
+                "only 64-bit pointers are supported");
+  IREE_AMDGPU_DEVICE_PTR void* ptr = (void*)iree_atomic_load(
+      (iree_atomic_uint64_t*)&buffer->handle->ptr, iree_memory_order_acquire);
+  if (!ptr) {
+    *out_ptr = NULL;
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "transient buffer has no backing allocation at this time; host usage "
+        "is only valid once an alloca has signaled completion and prior to "
+        "enqueuing any dealloca");
+  }
+  *out_ptr = ptr;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_transient_buffer_map_range(
+    iree_hal_buffer_t* base_buffer, iree_hal_mapping_mode_t mapping_mode,
+    iree_hal_memory_access_t memory_access,
+    iree_device_size_t local_byte_offset, iree_device_size_t local_byte_length,
+    iree_hal_buffer_mapping_t* mapping) {
+  iree_hal_amdgpu_transient_buffer_t* buffer =
+      iree_hal_amdgpu_transient_buffer_cast(base_buffer);
+
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_memory_type(
+      iree_hal_buffer_memory_type(base_buffer),
+      IREE_HAL_MEMORY_TYPE_HOST_VISIBLE));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
+      iree_hal_buffer_allowed_usage(base_buffer),
+      mapping_mode == IREE_HAL_MAPPING_MODE_PERSISTENT
+          ? IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT
+          : IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED));
+
+  // Resolve device pointer (if available).
+  IREE_AMDGPU_DEVICE_PTR void* ptr = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_transient_buffer_ptr(buffer, &ptr));
+
+  mapping->contents = iree_make_byte_span(ptr, local_byte_length);
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_transient_buffer_unmap_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length, iree_hal_buffer_mapping_t* mapping) {
+  // Nothing to do today (though maybe we may want to flush?).
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_transient_buffer_invalidate_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  // TODO(benvanik): anything we need to do to invalidate?
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_transient_buffer_flush_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  // TODO(benvanik): anything we need to do to flush?
+  return iree_ok_status();
+}
+
+static const iree_hal_buffer_vtable_t iree_hal_amdgpu_transient_buffer_vtable =
+    {
+        .recycle = iree_hal_amdgpu_transient_buffer_recycle,
+        .destroy = NULL,  // never used
+        .map_range = iree_hal_amdgpu_transient_buffer_map_range,
+        .unmap_range = iree_hal_amdgpu_transient_buffer_unmap_range,
+        .invalidate_range = iree_hal_amdgpu_transient_buffer_invalidate_range,
+        .flush_range = iree_hal_amdgpu_transient_buffer_flush_range,
+};
+
+//===----------------------------------------------------------------------===//
+// Buffer Resolution
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_resolve_buffer(
+    iree_hal_buffer_t* base_buffer,
+    iree_hal_amdgpu_device_buffer_type_t* out_type, uint64_t* out_bits) {
+  if (iree_hal_resource_is(base_buffer,
+                           &iree_hal_amdgpu_transient_buffer_vtable)) {
+    *out_type = IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE;
+    *out_bits =
+        (uint64_t)((iree_hal_amdgpu_transient_buffer_t*)base_buffer)->handle;
+    return iree_ok_status();
+  } else if (iree_hal_resource_is(base_buffer,
+                                  &iree_hal_amdgpu_external_buffer_vtable)) {
+    *out_type = IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_PTR;
+    *out_bits =
+        (uint64_t)((iree_hal_amdgpu_external_buffer_t*)base_buffer)->device_ptr;
+    return iree_ok_status();
+  } else {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "unsupported buffer type; expected something known to the AMDGPU HAL");
+  }
+}
+
+iree_status_t iree_hal_amdgpu_resolve_transient_buffer(
+    iree_hal_buffer_t* base_buffer,
+    iree_hal_amdgpu_device_allocation_handle_t** out_handle) {
+  if (!iree_hal_resource_is(base_buffer,
+                            &iree_hal_amdgpu_transient_buffer_vtable)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "provided buffer is not a transient allocation; only buffers allocated "
+        "with iree_hal_device_queue_alloca can be deallocated using "
+        "iree_hal_device_queue_dealloca");
+  }
+  iree_hal_amdgpu_transient_buffer_t* buffer =
+      (iree_hal_amdgpu_transient_buffer_t*)base_buffer;
+  *out_handle = buffer->handle;
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.h
@@ -1,0 +1,90 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_BUFFER_H_
+#define IREE_HAL_DRIVERS_AMDGPU_BUFFER_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/amdgpu/device/buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_external_buffer_t
+//===----------------------------------------------------------------------===//
+
+// Wraps an external device-accessible |device_ptr| allocation in an
+// iree_hal_buffer_t. The |release_callback| will be issued upon release of the
+// last buffer reference.
+iree_status_t iree_hal_amdgpu_external_buffer_wrap(
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_device_size_t byte_offset, iree_device_size_t byte_length,
+    uint64_t device_ptr, iree_hal_buffer_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_transient_buffer_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_amdgpu_transient_buffer_t {
+  iree_hal_buffer_t base;  // must be at 0
+
+  // Device-side allocation handle in a memory pool accessible to all agents.
+  // This may reside in host local memory.
+  IREE_AMDGPU_DEVICE_PTR iree_hal_amdgpu_device_allocation_handle_t* handle;
+
+  // Release callback that handles deallocation.
+  iree_hal_buffer_release_callback_t release_callback;
+} iree_hal_amdgpu_transient_buffer_t;
+
+// Initializes a transient buffer in-place with a 0 ref count.
+// The owning pool must increment the ref count to 1 before returning the
+// buffer to users.
+void iree_hal_amdgpu_transient_buffer_initialize(
+    iree_hal_buffer_placement_t placement,
+    iree_hal_amdgpu_device_allocation_handle_t* handle,
+    iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_amdgpu_transient_buffer_t* out_buffer);
+
+// Deinitializes a transient buffer in-place assuming it has a 0 ref count.
+void iree_hal_amdgpu_transient_buffer_deinitialize(
+    iree_hal_amdgpu_transient_buffer_t* buffer);
+
+// Resets |buffer| to the given parameters as if it had just been allocated.
+void iree_hal_amdgpu_transient_buffer_reset(
+    iree_hal_amdgpu_transient_buffer_t* buffer,
+    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_device_size_t byte_offset, iree_device_size_t byte_length);
+
+//===----------------------------------------------------------------------===//
+// Buffer Resolution
+//===----------------------------------------------------------------------===//
+
+// Resolves a HAL buffer to a device-side type and pointer/handle.
+// Returns success if the buffer is of a type that can be used toll-free on any
+// device but does not verify the memory referenced is accessible to any
+// particular device.
+iree_status_t iree_hal_amdgpu_resolve_buffer(
+    iree_hal_buffer_t* buffer, iree_hal_amdgpu_device_buffer_type_t* out_type,
+    uint64_t* out_bits);
+
+// Resolves a HAL buffer that is required to be a transient buffer allocated via
+// iree_hal_device_queue_alloca. Fails if the buffer is any other type.
+iree_status_t iree_hal_amdgpu_resolve_transient_buffer(
+    iree_hal_buffer_t* buffer,
+    iree_hal_amdgpu_device_allocation_handle_t** out_handle);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_BUFFER_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer_pool.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer_pool.c
@@ -1,0 +1,436 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/buffer_pool.h"
+
+#include "iree/hal/drivers/amdgpu/buffer.h"
+#include "iree/hal/drivers/amdgpu/device/buffer.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+
+static void iree_hal_amdgpu_buffer_pool_link_free_block(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool,
+    iree_hal_amdgpu_buffer_pool_block_t* block);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_buffer_pool_block_t
+//===----------------------------------------------------------------------===//
+
+// A block of allocated buffers. Manages both host heap memory and
+// device-visible memory for the device-side library resources.
+//
+// Thread-safe; each block has its own lock for free list management.
+typedef struct iree_hal_amdgpu_buffer_pool_block_t {
+  // Pool that owns this block.
+  iree_hal_amdgpu_buffer_pool_t* buffer_pool;
+  // Previous block in the pool block linked list.
+  iree_hal_amdgpu_buffer_pool_block_t* prev_block;
+  // Next block in the pool block linked list.
+  iree_hal_amdgpu_buffer_pool_block_t* next_block;
+  // Next block in the pool block linked list with free entries.
+  iree_hal_amdgpu_buffer_pool_block_t* next_free;
+  // Capacity of the block in buffers.
+  iree_host_size_t capacity;
+  // Device memory base pointer used for
+  // `iree_hal_amdgpu_device_allocation_handle_t`.
+  IREE_AMDGPU_DEVICE_PTR uint8_t* device_allocation_ptr;
+  // Mutex guarding the mutable block fields.
+  iree_slim_mutex_t mutex;
+  // Count of free buffers in the block stored in the free_list.
+  iree_host_size_t free_count IREE_GUARDED_BY(mutex);
+  // Free buffers that are available for use.
+  iree_hal_amdgpu_transient_buffer_t* free_list[/*capacity*/] IREE_GUARDED_BY(
+      mutex);
+  // Trailing list of iree_hal_amdgpu_transient_buffer_t[capacity].
+} iree_hal_amdgpu_buffer_pool_block_t;
+
+static void iree_hal_amdgpu_buffer_pool_block_free(
+    iree_hal_amdgpu_buffer_pool_block_t* block);
+static void iree_hal_amdgpu_buffer_pool_block_recycle(
+    void* user_data, iree_hal_buffer_t* base_buffer);
+
+// Allocates a block of |capacity| buffers on host and device.
+static iree_status_t iree_hal_amdgpu_buffer_pool_block_allocate(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool, iree_host_size_t capacity,
+    iree_hal_amdgpu_buffer_pool_block_t** out_block) {
+  IREE_ASSERT_ARGUMENT(out_block);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_block = NULL;
+
+  // Allocate and initialize host memory.
+  iree_hal_amdgpu_buffer_pool_block_t* block = NULL;
+  const iree_host_size_t free_list_size =
+      capacity * sizeof(block->free_list[0]);
+  const iree_host_size_t total_block_size =
+      sizeof(*block) + free_list_size +
+      capacity * sizeof(iree_hal_amdgpu_transient_buffer_t);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(buffer_pool->host_allocator, total_block_size,
+                                (void**)&block));
+  block->buffer_pool = buffer_pool;
+  block->prev_block = NULL;
+  block->next_block = NULL;
+  block->next_free = NULL;
+  block->capacity = capacity;
+  block->device_allocation_ptr = NULL;
+  iree_slim_mutex_initialize(&block->mutex);
+
+  // Allocate device memory from the device memory pool.
+  const iree_host_size_t total_device_size =
+      capacity * sizeof(iree_hal_amdgpu_device_allocation_handle_t);
+  iree_status_t status = iree_hsa_amd_memory_pool_allocate(
+      IREE_LIBHSA(buffer_pool->libhsa), buffer_pool->memory_pool,
+      total_device_size, HSA_AMD_MEMORY_POOL_STANDARD_FLAG,
+      (void**)&block->device_allocation_ptr);
+
+  // Make the allocation visible to all devices.
+  if (iree_status_is_ok(status)) {
+    status = iree_hsa_amd_agents_allow_access(
+        IREE_LIBHSA(buffer_pool->libhsa),
+        buffer_pool->topology->all_agent_count,
+        buffer_pool->topology->all_agents, /*flags=*/NULL,
+        block->device_allocation_ptr);
+  }
+
+  // Initialize each host buffer and build the free list.
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_transient_buffer_t* base_host_ptr =
+        (iree_hal_amdgpu_transient_buffer_t*)((uint8_t*)block + sizeof(*block) +
+                                              free_list_size);
+    iree_hal_amdgpu_device_allocation_handle_t* base_device_ptr =
+        (iree_hal_amdgpu_device_allocation_handle_t*)
+            block->device_allocation_ptr;
+    block->free_count = capacity;
+    iree_hal_buffer_release_callback_t release_callback = {
+        .fn = iree_hal_amdgpu_buffer_pool_block_recycle,
+        .user_data = block,
+    };
+    for (iree_host_size_t i = 0; i < capacity; ++i) {
+      iree_hal_amdgpu_transient_buffer_t* buffer = &base_host_ptr[i];
+      iree_hal_amdgpu_device_allocation_handle_t* handle = &base_device_ptr[i];
+      iree_hal_amdgpu_transient_buffer_initialize(
+          buffer_pool->placement, handle, release_callback, buffer);
+      block->free_list[i] = buffer;
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_block = block;
+  } else {
+    iree_hal_amdgpu_buffer_pool_block_free(block);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+// Frees a |block| of buffers and its device memory.
+static void iree_hal_amdgpu_buffer_pool_block_free(
+    iree_hal_amdgpu_buffer_pool_block_t* block) {
+  IREE_ASSERT_ARGUMENT(block);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&block->mutex);
+  IREE_ASSERT_EQ(block->free_count, block->capacity);
+  iree_slim_mutex_unlock(&block->mutex);
+
+  // Deinitialize all host buffers. They are allocated as part of the block
+  // and only need to be cleaned up.
+  iree_hal_amdgpu_transient_buffer_t* base_host_ptr =
+      (iree_hal_amdgpu_transient_buffer_t*)((uint8_t*)block +
+                                            block->capacity *
+                                                sizeof(block->free_list[0]));
+  for (iree_host_size_t i = 0; i < block->capacity; ++i) {
+    iree_hal_amdgpu_transient_buffer_t* buffer = &base_host_ptr[i];
+    iree_hal_amdgpu_transient_buffer_deinitialize(buffer);
+  }
+
+  // Deallocate device memory.
+  if (block->device_allocation_ptr) {
+    IREE_IGNORE_ERROR(iree_hsa_amd_memory_pool_free(
+        IREE_LIBHSA(block->buffer_pool->libhsa), block->device_allocation_ptr));
+    block->device_allocation_ptr = NULL;
+  }
+
+  // Frees the block and its embedded storage.
+  iree_slim_mutex_deinitialize(&block->mutex);
+  iree_allocator_free(block->buffer_pool->host_allocator, block);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Recycles a buffer after it has no remaining uses.
+static void iree_hal_amdgpu_buffer_pool_block_recycle(
+    void* user_data, iree_hal_buffer_t* base_buffer) {
+  iree_hal_amdgpu_buffer_pool_block_t* block =
+      (iree_hal_amdgpu_buffer_pool_block_t*)user_data;
+  iree_hal_amdgpu_transient_buffer_t* buffer =
+      (iree_hal_amdgpu_transient_buffer_t*)base_buffer;
+
+  // Buffer should have zero references before being recycled.
+  IREE_ASSERT_REF_COUNT_ZERO(&base_buffer->resource.ref_count);
+
+  // Add to the block free list.
+  iree_slim_mutex_lock(&block->mutex);
+
+  const bool full_to_free = block->free_count == 0;
+  block->free_list[block->free_count++] = buffer;
+
+  iree_slim_mutex_unlock(&block->mutex);
+
+  // If the block has gone from 0 to >0 free entries then link it back into the
+  // pool free list for use. Note that we can only do this on the transition
+  // from full to free as otherwise the block is already in the free list.
+  //
+  // NOTE: this happens outside of the per-block lock as the pool will hold its
+  // lock over the free list while acquiring a new entry. This may lead to
+  // (safe) races where an acquire checks the free list while we are updating
+  // the block above but before we update the free list but that's rare and
+  // bounded (there may be one extra block in the pool).
+  if (full_to_free) {
+    iree_hal_amdgpu_buffer_pool_link_free_block(block->buffer_pool, block);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_buffer_pool_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_amdgpu_buffer_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_buffer_placement_t placement, iree_host_size_t block_capacity,
+    iree_allocator_t host_allocator, hsa_amd_memory_pool_t memory_pool,
+    iree_hal_amdgpu_buffer_pool_t* out_buffer_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_buffer_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  out_buffer_pool->libhsa = libhsa;
+  out_buffer_pool->topology = topology;
+  out_buffer_pool->placement = placement;
+  out_buffer_pool->host_allocator = host_allocator;
+  out_buffer_pool->memory_pool = memory_pool;
+
+  // TODO(benvanik): set a pool handle we can use to route requests across the
+  // host service.
+  out_buffer_pool->pool = 0;
+
+  iree_slim_mutex_initialize(&out_buffer_pool->mutex);
+  out_buffer_pool->list_head = NULL;
+  out_buffer_pool->free_head = NULL;
+
+  // Query the memory pool for its allocation granularity.
+  // This is not the minimum allocation size
+  // (HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE) but the recommended size
+  // to prevent internal fragmentation. We will always make allocations of this
+  // size and adjust the block capacity to match.
+  size_t alloc_rec_granule = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hsa_amd_memory_pool_get_info(
+          IREE_LIBHSA(libhsa), memory_pool,
+          HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE,
+          &alloc_rec_granule),
+      "querying HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE to "
+      "determine block capacity");
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, alloc_rec_granule);
+
+  // Allocate aligned to the recommended allocation granularity.
+  // We'll always be some multiple of the recommended size so we waste no device
+  // space.
+  const iree_host_size_t min_capacity_per_allocation = iree_host_size_ceil_div(
+      alloc_rec_granule, sizeof(iree_hal_amdgpu_device_allocation_handle_t));
+  const iree_host_size_t capacity_per_allocation =
+      iree_host_size_ceil_div(block_capacity, min_capacity_per_allocation);
+  out_buffer_pool->block_capacity = capacity_per_allocation;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_buffer_pool_deinitialize(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool) {
+  IREE_ASSERT_ARGUMENT(buffer_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&buffer_pool->mutex);
+  iree_hal_amdgpu_buffer_pool_block_t* block = buffer_pool->list_head;
+  while (block != NULL) {
+    iree_hal_amdgpu_buffer_pool_block_t* next_block = block->next_block;
+    IREE_ASSERT_EQ(block->free_count, block->capacity);
+    iree_hal_amdgpu_buffer_pool_block_free(block);
+    block = next_block;
+  }
+  buffer_pool->list_head = NULL;
+  buffer_pool->free_head = NULL;
+  iree_slim_mutex_unlock(&buffer_pool->mutex);
+
+  iree_slim_mutex_deinitialize(&buffer_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Grows the |buffer_pool| by one block.
+// Requires the pool lock be held.
+static iree_status_t iree_hal_amdgpu_buffer_pool_grow(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool) {
+  IREE_ASSERT_ARGUMENT(buffer_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate the new block and its resources.
+  iree_hal_amdgpu_buffer_pool_block_t* block = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_amdgpu_buffer_pool_block_allocate(
+              buffer_pool, buffer_pool->block_capacity, &block));
+
+  // Link the block into the allocated list and the free list.
+  block->prev_block = NULL;
+  block->next_block = buffer_pool->list_head;
+  if (block->next_block) {
+    block->next_block->prev_block = block;
+  }
+  buffer_pool->list_head = block;
+  block->next_free = buffer_pool->free_head;
+  buffer_pool->free_head = block;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_buffer_pool_preallocate(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool, iree_host_size_t count) {
+  IREE_ASSERT_ARGUMENT(buffer_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
+
+  iree_status_t status = iree_ok_status();
+  if (count > 0) {
+    const iree_host_size_t block_count =
+        iree_host_size_ceil_div(count, buffer_pool->block_capacity);
+    for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < block_count;
+         ++i) {
+      status = iree_hal_amdgpu_buffer_pool_grow(buffer_pool);
+    }
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_buffer_pool_acquire(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size, iree_hal_buffer_t** out_buffer,
+    iree_hal_amdgpu_device_allocation_handle_t** out_handle) {
+  IREE_ASSERT_ARGUMENT(buffer_pool);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  IREE_ASSERT_ARGUMENT(out_handle);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_buffer = NULL;
+  *out_handle = NULL;
+
+  iree_slim_mutex_lock(&buffer_pool->mutex);
+
+  // If there are no blocks with free buffers allocate a new one.
+  iree_status_t status = iree_ok_status();
+  if (buffer_pool->free_head == NULL) {
+    // TODO(benvanik): do this outside of the lock? This allocates device
+    // resources. We could have an exclusive growth lock that does not block
+    // recycling.
+    status = iree_hal_amdgpu_buffer_pool_grow(buffer_pool);
+  }
+
+  // Get the next free buffer and possibly maintain the free list.
+  iree_hal_amdgpu_transient_buffer_t* buffer = NULL;
+  if (iree_status_is_ok(status)) {
+    // Pop the last free buffer from the block.
+    iree_hal_amdgpu_buffer_pool_block_t* block = buffer_pool->free_head;
+    buffer = block->free_list[block->free_count - 1];
+    block->free_list[block->free_count - 1] = NULL;
+    --block->free_count;
+
+    // If there are no more free buffers in the block remove it from the
+    // free list.
+    if (block->free_count == 0) {
+      buffer_pool->free_head = block->next_free;
+      block->next_free = NULL;
+    }
+  }
+
+  iree_slim_mutex_unlock(&buffer_pool->mutex);
+
+  if (iree_status_is_ok(status)) {
+    // Assign queue affinity based on the requested parameters.
+    buffer->base.placement.queue_affinity = params.queue_affinity
+                                                ? params.queue_affinity
+                                                : IREE_HAL_QUEUE_AFFINITY_ANY;
+
+    // Return with a 1 ref count as if we had allocated it.
+    iree_atomic_ref_count_inc(&buffer->base.resource.ref_count);
+    *out_buffer = &buffer->base;
+    *out_handle = buffer->handle;
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+// Links |block| into the |buffer_pool| free list.
+// Must not already be in the list.
+// The block is inserted at the head to try to have new acquisitions reuse it
+// before any others and keep the utilization high.
+static void iree_hal_amdgpu_buffer_pool_link_free_block(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool,
+    iree_hal_amdgpu_buffer_pool_block_t* block) {
+  iree_slim_mutex_lock(&buffer_pool->mutex);
+  block->next_free = buffer_pool->free_head;
+  buffer_pool->free_head = block;
+  iree_slim_mutex_unlock(&buffer_pool->mutex);
+}
+
+void iree_hal_amdgpu_buffer_pool_trim(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool) {
+  IREE_ASSERT_ARGUMENT(buffer_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Walk each block in the free list. If all buffers are free then drop it.
+  iree_slim_mutex_lock(&buffer_pool->mutex);
+  iree_hal_amdgpu_buffer_pool_block_t* prev_block = NULL;
+  iree_hal_amdgpu_buffer_pool_block_t* block = buffer_pool->free_head;
+  while (block != NULL) {
+    iree_hal_amdgpu_buffer_pool_block_t* next_block = block->next_free;
+    if (block->free_count == block->capacity) {
+      // One or more buffers in use - cannot free the block.
+      prev_block = block;
+      block = next_block;
+      continue;
+    }
+
+    // Unlink the block from the free list.
+    if (prev_block != NULL) {
+      prev_block->next_free = next_block;
+    } else {
+      buffer_pool->free_head = next_block;
+    }
+
+    // Unlink the block from the main list.
+    if (block->prev_block != NULL) {
+      block->prev_block->next_block = block->next_block;
+    } else {
+      buffer_pool->list_head = block->next_block;
+    }
+    if (block->next_block != NULL) {
+      block->next_block->prev_block = block->prev_block;
+    }
+
+    // Free the block and its resources.
+    iree_hal_amdgpu_buffer_pool_block_free(block);
+
+    block = next_block;
+  }
+
+  iree_slim_mutex_unlock(&buffer_pool->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer_pool.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer_pool.h
@@ -1,0 +1,116 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_BUFFER_POOL_H_
+#define IREE_HAL_DRIVERS_AMDGPU_BUFFER_POOL_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/synchronization.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_device_allocation_handle_t
+    iree_hal_amdgpu_device_allocation_handle_t;
+
+typedef struct iree_hal_amdgpu_buffer_pool_block_t
+    iree_hal_amdgpu_buffer_pool_block_t;
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_buffer_pool_t
+//===----------------------------------------------------------------------===//
+
+// Default buffer count per block in the pool.
+// Larger is better to reduce the number of device memory allocations but we
+// don't want to have too high of a fixed overhead. Most programs only have a
+// few dozen live buffers at a time but some with heavy async behavior may have
+// many more for outstanding async allocations.
+#define IREE_HAL_AMDGPU_BUFFER_POOL_DEFAULT_BLOCK_CAPACITY (2 * 1024)
+
+// A pool of transient buffers and their corresponding device handles.
+// Buffers are allocated in blocks to reduce the number of device allocations
+// we make (as some devices/drivers may have limits). Blocks are allocated
+// on-demand and contain a fixed-size set of HAL buffers allocated inline.
+//
+// Thread-safe; multiple host threads may share the same pool.
+typedef struct iree_hal_amdgpu_buffer_pool_t {
+  // Unowned libhsa handle. Must be retained by the owner.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+  // Topology with all CPU and GPU agents. Buffers must be visible to all.
+  const iree_hal_amdgpu_topology_t* topology;
+
+  // Placement of all buffers allocated from this pool. This is the logical HAL
+  // device and queues that map to the physical device the pool is for.
+  iree_hal_buffer_placement_t placement;
+
+  // Allocator used for host allocations.
+  iree_allocator_t host_allocator;
+  // Device memory pool for device allocations.
+  hsa_amd_memory_pool_t memory_pool;
+
+  // Unused/opaque pool ID.
+  // TODO(benvanik): make this link back to this pool somehow.
+  uint64_t pool;
+
+  // Capacity of each block in buffers.
+  // Most likely IREE_HAL_AMDGPU_BUFFER_POOL_DEFAULT_BLOCK_CAPACITY (rounded up
+  // to the recommended allocation granularity).
+  iree_host_size_t block_capacity;
+
+  // Guards pool resources during acquisition.
+  iree_slim_mutex_t mutex;
+  // A doubly-linked list of all allocated blocks.
+  iree_hal_amdgpu_buffer_pool_block_t* list_head IREE_GUARDED_BY(mutex);
+  // A singly-linked list of blocks that have one or more free buffer.
+  iree_hal_amdgpu_buffer_pool_block_t* free_head IREE_GUARDED_BY(mutex);
+} iree_hal_amdgpu_buffer_pool_t;
+
+// Initializes |out_buffer_pool| for use. Performs no allocation.
+// Buffers will be usable on all GPU devices in |topology|. |placement| is used
+// as the base placement for all buffers but exact queues will be assigned when
+// buffers are acquired. Device-accessible allocation handle storage will be
+// allocated from |memory_pool| as needed (not the actual buffers - just
+// iree_hal_amdgpu_device_allocation_handle_t).
+iree_status_t iree_hal_amdgpu_buffer_pool_initialize(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_buffer_placement_t placement, iree_host_size_t block_capacity,
+    iree_allocator_t host_allocator, hsa_amd_memory_pool_t memory_pool,
+    iree_hal_amdgpu_buffer_pool_t* out_buffer_pool);
+
+// Deinitializes |buffer_pool| and releases underlying memory.
+// All buffers created from the pool must have been released back to it.
+void iree_hal_amdgpu_buffer_pool_deinitialize(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool);
+
+// Preallocates |count| buffer handles and adds them to the pool free list.
+iree_status_t iree_hal_amdgpu_buffer_pool_preallocate(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool, iree_host_size_t count);
+
+// Acquires an |allocation_size| buffer from the pool with the given |params|.
+// The pool must remain live until the returned |out_buffer| has been fully
+// recycled (ref count 0). The returned |out_handle| is the device-side handle
+// owned by the buffer and is provided to callers as a convenience; it can be
+// accessed from the buffer in the future using
+// iree_hal_amdgpu_resolve_transient_buffer.
+iree_status_t iree_hal_amdgpu_buffer_pool_acquire(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size, iree_hal_buffer_t** out_buffer,
+    iree_hal_amdgpu_device_allocation_handle_t** out_handle);
+
+// Trims all blocks that have no allocated buffers.
+void iree_hal_amdgpu_buffer_pool_trim(
+    iree_hal_amdgpu_buffer_pool_t* buffer_pool);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_BUFFER_POOL_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer_pool_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer_pool_test.cc
@@ -1,0 +1,271 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/buffer_pool.h"
+
+#include <vector>
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/amdgpu/buffer.h"
+#include "iree/hal/drivers/amdgpu/device/buffer.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+using iree::testing::status::StatusIs;
+
+struct BufferPoolTest : public ::testing::Test {
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_hal_amdgpu_libhsa_t libhsa;
+  iree_hal_amdgpu_topology_t topology;
+  hsa_amd_memory_pool_t gpu_memory_pool;
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator, &libhsa);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_ignore(status);
+      GTEST_SKIP() << "HSA not available, skipping tests";
+    }
+    IREE_ASSERT_OK(
+        iree_hal_amdgpu_topology_initialize_with_defaults(&libhsa, &topology));
+    if (topology.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping tests";
+    }
+
+    hsa_agent_t gpu_agent = topology.gpu_agents[0];
+    IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
+        &libhsa, gpu_agent, &gpu_memory_pool));
+  }
+
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    iree_hal_amdgpu_topology_deinitialize(&topology);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa);
+  }
+};
+
+// Tests that a pool can be initialized/deinitialized successfully.
+// Note that pools do not allocate anything on initialization so this should
+// never allocate.
+TEST_F(BufferPoolTest, Lifetime) {
+  IREE_TRACE_SCOPE();
+
+  iree_hal_buffer_placement_t placement = {
+      /*.device=*/NULL,  // not available in test
+      /*.queue_affinity=*/IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*.flags=*/IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS,
+  };
+  iree_hal_amdgpu_buffer_pool_t buffer_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_initialize(
+      &libhsa, &topology, placement,
+      IREE_HAL_AMDGPU_BUFFER_POOL_DEFAULT_BLOCK_CAPACITY, host_allocator,
+      gpu_memory_pool, &buffer_pool));
+
+  // No-op since nothing has been allocated.
+  iree_hal_amdgpu_buffer_pool_trim(&buffer_pool);
+
+  iree_hal_amdgpu_buffer_pool_deinitialize(&buffer_pool);
+}
+
+// Tests a pool that has preallocation requests.
+// We make a few requests interleaved with trims and then rely on
+// deinitialization to free the remaining resources to ensure there are no
+// leaks.
+TEST_F(BufferPoolTest, LifetimePreallocate) {
+  IREE_TRACE_SCOPE();
+
+  iree_hal_buffer_placement_t placement = {
+      /*.device=*/NULL,  // not available in test
+      /*.queue_affinity=*/IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*.flags=*/IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS,
+  };
+  iree_hal_amdgpu_buffer_pool_t buffer_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_initialize(
+      &libhsa, &topology, placement,
+      /*block_capacity=*/32, host_allocator, gpu_memory_pool, &buffer_pool));
+
+  // No-op since nothing has been allocated yet.
+  iree_hal_amdgpu_buffer_pool_trim(&buffer_pool);
+
+  // No-op preallocation (can happen if we blindly pass options/flags of 0).
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_preallocate(&buffer_pool, 0));
+
+  // Preallocate one block.
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_preallocate(&buffer_pool, 32));
+
+  // Trim the entire block (nothing is used).
+  iree_hal_amdgpu_buffer_pool_trim(&buffer_pool);
+
+  // Preallocate two blocks.
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_preallocate(&buffer_pool, 33));
+
+  // Preallocate one more block (1 buffer ceildiv 32 capacity = 1 block).
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_preallocate(&buffer_pool, 1));
+
+  // Deinitialize with remaining preallocated blocks to test cleanup.
+  iree_hal_amdgpu_buffer_pool_deinitialize(&buffer_pool);
+}
+
+// Tests acquiring and releasing a buffer handle from the pool.
+TEST_F(BufferPoolTest, AcquireRelease) {
+  IREE_TRACE_SCOPE();
+
+  iree_hal_buffer_placement_t placement = {
+      /*.device=*/(iree_hal_device_t*)0xF00Du,  // not available in test
+      /*.queue_affinity=*/1ull,
+      /*.flags=*/IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS,
+  };
+  iree_hal_amdgpu_buffer_pool_t buffer_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_initialize(
+      &libhsa, &topology, placement,
+      /*block_capacity=*/32, host_allocator, gpu_memory_pool, &buffer_pool));
+
+  iree_hal_buffer_params_t buffer_params = {
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_DEFAULT |
+          IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE |
+          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+      /*.queue_affinity=*/placement.queue_affinity,
+      /*.min_alignment=*/0,
+  };
+  iree_device_size_t requested_size = 127u;
+
+  // Handle is just for convenience and is stored within the buffer as well.
+  iree_hal_buffer_t* buffer = NULL;
+  iree_hal_amdgpu_device_allocation_handle_t* handle = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_acquire(
+      &buffer_pool, buffer_params, /*allocation_size=*/requested_size, &buffer,
+      &handle));
+  ASSERT_NE(buffer, nullptr);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_GE(iree_hal_buffer_allocation_size(buffer), requested_size);
+  EXPECT_EQ(iree_hal_buffer_allocation_placement(buffer).device,
+            placement.device);
+  EXPECT_EQ(iree_hal_buffer_allocation_placement(buffer).queue_affinity,
+            placement.queue_affinity);
+  EXPECT_EQ(iree_hal_buffer_allocation_placement(buffer).flags,
+            placement.flags);
+  EXPECT_EQ(iree_hal_buffer_byte_length(buffer), requested_size);
+
+  // Handle should have no physical pointer since nothing has been allocated.
+  EXPECT_EQ(handle->ptr, nullptr);
+
+  // Ensure the buffer resolves to the handle.
+  iree_hal_amdgpu_device_buffer_type_t type = 0;
+  uint64_t bits = 0;
+  IREE_ASSERT_OK(iree_hal_amdgpu_resolve_buffer(buffer, &type, &bits));
+  EXPECT_EQ(type, IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE);
+  EXPECT_EQ(bits, (uint64_t)handle);
+
+  // Same as above but for when we're confident we're dealing with a transient
+  // buffer (here we are).
+  iree_hal_amdgpu_device_allocation_handle_t* queried_handle = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_resolve_transient_buffer(buffer, &queried_handle));
+  EXPECT_EQ(handle, queried_handle);
+
+  // Since the buffer is not actually allocated any attempt to map (even though
+  // we requested it) should fail.
+  iree_hal_buffer_mapping_t mapping = {};
+  EXPECT_THAT(
+      Status(iree_hal_buffer_map_range(buffer, IREE_HAL_MAPPING_MODE_PERSISTENT,
+                                       IREE_HAL_MEMORY_ACCESS_READ, 0,
+                                       IREE_HAL_WHOLE_BUFFER, &mapping)),
+      StatusIs(StatusCode::kFailedPrecondition));
+
+  // Release the buffer back to the pool - we're the last reference and it
+  // should be recycled.
+  iree_hal_buffer_release(buffer);
+
+  iree_hal_amdgpu_buffer_pool_deinitialize(&buffer_pool);
+}
+
+// Explicitly tests pool growth by acquiring an entire block worth of buffers+1.
+// We then release all the buffers that should have been in the first block and
+// trim with the second block outstanding to ensure it is not reclaimed with the
+// buffer outstanding.
+TEST_F(BufferPoolTest, Growth) {
+  IREE_TRACE_SCOPE();
+
+  iree_hal_buffer_placement_t placement = {
+      /*.device=*/NULL,  // not available in test
+      /*.queue_affinity=*/IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*.flags=*/IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS,
+  };
+  iree_hal_amdgpu_buffer_pool_t buffer_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_initialize(
+      &libhsa, &topology, placement, /*block_capacity=*/32, host_allocator,
+      gpu_memory_pool, &buffer_pool));
+  // NOTE: the capacity may be larger than requested due to alignment.
+  const iree_host_size_t block_capacity = buffer_pool.block_capacity;
+
+  iree_hal_buffer_params_t buffer_params = {
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_DEFAULT,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE,
+      /*.queue_affinity=*/placement.queue_affinity,
+      /*.min_alignment=*/0,
+  };
+  iree_device_size_t requested_size = 128u;
+  std::vector<iree_hal_buffer_t*> buffers(block_capacity);
+  std::vector<iree_hal_amdgpu_device_allocation_handle_t*> handles(
+      block_capacity);
+
+  // Preallocate the first block (just to put more load on that path).
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_buffer_pool_preallocate(&buffer_pool, block_capacity));
+
+  // Allocate enough to consume the entire first block.
+  for (iree_host_size_t i = 0; i < block_capacity; ++i) {
+    IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_acquire(
+        &buffer_pool, buffer_params, /*allocation_size=*/requested_size,
+        &buffers[i], &handles[i]));
+    EXPECT_EQ(handles[i]->ptr, nullptr);
+  }
+
+  // Allocate +1 to trigger growth and acquire the next block.
+  iree_hal_buffer_t* growth_buffer = NULL;
+  iree_hal_amdgpu_device_allocation_handle_t* growth_handle = NULL;
+  IREE_ASSERT_OK(iree_hal_amdgpu_buffer_pool_acquire(
+      &buffer_pool, buffer_params, /*allocation_size=*/requested_size,
+      &growth_buffer, &growth_handle));
+  ASSERT_NE(growth_buffer, nullptr);
+  ASSERT_NE(growth_handle, nullptr);
+  EXPECT_EQ(growth_handle->ptr, nullptr);
+
+  // Recycle all the buffers from the first block. After this it should have no
+  // outstanding buffers allocated it from it and be a candidate for trimming.
+  for (iree_host_size_t i = 0; i < block_capacity; ++i) {
+    iree_hal_buffer_release(buffers[i]);
+  }
+
+  // Ensure the growth buffer is still valid (should be, as we shouldn't have
+  // deallocated anything).
+  EXPECT_EQ(growth_handle->ptr, nullptr);
+
+  // Trim to drop the unused first block.
+  iree_hal_amdgpu_buffer_pool_trim(&buffer_pool);
+
+  // Check that we didn't drop the growth buffer that's in the second block.
+  EXPECT_EQ(growth_handle->ptr, nullptr);
+
+  // Release the last buffer and let the deinitialize cleanup the second block.
+  iree_hal_buffer_release(growth_buffer);
+
+  iree_hal_amdgpu_buffer_pool_deinitialize(&buffer_pool);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/device/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/CMakeLists.txt
@@ -9,10 +9,12 @@
 #===------------------------------------------------------------------------===#
 
 set(_BITCODE_SRCS
+  "buffer.c"
   "dummy.c"
 )
 
 set(_BITCODE_HDRS
+  "buffer.h"
   "kernel_tables.h"
   "kernels.h"
   "support/common.h"

--- a/runtime/src/iree/hal/drivers/amdgpu/device/buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/buffer.c
@@ -1,0 +1,65 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/device/buffer.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_buffer_ref_t
+//===----------------------------------------------------------------------===//
+
+// TODO(benvanik): simplify this for command buffers by pre-baking as much as we
+// can during the queue issue - we can at least dereference handles and add in
+// the offset for everything such that we only have to deal with the slot offset
+// and have less branchy code.
+void* iree_hal_amdgpu_device_buffer_ref_resolve(
+    iree_hal_amdgpu_device_buffer_ref_t buffer_ref,
+    IREE_AMDGPU_ALIGNAS(64)
+        const iree_hal_amdgpu_device_buffer_ref_t* IREE_AMDGPU_RESTRICT
+            binding_table) {
+  if (buffer_ref.type == IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_SLOT) {
+    const iree_hal_amdgpu_device_buffer_ref_t binding =
+        binding_table[buffer_ref.value.slot];
+    const uint64_t offset = buffer_ref.offset + binding.offset;
+    const uint64_t length = binding.length == UINT64_MAX
+                                ? buffer_ref.length - offset
+                                : buffer_ref.length;
+    buffer_ref = (iree_hal_amdgpu_device_buffer_ref_t){
+        .type = binding.type,
+        .offset = offset,
+        .length = length,
+        .value.bits = binding.value.bits,
+    };
+  }
+  if (buffer_ref.type == IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE) {
+    buffer_ref.value.ptr = buffer_ref.value.handle->ptr;
+  }
+  return buffer_ref.value.ptr
+             ? (uint8_t*)buffer_ref.value.ptr + buffer_ref.offset
+             : NULL;
+}
+
+void* iree_hal_amdgpu_device_workgroup_count_buffer_ref_resolve(
+    iree_hal_amdgpu_device_workgroup_count_buffer_ref_t buffer_ref,
+    IREE_AMDGPU_ALIGNAS(64)
+        const iree_hal_amdgpu_device_buffer_ref_t* IREE_AMDGPU_RESTRICT
+            binding_table) {
+  if (buffer_ref.type == IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_SLOT) {
+    const iree_hal_amdgpu_device_buffer_ref_t binding =
+        binding_table[buffer_ref.value.slot];
+    const uint64_t offset = buffer_ref.offset + binding.offset;
+    buffer_ref = (iree_hal_amdgpu_device_workgroup_count_buffer_ref_t){
+        .type = binding.type,
+        .offset = offset,
+        .value.bits = binding.value.bits,
+    };
+  }
+  if (buffer_ref.type == IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE) {
+    buffer_ref.value.ptr = buffer_ref.value.handle->ptr;
+  }
+  return buffer_ref.value.ptr
+             ? (uint8_t*)buffer_ref.value.ptr + buffer_ref.offset
+             : NULL;
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/device/buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/buffer.h
@@ -1,0 +1,160 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_DEVICE_BUFFER_H_
+#define IREE_HAL_DRIVERS_AMDGPU_DEVICE_BUFFER_H_
+
+#include "iree/hal/drivers/amdgpu/device/support/common.h"
+
+typedef struct iree_hal_amdgpu_device_allocator_pool_t
+    iree_hal_amdgpu_device_allocator_pool_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_allocation_handle_t
+//===----------------------------------------------------------------------===//
+
+// Fat allocation pool identifier used to allow both the host and the device to
+// route to their respective pool implementations without lookups.
+typedef struct iree_hal_amdgpu_device_allocation_pool_id_t {
+  // Device-side pool in the memory space of the device that owns the
+  // allocation. Note that this may not be the local device.
+  iree_hal_amdgpu_device_allocator_pool_t* device_pool;
+  // Opaque host-side pool token.
+  uint64_t host_pool;
+} iree_hal_amdgpu_device_allocation_pool_id_t;
+
+// A handle for a dynamically device-allocated pointer.
+// The owner of the handle is responsible for storing it in device-visible
+// memory and consistently passing it in buffer references with the
+// IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE type. The device will dereference
+// the handle to get the actual pointer before using it. Device-side allocs and
+// frees will update the pointer in queue-order. The handle contents are only
+// valid on the device between an alloca/dealloca pair and we assume the client
+// code is not going to do something invalid (free and then try to use the
+// handle).
+//
+// Though the on-device allocator is usually responsible for manipulating the
+// handle there are cases where the host or a remote device may need to. For
+// example if the user has the last iree_hal_buffer_t reference and drops it
+// we'll need to enqueue a device-side deallocation to handle the cleanup. To
+// avoid extra round-trips we also optimize for host-side pool growth by
+// allowing the host to initialize the handle after it has grown a pool without
+// needing to requeue the device allocation.
+typedef struct iree_hal_amdgpu_device_allocation_handle_t {
+  // Allocated pointer, if any assigned.
+  void* ptr;
+  // Pool identifier the pointer resides in.
+  iree_hal_amdgpu_device_allocation_pool_id_t pool_id;
+  // Opaque data used by the allocator.
+  struct {
+    // TODO(benvanik): block the allocation resides in and other information
+    // the allocator needs to avoid lookups when deallocating.
+    int reserved;
+  } metadata;
+} iree_hal_amdgpu_device_allocation_handle_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_amdgpu_device_buffer_ref_t
+//===----------------------------------------------------------------------===//
+
+// Identifies the type of a buffer reference and how it should be resolved.
+typedef uint8_t iree_hal_amdgpu_device_buffer_type_t;
+enum iree_hal_amdgpu_device_buffer_type_e {
+  // Reference is to an absolute device pointer that can be directly accessed.
+  IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_PTR = 0u,
+  // Reference is to a queue-ordered allocation handle that is only valid at
+  // the time the buffer is committed. The handle will be valid for the lifetime
+  // of the logical buffer and any resources referencing it but the pointer must
+  // only be resolved between a corresponding alloca/dealloca.
+  IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE,
+  // Reference is to a slot in the binding table provided during execution.
+  // Only one indirection is allowed (table slots cannot reference other slots
+  // - yet).
+  IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_SLOT,
+};
+
+// The ordinal of a slot in the binding table.
+typedef uint32_t iree_hal_amdgpu_device_buffer_ordinal_t;
+
+// Describes a subrange of a buffer that can be bound to a binding slot.
+typedef struct iree_hal_amdgpu_device_buffer_ref_t {
+  // Offset, in bytes, into the buffer that the binding starts at.
+  // This will be added to the offset specified on each usage of the slot.
+  uint64_t offset;
+  // Type of the buffer reference used to resolve the device pointer.
+  uint64_t type : 2;
+  // Length, in bytes, of the buffer that is available to the executable.
+  uint64_t length : 62;
+  union {
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_PTR: device pointer.
+    void* ptr;
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE: queue-ordered allocation
+    // handle.
+    iree_hal_amdgpu_device_allocation_handle_t* handle;
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_SLOT: binding table slot.
+    iree_hal_amdgpu_device_buffer_ordinal_t slot;
+    // Used for setting the value.
+    uint64_t bits;
+  } value;
+} iree_hal_amdgpu_device_buffer_ref_t;
+static_assert(sizeof(iree_hal_amdgpu_device_buffer_ref_t) == 24,
+              "binding table entries should be 8 byte aligned");
+
+// Describes a buffer binding that contains a uint32_t[3] XYZ workgroup count.
+// This is a size-optimized version of iree_hal_amdgpu_device_buffer_ref_t so
+// that it will fit in our tiny packets. We know the length is a constant 12 and
+// only need the offset, type, and value.
+typedef struct iree_hal_amdgpu_device_workgroup_count_buffer_ref_t {
+  // Type of the buffer reference used to resolve the device pointer.
+  uint64_t type : 2;  // iree_hal_amdgpu_device_buffer_type_t
+  // Offset, in bytes, into the buffer that the binding starts at.
+  // This will be added to the offset specified on each usage of the slot.
+  uint64_t offset : 62;
+  union {
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_PTR: raw device pointer.
+    void* ptr;
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_HANDLE: queue-ordered allocation
+    // handle.
+    iree_hal_amdgpu_device_allocation_handle_t* handle;
+    // IREE_HAL_AMDGPU_DEVICE_BUFFER_TYPE_SLOT: binding table slot.
+    iree_hal_amdgpu_device_buffer_ordinal_t slot;
+    // Used for setting the value.
+    uint64_t bits;
+  } value;
+} iree_hal_amdgpu_device_workgroup_count_buffer_ref_t;
+static_assert(sizeof(iree_hal_amdgpu_device_workgroup_count_buffer_ref_t) == 16,
+              "binding table entries should be 8 byte aligned and tiny");
+
+#define iree_hal_amdgpu_device_workgroup_count_buffer_ref_length(buffer_ref) \
+  (sizeof(uint32_t) * 3)
+
+#if defined(IREE_AMDGPU_TARGET_DEVICE)
+
+// Resolves a buffer reference to an absolute device pointer.
+// Expects that the binding table is provided if needed and has sufficient
+// capacity for any slot that may be referenced. All queue-ordered allocations
+// that may be provided via allocation handles must be committed prior to
+// attempting to resolve them and must remain committed until all commands using
+// the returned device pointer have completed.
+void* iree_hal_amdgpu_device_buffer_ref_resolve(
+    iree_hal_amdgpu_device_buffer_ref_t buffer_ref,
+    IREE_AMDGPU_ALIGNAS(64)
+        const iree_hal_amdgpu_device_buffer_ref_t* IREE_AMDGPU_RESTRICT
+            binding_table);
+
+// Resolves a workgroup count buffer reference to an absolute device pointer.
+// This is equivalent to iree_hal_amdgpu_device_buffer_ref_resolve but for a
+// fixed-size uint32_t[3] value. The returned pointer should have 4-byte
+// alignment.
+void* iree_hal_amdgpu_device_workgroup_count_buffer_ref_resolve(
+    iree_hal_amdgpu_device_workgroup_count_buffer_ref_t buffer_ref,
+    IREE_AMDGPU_ALIGNAS(64)
+        const iree_hal_amdgpu_device_buffer_ref_t* IREE_AMDGPU_RESTRICT
+            binding_table);
+
+#endif  // IREE_AMDGPU_TARGET_DEVICE
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_DEVICE_BUFFER_H_


### PR DESCRIPTION
The driver will implement two buffer types to start (or more?): `iree_hal_amdgpu_external_buffer_t` and `iree_hal_amdgpu_transient_buffer_t`. The external buffer will be used for imported buffers and synchronous allocations (probably), while the transient buffer is used for all asynchronous allocations. The transient buffer maintains a reference to a device-accessible `iree_hal_amdgpu_device_allocation_handle_t` that stores the allocated pointer. The device-side allocator will update the handle as it allocates/deallocates and anyone resolving buffer pointers (e.g. `iree_hal_amdgpu_device_buffer_ref_resolve`) fetches the current pointer from the handle. The pointer is only valid between alloca/dealloca ops (which will set/reset the pointer).

`iree_hal_amdgpu_device_buffer_ref_t` is a variant that allows binding tables and command buffer ops to reference typed buffers. Most code can dereference device pointers (synchronously allocated buffers, imported buffers, etc) and the transient buffer handles. Command buffers can reference binding table slots with a relative offset/length. `iree_hal_amdgpu_device_workgroup_count_buffer_ref_t` is a special case for indirect dispatches (where the length is always known) as it packs better into space-constrained structs.

A simple `iree_hal_amdgpu_buffer_pool_t` handles both the host `iree_hal_buffer_t` instances and device allocation handles. The device allocation handles can be stored in device memory to avoid additional bus traffic on each dereference. In the steady state of invocations with alloca/dealloca the pool should remove all host/device allocations.