### PR TITLE
[LinalgExt] support converting argcompare to loops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -670,7 +670,12 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 
 def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
-  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+  DeclareOpInterfaceMethods<LinalgExtInterface>,
+  DeclareOpInterfaceMethods<TilingInterface,
+  ["generateScalarImplementation",
+   "getIterationDomain"]
+  >
 ]> {
   let summary = "Performs an arg-reduction using a user-defined comparator.";
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1362,8 +1362,7 @@ LogicalResult ArgCompareOp::generateScalarImplementation(OpBuilder &b,
                                                          ValueRange ivs) {
   uint64_t reductionDim = getDimension();
   SmallVector<Value> parallelIndices;
-  size_t rank = ivs.size();
-  for (size_t i = 0; i < rank; ++i) {
+  for (size_t i = 0, rank = ivs.size(); i < rank; ++i) {
     if (i == reductionDim)
       continue;
     parallelIndices.push_back(ivs[i]);
@@ -1408,10 +1407,8 @@ LogicalResult ArgCompareOp::generateScalarImplementation(OpBuilder &b,
       elseBuilder.clone(op, regionMap);
     }
     Value cmpResult = regionMap.lookup(srcBlock.getTerminator()->getOperand(0));
-
     Value selectedValue = elseBuilder.create<arith::SelectOp>(
         loc, cmpResult, candidateValue, bestValueSoFar);
-
     Value selectedIndex = elseBuilder.create<arith::SelectOp>(
         loc, cmpResult, castedIndex, bestIndexSoFar);
     elseBuilder.create<memref::StoreOp>(loc, selectedValue, outputValue(),

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -733,6 +733,172 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
 
 // -----
 
+func.func @arg_compare_memref(
+    %input_values: memref<2x10xf32>,
+    %out_values: memref<2xf32>,
+    %out_indices: memref<2xi32>
+) {
+  iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_values : memref<2x10xf32>)
+    outs(%out_values, %out_indices : memref<2xf32>, memref<2xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @arg_compare_memref
+// CHECK-SAME: %[[INPUT:.+]]: memref<2x10xf32>
+// CHECK-SAME: %[[OUTVAL:.+]]: memref<2xf32>
+// CHECK-SAME: %[[OUTIDX:.+]]: memref<2xi32>
+
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
+
+// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
+// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
+// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
+// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
+// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
+// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+
+// -----
+
+func.func @arg_compare_memref_dynamic(
+    %input_values: memref<?x?xf32>,
+    %out_values: memref<?xf32>,
+    %out_indices: memref<?xi32>
+) {
+  iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_values : memref<?x?xf32>)
+    outs(%out_values, %out_indices : memref<?xf32>, memref<?xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @arg_compare_memref_dynamic
+// CHECK-SAME: %[[INPUT:.+]]: memref<?x?xf32>
+// CHECK-SAME: %[[OUTVAL:.+]]: memref<?xf32>
+// CHECK-SAME: %[[OUTIDX:.+]]: memref<?xi32>
+
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[DIM0:.+]] = memref.dim %[[INPUT]], %[[C0]] : memref<?x?xf32>
+// CHECK-DAG: %[[DIM1:.+]] = memref.dim %[[INPUT]], %[[C1]] : memref<?x?xf32>
+
+// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[DIM0]] step %[[C1]] {
+// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[DIM1]] step %[[C1]] {
+// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<?xf32>
+// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<?xi32>
+// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<?x?xf32>
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
+// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
+// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
+// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
+// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<?xf32>
+// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<?xi32>
+
+// -----
+
+func.func @arg_compare_memref_with_base(
+    %input_values: memref<2x10xf32>,
+    %index_base: index,
+    %out_values: memref<2xf32>,
+    %out_indices: memref<2xi32>
+) {
+  iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%input_values : memref<2x10xf32>)
+    outs(%out_values, %out_indices : memref<2xf32>, memref<2xi32>)
+    index_base(%index_base : index) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @arg_compare_memref_with_base
+// CHECK-SAME: %[[INPUT:.+]]: memref<2x10xf32>
+// CHECK-SAME: %[[INDEX_BASE:.+]]: index
+// CHECK-SAME: %[[OUT_VAL:.+]]: memref<2xf32>
+// CHECK-SAME: %[[OUT_IDX:.+]]: memref<2xi32>
+
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
+
+// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
+// CHECK:     %[[INIT_VAL:.+]] = memref.load %[[OUT_VAL]][%[[I]]] : memref<2xf32>
+// CHECK:     %[[INIT_IDX:.+]] = memref.load %[[OUT_IDX]][%[[I]]] : memref<2xi32>
+// CHECK:     %[[CAND_VAL:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[CAND_VAL]], %[[INIT_VAL]] : f32
+// CHECK:     %[[SELECT_VAL:.+]] = arith.select %[[CMP]], %[[CAND_VAL]], %[[INIT_VAL]] : f32
+// CHECK:     %[[OFFSET_IDX:.+]] = arith.addi %[[INDEX_BASE]], %[[J]] : index
+// CHECK:     %[[OFFSET_I32:.+]] = arith.index_cast %[[OFFSET_IDX]] : index to i32
+// CHECK:     %[[SELECT_IDX:.+]] = arith.select %[[CMP]], %[[OFFSET_I32]], %[[INIT_IDX]] : i32
+// CHECK:     memref.store %[[SELECT_VAL]], %[[OUT_VAL]][%[[I]]] : memref<2xf32>
+// CHECK:     memref.store %[[SELECT_IDX]], %[[OUT_IDX]][%[[I]]] : memref<2xi32>
+
+// -----
+
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-linalg-ext-to-loops))" %s | FileCheck %s
+
+func.func @arg_compare_reduce_dim0(
+    %input_values: memref<2x10xf32>,
+    %out_values: memref<10xf32>,
+    %out_indices: memref<10xi32>
+) {
+  iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input_values : memref<2x10xf32>)
+    outs(%out_values, %out_indices : memref<10xf32>, memref<10xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @arg_compare_reduce_dim0
+// CHECK-SAME: %[[INPUT:.+]]: memref<2x10xf32>
+// CHECK-SAME: %[[OUTVAL:.+]]: memref<10xf32>
+// CHECK-SAME: %[[OUTIDX:.+]]: memref<10xi32>
+
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
+
+// CHECK: scf.for %[[J:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
+// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<10xf32>
+// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<10xi32>
+// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[J]], %[[I]]] : memref<2x10xf32>
+// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
+// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
+// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
+// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
+// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<10xf32>
+// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<10xi32>
+
+// -----
+
 func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {
   iree_linalg_ext.pack %arg0 inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
   return

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -761,15 +761,23 @@ func.func @arg_compare_memref(
 
 // CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
-// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<2xf32>
-// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<2xi32>
-// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
-// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
-// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
-// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
-// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
-// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     %[[CAND:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
+// CHECK:     %[[IDXCAST:.+]] = arith.index_cast %[[J]] : index to i32
+// CHECK:     %[[IS_FIRST:.+]] = arith.cmpi eq, %[[J]], %[[C0]] : index
+// CHECK:     scf.if %[[IS_FIRST]] {
+// CHECK:       memref.store %[[CAND]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       memref.store %[[IDXCAST]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     } else {
+// CHECK:       %[[BESTVAL:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       %[[BESTIDX:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:       %[[CMP:.+]] = arith.cmpf ogt, %[[CAND]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELVAL:.+]] = arith.select %[[CMP]], %[[CAND]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELIDX:.+]] = arith.select %[[CMP]], %[[IDXCAST]], %[[BESTIDX]] : i32
+// CHECK:       memref.store %[[SELVAL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       memref.store %[[SELIDX]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 // -----
 
@@ -796,20 +804,30 @@ func.func @arg_compare_memref_dynamic(
 
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[DIM0:.+]] = memref.dim %[[INPUT]], %[[C0]] : memref<?x?xf32>
-// CHECK-DAG: %[[DIM1:.+]] = memref.dim %[[INPUT]], %[[C1]] : memref<?x?xf32>
 
-// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[DIM0]] step %[[C1]] {
-// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[DIM1]] step %[[C1]] {
-// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<?xf32>
-// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<?xi32>
-// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<?x?xf32>
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
-// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
-// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
-// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
-// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<?xf32>
-// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<?xi32>
+// CHECK: %[[D0:.+]] = memref.dim %[[INPUT]], %[[C0]] : memref<?x?xf32>
+// CHECK: %[[D1:.+]] = memref.dim %[[INPUT]], %[[C1]] : memref<?x?xf32>
+
+// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C1]] {
+// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C1]] {
+
+// CHECK:     %[[VAL:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<?x?xf32>
+// CHECK:     %[[IDX:.+]] = arith.index_cast %[[J]] : index to i32
+// CHECK:     %[[IS_FIRST:.+]] = arith.cmpi eq, %[[J]], %[[C0]] : index
+// CHECK:     scf.if %[[IS_FIRST]] {
+// CHECK:       memref.store %[[VAL]], %[[OUTVAL]][%[[I]]] : memref<?xf32>
+// CHECK:       memref.store %[[IDX]], %[[OUTIDX]][%[[I]]] : memref<?xi32>
+// CHECK:     } else {
+// CHECK:       %[[BESTVAL:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<?xf32>
+// CHECK:       %[[BESTIDX:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<?xi32>
+// CHECK:       %[[CMP:.+]] = arith.cmpf ogt, %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELVAL:.+]] = arith.select %[[CMP]], %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELIDX:.+]] = arith.select %[[CMP]], %[[IDX]], %[[BESTIDX]] : i32
+// CHECK:       memref.store %[[SELVAL]], %[[OUTVAL]][%[[I]]] : memref<?xf32>
+// CHECK:       memref.store %[[SELIDX]], %[[OUTIDX]][%[[I]]] : memref<?xi32>
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 // -----
 
@@ -833,9 +851,9 @@ func.func @arg_compare_memref_with_base(
 
 // CHECK-LABEL: func.func @arg_compare_memref_with_base
 // CHECK-SAME: %[[INPUT:.+]]: memref<2x10xf32>
-// CHECK-SAME: %[[INDEX_BASE:.+]]: index
-// CHECK-SAME: %[[OUT_VAL:.+]]: memref<2xf32>
-// CHECK-SAME: %[[OUT_IDX:.+]]: memref<2xi32>
+// CHECK-SAME: %[[BASE:.+]]: index
+// CHECK-SAME: %[[OUTVAL:.+]]: memref<2xf32>
+// CHECK-SAME: %[[OUTIDX:.+]]: memref<2xi32>
 
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
@@ -844,20 +862,28 @@ func.func @arg_compare_memref_with_base(
 
 // CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
-// CHECK:     %[[INIT_VAL:.+]] = memref.load %[[OUT_VAL]][%[[I]]] : memref<2xf32>
-// CHECK:     %[[INIT_IDX:.+]] = memref.load %[[OUT_IDX]][%[[I]]] : memref<2xi32>
-// CHECK:     %[[CAND_VAL:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[CAND_VAL]], %[[INIT_VAL]] : f32
-// CHECK:     %[[SELECT_VAL:.+]] = arith.select %[[CMP]], %[[CAND_VAL]], %[[INIT_VAL]] : f32
-// CHECK:     %[[OFFSET_IDX:.+]] = arith.addi %[[INDEX_BASE]], %[[J]] : index
-// CHECK:     %[[OFFSET_I32:.+]] = arith.index_cast %[[OFFSET_IDX]] : index to i32
-// CHECK:     %[[SELECT_IDX:.+]] = arith.select %[[CMP]], %[[OFFSET_I32]], %[[INIT_IDX]] : i32
-// CHECK:     memref.store %[[SELECT_VAL]], %[[OUT_VAL]][%[[I]]] : memref<2xf32>
-// CHECK:     memref.store %[[SELECT_IDX]], %[[OUT_IDX]][%[[I]]] : memref<2xi32>
+
+// CHECK:     %[[VAL:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
+// CHECK:     %[[OFFSET:.+]] = arith.addi %[[BASE]], %[[J]] : index
+// CHECK:     %[[CASTED:.+]] = arith.index_cast %[[OFFSET]] : index to i32
+
+// CHECK:     %[[IS_FIRST:.+]] = arith.cmpi eq, %[[J]], %[[C0]] : index
+// CHECK:     scf.if %[[IS_FIRST]] {
+// CHECK:       memref.store %[[VAL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       memref.store %[[CASTED]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     } else {
+// CHECK:       %[[BESTVAL:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       %[[BESTIDX:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:       %[[CMP:.+]] = arith.cmpf ogt, %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELVAL:.+]] = arith.select %[[CMP]], %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELIDX:.+]] = arith.select %[[CMP]], %[[CASTED]], %[[BESTIDX]] : i32
+// CHECK:       memref.store %[[SELVAL]], %[[OUTVAL]][%[[I]]] : memref<2xf32>
+// CHECK:       memref.store %[[SELIDX]], %[[OUTIDX]][%[[I]]] : memref<2xi32>
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 // -----
-
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-linalg-ext-to-loops))" %s | FileCheck %s
 
 func.func @arg_compare_reduce_dim0(
     %input_values: memref<2x10xf32>,
@@ -885,17 +911,25 @@ func.func @arg_compare_reduce_dim0(
 // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
 // CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
 
-// CHECK: scf.for %[[J:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
-// CHECK:     %[[V0:.+]] = memref.load %[[OUTVAL]][%[[I]]] : memref<10xf32>
-// CHECK:     %[[I0:.+]] = memref.load %[[OUTIDX]][%[[I]]] : memref<10xi32>
-// CHECK:     %[[V1:.+]] = memref.load %[[INPUT]][%[[J]], %[[I]]] : memref<2x10xf32>
-// CHECK:     %[[CMP:.+]] = arith.cmpf ogt, %[[V1]], %[[V0]] : f32
-// CHECK:     %[[VAL_SEL:.+]] = arith.select %[[CMP]], %[[V1]], %[[V0]] : f32
-// CHECK:     %[[IDX_CAST:.+]] = arith.index_cast %[[J]] : index to i32
-// CHECK:     %[[IDX_SEL:.+]] = arith.select %[[CMP]], %[[IDX_CAST]], %[[I0]] : i32
-// CHECK:     memref.store %[[VAL_SEL]], %[[OUTVAL]][%[[I]]] : memref<10xf32>
-// CHECK:     memref.store %[[IDX_SEL]], %[[OUTIDX]][%[[I]]] : memref<10xi32>
+// CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:   scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
+// CHECK:     %[[VAL:.+]] = memref.load %[[INPUT]][%[[I]], %[[J]]] : memref<2x10xf32>
+// CHECK:     %[[IDX:.+]] = arith.index_cast %[[I]] : index to i32
+// CHECK:     %[[IS_FIRST:.+]] = arith.cmpi eq, %[[I]], %[[C0]] : index
+// CHECK:     scf.if %[[IS_FIRST]] {
+// CHECK:       memref.store %[[VAL]], %[[OUTVAL]][%[[J]]] : memref<10xf32>
+// CHECK:       memref.store %[[IDX]], %[[OUTIDX]][%[[J]]] : memref<10xi32>
+// CHECK:     } else {
+// CHECK:       %[[BESTVAL:.+]] = memref.load %[[OUTVAL]][%[[J]]] : memref<10xf32>
+// CHECK:       %[[BESTIDX:.+]] = memref.load %[[OUTIDX]][%[[J]]] : memref<10xi32>
+// CHECK:       %[[CMP:.+]] = arith.cmpf ogt, %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELVAL:.+]] = arith.select %[[CMP]], %[[VAL]], %[[BESTVAL]] : f32
+// CHECK:       %[[SELIDX:.+]] = arith.select %[[CMP]], %[[IDX]], %[[BESTIDX]] : i32
+// CHECK:       memref.store %[[SELVAL]], %[[OUTVAL]][%[[J]]] : memref<10xf32>
+// CHECK:       memref.store %[[SELIDX]], %[[OUTIDX]][%[[J]]] : memref<10xi32>
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 // -----
 


### PR DESCRIPTION
On top of #21106.

This PR Adds `generateScalarImplementation` for ArgCompareOp, defining the scalar behavior within the innermost loop during loop lowering.

The lowering performs the following: 
- Loads the current best value and corresponding index (accumulator) from the output tensor.
- Loads the candidate value at the current loop indices.
- Invokes the provided comparator region (T a, T b) -> i1 to compare values.
- Selects the new best value and index based on the comparison result.
- Supports an optional index_base operand, which is added to the computed index before storing.

Next, will add tiling support. 