### PR TITLE
[mlir][Codegen] Remove workaround for handling consumer fusion along multiple operands.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -23,83 +23,23 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
                            scf::SCFTileAndFuseOptions &options,
                            MutableArrayRef<LoopLikeOpInterface> loops);
 
-/// Consider the following case
-///
-/// ```mlir
-/// %0:2 = linalg.generic {
-///     indexing_maps = [....,
-///                      affine_map<(d0, d1, d2) -> (d0, d1),
-///                      affine_map<(d0, d1, d2) -> (d0, d1)>]}
-/// %1 = linalg.generic ins(%0#0, %0#1) {
-///     indexing_maps = [affine_map<(d0, d1) -> (d0, d1),
-///                      affine_map<(d0, d1) -> (d0, d1)]}
-/// ```
-///
-/// After tiling the first op we get
-///
-/// ```
-/// %0:2 = scf.forall ... {
-///   %1:2 = linalg.generic {
-///       indexing_maps = [....,
-///                        affine_map<(d0, d1, d2) -> (d0, d1),
-///                        affine_map<(d0, d1, d2) -> (d0, d1)>]}
-///   }
-/// }
-/// %2 = linalg.generic ins(%0#0, %0#1) {
-///     indexing_maps = [affine_map<(d0, d1) -> (d0, d1),
-///                      affine_map<(d0, d1) -> (d0, d1)]}
-/// ```
-///
-/// Due to a quirk of the fusion of consumers, fusing this consumer into the
-/// loop results in
-///
-/// ```
-/// %0:2 = scf.forall ... {
-///   %1:2 = linalg.generic {
-///       indexing_maps = [....,
-///                        affine_map<(d0, d1, d2) -> (d0, d1),
-///                        affine_map<(d0, d1, d2) -> (d0, d1)>]}
-///   %2 = tensor.extract_slice %0#1 [...]
-///   %3 = linalg.generic ins(%1#0, %2) {
-///       indexing_maps = [affine_map<(d0, d1) -> (d0, d1),
-///                        affine_map<(d0, d1) -> (d0, d1)]}
-///   }
-/// }
-/// ```
-///
-/// This is an SSA violation because of `%0#1` being used in the loop. This
-/// needs to be fixed upstream, but for cases where
-/// 1. The root operation produces results using an identity indexing map (when
-/// ignoring the iteration space dimensions corresponding to the reduction
-/// loops)
-/// 2. For all consumers of the results of the root operation, access the data
-/// using identity indexing map then for each consumer fusion step it is valid
-/// to replace all uses of slices of the outer loop that occur within the loop
-/// with the correponding tiled result value.
-/// This is a workaround till upstream transformation can fix this issue. The
-/// following method is testing if such a case exists to implement the
-/// work-around.
-bool warForConsumerFusionSSAViolation(
-    Operation *rootOp,
-    const llvm::SmallDenseSet<Operation *> &tiledAndFusedOps);
-
 /// Starting from `op` walk all operands backwards to find all
 /// potentially fusible operations, i.e. operations that implement
 /// the `TilingInterface`.
 void collectTiledAndFusedOps(Operation *rootOp,
                              llvm::SmallDenseSet<Operation *> &result);
-/// Fuses consumers of `tiledOp` into the surrounding `loops`.
-///
-/// For any previous producer consumer fusion it's expected that `tiledOp` was
-/// the consumer into which producers were fused, i.e. `loops` shouldn't contain
-/// a consumer of `tiledOp` that isn't an insert_slice op.
-/// `fuseConsumersIntoLoops` will fuse consumers of `tiledOp` into surrounding
-/// `scf.forall` or `scf.for` loops and return a list of slice ops that expose
-/// new fusion opportunities.
-FailureOr<std::queue<Operation *>>
-fuseConsumersIntoLoops(RewriterBase &rewriter, Operation *tiledOp,
-                       MutableArrayRef<LoopLikeOpInterface> loops,
-                       bool useWARForConsumerFusionSSAViolation);
+
+/// Fuse all consumers of the given `tiledOp` into the surrounding `scf.forall`.
+/// Returns a list of new `tensor.extract_slice` ops with new fusion
+/// opportunities, as well as the new surrounding `scf.forall` (because consumer
+/// fusion replaces the loop).
+FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
+    RewriterBase &rewriter, Operation *tiledOp,
+    MutableArrayRef<LoopLikeOpInterface> loops,
+    std::function<bool(Operation *)> filterFn = [](Operation *) {
+      return true;
+    });
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/145193 it is possible
to tile and fuse consumers when the consumer uses multiple results of
the tiled loop (as long the as the slices of the uses/operands are
consistent w.r.t to their use in the consumer). This removes the need
for the workaround that was added to handle such cases and generalizes
the cases of consumer fusion that can be handled.

Fixes https://github.com/iree-org/iree/issues/21087
Fixes https://github.com/iree-org/iree/issues/21091

Depends on https://github.com/llvm/llvm-project/pull/145193

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>