### PR TITLE
Force install python version 3.13.5 for windows

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -227,7 +227,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13"
+          override_python_versions: "3.13.3"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
@@ -269,7 +269,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13"
+          override_python_versions: "3.13.3"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -117,58 +117,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu packages.
-          - runs-on: ubuntu-24.04
-            build-family: linux-x86_64
-            build-package: main-dist-linux
-            experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: main-dist-linux
-            experimental: true
-          - runs-on: ubuntu-24.04
-            build-family: linux-x86_64
-            build-package: py-compiler-pkg
-            experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: py-compiler-pkg
-            experimental: true
-          - runs-on: ubuntu-24.04
-            build-family: linux-x86_64
-            build-package: py-runtime-pkg
-            experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: py-runtime-pkg
-            experimental: true
-          - runs-on: ubuntu-24.04
-            build-family: linux-x86_64
-            build-package: py-tf-compiler-tools-pkg
-            experimental: false
-
-          # MacOS packages.
-          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
-          # - runs-on:
-          #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
-          #     - os-family=macOS
-          - runs-on: macos-14
-            build-family: macos
-            build-package: py-compiler-pkg
-            experimental: true
-          - runs-on: macos-14
-            build-family: macos
-            build-package: py-runtime-pkg
-            experimental: true
-
-          # Windows packages.
-          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
-          # - runs-on:
-          #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
-          - runs-on: windows-2022
-            build-family: windows
-            build-package: py-compiler-pkg
-            experimental: false
           - runs-on: windows-2022
             build-family: windows
             build-package: py-runtime-pkg
@@ -279,7 +227,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12 3.13"
+          override_python_versions: "3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
@@ -321,7 +269,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12 3.13"
+          override_python_versions: "3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -117,6 +117,58 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Ubuntu packages.
+          - runs-on: ubuntu-24.04
+            build-family: linux-x86_64
+            build-package: main-dist-linux
+            experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: main-dist-linux
+            experimental: true
+          - runs-on: ubuntu-24.04
+            build-family: linux-x86_64
+            build-package: py-compiler-pkg
+            experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-compiler-pkg
+            experimental: true
+          - runs-on: ubuntu-24.04
+            build-family: linux-x86_64
+            build-package: py-runtime-pkg
+            experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-runtime-pkg
+            experimental: true
+          - runs-on: ubuntu-24.04
+            build-family: linux-x86_64
+            build-package: py-tf-compiler-tools-pkg
+            experimental: false
+
+          # MacOS packages.
+          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # - runs-on:
+          #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
+          #     - os-family=macOS
+          - runs-on: macos-14
+            build-family: macos
+            build-package: py-compiler-pkg
+            experimental: true
+          - runs-on: macos-14
+            build-family: macos
+            build-package: py-runtime-pkg
+            experimental: true
+
+          # Windows packages.
+          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # - runs-on:
+          #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
+          - runs-on: windows-2022
+            build-family: windows
+            build-package: py-compiler-pkg
+            experimental: false
           - runs-on: windows-2022
             build-family: windows
             build-package: py-runtime-pkg

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -227,7 +227,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13.3"
+          override_python_versions: "3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
@@ -269,7 +269,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13.3"
+          override_python_versions: "3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -227,7 +227,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
@@ -269,7 +269,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.13"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -64,6 +64,9 @@ for($i=0 ; $i -lt $PYTHON_VERSIONS.Length; $i++) {
   }
 
   Write-Host "::  Python version $PYTHON_VERSION installed:"
+  if ($PYTHON_VERSION -eq "3.13.3") {
+    $PYTHON_VERSION = "3.13"
+  }
   & py -${PYTHON_VERSION} --version
   & py -${PYTHON_VERSION} -m pip --version
 

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -23,7 +23,7 @@ $PYTHON_VERSIONS_NO_DOT = @(
 )
 
 $PYTHON_UNINSTALLER_URLS = @(
-    "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe" #,
+    #"https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe" #,
 )
 
 # Uninstalling python versions
@@ -49,7 +49,7 @@ for($i=0 ; $i -lt $PYTHON_UNINSTALLER_URLS.Length; $i++) {
 
 # These can be discovered at https://www.python.org/downloads/windows/
 $PYTHON_INSTALLER_URLS = @(
-  "https://www.python.org/ftp/python/3.13.3/python-3.13.3-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe" #,
   "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe" #,
   "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
   # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",
@@ -70,23 +70,19 @@ for($i=0 ; $i -lt $PYTHON_VERSIONS.Length; $i++) {
   $PYTHON_INSTALLER_URL = $PYTHON_INSTALLER_URLS[$i]
   Write-Host "-- Installing Python ${PYTHON_VERSION} from ${PYTHON_INSTALLER_URL}"
 
-  if ("${INSTALLED_VERSIONS_OUTPUT}" -like "*${PYTHON_VERSION}*") {
-    Write-Host "::  Python version already installed. Not reinstalling."
-  } else {
-    $DOWNLOAD_ROOT = "$env:TEMP/iree_python_install"
-    $DOWNLOAD_FILENAME = $PYTHON_INSTALLER_URL.Substring($PYTHON_INSTALLER_URL.LastIndexOf("/") + 1)
-    $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
+  $DOWNLOAD_ROOT = "$env:TEMP/iree_python_install"
+  $DOWNLOAD_FILENAME = $PYTHON_INSTALLER_URL.Substring($PYTHON_INSTALLER_URL.LastIndexOf("/") + 1)
+  $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
 
-    # Create download folder as needed.
-    md -Force ${DOWNLOAD_ROOT} | Out-Null
+  # Create download folder as needed.
+  md -Force ${DOWNLOAD_ROOT} | Out-Null
 
-    Write-Host "::  Downloading $PYTHON_INSTALLER_URL -> $DOWNLOAD_PATH"
-    curl $PYTHON_INSTALLER_URL -o $DOWNLOAD_PATH
+  Write-Host "::  Downloading $PYTHON_INSTALLER_URL -> $DOWNLOAD_PATH"
+  curl $PYTHON_INSTALLER_URL -o $DOWNLOAD_PATH
 
-    Write-Host "::  Running installer: $DOWNLOAD_PATH"
-    # https://docs.python.org/3/using/windows.html#installing-without-ui
-    & "$DOWNLOAD_PATH" /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
-  }
+  Write-Host "::  Running installer: $DOWNLOAD_PATH"
+  # https://docs.python.org/3/using/windows.html#installing-without-ui
+  & "$DOWNLOAD_PATH" /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
 
   Write-Host "::  Python version $PYTHON_VERSION installed:"
   & py -${PYTHON_VERSION} --version

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -22,31 +22,6 @@ $PYTHON_VERSIONS_NO_DOT = @(
   # "39"
 )
 
-$PYTHON_UNINSTALLER_URLS = @(
-    #"https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe" #,
-)
-
-# Uninstalling python versions
-for($i=0 ; $i -lt $PYTHON_UNINSTALLER_URLS.Length; $i++) {
-  $PYTHON_UNINSTALLER_URL = $PYTHON_UNINSTALLER_URLS[$i]
-  Write-Host "-- Uninstalling Python from ${PYTHON_UNINSTALLER_URL}"
-
-  $DOWNLOAD_ROOT = "$env:TEMP/iree_python_uninstall"
-  $DOWNLOAD_FILENAME = $PYTHON_UNINSTALLER_URL.Substring($PYTHON_UNINSTALLER_URL.LastIndexOf("/") + 1)
-  $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
-
-  # Create download folder as needed.
-  md -Force ${DOWNLOAD_ROOT} | Out-Null
-
-  Write-Host "::  Downloading $PYTHON_UNINSTALLER_URL -> $DOWNLOAD_PATH"
-  curl $PYTHON_UNINSTALLER_URL -o $DOWNLOAD_PATH
-
-  Write-Host "::  Running uninstaller: $DOWNLOAD_PATH"
-  # https://docs.python.org/3/using/windows.html#installing-without-ui
-  # & "$DOWNLOAD_PATH" /quiet /uninstall
-  Start-Process -FilePath "$DOWNLOAD_PATH" -ArgumentList "/quiet /uninstall" -Wait
-}
-
 # These can be discovered at https://www.python.org/downloads/windows/
 $PYTHON_INSTALLER_URLS = @(
   "https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe" #,
@@ -70,19 +45,23 @@ for($i=0 ; $i -lt $PYTHON_VERSIONS.Length; $i++) {
   $PYTHON_INSTALLER_URL = $PYTHON_INSTALLER_URLS[$i]
   Write-Host "-- Installing Python ${PYTHON_VERSION} from ${PYTHON_INSTALLER_URL}"
 
-  $DOWNLOAD_ROOT = "$env:TEMP/iree_python_install"
-  $DOWNLOAD_FILENAME = $PYTHON_INSTALLER_URL.Substring($PYTHON_INSTALLER_URL.LastIndexOf("/") + 1)
-  $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
+  if ($PYTHON_VERSION -ne "3.13" -and "${INSTALLED_VERSIONS_OUTPUT}" -like "*${PYTHON_VERSION}*") {
+    Write-Host "::  Python version already installed. Not reinstalling."
+  } else {
+    $DOWNLOAD_ROOT = "$env:TEMP/iree_python_install"
+    $DOWNLOAD_FILENAME = $PYTHON_INSTALLER_URL.Substring($PYTHON_INSTALLER_URL.LastIndexOf("/") + 1)
+    $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
 
-  # Create download folder as needed.
-  md -Force ${DOWNLOAD_ROOT} | Out-Null
+    # Create download folder as needed.
+    md -Force ${DOWNLOAD_ROOT} | Out-Null
 
-  Write-Host "::  Downloading $PYTHON_INSTALLER_URL -> $DOWNLOAD_PATH"
-  curl $PYTHON_INSTALLER_URL -o $DOWNLOAD_PATH
+    Write-Host "::  Downloading $PYTHON_INSTALLER_URL -> $DOWNLOAD_PATH"
+    curl $PYTHON_INSTALLER_URL -o $DOWNLOAD_PATH
 
-  Write-Host "::  Running installer: $DOWNLOAD_PATH"
-  # https://docs.python.org/3/using/windows.html#installing-without-ui
-  & "$DOWNLOAD_PATH" /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+    Write-Host "::  Running installer: $DOWNLOAD_PATH"
+    # https://docs.python.org/3/using/windows.html#installing-without-ui
+    & "$DOWNLOAD_PATH" /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+  }
 
   Write-Host "::  Python version $PYTHON_VERSION installed:"
   & py -${PYTHON_VERSION} --version

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -43,7 +43,8 @@ for($i=0 ; $i -lt $PYTHON_UNINSTALLER_URLS.Length; $i++) {
 
   Write-Host "::  Running uninstaller: $DOWNLOAD_PATH"
   # https://docs.python.org/3/using/windows.html#installing-without-ui
-  & "$DOWNLOAD_PATH" /quiet /uninstall
+  # & "$DOWNLOAD_PATH" /quiet /uninstall
+  Start-Process -FilePath "$DOWNLOAD_PATH" -ArgumentList "/quiet /uninstall" -Wait
 }
 
 # These can be discovered at https://www.python.org/downloads/windows/

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -7,7 +7,7 @@
 # Installs dependencies on Windows necessary to build IREE Python wheels.
 
 $PYTHON_VERSIONS = @(
-  "3.13" #,
+  "3.13.3" #,
   "3.12" #,
   "3.11" #,
   # "3.10",
@@ -24,7 +24,7 @@ $PYTHON_VERSIONS_NO_DOT = @(
 
 # These can be discovered at https://www.python.org/downloads/windows/
 $PYTHON_INSTALLER_URLS = @(
-  "https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.13.3/python-3.13.3-amd64.exe" #,
   "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe" #,
   "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
   # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -7,7 +7,7 @@
 # Installs dependencies on Windows necessary to build IREE Python wheels.
 
 $PYTHON_VERSIONS = @(
-  "3.13.3" #,
+  "3.13" #,
   "3.12" #,
   "3.11" #,
   # "3.10",
@@ -21,6 +21,30 @@ $PYTHON_VERSIONS_NO_DOT = @(
   # "310",
   # "39"
 )
+
+$PYTHON_UNINSTALLER_URLS = @(
+    "https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe" #,
+)
+
+# Uninstalling python versions
+for($i=0 ; $i -lt $PYTHON_UNINSTALLER_URLS.Length; $i++) {
+  $PYTHON_UNINSTALLER_URL = $PYTHON_UNINSTALLER_URLS[$i]
+  Write-Host "-- Uninstalling Python from ${PYTHON_UNINSTALLER_URL}"
+
+  $DOWNLOAD_ROOT = "$env:TEMP/iree_python_uninstall"
+  $DOWNLOAD_FILENAME = $PYTHON_UNINSTALLER_URL.Substring($PYTHON_UNINSTALLER_URL.LastIndexOf("/") + 1)
+  $DOWNLOAD_PATH = "${DOWNLOAD_ROOT}/$DOWNLOAD_FILENAME"
+
+  # Create download folder as needed.
+  md -Force ${DOWNLOAD_ROOT} | Out-Null
+
+  Write-Host "::  Downloading $PYTHON_UNINSTALLER_URL -> $DOWNLOAD_PATH"
+  curl $PYTHON_UNINSTALLER_URL -o $DOWNLOAD_PATH
+
+  Write-Host "::  Running uninstaller: $DOWNLOAD_PATH"
+  # https://docs.python.org/3/using/windows.html#installing-without-ui
+  & "$DOWNLOAD_PATH" /quiet /uninstall
+}
 
 # These can be discovered at https://www.python.org/downloads/windows/
 $PYTHON_INSTALLER_URLS = @(
@@ -64,9 +88,6 @@ for($i=0 ; $i -lt $PYTHON_VERSIONS.Length; $i++) {
   }
 
   Write-Host "::  Python version $PYTHON_VERSION installed:"
-  if ($PYTHON_VERSION -eq "3.13.3") {
-    $PYTHON_VERSION = "3.13"
-  }
   & py -${PYTHON_VERSION} --version
   & py -${PYTHON_VERSION} -m pip --version
 


### PR DESCRIPTION
There is an issue with python version 3.13.4 on github windows runners. 

Github issue: https://github.com/actions/runner-images/issues/12377

This PR should be reverted once the above mentioned github issue is resolved