### PR TITLE
[LinalgExt] fix arg_compare op with region and start index

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -913,7 +913,7 @@ TopkOp::reifyResultShapes(OpBuilder &b,
 // ArgmaxOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult ArgmaxOp::verify() {
+LogicalResult ArgCompareOp::verify() {
   Operation *op = getOperation();
 
   unsigned numInputVals = llvm::size(getInputs());
@@ -995,11 +995,7 @@ LogicalResult ArgmaxOp::verify() {
            << " and " << arg1Type;
   }
 
-  auto yieldOp = dyn_cast<IREE::LinalgExt::YieldOp>(block.getTerminator());
-  if (!yieldOp) {
-    return op->emitOpError("linalg_ext.yield is missing");
-  }
-
+  auto yieldOp = cast<IREE::LinalgExt::YieldOp>(block.getTerminator());
   unsigned numOperands = yieldOp->getNumOperands();
   if (numOperands != 1) {
     return op->emitOpError(
@@ -1016,9 +1012,8 @@ LogicalResult ArgmaxOp::verify() {
   return success();
 }
 
-LogicalResult
-ArgmaxOp::reifyResultShapes(OpBuilder &b,
-                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+LogicalResult ArgCompareOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   return cast<LinalgExtOp>(getOperation())
       .reifyResultShapes(b, reifiedReturnShapes);
 }
@@ -2447,7 +2442,7 @@ DEFINE_OP_GET_EFFECTS(SortOp)
 DEFINE_OP_GET_EFFECTS(FftOp)
 DEFINE_OP_GET_EFFECTS(ScanOp)
 DEFINE_OP_GET_EFFECTS(TopkOp)
-DEFINE_OP_GET_EFFECTS(ArgmaxOp)
+DEFINE_OP_GET_EFFECTS(ArgCompareOp)
 DEFINE_OP_GET_EFFECTS(PackOp)
 DEFINE_OP_GET_EFFECTS(UnPackOp)
 DEFINE_OP_GET_EFFECTS(WinogradInputTransformOp)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -923,15 +923,6 @@ LogicalResult ArgCompareOp::verify() {
            << numInputVals;
   }
 
-  TypedValue<IndexType> indexBase = getIndexBase();
-  if (indexBase) {
-    Type indexType = indexBase.getType();
-    if (!isa<IndexType>(indexType)) {
-      return op->emitOpError("index_base must be of index type, got: ")
-             << indexType;
-    }
-  }
-
   unsigned numOutputs = getNumDpsInits();
   if (numOutputs != 2) {
     return op->emitOpError(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -679,19 +679,21 @@ def IREELinalgExt_ArgmaxOp : IREELinalgExt_Op<"argmax", [
   let arguments = (ins
     Variadic<AnyShaped>:$inputs,
     Variadic<AnyShaped>:$outputs,
+    Optional<Index>:$index_base,
     I64Attr:$dimension
   );
 
   let results = (outs
     Variadic<AnyRankedTensor>:$results
   );
-
-let assemblyFormat = [{
+  let regions = (region AnyRegion:$region);
+  let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
-    (`:` type($results)^)?
+    (`index_base` `(` $index_base^ `:` type($index_base) `)`)?
+    $region (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -684,6 +684,39 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     This region defines the sorting rule, e.g., "greater than" for argmax or
     "less than" for argmin. It allows for generalization beyond simple argmax-style
     behavior.
+
+    Example (argmax over dim 1):
+
+    %input = memref<2x10xf32>
+    %out_val = memref<2xf32>
+    %out_idx = memref<2xi32>
+    iree_linalg_ext.arg_compare
+      dimension(1)
+      ins(%input : memref<2x10xf32>)
+      outs(%out_val, %out_idx : memref<2xf32>, memref<2xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+    }
+
+  Example with index_base = 5 (i.e., indices start counting from 5):
+
+    %input = memref<2x10xf32>
+    %out_val = memref<2xf32>
+    %out_idx = memref<2xi32>
+    %base = arith.constant 5 : index
+    iree_linalg_ext.arg_compare
+      dimension(1)
+      ins(%input : memref<2x10xf32>)
+      outs(%out_val, %out_idx : memref<2xf32>, memref<2xi32>)
+      index_base(%base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+    }
+
+  The `index_base` is optional. When specified, it is added to the selected index
+  in the result, which is useful when reducing over a tiled or sliced subregion.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -668,13 +668,22 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   }];
 }
 
-def IREELinalgExt_ArgmaxOp : IREELinalgExt_Op<"argmax", [
+def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
 ]> {
-  let summary = "Argmax reduction op.";
+  let summary = "Performs an arg-reduction using a user-defined comparator.";
   let description = [{
-    An argmax op that reduces along a given dimension, returning the max value and its index.
+    The `arg_compare` op performs a reduction over a given dimension of a tensor,
+    returning both the selected value and its corresponding index. The selection
+    logic is defined by a user-specified comparator region.
+
+    The comparator region receives two candidate values and returns a single `i1`
+    result indicating whether the first argument should be preferred over the second.
+
+    This region defines the sorting rule, e.g., "greater than" for argmax or
+    "less than" for argmin. It allows for generalization beyond simple argmax-style
+    behavior.
   }];
 
   let arguments = (ins
@@ -687,7 +696,7 @@ def IREELinalgExt_ArgmaxOp : IREELinalgExt_Op<"argmax", [
   let results = (outs
     Variadic<AnyRankedTensor>:$results
   );
-  let regions = (region AnyRegion:$region);
+  let regions = (region SizedRegion<1>:$region);
   let assemblyFormat = [{
     attr-dict
     `dimension` `(` $dimension `)`

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -669,6 +669,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 }
 
 def IREELinalgExt_ArgmaxOp : IREELinalgExt_Op<"argmax", [
+  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
 ]> {
   let summary = "Argmax reduction op.";

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -686,7 +686,7 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     behavior.
 
     Example (argmax over dim 1):
-
+    ```mlir
     %input = memref<2x10xf32>
     %out_val = memref<2xf32>
     %out_idx = memref<2xi32>
@@ -698,9 +698,10 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
       %cmp = arith.cmpf ogt, %a, %b : f32
       iree_linalg_ext.yield %cmp : i1
     }
+    ```
 
-  Example with index_base = 5 (i.e., indices start counting from 5):
-
+    Example with index_base = 5 (i.e., indices start counting from 5):
+    ```mlir
     %input = memref<2x10xf32>
     %out_val = memref<2xf32>
     %out_idx = memref<2xi32>
@@ -714,9 +715,10 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
       %cmp = arith.cmpf ogt, %a, %b : f32
       iree_linalg_ext.yield %cmp : i1
     }
+    ```
 
-  The `index_base` is optional. When specified, it is added to the selected index
-  in the result, which is useful when reducing over a tiled or sliced subregion.
+    The `index_base` is optional. When specified, it is added to the selected index
+    in the result, which is useful when reducing over a tiled or sliced subregion.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -568,14 +568,14 @@ func.func @map_scatter_wrong_num_yielded_values(
 
 // -----
 
-func.func @argmax_invalid_too_many_inputs(
+func.func @arg_compare_invalid_too_many_inputs(
     %input_val: tensor<2x10xf32>,
     %input_extra: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>
 ) -> (tensor<2xf32>, tensor<2xi32>) {
   // expected-error@+1 {{expected exactly one tensor input operand, but got 2}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val, %input_extra : tensor<2x10xf32>, tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
@@ -588,11 +588,11 @@ func.func @argmax_invalid_too_many_inputs(
 
 // -----
 
-func.func @argmax_invalid_missing_output(
+func.func @arg_compare_invalid_missing_output(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xi32>) {
   // expected-error@+1 {{expected two output operands (value and index), but got 1}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val : tensor<2xf32>) {
@@ -605,12 +605,12 @@ func.func @argmax_invalid_missing_output(
 
 // -----
 
-func.func @argmax_invalid_dim(
+func.func @arg_compare_invalid_dim(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
   // expected-error@+1 {{reduction dimension exceeds or equals input rank. got dimension: 2, but input rank is: 2}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(2)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2xf32>, tensor<2xi32>) {
@@ -623,12 +623,12 @@ func.func @argmax_invalid_dim(
 
 // -----
 
-func.func @argmax_invalid_type_mismatch(
+func.func @arg_compare_invalid_type_mismatch(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf16>,
     %out_idx: tensor<2xi32>) -> (tensor<2xf16>, tensor<2xi32>) {
   // expected-error@+1 {{input and output value element types must match. Input type: 'f32', output value type: 'f16'}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2xf16>, tensor<2xi32>) {
@@ -641,12 +641,12 @@ func.func @argmax_invalid_type_mismatch(
 
 // -----
 
-func.func @argmax_invalid_output_shape_mismatch(
+func.func @arg_compare_invalid_output_shape_mismatch(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2xf32>,
     %out_idx: tensor<10xi32>) -> (tensor<2xf32>, tensor<10xi32>) {
   // expected-error@+1 {{output indices/values shape must match. Output value shape: [2], output index shape: [10]}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2xf32>, tensor<10xi32>) {
@@ -659,12 +659,12 @@ func.func @argmax_invalid_output_shape_mismatch(
 
 // -----
 
-func.func @argmax_invalid_output_shape_wrong_reduction(
+func.func @arg_compare_invalid_output_shape_wrong_reduction(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<1xf32>,
     %out_idx: tensor<1xi32>) -> (tensor<1xf32>, tensor<1xi32>) {
   // expected-error@+1 {{output shape must match input shape with reduction dimension removed. Expected: [2], but got: [1]}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<1xf32>, tensor<1xi32>) {
@@ -677,12 +677,12 @@ func.func @argmax_invalid_output_shape_wrong_reduction(
 
 // -----
 
-func.func @argmax_invalid_output_same_as_input(
+func.func @arg_compare_invalid_output_same_as_input(
     %input_val: tensor<2x10xf32>,
     %out_val: tensor<2x10xf32>,
     %out_idx: tensor<2x10xi32>) -> (tensor<2x10xf32>, tensor<2x10xi32>) {
   // expected-error@+1 {{output shape must match input shape with reduction dimension removed. Expected: [2], but got: [2, 10]}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input_val : tensor<2x10xf32>)
     outs(%out_val, %out_idx : tensor<2x10xf32>, tensor<2x10xi32>) {
@@ -695,13 +695,13 @@ func.func @argmax_invalid_output_same_as_input(
 
 // -----
 
-func.func @argmax_missing_region_yield(
+func.func @arg_compare_missing_region_yield(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
   // expected-error@+1 {{region block should have 2 arguments}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {} -> tensor<2xf32>, tensor<2xindex>
@@ -710,13 +710,13 @@ func.func @argmax_missing_region_yield(
 
 // -----
 
-func.func @argmax_invalid_region_argument_type(
+func.func @arg_compare_invalid_region_argument_type(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
   // expected-error@+1 {{ comparator region arguments must match input element type. Expected: 'f32', but got: 'f32' and 'i32'}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {
@@ -729,12 +729,12 @@ func.func @argmax_invalid_region_argument_type(
 
 // -----
 
-func.func @argmax_missing_yield_operand(
+func.func @arg_compare_missing_yield_operand(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>, %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
   // expected-error@+1 {{expected linalg_ext.yield to return 1 operand, but got 0}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {
@@ -746,13 +746,13 @@ func.func @argmax_missing_yield_operand(
 
 // -----
 
-func.func @argmax_yield_two_operands(
+func.func @arg_compare_yield_two_operands(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
   // expected-error@+1 {{expected linalg_ext.yield to return 1 operand, but got 2}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {
@@ -766,13 +766,13 @@ func.func @argmax_yield_two_operands(
 
 // -----
 
-func.func @argmax_invalid_region_terminator(
+func.func @arg_compare_invalid_region_terminator(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
   // expected-error@+1 {{region block must end with a linalg_ext.yield i1, but got: 'f32'}}
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -785,6 +785,27 @@ func.func @arg_compare_invalid_region_terminator(
 
 // -----
 
+func.func @arg_compare_invalid_index_base_type(
+    %input: tensor<2x10xf32>,
+    %outv: tensor<2xf32>,
+    %outi: tensor<2xindex>,
+    %bad_index_base: i32
+) -> (tensor<2xf32>, tensor<2xindex>) {
+  // expected-error@+1 {{operand #3 must be index, but got 'i32'}}
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input : tensor<2x10xf32>)
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>)
+    index_base(%bad_index_base : i32) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xindex>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
+}
+
+// -----
+
 func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
   // expected-error@+1 {{expected one or two input operands}}
   %0:2 = iree_linalg_ext.topk

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -833,11 +833,11 @@ func.func @map_scatter_memref_static(
 
 // -----
 
-func.func @argmax_static(
+func.func @arg_compare_static(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>, %outi : tensor<2xindex>
 ) -> (tensor<2xf32>, tensor<2xindex>) {
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {
@@ -848,11 +848,11 @@ func.func @argmax_static(
   return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
 }
 
-// CHECK-LABEL: func.func @argmax_static(
+// CHECK-LABEL: func.func @arg_compare_static(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<2x6xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xindex>
-// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : tensor<2x6xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xindex>)
@@ -863,11 +863,11 @@ func.func @argmax_static(
 
 // -----
 
-func.func @argmax_dynamic(
+func.func @arg_compare_dynamic(
     %input : tensor<?x?xf32>,
     %outv : tensor<?xf32>, %outi : tensor<?xindex>
 ) -> (tensor<?xf32>, tensor<?xindex>) {
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<?x?xf32>)
     outs(%outv, %outi : tensor<?xf32>, tensor<?xindex>) {
@@ -878,11 +878,11 @@ func.func @argmax_dynamic(
   return %0#0, %0#1 : tensor<?xf32>, tensor<?xindex>
 }
 
-// CHECK-LABEL: func.func @argmax_dynamic(
+// CHECK-LABEL: func.func @arg_compare_dynamic(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<?xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<?xindex>
-// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : tensor<?x?xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<?xf32>, tensor<?xindex>)
@@ -893,11 +893,11 @@ func.func @argmax_dynamic(
 
 // -----
 
-func.func @argmax_static_memref(
+func.func @arg_compare_static_memref(
     %input : memref<2x6xf32>,
     %outv : memref<2xf32>, %outi : memref<2xindex>
 ) {
-  iree_linalg_ext.argmax
+  iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : memref<2x6xf32>)
     outs(%outv, %outi : memref<2xf32>, memref<2xindex>) {
@@ -908,11 +908,11 @@ func.func @argmax_static_memref(
   return
 }
 
-// CHECK-LABEL: func.func @argmax_static_memref(
+// CHECK-LABEL: func.func @arg_compare_static_memref(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: memref<2x6xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: memref<2xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: memref<2xindex>
-// CHECK:   iree_linalg_ext.argmax
+// CHECK:   iree_linalg_ext.arg_compare
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : memref<2x6xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : memref<2xf32>, memref<2xindex>)
@@ -922,11 +922,11 @@ func.func @argmax_static_memref(
 
 // -----
 
-func.func @argmax_dynamic_memref(
+func.func @arg_compare_dynamic_memref(
     %input : memref<?x?xf32>,
     %outv : memref<?xf32>, %outi : memref<?xindex>
 ) {
-  iree_linalg_ext.argmax
+  iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : memref<?x?xf32>)
     outs(%outv, %outi : memref<?xf32>, memref<?xindex>) {
@@ -937,11 +937,11 @@ func.func @argmax_dynamic_memref(
   return
 }
 
-// CHECK-LABEL: func.func @argmax_dynamic_memref(
+// CHECK-LABEL: func.func @arg_compare_dynamic_memref(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: memref<?x?xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: memref<?xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: memref<?xindex>
-// CHECK:   iree_linalg_ext.argmax
+// CHECK:   iree_linalg_ext.arg_compare
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : memref<?x?xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : memref<?xf32>, memref<?xindex>)
@@ -951,13 +951,13 @@ func.func @argmax_dynamic_memref(
 
 // -----
 
-func.func @argmax_with_base(
+func.func @arg_compare_with_base(
     %input : tensor<2x6xf32>,
     %outv : tensor<2xf32>,
     %outi : tensor<2xindex>,
     %base : index
 ) -> (tensor<2xf32>, tensor<2xindex>) {
-  %0:2 = iree_linalg_ext.argmax
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
     ins(%input : tensor<2x6xf32>)
     outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>)
@@ -969,12 +969,12 @@ func.func @argmax_with_base(
   return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
 }
 
-// CHECK-LABEL: func.func @argmax_with_base(
+// CHECK-LABEL: func.func @arg_compare_with_base(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<2x6xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xindex>
 // CHECK-SAME:   %[[BASE:[a-zA-Z0-9_]+]]: index
-// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.arg_compare
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : tensor<2x6xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xindex>)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -840,8 +840,11 @@ func.func @argmax_static(
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input : tensor<2x6xf32>)
-    outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>)
-    : tensor<2xf32>, tensor<2xindex>
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xindex>
   return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
 }
 
@@ -849,12 +852,14 @@ func.func @argmax_static(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<2x6xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xindex>
-//      CHECK:   %[[VAL:.+]]:2 = iree_linalg_ext.argmax
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : tensor<2x6xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xindex>)
-// CHECK-SAME:     : tensor<2xf32>, tensor<2xindex>
-//      CHECK:   return %[[VAL]]#0, %[[VAL]]#1 : tensor<2xf32>, tensor<2xindex>
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<2xf32>, tensor<2xindex>
 
 // -----
 
@@ -865,8 +870,11 @@ func.func @argmax_dynamic(
   %0:2 = iree_linalg_ext.argmax
     dimension(1)
     ins(%input : tensor<?x?xf32>)
-    outs(%outv, %outi : tensor<?xf32>, tensor<?xindex>)
-    : tensor<?xf32>, tensor<?xindex>
+    outs(%outv, %outi : tensor<?xf32>, tensor<?xindex>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<?xf32>, tensor<?xindex>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?xindex>
 }
 
@@ -874,12 +882,14 @@ func.func @argmax_dynamic(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 // CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<?xf32>
 // CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<?xindex>
-//      CHECK:   %[[VAL:.+]]:2 = iree_linalg_ext.argmax
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : tensor<?x?xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<?xf32>, tensor<?xindex>)
-// CHECK-SAME:     : tensor<?xf32>, tensor<?xindex>
-//      CHECK:   return %[[VAL]]#0, %[[VAL]]#1 : tensor<?xf32>, tensor<?xindex>
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<?xf32>, tensor<?xindex>
 
 // -----
 
@@ -890,10 +900,13 @@ func.func @argmax_static_memref(
   iree_linalg_ext.argmax
     dimension(1)
     ins(%input : memref<2x6xf32>)
-    outs(%outv, %outi : memref<2xf32>, memref<2xindex>)
+    outs(%outv, %outi : memref<2xf32>, memref<2xindex>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  }
   return
 }
-
 
 // CHECK-LABEL: func.func @argmax_static_memref(
 // CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: memref<2x6xf32>
@@ -903,6 +916,73 @@ func.func @argmax_static_memref(
 // CHECK-SAME:     dimension(1)
 // CHECK-SAME:     ins(%[[INPUT]] : memref<2x6xf32>)
 // CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : memref<2xf32>, memref<2xindex>)
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+
+// -----
+
+func.func @argmax_dynamic_memref(
+    %input : memref<?x?xf32>,
+    %outv : memref<?xf32>, %outi : memref<?xindex>
+) {
+  iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input : memref<?x?xf32>)
+    outs(%outv, %outi : memref<?xf32>, memref<?xindex>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @argmax_dynamic_memref(
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: memref<?x?xf32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: memref<?xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: memref<?xindex>
+// CHECK:   iree_linalg_ext.argmax
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]] : memref<?x?xf32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : memref<?xf32>, memref<?xindex>)
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+
+// -----
+
+func.func @argmax_with_base(
+    %input : tensor<2x6xf32>,
+    %outv : tensor<2xf32>,
+    %outi : tensor<2xindex>,
+    %base : index
+) -> (tensor<2xf32>, tensor<2xindex>) {
+  %0:2 = iree_linalg_ext.argmax
+    dimension(1)
+    ins(%input : tensor<2x6xf32>)
+    outs(%outv, %outi : tensor<2xf32>, tensor<2xindex>)
+    index_base(%base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<2xf32>, tensor<2xindex>
+  return %0#0, %0#1 : tensor<2xf32>, tensor<2xindex>
+}
+
+// CHECK-LABEL: func.func @argmax_with_base(
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]: tensor<2x6xf32>
+// CHECK-SAME:   %[[OUTV:[a-zA-Z0-9_]+]]: tensor<2xf32>
+// CHECK-SAME:   %[[OUTI:[a-zA-Z0-9_]+]]: tensor<2xindex>
+// CHECK-SAME:   %[[BASE:[a-zA-Z0-9_]+]]: index
+// CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.argmax
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]] : tensor<2x6xf32>)
+// CHECK-SAME:     outs(%[[OUTV]], %[[OUTI]] : tensor<2xf32>, tensor<2xindex>)
+// CHECK-SAME:     index_base(%[[BASE]] : index)
+// CHECK:   ^bb0(%[[A:.+]]: f32, %[[B:.+]]: f32):
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[A]], %[[B]] : f32
+// CHECK:     iree_linalg_ext.yield %[[CMP]] : i1
+// CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1 : tensor<2xf32>, tensor<2xindex>
 
 // -----
 


### PR DESCRIPTION
This is a follow-up PR to address feedback on the previously landed PR for the argmax op #21021 according to comments in https://github.com/iree-org/iree/pull/21021#discussion_r2143962580: 
- Adds support for a comparator region in the arg_compare (argmax) op
- Introduces an optional index_base operand to specify the starting index offset.