### PR TITLE
[LLVMGPU] Add early bufferization pass to configuration pipieline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -13,6 +13,7 @@
 #include "compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUSelectUKernels.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
@@ -595,8 +596,11 @@ static FailureOr<SetVector<linalg::LinalgOp>>
 checkDispatchForVectorDistribution(mlir::FunctionOpInterface entryPoint) {
   SmallVector<Operation *> storeOps;
 
-  entryPoint.walk([&](IREE::TensorExt::DispatchTensorStoreOp op) {
-    storeOps.push_back(op.getOperation());
+  entryPoint.walk([&](Operation *op) {
+    if (isa<IREE::TensorExt::DispatchTensorStoreOp,
+            IREE::Codegen::StoreToBufferOp>(op)) {
+      storeOps.push_back(op);
+    }
   });
 
   if (storeOps.empty()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1226,6 +1226,7 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
     addCommonTargetExecutablePreprocessingPasses(funcPassManager);
     // This materializes into 'nop' in the absence of pad encoding layout
     // attributes.
+    funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass);
     funcPassManager.addPass(createBlockDynamicDimensionsPass);
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass);
     funcPassManager.addPass(createCSEPass);


### PR DESCRIPTION
Adds the `BufferizeDispatchTensorLoadStorePass` to the LLVMGPU configuration pipeline. One remaining instance of iree_tensor_ext.dispatch.tensor.store ops being matched for in KernelConfig is also fixed to additionally check for iree_codegen.store_to_buffer ops.

This will convert all `iree_tensor_ext.dispatch.tensor.load` and `iree_tensor_ext.dispatch.tensor.store` ops into `iree_codegen.load_from_buffer` and `iree_codegen.store_to_buffer` ops in LLVMGPU codegen. After this PR, the LLVMGPU codegen pipelines should not expect to see the tensor_ext ops anymore.