### PR TITLE
 [Codegen][GPU] Add a inner tiled op descriptor for scaled MMA

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1445,7 +1445,7 @@ void ScaledMMAAttr::getUndistributedTileTypes(
   int64_t m = lhsLayout.outer[0] * lhsLayout.thread[0] * lhsLayout.element[0];
   int64_t kScale =
       lhsLayout.outer[1] * lhsLayout.thread[1] * lhsLayout.element[1];
-  int64_t layoutBlockSize =
+  [[maybe_unused]] int64_t layoutBlockSize =
       lhsLayout.outer[2] * lhsLayout.thread[2] * lhsLayout.element[2];
   assert(blockSize == layoutBlockSize &&
          "expected block size to be set up correctly");

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1326,6 +1326,263 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
 }
 
 //===----------------------------------------------------------------------===//
+// ScaledMMA Attributes
+//===----------------------------------------------------------------------===//
+
+int64_t ScaledMMAAttr::getExpectedNumInputs() const { return 4; }
+
+int64_t ScaledMMAAttr::getExpectedNumOutputs() const { return 1; }
+
+MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
+                                                int64_t operandIndex) {
+  const MMASingleSubgroupLayout mfmaAcc16x16 = {
+      /*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+      /*element=*/{4, 1}};
+  const MMASingleSubgroupLayout mfmaAcc32x32 = {
+      /*outer=*/{4, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
+      /*element=*/{4, 1}};
+
+  switch (intrinsic) {
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+    switch (operandIndex) {
+    case 0: // LHS
+      return {/*outer=*/{1, 1, 1}, /*thread=*/{16, 4, 1},
+              /*tstrides=*/{1, 16, 1},
+              /*element=*/{1, 1, 32}};
+    case 1: // LHS scales
+      return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
+              /*element=*/{1, 1}};
+    case 2: // RHS
+      return {/*outer=*/{1, 1, 1}, /*thread=*/{4, 1, 16},
+              /*tstrides=*/{16, 1, 1},
+              /*element=*/{1, 32, 1}};
+    case 3: // RHS scale
+      return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
+              /*element=*/{1, 1}};
+    case 4: // acc
+      return mfmaAcc16x16;
+    }
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
+    switch (operandIndex) {
+    case 0: // LHS
+      return {/*outer=*/{1, 1, 1}, /*thread=*/{32, 2, 1},
+              /*tstrides=*/{1, 32, 1},
+              /*element=*/{1, 1, 32}};
+    case 1: // LHS scales
+      return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*tstrides=*/{1, 32},
+              /*element=*/{1, 1}};
+    case 2: // RHS
+      return {/*outer=*/{1, 1, 1}, /*thread=*/{2, 1, 32},
+              /*tstrides=*/{32, 1, 1},
+              /*element=*/{1, 32, 1}};
+    case 3: // RHS scales
+      return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
+              /*element=*/{1, 1}};
+    case 4: // Acc
+      return mfmaAcc32x32;
+    }
+  }
+  assert(false && "Unhandled scaled MMA intrinsic");
+  return {};
+}
+
+int64_t ScaledMMAAttr::getBlockSize() const {
+  switch (getIntrinsic()) {
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
+    return 32;
+  }
+  assert(false &&
+         "all cases should'vee been handled in ScaledMMA::getBlockSize()");
+  return 0;
+}
+
+int64_t ScaledMMAAttr::getSubgroupSize() const {
+  switch (getIntrinsic()) {
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
+    return 64;
+  }
+  assert(false &&
+         "all cases should'vee been handled in ScaledMMA::getBlockSize()");
+  return 0;
+}
+
+LogicalResult
+ScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
+  if (failed(verifyMmaIndexingMaps({maps[0], maps[2], maps[4]}))) {
+    return failure();
+  }
+
+  SmallVector<llvm::SmallDenseSet<AffineExpr, 4>> resExprs(
+      maps.size(), llvm::SmallDenseSet<AffineExpr, 4>());
+  for (auto [set, map] : llvm::zip_equal(resExprs, maps)) {
+    set.insert_range(map.getResults());
+  }
+  // Note: the below conditions are a best guess and may be too strict.
+
+  // Check LHS scales aren't using indexes that LHS isn't.
+  if (llvm::any_of(resExprs[1],
+                   [&](auto e) { return !resExprs[0].contains(e); })) {
+    return failure();
+  }
+  // Check RHS scales aren't using indexes that RHS isn't.
+  if (llvm::any_of(resExprs[3],
+                   [&](auto e) { return !resExprs[2].contains(e); })) {
+    return failure();
+  }
+  return success();
+}
+
+void ScaledMMAAttr::getUndistributedTileTypes(
+    SmallVectorImpl<VectorType> &results) const {
+  MMASingleSubgroupLayout lhsLayout =
+      getSingleSubgroupLayout(getIntrinsic(), 0);
+  MMASingleSubgroupLayout rhsLayout =
+      getSingleSubgroupLayout(getIntrinsic(), 2);
+
+  int64_t blockSize = getBlockSize();
+  int64_t m = lhsLayout.outer[0] * lhsLayout.thread[0] * lhsLayout.element[0];
+  int64_t kScale =
+      lhsLayout.outer[1] * lhsLayout.thread[1] * lhsLayout.element[1];
+  int64_t layoutBlockSize =
+      lhsLayout.outer[2] * lhsLayout.thread[2] * lhsLayout.element[2];
+  assert(blockSize == layoutBlockSize &&
+         "expected block size to be set up correctly");
+  int64_t n = rhsLayout.outer[2] * rhsLayout.thread[2] * rhsLayout.element[2];
+
+  Type lhsType = getLhsElemType();
+  Type rhsType = getRhsElemType();
+  Type accType = getAccElemType();
+  Type scaleType = Float8E8M0FNUType::get(getContext());
+
+  results.push_back(VectorType::get({m, kScale, blockSize}, lhsType));
+  results.push_back(VectorType::get({m, kScale}, scaleType));
+  results.push_back(VectorType::get({kScale, blockSize, n}, rhsType));
+  results.push_back(VectorType::get({kScale, n}, scaleType));
+  results.push_back(VectorType::get({m, n}, accType));
+}
+
+void ScaledMMAAttr::getDistributedTileTypes(
+    SmallVectorImpl<VectorType> &results) const {
+  Type lhsType = getLhsElemType();
+  Type rhsType = getRhsElemType();
+  Type accType = getAccElemType();
+  Type scaleType = Float8E8M0FNUType::get(getContext());
+
+  std::array<Type, 5> argTypes = {lhsType, scaleType, rhsType, scaleType,
+                                  accType};
+  for (auto [opIndex, type] : llvm::enumerate(argTypes)) {
+    MMASingleSubgroupLayout layout =
+        getSingleSubgroupLayout(getIntrinsic(), opIndex);
+    int64_t outer = ShapedType::getNumElements(layout.outer);
+    int64_t element = ShapedType::getNumElements(layout.element);
+    results.push_back(VectorType::get({outer * element}, type));
+  }
+}
+
+Attribute ScaledMMAAttr::getDistributionMappingKind() const {
+  return IREE::GPU::LaneIdAttr::get(getContext(), 0);
+}
+
+OpFoldResult ScaledMMAAttr::getDistributionWorkerCount(OpBuilder &, Location,
+                                                       Operation *) const {
+  return getAsIndexOpFoldResult(getContext(), getSubgroupSize());
+}
+
+LogicalResult ScaledMMAAttr::populateOperandOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, uint32_t operandIndex, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
+    SmallVectorImpl<OpFoldResult> &sizes,
+    SmallVectorImpl<OpFoldResult> &strides) const {
+  assert(operandIndex <= 4 && "Scaled MFMA has 5 operands");
+
+  MMASingleSubgroupLayout subgroupLayout =
+      getSingleSubgroupLayout(getIntrinsic(), operandIndex);
+  if (operandIndex == 4 && getColMajor()) {
+    std::swap(subgroupLayout.outer[0], subgroupLayout.outer[1]);
+    std::swap(subgroupLayout.thread[0], subgroupLayout.thread[1]);
+    std::swap(subgroupLayout.tstrides[0], subgroupLayout.tstrides[1]);
+    std::swap(subgroupLayout.element[0], subgroupLayout.element[1]);
+  }
+  SmallVector<OpFoldResult> canonicalOffsets;
+  SmallVector<OpFoldResult> canonicalSizes;
+  if (failed(populateCanonicalOffsetsSizesAndStrides(
+          builder, loc, laneId, permutation, subgroupLayout, canonicalOffsets,
+          canonicalSizes, strides))) {
+    return failure();
+  }
+  offsets.append(canonicalOffsets);
+  sizes.append(canonicalSizes);
+
+  return success();
+}
+
+LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
+    OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
+    SmallVectorImpl<Value> &results) const {
+  if (inputs.size() != 4) {
+    return failure();
+  }
+  if (outputs.size() != 1) {
+    return failure();
+  }
+  SmallVector<VectorType> threadTypes;
+  getDistributedTileTypes(threadTypes);
+  if (!llvm::equal(threadTypes,
+                   llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
+    return failure();
+  }
+
+  SmallVector<VectorType> subgroupTypes;
+  getUndistributedTileTypes(subgroupTypes);
+
+  // Note to data tiling people: the scales argument is given as a vector of 4
+  // scales + a constant selector to say which byte in the vector is to be used.
+  // This'll allow better value reuse, hence why we extend to 4-vectors
+  // instead of clamping to scalars here.
+
+  FloatType f8E8M0 = builder.getF8E8M0Type();
+  Value zeroScales = builder.create<arith::ConstantOp>(
+      loc, SplatElementsAttr::get(
+               VectorType::get({4}, f8E8M0),
+               llvm::APFloat::getSmallest(f8E8M0.getFloatSemantics())));
+  auto padScales = [&](Value scales) {
+    Value scale = builder.create<vector::ExtractOp>(loc, scales, 0);
+    Value padded = builder.create<vector::InsertOp>(loc, scale, zeroScales, 0);
+    return padded;
+  };
+
+  Value lhs = inputs[0];
+  Value lhsScales = padScales(inputs[1]);
+  Value rhs = inputs[2];
+  Value rhsScales = padScales(inputs[3]);
+  Value acc = outputs[0];
+
+  ArrayRef<int64_t> lhsShape = subgroupTypes[0].getShape();
+  ArrayRef<int64_t> rhsShape = subgroupTypes[2].getShape();
+  int64_t m = lhsShape[0];
+  // We use m x [k / kPerBlock] x blockSize as the LHS pre-distribution shape
+  // since this makes the higher-level tiling clearer.
+  int64_t k = lhsShape[1] * lhsShape[2];
+  int64_t n = rhsShape[2];
+
+  // Since the LHS and RHS layouts are both {M,N}xK, we can get a column-major
+  // result just by swapping the LHS and RHS.
+  if (getColMajor()) {
+    std::swap(lhs, rhs);
+    std::swap(lhsScales, rhsScales);
+    std::swap(n, m);
+  }
+
+  Value result = builder.create<amdgpu::ScaledMFMAOp>(
+      loc, m, n, k, lhs, rhs, acc, lhsScales, rhsScales, /*scalesIdxA=*/0,
+      /*scalesIdxB=*/0);
+  results.push_back(result);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Target Attributes
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -288,9 +288,9 @@ def IREEGPU_VirtualMMAAttr :
     "verifyIndexingMaps",
     "getUndistributedTileTypes",
     "getDistributedTileTypes",
-    "populateOperandOffsetsSizesStrides",
     "getDistributionMappingKind",
     "getDistributionWorkerCount",
+    "populateOperandOffsetsSizesStrides",
     "buildUnderlyingOperations",
   ]>
 ]> {
@@ -326,6 +326,55 @@ def IREEGPU_VirtualMMAAttr :
 def IREEGPU_MMAOpsArrayAttr : ArrayOfAttr<
   IREEGPU_Dialect, "MMAOpsArray", "mma_ops", "MMAAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+}
+
+def IREEGPU_ScaledMMAAttr :
+    AttrDef<IREEGPU_Dialect, "ScaledMMA", [
+  DeclareAttrInterfaceMethods<IREECodegen_InnerTileDescAttrInterface, [
+    "getExpectedNumInputs",
+    "getExpectedNumOutputs",
+    "verifyIndexingMaps",
+    "getUndistributedTileTypes",
+    "getDistributedTileTypes",
+    "populateOperandOffsetsSizesStrides",
+    "getDistributionMappingKind",
+    "getDistributionWorkerCount",
+    "buildUnderlyingOperations",
+  ]>
+]> {
+  let mnemonic = "scaled_mma_layout";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let description = [{
+    This attribute represents MMAs that operate on low-precision floating point
+    types (like fp4 or fp8) and apply _block scales_ to their inputs,
+    where each |blockSize| elements share a scale (which is currently
+    always a f32 exponent / f8E8M0).
+
+    The intrinsic is a ScaledMMAIntrinsic, and the element types are given
+    on the attribute, not in the intrinsic enum, since these scaled
+    operations allow arbitrary combinations of fp4/fp6/fp8 inputs.
+
+    This intrinsic takes its four parameters as (lhs, lhs_scale, rhs, rhs_scale).
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let parameters = (ins
+    EnumParameter<IREEGPU_ScaledMMAIntrinsic>:$intrinsic,
+    "::mlir::Type":$lhs_elem_type,
+    "::mlir::Type":$rhs_elem_type,
+    "::mlir::Type":$acc_elem_type,
+    DefaultValuedParameter<"bool", "false", "if this is a column-major scaled MFMA">:$col_major
+  );
+
+  let extraClassDeclaration = [{
+    // Return the number of elements per shared scale.
+    int64_t getBlockSize() const;
+
+    // Return the required subgroup size for this intrinsic.
+    int64_t getSubgroupSize() const;
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -98,6 +98,11 @@ class IREEGPU_I32EnumAttr<string name, string summary, list<I32EnumAttrCase> cas
   let genSpecializedAttr = 0;
 }
 
+class IREEGPU_I32Enum<string name, string summary, list<EnumCase> cases>
+    : I32Enum<name, summary, cases> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+}
+
 // These enum values are loosely named to match the target intrinsics that they
 // lower to, with wiggle room. The general name format used here is, similar to
 // typical target intrinsics:
@@ -313,6 +318,38 @@ def IREEGPU_MMAFragment : IREEGPU_I32EnumAttr<"MMAFragment",
       MMA_LHS,
       MMA_RHS,
       MMA_ACC
+    ]>;
+
+// Enum for scaled mma intrinsic, loosely matching the MMAIntrinsic enum above
+// but not including the input types.
+//
+// The main variation from intrinsic names is that, after the K dimension, we
+// include the block size (that is, how many elements along the K dimension
+// the shared scale applies to), which is given as "_Bxx"
+//
+// Values: 0xABCD where:
+// * A = vendor:
+//   * 1 = AMD
+//   * 2 = NVIDIA
+// * B = architecture. When an intrinsic exists in multiple architectures, this
+//       should be the architecture it was introduced in, as long as it still
+//       has the same semantics. If a new architecture breaks an existing
+//       intrinsic's semantics, we can use that field for versioning.
+//   * For AMD:
+//     * 0 = CDNA4
+// * C = element type of output/accumulator matrix and scale block size:
+//   * 0 = IEEE 32-bit float output, 32 elems/scale
+// * D enumerates intrinsics that share the same 0xABC* bits.
+//
+
+// Introduced in CDNA4
+def MFMA_SCALE_F32_16x16x128_B32 : I32EnumCase<"MFMA_SCALE_F32_16x16x128_B32", 0x1000>;
+def MFMA_SCALE_F32_32x32x64_B32 : I32EnumCase<"MFMA_SCALE_F32_32x32x64_B32", 0x1001>;
+def IREEGPU_ScaledMMAIntrinsic : IREEGPU_I32Enum<"ScaledMMAIntrinsic",
+    "Descriptor for different scaled MMA intrinsics", [
+      // Introduced in CDNA4.
+      MFMA_SCALE_F32_16x16x128_B32,
+      MFMA_SCALE_F32_32x32x64_B32
     ]>;
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -245,3 +245,245 @@ func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %
 //  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 //  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, subgroups_m = 2, subgroups_n = 2, intrinsics_k = 4>
 //  CHECK-SAME:     : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+func.func @vector_scaled_multi_mma(%lhs: vector<2x3x1x32xf4E2M1FN>, %lhsScale: vector<2x3x1xf8E8M0FNU>,
+    %rhs: vector<3x1x5x32xf8E4M3FN>, %rhsScale: vector<3x5x1xf8E8M0FNU>,
+    %acc: vector<2x5x4xf32>) -> vector<2x5x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>
+  } : vector<2x3x1x32xf4E2M1FN>, vector<2x3x1xf8E8M0FNU>,
+    vector<3x1x5x32xf8E4M3FN>, vector<3x5x1xf8E8M0FNU>
+    into vector<2x5x4xf32>
+  return %0 : vector<2x5x4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @vector_scaled_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+//  CHECK-SAME:     : vector<2x3x1x32xf4E2M1FN>, vector<2x3x1xf8E8M0FNU>, vector<3x1x5x32xf8E4M3FN>, vector<3x5x1xf8E8M0FNU> into vector<2x5x4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %lhsScale: tensor<?x?x1xf8E8M0FNU>,
+    %rhs: tensor<?x1x?x32xf8E4M3FN>, %rhsScale: tensor<?x?x1xf8E8M0FNU>,
+    %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>
+  } : tensor<?x?x1x32xf4E2M1FN>, tensor<?x?x1xf8E8M0FNU>,
+    tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU>
+    into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @tensor_scaled_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+//  CHECK-SAME:     : tensor<?x?x1x32xf4E2M1FN>, tensor<?x?x1xf8E8M0FNU>, tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU> into tensor<?x?x4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @single_scaled_multi_mma(%lhs: vector<32xf4E2M1FN>, %lhsScale: vector<1xf8E8M0FNU>,
+    %rhs: vector<32xf8E4M3FN>, %rhsScale: vector<1xf8E8M0FNU>,
+    %acc: vector<4xf32>) -> vector<4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>
+  } : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>,
+    vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>
+    into vector<4xf32>
+  return %0 : vector<4xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<() -> ()>
+
+// CHECK-LABEL: func @single_scaled_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]]]
+//  CHECK-SAME:       iterator_types = []
+//  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+//  CHECK-SAME:     : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU> into vector<4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @tensor_subgroup_scaled_multi_mma(%lhs: tensor<?x?x2x16x4x32xf4E2M1FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>,
+    %rhs: tensor<?x2x?x4x32x16xf8E4M3FN>, %rhsScale: tensor<?x?x4x16xf8E8M0FNU>,
+    %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>
+  } : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>,
+    tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x4x16xf8E8M0FNU>
+    into tensor<?x?x16x16xf32>
+  return %0 : tensor<?x?x16x16xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @tensor_subgroup_scaled_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
+//  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+//  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+//  CHECK-SAME:     : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x16x16xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma(%lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>,
+    %rhs: tensor<?x1x?x16x4x32xf8E4M3FN>, %rhsScale: tensor<?x?x16x4xf8E8M0FNU>,
+    %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
+      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      array<i64: 0, 1>]
+  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>,
+    tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>
+    into tensor<?x?x16x16xf32>
+  return %0 : tensor<?x?x16x16xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
+//  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+//  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
+//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>,
+    %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
+    %acc: tensor<?x?x32x32xf32>) -> tensor<?x?x32x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_32x32x64_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
+      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      array<i64: 0, 1>]
+  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>,
+    tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>
+    into tensor<?x?x32x32xf32>
+  return %0 : tensor<?x?x32x32xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4)
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
+//  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+//  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
+//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/drop_inner_tiled_unit_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/drop_inner_tiled_unit_dims.mlir
@@ -76,3 +76,43 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]], iterator_types = []
 //  CHECK-SAME:     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>} : vector<4xf16>, vector<4xf16> into vector<4xf32>
 //       CHECK:   vector.broadcast %[[MMA]] : vector<4xf32> to vector<1x4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+func.func @drop_inner_tiled_scaled_mma_unit_dims(%lhs: vector<1x1x1x32xf4E2M1FN>, %lhsScale: vector<1x1x1xf8E8M0FNU>,
+    %rhs: vector<1x1x1x32xf8E4M3FN>, %rhsScale: vector<1x1x1xf8E8M0FNU>,
+    %acc: vector<1x1x4xf32>) -> vector<1x1x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+  } : vector<1x1x1x32xf4E2M1FN>, vector<1x1x1xf8E8M0FNU>,
+    vector<1x1x1x32xf8E4M3FN>, vector<1x1x1xf8E8M0FNU> into vector<1x1x4xf32>
+  return %0 : vector<1x1x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.drop_inner_tiled_unit_dims
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: #[[$MAP:.+]] =  affine_map<() -> ()>
+
+// CHECK-LABEL: func @drop_inner_tiled_scaled_mma_unit_dims
+//       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]]], iterator_types = []
+//  CHECK-SAME:     : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU> into vector<4xf32>
+//       CHECK:   vector.broadcast %[[MMA]] : vector<4xf32> to vector<1x1x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
@@ -93,3 +93,43 @@ module attributes { transform.with_named_sequence } {
 //    CHECK-LABEL: func @unroll_multi_mma_count
 // CHECK-COUNT-30:   %[[MMA:.+]] = iree_codegen.inner_tiled {{.*}} : vector<1x1x4xf16>, vector<1x1x4xf16> into vector<1x1x4xf32>
 // CHECK-COUNT-10:   vector.insert_strided_slice {{.*}} : vector<1x1x4xf32> into vector<2x5x4xf32>
+
+// -----
+
+// Test unrolling scaled MFMA where the scales repeat every 64 elements (hence
+// 2 x 32).
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+func.func @unroll_scaled_multi_mma(%lhs: vector<1x2x2x32xf4E2M1FN>, %lhsScale: vector<1x2x1xf8E8M0FNU>,
+    %rhs: vector<2x2x1x32xf8E4M3FN>, %rhsScale: vector<2x1x1xf8E8M0FNU>,
+    %acc: vector<1x1x4xf32>) -> vector<1x1x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+  } : vector<1x2x2x32xf4E2M1FN>, vector<1x2x1xf8E8M0FNU>, vector<2x2x1x32xf8E4M3FN>, vector<2x1x1xf8E8M0FNU> into vector<1x1x4xf32>
+  return %0 : vector<1x1x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.unroll_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @unroll_scaled_multi_mma
+// CHECK-SAME: %[[LHS_SCALE:[A-Za-z0-9]+]]: vector<1x2x1xf8E8M0FNU>
+// CHECK-COUNT-2: vector.extract_strided_slice %[[LHS_SCALE]] {offsets = [0, 0]
+// CHECK-NOT: vector.extract_strided_slice %[[LHS_SCALE]] {offsets = [0, 0]
+// CHECK-COUNT-2: vector.extract_strided_slice %[[LHS_SCALE]] {offsets = [0, 1]
+// CHECK-NOT: vector.extract_strided_slice %[[LHS_SCALE]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/vectorize_iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/vectorize_iree_gpu_ops.mlir
@@ -71,3 +71,59 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 //  CHECK-SAME:     : vector<4xf16>, vector<4xf16> into vector<4xf32>
 //       CHECK:   vector.transfer_write %[[MMA]], %arg2[%c0] {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+#iterator_types = [
+  #linalg.iterator_type<parallel>,
+  #linalg.iterator_type<parallel>,
+  #linalg.iterator_type<reduction>,
+  #linalg.iterator_type<reduction>
+]
+
+func.func @scaled_tensor_multi_mma(%arg0: tensor<3x5x1x32xf4E2M1FN>, %arg1: tensor<3x5x1xf8E8M0FNU>,
+  %arg2: tensor<5x1x7x32xf8E4M3FN>, %arg3: tensor<5x7x1xf8E8M0FNU>,
+  %arg4: tensor<3x7x4xf32>) -> tensor<3x7x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%arg0, %arg1, %arg2, %arg3) outs(%arg4) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = #iterator_types,
+    kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
+    } : tensor<3x5x1x32xf4E2M1FN>, tensor<3x5x1xf8E8M0FNU>,
+      tensor<5x1x7x32xf8E4M3FN>, tensor<5x7x1xf8E8M0FNU>
+      into tensor<3x7x4xf32>
+  return %0 : tensor<3x7x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.vectorize_iree_gpu
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @scaled_tensor_multi_mma
+
+//   CHECK-DAG:   %[[CSTFP4:.+]] = arith.constant 0.000000e+00 : f4E2M1FN
+//   CHECK-DAG:   %[[CSTFP8:.+]] = arith.constant 0.000000e+00 : f8E4M3FN
+//   CHECK-DAG:   %[[CSTSCALE:.+]] = arith.constant 5.877470e-39 : f8E8M0FNU
+//   CHECK-DAG:   %[[CSTF32:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-DAG:   %[[LHS:.+]] = vector.transfer_read %arg0[%c0, %c0, %c0, %c0], %[[CSTFP4]] {{.*}} : tensor<3x5x1x32xf4E2M1FN>, vector<3x5x1x32xf4E2M1FN>
+//   CHECK-DAG:   %[[LHS_SCALE:.+]] = vector.transfer_read %arg1[%c0, %c0, %c0], %[[CSTSCALE]] {{.*}} : tensor<3x5x1xf8E8M0FNU>, vector<3x5x1xf8E8M0FNU>
+//   CHECK-DAG:   %[[RHS:.+]] = vector.transfer_read %arg2[%c0, %c0, %c0, %c0], %[[CSTFP8]] {{.*}} : tensor<5x1x7x32xf8E4M3FN>, vector<5x1x7x32xf8E4M3FN>
+//   CHECK-DAG:   %[[RHS_SCALE:.+]] = vector.transfer_read %arg3[%c0, %c0, %c0], %[[CSTSCALE]] {{.*}} : tensor<5x7x1xf8E8M0FNU>, vector<5x7x1xf8E8M0FNU>
+//   CHECK-DAG:   %[[ACC:.+]] = vector.transfer_read %arg4[%c0, %c0, %c0], %[[CSTF32]] {{.*}} : tensor<3x7x4xf32>, vector<3x7x4xf32>
+//       CHECK:   %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[LHS_SCALE]], %[[RHS]], %[[RHS_SCALE]]) outs(%[[ACC]])
+//  CHECK-SAME: : vector<3x5x1x32xf4E2M1FN>, vector<3x5x1xf8E8M0FNU>, vector<5x1x7x32xf8E4M3FN>, vector<5x7x1xf8E8M0FNU> into vector<3x7x4xf32>
+//       CHECK:   vector.transfer_write %[[MMA]], %arg4[%c0, %c0, %c0] {{.*}} : vector<3x7x4xf32>, tensor<3x7x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -1346,34 +1346,35 @@ static bool isParallelIterator(Attribute attr) {
          utils::IteratorType::parallel;
 }
 
-/// Pick an unrolling order that reuses the LHS register.
+/// Pick an unrolling order that reuses the LHS register, assuming that the LHS
+/// register is the frist argument.
 static std::optional<SmallVector<int64_t>>
-gpuMultiMmaUnrollOrder(Operation *op) {
-  IREE::Codegen::InnerTiledOp mmaOp = dyn_cast<IREE::Codegen::InnerTiledOp>(op);
-  // TODO: review for generalizability to other inner tiled ops.
-  if (!mmaOp || !isa<GPU::MmaInterfaceAttr>(mmaOp.getKind())) {
+gpuMatmulLikeUnrollOrder(Operation *op) {
+  IREE::Codegen::InnerTiledOp tiledOp =
+      dyn_cast<IREE::Codegen::InnerTiledOp>(op);
+  if (!tiledOp) {
     return std::nullopt;
   }
   SmallVector<int64_t> order;
   // First make reduction the outer dimensions.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+  for (auto [index, iter] : llvm::enumerate(tiledOp.getIteratorTypes())) {
     if (isReductionIterator(iter)) {
       order.push_back(index);
     }
   }
 
   llvm::SmallDenseSet<int64_t> dimsInLhs;
-  for (AffineExpr expr : mmaOp.getIndexingMapsArray()[0].getResults()) {
+  for (AffineExpr expr : tiledOp.getIndexingMapsArray()[0].getResults()) {
     dimsInLhs.insert(cast<AffineDimExpr>(expr).getPosition());
   }
   // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+  for (auto [index, iter] : llvm::enumerate(tiledOp.getIteratorTypes())) {
     if (isParallelIterator(iter) && dimsInLhs.count(index)) {
       order.push_back(index);
     }
   }
   // Then the remaining parallel loops.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+  for (auto [index, iter] : llvm::enumerate(tiledOp.getIteratorTypes())) {
     if (isParallelIterator(iter) && !dimsInLhs.count(index)) {
       order.push_back(index);
     }
@@ -1395,7 +1396,7 @@ void populateIREEGPUVectorUnrollPatterns(RewritePatternSet &patterns) {
   populateIREEGPUVectorUnrollPatterns(
       patterns, vector::UnrollVectorOptions()
                     .setNativeShapeFn(getInnerTiledUnitShape)
-                    .setUnrollTraversalOrderFn(gpuMultiMmaUnrollOrder));
+                    .setUnrollTraversalOrderFn(gpuMatmulLikeUnrollOrder));
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -569,6 +569,157 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(%lhs: tensor<
 
 // -----
 
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4E2M1FN>, %lhsScale: tensor<3x5x16x4xf8E8M0FNU>,
+    %rhs: tensor<5x1x7x4x32x16xf8E4M3FN>, %rhsScale: tensor<5x7x4x16xf8E8M0FNU>,
+    %acc: tensor<3x7x16x16xf32>) -> tensor<3x7x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>
+  } : tensor<3x5x1x16x4x32xf4E2M1FN>, tensor<3x5x16x4xf8E8M0FNU>,
+    tensor<5x1x7x4x32x16xf8E4M3FN>, tensor<5x7x4x16xf8E8M0FNU>
+    into tensor<3x7x16x16xf32>
+  return %0 : tensor<3x7x16x16xf32>
+}
+
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK-DAG: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+// CHECK-DAG: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// CHECK-LABEL: func @scaled_matmul_f32_16x16x128_b32_fp4_fp8
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x1x16x4x32xf4E2M1FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x1x7x4x32x16xf8E4M3FN>
+//  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x4x16xf8E8M0FNU>
+//       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
+//   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
+//   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (4, 4)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 1, 1, 1, 32]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#1, 0, %[[ID]]#2] [5, 1, 7, 1, 32, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#1, %[[ID]]#2] [5, 7, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
+//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x1x7x1x32x1xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
+//       CHECK:   mapping = [#iree_gpu.lane_id<0>]
+
+// -----
+
+// Note: thete tests don't check the affine maps and the like since it's assumed
+// the above tests covered that code, which doesn't depend on the mma kind.
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x32xf4E2M1FN>, %lhsScale: tensor<3x5x16x4xf8E8M0FNU>,
+    %rhs: tensor<5x4x7x16x4x32xf8E4M3FN>, %rhsScale: tensor<5x7x16x4xf8E8M0FNU>,
+    %acc: tensor<3x7x16x16xf32>) -> tensor<3x7x16x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
+      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      array<i64: 0, 1>]
+  } : tensor<3x5x4x16x4x32xf4E2M1FN>, tensor<3x5x16x4xf8E8M0FNU>,
+    tensor<5x4x7x16x4x32xf8E4M3FN>, tensor<5x7x16x4xf8E8M0FNU>
+    into tensor<3x7x16x16xf32>
+  return %0 : tensor<3x7x16x16xf32>
+}
+
+// CHECK-LABEL: func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x4x16x4x32xf4E2M1FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x4x7x16x4x32xf8E4M3FN>
+//  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x16x4xf8E8M0FNU>
+//       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
+//   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
+//   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (4, 4)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 4, 1, 1, 32]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [5, 4, 7, 1, 1, 32]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [5, 7, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       : tensor<3x5x4x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x4x7x1x1x32xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
+//       CHECK:   mapping = [#iree_gpu.lane_id<0>]
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k, b) -> (i, k, b)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
+ affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (k, j)>,
+ affine_map<(i, j, k, b) -> (i, j)>
+]
+
+func.func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8(%lhs: tensor<3x5x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<3x5x32x2xf8E8M0FNU>,
+    %rhs: tensor<5x1x7x32x2x32xf8E4M3FN>, %rhsScale: tensor<5x7x32x2xf8E8M0FNU>,
+    %acc: tensor<3x7x4x8x32xf32>) -> tensor<3x7x4x8x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.scaled_mma_layout<
+      intrinsic = MFMA_SCALE_F32_32x32x64_B32,
+      lhs_elem_type = f4E2M1FN,
+      rhs_elem_type = f8E4M3FN,
+      acc_elem_type = f32>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
+      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      array<i64: 0, 1, 2>]
+  } : tensor<3x5x1x32x2x32xf4E2M1FN>, tensor<3x5x32x2xf8E8M0FNU>,
+    tensor<5x1x7x32x2x32xf8E4M3FN>, tensor<5x7x32x2xf8E8M0FNU>
+    into tensor<3x7x4x8x32xf32>
+  return %0 : tensor<3x7x4x8x32xf32>
+}
+
+// CHECK-LABEL: func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x1x32x2x32xf4E2M1FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x32x2xf8E8M0FNU>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x1x7x32x2x32xf8E4M3FN>
+//  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x32x2xf8E8M0FNU>
+//       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x4x8x32xf32>)
+//   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
+//   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (2, 4)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 1, 1, 1, 32]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [5, 1, 7, 1, 1, 32]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [5, 7, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 4, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x1x7x1x1x32xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x4x1xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 4, 1]
+//       CHECK:   mapping = [#iree_gpu.lane_id<0>]
+
+// -----
+
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Utils/Indexing.cpp
+++ b/compiler/src/iree/compiler/Utils/Indexing.cpp
@@ -17,17 +17,17 @@ LogicalResult basisFromSizesStrides(ArrayRef<int64_t> sizes,
   size_t numDims = sizes.size();
   basis.reserve(numDims);
 
-  SmallVector<std::tuple<int64_t, size_t, int64_t>> terms =
+  SmallVector<std::tuple<int64_t, int64_t, size_t>> terms =
       llvm::map_to_vector(llvm::enumerate(strides, sizes), [&](auto tuple) {
         auto [dim, stride, size] = tuple;
-        return std::make_tuple(stride, dim, size);
+        return std::make_tuple(stride, size, dim);
       });
   llvm::sort(terms);
 
   int64_t previousSizes = 1;
   SmallVector<std::optional<size_t>> basisEntryToDim;
   basisEntryToDim.reserve(numDims);
-  for (auto [stride, dim, size] : terms) {
+  for (auto [stride, size, dim] : terms) {
     if (stride == 0) {
       stride = 1;
       size = 1;


### PR DESCRIPTION
This commit adds a descriptor attribute - #iree_gpu.scaled_mma_layout -
for MMAs that take "scale" operands and tests for its lowering
from DistributeInnerTiledToLanes and afterwards.

This descriptor takes four input operands - the lleft-hand side of the
matrix, the LHS scales, the right-hand side, and the RHS scales, in
that order. The operation has one accumulator.

Scaled MMAs are, like MMA intrinsics, represented by an enum, which
litss out the available intrinsics (currenvtly, we only have AMD's
MI-350). However, unlike with MMA intrinsics, the input and output
types are given in the scaled_mma_layout attribute itself. This is
because these scaled MMAs support arbitrary pairs of left- and
right-hand side types from {f4E2M1FN, f6E3M2FN, f6E3M2FN, f8E4M3FN,
f8E5M2}, so listing out all the combinations would take up a lot of
space and produce a large number of nearly-identical cases in the
descriotor logic.

This inner tiled operation treats the k values that have distinct
scales and the "block" (the B (currently always 32) values that share
a common scale) as separate reduction dimensions. This means that the
scale operands, in effect, don't have a block dimension. This also
means that models where the block size is larger than 32 can be
supported by tiling across the scale dimension.

The following work is not yet implemented:
- ContretizeMmaShapes has not yet been generalized to arbitrary inner
tiled ops. This will be needed to correctly lower the 32x32x64
intrinsic, which has an outer dimension on the accumulator.
- Lowering configuration logic and PackToIntrinsics have not been
addressed

Note that this PR does contain a few code changes. One is declaring
the vector unrolling logic to be safe for non-MMA inner_tiled ops. The
other is a bug fix to basisFromSizesStrides(), which used an incorrect
tiebreaking strategy for multiple dimensions that had the same
stride (now it's ties broken by the length of the dimension and _then_
its position in the list).