### PR TITLE
[Flow] Improve reduction dispatch names

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -30,8 +30,12 @@ namespace mlir::iree_compiler::IREE::Flow {
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
 
 static constexpr int64_t kMaxCost = INT64_MAX;
+static constexpr int64_t kReductionCost = 2;
 
-namespace {
+static int64_t saturatingMul(int64_t lhs, int64_t rhs) {
+  assert(lhs > 0 && rhs > 0);
+  return (lhs > kMaxCost / rhs) ? kMaxCost : lhs * rhs;
+}
 
 // This op estimates the cost of a list of perfectly nested loop ranges simply
 // as the product of ranges. Note that this does not take into account the cost
@@ -48,11 +52,7 @@ static int64_t costOfDomain(ArrayRef<int64_t> domain) {
       multiplier = 1024;
     }
 
-    // Preform saturating multiplication
-    if (product > kMaxCost / multiplier) {
-      return kMaxCost;
-    }
-    product *= multiplier;
+    product = saturatingMul(product, multiplier);
   }
   return product;
 }
@@ -62,6 +62,12 @@ static int64_t estimateLinalgOpCost(linalg::LinalgOp op) {
   // For linalg ops we know the iteration domain, so return the number
   // of iterations of the iteration domain (or INT64_MAX for dynamic.)
   int64_t cost = costOfDomain(op.getStaticLoopRanges());
+
+  // Operations with reduction iterators are generally more costly and are
+  // likely to be the most important operation in the dispatch.
+  if (op.getNumReductionLoops()) {
+    cost = saturatingMul(cost, kReductionCost);
+  }
   LLVM_DEBUG(llvm::dbgs() << "// " << op->getName() << " cost: " << cost
                           << "\n");
   return cost;
@@ -484,8 +490,6 @@ static std::string summarizeDispatchRegion(Region &region) {
   LLVM_DEBUG(llvm::dbgs() << "// best op summary: '" << bestSummary << "'\n");
   return bestSummary;
 }
-
-} // namespace
 
 struct AnnotateDispatchesPass
     : public IREE::Flow::impl::AnnotateDispatchesPassBase<

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -295,6 +295,8 @@ static std::string summarizeLinalgOp(linalg::LinalgOp op) {
       prefix = "horizontal_multi_contract";
     } else if (succeeded(linalg::inferConvolutionDims(op))) {
       prefix = "conv";
+    } else if (op.getNumReductionLoops()) {
+      prefix = "reduction";
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -760,3 +760,30 @@ flow.executable private @ex {
     }
   }
 }
+
+// -----
+
+flow.executable private @ex {
+  // CHECK: flow.executable.export public @dispatch0_reduction_4x4096_f32
+  flow.executable.export public @dispatch0
+  builtin.module {
+    // CHECK: func.func @dispatch0_reduction_4x4096_f32
+    func.func @dispatch0(
+                 %arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>>,
+                 %arg1: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>) {
+      %0 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>> -> tensor<4x4096xf32>
+      %c2_i64 = arith.constant 2 : i64
+      %cst = arith.constant 1.000000e+02 : f32
+      %empty = tensor.empty() : tensor<4xf32>
+      %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4xf32>) -> tensor<4xf32>
+      %reduction = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%0 : tensor<4x4096xf32>) outs(%fill : tensor<4xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %20 = math.fpowi %in, %c2_i64 : f32, i64
+        %21 = arith.addf %20, %out : f32
+        linalg.yield %21 : f32
+      } -> tensor<4xf32>
+      iree_tensor_ext.dispatch.tensor.store %reduction, %arg1, offsets = [0], sizes = [4], strides = [1] : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+      return
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -787,3 +787,36 @@ flow.executable private @ex {
     }
   }
 }
+
+// -----
+
+flow.executable private @ex {
+  // CHECK: flow.executable.export public @dispatch0_reduction_4x4096_f32
+  flow.executable.export public @dispatch0
+  builtin.module {
+    // CHECK: func.func @dispatch0_reduction_4x4096_f32
+    func.func @dispatch0(
+             %arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>>,
+             %arg1: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>) {
+      %0 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>> -> tensor<4x4096xf32>
+      %c2_i64 = arith.constant 2 : i64
+      %cst = arith.constant 1.000000e+02 : f32
+      %empty = tensor.empty() : tensor<4xf32>
+      %empty0 = tensor.empty() : tensor<4x4096xf32>
+      %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4xf32>) -> tensor<4xf32>
+      %reduction = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%0 : tensor<4x4096xf32>) outs(%fill : tensor<4xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %20 = math.fpowi %in, %c2_i64 : f32, i64
+        %21 = arith.addf %20, %out : f32
+        linalg.yield %21 : f32
+      } -> tensor<4xf32>
+      %elem = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %reduction : tensor<4x4096xf32>, tensor<4xf32>) outs(%empty0 : tensor<4x4096xf32>) {
+      ^bb0(%in: f32, %in0 : f32, %out: f32):
+        %21 = arith.addf %in, %in0 : f32
+        linalg.yield %21 : f32
+      } -> tensor<4x4096xf32>
+      iree_tensor_ext.dispatch.tensor.store %elem, %arg1, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : tensor<4x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
+      return
+    }
+  }
+}


### PR DESCRIPTION
Adds "reduction" annotation for `linalg.generic` ops with reduction loops (if the ops isn't a matmul/conv/etc) and increases the cost of reduction ops to break ties with elementwise consumers (see second test).