### PR TITLE
Translate flat operand index into segment relative index.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -218,6 +218,8 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp,
     // only for resources. operandIndex is in the mixed domain and we have to
     // calculate the corresponding resource domain index.
     auto operandIndex = dispatchOp.getTiedResultOperandIndex(resultIndex);
+    operandIndex =
+        *operandIndex - dispatchOp.getTiedOperandsIndexAndLength().first;
     assert(operandIndex.has_value() && "should have been tied above");
     unsigned resourceIndex = 0;
     for (unsigned i = 0; i < *operandIndex; ++i) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
@@ -16,9 +16,9 @@ util.func public @emplaceDispatch(
   // CHECK-DAG: %[[UNIFORM1:.+]] = arith.constant 456
   %uniform1 = arith.constant 456 : i32
   // CHECK: %[[UPDATE_END:.+]] = arith.addi %[[UPDATE_OFFSET]], %[[UPDATE_SIZE]]
-  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch(%[[UNIFORM0]], %[[INPUT]][%c0 to %[[INPUT_SIZE]] for %[[INPUT_SIZE]]], %[[UNIFORM1]], %[[TARGET]][%[[UPDATE_OFFSET]] to %[[UPDATE_END]] for %[[UPDATE_SIZE]]]) :
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch[%c0](%[[UNIFORM0]], %[[INPUT]][%c0 to %[[INPUT_SIZE]] for %[[INPUT_SIZE]]], %[[UNIFORM1]], %[[TARGET]][%[[UPDATE_OFFSET]] to %[[UPDATE_END]] for %[[UPDATE_SIZE]]]) :
   // CHECK-SAME: (i32, !stream.resource<*>{%[[INPUT_SIZE]]}, i32, !stream.resource<*>{%[[TARGET_SIZE]]}) -> %[[TARGET]]{%[[TARGET_SIZE]]}
-  %update = stream.async.dispatch @ex::@dispatch(%uniform0, %input[%c0 to %input_size for %input_size], %uniform1) : (i32, !stream.resource<*>{%input_size}, i32) -> !stream.resource<*>{%update_size}
+  %update = stream.async.dispatch @ex::@dispatch[%c0](%uniform0, %input[%c0 to %input_size for %input_size], %uniform1) : (i32, !stream.resource<*>{%input_size}, i32) -> !stream.resource<*>{%update_size}
   // NOTE: this gets hoisted above the dispatch.
   %update_end = arith.addi %update_offset, %update_size : index
   // CHECK-NOT: stream.async.update


### PR DESCRIPTION
All of our tests passed with this bug by virtue of having static shapes (and thus empty workloads) or by the stars aligning and the resource operands matching the non-resource uniform operands due to how dispatches are formed.

Fixes #21058.