### PR TITLE
[Codegen][GPU] Move operand promotion control to attribute interface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -154,8 +154,8 @@ struct GPUPromoteMatmulOperandsPass final
 
       std::optional<ArrayRef<Attribute>> maybePromotionTypes =
           getPromotionTypesList(loweringConfig);
-      if (maybePromotionTypes && maybePromotionTypes.value().size() !=
-                                     promotedOperands.value().size()) {
+      if (maybePromotionTypes &&
+          maybePromotionTypes->size() != promotedOperands->size()) {
         op->emitOpError(
             "promoted operand and promotion types lists size mismatch");
         return WalkResult::interrupt();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -111,29 +111,8 @@ void promoteResult(OpBuilder &builder, Operation *op, Value valToMakeShared) {
   });
 }
 
-/// Inserts a `linalg.copy` directly before the given operation on the
-/// specified operand, for example with operand index = 1:
-///
-///   %2 = linalg.matmul ins(%0, %1)
-///
-/// becomes
-///
-///   %empty = tensor.empty()
-///   %copy = linalg.copy %1 to %empty {
-///     lowering_config = #iree_gpu.{derived_thread_config|use_global_dma}}
-///   linalg.matmul ins(%0, %copy)
-///
-/// If the producer is already a tilable op, the producer is just annotated with
-/// #iree_gpu.derived_thread_config to indicate that it should be distributed
-/// to threads independently of the matmul.
-/// Additionally we can also promote results so in above example we will
-/// generate for index = 2 :
-///   %out_buffer = bufferization.alloc_tensor
-///   %copy1 = linalg.copy %2 to %out_buffer
-///   %copy2 = linalg.copy %copy1 to %empty {
-///     lowering_config = #iree_gpu.derived_thread_config}
 void promoteOperand(OpBuilder &builder, Operation *op, unsigned index,
-                    bool useDirectLoad) {
+                    IREE::GPU::PromotionAttr promotionAttr) {
   auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
   if (!dpsOp)
     return;
@@ -143,38 +122,12 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index,
     index -= dpsOp.getNumDpsInputs();
     assert(index < op->getNumResults() &&
            "trying to promote out of bound result index");
+    // TODO(qedawkins): Move result promotion to attribute interface.
     return promoteResult(builder, op, op->getResult(index));
   }
-  Value operand = op->getOperand(index);
+  OpOperand &operand = op->getOpOperand(index);
 
-  if (auto producer = operand.getDefiningOp<TilingInterface>()) {
-    // Skip promotion of fills.
-    if (isa<linalg::FillOp>(producer)) {
-      return;
-    }
-    if (auto generic = dyn_cast<linalg::GenericOp>(&*producer)) {
-      if (linalg::isaFillOpInterface(generic)) {
-        return;
-      }
-    }
-
-    // We only support thread tile size derivation of linalgOp and Im2colOp for
-    // now.
-    if (isa<linalg::LinalgOp, IREE::LinalgExt::Im2colOp>(
-            producer.getOperation())) {
-      setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
-                                      builder.getContext()));
-      return;
-    }
-  }
-
-  auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
-  if (!tensorType) {
-    return;
-  }
-
-  auto replacement =
-      promoteValue(builder, op->getLoc(), operand, useDirectLoad);
+  Value replacement = promotionAttr.promoteOperand(builder, operand);
   op->setOperand(index, replacement);
 }
 
@@ -186,32 +139,51 @@ struct GPUPromoteMatmulOperandsPass final
     FunctionOpInterface funcOp = getOperation();
 
     OpBuilder builder(funcOp);
-    funcOp.walk([&](Operation *op) {
+    WalkResult walkResult = funcOp.walk([&](Operation *op) {
       auto loweringConfig =
           getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
       if (!loweringConfig) {
-        return;
+        return WalkResult::advance();
       }
 
       std::optional<SmallVector<int64_t>> promotedOperands =
           getPromotedOperandList(loweringConfig);
       if (!promotedOperands) {
-        return;
+        return WalkResult::advance();
       }
 
-      SmallVector<bool> useDirectLoad =
-          getUseDirectLoad(loweringConfig)
-              .value_or(SmallVector<bool>(promotedOperands->size(), false));
+      std::optional<ArrayRef<Attribute>> maybePromotionTypes =
+          getPromotionTypesList(loweringConfig);
+      if (maybePromotionTypes && maybePromotionTypes.value().size() !=
+                                     promotedOperands.value().size()) {
+        op->emitOpError(
+            "promoted operand and promotion types lists size mismatch");
+        return WalkResult::interrupt();
+      }
+
+      Attribute derived =
+          IREE::GPU::DerivedThreadConfigAttr::get(op->getContext());
+      ArrayRef<Attribute> promotionTypes =
+          maybePromotionTypes.value_or(ArrayRef<Attribute>());
 
       builder.setInsertionPoint(op);
-      for (auto [operand, directLoadOperand] :
-           llvm::zip_equal(promotedOperands.value(), useDirectLoad)) {
-        // TODO: move switch `useDirectLoad` to the promotion attr list.
-        // Here using a command line option should be only a temporary
-        // solution.
-        promoteOperand(builder, op, operand, directLoadOperand);
+      for (auto [operand, maybePromotionType] :
+           llvm::zip_longest(promotedOperands.value(), promotionTypes)) {
+        auto promotionType = dyn_cast<IREE::GPU::PromotionAttr>(
+            maybePromotionType.value_or(derived));
+        if (!promotionType) {
+          op->emitOpError(
+              "promotion types does not implement promotion attr interface");
+          return WalkResult::interrupt();
+        }
+        promoteOperand(builder, op, operand.value(), promotionType);
       }
+      return WalkResult::advance();
     });
+
+    if (walkResult.wasInterrupted()) {
+      return signalPassFailure();
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -229,8 +229,17 @@ def GPUPipeliningPass :
 def GPUPromoteMatmulOperandsPass :
     InterfacePass<"iree-codegen-gpu-promote-matmul-operands",
                   "mlir::FunctionOpInterface"> {
-  let summary = "Pass to insert copies with a different thread configuration "
+  let summary = "Pass to insert copies with a different lowering configuration "
                 "on matmul operands";
+  let description = [{
+    Looks for all matmuls annotated with `promote_operands = I64Array` and
+    inserts copies on the specified operands with a thread lowering config
+    optimized for coalesced loads.
+
+    If the matmul is also annotated with `promotion_types = ArrayAttr`, the
+    logic for "promoting" an operand is deferred to an attribute interface
+    allowing for custom logic.
+  }];
   let dependentDialects = [
     "::mlir::bufferization::BufferizationDialect",
     "::mlir::gpu::GPUDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -104,6 +104,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:VectorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     MLIRSideEffectInterfaces
     MLIRSupport
     MLIRTensorDialect
+    MLIRTilingInterface
     MLIRVectorDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -117,7 +117,7 @@ FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
 }
 
 constexpr StringLiteral kPromoteOperandsName = "promote_operands";
-constexpr StringLiteral kDirectLoadOperandsName = "direct_load_operands";
+constexpr StringLiteral kPromotionTypesName = "promotion_types";
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config) {
   auto array = config.getAttributes().getAs<ArrayAttr>(kPromoteOperandsName);
@@ -127,37 +127,34 @@ getPromotedOperandList(LoweringConfigAttr config) {
   return getIntegerVector(array);
 }
 
-std::optional<SmallVector<bool>> getUseDirectLoad(LoweringConfigAttr config) {
-  auto array = config.getAttributes().getAs<ArrayAttr>(kDirectLoadOperandsName);
+std::optional<ArrayRef<Attribute>>
+getPromotionTypesList(LoweringConfigAttr config) {
+  auto array = config.getAttributes().getAs<ArrayAttr>(kPromotionTypesName);
   if (!array) {
     return std::nullopt;
   }
-  if (!llvm::all_of(array.getValue(), llvm::IsaPred<BoolAttr>)) {
-    return std::nullopt;
-  }
-  return llvm::map_to_vector(array.getValue(), [](Attribute s) -> bool {
-    return cast<BoolAttr>(s).getValue();
-  });
+  return array.getValue();
 }
 
 void appendPromotedOperandsList(MLIRContext *context,
                                 SmallVectorImpl<NamedAttribute> &attrs,
                                 ArrayRef<int64_t> operands,
-                                ArrayRef<bool> directLoadOperands) {
+                                ArrayRef<Attribute> promotionTypes) {
   Builder b(context);
   attrs.emplace_back(StringAttr::get(context, kPromoteOperandsName),
                      b.getI64ArrayAttr(operands));
-  if (!directLoadOperands.empty()) {
-    assert(directLoadOperands.size() == operands.size() &&
-           "Direct load operands size must match promoted operands size");
-    attrs.emplace_back(StringAttr::get(context, kDirectLoadOperandsName),
-                       b.getBoolArrayAttr(directLoadOperands));
+  if (!promotionTypes.empty()) {
+    assert(promotionTypes.size() == operands.size() &&
+           "Promotion types size must match promoted operands size");
+    attrs.emplace_back(StringAttr::get(context, kPromotionTypesName),
+                       b.getArrayAttr(promotionTypes));
   }
 }
 IREE::GPU::LoweringConfigAttr
 setPromotedOperandsList(MLIRContext *context,
                         IREE::GPU::LoweringConfigAttr currAttr,
-                        ArrayRef<int64_t> operands) {
+                        ArrayRef<int64_t> operands,
+                        std::optional<ArrayRef<Attribute>> promotionTypes) {
   Builder b(context);
   DictionaryAttr currAttributes = currAttr.getAttributes();
   NamedAttrList attributes(currAttributes);
@@ -171,6 +168,10 @@ setPromotedOperandsList(MLIRContext *context,
   Attribute newPromotedOperandsListAttr = b.getI64ArrayAttr(operands);
 
   attributes.set(kPromoteOperandsName, newPromotedOperandsListAttr);
+
+  if (promotionTypes) {
+    attributes.set(kPromotionTypesName, b.getArrayAttr(promotionTypes.value()));
+  }
   return IREE::GPU::LoweringConfigAttr::get(context,
                                             attributes.getDictionary(context));
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -26,7 +26,7 @@ IREE::GPU::MmaInterfaceAttr getMmaKind(LoweringConfigAttr config) {
 
 void setMmaKind(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
                 IREE::GPU::MmaInterfaceAttr kind) {
-  attrs.emplace_back(StringAttr::get(context, kMmaKindName), kind);
+  attrs.emplace_back(kMmaKindName, kind);
 }
 
 // TODO: Merge subgroup counts functionality into subgroup tiling level
@@ -56,7 +56,7 @@ void setSubgroupMCount(MLIRContext *context,
                        SmallVectorImpl<NamedAttribute> &attrs,
                        int64_t subgroup_m_count) {
   attrs.emplace_back(
-      StringAttr::get(context, kSubgroupMCountName),
+      kSubgroupMCountName,
       IntegerAttr::get(IntegerType::get(context, 64), subgroup_m_count));
 }
 
@@ -64,7 +64,7 @@ void setSubgroupNCount(MLIRContext *context,
                        SmallVectorImpl<NamedAttribute> &attrs,
                        int64_t subgroup_n_count) {
   attrs.emplace_back(
-      StringAttr::get(context, kSubgroupNCountName),
+      kSubgroupNCountName,
       IntegerAttr::get(IntegerType::get(context, 64), subgroup_n_count));
 }
 
@@ -88,7 +88,7 @@ void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
   Builder b(context);
   ArrayAttr basisAttr = b.getArrayAttr(
       {b.getI64ArrayAttr(basis.counts), b.getI64ArrayAttr(basis.mapping)});
-  attrs.emplace_back(b.getNamedAttr(getBasisLevelName(level), basisAttr));
+  attrs.emplace_back(getBasisLevelName(level), basisAttr);
 }
 
 FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
@@ -141,13 +141,11 @@ void appendPromotedOperandsList(MLIRContext *context,
                                 ArrayRef<int64_t> operands,
                                 ArrayRef<Attribute> promotionTypes) {
   Builder b(context);
-  attrs.emplace_back(StringAttr::get(context, kPromoteOperandsName),
-                     b.getI64ArrayAttr(operands));
+  attrs.emplace_back(kPromoteOperandsName, b.getI64ArrayAttr(operands));
   if (!promotionTypes.empty()) {
     assert(promotionTypes.size() == operands.size() &&
            "Promotion types size must match promoted operands size");
-    attrs.emplace_back(StringAttr::get(context, kPromotionTypesName),
-                       b.getArrayAttr(promotionTypes));
+    attrs.emplace_back(kPromotionTypesName, b.getArrayAttr(promotionTypes));
   }
 }
 IREE::GPU::LoweringConfigAttr

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -49,25 +49,25 @@ FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
 void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
               IREE::GPU::TilingLevel level, const Basis &basis);
 
-/// Helper to retrieve/set a list of operand indices to promote.
+/// Helper to retrieve a list of operand indices to promote.
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config);
-/// Helper to retrieve/set a list of booleans indicating whether the
-/// corresponding operand should use direct load.
-std::optional<SmallVector<bool>> getUseDirectLoad(LoweringConfigAttr config);
+/// Helper to retrieve a list of operand promotion types.
+std::optional<ArrayRef<Attribute>>
+getPromotionTypesList(LoweringConfigAttr config);
 /// Append to `attrs` an `ArrayAttr` for `promotedOperands`.
 /// The `directLoadOperands` is an optional list of booleans
 /// indicating whether the corresponding operand should use direct load.
 void appendPromotedOperandsList(MLIRContext *context,
                                 SmallVectorImpl<NamedAttribute> &attrs,
                                 ArrayRef<int64_t> operands,
-                                ArrayRef<bool> directLoadOperands = {});
+                                ArrayRef<Attribute> promotionTypes = {});
 /// Create a new `LoweringConfigAttr` from `currAttr` with the promoted operands
 /// list modified/set to `operands`.
-IREE::GPU::LoweringConfigAttr
-setPromotedOperandsList(MLIRContext *context,
-                        IREE::GPU::LoweringConfigAttr currAttr,
-                        ArrayRef<int64_t> operands);
+IREE::GPU::LoweringConfigAttr setPromotedOperandsList(
+    MLIRContext *context, IREE::GPU::LoweringConfigAttr currAttr,
+    ArrayRef<int64_t> operands,
+    std::optional<ArrayRef<Attribute>> promotionTypes = std::nullopt);
 
 /// Helper to retrieve  list of operand to pad.
 std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -56,14 +56,15 @@ getPromotedOperandList(LoweringConfigAttr config);
 std::optional<ArrayRef<Attribute>>
 getPromotionTypesList(LoweringConfigAttr config);
 /// Append to `attrs` an `ArrayAttr` for `promotedOperands`.
-/// The `directLoadOperands` is an optional list of booleans
-/// indicating whether the corresponding operand should use direct load.
+/// The `promotionTypes` is an optional list of Attributes
+/// describing how to promote each individual operand.
 void appendPromotedOperandsList(MLIRContext *context,
                                 SmallVectorImpl<NamedAttribute> &attrs,
                                 ArrayRef<int64_t> operands,
                                 ArrayRef<Attribute> promotionTypes = {});
 /// Create a new `LoweringConfigAttr` from `currAttr` with the promoted operands
-/// list modified/set to `operands`.
+/// list modified/set to `operands`. Optional `promotionTypes` specifies how to
+/// promote each operand.
 IREE::GPU::LoweringConfigAttr setPromotedOperandsList(
     MLIRContext *context, IREE::GPU::LoweringConfigAttr currAttr,
     ArrayRef<int64_t> operands,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -54,7 +54,8 @@ def IREEGPU_DerivedThreadConfig :
         "getStaticTilingLevelSizes",
         "getTilingLevelSizes",
         "hasTilingLevel",
-      ]>
+      ]>,
+      DeclareAttrInterfaceMethods<IREEGPU_PromotionAttr>
     ]> {
   let mnemonic = "derived_thread_config";
   let summary = [{
@@ -77,7 +78,8 @@ def IREEGPU_UseGlobalLoadDma :
         "getStaticTilingLevelSizes",
         "getTilingLevelSizes",
         "hasTilingLevel",
-      ]>
+      ]>,
+      DeclareAttrInterfaceMethods<IREEGPU_PromotionAttr>
     ]> {
   let mnemonic = "use_global_load_dma";
   let summary = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -6,7 +6,79 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+/// Helper to insert copy with the specified attr.
+Value promoteValue(OpBuilder &builder, Location loc, Value v, Attribute attr) {
+  auto tensorType = cast<RankedTensorType>(v.getType());
+  SmallVector<OpFoldResult> mixedSizes = tensor::getMixedSizes(builder, loc, v);
+
+  Value empty = builder.create<tensor::EmptyOp>(loc, mixedSizes,
+                                                tensorType.getElementType());
+  auto copy = builder.create<linalg::CopyOp>(loc, v, empty);
+  setLoweringConfig(copy, attr);
+  return copy.getResult(0);
+}
+
+/// Inserts a `linalg.copy` directly before the given operation on the
+/// specified operand, for example with operand index = 1:
+///
+///   %2 = linalg.matmul ins(%0, %1)
+///
+/// becomes
+///
+///   %empty = tensor.empty()
+///   %copy = linalg.copy %1 to %empty {
+///     lowering_config = #iree_gpu.{derived_thread_config|use_global_dma}}
+///   linalg.matmul ins(%0, %copy)
+///
+/// If the producer is already a tilable op, the producer is just annotated with
+/// the underlying attribute.
+/// Additionally we can also promote results so in above example we will
+/// generate for index = 2 :
+///   %out_buffer = bufferization.alloc_tensor
+///   %copy1 = linalg.copy %2 to %out_buffer
+///   %copy2 = linalg.copy %copy1 to %empty {
+///     lowering_config = #iree_gpu.derived_thread_config}
+Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
+                           Attribute attr) {
+  if (auto producer = operand.get().getDefiningOp<TilingInterface>()) {
+    // Skip promotion of fills.
+    if (isa<linalg::FillOp>(producer)) {
+      return operand.get();
+    }
+    if (auto generic = dyn_cast<linalg::GenericOp>(&*producer)) {
+      if (linalg::isaFillOpInterface(generic)) {
+        return operand.get();
+      }
+    }
+
+    // We only support thread tile size derivation of linalgOp and Im2colOp for
+    // now.
+    if (isa<linalg::LinalgOp, IREE::LinalgExt::Im2colOp>(
+            producer.getOperation())) {
+      setLoweringConfig(producer, attr);
+      return operand.get();
+    }
+  }
+
+  auto tensorType = dyn_cast<RankedTensorType>(operand.get().getType());
+  if (!tensorType) {
+    return operand.get();
+  }
+
+  return promoteValue(builder, operand.getOwner()->getLoc(), operand.get(),
+                      attr);
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp.inc"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h
@@ -15,6 +15,11 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
+namespace mlir::iree_compiler::IREE::GPU {
+Value defaultPromotionImpl(OpBuilder &builder, OpOperand &operand,
+                           Attribute attr);
+} // namespace mlir::iree_compiler::IREE::GPU
+
 // clang-format off
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h.inc"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -97,8 +97,8 @@ def IREEGPU_PromotionAttr
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
-        Promote the given operand. The operation owning the operand cannot be
-        changed by this method.
+        Returns the promoted operand. The operation owning the operand cannot be
+        modified by this method.
       }],
       /*retType=*/"::mlir::Value",
       /*methodName=*/"promoteOperand",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -86,4 +86,31 @@ def IREEGPU_AnyMmaAttr : Attr<Or<[
   let convertFromStorage = "$_self";
 }
 
+def IREEGPU_PromotionAttr
+    : AttrInterface<"PromotionAttr"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let description = [{
+    Interface used to control promotion of operands.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Promote the given operand. The operation owning the operand cannot be
+        changed by this method.
+      }],
+      /*retType=*/"::mlir::Value",
+      /*methodName=*/"promoteOperand",
+      /*args=*/(ins
+        "::mlir::OpBuilder&":$builder,
+        "::mlir::OpOperand&":$operand),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::mlir::iree_compiler::IREE::GPU::defaultPromotionImpl(builder, operand, $_attr);
+      }]
+    >,
+  ];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUINTERFACES

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -363,10 +363,12 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
                      b.getI64ArrayAttr(subgroupTileSizes));
   attrs.emplace_back(StringAttr::get(context, "mma_kind"), mmaKind);
   if (mustBeAligned) {
-    bool directLoadArray[] = {true, true};
-    ArrayRef<bool> directLoadOperands =
-        useDirectLoad ? directLoadArray : ArrayRef<bool>{};
-    GPU::appendPromotedOperandsList(context, attrs, {0, 1}, directLoadOperands);
+    Attribute useGlobalDma = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+    Attribute promotionArray[] = {useGlobalDma, useGlobalDma};
+    ArrayRef<Attribute> promotionTypes =
+        useDirectLoad ? ArrayRef<Attribute>(promotionArray)
+                      : ArrayRef<Attribute>{};
+    GPU::appendPromotedOperandsList(context, attrs, {0, 1}, promotionTypes);
   } else {
     // TODO (nirvedhmeshram, Max191, jerryyin) : Add support so that unaligned
     // shapes do not require c promotion.


### PR DESCRIPTION
Enables customized control over how to promote an operand by way of an attribute interface. This change is motivated by the growing set of operand promotion cases:

Existing
1. Common global -> LDS via a copy
2. global_load_dma

Upcoming
3. Setting cache swizzle values on promotion

Rather than growing the GPUPromoteMatmulOperands pass, an interface keeps different algorithms separate and opens up the possibility of target specific promotion logic in the future.