### PR TITLE
[Codegen] Add reshape map_scatter folding to BlockDynamicDimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TensorDynamicDimAnalysis.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
@@ -374,6 +375,7 @@ void BlockDynamicDimensionsPass::runOnOperation() {
     // "pushed-down" `tensor.collapse_shape` operation with their interface
     // bindings or `tensor.empty` operations.
     populateReshapeToInterfaceTensorPatterns(bubbleExpandShapePatterns);
+    populateCombineRelayoutOpPatterns(bubbleExpandShapePatterns);
     populateFoldTensorReshapeIntoBufferPatterns(bubbleExpandShapePatterns);
     tensor::populateFoldTensorEmptyPatterns(bubbleExpandShapePatterns);
     tensor::populateBubbleUpExpandShapePatterns(bubbleExpandShapePatterns);
@@ -409,6 +411,7 @@ void BlockDynamicDimensionsPass::runOnOperation() {
     // Add patterns to fold the remaining reshape operation with their interface
     // bindings or `tensor.empty` operations.
     populateReshapeToInterfaceTensorPatterns(removeBarrierOpsPatterns);
+    populateCombineRelayoutOpPatterns(removeBarrierOpsPatterns);
     populateFoldTensorReshapeIntoBufferPatterns(removeBarrierOpsPatterns);
     tensor::populateFoldTensorEmptyPatterns(removeBarrierOpsPatterns);
     linalg::FillOp::getCanonicalizationPatterns(removeBarrierOpsPatterns,

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -5,12 +5,109 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-common-transforms"
 
 namespace mlir::iree_compiler {
+
+//===----------------------------------------------------------------------===//
+// Combining Layout Transformation Ops
+//===----------------------------------------------------------------------===//
+
+/// Fold a tensor::ExpandShapeOp or tensor::CollapseShapeOp into a consumer
+/// `mapScatterOp`, by linearizing and then delinearizing the source indices
+/// of the `mapScatterOp`s index transformation.
+template <typename ReshapeOpTy>
+static IREE::LinalgExt::MapScatterOp
+foldReshapeIntoMapScatter(RewriterBase &rewriter, ReshapeOpTy reshapeOp,
+                          IREE::LinalgExt::MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == reshapeOp->getResult(0) &&
+         "expected reshapeOp to be the producer of mapScatterOp");
+  Location loc = reshapeOp->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfter(reshapeOp);
+  SmallVector<OpFoldResult> srcDims =
+      tensor::getMixedSizes(rewriter, loc, reshapeOp.getSrc());
+  // There can be leftover tensor.dim ops consuming the result of the reshape,
+  // but they are expected to be folded into some affine.apply ops on the source
+  // sizes by later cleanup patterns.
+  SmallVector<OpFoldResult> resultDims =
+      tensor::getMixedSizes(rewriter, loc, reshapeOp.getResult());
+
+  auto indexTransformBuilder =
+      [&](ArrayRef<BlockArgument> srcIndices) -> SmallVector<Value> {
+    auto linearizeIndexOp = rewriter.create<affine::AffineLinearizeIndexOp>(
+        mapScatterOp->getLoc(), srcIndices, srcDims, /*disjoint=*/true);
+    auto delinearizeIndexOp = rewriter.create<affine::AffineDelinearizeIndexOp>(
+        mapScatterOp->getLoc(), linearizeIndexOp.getResult(), resultDims,
+        /*hasOuterBound=*/true);
+    return delinearizeIndexOp->getResults();
+  };
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.insertTransformationAtStart(rewriter, indexTransformBuilder,
+                                             srcDims.size());
+    mapScatterOp.getInputMutable().assign(reshapeOp->getOperand(0));
+  });
+  return mapScatterOp;
+}
+
+IREE::LinalgExt::MapScatterOp
+foldExpandShapeIntoMapScatter(RewriterBase &rewriter,
+                              tensor::ExpandShapeOp expandShapeOp,
+                              IREE::LinalgExt::MapScatterOp mapScatterOp) {
+  return foldReshapeIntoMapScatter(rewriter, expandShapeOp, mapScatterOp);
+}
+
+IREE::LinalgExt::MapScatterOp
+foldCollapseShapeIntoMapScatter(RewriterBase &rewriter,
+                                tensor::CollapseShapeOp collapseShapeOp,
+                                IREE::LinalgExt::MapScatterOp mapScatterOp) {
+  return foldReshapeIntoMapScatter(rewriter, collapseShapeOp, mapScatterOp);
+}
+
+namespace {
+
+struct FoldExpandShapeIntoMapScatterPattern
+    : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
+  using OpRewritePattern<IREE::LinalgExt::MapScatterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
+                                PatternRewriter &rewriter) const override {
+    auto expandOp =
+        mapScatterOp.getInput().getDefiningOp<tensor::ExpandShapeOp>();
+    if (!expandOp) {
+      return failure();
+    }
+    (void)foldExpandShapeIntoMapScatter(rewriter, expandOp, mapScatterOp);
+    return success();
+  }
+};
+
+struct FoldCollapseShapeIntoMapScatterPattern
+    : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
+  using OpRewritePattern<IREE::LinalgExt::MapScatterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
+                                PatternRewriter &rewriter) const override {
+    auto collapseOp =
+        mapScatterOp.getInput().getDefiningOp<tensor::CollapseShapeOp>();
+    if (!collapseOp) {
+      return failure();
+    }
+    (void)foldCollapseShapeIntoMapScatter(rewriter, collapseOp, mapScatterOp);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateCombineRelayoutOpPatterns(RewritePatternSet &patterns) {
+  patterns.add<FoldCollapseShapeIntoMapScatterPattern,
+               FoldExpandShapeIntoMapScatterPattern>(patterns.getContext());
+}
 
 /// Converts `tensor.extract_slice(tensor.expand_shape)` to
 /// `tensor.expand_shape(tensor.extract_slice)`.

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -26,6 +26,22 @@ public:
   void notifyOperationReplaced(Operation *op, ValueRange replacement) override;
 };
 
+/// Fold a tensor::ExpandShapeOp into a consumer `mapScatterOp`, by linearizing
+/// and then delinearizing the source indices of the `mapScatterOp`s index
+/// transformation.
+IREE::LinalgExt::MapScatterOp
+foldExpandShapeIntoMapScatter(RewriterBase &rewriter,
+                              tensor::ExpandShapeOp expandShapeOp,
+                              IREE::LinalgExt::MapScatterOp mapScatterOp);
+
+/// Fold a tensor::CollapseShapeOp into a consumer `mapScatterOp`, by
+/// linearizing and then delinearizing the source indices of the
+/// `mapScatterOp`s index transformation.
+IREE::LinalgExt::MapScatterOp
+foldCollapseShapeIntoMapScatter(RewriterBase &rewriter,
+                                tensor::CollapseShapeOp collapseShapeOp,
+                                IREE::LinalgExt::MapScatterOp mapScatterOp);
+
 using IGEMMConfigFn =
     std::function<LogicalResult(linalg::GenericOp, IREE::LinalgExt::Im2colOp)>;
 using IGEMMControlFn = std::function<bool(Operation *)>;
@@ -93,6 +109,9 @@ void populateIREEResolveExtractStridedMetadataPatterns(
 void populateReplaceSlowMinMaxOpsPatterns(RewritePatternSet &patterns);
 
 void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns);
+
+/// Populate patterns to fold relayout operations into map_scatter ops.
+void populateCombineRelayoutOpPatterns(RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -399,3 +399,31 @@ func.func @check_bubble_up_patterns(%arg0 : tensor<4x32x?x32x?x32xf32>, %arg1 : 
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<4x32x?x32x?x32xf32>
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //       CHECK:   return %[[COLLAPSED]]
+
+// -----
+
+func.func @block_dims_with_map_scatter(%size: index) -> tensor<?xf32> {
+  %0 = util.assume.int %size<umin = 16, umax = 4080, udiv = 16> : index
+  %cst = arith.constant 0.0 : f32
+  %1 = tensor.empty(%0) : tensor<?xf32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>],
+                       iterator_types = ["parallel"]}
+                       outs(%1 : tensor<?xf32>) {
+  ^bb0(%out: f32):
+    linalg.yield %cst : f32
+  } -> tensor<?xf32>
+  %3 = iree_linalg_ext.map_scatter %2 into %1 {
+  ^bb0(%arg0: index):
+    %true = arith.constant true
+    iree_linalg_ext.yield %arg0, %true : index, i1
+  } : tensor<?xf32> into tensor<?xf32> -> tensor<?xf32>
+  return %3 : tensor<?xf32>
+}
+// Check that the reshapes are able to be folded into the map_scatter op
+//
+// CHECK-LABEL: func @block_dims_with_map_scatter(
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty{{.*}} tensor<?x16xf32>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:     outs(%[[EMPTY]] : tensor<?x16xf32>)
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//       CHECK:   return %[[MAP_SCATTER]]


### PR DESCRIPTION
Refactors the map_scatter folding transformations with tensor.collapse_shape and tensor.expand_shape into pattern rewrites, and adds the patterns to the BlockDynamicDimensions pass. This allows the CombineLayoutTransformation pass to be run before BlockDynamicDimensions, without creating additional reshapes in the IR.