### PR TITLE
Guard HIP macro against redefinition

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_headers.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_headers.h
@@ -11,7 +11,10 @@
 #error "32-bit not supported on HIP backend"
 #endif  // defined(IREE_PTR_SIZE_32)
 
+#if !defined(__HIP_PLATFORM_AMD__)
 #define __HIP_PLATFORM_AMD__
+#endif
+
 // Order matters here--hip_deprecated.h depends on hip_runtime_api.h. So turn
 // off clang-format.
 //


### PR DESCRIPTION
This is necessary for IREE to be built against the tracy with rocprof fork. The rocprof cmake module defines this macro; causing a redefinition error in IREE.

Tracy fork here: https://github.com/nod-ai/smutracy/tree/rocprofv3