### PR TITLE
[Codegen][GPU] Sort intrinsic according to k alignment - Step 1 of 2- Track MmaInterfaceAttr via field instead of index

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -180,6 +180,7 @@ iree_compiler_cc_library(
         "GPUHeuristics.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -167,6 +167,7 @@ iree_cc_library(
     LLVMSupport
     MLIRIR
     MLIRSupport
+    iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -313,9 +313,8 @@ getBestKTileSizes(const GPUMatmulShapeType &problem,
 /// amount of data read from global memory, per workgroup, respecting the
 /// heuristic seeds.
 static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
-                                            const GPUMatmulShapeType &intrinsic,
-                                            const GPUMMAHeuristicSeeds &seeds,
-                                            uint64_t intrinsicIndex) {
+                                            const GPUIntrinsicType &intrinsic,
+                                            const GPUMMAHeuristicSeeds &seeds) {
   assert(intrinsic.mSizes.size() == 1 && intrinsic.nSizes.size() == 1 &&
          intrinsic.kSizes.size() == 1 &&
          "expected intrinsic to have a single M, N, and K dimension.");
@@ -406,24 +405,23 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
       getBestKTileSizes(problem, intrinsic, seeds);
 
   return GPUMMASchedule{
-      intrinsicIndex,      intrinsic.mSizes[0], intrinsic.nSizes[0],
+      intrinsic.mmaKind,   intrinsic.mSizes[0], intrinsic.nSizes[0],
       intrinsic.kSizes[0], mSubgroupCounts,     nSubgroupCounts,
       mTileSizes,          nTileSizes,          kTileSizes};
 }
 
 FailureOr<GPUMMASchedule> deduceMMASchedule(
-    const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
+    const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedLhs, bool transposedRhs,
     bool canUpcastAcc, bool mustBeAligned, bool doCPromotion) {
-  for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
+  for (auto intrinsic : intrinsics) {
     if (failed(canTargetIntrinsic(problem, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;
     }
 
-    GPUMMASchedule schedule =
-        getOptimalMMASchedule(problem, intrinsic, seeds, index);
+    GPUMMASchedule schedule = getOptimalMMASchedule(problem, intrinsic, seeds);
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
@@ -431,12 +429,9 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     });
 
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
-      int64_t lhsBitwidth =
-          intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
-      int64_t rhsBitwidth =
-          intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
-      int64_t resultBitwidth =
-          intrinsics[schedule.index].cType.getIntOrFloatBitWidth();
+      int64_t lhsBitwidth = intrinsic.aType.getIntOrFloatBitWidth();
+      int64_t rhsBitwidth = intrinsic.bType.getIntOrFloatBitWidth();
+      int64_t resultBitwidth = intrinsic.cType.getIntOrFloatBitWidth();
       bool isAligned =
           isValidMMASchedule(problem, schedule, mustBeAligned, subgroupSize,
                              transposedLhs, transposedRhs);
@@ -464,9 +459,10 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
 /// Choose an optimal attention PV schedule with the heuristic that minimized
 /// the total amount of data read from global memory, per workgroup, respecting
 /// the heuristic seeds.
-static GPUMMASchedule getOptimalAttentionPVSchedule(
-    const GPUMatmulShapeType &problem, const GPUMatmulShapeType &intrinsic,
-    const GPUMMAHeuristicSeeds &seeds, uint64_t intrinsicIndex) {
+static GPUMMASchedule
+getOptimalAttentionPVSchedule(const GPUMatmulShapeType &problem,
+                              const GPUIntrinsicType &intrinsic,
+                              const GPUMMAHeuristicSeeds &seeds) {
   assert(intrinsic.mSizes.size() == 1 && intrinsic.nSizes.size() == 1 &&
          intrinsic.kSizes.size() == 1 &&
          "expected intrinsic to have a single M, N, and K dimension.");
@@ -530,14 +526,14 @@ static GPUMMASchedule getOptimalAttentionPVSchedule(
       getBestKTileSizes(problem, intrinsic, seeds);
 
   return GPUMMASchedule{
-      intrinsicIndex,      intrinsic.mSizes[0], intrinsic.nSizes[0],
+      intrinsic.mmaKind,   intrinsic.mSizes[0], intrinsic.nSizes[0],
       intrinsic.kSizes[0], mSubgroupCounts,     nSubgroupCounts,
       mTileSizes,          nTileSizes,          kTileSizes};
 }
 
 FailureOr<GPUMMASchedule> deduceAttentionSchedule(
     const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
-    ArrayRef<GPUMatmulShapeType> intrinsics,
+    ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedQ, bool transposedK, bool transposedV,
     bool canUpcastAcc, bool mustBeAligned) {
@@ -545,7 +541,7 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
          pvMatmul.kSizes.size() == 1 && qkMatmul.mSizes.size() == 1 &&
          qkMatmul.nSizes.size() == 1 && qkMatmul.kSizes.size() == 1 &&
          "unimplemented: multi M/N/K attention schedule");
-  for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
+  for (auto intrinsic : intrinsics) {
     if (failed(canTargetIntrinsic(qkMatmul, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;
@@ -556,8 +552,8 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
       continue;
     }
 
-    GPUMMASchedule schedule = getOptimalAttentionPVSchedule(
-        pvMatmul, intrinsic, pvMatmulSeeds, index);
+    GPUMMASchedule schedule =
+        getOptimalAttentionPVSchedule(pvMatmul, intrinsic, pvMatmulSeeds);
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
@@ -570,7 +566,7 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
       // qkMatmul.M = pvMatmul.M
       // qkMatmul.N = pvMatmul.K
       // qkMatmul.K = problem.K
-      GPUMMASchedule qkSchedule{schedule.index,
+      GPUMMASchedule qkSchedule{schedule.mmaKind,
                                 schedule.mSize,
                                 schedule.kSize,
                                 intrinsicK,
@@ -589,10 +585,8 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
       bool isPVAligned = isValidMMASchedule(pvMatmul, schedule, mustBeAligned,
                                             subgroupSize, false, transposedV);
 
-      int64_t lhsBitwidth =
-          intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
-      int64_t rhsBitwidth =
-          intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
+      int64_t lhsBitwidth = intrinsic.aType.getIntOrFloatBitWidth();
+      int64_t rhsBitwidth = intrinsic.bType.getIntOrFloatBitWidth();
       int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
                                      qkSchedule, lhsBitwidth, rhsBitwidth) +
                                  calculateOperandsSharedMemoryUsedInBytes(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -415,7 +415,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedLhs, bool transposedRhs,
     bool canUpcastAcc, bool mustBeAligned, bool doCPromotion) {
-  for (auto intrinsic : intrinsics) {
+  for (const GPUIntrinsicType &intrinsic : intrinsics) {
     if (failed(canTargetIntrinsic(problem, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;
@@ -541,7 +541,7 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
          pvMatmul.kSizes.size() == 1 && qkMatmul.mSizes.size() == 1 &&
          qkMatmul.nSizes.size() == 1 && qkMatmul.kSizes.size() == 1 &&
          "unimplemented: multi M/N/K attention schedule");
-  for (auto intrinsic : intrinsics) {
+  for (const GPUIntrinsicType &intrinsic : intrinsics) {
     if (failed(canTargetIntrinsic(qkMatmul, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -31,7 +31,6 @@ struct GPUMatmulShapeType {
 
 /// Struct containing information about a GPU MMA intrinsic type.
 struct GPUIntrinsicType : public GPUMatmulShapeType {
-  // The MMA intrinsic kind to use for this schedule.
   IREE::GPU::MmaInterfaceAttr mmaKind;
   GPUIntrinsicType(int64_t m, int64_t n, int64_t k, Type a, Type b, Type c,
                    IREE::GPU::MmaInterfaceAttr kind)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "mlir/IR/Types.h"
 
 namespace mlir::iree_compiler {
@@ -28,6 +29,19 @@ struct GPUMatmulShapeType {
         cType(c) {}
 };
 
+/// Struct containing information about a GPU MMA intrinsic type.
+struct GPUIntrinsicType : public GPUMatmulShapeType {
+  // The MMA intrinsic kind to use for this schedule.
+  IREE::GPU::MmaInterfaceAttr mmaKind;
+  GPUIntrinsicType(int64_t m, int64_t n, int64_t k, Type a, Type b, Type c,
+                   IREE::GPU::MmaInterfaceAttr kind)
+      : GPUMatmulShapeType(m, n, k, a, b, c), mmaKind(kind) {}
+  GPUIntrinsicType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
+                   ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a, Type b,
+                   Type c, IREE::GPU::MmaInterfaceAttr kind)
+      : GPUMatmulShapeType(m, n, k, batch, a, b, c), mmaKind(kind) {}
+};
+
 /// Struct containing seed tile sizes for GPU MMA heuristics deduction logic.
 struct GPUMMAHeuristicSeeds {
   // The best number of subgroups to use per workgroup
@@ -43,8 +57,8 @@ struct GPUMMAHeuristicSeeds {
 };
 
 struct GPUMMASchedule {
-  // Index of the chosen intrinsic into the list of given MMA intrinsics
-  uint64_t index;
+  // The MMA intrinsic kind to use for this schedule.
+  IREE::GPU::MmaInterfaceAttr mmaKind;
   int64_t mSize; // Native MMA intrinsic size along M dimension for a subgroup.
   int64_t nSize; // Native MMA intrinsic size along N dimension for a subgroup.
   int64_t kSize; // Native MMA intrinsic size along K dimension for a subgroup.
@@ -62,22 +76,24 @@ struct GPUMMASchedule {
   SmallVector<int64_t> kTileSizes; // K tile sizes.
 
   // Constructor for multi M, N, K dim schedules.
-  GPUMMASchedule(uint64_t i, int64_t mIntrinsicSize, int64_t nIntrinsicSize,
-                 int64_t kIntrinsicSize, SmallVector<int64_t> mSubgroupCounts,
+  GPUMMASchedule(IREE::GPU::MmaInterfaceAttr kind, int64_t mIntrinsicSize,
+                 int64_t nIntrinsicSize, int64_t kIntrinsicSize,
+                 SmallVector<int64_t> mSubgroupCounts,
                  SmallVector<int64_t> nSubgroupCounts,
                  SmallVector<int64_t> mTileSizes,
                  SmallVector<int64_t> nTileSizes,
                  SmallVector<int64_t> kTileSizes)
-      : index(i), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
+      : mmaKind(kind), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
         kSize(kIntrinsicSize), mSubgroupCounts(mSubgroupCounts),
         nSubgroupCounts(nSubgroupCounts), mTileSizes(mTileSizes),
         nTileSizes(nTileSizes), kTileSizes(kTileSizes) {}
 
   // Constructor for single M, N, K dim schedules.
-  GPUMMASchedule(uint64_t i, int64_t mIntrinsicSize, int64_t nIntrinsicSize,
-                 int64_t kIntrinsicSize, int64_t mSubgroup, int64_t nSubgroup,
-                 int64_t mTileSize, int64_t nTileSize, int64_t kTileSize)
-      : index(i), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
+  GPUMMASchedule(IREE::GPU::MmaInterfaceAttr kind, int64_t mIntrinsicSize,
+                 int64_t nIntrinsicSize, int64_t kIntrinsicSize,
+                 int64_t mSubgroup, int64_t nSubgroup, int64_t mTileSize,
+                 int64_t nTileSize, int64_t kTileSize)
+      : mmaKind(kind), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
         kSize(kIntrinsicSize), mSubgroupCounts({mSubgroup}),
         nSubgroupCounts({nSubgroup}), mTileSizes({mTileSize}),
         nTileSizes({nTileSize}), kTileSizes({kTileSize}) {}
@@ -86,7 +102,7 @@ struct GPUMMASchedule {
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
 FailureOr<GPUMMASchedule> deduceMMASchedule(
-    const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
+    const GPUMatmulShapeType &problem, ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedLhs = false,
     bool transposedRhs = false, bool canUpcastAcc = false,
@@ -97,7 +113,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
 /// and |pvMatmul|. Returns std::nullopt if we cannot find such a schedule.
 FailureOr<GPUMMASchedule> deduceAttentionSchedule(
     const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
-    ArrayRef<GPUMatmulShapeType> intrinsics,
+    ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedQ = false, bool transposedK = true,
     bool transposedV = false, bool canUpcastAcc = false,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -883,12 +883,12 @@ setCooperativeMatrixConfig(IREE::GPU::TargetAttr target, linalg::LinalgOp op,
   // just the first element.
   GPUMatmulShapeType problem(dimM, dimN, dimK, lhsElem, rhsElem, initElem);
 
-  SmallVector<GPUMatmulShapeType> intrinsics;
+  SmallVector<GPUIntrinsicType> intrinsics;
   intrinsics.reserve(target.getWgp().getMma().size());
   for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
     auto [mSize, nSize, kSize] = mma.getMNKShape();
     auto [aType, bType, cType] = mma.getABCElementTypes();
-    intrinsics.emplace_back(mSize, nSize, kSize, aType, bType, cType);
+    intrinsics.emplace_back(mSize, nSize, kSize, aType, bType, cType, mma);
   }
 
   GPUMMAHeuristicSeeds seeds{numSubgroupsPerWorkgroup, numMNTilesPerSubgroup,

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -147,7 +147,7 @@ expandMapsAndIterators(SmallVector<AffineMap> &expandedMaps,
   }
 }
 
-static SmallVector<GPUMatmulShapeType>
+static SmallVector<GPUIntrinsicType>
 getIntrinsics(linalg::LinalgOp linalgOp,
               ArrayRef<IREE::HAL::ExecutableTargetAttr> executableTargets) {
   IREE::GPU::TargetAttr target;
@@ -166,7 +166,7 @@ getIntrinsics(linalg::LinalgOp linalgOp,
   return llvm::map_to_vector(mmaKinds, [](IREE::GPU::MMAAttr mma) {
     auto [mSize, nSize, kSize] = mma.getMNKShape();
     auto [aType, bType, cType] = mma.getABCElementTypes();
-    return GPUMatmulShapeType{mSize, nSize, kSize, aType, bType, cType};
+    return GPUIntrinsicType{mSize, nSize, kSize, aType, bType, cType, mma};
   });
 }
 
@@ -174,7 +174,7 @@ static void
 padConvOp(RewriterBase &rewriter, linalg::LinalgOp linalgOp,
           ArrayRef<IREE::HAL::ExecutableTargetAttr> executableTargets) {
   // Early exit if cannot find intrinsics or if multiple executable targets.
-  SmallVector<GPUMatmulShapeType> intrinsics =
+  SmallVector<GPUIntrinsicType> intrinsics =
       getIntrinsics(linalgOp, executableTargets);
   if (intrinsics.empty())
     return;
@@ -346,7 +346,7 @@ static void padContractionLikeOp(
   }
 
   // Early exit if cannot find intrinsics or if multiple executable targets.
-  SmallVector<GPUMatmulShapeType> intrinsics =
+  SmallVector<GPUIntrinsicType> intrinsics =
       getIntrinsics(linalgOp, executableTargets);
   if (intrinsics.empty())
     return;


### PR DESCRIPTION
This PR is NFC. This PR simplified the intrinsic derive process via:
 - Created a dedicated `GPUIntrinsicType` to differentiate from a `GPUMatmulShapeType`
   - This newly created  `GPUIntrinsicType` inherits from `GPUMatmulShapeType`
   - It keep track of the `MmaInterfaceAttr` directly in a field
 - Removed the need to track the intrinsic separately through a index like `intrinsicIndex`
   - The separately maintained index used reference only to the position of intrinsic, making it error prone. To sort and prioritize the intrinsic will have to keep track of the intrinsic before and after sorting.
   - Keeping track of intrinsic instead of index makes tracking much easier
 - Replaced the index field from `GPUMMASchedule` to `MmaInterfaceAttr` for the same reasoning

Sort intrinsic according to K alignment is dependent on this change to land. I break the NFC aspect of the feature into this PR so it is easier to do code reviews. For the convolution configurations that are not k-aligned by 16x16x16 intrinsic (but aligned with 32x32x8), this together with next PR will bring 5-10x perf lift.