### PR TITLE
[Dispatch Creation] Improve extract_slice expand_shape bubbling

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -161,8 +161,8 @@ struct SwapExtractSliceOfFill final
 
 /// Bubbles a `tensor.expand_shape` op through a `tensor.extract_slice` op. This
 /// pattern only gets applied when the `extract_slice` doesn't modify dimensions
-/// that are expanded by the `expand_shape` and when the `extract_slice` is
-/// completely static.
+/// that are expanded by the `expand_shape` and none of the expanded dimensions
+/// are dynamic.
 /// TODO: move this upstream with other tensor bubbling patterns.
 struct BubbleExpandThroughExtract final
     : public OpRewritePattern<tensor::ExpandShapeOp> {
@@ -176,60 +176,92 @@ struct BubbleExpandThroughExtract final
       return failure();
     }
 
-    auto srcType = extractOp.getSourceType();
-    auto extractedType = extractOp.getType();
-    auto expandedType = expandOp.getType();
+    ArrayRef<int64_t> extractSrcShape = extractOp.getSourceType().getShape();
+    ArrayRef<int64_t> extractDstShape = extractOp.getResultType().getShape();
+    const uint64_t extractSrcRank = extractSrcShape.size();
 
-    if (srcType.getRank() != extractedType.getRank()) {
-      return rewriter.notifyMatchFailure(
-          extractOp, "Rank reducing extract_slice not supported");
-    }
-
-    if (!srcType.hasStaticShape() || !extractedType.hasStaticShape() ||
-        !expandedType.hasStaticShape()) {
-      return failure();
-    }
-
-    auto reassoc = expandOp.getReassociationIndices();
-    for (auto i : llvm::seq<uint64_t>(0, extractedType.getRank())) {
-      if (reassoc[i].size() == 1) {
+    // Check that none of the expanded dimensions are dynamic or are sliced by
+    // the `extract_slice`.
+    const llvm::SmallBitVector droppedDims = extractOp.getDroppedDims();
+    const SmallVector<ReassociationIndices, 4> reassoc =
+        expandOp.getReassociationIndices();
+    int64_t droppedDimCount = 0;
+    for (uint64_t i = 0; i < extractSrcRank; i++) {
+      if (droppedDims.test(i)) {
+        ++droppedDimCount;
         continue;
       }
-
-      if (srcType.getShape()[i] != extractedType.getShape()[i]) {
+      if (reassoc[i - droppedDimCount].size() == 1) {
+        continue;
+      }
+      if (ShapedType::isDynamic(extractSrcShape[i]) ||
+          extractSrcShape[i] != extractDstShape[i - droppedDimCount]) {
         return rewriter.notifyMatchFailure(
             extractOp, "Extract modifies the expanded dimension");
       }
     }
 
-    SmallVector<int64_t> newExpandShape;
-    SmallVector<int64_t> offsets;
-    SmallVector<int64_t> sizes;
-    SmallVector<int64_t> strides;
-    for (auto [inDim, outDims] : llvm::enumerate(reassoc)) {
-      if (outDims.size() == 1) {
-        newExpandShape.push_back(srcType.getShape()[inDim]);
-        offsets.push_back(extractOp.getStaticOffsets()[inDim]);
-        sizes.push_back(extractOp.getStaticSizes()[inDim]);
-        strides.push_back(extractOp.getStaticStrides()[inDim]);
+    // Construct a reassociation that expands `extract_slice`'s source by
+    // combining the reassociation from the `expand_shape` with the dropped dims
+    // from the `extract_slice`.
+    SmallVector<ReassociationIndices> newReassociation;
+    newReassociation.reserve(extractSrcRank);
+    int64_t count = 0;
+    uint64_t expandedIdx = 0;
+    for (uint64_t i = 0; i < extractSrcRank; i++) {
+      if (droppedDims.test(i)) {
+        newReassociation.push_back(ReassociationIndices{count++});
       } else {
-        for (auto outDim : outDims) {
-          newExpandShape.push_back(expandedType.getShape()[outDim]);
-          offsets.push_back(0);
-          sizes.push_back(expandedType.getShape()[outDim]);
-          strides.push_back(1);
-        }
+        int64_t numExpanded = reassoc[expandedIdx++].size();
+        newReassociation.push_back(
+            llvm::to_vector(llvm::seq(count, count + numExpanded)));
+        count += numExpanded;
       }
     }
 
-    Type newExpandType =
+    const SmallVector<OpFoldResult> oldOffsets = extractOp.getMixedOffsets();
+    const SmallVector<OpFoldResult> oldSizes = extractOp.getMixedSizes();
+    const SmallVector<OpFoldResult> oldStrides = extractOp.getMixedStrides();
+
+    RankedTensorType expandedType = expandOp.getResultType();
+    ArrayRef<int64_t> expandedShape = expandedType.getShape();
+    auto zeroAttr = rewriter.getIndexAttr(0);
+    auto oneAttr = rewriter.getIndexAttr(1);
+
+    SmallVector<int64_t> newExpandShape;
+    SmallVector<OpFoldResult> newOffsets;
+    SmallVector<OpFoldResult> newSizes;
+    SmallVector<OpFoldResult> newStrides;
+    droppedDimCount = 0;
+    for (const auto &[inDim, outDims] : llvm::enumerate(newReassociation)) {
+      droppedDimCount += droppedDims.test(inDim) ? 1 : 0;
+      if (outDims.size() == 1) {
+        newExpandShape.push_back(extractSrcShape[inDim]);
+        newOffsets.push_back(oldOffsets[inDim]);
+        newSizes.push_back(oldSizes[inDim]);
+        newStrides.push_back(oldStrides[inDim]);
+        continue;
+      }
+      for (auto outDim : outDims) {
+        int64_t expandedDim = expandedShape[outDim - droppedDimCount];
+        assert(!ShapedType::isDynamic(expandedDim));
+        newExpandShape.push_back(expandedDim);
+        newOffsets.push_back(zeroAttr);
+        newSizes.push_back(rewriter.getIndexAttr(expandedDim));
+        newStrides.push_back(oneAttr);
+      }
+    }
+
+    auto newExpandType =
         RankedTensorType::get(newExpandShape, expandedType.getElementType());
+    // The builder can't fail to compute the output_shape because none of
+    // the dynamic dimensions are expanded.
     auto newExpand = rewriter.create<tensor::ExpandShapeOp>(
-        expandOp.getLoc(), newExpandType, extractOp.getSource(), reassoc);
+        expandOp.getLoc(), newExpandType, extractOp.getSource(),
+        newReassociation);
 
     rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
-        expandOp, expandedType, newExpand, ValueRange{}, ValueRange{},
-        ValueRange{}, offsets, sizes, strides);
+        expandOp, expandedType, newExpand, newOffsets, newSizes, newStrides);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_extract_slice.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_extract_slice.mlir
@@ -219,3 +219,74 @@ func.func @bubble_up_expand_of_extract_of_expand(%arg0: tensor<131072xi64>, %arg
 //  CHECK-SAME:       ins(%[[SLICE0]], %[[EXPAND2]] :
 //  CHECK-SAME:       outs(%[[EMPTY]] :
 //       CHECK:   return %[[GENERIC]]
+
+// -----
+
+util.func public @no_bubble_expand_sliced_dim(%arg0 : tensor<1024xf16>) -> (tensor<32x10xf16>) {
+  %extracted_slice = tensor.extract_slice %arg0[0] [320] [1] : tensor<1024xf16> to tensor<320xf16>
+  %expanded = tensor.expand_shape %extracted_slice[[0, 1]] output_shape [32, 10] : tensor<320xf16> into tensor<32x10xf16>
+  util.return %expanded : tensor<32x10xf16>
+}
+// CHECK-LABEL: util.func public @no_bubble_expand_sliced_dim
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[ARG0]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[EXTRACT]]
+
+// -----
+
+util.func public @no_bubble_slice_dynamic(%arg0 : tensor<?xf16>, %val : index) -> (tensor<32x?xf16>) {
+  %extracted_slice = tensor.extract_slice %arg0[0] [%val] [1] : tensor<?xf16> to tensor<?xf16>
+  %cst32 = arith.constant 32 : index
+  %div = arith.divsi %val, %cst32 : index
+  %expanded_239 = tensor.expand_shape %extracted_slice[[0, 1]] output_shape [32, %div] : tensor<?xf16> into tensor<32x?xf16>
+  util.return %expanded_239 : tensor<32x?xf16>
+}
+// CHECK-LABEL: util.func public @no_bubble_slice_dynamic
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[ARG0]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[EXTRACT]]
+
+// -----
+
+util.func public @bubble_slice_dynamic(%arg0 : tensor<?x10x128xf16>, %val : index) -> (tensor<?x5x2x16xf16>) {
+  %extracted_slice = tensor.extract_slice %arg0[0, 0, 0] [%val, 10, 16] [1, 1, 1] : tensor<?x10x128xf16> to tensor<?x10x16xf16>
+  %expanded = tensor.expand_shape %extracted_slice[[0], [1, 2], [3]] output_shape [%val, 5, 2, 16] : tensor<?x10x16xf16> into tensor<?x5x2x16xf16>
+  util.return %expanded : tensor<?x5x2x16xf16>
+}
+// CHECK-LABEL: util.func public @bubble_slice_dynamic
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+//       CHECK:   %[[CST0:.+]] = arith.constant 0
+//       CHECK:   %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[CST0]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     output_shape [%[[DIM]], 5, 2, 128]
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[EXPAND]]
+//  CHECK-SAME:     [0, 0, 0, 0] [%[[ARG1]], 5, 2, 16] [1, 1, 1, 1]
+
+// -----
+
+util.func public @bubble_expand_rank_reducing_inner(%arg0 : tensor<1024x10xf16>) -> (tensor<32x32xf16>) {
+  %extracted_slice = tensor.extract_slice %arg0[0, 0] [1024, 1] [1, 1] : tensor<1024x10xf16> to tensor<1024xf16>
+  %expanded = tensor.expand_shape %extracted_slice[[0, 1]] output_shape [32, 32] : tensor<1024xf16> into tensor<32x32xf16>
+  util.return %expanded : tensor<32x32xf16>
+}
+// CHECK-LABEL: util.func public @bubble_expand_rank_reducing_inner
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1024x10xf16> into tensor<32x32x10xf16>
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[EXPAND]]
+//  CHECK-SAME:     tensor<32x32x10xf16> to tensor<32x32xf16>
+
+// -----
+
+util.func public @bubble_expand_rank_reducing_outer(%arg0 : tensor<10x1024xf16>) -> (tensor<32x32xf16>) {
+  %extracted_slice = tensor.extract_slice %arg0[0, 0] [1, 1024] [1, 1] : tensor<10x1024xf16> to tensor<1024xf16>
+  %expanded = tensor.expand_shape %extracted_slice[[0, 1]] output_shape [32, 32] : tensor<1024xf16> into tensor<32x32xf16>
+  util.return %expanded : tensor<32x32xf16>
+}
+// CHECK-LABEL: util.func public @bubble_expand_rank_reducing_outer
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<10x1024xf16> into tensor<10x32x32xf16>
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[EXPAND]]
+//  CHECK-SAME:     tensor<10x32x32xf16> to tensor<32x32xf16>


### PR DESCRIPTION
Extends the pattern to handle rank reducing `extract_slice`s as well instances where the `expand_shape` contains but doesn't expand any dynamic dimensions. This is useful to improve fusion (by cloning the slice) and prevent the `extract_slice` from materializing to a slow memcpy.

Closes https://github.com/iree-org/iree/issues/21015