### PR TITLE
[Encoding][LLVMGPU] Add encoding fusion e2e test

### DIFF
--- a/tests/e2e/encoding/BUILD.bazel
+++ b/tests/e2e/encoding/BUILD.bazel
@@ -19,6 +19,7 @@ iree_check_single_backend_test_suite(
     compiler_flags = [
         "--iree-global-opt-enable-early-materialization=false",
         "--iree-hip-encoding-layout-resolver=data-tiling",
+        "--iree-llvmgpu-test-combine-layout-transformation=true",
     ],
     driver = "hip",
     target_backend = "rocm",

--- a/tests/e2e/encoding/CMakeLists.txt
+++ b/tests/e2e/encoding/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-global-opt-enable-early-materialization=false"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
Adds a new data tiling encoding e2e test for a dispatch containing `unset_encoding -> elementwise -> set_encoding`. This uses the `iree-llvmgpu-test-combine-layout-transformation` test flag, and tests the ability for the LLVMGPU backend to handle the fusion case that arises when there are chained data-tiled matmuls.