### PR TITLE
CMake: catch some recurring problems with LLVM configuration.

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -129,6 +129,11 @@ macro(iree_llvm_set_bundled_cmake_options)
   set(IREE_DEFAULT_CPU_LLVM_TARGETS "X86;ARM;AArch64;RISCV"
       CACHE STRING "Initialization value for default LLVM CPU targets.")
 
+  # Catch an incorrect usage pattern that has been used in the past.
+  if("host" IN_LIST IREE_DEFAULT_CPU_LLVM_TARGETS)
+    message(SEND_ERROR "IREE_DEFAULT_CPU_LLVM_TARGETS may not contain 'host'.")
+  endif()
+
   # These defaults are moderately important to us, but the user *can*
   # override them (enabling some of these brings in deps that will conflict,
   # so ymmv).
@@ -223,6 +228,13 @@ macro(iree_llvm_set_bundled_cmake_options)
 
   list(REMOVE_DUPLICATES LLVM_ENABLE_PROJECTS)
   list(REMOVE_DUPLICATES LLVM_TARGETS_TO_BUILD)
+
+  # Misconfiguration of LLVM sometimes results in empty LLVM_TARGETS_TO_BUILD.
+  # This has led to hard-to-diagnose issues, so better catch that here.
+  if (NOT LLVM_TARGETS_TO_BUILD)
+    message(SEND_ERROR "LLVM_TARGETS_TO_BUILD should not be empty.")
+  endif()
+
   message(VERBOSE "Building LLVM Targets: ${LLVM_TARGETS_TO_BUILD}")
   message(VERBOSE "Building LLVM Projects: ${LLVM_ENABLE_PROJECTS}")
 endmacro()

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -193,6 +193,16 @@ macro(iree_llvm_set_bundled_cmake_options)
   if(IREE_TARGET_BACKEND_LLVM_CPU)
     message(STATUS "  - llvm-cpu")
     list(APPEND LLVM_TARGETS_TO_BUILD "${IREE_DEFAULT_CPU_LLVM_TARGETS}")
+    # Misconfiguration of LLVM sometimes results in empty LLVM_TARGETS_TO_BUILD.
+    # This has led to hard-to-diagnose issues, so better catch that here.
+    # Note that the placement of that check matters:
+    # - Here we are inside the if IREE_TARGET_BACKEND_LLVM_CPU, so we know that
+    #   we should have at least one LLVM CPU target enabled.
+    # - Here we are before some other if branches below for other backends that
+    #   append more targets to the list, making it it unconditionally nonempty.
+    if (NOT LLVM_TARGETS_TO_BUILD)
+      message(SEND_ERROR "LLVM_TARGETS_TO_BUILD should not be empty.")
+    endif()
     set(IREE_CLANG_TARGET clang)
     set(IREE_LLD_TARGET lld)
   endif()
@@ -228,12 +238,6 @@ macro(iree_llvm_set_bundled_cmake_options)
 
   list(REMOVE_DUPLICATES LLVM_ENABLE_PROJECTS)
   list(REMOVE_DUPLICATES LLVM_TARGETS_TO_BUILD)
-
-  # Misconfiguration of LLVM sometimes results in empty LLVM_TARGETS_TO_BUILD.
-  # This has led to hard-to-diagnose issues, so better catch that here.
-  if (NOT LLVM_TARGETS_TO_BUILD)
-    message(SEND_ERROR "LLVM_TARGETS_TO_BUILD should not be empty.")
-  endif()
 
   message(VERBOSE "Building LLVM Targets: ${LLVM_TARGETS_TO_BUILD}")
   message(VERBOSE "Building LLVM Projects: ${LLVM_ENABLE_PROJECTS}")

--- a/build_tools/cmake/presets/options.json
+++ b/build_tools/cmake/presets/options.json
@@ -14,10 +14,6 @@
       "displayName": "Minimal config",
       "description": "Project configured with minimal features enabled",
       "cacheVariables": {
-        "IREE_DEFAULT_CPU_LLVM_TARGETS": {
-          "type": "STRING",
-          "value": "host"
-        },
         "IREE_BUILD_SAMPLES": {
           "type": "BOOL",
           "value": "OFF"


### PR DESCRIPTION
This [discord thread](https://discord.com/channels/689900678990135345/1385756730796933360) is only the latest iteration of a recurring hard-to-diagnose bug that occurs when LLVM is improperly configured. The CMake changes here help diagnose that early. This PR also fixes an instance of that incorrect usage in our own JSON configuration file (thanks Scott for finding it).