### PR TITLE
Add tiling interface to `tensor.concat`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h
@@ -28,7 +28,9 @@ class LinalgExtOp;
 
 namespace detail {
 LogicalResult verifyLinalgExtOpInterface(Operation *op);
-}
+} // namespace detail
+
+void registerConcatOpTilingInterfaceExternalModel(MLIRContext *ctx);
 
 /// Include the generated interface declarations.
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h.inc" // IWYU pragma: export

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -3093,4 +3093,120 @@ LogicalResult CustomOp::getResultTilePosition(
   return success();
 }
 
+//===---------------------------------------------------------------------===//
+// tensor::ConcatOp
+//===---------------------------------------------------------------------===//
+
+namespace {
+struct ConcatOpTilingExternalModel
+    : public TilingInterface::ExternalModel<ConcatOpTilingExternalModel,
+                                            tensor::ConcatOp> {
+  SmallVector<utils::IteratorType> getLoopIteratorTypes(Operation *op) const {
+    auto concatOp = cast<tensor::ConcatOp>(op);
+    SmallVector<utils::IteratorType> iteratorTypes(
+        concatOp.getResultType().getRank(), utils::IteratorType::parallel);
+    iteratorTypes[concatOp.getDim()] = utils::IteratorType::reduction;
+    return iteratorTypes;
+  }
+  SmallVector<Range> getIterationDomain(Operation *op,
+                                        OpBuilder &builder) const;
+  FailureOr<TilingResult>
+  getTiledImplementation(Operation *op, OpBuilder &builder,
+                         ArrayRef<OpFoldResult> offsets,
+                         ArrayRef<OpFoldResult> sizes) const;
+
+  FailureOr<TilingResult>
+  generateResultTileValue(Operation *op, OpBuilder &builder,
+                          unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+                          ArrayRef<OpFoldResult> sizes) const {
+    return getTiledImplementation(op, builder, offsets, sizes);
+  }
+
+  LogicalResult
+  getResultTilePosition(Operation *op, OpBuilder &builder,
+                        unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+                        ArrayRef<OpFoldResult> sizes,
+                        SmallVector<OpFoldResult> &resultOffsets,
+                        SmallVector<OpFoldResult> &resultSizes) const {
+    resultOffsets.assign(offsets.begin(), offsets.end());
+    resultSizes.assign(sizes.begin(), sizes.end());
+    return success();
+  }
+};
+} // namespace
+
+SmallVector<Range>
+ConcatOpTilingExternalModel::getIterationDomain(Operation *op,
+                                                OpBuilder &builder) const {
+  auto concatOp = cast<tensor::ConcatOp>(op);
+  Location loc = concatOp.getLoc();
+  OpFoldResult zero = builder.getIndexAttr(0);
+  OpFoldResult one = builder.getIndexAttr(1);
+  SmallVector<Range> ranges;
+  for (auto dim : llvm::seq<int64_t>(0, concatOp.getResultType().getRank())) {
+    if (dim != concatOp.getDim()) {
+      OpFoldResult size = getDim(builder, loc, concatOp.getOperand(0), dim);
+      ranges.push_back(Range{zero, size, one});
+      continue;
+    }
+    SmallVector<AffineExpr> exprs(concatOp.getNumOperands());
+    bindSymbolsList(builder.getContext(), MutableArrayRef<AffineExpr>(exprs));
+    AffineExpr sum = exprs.front();
+    for (auto expr : llvm::drop_begin(exprs)) {
+      sum = sum + expr;
+    }
+    SmallVector<OpFoldResult> concatedDims =
+        llvm::map_to_vector(concatOp.getOperands(), [&](Value operand) {
+          return getDim(builder, loc, operand, dim);
+        });
+    OpFoldResult size =
+        affine::makeComposedFoldedAffineApply(builder, loc, sum, concatedDims);
+    ranges.push_back(Range{zero, size, one});
+  }
+
+  return ranges;
+}
+
+FailureOr<TilingResult> ConcatOpTilingExternalModel::getTiledImplementation(
+    Operation *op, OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) const {
+  auto concatOp = cast<tensor::ConcatOp>(op);
+  Location loc = concatOp.getLoc();
+  uint64_t dim = concatOp.getDim();
+  RankedTensorType resultType = concatOp.getResultType();
+
+  // Don't support tiling along the concated dimension.
+  std::optional<int64_t> concatDimSize = getConstantIntValue(sizes[dim]);
+  if (!concatDimSize || concatDimSize.value() != resultType.getDimSize(dim)) {
+    return failure();
+  }
+
+  // Collect slices of each operand.
+  SmallVector<OpFoldResult> strides(resultType.getRank(),
+                                    builder.getI64IntegerAttr(1));
+  SmallVector<OpFoldResult> operandSizes(sizes);
+  operandSizes[dim] = getDim(builder, loc, concatOp.getOperand(0), dim);
+  SmallVector<Operation *> slices =
+      llvm::map_to_vector(concatOp.getOperands(), [&](Value operand) {
+        return getSlice(builder, loc, operand, offsets, operandSizes, strides);
+      });
+  SmallVector<Value> sliceValues = llvm::map_to_vector(
+      slices, [](Operation *slice) -> Value { return slice->getResult(0); });
+
+  // Create tiled `tensor.concat`.
+  SmallVector<int64_t> resultStaticShape;
+  SmallVector<Value> resultDynamicShape;
+  dispatchIndexOpFoldResults(sizes, resultDynamicShape, resultStaticShape);
+  auto newResultType = resultType.clone(resultStaticShape);
+  Operation *tiledConcatOp =
+      mlir::clone(builder, concatOp.getOperation(), TypeRange{newResultType},
+                  ValueRange(sliceValues));
+  return TilingResult{
+      {tiledConcatOp}, SmallVector<Value>(tiledConcatOp->getResults()), slices};
+}
+
+void registerConcatOpTilingInterfaceExternalModel(MLIRContext *ctx) {
+  tensor::ConcatOp::attachInterface<ConcatOpTilingExternalModel>(*ctx);
+}
+
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2740,3 +2740,63 @@ module attributes { transform.with_named_sequence } {
 // CHECK-NEXT:       ^bb0(%[[IDX:.+]]: index):
 //  CHECK-DAG:         %[[IDX_OFFSET:.+]] = affine.apply #[[MAP1]](%[[IDX]], %[[IV]])
 //      CHECK:         iree_linalg_ext.yield %[[IDX_OFFSET]], %[[TRUE]]
+
+// -----
+
+func.func @concat_dynamic(%arg0 : tensor<?x64xi32>, %arg1 : tensor<?x64xi32>) -> tensor<?x128xi32> {
+  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x64xi32>, tensor<?x64xi32>) -> tensor<?x128xi32>
+  return %0 : tensor<?x128xi32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.concat"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [10, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+//  CHECK-LABEL: func @concat_dynamic
+//   CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//   CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor
+//    CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//    CHECK-DAG:   %[[C10:.+]] = arith.constant 10
+//    CHECK-DAG:   %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//        CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[DIM]] step %[[C10]]
+//        CHECK:     %[[MIN:.+]] = affine.min
+//    CHECK-DAG:     %[[EXTRACT0:.+]] = tensor.extract_slice %[[ARG0]]
+//   CHECK-SAME:       [%[[I]], 0] [%[[MIN]], 64] [1, 1]
+//    CHECK-DAG:     %[[EXTRACT1:.+]] = tensor.extract_slice %[[ARG1]]
+//   CHECK-SAME:       [%[[I]], 0] [%[[MIN]], 64] [1, 1]
+//        CHECK:     tensor.concat dim(1) %[[EXTRACT0]], %[[EXTRACT1]]
+//   CHECK-SAME:       : (tensor<?x64xi32>, tensor<?x64xi32>) -> tensor<?x128xi32>
+
+// -----
+
+func.func @no_tile_concat_dynamic(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?x?xi32>) -> tensor<?x128xi32> {
+ // expected-error @below {{faild to tile operation}}
+ // expected-error @below {{failed to generate tiling loops}}
+  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x128xi32>
+  return %0 : tensor<?x128xi32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.concat"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [10, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @no_tile_concat_concated_dim(%arg0 : tensor<?x64xi32>, %arg1 : tensor<?x64xi32>) -> tensor<?x128xi32> {
+ // expected-error @below {{faild to tile operation}}
+ // expected-error @below {{failed to generate tiling loops}}
+  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x64xi32>, tensor<?x64xi32>) -> tensor<?x128xi32>
+  return %0 : tensor<?x128xi32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["tensor.concat"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [10, 64] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2771,11 +2771,11 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
-func.func @no_tile_concat_dynamic(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?x?xi32>) -> tensor<?x128xi32> {
+func.func @no_tile_concat_dynamic(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?x?xi32>) -> tensor<?x?xi32> {
  // expected-error @below {{faild to tile operation}}
  // expected-error @below {{failed to generate tiling loops}}
-  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x128xi32>
-  return %0 : tensor<?x128xi32>
+  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %0 : tensor<?x?xi32>
 }
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -174,7 +174,8 @@ static bool isRootOp(Operation *op) {
     return !isa<linalg::FillOp>(op);
   }
   if (isa<TilingInterface>(op)) {
-    return !isa<IREE::LinalgExt::GatherOp, tensor::PadOp, linalg::PackOp>(op);
+    return !isa<IREE::LinalgExt::GatherOp, tensor::PadOp, tensor::ConcatOp,
+                linalg::PackOp>(op);
   }
   return isa<linalg::UnPackOp>(op);
 }

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
@@ -129,6 +130,9 @@ void registerLinalgExtExternalModels(DialectRegistry &registry) {
 #include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
         >(ctx);
     linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
+    IREE::LinalgExt::registerConcatOpTilingInterfaceExternalModel(ctx);
   });
 }
 


### PR DESCRIPTION
Implements `TilingInterface` for `tensor.concat` by attaching an external model.