### PR TITLE
[compiler] remove uses of memref::ExpandOps pass

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -66,7 +66,6 @@ void createTorchToIREEPipeline(
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToSCFPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToArithPass());
   pm.addPass(torch::createConvertTorchConversionToMLProgramPass());
-  pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
 
   // Clean up any non-canonical code introduced above..
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -780,7 +780,6 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
       // (HAL, IREE, Linalg, CF) -> LLVM
-      .addPass(memref::createExpandOpsPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(affine::createAffineExpandIndexOpsPass)
       .addPass(arith::createArithExpandOpsPass)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1079,8 +1079,8 @@ void addGPUBaseLoweringPassPipeline(OpPassManager &funcPassManager) {
 // Note that this needs to run before SCF -> CF.
 static void
 addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
-  funcPassManager.addPass(createExtractAddressComputationGPUPass)
-      .addPass(memref::createExpandOpsPass)
+  funcPassManager
+      .addPass(createExtractAddressComputationGPUPass)
       // Lower any remaining vector.transfer_read and vector.transfer_write ops,
       // since some of the following patterns have trouble dealing with their
       // full complexity.
@@ -1171,7 +1171,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createConvertComplexToStandardPass)
       // Math dialect ops rewrites, approximations, casts.
       .addPass(createMathTransformPass)
-      .addPass(memref::createExpandOpsPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass([]() {
         IREEExpandStridedMetadataPassOptions options;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -202,7 +202,6 @@ static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
       // to handle subview ops.
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(createEmulateNarrowTypePass)
-      .addPass(memref::createExpandOpsPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -82,8 +82,7 @@ buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
       .addPass(createCSEPass)
       .addPass([]() { return createConvertVectorToSCFPass(); })
       .addPass(createCanonicalizerPass)
-      .addPass(arith::createArithExpandOpsPass)
-      .addPass(memref::createExpandOpsPass);
+      .addPass(arith::createArithExpandOpsPass);
 
   // Handle tensor-type constants.
   modulePassManager.addPass(createIREEBufferizeConstantsPass());


### PR DESCRIPTION
This pass currently performs two rewrites:

  1. *incorrectly* rewrite `atomic_rmw` for floating-point min/max, see #21101;
  2. rewrite `reshape` into `reinterpret_cast`.

The rewrite 1 was added years ago, prior to LLVM IR supporting floating-point atomics sufficiently and is no longer necessary. I will remove it upstream anyway.

The rewrite 2 looks like a canonicalizaiton and it is unclear why it was put into a separate pass, it will likely not remain there. It may have some minor effect on performance if this rewrite is important to simplify address computation, at which point it belongs to the set of canonicalization patterns.

In general, I highly suspect that the usage of this pass was either cargo-culted from existing sub-pipelines or confused with `--expand-strided-metadata`, which is both necessary for lowering and beneficial for address computation performance.