### PR TITLE
[CodeGen] Re-enable memref::AssumeAlignmentOp for SPIRV pipelines. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -283,11 +283,8 @@ createIREEComprehensiveBufferizePass(
                                                           memCpyFn.value());
 }
 
-void addIREEPostBufferizationPasses(OpPassManager &funcPassManager,
-                                    bool injectAssumeAlignmentOp) {
-  if (injectAssumeAlignmentOp) {
-    funcPassManager.addPass(createIREEInjectAssumeAlignmentPass());
-  }
+void addIREEPostBufferizationPasses(OpPassManager &funcPassManager) {
+  funcPassManager.addPass(createIREEInjectAssumeAlignmentPass());
   funcPassManager.addPass(memref::createResolveShapedTypeResultDimsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -301,13 +298,12 @@ void addIREEPostBufferizationPasses(OpPassManager &funcPassManager,
 void addIREEComprehensiveBufferizePasses(
     OpPassManager &funcPassManager,
     std::optional<BufferizationOptions::AllocationFn> allocationFn,
-    std::optional<BufferizationOptions::MemCpyFn> memCpyFn,
-    bool injectAssumeAlignmentOp) {
+    std::optional<BufferizationOptions::MemCpyFn> memCpyFn) {
   funcPassManager.addPass(createEliminateEmptyTensorsPass());
   funcPassManager.addPass(bufferization::createEmptyTensorToAllocTensorPass());
   funcPassManager.addPass(
       createIREEComprehensiveBufferizePass(allocationFn, memCpyFn));
-  addIREEPostBufferizationPasses(funcPassManager, injectAssumeAlignmentOp);
+  addIREEPostBufferizationPasses(funcPassManager);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -39,18 +39,14 @@ void addCommonTargetExecutablePreprocessingPasses(
 /// Post-bufferization passes run to cleanup the IR
 /// (ResolveShapedTypeResultDims, Canonicalization/CSE and
 /// CleanupBufferAllocView).
-/// TODO(#20912): Enable the injection of assume_alignment ops after the
-/// hoisting bug is fixed.
-void addIREEPostBufferizationPasses(OpPassManager &funcPassManager,
-                                    bool injectAssumeAlignmentOp = true);
+void addIREEPostBufferizationPasses(OpPassManager &funcPassManager);
 
 using bufferization::BufferizationOptions;
 void addIREEComprehensiveBufferizePasses(
     OpPassManager &funcPassManager,
     std::optional<BufferizationOptions::AllocationFn> allocationFn =
         std::nullopt,
-    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt,
-    bool injectAssumeAlignmentOp = true);
+    std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt);
 
 /// Populate Encoding to Nop pass and canonicalizer pass to the pipeline.
 void addEncodingToNopPasses(FunctionLikeNest &passManager);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
@@ -70,12 +70,15 @@ func.func @matmul_i4_quant_weight() {
 //           CHECK:   %[[A_ALLOC:.+]] = memref.alloc() : memref<32x1x36xf32, #gpu.address_space<workgroup>>
 //           CHECK:   %[[B_ALLOC:.+]] = memref.alloc() : memref<1x32x132xf32, #gpu.address_space<workgroup>>
 //           CHECK:   %[[WEIGHT_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//           CHECK:   %[[WEIGHT_ALIGNED:.+]] = memref.assume_alignment %[[WEIGHT_BINDING]]
 //           CHECK:   %[[SCALE_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//           CHECK:   %[[SCALE_ALIGNED:.+]] = memref.assume_alignment %[[SCALE_BINDING]]
 //           CHECK:   %[[ZP_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
+//           CHECK:   %[[ZP_ALIGNED:.+]] = memref.assume_alignment %[[ZP_BINDING]]
 //           CHECK:   scf.for %arg0 = %c0 to %c86 step %c1 iter_args({{.+}}) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
-//           CHECK:     %[[SCALE0:.+]] = vector.transfer_read %[[SCALE_BINDING]]
-//           CHECK:     %[[SCALE1:.+]] = vector.transfer_read %[[SCALE_BINDING]]
-//           CHECK:     %[[ZP:.+]] = vector.transfer_read %[[ZP_BINDING]]
+//           CHECK:     %[[SCALE0:.+]] = vector.transfer_read %[[SCALE_ALIGNED]]
+//           CHECK:     %[[SCALE1:.+]] = vector.transfer_read %[[SCALE_ALIGNED]]
+//           CHECK:     %[[ZP:.+]] = vector.transfer_read %[[ZP_ALIGNED]]
 //           CHECK:     %[[SLICE0:.+]] = vector.extract_strided_slice %[[ZP]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xi4> to vector<4xi4>
 //           CHECK:     %[[ZP_EXT0:.+]] = arith.extsi %[[SLICE0]] : vector<4xi4> to vector<4xi32>
 //           CHECK:     %[[SLICE1:.+]] = vector.extract_strided_slice %[[ZP]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xi4> to vector<4xi4>
@@ -83,7 +86,7 @@ func.func @matmul_i4_quant_weight() {
 
 //           CHECK:     scf.for %arg5 = %c0 to %c96 step %c32 iter_args({{.+}}) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>)
 
-//           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
+//           CHECK:       vector.transfer_read %[[WEIGHT_ALIGNED]]
 //   CHECK-COUNT-2:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
 //           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT0]] : vector<4xi32>
 //           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT1]] : vector<4xi32>
@@ -92,7 +95,7 @@ func.func @matmul_i4_quant_weight() {
 //           CHECK:       arith.mulf %{{.+}}, %[[SCALE1]] : vector<4xf32>
 //     CHECK-COUNT:       vector.transfer_write %{{.+}}, %[[B_ALLOC]]
 
-//           CHECK:       vector.transfer_read %[[WEIGHT_BINDING]]
+//           CHECK:       vector.transfer_read %[[WEIGHT_ALIGNED]]
 //   CHECK-COUNT-2:       arith.extsi %{{.+}} : vector<4xi4> to vector<4xi32>
 //           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT0]] : vector<4xi32>
 //           CHECK:       arith.subi %{{.+}}, %[[ZP_EXT1]] : vector<4xi32>


### PR DESCRIPTION
It also drops the option from bufferization, which means that all the pipelines are using AssumeAlignmentOp now. The upstream fix is https://github.com/llvm/llvm-project/commit/541f33e0751d60b33e75efe0cd436396f27b91ca

Fixes https://github.com/iree-org/iree/issues/20912