### PR TITLE
Change linux arm64 runners to newly available github hosted runners

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -122,7 +122,7 @@ jobs:
             build-family: linux-x86_64
             build-package: main-dist-linux
             experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          - runs-on: ubuntu-24.04-arm
             build-family: linux-aarch64
             build-package: main-dist-linux
             experimental: true
@@ -130,7 +130,7 @@ jobs:
             build-family: linux-x86_64
             build-package: py-compiler-pkg
             experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          - runs-on: ubuntu-24.04-arm
             build-family: linux-aarch64
             build-package: py-compiler-pkg
             experimental: true
@@ -138,7 +138,7 @@ jobs:
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          - runs-on: ubuntu-24.04-arm
             build-family: linux-aarch64
             build-package: py-runtime-pkg
             experimental: true


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories