### PR TITLE
[Dispatch Creation] Add concat expand_shape bubbling

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -354,16 +354,8 @@ struct BubbleExpandThroughConcat final
 
       AffineExpr concatDimExpr, productExpr;
       OpFoldResult productOpFold = rewriter.getIndexAttr(product);
-      OpFoldResult dimOfr;
-      if (ShapedType::isDynamic(inputShape[concatDim])) {
-        // Get the runtime value for the dynamic dimension.
-        dimOfr =
-            rewriter.create<tensor::DimOp>(expandOp.getLoc(), input, concatDim)
-                .getResult();
-      } else {
-        // Use the static value as an Attribute.
-        dimOfr = rewriter.getIndexAttr(inputShape[concatDim]);
-      }
+      OpFoldResult dimOfr =
+          tensor::getMixedSizes(rewriter, expandOp.getLoc(), input)[concatDim];
       bindSymbols(rewriter.getContext(), concatDimExpr, productExpr);
       OpFoldResult concatDimValue = affine::makeComposedFoldedAffineApply(
           rewriter, expandOp.getLoc(), concatDimExpr.ceilDiv(productExpr),

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -359,18 +359,11 @@ struct BubbleExpandThroughConcat final
       SmallVector<OpFoldResult> expandShapeOutputDims;
       SmallVector<int64_t> expandShapeOutputDimsInt;
       // i = input shape index, k = expanded shape index, j = reassoc index
+      // Only the concat dim can differ from the original expanded dim
+      // The concat dim must be at j = 0.
+      // Iterate from j = 0 to size, and multiply each non-concat dim.
+      // after looping, divide by inputShape[i].
       for (int64_t i = 0, k = 0; i < inputShape.size(); i++) {
-        // If the input is not expanded, just copy the shape.
-        if (reassoc[i].size() == 1) {
-          expandShapeOutputDims.push_back(rewriter.getIndexAttr(inputShape[i]));
-          expandShapeOutputDimsInt.push_back(inputShape[i]);
-          k++;
-          continue;
-        }
-        // Only the concat dim can differ from the original expanded dim
-        // The concat dim must be at j = 0.
-        // Iterate from j = 1 to size, and multiply each. after looping, divide
-        // by inputShape[i].
         int64_t nonConcatDimProduct = 1;
         bool concatInThisLoop = false;
         for (int64_t j = 0; j < reassoc[i].size(); j++, k++) {

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -314,11 +314,7 @@ struct BubbleExpandThroughConcat final
 
       for (Value input : concatOp.getInputs()) {
         // Check all static input shapes for divisibility.
-        auto inputType = dyn_cast<RankedTensorType>(input.getType());
-        if (!inputType) {
-          return rewriter.notifyMatchFailure(
-              expandOp, "Input to concat is not a RankedTensorType");
-        }
+        auto inputType = cast<RankedTensorType>(input.getType());
         int64_t inputDim = inputType.getShape()[concatDim];
         // if the input dim is dynamic, we rely on checking the divisibility of
         // the other inputs. Example:

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -341,5 +341,6 @@ util.func public @test_expand_prop_through_concat_mixed_dynamic_static_args(%arg
 }
 // CHECK-LABEL: func public @test_expand_prop_through_concat_mixed_dynamic_static_args
 //       CHECK: tensor.expand_shape {{.*}}: tensor<4x100x100xf32> into tensor<1x4x1x2x5x10x100xf32>
-//       CHECK: tensor.expand_shape {{.*}}: tensor<4x?x100xf32> into tensor<1x4x?x2x5x10x100xf32>
+//       CHECK: %[[AFF:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 100)>()[%dim]
+//       CHECK: tensor.expand_shape {{.*}}output_shape [1, 4, %[[AFF]], 2, 5, 10, 100] : tensor<4x?x100xf32> into tensor<1x4x?x2x5x10x100xf32>
 //       CHECK: tensor.concat dim(2) {{.*}}: (tensor<1x4x1x2x5x10x100xf32>, tensor<1x4x?x2x5x10x100xf32>) -> tensor<1x4x?x2x5x10x100xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -6,7 +6,6 @@ util.func public @bubbble_expand_through_extract(%arg0 : tensor<2x4096x5120xf16>
   %expanded_239 = tensor.expand_shape %extracted_slice_237 [[0], [1, 2], [3]] output_shape [2, 64, 64, 2560] : tensor<2x4096x2560xf16> into tensor<2x64x64x2560xf16>
   util.return %expanded_239 : tensor<2x64x64x2560xf16>
 }
-
 // CHECK-LABEL:  @bubbble_expand_through_extract
 //       CHECK:    %[[EXPAND:.+]] = tensor.expand_shape
 //       CHECK:    %[[EXTRACT:.+]] = tensor.extract_slice %[[EXPAND]]
@@ -18,7 +17,6 @@ util.func public @unsupported_bubbble_expand_through_extract(%arg0 : tensor<2x40
   %expanded_239 = tensor.expand_shape %extracted_slice_237 [[0], [1, 2], [3]] output_shape [2, 32, 64, 2560] : tensor<2x2048x2560xf16> into tensor<2x32x64x2560xf16>
   util.return %expanded_239 : tensor<2x32x64x2560xf16>
 }
-
 // CHECK-LABEL:  @unsupported_bubbble_expand_through_extract
 //       CHECK:    %[[EXTRACT:.+]] = tensor.extract_slice
 //       CHECK:    %[[EXPAND:.+]] = tensor.expand_shape %[[EXTRACT]]
@@ -198,13 +196,12 @@ util.func public @test_no_infinite_loop_unit_dim_expansion(%arg0 : tensor<4xi64>
 
   util.return %11 : tensor<4xi64>
 }
-
 // CHECK-LABEL: test_no_infinite_loop_unit_dim_expansion
-// CHECK-NOT: tensor.expand_shape
-// CHECK: linalg.generic
-// CHECK: tensor.expand_shape
-// CHECK: linalg.generic
-// CHECK-NOT: tensor.expand_shape
+//   CHECK-NOT: tensor.expand_shape
+//       CHECK: linalg.generic
+//       CHECK: tensor.expand_shape
+//       CHECK: linalg.generic
+//   CHECK-NOT: tensor.expand_shape
 
 // -----
 
@@ -226,22 +223,73 @@ util.func @dont_propagate_edge_unit_reshapes(%arg0: tensor<?x1xi32>) -> tensor<?
 
 // -----
 
+// Basic check
+util.func public @test_basic_expand_bubble_through_concat(%arg0 : tensor<50xf32>, %arg1 : tensor<50xf32>) -> tensor<10x10xf32>{
+  %0 = tensor.concat dim(0) %arg0, %arg1 : (tensor<50xf32>, tensor<50xf32>) -> tensor<100xf32>
+  %1 = tensor.expand_shape %0 [[0, 1]] output_shape [10, 10] : tensor<100xf32> into tensor<10x10xf32>
+  util.return %1 : tensor<10x10xf32>
+}
+// CHECK-LABEL: func public @test_basic_expand_bubble_through_concat
+//       CHECK: tensor.expand_shape {{.*}}: tensor<50xf32> into tensor<5x10xf32>
+//       CHECK: tensor.expand_shape {{.*}}: tensor<50xf32> into tensor<5x10xf32>
+//       CHECK: tensor.concat dim(0) {{.*}}: (tensor<5x10xf32>, tensor<5x10xf32>) -> tensor<10x10xf32>
+
+// -----
+
+// Check pattern doesn't apply when operands are not statically divisible
+util.func public @test_dont_bubble_expand_statically_indivisible(%arg0 : tensor<51xf32>, %arg1 : tensor<49xf32>) -> tensor<10x10xf32>{
+  %0 = tensor.concat dim(0) %arg0, %arg1 : (tensor<51xf32>, tensor<49xf32>) -> tensor<100xf32>
+  %1 = tensor.expand_shape %0 [[0, 1]] output_shape [10, 10] : tensor<100xf32> into tensor<10x10xf32>
+  util.return %1 : tensor<10x10xf32>
+}
+// CHECK-LABEL: func public @test_dont_bubble_expand_statically_indivisible
+//   CHECK-NOT: tensor.expand_shape
+//       CHECK: tensor.concat dim(0) {{.*}}: (tensor<51xf32>, tensor<49xf32>) -> tensor<100xf32>
+//       CHECK: tensor.expand_shape %{{.*}} : tensor<100xf32> into tensor<10x10xf32>
+
+// -----
+
+// Check pattern doesn't apply when operands are not dynamically divisible
+util.func public @test_dont_bubble_expand_dynamically_indivisible(%arg0 : tensor<?xf32>, %arg1 : tensor<?xf32>, %dim : index) -> tensor<10x?xf32>{
+  %0 = tensor.concat dim(0) %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %1 = tensor.expand_shape %0 [[0, 1]] output_shape [10, %dim] : tensor<?xf32> into tensor<10x?xf32>
+  util.return %1 : tensor<10x?xf32>
+}
+// CHECK-LABEL: func public @test_dont_bubble_expand_dynamically_indivisible
+//   CHECK-NOT: tensor.expand_shape
+//       CHECK: tensor.concat dim(0) {{.*}}: (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+//       CHECK: tensor.expand_shape %{{.*}} : tensor<?xf32> into tensor<10x?xf32>
+
+// -----
+
+// Check pattern doesn't apply when expanded shape has dynamic non outermost dimension
+util.func public @test_dont_bubble_expand_dynamic_non_outermost(%arg0 : tensor<10x?xf32>, %arg1 : tensor<10x10xf32>, %dim : index) -> tensor<10x5x?xf32>{
+  %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<10x?xf32>, tensor<10x10xf32>) -> tensor<10x?xf32>
+  %1 = tensor.expand_shape %0 [[0],[1, 2]] output_shape [10, 5, %dim] : tensor<10x?xf32> into tensor<10x5x?xf32>
+  util.return %1 : tensor<10x5x?xf32>
+}
+// CHECK-LABEL: func public @test_dont_bubble_expand_dynamic_non_outermost
+//   CHECK-NOT: tensor.expand_shape
+//       CHECK: tensor.concat dim(1) {{.*}}: (tensor<10x?xf32>, tensor<10x10xf32>) -> tensor<10x?xf32>
+//       CHECK: tensor.expand_shape %{{.*}} : tensor<10x?xf32> into tensor<10x5x?xf32>
+
+// -----
+
 //  Check basic expand_shape propagation through a concat op
-util.func public @test_expand_shape_propagation_through_concat(%arg0 : tensor<100x50x32xf32>, %arg1 : tensor<100x100x32xf32>) -> tensor<10x10x150x16x2xf32>{
+util.func public @test_multi_dim_expand_shape_propagation_through_concat(%arg0 : tensor<100x50x32xf32>, %arg1 : tensor<100x100x32xf32>) -> tensor<10x10x150x16x2xf32>{
   %0 = tensor.concat dim(1) %arg0, %arg1 : (tensor<100x50x32xf32>, tensor<100x100x32xf32>) -> tensor<100x150x32xf32>
   %1 = tensor.expand_shape %0 [[0, 1], [2], [3, 4]] output_shape [10, 10, 150, 16, 2] : tensor<100x150x32xf32> into tensor<10x10x150x16x2xf32>
   util.return %1 : tensor<10x10x150x16x2xf32>
 }
-
-// CHECK-LABEL: func public @test_expand_shape_propagation_through_concat
-// CHECK: tensor.expand_shape {{.*}}: tensor<100x50x32xf32> into tensor<10x10x50x16x2xf32>
-// CHECK: tensor.expand_shape {{.*}}: tensor<100x100x32xf32> into tensor<10x10x100x16x2xf32>
-// CHECK: tensor.concat dim(2) {{.*}}: (tensor<10x10x50x16x2xf32>, tensor<10x10x100x16x2xf32>) -> tensor<10x10x150x16x2xf32>
+// CHECK-LABEL: func public @test_multi_dim_expand_shape_propagation_through_concat
+//       CHECK: tensor.expand_shape {{.*}}: tensor<100x50x32xf32> into tensor<10x10x50x16x2xf32>
+//       CHECK: tensor.expand_shape {{.*}}: tensor<100x100x32xf32> into tensor<10x10x100x16x2xf32>
+//       CHECK: tensor.concat dim(2) {{.*}}: (tensor<10x10x50x16x2xf32>, tensor<10x10x100x16x2xf32>) -> tensor<10x10x150x16x2xf32>
 
 // -----
 
 // Check that expand_shape can be propagated through a concat op with mixed static and dynamic dimensions
-// Covers multiple expansions,
+// Covers multiple expansions, including one before the concat dim
 util.func public @test_expand_prop_through_concat_mixed_dynamic_static_args(%arg0: tensor<4x100x100xf32>, %arg1: tensor<4x?x100xf32>) -> tensor<1x4x?x2x5x10x100xf32> {
   %c0 = arith.constant 1 : index
   %concat = tensor.concat dim(1) %arg0, %arg1 : (tensor<4x100x100xf32>, tensor<4x?x100xf32>) -> tensor<4x?x100xf32>
@@ -250,9 +298,7 @@ util.func public @test_expand_prop_through_concat_mixed_dynamic_static_args(%arg
   %expanded = tensor.expand_shape %concat [[0, 1], [2,3, 4,5], [6]] output_shape [1, 4, %0, 2, 5, 10, 100] : tensor<4x?x100xf32> into tensor<1x4x?x2x5x10x100xf32>
   util.return %expanded : tensor<1x4x?x2x5x10x100xf32>
 }
-
-
 // CHECK-LABEL: func public @test_expand_prop_through_concat_mixed_dynamic_static_args
-// CHECK: tensor.expand_shape {{.*}}: tensor<4x100x100xf32> into tensor<1x4x1x2x5x10x100xf32>
-// CHECK: tensor.expand_shape {{.*}}: tensor<4x?x100xf32> into tensor<1x4x?x2x5x10x100xf32>
-// CHECK: tensor.concat dim(2) {{.*}}: (tensor<1x4x1x2x5x10x100xf32>, tensor<1x4x?x2x5x10x100xf32>) -> tensor<1x4x?x2x5x10x100xf32>
+//       CHECK: tensor.expand_shape {{.*}}: tensor<4x100x100xf32> into tensor<1x4x1x2x5x10x100xf32>
+//       CHECK: tensor.expand_shape {{.*}}: tensor<4x?x100xf32> into tensor<1x4x?x2x5x10x100xf32>
+//       CHECK: tensor.concat dim(2) {{.*}}: (tensor<1x4x1x2x5x10x100xf32>, tensor<1x4x?x2x5x10x100xf32>) -> tensor<1x4x?x2x5x10x100xf32>


### PR DESCRIPTION
This adds support for propagating expand shapes through concats to allow fusion of tensor.concat with a consumer attention op. The propagation is trivial when the concat dim is not expanded. If it is expanded, propagation is only possible when the concatenation occurs along the outermost dimension in the expanded shape, and if dynamic, the product of the other expanded dims divide evenly into the original dim.

More aggressive fusions may be possible if symbolic shape information is present.