### PR TITLE
Adding _base variants of all string view int parsing and clean up hip options.

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -315,8 +315,9 @@ IREE_API_EXPORT iree_host_size_t iree_string_view_append_to_buffer(
 // perform. These _should_ never be on a hot path, though, so this keeps our
 // code size small.
 
-IREE_API_EXPORT bool iree_string_view_atoi_int32(iree_string_view_t value,
-                                                 int32_t* out_value) {
+IREE_API_EXPORT bool iree_string_view_atoi_int32_base(iree_string_view_t value,
+                                                      int base,
+                                                      int32_t* out_value) {
   // Copy to scratch memory with a NUL terminator.
   char temp[16] = {0};
   if (value.size >= IREE_ARRAYSIZE(temp)) return false;
@@ -335,8 +336,14 @@ IREE_API_EXPORT bool iree_string_view_atoi_int32(iree_string_view_t value,
   return parsed_value != 0 || errno == 0;
 }
 
-IREE_API_EXPORT bool iree_string_view_atoi_uint32(iree_string_view_t value,
-                                                  uint32_t* out_value) {
+IREE_API_EXPORT bool iree_string_view_atoi_int32(iree_string_view_t value,
+                                                 int32_t* out_value) {
+  return iree_string_view_atoi_int32_base(value, /*base=*/0, out_value);
+}
+
+IREE_API_EXPORT bool iree_string_view_atoi_uint32_base(iree_string_view_t value,
+                                                       int base,
+                                                       uint32_t* out_value) {
   // Copy to scratch memory with a NUL terminator.
   char temp[16] = {0};
   if (value.size >= IREE_ARRAYSIZE(temp)) return false;
@@ -345,15 +352,21 @@ IREE_API_EXPORT bool iree_string_view_atoi_uint32(iree_string_view_t value,
   // Attempt to parse.
   errno = 0;
   char* end = NULL;
-  unsigned long parsed_value = strtoul(temp, &end, 0);
+  unsigned long parsed_value = strtoul(temp, &end, base);
   if (temp == end) return false;
   if (parsed_value == ULONG_MAX && errno == ERANGE) return false;
   *out_value = (uint32_t)parsed_value;
   return parsed_value != 0 || errno == 0;
 }
 
-IREE_API_EXPORT bool iree_string_view_atoi_int64(iree_string_view_t value,
-                                                 int64_t* out_value) {
+IREE_API_EXPORT bool iree_string_view_atoi_uint32(iree_string_view_t value,
+                                                  uint32_t* out_value) {
+  return iree_string_view_atoi_uint32_base(value, /*base=*/0, out_value);
+}
+
+IREE_API_EXPORT bool iree_string_view_atoi_int64_base(iree_string_view_t value,
+                                                      int base,
+                                                      int64_t* out_value) {
   // Copy to scratch memory with a NUL terminator.
   char temp[32] = {0};
   if (value.size >= IREE_ARRAYSIZE(temp)) return false;
@@ -362,7 +375,7 @@ IREE_API_EXPORT bool iree_string_view_atoi_int64(iree_string_view_t value,
   // Attempt to parse.
   errno = 0;
   char* end = NULL;
-  long long parsed_value = strtoll(temp, &end, 0);
+  long long parsed_value = strtoll(temp, &end, base);
   if (temp == end) return false;
   if ((parsed_value == LLONG_MIN || parsed_value == LLONG_MAX) &&
       errno == ERANGE) {
@@ -370,6 +383,11 @@ IREE_API_EXPORT bool iree_string_view_atoi_int64(iree_string_view_t value,
   }
   *out_value = (int64_t)parsed_value;
   return parsed_value != 0 || errno == 0;
+}
+
+IREE_API_EXPORT bool iree_string_view_atoi_int64(iree_string_view_t value,
+                                                 int64_t* out_value) {
+  return iree_string_view_atoi_int64_base(value, /*base=*/0, out_value);
 }
 
 IREE_API_EXPORT bool iree_string_view_atoi_uint64_base(iree_string_view_t value,
@@ -392,7 +410,7 @@ IREE_API_EXPORT bool iree_string_view_atoi_uint64_base(iree_string_view_t value,
 
 IREE_API_EXPORT bool iree_string_view_atoi_uint64(iree_string_view_t value,
                                                   uint64_t* out_value) {
-  return iree_string_view_atoi_uint64_base(value, 0, out_value);
+  return iree_string_view_atoi_uint64_base(value, /*base=*/0, out_value);
 }
 
 IREE_API_EXPORT bool iree_string_view_atof(iree_string_view_t value,

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -232,10 +232,19 @@ IREE_API_EXPORT iree_host_size_t iree_string_view_append_to_buffer(
     iree_string_view_t source_value, iree_string_view_t* target_value,
     char* buffer);
 
+IREE_API_EXPORT bool iree_string_view_atoi_int32_base(iree_string_view_t value,
+                                                      int base,
+                                                      int32_t* out_value);
 IREE_API_EXPORT bool iree_string_view_atoi_int32(iree_string_view_t value,
                                                  int32_t* out_value);
+IREE_API_EXPORT bool iree_string_view_atoi_uint32_base(iree_string_view_t value,
+                                                       int base,
+                                                       uint32_t* out_value);
 IREE_API_EXPORT bool iree_string_view_atoi_uint32(iree_string_view_t value,
                                                   uint32_t* out_value);
+IREE_API_EXPORT bool iree_string_view_atoi_int64_base(iree_string_view_t value,
+                                                      int base,
+                                                      int64_t* out_value);
 IREE_API_EXPORT bool iree_string_view_atoi_int64(iree_string_view_t value,
                                                  int64_t* out_value);
 IREE_API_EXPORT bool iree_string_view_atoi_uint64_base(iree_string_view_t value,

--- a/runtime/src/iree/hal/drivers/hip/api.h
+++ b/runtime/src/iree/hal/drivers/hip/api.h
@@ -126,7 +126,7 @@ IREE_API_EXPORT void iree_hal_hip_device_params_initialize(
 typedef struct iree_hal_hip_driver_options_t {
   // The index of the default HIP device to use within the list of available
   // devices.
-  int default_device_index;
+  int32_t default_device_index;
 
   // List of paths to guide searching for the dynamic libamdhip64.so (or
   // amdhip64.dll), which contains the backing HIP runtime library. If this


### PR DESCRIPTION
A uint64 version was added awhile back but the rest were missing. C's strtol and co all take a base and this just passes that through. The non-_base methods assume 0 ("interpret from string") as before.

Also cleaned up hip driver int parsing code a bit (noticed while touching the string view functions).