### PR TITLE
Adding support for group_any in iree_thread_affinity_t.

### DIFF
--- a/runtime/src/iree/base/internal/threading.c
+++ b/runtime/src/iree/base/internal/threading.c
@@ -41,6 +41,13 @@ void iree_thread_affinity_set_any(iree_thread_affinity_t* out_thread_affinity) {
   memset(out_thread_affinity, 0x00, sizeof(*out_thread_affinity));
 }
 
+void iree_thread_affinity_set_group_any(
+    uint32_t group, iree_thread_affinity_t* out_thread_affinity) {
+  memset(out_thread_affinity, 0x00, sizeof(*out_thread_affinity));
+  out_thread_affinity->group_any = 1;
+  out_thread_affinity->group = group;
+}
+
 //==============================================================================
 // iree_thread_override_list_t
 //==============================================================================

--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -234,7 +234,9 @@ static void iree_task_flags_dump_task_topology(
     fprintf(stdout, "# group[%d]: '%s'\n", group->group_index, group->name);
     fprintf(stdout, "#      processor: %u\n", group->processor_index);
     fprintf(stdout, "#       affinity: ");
-    if (group->ideal_thread_affinity.specified) {
+    if (group->ideal_thread_affinity.group_any) {
+      fprintf(stdout, "group=%u (any)", group->ideal_thread_affinity.group);
+    } else if (group->ideal_thread_affinity.id_assigned) {
       fprintf(
           stdout, "group=%u, id=%u, smt=%u", group->ideal_thread_affinity.group,
           group->ideal_thread_affinity.id, group->ideal_thread_affinity.smt);

--- a/runtime/src/iree/task/topology_darwin.c
+++ b/runtime/src/iree/task/topology_darwin.c
@@ -213,8 +213,8 @@ iree_status_t iree_task_topology_initialize_from_physical_cores(
     // affinity info. Note that we pack "use efficiency cores only" into the SMT
     // bit and use that to force a QoS level that ensures only efficiency cores
     // are used when present. Probably.
-    group->ideal_thread_affinity.specified = 1;
     group->ideal_thread_affinity.group = (uint32_t)node_id;
+    group->ideal_thread_affinity.id_assigned = 1;
     group->ideal_thread_affinity.id = i;
     switch (performance_level) {
       default:

--- a/runtime/src/iree/task/topology_emscripten.c
+++ b/runtime/src/iree/task/topology_emscripten.c
@@ -54,7 +54,7 @@ iree_status_t iree_task_topology_initialize_from_logical_cpu_set(
     // really used on Linux today anyway.
     iree_thread_affinity_t* affinity = &group->ideal_thread_affinity;
     memset(affinity, 0, sizeof(*affinity));
-    affinity->specified = 1;
+    affinity->id_assigned = 1;
     affinity->id = cpu_ids[i];
   }
 


### PR DESCRIPTION
This allows code launching threads to specify that a thread should be assigned to a processor associated with a specific group (Windows GROUP_AFFINITY, Linux NUMA node ID, etc) instead of a specific processor within the group. This is useful for threads created in various parts of the codebase that don't globally coordinate (service workers/etc), while things like the task system that explicitly layout large collections of threads will continue to explicitly assign them.