### PR TITLE
[Encoding] Refresh practical encodings to follow the naming convention.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -174,7 +174,7 @@ public:
     target.storeToConfigAttrs(context, configItems);
     configItems.emplace_back(
         b.getStringAttr(IREE::Encoding::kEncodingResolverAttrName),
-        IREE::CPU::CPUEncodingLayoutAttr::get(context, {}));
+        IREE::CPU::CPUEncodingResolverAttr::get(context, {}));
 
     // Compute the format used at runtime to select the executable loader.
     std::string format;

--- a/compiler/plugins/target/LLVMCPU/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/materialize_homogeneous_encodings.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-hal-device-assignment-pipeline --iree-global-opt-materialize-homogeneous-encodings %s | FileCheck %s
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-none-elf", cpu_features = "+avx512f"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, target_triple = "x86_64-none-elf", cpu_features = "+avx512f"}>
 #map = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
+++ b/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
@@ -11,7 +11,7 @@
 // RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=none %s | FileCheck %s --check-prefix=NONE
 
 // PAD:      #hal.executable.target<"rocm"
-// PAD-SAME:   iree.encoding.resolver = #iree_gpu.gpu_pad_layout<>
+// PAD-SAME:   iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>
 
 // DATA-TILING:      #hal.executable.target<"rocm"
 // DATA-TILING-SAME:   iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>

--- a/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
+++ b/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
@@ -14,7 +14,7 @@
 // PAD-SAME:   iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>
 
 // DATA-TILING:      #hal.executable.target<"rocm"
-// DATA-TILING-SAME:   iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+// DATA-TILING-SAME:   iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 
 // NONE:      #hal.executable.target<"rocm"
 // NONE-NOT:    iree.encoding.resolver

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -51,7 +51,7 @@ getVMVXExecutableTarget(bool enableMicrokernels, MLIRContext *context,
       b.getStringAttr(enableMicrokernels ? "all" : "none"));
   configItems.emplace_back(
       b.getStringAttr(IREE::Encoding::kEncodingResolverAttrName),
-      IREE::CPU::VMVXEncodingLayoutAttr::get(context, {}));
+      IREE::CPU::VMVXEncodingResolverAttr::get(context, {}));
   return b.getAttr<IREE::HAL::ExecutableTargetAttr>(
       b.getStringAttr(backend), b.getStringAttr(format),
       b.getDictionaryAttr(configItems));

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -551,7 +551,7 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
     if (layoutAttr.getLayouts().size() != 1) {
       return rewriter.notifyMatchFailure(op, "only single layout is handled");
     }
-    auto encodingLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingLayoutAttr>(
+    auto encodingLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingResolverAttr>(
         layoutAttr.getLayouts().getValue()[0]);
     if (!encodingLayoutAttr || !encodingLayoutAttr.getConfiguration()) {
       return rewriter.notifyMatchFailure(

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
@@ -555,7 +555,7 @@ func.func @query_tile_sizes_2d() -> (index, index)  attributes {
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_attr = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32]>
-#encoding = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_layout<configuration = {encoding_attr = #encoding_attr, encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [-9223372036854775808, -9223372036854775808], outerDimsPerm = [0, 1]}}>]>
+#encoding = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_resolver<configuration = {encoding_attr = #encoding_attr, encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [-9223372036854775808, -9223372036854775808], outerDimsPerm = [0, 1]}}>]>
 func.func @query_tile_sizes_2d_with_layouts() -> (index, index)  attributes {
   hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "all"}>
 } {

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -128,11 +128,11 @@ LogicalResult MaterializeEncodingTypeConverter::getOffsetsSizesStrides(
   if (!boundType || !boundType.getEncoding()) {
     return failure();
   }
-  // TODO(jornt): The isa<IREE::GPU::GPUPadLayoutAttr> check is
+  // TODO(jornt): The isa<IREE::GPU::GPUPaddingResolverAttr> check is
   // needed because PaddingAttr is a serializable attribute, but it
-  // relies on its own type conversion for now. Once GPUPadLayoutAttr
+  // relies on its own type conversion for now. Once GPUPaddingResolverAttr
   // implements `getOffsetsSizesStrides`, this can be removed.
-  if (!isa<IREE::GPU::GPUPadLayoutAttr>(getLayoutAttr())) {
+  if (!isa<IREE::GPU::GPUPaddingResolverAttr>(getLayoutAttr())) {
     return getLayoutAttr().getOffsetsSizesStrides(
         builder, loc, type, dynamicDims, offsets, sizes, strides, newOffsets,
         newSizes, newStrides);

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -23,7 +23,7 @@
 namespace mlir::iree_compiler {
 
 using IREE::Codegen::MaterializeEncodingInfo;
-using IREE::Encoding::PadEncodingLayoutAttr;
+using IREE::Encoding::PaddingAttr;
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     IREE::Encoding::LayoutMaterializerAttr layoutAttr)
@@ -33,11 +33,11 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
   addConversion([](FloatType floatType) { return floatType; });
   addConversion([](MemRefType memrefType) { return memrefType; });
   addConversion([=](RankedTensorType type) {
-    // TODO(jornt): The isa<IREE::Encoding::PadEncodingLayoutAttr> check is
-    // needed because PadEncodingLayoutAttr is a serializable attribute, but it
-    // relies on its own type conversion for now. Once PadEncodingLayoutAttr
+    // TODO(jornt): The isa<IREE::Encoding::PaddingAttr> check is
+    // needed because PaddingAttr is a serializable attribute, but it
+    // relies on its own type conversion for now. Once PaddingAttr
     // implements `convertType`, this can be removed.
-    if (!isa<IREE::Encoding::PadEncodingLayoutAttr>(getLayoutAttr())) {
+    if (!isa<IREE::Encoding::PaddingAttr>(getLayoutAttr())) {
       return cast<RankedTensorType>(getLayoutAttr().convertType(type));
     }
     return type.dropEncoding();
@@ -48,11 +48,11 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     if (!boundType || !boundType.getEncoding()) {
       return dispatchTensorType;
     }
-    // TODO(jornt): The isa<IREE::Encoding::PadEncodingLayoutAttr> check is
-    // needed because PadEncodingLayoutAttr is a serializable attribute, but it
-    // relies on its own type conversion for now. Once PadEncodingLayoutAttr
+    // TODO(jornt): The isa<IREE::Encoding::PaddingAttr> check is
+    // needed because PaddingAttr is a serializable attribute, but it
+    // relies on its own type conversion for now. Once PaddingAttr
     // implements `convertType`, this can be removed.
-    if (!isa<IREE::Encoding::PadEncodingLayoutAttr>(getLayoutAttr())) {
+    if (!isa<IREE::Encoding::PaddingAttr>(getLayoutAttr())) {
       return cast<IREE::TensorExt::DispatchTensorType>(
           getLayoutAttr().convertType(dispatchTensorType));
     }
@@ -129,7 +129,7 @@ LogicalResult MaterializeEncodingTypeConverter::getOffsetsSizesStrides(
     return failure();
   }
   // TODO(jornt): The isa<IREE::GPU::GPUPadLayoutAttr> check is
-  // needed because PadEncodingLayoutAttr is a serializable attribute, but it
+  // needed because PaddingAttr is a serializable attribute, but it
   // relies on its own type conversion for now. Once GPUPadLayoutAttr
   // implements `getOffsetsSizesStrides`, this can be removed.
   if (!isa<IREE::GPU::GPUPadLayoutAttr>(getLayoutAttr())) {

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -58,16 +58,16 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     // pass, and remove the ad-hoc materialization pass for padding.
     if (targetConfig && targetConfig.getAs<IREE::GPU::GPUPaddingResolverAttr>(
                             IREE::Encoding::kEncodingResolverAttrName)) {
-      LDBG("Found GPUPaddingResolverAttr encoding resolver. Materialization will "
-           "be handled later.");
+      LDBG("Found GPUPaddingResolverAttr encoding resolver. Materialization "
+           "will be handled later.");
       return success();
     }
 
     auto getTestTargetOrNopLayout =
         [&]() -> IREE::Encoding::LayoutMaterializerAttr {
       if (testCLGPUTarget) {
-        LDBG("Select GPUEncodingResolverAttr attribute as the layout attribute. "
-             "(testCLGPUTarget)");
+        LDBG("Select GPUEncodingResolverAttr attribute as the layout "
+             "attribute. (testCLGPUTarget)");
         return cast<IREE::Encoding::LayoutMaterializerAttr>(
             IREE::GPU::GPUEncodingResolverAttr::get(
                 ctx,

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -66,10 +66,10 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     auto getTestTargetOrNopLayout =
         [&]() -> IREE::Encoding::LayoutMaterializerAttr {
       if (testCLGPUTarget) {
-        LDBG("Select GPUEncodingLayoutAttr attribute as the layout attribute. "
+        LDBG("Select GPUEncodingResolverAttr attribute as the layout attribute. "
              "(testCLGPUTarget)");
         return cast<IREE::Encoding::LayoutMaterializerAttr>(
-            IREE::GPU::GPUEncodingLayoutAttr::get(
+            IREE::GPU::GPUEncodingResolverAttr::get(
                 ctx,
                 DictionaryAttr::get(ctx, NamedAttribute(kGPUTargetAttrName,
                                                         getCLGPUTarget(ctx)))));

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -51,14 +51,14 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     RewritePatternSet patterns(ctx);
     DictionaryAttr targetConfig =
         targetAttr ? targetAttr.getConfiguration() : nullptr;
-    // Check if the encoding resolver is a GPUPadLayoutAttr. For padding
+    // Check if the encoding resolver is a GPUPaddingResolverAttr. For padding
     // encoding materialization, we use a separate pass, so skip materialization
     // here.
-    // TODO(#20160): Support GPUPadLayoutAttr materialization through this
+    // TODO(#20160): Support GPUPaddingResolverAttr materialization through this
     // pass, and remove the ad-hoc materialization pass for padding.
-    if (targetConfig && targetConfig.getAs<IREE::GPU::GPUPadLayoutAttr>(
+    if (targetConfig && targetConfig.getAs<IREE::GPU::GPUPaddingResolverAttr>(
                             IREE::Encoding::kEncodingResolverAttrName)) {
-      LDBG("Found GPUPadLayoutAttr encoding resolver. Materialization will "
+      LDBG("Found GPUPaddingResolverAttr encoding resolver. Materialization will "
            "be handled later.");
       return success();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -40,8 +40,7 @@ namespace {
 
 // Returns the pad encoding layout, or nullptr if this is not the only layout or
 // if there's no encoding at all.
-static PaddingAttr getPadLayout(Attribute layoutAttr,
-                                          RankedTensorType type) {
+static PaddingAttr getPadLayout(Attribute layoutAttr, RankedTensorType type) {
   if (!type.getEncoding()) {
     return nullptr;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -40,7 +40,7 @@ namespace {
 
 // Returns the pad encoding layout, or nullptr if this is not the only layout or
 // if there's no encoding at all.
-static PadEncodingLayoutAttr getPadLayout(Attribute layoutAttr,
+static PaddingAttr getPadLayout(Attribute layoutAttr,
                                           RankedTensorType type) {
   if (!type.getEncoding()) {
     return nullptr;
@@ -52,7 +52,7 @@ static PadEncodingLayoutAttr getPadLayout(Attribute layoutAttr,
     if (layouts.size() != 1) {
       return nullptr;
     }
-    return dyn_cast<PadEncodingLayoutAttr>(*layouts.begin());
+    return dyn_cast<PaddingAttr>(*layouts.begin());
   }
   Attribute resolvedEncoding =
       cast<IREE::Encoding::LayoutResolverAttr>(layoutAttr).getLayout(type);
@@ -61,14 +61,14 @@ static PadEncodingLayoutAttr getPadLayout(Attribute layoutAttr,
     llvm::dbgs() << "layoutAttr: " << layoutAttr << "\n";
     llvm::dbgs() << "Resolved into: " << resolvedEncoding << "\n";
   });
-  return dyn_cast<PadEncodingLayoutAttr>(resolvedEncoding);
+  return dyn_cast<PaddingAttr>(resolvedEncoding);
 }
 
 // Returns a padded tensor type (without encoding) for tensor types with the pad
 // encoding layout, or the same type for all other tensors.
 static RankedTensorType getPaddedType(Attribute layoutAttr,
                                       RankedTensorType type) {
-  PadEncodingLayoutAttr layout = getPadLayout(layoutAttr, type);
+  PaddingAttr layout = getPadLayout(layoutAttr, type);
   if (layout.isIdentityLayout()) {
     return type.dropEncoding();
   }
@@ -90,7 +90,7 @@ struct MaterializePadEncodingTypeConverter final
       IREE::Encoding::LayoutMaterializerAttr layoutAttr)
       : MaterializeEncodingTypeConverter(layoutAttr) {
     addConversion([](RankedTensorType type) -> std::optional<RankedTensorType> {
-      // The type converter is designed for `pad_encoding_layout` encoding
+      // The type converter is designed for `padding` encoding
       // attribute. By the definition, the final converted type is the same
       // tensor type without encodings.
       return type.dropEncoding();
@@ -101,7 +101,7 @@ struct MaterializePadEncodingTypeConverter final
       if (!type || !type.getEncoding()) {
         return dispatchTensorType;
       }
-      // The incoming bindings have the padded type, if `pad_encoding_layout` is
+      // The incoming bindings have the padded type, if `padding` is
       // present.
       if (getPadLayout(getLayoutAttr(), type)) {
         type = getPaddedType(getLayoutAttr(), type);
@@ -112,7 +112,7 @@ struct MaterializePadEncodingTypeConverter final
   }
 
   bool hasNonZeroPadding(RankedTensorType type) const {
-    PadEncodingLayoutAttr layout = getPadLayout(getLayoutAttr(), type);
+    PaddingAttr layout = getPadLayout(getLayoutAttr(), type);
     return layout && !layout.isIdentityLayout();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -577,9 +577,9 @@ def MaterializeEncodingIntoNopPass :
 
 def MaterializeEncodingIntoPaddingPass :
     InterfacePass<"iree-codegen-materialize-encoding-into-padding", "mlir::FunctionOpInterface"> {
-  let summary = "Materialize `#iree_encoding.pad_encoding_layout` attributes.";
+  let summary = "Materialize `#iree_encoding.padding` attributes.";
   let description = [{
-    Handles padding introduced by `pad_encoding_layout` encoding layouts, which
+    Handles padding introduced by `padding` encoding layouts, which
     requires `iree_tensor_ext.dispatch.tensor.load`/`.store` to be adjusted to account for
     padding regions.
     Materializes any other encoding layouts into nop.

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
@@ -7,7 +7,7 @@
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iteration_sizes = [16, 1, 16]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iteration_sizes = [16, 1, 16]>
 func.func @matvec_shaped_matmul_lowering_f32f32f32_aarch64(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !hal.buffer_view attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %0 = hal.tensor.import %arg0 "input0" : !hal.buffer_view -> tensor<16x16xf32>
@@ -40,7 +40,7 @@ func.func @matvec_shaped_matmul_lowering_f32f32f32_aarch64(%arg0: !hal.buffer_vi
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -106,7 +106,7 @@ func.func @matmul_lowering_f32f32f32_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iteration_sizes= [16, 16]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iteration_sizes = [16, 16]>
 func.func @matvec_lowering_f32f32f32_aarch64(%arg0: tensor<16x16xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>) -> tensor<16xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %3 = iree_encoding.set_encoding %arg0 : tensor<16x16xf32> -> tensor<16x16xf32, #encoding_lhs>
@@ -135,7 +135,7 @@ func.func @matvec_lowering_f32f32f32_aarch64(%arg0: tensor<16x16xf32>, %arg1: te
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [16, 1, 16]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [16, 1, 16]>
 func.func @matvec_lowering_f32f32f32_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
@@ -197,7 +197,7 @@ func.func @matvec_lowering_f32f32f32_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f16f16f16_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -268,7 +268,7 @@ func.func @matmul_lowering_f16f16f16_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f16f16_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -341,7 +341,7 @@ func.func @matmul_lowering_f32f16f16_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -409,7 +409,7 @@ func.func @matmul_lowering_i8i8i32_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_aarch64_dotprod() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -482,7 +482,7 @@ func.func @matmul_lowering_i8i8i32_aarch64_dotprod() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_aarch64_i8mm() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod,+i8mm", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod,+i8mm", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -554,7 +554,7 @@ func.func @matmul_lowering_i8i8i32_aarch64_i8mm() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i4i32_aarch64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -628,7 +628,7 @@ func.func @matmul_lowering_i8i4i32_aarch64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i4i32_aarch64_dotprod() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -700,7 +700,7 @@ func.func @matmul_lowering_i8i4i32_aarch64_dotprod() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i4i32_aarch64_i8mm() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod,+i8mm", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="aarch64-xyz-xyz", cpu_features="+dotprod,+i8mm", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -769,7 +769,7 @@ func.func @matmul_lowering_i8i4i32_aarch64_i8mm() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_aarch64_sve(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+sve", target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+sve", target_triple="aarch64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -652,7 +652,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8() {
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -726,7 +726,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -800,7 +800,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -874,7 +874,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1() attribu
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -948,7 +948,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192() at
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -1022,7 +1022,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096() at
     >
   >,
   ukernels = "none",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 }>
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -1203,8 +1203,8 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16() {
 // Test suite for encodings with resolved layouts.
 //----------------------------------------------------------------------------//
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>}>
-#encoding = #iree_encoding.layout<[#iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>]>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>}>
+#encoding = #iree_encoding.layout<[#iree_gpu.gpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -5,7 +5,7 @@
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 func.func @set_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -37,7 +37,7 @@ func.func @set_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 0]>]>
 func.func @set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -69,7 +69,7 @@ func.func @set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 func.func @dynamic_set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 2, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -105,9 +105,9 @@ func.func @dynamic_set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 #encoding_mmt_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 128]>]>
+#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.padding<[0, 128]>]>
 #encoding_mmt_out = #iree_encoding.encoding<operand_index = 2 : index, op_type = matmul, element_types = [f16, f16, f16]>
 func.func @load_from_padded_and_mmt() {
   %c0 = arith.constant 0 : index
@@ -172,7 +172,7 @@ func.func @load_from_padded_and_mmt() {
 
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
-#pad_encoding = #iree_encoding.pad_encoding_layout<[0, ?]>
+#pad_encoding = #iree_encoding.padding<[0, ?]>
 #executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {
     abi = "hip",
@@ -219,7 +219,7 @@ func.func @set_pad_encoding_and_store_with_unresolved_encodings_from_executable(
 
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 func.func @set_pad_encoding_and_store_with_resolved_layout() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -248,7 +248,7 @@ func.func @set_pad_encoding_and_store_with_resolved_layout() {
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 32]>]>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -263,11 +263,11 @@ func.func @materialize_pad_encoding_on_partial_dynamic_shape() {
   %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
   %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #encoding>>{%4}
   %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x4096xf32>>{%4}
-  %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #encoding>>{%4} -> tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>
+  %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf32, #encoding>>{%4} -> tensor<?x2048xf32, #iree_encoding.padding<[0, ?]>>
   %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [4096, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x2048xf32>> -> tensor<4096x2048xf32>
   %9 = tensor.empty(%4) : tensor<?x4096xf32>
   %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x4096xf32>) -> tensor<?x4096xf32>
-  %11 = iree_encoding.unset_encoding %7 : tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>> -> tensor<?x2048xf32>{%4}
+  %11 = iree_encoding.unset_encoding %7 : tensor<?x2048xf32, #iree_encoding.padding<[0, ?]>> -> tensor<?x2048xf32>{%4}
   %12 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%11, %8 : tensor<?x2048xf32>, tensor<4096x2048xf32>) outs(%10 : tensor<?x4096xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %13 = arith.mulf %in, %in_0 : f32
@@ -285,7 +285,7 @@ func.func @materialize_pad_encoding_on_partial_dynamic_shape() {
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 32]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 32]>]>
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 #pipeline_layout1 = #hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 func.func @materialize_pad_encoding_dynamic_load_store() {
@@ -298,8 +298,8 @@ func.func @materialize_pad_encoding_dynamic_load_store() {
   %5 = hal.interface.binding.subspan layout(#pipeline_layout1) binding(0) alignment(64) offset(%4) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%2}
   %6 = hal.interface.binding.subspan layout(#pipeline_layout1) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #encoding>>{%2}
   %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%2, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x2048xf16>>{%2} -> tensor<?x2048xf16>
-  %8 = iree_encoding.set_encoding %7 : tensor<?x2048xf16> -> tensor<?x2048xf16, #iree_encoding.pad_encoding_layout<[0, ?]>>
-  iree_tensor_ext.dispatch.tensor.store %8, %6, offsets = [0, 0], sizes = [%2, 2048], strides = [1, 1] : tensor<?x2048xf16, #iree_encoding.pad_encoding_layout<[0, ?]>> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #encoding>>{%2}
+  %8 = iree_encoding.set_encoding %7 : tensor<?x2048xf16> -> tensor<?x2048xf16, #iree_encoding.padding<[0, ?]>>
+  iree_tensor_ext.dispatch.tensor.store %8, %6, offsets = [0, 0], sizes = [%2, 2048], strides = [1, 1] : tensor<?x2048xf16, #iree_encoding.padding<[0, ?]>> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x2048xf16, #encoding>>{%2}
   return
 }
 // CHECK-LABEL: @materialize_pad_encoding_dynamic_load_store

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -176,7 +176,7 @@ func.func @load_from_padded_and_mmt() {
 #executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {
     abi = "hip",
-    iree.encoding.resolver = #iree_gpu.gpu_pad_layout<>,
+    iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>,
     iree.gpu.target = #iree_gpu.target<arch = "gfx1100",
                                        features = "",
                                        wgp = <compute =  fp32,

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
@@ -7,7 +7,7 @@
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_riscv(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="riscv32-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="riscv32-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -43,7 +43,7 @@ func.func @matmul_lowering_f32f32f32_riscv(%lhs: tensor<?x?xf32>, %rhs: tensor<?
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_riscv32_ukernel() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="riscv32-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="riscv32-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -6,7 +6,7 @@
 ]>
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iteration_sizes = [1, 1000, ?]>
 func.func @set_encoding_with_padding_semantics_bf16_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 }{
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1000xbf16>>
@@ -44,7 +44,7 @@ func.func @set_encoding_with_padding_semantics_bf16_x86_64_avx512f() attributes 
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [7, 7, 7]>
 func.func @set_encoding_7x7x7_matmul_LHS() attributes {
-   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<7x7xf32>>
@@ -74,7 +74,7 @@ func.func @set_encoding_7x7x7_matmul_LHS() attributes {
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 80, 32, ?]>
 func.func @set_encoding_128x80x32_batch_matmul_LHS() attributes {
-   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x80x32xf32>>
@@ -105,7 +105,7 @@ func.func @set_encoding_128x80x32_batch_matmul_LHS() attributes {
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 32, 320, ?]>
 func.func @set_encoding_128x32x320_batch_matmul_RHS() attributes {
-   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
@@ -138,7 +138,7 @@ func.func @set_encoding_128x32x320_batch_matmul_RHS() attributes {
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 80, 320, ?]>
 func.func @unset_encoding_128x80x320_batch_matmul_RESULT() attributes {
-   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
@@ -176,7 +176,7 @@ func.func @unset_encoding_128x80x320_batch_matmul_RESULT() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> attributes {
-   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx,+avx2,+fma", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -217,7 +217,7 @@ func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf3
 
 // -----
 
-#executable_target_xyz = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+#executable_target_xyz = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
 #map2 = affine_map<(d0, d1) -> (d0)>
@@ -264,7 +264,7 @@ func.func @matvec_f32_x86_64_generic() attributes {hal.executable.target = #exec
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_x86_64() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -336,7 +336,7 @@ func.func @matmul_lowering_f32f32f32_x86_64() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_x86_64_avx2() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -407,7 +407,7 @@ func.func @matmul_lowering_f32f32f32_x86_64_avx2() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -478,7 +478,7 @@ func.func @matmul_lowering_f32f32f32_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f16f16f32_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -549,7 +549,7 @@ func.func @matmul_lowering_f16f16f32_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f16f16f16_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -620,7 +620,7 @@ func.func @matmul_lowering_f16f16f16_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_bf16bf16f32_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -691,7 +691,7 @@ func.func @matmul_lowering_bf16bf16f32_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_bf16bf16bf16_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -762,7 +762,7 @@ func.func @matmul_lowering_bf16bf16bf16_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_bf16bf16f32_x86_64_avx512bf16() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -835,7 +835,7 @@ func.func @matmul_lowering_bf16bf16f32_x86_64_avx512bf16() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, bf16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_bf16bf16bf16_x86_64_avx512bf16() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -908,7 +908,7 @@ func.func @matmul_lowering_bf16bf16bf16_x86_64_avx512bf16() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f16f16_x86_64_avx512f() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f,+avx512bf16", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -982,7 +982,7 @@ func.func @matmul_lowering_f32f16f16_x86_64_avx512f() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_x86_64_avx2() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx2", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx2", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -1055,7 +1055,7 @@ func.func @matmul_lowering_i8i8i32_x86_64_avx2() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_x86_64_avx512bw() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512bw", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512bw", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -1128,7 +1128,7 @@ func.func @matmul_lowering_i8i8i32_x86_64_avx512bw() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_x86_64_avx512vnni() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -1196,7 +1196,7 @@ func.func @matmul_lowering_i8i8i32_x86_64_avx512vnni() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1, 11008, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1, 11008, 128]>
 func.func @extend_batch_vecmat_explicit_unit_dim(%arg0: tensor<32x1x128xi8>, %arg1: tensor<32x128x11008xi8>) -> tensor<32x1x11008xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %4 = iree_encoding.set_encoding %arg0 : tensor<32x1x128xi8> -> tensor<32x1x128xi8, #encoding_lhs>
@@ -1259,7 +1259,7 @@ func.func @extend_batch_vecmat_explicit_unit_dim(%arg0: tensor<32x1x128xi8>, %ar
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i16, i16, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i16, i16, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i16i16i32_x86_64_avx2() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx2", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx2", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -1332,7 +1332,7 @@ func.func @matmul_lowering_i16i16i32_x86_64_avx2() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i16, ui4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i16, ui4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i16ui4i32_x86_64_avx512vnni() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -1400,7 +1400,7 @@ func.func @matmul_lowering_i16ui4i32_x86_64_avx512vnni() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [11008, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [11008, 128]>
 func.func @vecmat(%arg0: tensor<128xi8>, %arg1: tensor<128x11008xi8>) -> tensor<11008xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %4 = iree_encoding.set_encoding %arg0 : tensor<128xi8> -> tensor<128xi8, #encoding_lhs>
@@ -1461,7 +1461,7 @@ func.func @vecmat(%arg0: tensor<128xi8>, %arg1: tensor<128x11008xi8>) -> tensor<
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [11008, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [11008, 128]>
 func.func @matvec(%arg0: tensor<11008x128xi8>, %arg1: tensor<128xi8>) -> tensor<11008xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %4 = iree_encoding.set_encoding %arg0 : tensor<11008x128xi8> -> tensor<11008x128xi8, #encoding_lhs>
@@ -1522,7 +1522,7 @@ func.func @matvec(%arg0: tensor<11008x128xi8>, %arg1: tensor<128xi8>) -> tensor<
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [15, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [15, 128]>
 func.func @matvec_with_narrow_M(%arg0: tensor<15x128xi8>, %arg1: tensor<128xi8>) -> tensor<15xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %4 = iree_encoding.set_encoding %arg0 : tensor<15x128xi8> -> tensor<15x128xi8, #encoding_lhs>
@@ -1584,7 +1584,7 @@ func.func @matvec_with_narrow_M(%arg0: tensor<15x128xi8>, %arg1: tensor<128xi8>)
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [1, 11008, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [1, 11008, 128]>
 func.func @batch_vecmat(%arg0: tensor<32x128xi8>, %arg1: tensor<32x128x11008xi8>) -> tensor<32x11008xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %4 = iree_encoding.set_encoding %arg0 : tensor<32x128xi8> -> tensor<32x128xi8, #encoding_lhs>
@@ -1642,7 +1642,7 @@ func.func @batch_vecmat(%arg0: tensor<32x128xi8>, %arg1: tensor<32x128x11008xi8>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iteration_sizes = [11008, 1, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iteration_sizes = [11008, 1, 128]>
 func.func @batch_matvec(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !hal.buffer_view attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %0 = hal.tensor.import %arg0 "input0" : !hal.buffer_view -> tensor<32x11008x128xi8>
   %1 = hal.tensor.import %arg1 "input1" : !hal.buffer_view -> tensor<32x128xi8>
@@ -1668,7 +1668,7 @@ func.func @batch_matvec(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2:
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 512, 256]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 512, 256]>
 func.func @matmul_transpose_a_f32f32f32(%arg0: tensor<256x128xf32>, %arg1: tensor<256x512xf32>, %arg2: tensor<128x512xf32>) -> tensor<128x512xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c256 = arith.constant 256 : index
   %c128 = arith.constant 128 : index
@@ -1707,7 +1707,7 @@ func.func @matmul_transpose_a_f32f32f32(%arg0: tensor<256x128xf32>, %arg1: tenso
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 512, 256]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [128, 512, 256]>
 func.func @matmul_transpose_b_f32f32f32(%arg0: tensor<128x256xf32>, %arg1: tensor<512x256xf32>, %arg2: tensor<128x512xf32>) -> tensor<128x512xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c128 = arith.constant 128 : index
   %c256 = arith.constant 256 : index
@@ -1745,7 +1745,7 @@ func.func @matmul_transpose_b_f32f32f32(%arg0: tensor<128x256xf32>, %arg1: tenso
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [2, 128, 512, 256]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [2, 128, 512, 256]>
 func.func @batch_matmul_transpose_a_f32f32f32(%arg0: tensor<2x256x128xf32>, %arg1: tensor<2x256x512xf32>, %arg2: tensor<2x128x512xf32>) -> tensor<2x128x512xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c2 = arith.constant 2 : index
   %c256 = arith.constant 256 : index
@@ -1784,7 +1784,7 @@ func.func @batch_matmul_transpose_a_f32f32f32(%arg0: tensor<2x256x128xf32>, %arg
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [2, 128, 512, 256]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [2, 128, 512, 256]>
 func.func @batch_matmul_transpose_b_f32f32f32(%arg0: tensor<2x128x256xf32>, %arg1: tensor<2x512x256xf32>, %arg2: tensor<2x128x512xf32>) -> tensor<2x128x512xf32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c2 = arith.constant 2 : index
   %c128 = arith.constant 128 : index
@@ -1823,7 +1823,7 @@ func.func @batch_matmul_transpose_b_f32f32f32(%arg0: tensor<2x128x256xf32>, %arg
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i16, ui4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [1, 4096, 128]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i16, ui4, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [1, 4096, 128]>
 func.func @generic_batch_vecmat_transposed_i16u4i32(%arg0: tensor<32x128xi16>, %arg1: tensor<4096x32x128xi4>, %arg2: tensor<4096x32xi32>) -> tensor<4096x32xi32> attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512vnni", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0_i32 = arith.constant 0 : i32
   %c0_i4 = arith.constant 0 : i4
@@ -1880,7 +1880,7 @@ func.func @generic_batch_vecmat_transposed_i16u4i32(%arg0: tensor<32x128xi16>, %
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 func.func @dequantization() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -1935,7 +1935,7 @@ func.func @dequantization() attributes {
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>,  affine_map<(d0, d1, d2) -> (d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 func.func @broadcast_batch() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -1974,7 +1974,7 @@ func.func @broadcast_batch() attributes {
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 func.func @broadcast_M() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -2013,7 +2013,7 @@ func.func @broadcast_M() attributes {
 #encoding = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2) -> (d0, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 func.func @broadcast_N() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -2052,7 +2052,7 @@ func.func @broadcast_N() attributes {
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iteration_sizes = [2, 128, 64, ?]>
 func.func @broadcast_K() attributes {
-  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="x86_64-xyz-xyz", cpu_features="+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -2092,8 +2092,8 @@ func.func @broadcast_K() attributes {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
-#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 1], outerDimsPerm = [0, 1]}}>]>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 1], outerDimsPerm = [0, 1]}}>]>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -2122,8 +2122,8 @@ func.func @set_encoding_LHS_with_layout() attributes {
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [16, 1], outerDimsPerm = [1, 0]}}>]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [16, 1], outerDimsPerm = [1, 0]}}>]>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -2155,8 +2155,8 @@ func.func @set_encoding_RHS_with_layout() attributes {
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 16], outerDimsPerm = [0, 1]}}>]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 16], outerDimsPerm = [0, 1]}}>]>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Codegen/Common/test/vmvx_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vmvx_materialize_encoding.mlir
@@ -12,7 +12,7 @@
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_i8i8i32_vmvx_ukernel() attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "all", iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "all", iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -98,7 +98,7 @@ func.func @matmul_lowering_i8i8i32_vmvx_ukernel() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map2, #map3, #map4], iteration_sizes = [1, 3, 2]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map2, #map3, #map4], iteration_sizes = [1, 3, 2]>
 func.func @fill_matmul(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index) attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
   %c32_i64 = arith.constant 32 : i64
   %cst = arith.constant 0.000000e+00 : f32
@@ -147,7 +147,7 @@ func.func @fill_matmul(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @set_encoding_dynamic() attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %d0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
@@ -195,7 +195,7 @@ func.func @set_encoding_dynamic() attributes {
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @unset_encoding_dynamic() attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
@@ -247,7 +247,7 @@ func.func @unset_encoding_dynamic() attributes {
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 func.func @matmul_lowering_f32f32f32_generic() attributes {
-  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 } {
   %c0 = arith.constant 0 : index
   %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -12,7 +12,7 @@ include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 
 //===----------------------------------------------------------------------===//
-// iree_cpu.encoding_layout_attr
+// Encoding Resolvers.
 //===----------------------------------------------------------------------===//
 
 def IREECPU_CPUEncodingResolverAttr :

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -34,9 +34,9 @@ def IREECPU_CPUEncodingResolverAttr :
   );
 }
 
-def IREECPU_VMVXEncodingLayoutAttr :
-    AttrDef<IREECPU_Dialect, "VMVXEncodingLayout"> {
-  let mnemonic = "vmvx_encoding_layout";
+def IREECPU_VMVXEncodingResolverAttr :
+    AttrDef<IREECPU_Dialect, "VMVXEncodingResolver"> {
+  let mnemonic = "vmvx_encoding_resolver";
   let summary = [{The encoding layout attribute for VMVX backend.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -15,9 +15,9 @@ include "mlir/IR/AttrTypeBase.td"
 // iree_cpu.encoding_layout_attr
 //===----------------------------------------------------------------------===//
 
-def IREECPU_CPUEncodingLayoutAttr :
-    AttrDef<IREECPU_Dialect, "CPUEncodingLayout"> {
-  let mnemonic = "cpu_encoding_layout";
+def IREECPU_CPUEncodingResolverAttr :
+    AttrDef<IREECPU_Dialect, "CPUEncodingResolver"> {
+  let mnemonic = "cpu_encoding_resolver";
   let summary = [{The encoding layout attribute for CPU backends.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -351,12 +351,12 @@ def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
 }
 
 //===----------------------------------------------------------------------===//
-// iree_gpu.gpu_encoding_layout
+// iree_gpu.gpu_encoding_resolver
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_GPUEncodingLayoutAttr :
-    AttrDef<IREEGPU_Dialect, "GPUEncodingLayout"> {
-  let mnemonic = "gpu_encoding_layout";
+def IREEGPU_GPUEncodingResolverAttr :
+    AttrDef<IREEGPU_Dialect, "GPUEncodingResolver"> {
+  let mnemonic = "gpu_encoding_resolver";
   let summary = [{The encoding layout attribute for GPU backend.}];
   let description = [{
     This attribute can implement any layout interface methods for encoding

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -376,11 +376,11 @@ def IREEGPU_GPUEncodingLayoutAttr :
 }
 
 //===----------------------------------------------------------------------===//
-// iree_gpu.gpu_pad_layout
+// iree_gpu.gpu_padding_resolver
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
-  let mnemonic = "gpu_pad_layout";
+def IREEGPU_GPUPaddingResolverAttr : AttrDef<IREEGPU_Dialect, "GPUPaddingResolver"> {
+  let mnemonic = "gpu_padding_resolver";
   let summary = [{The padded encoding layout attribute for GPU targets.}];
   let assemblyFormat = "`<` struct(params) `>`";
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -843,16 +843,17 @@ TargetAttr getHIPTargetDetails(StringRef target, StringRef features,
 Attribute getHIPTargetEncodingLayoutAttr(TargetAttr target,
                                          StringRef resolver) {
   if (resolver == kDataTilingEncodingLayoutResolverName) {
-    // Return a GPUEncodingResolverAttr with an empty configuration. The addtional
-    // attributes will be attached by the `cloneWithSimplifiedConfig` interface
-    // method when the resolver needs to be configured.
+    // Return a GPUEncodingResolverAttr with an empty configuration. The
+    // addtional attributes will be attached by the `cloneWithSimplifiedConfig`
+    // interface method when the resolver needs to be configured.
     return IREE::GPU::GPUEncodingResolverAttr::get(target.getContext(), {});
   }
 
   if (resolver == kPadEncodingLayoutResolverName) {
-    return IREE::GPU::GPUPaddingResolverAttr::get(target.getContext(),
-                                            /*cache_line_bytes=*/std::nullopt,
-                                            /*cache_sets=*/std::nullopt);
+    return IREE::GPU::GPUPaddingResolverAttr::get(
+        target.getContext(),
+        /*cache_line_bytes=*/std::nullopt,
+        /*cache_sets=*/std::nullopt);
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -843,10 +843,10 @@ TargetAttr getHIPTargetDetails(StringRef target, StringRef features,
 Attribute getHIPTargetEncodingLayoutAttr(TargetAttr target,
                                          StringRef resolver) {
   if (resolver == kDataTilingEncodingLayoutResolverName) {
-    // Return a GPUEncodingLayoutAttr with an empty configuration. The addtional
+    // Return a GPUEncodingResolverAttr with an empty configuration. The addtional
     // attributes will be attached by the `cloneWithSimplifiedConfig` interface
     // method when the resolver needs to be configured.
-    return IREE::GPU::GPUEncodingLayoutAttr::get(target.getContext(), {});
+    return IREE::GPU::GPUEncodingResolverAttr::get(target.getContext(), {});
   }
 
   if (resolver == kPadEncodingLayoutResolverName) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -850,7 +850,7 @@ Attribute getHIPTargetEncodingLayoutAttr(TargetAttr target,
   }
 
   if (resolver == kPadEncodingLayoutResolverName) {
-    return IREE::GPU::GPUPadLayoutAttr::get(target.getContext(),
+    return IREE::GPU::GPUPaddingResolverAttr::get(target.getContext(),
                                             /*cache_line_bytes=*/std::nullopt,
                                             /*cache_sets=*/std::nullopt);
   }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -695,8 +695,8 @@ struct CPUEncodingResolverMaterializerAttr final
 };
 
 struct CPULayoutResolverAttr final
-    : IREE::Encoding::LayoutResolverAttr::ExternalModel<CPULayoutResolverAttr,
-                                                        CPUEncodingResolverAttr> {
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          CPULayoutResolverAttr, CPUEncodingResolverAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -705,7 +705,7 @@ struct CPULayoutResolverAttr final
     storeNamedAttrIfPresent(configItems, config, "target_triple");
     storeNamedAttrIfPresent(configItems, config, "ukernels");
     return CPUEncodingResolverAttr::get(ctx,
-                                      DictionaryAttr::get(ctx, configItems));
+                                        DictionaryAttr::get(ctx, configItems));
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
@@ -839,7 +839,7 @@ struct VMVXLayoutResolverAttr final
     SmallVector<NamedAttribute> configItems;
     storeNamedAttrIfPresent(configItems, config, "ukernels");
     return VMVXEncodingResolverAttr::get(ctx,
-                                       DictionaryAttr::get(ctx, configItems));
+                                         DictionaryAttr::get(ctx, configItems));
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
@@ -850,8 +850,8 @@ struct VMVXLayoutResolverAttr final
 };
 
 struct VMVXSerializableAttr final
-    : IREE::Encoding::SerializableAttr::ExternalModel<VMVXSerializableAttr,
-                                                      VMVXEncodingResolverAttr> {
+    : IREE::Encoding::SerializableAttr::ExternalModel<
+          VMVXSerializableAttr, VMVXEncodingResolverAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
                                     ValueRange dynamicDims) const {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -449,14 +449,14 @@ struct GPUPadLayoutResolverAttr final
 
     int64_t rank = type.getRank();
     auto noPaddingAttr =
-        IREE::Encoding::PadEncodingLayoutAttr::getIdentityAttr(ctx, rank);
+        IREE::Encoding::PaddingAttr::getIdentityAttr(ctx, rank);
     if (!gpuPadLayoutAttr.getCacheLineBytes() ||
         !gpuPadLayoutAttr.getCacheSets()) {
       return noPaddingAttr;
     }
 
     auto paddingEncodingAttr =
-        dyn_cast_or_null<IREE::Encoding::PadEncodingLayoutAttr>(
+        dyn_cast_or_null<IREE::Encoding::PaddingAttr>(
             type.getEncoding());
     if (!paddingEncodingAttr) {
       return nullptr;
@@ -525,7 +525,7 @@ struct GPUPadLayoutResolverAttr final
     int64_t numPadElements = (padBytes * 8) / elementBits;
     SmallVector<int64_t> padValues(rank, 0);
     padValues.back() = numPadElements;
-    auto padLayout = IREE::Encoding::PadEncodingLayoutAttr::get(ctx, padValues);
+    auto padLayout = IREE::Encoding::PaddingAttr::get(ctx, padValues);
     return padLayout;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -420,7 +420,7 @@ struct GPULayoutResolverAttr final
 
 struct GPUPadEncodingLayoutMaterializerAttr final
     : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
-          GPUPadEncodingLayoutMaterializerAttr, GPUPadLayoutAttr> {
+          GPUPadEncodingLayoutMaterializerAttr, GPUPaddingResolverAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
@@ -430,7 +430,7 @@ struct GPUPadEncodingLayoutMaterializerAttr final
 
 struct GPUPadLayoutResolverAttr final
     : IREE::Encoding::LayoutResolverAttr::ExternalModel<
-          GPUPadLayoutResolverAttr, GPUPadLayoutAttr> {
+          GPUPadLayoutResolverAttr, GPUPaddingResolverAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -438,14 +438,14 @@ struct GPUPadLayoutResolverAttr final
     std::optional<IREE::GPU::L1CacheInfo> cache =
         IREE::GPU::getL1CacheInfo(gpuTarget);
     if (!cache) {
-      return GPUPadLayoutAttr::get(ctx, std::nullopt, std::nullopt);
+      return GPUPaddingResolverAttr::get(ctx, std::nullopt, std::nullopt);
     }
-    return GPUPadLayoutAttr::get(ctx, cache->cacheLineBytes, cache->cacheSets);
+    return GPUPaddingResolverAttr::get(ctx, cache->cacheLineBytes, cache->cacheSets);
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
     MLIRContext *ctx = attr.getContext();
-    auto gpuPadLayoutAttr = cast<GPUPadLayoutAttr>(attr);
+    auto gpuPadLayoutAttr = cast<GPUPaddingResolverAttr>(attr);
 
     int64_t rank = type.getRank();
     auto noPaddingAttr =
@@ -539,7 +539,7 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
         GPUEncodingPackedLayoutMaterializerAttr,
         GPUEncodingLayoutMaterializerAttr, GPULayoutResolverAttr,
         GPUSerializableAttr>(*ctx);
-    IREE::GPU::GPUPadLayoutAttr::attachInterface<
+    IREE::GPU::GPUPaddingResolverAttr::attachInterface<
         GPUPadEncodingLayoutMaterializerAttr, GPUPadLayoutResolverAttr>(*ctx);
   });
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -395,8 +395,8 @@ struct GPUSerializableAttr final
 };
 
 struct GPULayoutResolverAttr final
-    : IREE::Encoding::LayoutResolverAttr::ExternalModel<GPULayoutResolverAttr,
-                                                        GPUEncodingResolverAttr> {
+    : IREE::Encoding::LayoutResolverAttr::ExternalModel<
+          GPULayoutResolverAttr, GPUEncodingResolverAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -409,7 +409,7 @@ struct GPULayoutResolverAttr final
     }
     storeNamedAttrIfPresent(configItems, config, kGPUTargetAttrName);
     return GPUEncodingResolverAttr::get(ctx,
-                                      DictionaryAttr::get(ctx, configItems));
+                                        DictionaryAttr::get(ctx, configItems));
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
@@ -440,7 +440,8 @@ struct GPUPadLayoutResolverAttr final
     if (!cache) {
       return GPUPaddingResolverAttr::get(ctx, std::nullopt, std::nullopt);
     }
-    return GPUPaddingResolverAttr::get(ctx, cache->cacheLineBytes, cache->cacheSets);
+    return GPUPaddingResolverAttr::get(ctx, cache->cacheLineBytes,
+                                       cache->cacheSets);
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
@@ -456,8 +457,7 @@ struct GPUPadLayoutResolverAttr final
     }
 
     auto paddingEncodingAttr =
-        dyn_cast_or_null<IREE::Encoding::PaddingAttr>(
-            type.getEncoding());
+        dyn_cast_or_null<IREE::Encoding::PaddingAttr>(type.getEncoding());
     if (!paddingEncodingAttr) {
       return nullptr;
     }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -37,7 +37,7 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
     // moved to VMVX implementation details. However, we cook the logic here to
     // reduce code duplication.
     if (ShapedType::isDynamic(size)) {
-      assert(isa<IREE::CPU::VMVXEncodingLayoutAttr>(attr) &&
+      assert(isa<IREE::CPU::VMVXEncodingResolverAttr>(attr) &&
              "only VMVX backend attribute can handle dynamic tile sizes");
       size = 16;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
@@ -3,7 +3,7 @@
 
 // Make sure that the GPU configuration pipelines materialize encoding ops.
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>, iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  int8, storage =  b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_I32_16x16x32_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>, iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  int8, storage =  b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_I32_16x16x32_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -57,7 +57,7 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
   }
 
   // Only VMVX with ukernel config supports dynamic inner tile sizes.
-  auto vmvxLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingLayoutAttr>(layoutAttr);
+  auto vmvxLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingResolverAttr>(layoutAttr);
   if (!vmvxLayoutAttr || !hasUkernel(vmvxLayoutAttr.getConfiguration())) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -57,7 +57,8 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
   }
 
   // Only VMVX with ukernel config supports dynamic inner tile sizes.
-  auto vmvxLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingResolverAttr>(layoutAttr);
+  auto vmvxLayoutAttr =
+      dyn_cast<IREE::CPU::VMVXEncodingResolverAttr>(layoutAttr);
   if (!vmvxLayoutAttr || !hasUkernel(vmvxLayoutAttr.getConfiguration())) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -423,19 +423,16 @@ static int32_t getRoundedElementByteWidth(Type type) {
   return llvm::PowerOf2Ceil(byteAligned);
 }
 
-PaddingAttr PaddingAttr::get(MLIRContext *ctx,
-                                                 ArrayRef<int64_t> padding) {
+PaddingAttr PaddingAttr::get(MLIRContext *ctx, ArrayRef<int64_t> padding) {
   return get(ctx, DenseI64ArrayAttr::get(ctx, padding));
 }
 
-PaddingAttr PaddingAttr::getIdentityAttr(MLIRContext *ctx,
-                                                             int rank) {
+PaddingAttr PaddingAttr::getIdentityAttr(MLIRContext *ctx, int rank) {
   SmallVector<int64_t> zeros(rank, 0);
   return get(ctx, zeros);
 }
 
-Attribute
-PaddingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
+Attribute PaddingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
   MLIRContext *ctx = getContext();
   return LayoutAttr::get(ctx, ArrayAttr::get(ctx, layouts));
 }
@@ -449,9 +446,9 @@ bool PaddingAttr::isIdentityLayout() const {
   return llvm::all_of(padding, [](int64_t val) { return val == 0; });
 }
 
-Value PaddingAttr::calculateStorageSizeInBytes(
-    Location loc, OpBuilder &builder, RankedTensorType type,
-    ValueRange dynamicDims) const {
+Value PaddingAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
+                                               RankedTensorType type,
+                                               ValueRange dynamicDims) const {
   ArrayRef<int64_t> padding = getPadding().asArrayRef();
   assert(padding.size() == type.getRank() && "Invalid padding");
   LLVM_DEBUG(if (llvm::any_of(padding, [](int64_t x) { return x != 0; })) {
@@ -487,9 +484,8 @@ Value PaddingAttr::calculateStorageSizeInBytes(
       dynamicProduct, arith::IntegerOverflowFlags::nsw);
 }
 
-LogicalResult
-PaddingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                              DenseI64ArrayAttr padding) {
+LogicalResult PaddingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                  DenseI64ArrayAttr padding) {
   // You can only verify that the value is non-negative or dynamic.
   if (!llvm::all_of(padding.asArrayRef(), [](int64_t val) {
         return val == ShapedType::kDynamic || val >= 0;
@@ -512,8 +508,7 @@ IdentityResolverAttr::cloneWithSimplifiedConfig(DictionaryAttr) const {
 Attribute IdentityResolverAttr::getLayout(RankedTensorType type) const {
   MLIRContext *ctx = getContext();
   SmallVector<int64_t> zeros(type.getRank(), 0);
-  return Encoding::PaddingAttr::get(
-      ctx, DenseI64ArrayAttr::get(ctx, zeros));
+  return Encoding::PaddingAttr::get(ctx, DenseI64ArrayAttr::get(ctx, zeros));
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -376,7 +376,7 @@ Attribute MatmulKAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
 }
 
 //===---------------------------------------------------------------------===//
-// iree_encoding.pad_encoding_layout
+// iree_encoding.padding
 //===---------------------------------------------------------------------===//
 
 /// Custom printer/parser methods to handle dynamic shapes.
@@ -423,33 +423,33 @@ static int32_t getRoundedElementByteWidth(Type type) {
   return llvm::PowerOf2Ceil(byteAligned);
 }
 
-PadEncodingLayoutAttr PadEncodingLayoutAttr::get(MLIRContext *ctx,
+PaddingAttr PaddingAttr::get(MLIRContext *ctx,
                                                  ArrayRef<int64_t> padding) {
   return get(ctx, DenseI64ArrayAttr::get(ctx, padding));
 }
 
-PadEncodingLayoutAttr PadEncodingLayoutAttr::getIdentityAttr(MLIRContext *ctx,
+PaddingAttr PaddingAttr::getIdentityAttr(MLIRContext *ctx,
                                                              int rank) {
   SmallVector<int64_t> zeros(rank, 0);
   return get(ctx, zeros);
 }
 
 Attribute
-PadEncodingLayoutAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
+PaddingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
   MLIRContext *ctx = getContext();
   return LayoutAttr::get(ctx, ArrayAttr::get(ctx, layouts));
 }
 
-bool PadEncodingLayoutAttr::isSerialized() const {
+bool PaddingAttr::isSerialized() const {
   return !ShapedType::isDynamicShape(getPadding().asArrayRef());
 }
 
-bool PadEncodingLayoutAttr::isIdentityLayout() const {
+bool PaddingAttr::isIdentityLayout() const {
   ArrayRef<int64_t> padding = getPadding().asArrayRef();
   return llvm::all_of(padding, [](int64_t val) { return val == 0; });
 }
 
-Value PadEncodingLayoutAttr::calculateStorageSizeInBytes(
+Value PaddingAttr::calculateStorageSizeInBytes(
     Location loc, OpBuilder &builder, RankedTensorType type,
     ValueRange dynamicDims) const {
   ArrayRef<int64_t> padding = getPadding().asArrayRef();
@@ -488,7 +488,7 @@ Value PadEncodingLayoutAttr::calculateStorageSizeInBytes(
 }
 
 LogicalResult
-PadEncodingLayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+PaddingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                               DenseI64ArrayAttr padding) {
   // You can only verify that the value is non-negative or dynamic.
   if (!llvm::all_of(padding.asArrayRef(), [](int64_t val) {
@@ -512,7 +512,7 @@ IdentityResolverAttr::cloneWithSimplifiedConfig(DictionaryAttr) const {
 Attribute IdentityResolverAttr::getLayout(RankedTensorType type) const {
   MLIRContext *ctx = getContext();
   SmallVector<int64_t> zeros(type.getRank(), 0);
-  return Encoding::PadEncodingLayoutAttr::get(
+  return Encoding::PaddingAttr::get(
       ctx, DenseI64ArrayAttr::get(ctx, zeros));
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -246,10 +246,10 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
 }
 
 //===---------------------------------------------------------------------===//
-// iree_encoding.pad_encoding_layout
+// iree_encoding.padding
 //===---------------------------------------------------------------------===//
 
-def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
+def PaddingAttr : IREEEncoding_Attr<"Padding", [
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "calculateStorageSizeInBytes",
         "cloneWithLayouts",
@@ -257,7 +257,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
         "isSerialized"
         ]>
     ]> {
-  let mnemonic = "pad_encoding_layout";
+  let mnemonic = "padding";
   let assemblyFormat = "`<` custom<Padding>($padding) `>`";
 
   let summary = [{An attribute that encodes padding values of tensor dimensions.}];
@@ -290,8 +290,8 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
   ];
 
   let extraClassDeclaration = [{
-    /// Returns a PadEncodingLayoutAttr attribute that pads zero elements.
-    static PadEncodingLayoutAttr getIdentityAttr(MLIRContext *ctx, int rank);
+    /// Returns a PaddingAttr attribute that pads zero elements.
+    static PaddingAttr getIdentityAttr(MLIRContext *ctx, int rank);
   }];
 
   let genVerifyDecl = 1;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -189,7 +189,7 @@ func.func @illegal_layout_encoding_with_invalid_layouts(%arg0: tensor<?x?xf32, #
 // -----
 
 // expected-error @+1 {{expected all padding values need to be non-negative or dynamic}}
-#encoding = #iree_encoding.pad_encoding_layout<[0, ?, -1]>
+#encoding = #iree_encoding.padding<[0, ?, -1]>
 func.func @negative_layout_encoding(%arg0: tensor<?x?x?xf32, #encoding>) -> tensor<?x?x?xf32, #encoding> {
   return %arg0 : tensor<?x?x?xf32, #encoding>
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -245,20 +245,20 @@ func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 func.func @layout_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.padding<[0, 64]>]>
 //      CHECK: func.func @layout_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, ?, 64]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.padding<[0, ?, 64]>]>
 func.func @dynamic_layout_encoding(%arg0: tensor<?x?x?xf32, #encoding>) -> tensor<?x?x?xf32, #encoding> {
   return %arg0 : tensor<?x?x?xf32, #encoding>
 }
-//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, ?, 64]>]>
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.padding<[0, ?, 64]>]>
 //      CHECK: func.func @dynamic_layout_encoding(%[[ARG0:.+]]: tensor<?x?x?xf32, #[[ENCODING]]>)

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
@@ -38,7 +38,7 @@ TEST_F(EncodingAttrsTest, EncodingAttr) {
   EXPECT_FALSE(attr.isIdentityLayout());
 
   attr = cast<SerializableAttr>(attr.cloneWithLayouts(
-      PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2)));
+      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
 
@@ -49,18 +49,18 @@ TEST_F(EncodingAttrsTest, MatulKAttr) {
   EXPECT_FALSE(attr.isIdentityLayout());
 
   attr = cast<SerializableAttr>(attr.cloneWithLayouts(
-      PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2)));
+      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
 
-TEST_F(EncodingAttrsTest, PadEncodingLayoutAttr) {
+TEST_F(EncodingAttrsTest, PaddingAttr) {
   MLIRContext *ctx = getContext();
   auto zeroPaddingAttr =
-      PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2);
+      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2);
   EXPECT_TRUE(cast<SerializableAttr>(zeroPaddingAttr).isIdentityLayout());
 
   SmallVector<int64_t> paddings = {4, 2};
-  auto nonZeroPaddingAttr = PadEncodingLayoutAttr::get(ctx, paddings);
+  auto nonZeroPaddingAttr = PaddingAttr::get(ctx, paddings);
   EXPECT_FALSE(cast<SerializableAttr>(nonZeroPaddingAttr).isIdentityLayout());
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
@@ -37,8 +37,8 @@ TEST_F(EncodingAttrsTest, EncodingAttr) {
       ctx, /*operandIndex=*/0, EncodingOpType::matmul, elemTypes));
   EXPECT_FALSE(attr.isIdentityLayout());
 
-  attr = cast<SerializableAttr>(attr.cloneWithLayouts(
-      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
+  attr = cast<SerializableAttr>(
+      attr.cloneWithLayouts(PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
 
@@ -48,15 +48,14 @@ TEST_F(EncodingAttrsTest, MatulKAttr) {
   auto attr = cast<SerializableAttr>(MatmulKAttr::get(ctx, /*k_dims=*/{1}));
   EXPECT_FALSE(attr.isIdentityLayout());
 
-  attr = cast<SerializableAttr>(attr.cloneWithLayouts(
-      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
+  attr = cast<SerializableAttr>(
+      attr.cloneWithLayouts(PaddingAttr::getIdentityAttr(ctx, /*rank=*/2)));
   EXPECT_TRUE(attr.isIdentityLayout());
 }
 
 TEST_F(EncodingAttrsTest, PaddingAttr) {
   MLIRContext *ctx = getContext();
-  auto zeroPaddingAttr =
-      PaddingAttr::getIdentityAttr(ctx, /*rank=*/2);
+  auto zeroPaddingAttr = PaddingAttr::getIdentityAttr(ctx, /*rank=*/2);
   EXPECT_TRUE(cast<SerializableAttr>(zeroPaddingAttr).isIdentityLayout());
 
   SmallVector<int64_t> paddings = {4, 2};

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -209,7 +209,7 @@ util.func private @ElideUnneededTensorClones(%arg0: !stream.resource<*>, %arg1: 
 
 // -----
 
-#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+#encoding = #iree_encoding.padding<[0, 0]>
 // CHECK-LABEL: @FoldTensorEncodeOpWithIdentitySource(
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 util.func private @FoldTensorEncodeOpWithIdentitySource(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
@@ -220,7 +220,7 @@ util.func private @FoldTensorEncodeOpWithIdentitySource(%arg0: !stream.resource<
 
 // -----
 
-#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+#encoding = #iree_encoding.padding<[0, 0]>
 // CHECK-LABEL: @FoldTensorEncodeOpWithIdentityResult(
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 util.func private @FoldTensorEncodeOpWithIdentityResult(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
@@ -122,11 +122,11 @@ util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic_using_layo
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#no_pad_layout = #iree_encoding.pad_encoding_layout<[0, 0]>
+#no_pad_layout = #iree_encoding.padding<[0, 0]>
 #no_pad_encoding = #iree_encoding.layout<[#no_pad_layout]>
-#pad_layout_a = #iree_encoding.pad_encoding_layout<[0, 64]>
+#pad_layout_a = #iree_encoding.padding<[0, 64]>
 #pad_encoding_a = #iree_encoding.layout<[#pad_layout_a]>
-#pad_layout_b = #iree_encoding.pad_encoding_layout<[64, 0]>
+#pad_layout_b = #iree_encoding.padding<[64, 0]>
 #pad_encoding_b = #iree_encoding.layout<[#pad_layout_b]>
 util.func public @sizeof_lhs_pad_encoding_static() -> index, index, index {
   %0 = stream.tensor.sizeof tensor<2048x4096xf16, #no_pad_encoding>{} : index
@@ -148,11 +148,11 @@ util.func public @sizeof_lhs_pad_encoding_static() -> index, index, index {
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#no_pad_layout = #iree_encoding.pad_encoding_layout<[0, 0]>
+#no_pad_layout = #iree_encoding.padding<[0, 0]>
 #no_pad_encoding = #iree_encoding.layout<[#no_pad_layout]>
-#pad_layout_a = #iree_encoding.pad_encoding_layout<[0, 64]>
+#pad_layout_a = #iree_encoding.padding<[0, 64]>
 #pad_encoding_a = #iree_encoding.layout<[#pad_layout_a]>
-#pad_layout_b = #iree_encoding.pad_encoding_layout<[64, 0]>
+#pad_layout_b = #iree_encoding.padding<[64, 0]>
 #pad_encoding_b = #iree_encoding.layout<[#pad_layout_b]>
 util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) -> index, index, index, index {
   %0 = stream.tensor.sizeof tensor<2048x?xf16, #no_pad_encoding>{%arg0} : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
@@ -20,7 +20,7 @@ util.func public @tensorSizeOfAlignedPackedI1() -> index {
 
 // -----
 
-#encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
+#encoding_layout = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
@@ -39,7 +39,7 @@ util.func public @sizeof_lhs_encoding_dynamic_using_layouts(%arg0: index, %arg1:
 
 // -----
 
-#encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
+#encoding_layout = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_partially_dynamic_using_layouts(%arg0: index) -> index {
   %0 = stream.tensor.sizeof tensor<10x?xf32, #encoding>{%arg0} : index
@@ -58,7 +58,7 @@ util.func public @sizeof_lhs_encoding_partially_dynamic_using_layouts(%arg0: ind
 // In GEMM, the RHS has the `(M, N, K) -> (K, N)` layout. The  tile sizes
 // (i.e., [8, 16]) are for [dim_1, dim_0] in the encoding_info, where dim_1 is
 // N-dimension and dim_0 is K-dimension.
-#encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [8, 16], outerDimsPerm = [1, 0]}}>
+#encoding_layout = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [8, 16], outerDimsPerm = [1, 0]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_rhs_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
@@ -78,7 +78,7 @@ util.func public @sizeof_rhs_encoding_dynamic_using_layouts(%arg0: index, %arg1:
 
 // -----
 
-#encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
+#encoding_layout = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_result_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
@@ -99,7 +99,7 @@ util.func public @sizeof_result_encoding_dynamic_using_layouts(%arg0: index, %ar
 
 // The M-dimension inner tile is not present because it broadcasts across the
 // M-dimension. We do not need to pack the M-dimension in this case.
-#encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1], innerTileSizes = [16], outerDimsPerm = [0, 1]}}>
+#encoding_layout = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [1], innerTileSizes = [16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
@@ -180,7 +180,7 @@ util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) 
 // -----
 
 #encoding_layout_0 = #iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
-#encoding_layout_1 = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [2, 16], outerDimsPerm = [0, 1]}}>
+#encoding_layout_1 = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [2, 16], outerDimsPerm = [0, 1]}}>
 #encoding_layout_2 = #iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout_0, #encoding_layout_1, #encoding_layout_2]>
 util.func public @sizeof_multi_encoding_layouts(%arg0: index, %arg1: index) -> index {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
@@ -181,7 +181,7 @@ util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) 
 
 #encoding_layout_0 = #iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
 #encoding_layout_1 = #iree_cpu.vmvx_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [2, 16], outerDimsPerm = [0, 1]}}>
-#encoding_layout_2 = #iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>
+#encoding_layout_2 = #iree_gpu.gpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout_0, #encoding_layout_1, #encoding_layout_2]>
 util.func public @sizeof_multi_encoding_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
@@ -179,7 +179,7 @@ util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) 
 
 // -----
 
-#encoding_layout_0 = #iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
+#encoding_layout_0 = #iree_cpu.cpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
 #encoding_layout_1 = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [2, 16], outerDimsPerm = [0, 1]}}>
 #encoding_layout_2 = #iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>
 #encoding = #iree_encoding.layout<[#encoding_layout_0, #encoding_layout_1, #encoding_layout_2]>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -81,7 +81,7 @@ util.func public @gpu_with_encoding_layout(%d0: index, %d1: index) -> index {
 //------------------------------------------------------------------------------
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_pad_layout<>,
+  iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>,
   iree.gpu.target = #iree_gpu.target<arch = "gfx942",
                                      features = "",
                                      wgp = <compute = fp32,
@@ -121,7 +121,7 @@ util.func public @with_pad_encoding_using_pad_attr(%arg0: index, %arg1: index) {
 // Currently unsupported paddings.
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_pad_layout<>,
+  iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>,
   iree.gpu.target = #iree_gpu.target<arch = "gfx942",
                                      features = "",
                                      wgp = <compute = fp32,
@@ -154,7 +154,7 @@ util.func public @error_with_pad_encoding_using_pad_attr(%arg0: index, %arg1: in
 
 // Creates an nop encoding if no `iree.gpu.target` is provided.
 
-#executable_target_rocm_bytecode_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_pad_layout<> }>
+#executable_target_rocm_bytecode_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<> }>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_rocm_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.testing<>
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -8,7 +8,7 @@
 #map0 = affine_map<(m, n, k) -> (m, k)>
 #map1 = affine_map<(m, n, k) -> (k, n)>
 #map2 = affine_map<(m, n, k) -> (m, n)>
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_resolver<>}>
 #executable_target_x86_64 = #hal.executable.target<"llvm-cpu", "xyz", {iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, target_triple="x86_64-xyz-xyz", cpu_features="+avx512f"}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64]> : !hal.device
@@ -21,7 +21,7 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
   util.return %size0, %size1 : index, index
 }
-// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_layout{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_resolver{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.layout<[#iree_cpu.cpu_encoding_resolver{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @tensor_sizeof
 // CHECK:         %[[D0_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING0]]>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -31,7 +31,7 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
 // -----
 
 //------------------------------------------------------------------------------
-// #iree_gpu.gpu_encoding_layout specialization tests.
+// #iree_gpu.gpu_encoding_resolver specialization tests.
 // These get serialized to the layout attributes.
 //------------------------------------------------------------------------------
 
@@ -41,7 +41,7 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
   {
     abi = "hip",
-    iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>,
+    iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
     iree.gpu.target = #iree_gpu.target<arch = "gfx942",
                                        features = "",
                                        wgp = <compute = fp32,
@@ -67,7 +67,7 @@ util.func public @gpu_with_encoding_layout(%d0: index, %d1: index) -> index {
   util.return %size0 : index
 }
 // CHECK:       #[[$ENCODING:.+]] = #iree_encoding.layout
-// CHECK-SAME:    #iree_gpu.gpu_encoding_layout
+// CHECK-SAME:    #iree_gpu.gpu_encoding_resolver
 // CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @gpu_with_encoding_layout
 // CHECK:         %[[RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING]]>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -9,7 +9,7 @@
 #map1 = affine_map<(m, n, k) -> (k, n)>
 #map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_cpu.vmvx_encoding_layout<>}>
-#executable_target_x86_64 = #hal.executable.target<"llvm-cpu", "xyz", {iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>, target_triple="x86_64-xyz-xyz", cpu_features="+avx512f"}>
+#executable_target_x86_64 = #hal.executable.target<"llvm-cpu", "xyz", {iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, target_triple="x86_64-xyz-xyz", cpu_features="+avx512f"}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
@@ -22,7 +22,7 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
   util.return %size0, %size1 : index, index
 }
 // CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_layout{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
-// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
+// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.layout<[#iree_cpu.cpu_encoding_resolver{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @tensor_sizeof
 // CHECK:         %[[D0_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING0]]>
 // CHECK:         %[[D1_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING1]]>

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -194,7 +194,7 @@ void HoistEncodingOpsPass::runOnOperation() {
     }
     // Avoid hoisting set encodings that are using the padding encodings.
     Attribute encoding = setEncodingOp.getResultType().getEncoding();
-    if (isa_and_nonnull<IREE::Encoding::PadEncodingLayoutAttr>(encoding)) {
+    if (isa_and_nonnull<IREE::Encoding::PaddingAttr>(encoding)) {
       return;
     }
     Operation *src = setEncodingOp.getSource().getDefiningOp();

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -377,8 +377,8 @@ static std::optional<PaddedValue> padProducerOfValue(RewriterBase &rewriter,
   // value.
   SmallVector<int64_t> paddingValue(operandType.getRank(), 0);
   paddingValue.back() = ShapedType::kDynamic;
-  auto encoding = IREE::Encoding::PaddingAttr::get(
-      rewriter.getContext(), paddingValue);
+  auto encoding =
+      IREE::Encoding::PaddingAttr::get(rewriter.getContext(), paddingValue);
 
   // Compute the result types of the new dispatch.
   auto newResultType = operandType.cloneWithEncoding(encoding);

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -377,7 +377,7 @@ static std::optional<PaddedValue> padProducerOfValue(RewriterBase &rewriter,
   // value.
   SmallVector<int64_t> paddingValue(operandType.getRank(), 0);
   paddingValue.back() = ShapedType::kDynamic;
-  auto encoding = IREE::Encoding::PadEncodingLayoutAttr::get(
+  auto encoding = IREE::Encoding::PaddingAttr::get(
       rewriter.getContext(), paddingValue);
 
   // Compute the result types of the new dispatch.

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -258,7 +258,7 @@ util.func public @hoist_encoding_only() -> tensor<640x320xf32> {
 
 // Avoid hoisting `set_encoding` operations that have pad encodings
 
-#encoding = #iree_encoding.pad_encoding_layout<[0, ?]>
+#encoding = #iree_encoding.padding<[0, ?]>
 util.func public @dont_hoist_pad_encoding() -> tensor<640x320xf32, #encoding> {
   %cst = arith.constant dense<1.0> : tensor<640x320xf32>
   %0 = flow.dispatch.region -> (tensor<640x320xf32, #encoding>) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_padding.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_padding.mlir
@@ -34,7 +34,7 @@ util.func @simple_test(%lhs : tensor<?x?xf32>, %rhs0 : tensor<?x2048xf32>,
 //  CHECK-SAME:     %[[N:[a-zA-Z0-9_]+]]: index
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
 //  CHECK-SAME:       [%[[M]], %[[K]]]
-//  CHECK-SAME:       -> (tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>{%[[M]]})
+//  CHECK-SAME:       -> (tensor<?x2048xf32, #iree_encoding.padding<[0, ?]>>{%[[M]]})
 //       CHECK:     %[[OP0:.+]] = linalg.matmul
 //       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[OP0]]
 //       CHECK:     flow.return %[[SET_ENCODING]]
@@ -76,7 +76,7 @@ util.func @encoding_across_collapse(%lhs : tensor<?x2048xf32>, %rhs : tensor<204
 }
 // CHECK-LABEL: @encoding_across_collapse
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
-//  CHECK-SAME:       -> (tensor<?x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>
+//  CHECK-SAME:       -> (tensor<?x2048xf32, #iree_encoding.padding<[0, ?]>>
 //       CHECK:     %[[EMPTY:.+]] = tensor.empty
 //       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EMPTY]]
 //       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[COLLAPSE]]
@@ -118,7 +118,7 @@ util.func @encoding_across_collapse_expand(%lhs : tensor<?x2048xf32>, %rhs : ten
 }
 // CHECK-LABEL: @encoding_across_collapse_expand(
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//  CHECK-SAME:       #iree_encoding.pad_encoding_layout<[0, ?]>
+//  CHECK-SAME:       #iree_encoding.padding<[0, ?]>
 //       CHECK:     %[[EMPTY:.+]] = tensor.empty
 //       CHECK:     %[[EXPAND:.+]] = tensor.expand_shape %[[EMPTY]]
 //       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
@@ -159,7 +159,7 @@ util.func @no_pad_dynamic_reduction_dims(%lhs : tensor<?x?xf32>, %rhs0 : tensor<
   util.return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: @no_pad_dynamic_reduction_dims
-//   CHECK-NOT: #iree_encoding.pad_encoding_layout
+//   CHECK-NOT: #iree_encoding.padding
 
 // -----
 
@@ -191,7 +191,7 @@ util.func @no_pad_skinny_matmuls(%lhs : tensor<?x?xf32>, %rhs0 : tensor<?x2048xf
   util.return %1 : tensor<8x4xf32>
 }
 // CHECK-LABEL: @no_pad_skinny_matmuls
-//   CHECK-NOT: #iree_encoding.pad_encoding_layout
+//   CHECK-NOT: #iree_encoding.padding
 
 // -----
 
@@ -224,7 +224,7 @@ util.func @check_padding_threshold(%lhs : tensor<?x?xf32>, %rhs0 : tensor<?x2048
 }
 // CHECK-LABEL: @check_padding_threshold(
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
-//  CHECK-SAME:       -> (tensor<8x2048xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>)
+//  CHECK-SAME:       -> (tensor<8x2048xf32, #iree_encoding.padding<[0, ?]>>)
 //       CHECK:     %[[OP0:.+]] = linalg.matmul
 //       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[OP0]]
 //       CHECK:     flow.return %[[SET_ENCODING]]


### PR DESCRIPTION
- iree_encoding.pad_encoding_layout -> iree_encoding.padding 
- iree_gpu.gpu_pad_layout -> iree_gpu.gpu_padding_resolver
- iree_cpu.cpu_encoding_layout -> iree_cpu.cpu_encoding_resolver
- iree_cpu.vmvx_encoding_layout -> iree_cpu.vmvx_encoding_resolver
- iree_gpu.gpu_encoding_layout -> iree_gpu.gpu_encoding_resolver

It is a step towards https://github.com/iree-org/iree/issues/20742