### PR TITLE
[Codegen][GPU] Sort intrinsic according to k alignment - Step 2 of 2 - Creating intrinsic sort routine

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -135,23 +135,21 @@ static void sortMMAIntrinsics(GPUMatmulShapeType problem,
   llvm::sort(intrinsics, [&](const GPUMatmulShapeType &lhs,
                              const GPUMatmulShapeType &rhs) {
     // Prefer K-aligned intrinsics.
-    int64_t lhsKAligned =
-        problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
-    int64_t rhsKAligned =
-        problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
+    int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
+    int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
     if (lhsKAligned != rhsKAligned) {
       return lhsKAligned > rhsKAligned;
     }
 
     // If K alignment is the same, prefer the intrinsic that aligns M and N.
-    int64_t lhsMNAligned = (problem.mSizes.back() % lhs.mSizes.back() == 0 &&
-                            problem.nSizes.back() % lhs.nSizes.back() == 0)
-                               ? 1
-                               : 0;
-    int64_t rhsMNAligned = (problem.mSizes.back() % rhs.mSizes.back() == 0 &&
-                            problem.nSizes.back() % rhs.nSizes.back() == 0)
-                               ? 1
-                               : 0;
+    int lhsMNAligned = (problem.mSizes.back() % lhs.mSizes.back() == 0 &&
+                        problem.nSizes.back() % lhs.nSizes.back() == 0)
+                           ? 1
+                           : 0;
+    int rhsMNAligned = (problem.mSizes.back() % rhs.mSizes.back() == 0 &&
+                        problem.nSizes.back() % rhs.nSizes.back() == 0)
+                           ? 1
+                           : 0;
     if (lhsMNAligned != rhsMNAligned) {
       return lhsMNAligned > rhsMNAligned;
     }
@@ -161,8 +159,8 @@ static void sortMMAIntrinsics(GPUMatmulShapeType problem,
               ShapedType::getNumElements(intrinsic.nSizes)) *
              ShapedType::getNumElements(intrinsic.kSizes);
     };
-    auto lhsArea = intrinsicArea(lhs);
-    auto rhsArea = intrinsicArea(rhs);
+    int64_t lhsArea = intrinsicArea(lhs);
+    int64_t rhsArea = intrinsicArea(rhs);
     if (lhsArea != rhsArea) {
       return lhsArea > rhsArea;
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -156,15 +156,10 @@ static void sortMMAIntrinsics(GPUMatmulShapeType problem,
       return lhsMNAligned > rhsMNAligned;
     }
 
-    // If alignment situation is the same, prefer the intrinsic with larger size
-    auto collapseVector = [](const SmallVector<int64_t, 2> &sizes) {
-      return std::accumulate(sizes.begin(), sizes.end(), 1,
-                             std::multiplies<int64_t>());
-    };
     auto intrinsicArea = [&](const GPUMatmulShapeType &intrinsic) {
-      return (collapseVector(intrinsic.mSizes) +
-              collapseVector(intrinsic.nSizes)) *
-             collapseVector(intrinsic.kSizes);
+      return (ShapedType::getNumElements(intrinsic.mSizes) +
+              ShapedType::getNumElements(intrinsic.nSizes)) *
+             ShapedType::getNumElements(intrinsic.kSizes);
     };
     auto lhsArea = intrinsicArea(lhs);
     auto rhsArea = intrinsicArea(rhs);
@@ -173,7 +168,8 @@ static void sortMMAIntrinsics(GPUMatmulShapeType problem,
     }
 
     // Finally if everything else is the same, prefer large K size.
-    return collapseVector(lhs.kSizes) > collapseVector(rhs.kSizes);
+    return ShapedType::getNumElements(lhs.kSizes) >
+           ShapedType::getNumElements(rhs.kSizes);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -157,9 +157,10 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 
 // -----
 
+// This tests the mfma lowering intrinsic K alignment. Since gemmK = 360, and will
+// be aligned to 8 but not 16, we expect the 32x32x8xf16 intrinsic to be used.
 func.func @mfma_matmul_k_aligned_intrinsic(%lhs: tensor<1024x360xf16>, %rhs: tensor<360x1024xf16>) -> tensor<1024x1024xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
   %5 = tensor.empty() : tensor<1024x1024xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
   %7 = linalg.matmul ins(%lhs, %rhs : tensor<1024x360xf16>, tensor<360x1024xf16>) outs(%6 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
@@ -170,6 +171,24 @@ func.func @mfma_matmul_k_aligned_intrinsic(%lhs: tensor<1024x360xf16>, %rhs: ten
 // CHECK:         pipeline = LLVMGPUTileAndFuse
 // CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:    mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
+
+// LATE: LLVMGPUVectorDistribute
+
+// -----
+
+// This tests the mfma lowering intrinsic M alignment. Since gemmM = 176, and will
+// be aligned to 16 but not 32, we expect the 16x16x32xi8 intrinsic to be used.
+func.func @mfma_matmul_m_aligned_intrinsic(%lhs: tensor<176x1024xi8>, %rhs: tensor<1024x1024xi8>) -> tensor<176x1024xi32> {
+  %cst = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<176x1024xi32>
+  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<176x1024xi32>) -> tensor<176x1024xi32>
+  %7 = linalg.matmul ins(%lhs, %rhs : tensor<176x1024xi8>, tensor<1024x1024xi8>) outs(%6 : tensor<176x1024xi32>) -> tensor<176x1024xi32>
+  return %7 : tensor<176x1024xi32>
+}
+
+// CHECK-LABEL: func.func @mfma_matmul_m_aligned_intrinsic
+// CHECK:         linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>
 
 // LATE: LLVMGPUVectorDistribute
 


### PR DESCRIPTION
This is a follow-up of https://github.com/iree-org/iree/pull/21103.

This intrinsic sorting routine will sort the MMA intrinsics by following precedence rules:
  1) K-alignment. We prefer intrinsics that can evenly divide the K dimension of the problem.
  2) M/N-alignment. We prefer intrinsics that can evenly divide the M and N dimensions of the problem.
  3) Intrinsic with larger gemm size.
  4) Intrinsic with larger K size.

Scope of the impact is igemm and matmul problems. Other pipelines can choose to adopt this if the sorting turns out to be useful.

### Motivation:

convolution configuration with 
> BOO_CACHE_ON=0 python boo_driver.py convbfp16 -n 16 -c 40 -H 192 -W 128 -k 40 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 50

Since the gemmK size is 360, the best intrinsic is 32x32x8xbf16, not 16x16x16xbf16, as the former will end in aligned K. Before this PR: `362.06 us`. After this PR: `44.74 us`. Note that due to limitation of the tuner, this combination won't be covered by typical tuning run with 2k trials. So it is essential we bridge the gap through heuristic first before tuner is more capable of searching through different heuristics. 