### PR TITLE
Only consider executables with no external variants for linking.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/link_executables.mlir
@@ -135,7 +135,10 @@ hal.executable private @executable1 {
 
 // -----
 
-hal.executable private @executable0 {
+// Tests that externally defined executables (no inner module) don't get linked
+// into internal ones (inner module).
+
+hal.executable private @internal_executable {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
     hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
@@ -143,7 +146,7 @@ hal.executable private @executable0 {
     }
   }
 }
-hal.executable private @executable1 {
+hal.executable private @external_executable {
   hal.executable.variant public @rocm_hsaco_fb_0 target(<"rocm", "rocm-hsaco-fb">) {
     hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
@@ -158,11 +161,14 @@ hal.executable private @executable1 {
 //       CHECK:   hal.executable.export public @export1
 //   CHECK-NOT:   hal.executable.export public @export0
 //       CHECK:   builtin.module
-// CHECK-LABEL: hal.executable private @executable0
+// CHECK-LABEL: hal.executable private @external_executable
 
 // -----
 
-hal.executable private @executable0 {
+// Tests that externally defined executables (no inner module) don't get linked
+// into internal ones (inner module).
+
+hal.executable private @internal_executable {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
     hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
@@ -172,7 +178,7 @@ hal.executable private @executable0 {
     }
   }
 }
-hal.executable private @executable1 {
+hal.executable private @external_executable {
   hal.executable.variant public @rocm_hsaco_fb_0 target(<"rocm", "rocm-hsaco-fb">) {
     hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
@@ -184,4 +190,40 @@ hal.executable private @executable1 {
 //       CHECK:   hal.executable.export public @export0
 //   CHECK-NOT:   hal.executable.export public @export1
 //       CHECK:   builtin.module
-// CHECK-LABEL: hal.executable private @executable1
+// CHECK-LABEL: hal.executable private @external_executable
+
+// -----
+
+// Tests that any variant being externally defined disables linking.
+hal.executable private @internal_executable {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+    }
+  }
+}
+hal.executable private @external_executable {
+  hal.executable.variant public @rocm_hsaco_fb_0 target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+  }
+  hal.executable.variant public @rocm_hsaco_fb_1 target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private
+//       CHECK:   hal.executable.export public @export0
+//   CHECK-NOT:   hal.executable.export public @export1
+//       CHECK:   builtin.module
+// CHECK-LABEL: hal.executable private @external_executable

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -228,16 +228,28 @@ LogicalResult linkExecutablesInto(
 
   // Iterate over all source executable ops, linking as many as we can.
   for (auto sourceExecutableOp : sourceExecutableOps) {
+    // All variants must be linkable in order to process the executable.
+    auto variantOps = llvm::to_vector(
+        sourceExecutableOp.getOps<IREE::HAL::ExecutableVariantOp>());
+    if (llvm::any_of(variantOps, [](auto variantOp) {
+          return !variantOp.getInnerModule();
+        })) {
+      continue; // 1+ variants without bodies
+    }
+
     // Remap root executable refs.
+    //
+    // NOTE: this is currently risky as we assume that all targets need to link
+    // consistently but there's nothing ensuring that here. If some targets
+    // decide to link some subset of variants and others don't we'll still have
+    // replaced the executable name here. We may have to ensure root executable
+    // names are never used at the time this runs, or perform the linking as a
+    // global pipeline that uses each TargetBackend to link instead of running
+    // it per-backend/pass.
     symbolReplacements.executableRefs[SymbolRefAttr::get(sourceExecutableOp)] =
         SymbolRefAttr::get(linkedExecutableOp);
 
-    auto variantOps = llvm::to_vector(
-        sourceExecutableOp.getOps<IREE::HAL::ExecutableVariantOp>());
     for (auto variantOp : variantOps) {
-      if (!variantOp.getInnerModule()) {
-        continue;
-      }
       // Only process compatible targets.
       // TODO(benvanik): allow for grouping when multi-versioning is supported?
       // We could, for example, link all aarch64 variants together and then


### PR DESCRIPTION
External variants now disable linking of all variants in an executable as we can't rename the root executable symbol unless all variants are linked. This is a design quirk that would be good to fix in the future if we end up with mixed executables. Today with hal.dispatch.extern outlining into executables with no bodies we don't have that case but it's possible for it to arise once we support linking of those (if linkable).