### PR TITLE
[LinalgExt] Add decomposition for vector map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -533,6 +533,36 @@ void MapScatterOp::insertTransformationAtStart(
   transformBody.eraseArguments(0, oldSourceIndices.size());
 }
 
+void MapScatterOp::inlineMapScatterBody(
+    OpBuilder &b, Location loc, ValueRange transformBodyIndices,
+    function_ref<void(OpBuilder &, Location, ArrayRef<Value>)> bodyBuilder) {
+  Block &transformBlock = getTransformationRegion().front();
+  IRMapping mapping;
+  // Map the induction variables of the loop nest to the block arguments of the
+  // transformation body. The induction variables are the indices looping over
+  // the elements of input operand.
+  for (auto [idx, arg] : llvm::enumerate(transformBlock.getArguments())) {
+    mapping.map(arg, transformBodyIndices[idx]);
+  }
+  // Clone the operations within the transformation body to the current
+  // insertion point, and map their results to the new cloned operations'
+  // results.
+  for (Operation &op : transformBlock.without_terminator()) {
+    Operation *clonedOp = b.clone(op, mapping);
+    for (auto [result, clonedResult] :
+         llvm::zip_equal(op.getResults(), clonedOp->getResults())) {
+      mapping.map(result, clonedResult);
+    }
+  }
+
+  // Get the cloned values that were yielded by the transformation body to pass
+  // to the bodyBuilder.
+  SmallVector<Value> mappedYieldedValues = llvm::map_to_vector(
+      transformBlock.getTerminator()->getOperands(),
+      [&](Value operand) -> Value { return mapping.lookupOrDefault(operand); });
+  bodyBuilder(b, loc, mappedYieldedValues);
+}
+
 bool MapScatterOp::isIdentity() {
   if (getInputType() != getOutputType()) {
     return false;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -392,6 +392,15 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
             transformationBuilder,
         int64_t numSourceIndices);
 
+    // Inline the transformation region of the map_scatter op without its
+    // terminator, replacing the block arguments with the passed
+    // `transformBodyIndices`. The `bodyBuilder` function is called with the
+    // cloned index `Value`s that would have been yielded by the terminator of
+    // the inlined transformation body.
+    void inlineMapScatterBody(
+      OpBuilder &b, Location loc, ValueRange transformBodyIndices,
+      function_ref<void(OpBuilder &, Location, ArrayRef<Value>)> bodyBuilder);
+
     // Return true if the mapScatterOp is an identity transformation, meaning
     // it is just doing a copy from input to output. This is true if the mask
     // always evaluates to true, and the mapping from input to output index is

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -527,44 +527,28 @@ LogicalResult MapScatterOp::generateScalarImplementation(OpBuilder &b,
                                                          ValueRange ivs) {
   // The scalar implementation is currently only implemented for buffer
   // semantics, because we need to conditionally write values based on the
-  // mask.
-  if (!hasPureBufferSemantics()) {
+  // mask. Vectorized map_scatter ops should be decomposed, not tiled to loops,
+  // so vector types are not allowed.
+  if (!hasPureBufferSemantics() || isa<VectorType>(getInputType())) {
     return failure();
   }
-  Block &transformBlock = getTransformationRegion().front();
-  IRMapping mapping;
-  // Map the induction variables of the loop nest to the block arguments of the
-  // transformation body. The induction variables are the indices looping over
-  // the elements of input operand.
-  for (auto [idx, arg] : llvm::enumerate(transformBlock.getArguments())) {
-    mapping.map(arg, ivs[idx]);
-  }
-  // Clone the operations within the transformation body to the current
-  // insertion point, and map their results to the new cloned operations'
-  // results.
-  for (Operation &op : transformBlock.without_terminator()) {
-    Operation *clonedOp = b.clone(op, mapping);
-    for (auto [result, clonedResult] :
-         llvm::zip_equal(op.getResults(), clonedOp->getResults())) {
-      mapping.map(result, clonedResult);
-    }
-  }
-
-  // Get the cloned values that were yielded by the transformation body to use
-  // as the indices for the store into the output.
-  SmallVector<Value> storeIndexValues = llvm::map_to_vector(
-      transformBlock.getTerminator()->getOperands(),
-      [&](Value operand) { return mapping.lookupOrDefault(operand); });
-  // The last yielded Value is the mask, so use it as the if condition instead
-  // of the store indices.
-  Value ifCond = storeIndexValues.pop_back_val();
-  auto thenBuilder = [&](OpBuilder &nestedBuilder, Location nestedLoc) {
-    Value input = nestedBuilder.create<memref::LoadOp>(loc, getInput(), ivs);
-    nestedBuilder.create<memref::StoreOp>(nestedLoc, input, getOutput(),
-                                          storeIndexValues);
-    nestedBuilder.create<scf::YieldOp>(nestedLoc);
+  auto bodyBuilder = [&](OpBuilder nestedBuilder, Location nestedLoc,
+                         ArrayRef<Value> yieldedValues) {
+    // The last yielded Value is the mask, so use it as the if condition instead
+    // of the store indices.
+    Value ifCond = yieldedValues.back();
+    ArrayRef<Value> storeIndices =
+        yieldedValues.take_front(yieldedValues.size() - 1);
+    auto thenBuilder = [&](OpBuilder &ifBuilder, Location ifLoc) {
+      SmallVector<OpFoldResult> ivsOfr(ivs);
+      Value input = ifBuilder.create<memref::LoadOp>(ifLoc, getInput(), ivs);
+      ifBuilder.create<memref::StoreOp>(ifLoc, input, getOutput(),
+                                        storeIndices);
+      ifBuilder.create<scf::YieldOp>(ifLoc);
+    };
+    nestedBuilder.create<scf::IfOp>(nestedLoc, ifCond, thenBuilder);
   };
-  b.create<scf::IfOp>(loc, ifCond, thenBuilder);
+  inlineMapScatterBody(b, loc, ivs, bodyBuilder);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -537,8 +537,7 @@ LogicalResult MapScatterOp::generateScalarImplementation(OpBuilder &b,
     // The last yielded Value is the mask, so use it as the if condition instead
     // of the store indices.
     Value ifCond = yieldedValues.back();
-    ArrayRef<Value> storeIndices =
-        yieldedValues.take_front(yieldedValues.size() - 1);
+    ArrayRef<Value> storeIndices = yieldedValues.drop_back();
     auto thenBuilder = [&](OpBuilder &ifBuilder, Location ifLoc) {
       SmallVector<OpFoldResult> ivsOfr(ivs);
       Value input = ifBuilder.create<memref::LoadOp>(ifLoc, getInput(), ivs);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "ConvertToLoops.cpp",
         "DecomposeAttention.cpp",
         "DecomposeIm2col.cpp",
+        "DecomposeMapScatter.cpp",
         "DecomposeWinogradPass.cpp",
         "FoldUnitExtentDims.cpp",
         "PadContractionToBlockSize.cpp",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     ::PassesIncGen
     LLVMSupport
     MLIRAffineDialect
+    MLIRAffineTransforms
     MLIRAffineUtils
     MLIRArithDialect
     MLIRArithUtils

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     "ConvertToLoops.cpp"
     "DecomposeAttention.cpp"
     "DecomposeIm2col.cpp"
+    "DecomposeMapScatter.cpp"
     "DecomposeWinogradPass.cpp"
     "FoldUnitExtentDims.cpp"
     "PadContractionToBlockSize.cpp"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -100,14 +100,17 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
     }
   }
 
-  SmallVector<Value> newResults;
-  if (failed(linalg::vectorize(rewriter, genericOp, newResults))) {
+  FailureOr<linalg::VectorizationResult> result =
+      linalg::vectorize(rewriter, genericOp);
+  if (failed(result)) {
     return rewriter.notifyMatchFailure(mapScatterOp,
                                        "failed to generate index vector");
   }
 
-  auto indexWriteOp = newResults[0].getDefiningOp<vector::TransferWriteOp>();
-  auto maskWriteOp = newResults[1].getDefiningOp<vector::TransferWriteOp>();
+  auto indexWriteOp =
+      result->replacements[0].getDefiningOp<vector::TransferWriteOp>();
+  auto maskWriteOp =
+      result->replacements[1].getDefiningOp<vector::TransferWriteOp>();
   if (!indexWriteOp || !maskWriteOp) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -1,0 +1,175 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+#define GEN_PASS_DEF_DECOMPOSEMAPSCATTERPASS
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h.inc"
+
+/// Decompose an iree_linalg_ext.map_scatter op with a vector input, and a
+/// memref output. The map_scatter op is lowered into a sequence of vector ops
+/// to compute a vector of indices for the elements of the map_scatter input,
+/// and then a vector.scatter op to scatter the input vector to the output
+/// buffer at the indices in the computed index vector. The output buffer is
+/// also flattened to a 1D memref. If the collapse is not possible due to non
+/// collapsible strides, then the decomposition will fail.
+static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
+                                         RewriterBase &rewriter) {
+  auto inputType = dyn_cast<VectorType>(mapScatterOp.getInputType());
+  if (!inputType) {
+    return success();
+  }
+  auto outputType = dyn_cast<MemRefType>(mapScatterOp.getOutputType());
+  if (!outputType) {
+    return success();
+  }
+  if (!inputType.hasStaticShape()) {
+    return rewriter.notifyMatchFailure(mapScatterOp,
+                                       "expected static input shape");
+  }
+  SmallVector<ReassociationIndices> reassociations;
+  reassociations.push_back(
+      llvm::to_vector(llvm::seq<int64_t>(outputType.getRank())));
+  if (!memref::CollapseShapeOp::isGuaranteedCollapsible(outputType,
+                                                        reassociations)) {
+    return rewriter.notifyMatchFailure(mapScatterOp,
+                                       "output buffer is not collapsible");
+  }
+  Location loc = mapScatterOp.getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(mapScatterOp);
+  Value flatOutputBuffer = rewriter.create<memref::CollapseShapeOp>(
+      loc, mapScatterOp.getOutput(), reassociations);
+
+  auto idxInit = rewriter.create<tensor::EmptyOp>(loc, inputType.getShape(),
+                                                  rewriter.getIndexType());
+  auto maskInit = rewriter.create<tensor::EmptyOp>(loc, inputType.getShape(),
+                                                   rewriter.getIntegerType(1));
+  SmallVector<OpFoldResult> outputSizes =
+      memref::getMixedSizes(rewriter, loc, mapScatterOp.getOutput());
+
+  auto bodyBuilder = [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+    auto inlineBodyBuilder = [&](OpBuilder inlineBuilder, Location inlineLoc,
+                                 ArrayRef<Value> yieldedValues) {
+      SmallVector<Value> outputIndices(yieldedValues);
+      Value mask = outputIndices.pop_back_val();
+      Value linearIdx = inlineBuilder.create<affine::AffineLinearizeIndexOp>(
+          inlineLoc, outputIndices, outputSizes, /*disjoint=*/true);
+      inlineBuilder.create<linalg::YieldOp>(inlineLoc,
+                                            ValueRange{linearIdx, mask});
+    };
+    SmallVector<Value> indices = llvm::map_to_vector(
+        llvm::seq<int64_t>(inputType.getRank()), [&](int64_t dim) -> Value {
+          return b.create<linalg::IndexOp>(nestedLoc, b.getIndexType(), dim);
+        });
+    mapScatterOp.inlineMapScatterBody(b, nestedLoc, indices, inlineBodyBuilder);
+  };
+  SmallVector<AffineMap> maps(
+      2, rewriter.getMultiDimIdentityMap(inputType.getRank()));
+  SmallVector<utils::IteratorType> iterTypes(inputType.getRank(),
+                                             utils::IteratorType::parallel);
+  SmallVector<Value> outs = {idxInit.getResult(), maskInit.getResult()};
+  auto genericOp = rewriter.create<linalg::GenericOp>(
+      loc, TypeRange(outs), ValueRange(), outs, maps, iterTypes, bodyBuilder);
+
+  // Lower linearize and delinearize ops before vectorizing, because the
+  // vectorizer can't hendle them.
+  SmallVector<affine::AffineLinearizeIndexOp> linearizeOps(
+      genericOp.getBody()->getOps<affine::AffineLinearizeIndexOp>());
+  for (auto linearizeOp : linearizeOps) {
+    rewriter.setInsertionPoint(linearizeOp);
+    if (failed(affine::lowerAffineLinearizeIndexOp(rewriter, linearizeOp))) {
+      return rewriter.notifyMatchFailure(
+          linearizeOp, "failed to lower affine.linearize_index op");
+    }
+  }
+  SmallVector<affine::AffineDelinearizeIndexOp> delinearizeOps(
+      genericOp.getBody()->getOps<affine::AffineDelinearizeIndexOp>());
+  for (auto delinearizeOp : delinearizeOps) {
+    rewriter.setInsertionPoint(delinearizeOp);
+    if (failed(
+            affine::lowerAffineDelinearizeIndexOp(rewriter, delinearizeOp))) {
+      return rewriter.notifyMatchFailure(
+          delinearizeOp, "failed to lower affine.delinearize_index op");
+    }
+  }
+
+  SmallVector<Value> newResults;
+  if (failed(linalg::vectorize(rewriter, genericOp, newResults))) {
+    return rewriter.notifyMatchFailure(mapScatterOp,
+                                       "failed to generate index vector");
+  }
+
+  auto indexWriteOp = newResults[0].getDefiningOp<vector::TransferWriteOp>();
+  auto maskWriteOp = newResults[1].getDefiningOp<vector::TransferWriteOp>();
+  if (!indexWriteOp || !maskWriteOp) {
+    return failure();
+  }
+  Value indexVector = indexWriteOp.getVector();
+  Value maskVector = maskWriteOp.getVector();
+  // Erase unused tensor ops after vectorizing the linalg.generic.
+  rewriter.eraseOp(indexWriteOp);
+  rewriter.eraseOp(maskWriteOp);
+  rewriter.eraseOp(genericOp);
+
+  // Flatten all the vectors, since the scatter op lowering expects 1D vectors.
+  int64_t flatVectorSize =
+      std::reduce(inputType.getShape().begin(), inputType.getShape().end(), 1,
+                  std::multiplies<int64_t>());
+  rewriter.setInsertionPoint(mapScatterOp);
+  auto flatIndexType =
+      VectorType::get({flatVectorSize}, rewriter.getIndexType());
+  indexVector =
+      rewriter.create<vector::ShapeCastOp>(loc, flatIndexType, indexVector);
+  auto flatMaskType =
+      VectorType::get({flatVectorSize}, rewriter.getIntegerType(1));
+  maskVector =
+      rewriter.create<vector::ShapeCastOp>(loc, flatMaskType, maskVector);
+  auto flatInputType =
+      VectorType::get({flatVectorSize}, inputType.getElementType());
+  Value inputVector = rewriter.create<vector::ShapeCastOp>(
+      loc, flatInputType, mapScatterOp.getInput());
+
+  SmallVector<Value> offsets = {
+      rewriter.create<arith::ConstantIndexOp>(loc, 0)};
+  rewriter.replaceOpWithNewOp<vector::ScatterOp>(mapScatterOp, flatOutputBuffer,
+                                                 offsets, indexVector,
+                                                 maskVector, inputVector);
+  return success();
+}
+
+namespace {
+struct DecomposeMapScatterPass final
+    : impl::DecomposeMapScatterPassBase<DecomposeMapScatterPass> {
+  using impl::DecomposeMapScatterPassBase<
+      DecomposeMapScatterPass>::DecomposeMapScatterPassBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto funcOp = getOperation();
+
+    SmallVector<MapScatterOp> candidates;
+    funcOp->walk([&](MapScatterOp op) { candidates.push_back(op); });
+    IRRewriter rewriter(context);
+    for (auto mapScatterOp : candidates) {
+      if (failed(decomposeMapScatter(mapScatterOp, rewriter))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -28,10 +28,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
                                          RewriterBase &rewriter) {
   auto inputType = cast<VectorType>(mapScatterOp.getInputType());
-  if (!inputType.hasStaticShape()) {
-    return rewriter.notifyMatchFailure(mapScatterOp,
-                                       "expected static input shape");
-  }
+  assert(!inputType.hasStaticShape() && "expected vector type to be static");
   SmallVector<ReassociationIndices> reassociations;
   auto outputType = cast<MemRefType>(mapScatterOp.getOutputType());
   reassociations.push_back(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -28,7 +28,6 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
                                          RewriterBase &rewriter) {
   auto inputType = cast<VectorType>(mapScatterOp.getInputType());
-  assert(!inputType.hasStaticShape() && "expected vector type to be static");
   SmallVector<ReassociationIndices> reassociations;
   auto outputType = cast<MemRefType>(mapScatterOp.getOutputType());
   reassociations.push_back(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -60,6 +60,17 @@ def DecomposeIm2colPass :
   ];
 }
 
+def DecomposeMapScatterPass :
+    InterfacePass<"iree-linalg-ext-decompose-map-scatter", "mlir::FunctionOpInterface"> {
+  let summary =
+      "Decomposes vectorized map_scatter ops into vector ops";
+  let dependentDialects = [
+    "::mlir::tensor::TensorDialect",
+    "::mlir::vector::VectorDialect",
+    "::mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect"
+  ];
+}
+
 def DecomposeWinogradTransformPass :
     InterfacePass<"iree-linalg-ext-decompose-winograd", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "convert_to_loops.mlir",
             "convert_to_online_attention.mlir",
             "decompose_im2col.mlir",
+            "decompose_map_scatter.mlir",
             "decompose_winograd.mlir",
             "distribution.mlir",
             "fold_unit_dims.mlir",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "convert_to_loops.mlir"
     "convert_to_online_attention.mlir"
     "decompose_im2col.mlir"
+    "decompose_map_scatter.mlir"
     "decompose_winograd.mlir"
     "distribution.mlir"
     "fold_unit_dims.mlir"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -1,0 +1,58 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter,cse))" --split-input-file %s | FileCheck %s
+
+func.func @identity_map_scatter(
+    %input: vector<4x16xf32>, %output: memref<4x16xf32>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf32> into memref<4x16xf32>
+  return
+}
+// CHECK-LABEL: func.func @identity_map_scatter(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} memref<4x16xf32> into memref<64xf32>
+//   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
+//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
+//   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
+//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
+//  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
+
+// -----
+
+func.func @map_scatter_with_linearize_delinearize_idx(
+    %input: vector<2x2x64xf32>, %output: memref<4x32x2xf32>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index, %idx2: index):
+      %mask = arith.constant true
+      %out_idx_0 = affine.linearize_index [%idx0, %idx1] by (2, 2) : index
+      %out_idx:2 = affine.delinearize_index %idx2 into (32, 2) : index, index
+      iree_linalg_ext.yield %out_idx_0, %out_idx#0, %out_idx#1, %mask : index, index, index, i1
+  } : vector<2x2x64xf32> into memref<4x32x2xf32>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_with_linearize_delinearize_idx(
+//   CHECK-NOT:   iree_linalg_ext.map_scatter
+//       CHECK:   vector.scatter
+
+// -----
+
+func.func @map_scatter_with_mask(
+    %input: vector<64xf32>, %output: memref<?xf32>
+) {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %output, %c0 : memref<?xf32>
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.cmpi uge, %idx0, %dim : index
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : vector<64xf32> into memref<?xf32>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_with_mask(
+//   CHECK-NOT:   iree_linalg_ext.map_scatter
+//       CHECK:   vector.scatter


### PR DESCRIPTION
Adds a decomposition pass for `iree_linalg_ext.map_scatter` with a vector input and a memref output. The decomposition lowers the op into a series of vector ops to compute the index vector, and a vector.scatter op. This transformation completes the lowering of a vectorized map_scatter op.

The map_scatter op does not implement the `AggregatedOpInterface`, because the interface uses an `OpBuilder` to decompose operations, but the decomposition for map_scatter needs a `RewriterBase`, so it does not work with the current interface.