### PR TITLE
[Codegen][GPU] Adding scheduling barrier between compute and write stage in prefetcher

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -90,6 +90,7 @@ def ROCDLPrefetchSharedMemoryPass :
     InterfacePass<"iree-llvmgpu-prefetch-shared-memory", "mlir::FunctionOpInterface"> {
       let summary = "Rotate scf.for loops to prefetch shared memory with distance 1. This pass is only applicable"
           "to ROCDL targets because its effectiveness on non-AMD GPUs lacks testing and evaluation.";
+  let dependentDialects = ["amdgpu::AMDGPUDialect"];
 }
 
 def LLVMGPUSelectLoweringStrategyPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPrefetching.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
 #include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/IR/PatternMatch.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -113,6 +114,7 @@ public:
     emitBarrier(loc, rewriter);
     emitCompute(mapping[0], rewriter, indVar);
     emitBarrier(loc, rewriter);
+    emitSchedBarrier(loc, rewriter);
     emitWrite(mapping[1], rewriter, iPlusOne);
     updateYield(mapping[0], rewriter);
     return;
@@ -328,6 +330,12 @@ private:
   /// Creates a gpu.barrier op with |rewriter|.
   void emitBarrier(Location loc, RewriterBase &rewriter) {
     rewriter.create<gpu::BarrierOp>(loc);
+  }
+
+  void emitSchedBarrier(Location loc, RewriterBase &rewriter) {
+    rewriter.create<amdgpu::SchedBarrierOp>(
+        loc, amdgpu::sched_barrier_opt_enumAttr::get(
+                 rewriter.getContext(), amdgpu::sched_barrier_opt_enum::none));
   }
 
   /// Creates all compute stage ops for a loop iteration with |rewriter| and

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -28,6 +28,7 @@ func.func @prefetch_add(%arg0: memref<128xf32>) {
     // CHECK: %[[COMPUTE:.*]] = arith.addf %[[COMPUTE_READ]], %[[ARG]]
     %3 = arith.addf %2, %arg2 : vector<1xf32>
     // CHECK: gpu.barrier
+    // CHECK: amdgpu.sched_barrier allow = <none>
     // CHECK: vector.transfer_write %[[KER_READ]], %[[SHARED]]
     // CHECK: scf.yield %[[COMPUTE]]
     scf.yield %3 : vector<1xf32>
@@ -72,6 +73,7 @@ func.func @prefetch_multi_scf_return(%arg0: memref<128xf32>) -> (vector<1xf32>, 
     %3 = arith.addf %2, %arg2 : vector<1xf32>
     %4 = arith.addf %3, %arg3 : vector<1xf32>
     // CHECK: gpu.barrier
+    // CHECK: amdgpu.sched_barrier allow = <none>
     // CHECK: vector.transfer_write %[[KER_READ]], %[[SHARED]]
     // CHECK: scf.yield %[[COMPUTE]], %[[COMPUTE2]]
     scf.yield %3, %4 : vector<1xf32>, vector<1xf32>
@@ -127,6 +129,7 @@ func.func @prefetch_add_with_if(%arg0: memref<128xf32>) {
     // CHECK: %[[COMPUTE:.*]] = arith.addf %[[COMPUTE_READ]], %[[ARG]]
     %3 = arith.addf %2, %arg2 : vector<1xf32>
     // CHECK: gpu.barrier
+    // CHECK: amdgpu.sched_barrier allow = <none>
     // CHECK: vector.transfer_write %[[KER_READ]], %[[SHARED]]
     // CHECK: scf.yield %[[COMPUTE]]
     scf.yield %3 : vector<1xf32>
@@ -212,6 +215,7 @@ func.func @prefetch_scf_if(%arg0: memref<128xf32>, %cond : i1) {
 // CHECK:   %[[COMPUTE_READ:.*]] = vector.transfer_read %[[WG_ALLOC]][%[[C0]]]
 // CHECK:   %[[COMPUTE:.*]] = arith.addf %[[COMPUTE_READ]], %[[ARG]]
 // CHECK:   gpu.barrier
+// CHECK:   amdgpu.sched_barrier allow = <none>
 // CHECK:   scf.if %[[COND]] {
 // CHECK:     %[[COMPUTE_RELOAD:.*]] = vector.transfer_read %[[PRIV_ALLOC2]][%[[C0]]]
 // CHECK:     vector.transfer_write %[[COMPUTE_RELOAD]], %[[WG_ALLOC]][%[[C0]]]
@@ -319,6 +323,7 @@ func.func @prefetch_scf_if_transientreadwrite(%arg0: memref<128xf32>, %cond : i1
 // CHECK:   %[[READ3:.*]] = vector.transfer_read %[[WG_ALLOC]]
 // CHECK:   %[[COMP:.*]] = arith.addf
 // CHECK:   gpu.barrier
+// CHECK:   amdgpu.sched_barrier allow = <none>
 // CHECK:   %[[PRIV_ALLOC3:.*]] = memref.alloca() : memref<1xf32, #gpu.address_space<private>>
 // CHECK:   scf.if
 // CHECK:   %[[READ5:.*]] = vector.transfer_read %[[PRIV_ALLOC3]]


### PR DESCRIPTION
Motivation: I and @nirvedhmeshram observed a fair amount of misplacement of `s_waitcnt` instructions from the amdgpu backend. The backend tends to place the `s_waitcnt` overly early, sometimes in between MFMA instructions. This has caused irrelevant stalls between compute and load that should have overlap and can potentially hide the stalls.

This PR adds the scheduling barrier in between compute and write stage such that the backend compiler no longer can freely place the `s_waitcnt` earlier, in compute stage. It is forced to place the wait as early as the start of the write stage. 

I've verified through thread-trace that the scheduling barrier does what is intended and the `s_waitcnt` placement isn't interleaved with MFMA instructions any longer.

Upon looking at CI result, this seems to provide a bit of overall lift to all model level tests. Compared target (tip of main at): https://github.com/iree-org/iree/actions/runs/15767966101/job/44447951812



| Benchmark | Before    |   After  |
| --- | --- | --- |
| llama 8b_f16_decode | 10.020865534565278 ms | 9.531815848439127 ms |
| llama 8b_f16_prefill | 39.90881894197729 ms | 39.257620445763074 ms |
| sdxl clip | 8.061422783367593 ms | 7.982292237945579 ms |
| sdxl e2e | 286.39431609772146 ms | 285.5649597477168 ms |
| sdxl punet_int8_fp16 | 40.25666919153404 ms | 39.64519846356578 ms |
| sdxl punet_int8_fp8 | 42.10774295360727 ms | 40.13837954467711 ms |
| sdxl unet_fp16 | 68.40701173059642 ms | 68.04983000271024 ms |
| sdxl vae | 68.57368536293507 ms | 67.36758409999312 ms |