### PR TITLE
[LLVMGPU] Enable hip e2e tests for map_scatter

### DIFF
--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -127,6 +127,7 @@ ROCM_HIP_SRCS = enforce_glob(
     # keep sorted
     [
         "gather.mlir",
+        "map_scatter.mlir",
         "scan.mlir",
         "scatter.mlir",
         "sort.mlir",
@@ -138,7 +139,6 @@ ROCM_HIP_SRCS = enforce_glob(
         "top-k.mlir",
         "attention.mlir",
         "attention_i1_mask.mlir",
-        "map_scatter.mlir",
     ],
 )
 

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -95,6 +95,7 @@ iree_check_single_backend_test_suite(
     check_rocm_hip
   SRCS
     "gather.mlir"
+    "map_scatter.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"


### PR DESCRIPTION
Enables the map_scatter op e2e tests for rocm, the `iree-llvmgpu-test-combine-layout-transformation` flag (from https://github.com/iree-org/iree/pull/21076) is not needed, since the map_scatter op is present in the input IR.