### PR TITLE
[CodeGen] Fix gather fusion on vector distribute path

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
@@ -45,8 +45,9 @@ struct FuseElementWiseGenericOps : public OpRewritePattern<linalg::GenericOp> {
     for (OpOperand &opOperand : genericOp->getOpOperands()) {
       if (!linalg::areElementwiseOpsFusable(&opOperand))
         continue;
-      // If the producer is a generic op, don't fuse if it has external
-      // capture.
+      // Don't fuse if it has external capture. For e.g., the gather like
+      // payload operation like 'tensor.extract' would be cloned in
+      // every consumer op, which is not what we want.
       auto producer = opOperand.get().getDefiningOp<linalg::GenericOp>();
       if (producer && hasExternalCapture(producer)) {
         continue;

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -25,47 +25,6 @@ static bool isScalarOrTensorOfSizeOne(Type t) {
   return t.isIntOrIndexOrFloat();
 }
 
-///  This function checks whether the `genericOp` has any external captures,
-///  i.e., whether it uses any values that are defined outside of its body.
-///  %10 = linalg.generic {indexing_maps = [#map, #map],
-///          iterator_types = ["parallel", "parallel"]}
-///         ins(%5 : tensor<4096x64xi64>) outs(%9 : tensor<4096x64xf16>) {
-///          ^bb0(%in: i64, %out: f16):
-///            %14 = linalg.index 0 : index
-///            %15 = arith.index_cast %in : i64 to index
-///            %extracted = tensor.extract %4[%14, %15] : tensor<4096x64xf16>
-///            linalg.yield %extracted : f16
-///           } -> tensor<4096x64xf16>
-///  Here %4 is an external capture used via tensor.extract inside
-///  linalg.generic hence the above `genericOp` has an external capture.
-static bool hasExternalCapture(linalg::GenericOp genericOp) {
-  Block &body = genericOp.getRegion().front();
-  for (Operation &op : body.getOperations()) {
-    for (Value operand : op.getOperands()) {
-      if (auto bArg = dyn_cast<BlockArgument>(operand)) {
-        // Check whether the operand lies in the same block.
-        if (bArg.getOwner() == &body) {
-          continue;
-        }
-        return true;
-      }
-      Operation *defOp = operand.getDefiningOp();
-      // Scalar constant is allowed.
-      if (defOp && defOp->hasTrait<mlir::OpTrait::ConstantLike>()) {
-        Type type = operand.getType();
-        if (type.isIntOrFloat() || type.isIndex()) {
-          continue;
-        }
-      }
-      // If defining op is not inside the block, it’s an external value.
-      if (!defOp || defOp->getBlock() != &body) {
-        return true;
-      }
-    }
-  }
-  return false; // All operands are locally defined or block arguments.
-}
-
 /// Rematerialize all parallel elementwise operations into its users within a
 /// `flow.dispatch.region`.
 struct RematerializeParallelOpsPattern

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -544,6 +544,11 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
   // LinalgOp with only parallel dims. This is needed if the op cannot be fused
   // with a reduction or introduces new loop dimensions.
   auto shouldAttachLoweringConfig = [&](linalg::LinalgOp linalgOp) -> bool {
+    // If the operation has a gather, we want to fuse it with the
+    // reduction.
+    if (hasExternalCapture(cast<linalg::GenericOp>(linalgOp))) {
+      return false;
+    }
     // If some of the users are in computeOps and some are outside of
     // computeOps; attach lowering config, since the op can't be fused.
     if (llvm::any_of(linalgOp->getUsers(),

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1934,4 +1934,32 @@ bool neverRunsSecondIteration(scf::ForOp op) {
   return isUbUnderStep.value_or(false) && isLbNonNegative.value_or(false);
 }
 
+bool hasExternalCapture(linalg::GenericOp genericOp) {
+  Block &body = genericOp.getRegion().front();
+  for (Operation &op : body.getOperations()) {
+    for (Value operand : op.getOperands()) {
+      if (auto bArg = dyn_cast<BlockArgument>(operand)) {
+        // Check whether the operand lies in the same block.
+        if (bArg.getOwner() == &body) {
+          continue;
+        }
+        return true;
+      }
+      Operation *defOp = operand.getDefiningOp();
+      // Scalar constant is allowed.
+      if (defOp && defOp->hasTrait<mlir::OpTrait::ConstantLike>()) {
+        Type type = operand.getType();
+        if (type.isIntOrFloat() || type.isIndex()) {
+          continue;
+        }
+      }
+      // If defining op is not inside the block, it’s an external value.
+      if (!defOp || defOp->getBlock() != &body) {
+        return true;
+      }
+    }
+  }
+  return false; // All operands are locally defined or block arguments.
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -331,6 +331,21 @@ bool alwaysRunsFirstIteration(scf::ForOp op);
 /// the ForOp.
 bool neverRunsSecondIteration(scf::ForOp op);
 
+///  This function checks whether the `genericOp` has any external captures,
+///  i.e., whether it uses any values that are defined outside of its body.
+///  %10 = linalg.generic {indexing_maps = [#map, #map],
+///          iterator_types = ["parallel", "parallel"]}
+///         ins(%5 : tensor<4096x64xi64>) outs(%9 : tensor<4096x64xf16>) {
+///          ^bb0(%in: i64, %out: f16):
+///            %14 = linalg.index 0 : index
+///            %15 = arith.index_cast %in : i64 to index
+///            %extracted = tensor.extract %4[%14, %15] : tensor<4096x64xf16>
+///            linalg.yield %extracted : f16
+///           } -> tensor<4096x64xf16>
+///  Here %4 is an external capture used via tensor.extract inside
+///  linalg.generic hence the above `genericOp` has an external capture.
+bool hasExternalCapture(linalg::GenericOp genericOp);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_UTILS_H_


### PR DESCRIPTION
Don't attach lowering config to the gather operation. Let it fuse with the consumer operation. This eliminates the creation of a temporary buffer.
The change restricts element-wise fusion in the case of softmax with a gather-like operation.
Fixes https://github.com/iree-org/iree/issues/21107