### PR TITLE
Re-enable e2e pack.mlir tests for RISC-V targets.

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -24,6 +24,7 @@ LLVM_SRCS = enforce_glob(
         "conv2d.mlir",
         "fp_to_subbyte.mlir",
         "narrow_n_matmuls.mlir",
+        "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
         "subbyte_to_fp.mlir",
@@ -31,9 +32,6 @@ LLVM_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
-        # TODO(#20929): Enable the pack.mlir test after the numerical issue is
-        # fixed.
-        "pack.mlir",
         "large_linalg_matmul.mlir",
         "index.mlir",
         "argmax.mlir",
@@ -48,39 +46,6 @@ iree_check_single_backend_test_suite(
     tags = [
         # subbyte support for wasm is not on priorities.
         "nowasm",
-    ],
-    target_backend = "llvm-cpu",
-)
-
-NO_RISCV_SRCS = enforce_glob(
-    # keep sorted
-    [
-        "pack.mlir",
-    ],
-    include = ["*.mlir"],
-    exclude = [
-        "conv2d.mlir",
-        "fp_to_subbyte.mlir",
-        "index.mlir",
-        "large_linalg_matmul.mlir",
-        "narrow_n_matmuls.mlir",
-        "pack_dynamic_inner_tiles.mlir",
-        "pack_i8.mlir",
-        "subbyte_to_fp.mlir",
-        "unpack.mlir",
-        "argmax.mlir",
-    ],
-)
-
-iree_check_single_backend_test_suite(
-    name = "check_llvm-cpu_local-task_noriscv",
-    srcs = NO_RISCV_SRCS,
-    compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
-    driver = "local-task",
-    tags = [
-        # subbyte support for wasm is not on priorities.
-        "nowasm",
-        "noriscv",
     ],
     target_backend = "llvm-cpu",
 )

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_check_single_backend_test_suite(
     "conv2d.mlir"
     "fp_to_subbyte.mlir"
     "narrow_n_matmuls.mlir"
+    "pack.mlir"
     "pack_dynamic_inner_tiles.mlir"
     "pack_i8.mlir"
     "subbyte_to_fp.mlir"
@@ -29,22 +30,6 @@ iree_check_single_backend_test_suite(
     "--iree-llvmcpu-target-cpu=generic"
   LABELS
     "nowasm"
-)
-
-iree_check_single_backend_test_suite(
-  NAME
-    check_llvm-cpu_local-task_noriscv
-  SRCS
-    "pack.mlir"
-  TARGET_BACKEND
-    "llvm-cpu"
-  DRIVER
-    "local-task"
-  COMPILER_FLAGS
-    "--iree-llvmcpu-target-cpu=generic"
-  LABELS
-    "nowasm"
-    "noriscv"
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/d6e25c4d21ebe20aaa6cbf6e2b9afde8f6713160 fixes the issue in upstream, and the fix is propagted to IREE.

The revision is basically a revert of https://github.com/iree-org/iree/commit/b85451bf980060346939d484b02efb6cb2e4c068#diff-606399c20029976ded3d4f1f0443906d1b6f793f76143a7fc01dd7247608bb06

Fixes https://github.com/iree-org/iree/issues/20929