### PR TITLE
Expand all affine applies before and during Flow

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/canonicalize.mlir
@@ -59,3 +59,15 @@ util.func public @dont_fold_not_full_static_insert_into_empty(
 // CHECK-LABEL: util.func public @dont_fold_not_full_static_insert_into_empty
 //       CHECK:   %[[INSERT:.+]] = tensor.insert_slice
 //       CHECK:   util.return %[[INSERT]]
+
+// -----
+
+util.func public @expand_affine(%arg0: index) -> index {
+  %mul = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%arg0]
+  util.return %mul : index
+}
+
+// CHECK-LABEL: util.func public @expand_affine
+//  CHECK-SAME:   %[[ARG0:.+]]: index
+//       CHECK:   %[[MUL:.+]] = arith.muli %[[ARG0]], %c4
+//       CHECK:   util.return %[[MUL]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/canonicalize.mlir
@@ -69,5 +69,5 @@ util.func public @expand_affine(%arg0: index) -> index {
 
 // CHECK-LABEL: util.func public @expand_affine
 //  CHECK-SAME:   %[[ARG0:.+]]: index
-//       CHECK:   %[[MUL:.+]] = arith.muli %[[ARG0]], %c4
+//       CHECK:   %[[MUL:.+]] = arith.muli %[[ARG0]], %c4 overflow<nsw>
 //       CHECK:   util.return %[[MUL]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(canonicalize, util.func(iree-dispatch-creation-form-dispatch-regions{aggressive-fusion=true}, iree-dispatch-creation-clone-producers-into-dispatch-regions, iree-dispatch-creation-convert-dispatch-regions-to-workgroups, iree-dispatch-creation-convert-tensor-to-flow, canonicalize, iree-dispatch-creation-materialize-default-workgroup-count-region), cse, iree-flow-canonicalize, cse)" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(canonicalize, util.func(iree-dispatch-creation-form-dispatch-regions{aggressive-fusion=true}, iree-dispatch-creation-clone-producers-into-dispatch-regions, iree-dispatch-creation-convert-dispatch-regions-to-workgroups, iree-dispatch-creation-convert-tensor-to-flow, canonicalize, iree-dispatch-creation-materialize-default-workgroup-count-region), cse, canonicalize, cse)" %s | FileCheck %s
 
 util.func public @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/compiler/src/iree/compiler/DispatchCreation/test/tensor_pad_to_tensor_insert_slice.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/tensor_pad_to_tensor_insert_slice.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-dispatch-creation-tensor-pad-to-tensor-insert-slice --iree-flow-canonicalize %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-dispatch-creation-tensor-pad-to-tensor-insert-slice=skip-one-linalg-use-case --iree-flow-canonicalize %s | FileCheck %s --check-prefix=SKIP
+// RUN: iree-opt --split-input-file --iree-dispatch-creation-tensor-pad-to-tensor-insert-slice --canonicalize %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-dispatch-creation-tensor-pad-to-tensor-insert-slice=skip-one-linalg-use-case --canonicalize %s | FileCheck %s --check-prefix=SKIP
 
 util.func public @tensor_pad(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-global-opt-raise-special-ops --iree-flow-canonicalize --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --iree-global-opt-raise-special-ops --canonicalize --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 // CHECK-LABEL: @softmax
 //  CHECK-SAME: %[[ARG:.+]]: tensor<?x?x?xf32>


### PR DESCRIPTION
The mix of affine + arith operations generated at Flow and earlier hinders folding/canonicalization opportunities, so it's best for us to pick one to use. This picks arith over affine since it is easier to go from affine -> arith rather than the other way, and it composes better with dialects like Util.