### PR TITLE
[Flow] Fix crash when flow.return has no operands

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -381,14 +381,13 @@ LogicalResult DispatchRegionOp::verify() {
   }
 
   // Verify terminator.
-  SmallVector<Flow::ReturnOp> returnOps;
-  for (Block &block : getBody()) {
-    if (auto returnOp =
-            dyn_cast_or_null<Flow::ReturnOp>(block.getTerminator())) {
-      returnOps.push_back(returnOp);
+  for (auto returnOp : getBody().getOps<Flow::ReturnOp>()) {
+    if (returnOp.getNumOperands() != getNumResults()) {
+      return returnOp->emitOpError()
+             << "number of results (" << getNumResults()
+             << ") does not match number of returned values ("
+             << returnOp.getNumOperands() << ")";
     }
-  }
-  for (auto returnOp : returnOps) {
     for (const auto [resultType, returnType] :
          llvm::zip_equal(getResultTypes(), returnOp->getOperandTypes()))
       if (resultType != returnType) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
@@ -170,6 +170,26 @@ util.func public @regionDynamicShape(%arg0: tensor<?x?x16xf32>, %dim0: index, %d
 
 // -----
 
+util.func public @regionInvalidReturnCountMismatch() -> tensor<32xf16> {
+  %dispatch = flow.dispatch.region -> (tensor<32xf16>) {
+    // expected-error @+1 {{'flow.return' op number of results (1) does not match number of returned values (0)}}
+    flow.return
+  }
+  util.return %dispatch : tensor<32xf16>
+}
+
+// -----
+
+util.func public @regionInvalidReturnTypeMismatch(%arg0: tensor<1xf16>) -> tensor<32xf16> {
+  %dispatch = flow.dispatch.region -> (tensor<32xf16>) {
+    // expected-error @+1 {{'flow.return' op operand types do not match with parent results}}
+    flow.return %arg0 : tensor<1xf16>
+  }
+  util.return %dispatch : tensor<32xf16>
+}
+
+// -----
+
 // CHECK-LABEL: @complexWorkgroupsUsage
 util.func public @complexWorkgroupsUsage(
     // CHECK-SAME: %[[ARG0:.+]]: tensor<?x4xf32>


### PR DESCRIPTION
Fixes verifier crash when `flow.return`'s operand count doesn't match the number of results returned by the dispatch (test: `regionInvalidReturnCountMismatch`). Also, adds a test for return type mismatch `regionInvalidReturnTypeMismatch`.