### PR TITLE
[mlir][DispatchCreation] Avoid SSA violation due to consumer fusion while forming dispatches

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -259,8 +259,10 @@ void FoldUnitExtentDimsPass::runOnOperation() {
 
   RewritePatternSet foldUnitDimsPatterns(context);
   populatefoldUnitDimsPatterns(foldUnitDimsPatterns);
-  if (failed(
-          applyPatternsGreedily(moduleOp, std::move(foldUnitDimsPatterns)))) {
+  GreedyRewriteConfig rewriterConfig;
+  rewriterConfig.setMaxIterations(GreedyRewriteConfig::kNoLimit);
+  if (failed(applyPatternsGreedily(moduleOp, std::move(foldUnitDimsPatterns),
+                                   rewriterConfig))) {
     return signalPassFailure();
   }
 }
@@ -269,8 +271,10 @@ void FoldUnitExtentDimsForFuncPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet foldUnitDimsPatterns(context);
   populatefoldUnitDimsPatterns(foldUnitDimsPatterns);
-  if (failed(applyPatternsGreedily(getOperation(),
-                                   std::move(foldUnitDimsPatterns)))) {
+  GreedyRewriteConfig rewriterConfig;
+  rewriterConfig.setMaxIterations(GreedyRewriteConfig::kNoLimit);
+  if (failed(applyPatternsGreedily(
+          getOperation(), std::move(foldUnitDimsPatterns), rewriterConfig))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -1036,7 +1036,7 @@ createFusionGroups(TensorDimTrackingRewriter &rewriter,
       }
 
       if (failed(moveOperandDefs(rewriter, consumer, regionOp, dominanceInfo,
-                                 regionOp.getOperation()))) {
+                                 {}))) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -20,7 +20,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
-#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -888,40 +887,6 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
 // Dispatch region formation
 //===----------------------------------------------------------------------===//
 
-/// Check that `consumer` can be moved into `regionOp` without SSA violations.
-bool checkConsumerFusionLegality(Operation *regionOp, Operation *consumer,
-                                 DominanceInfo &dominance) {
-  // Compute the backward slice from consumer with cutoff being the dispatch.
-  BackwardSliceOptions sliceOptions;
-  sliceOptions.filter = [&](Operation *op) {
-    if (isa<tensor::DimOp>(op)) {
-      return false;
-    }
-    // If op dominates the regionOp, dont include in the slice.
-    if (dominance.properlyDominates(op, regionOp)) {
-      return false;
-    }
-    return true;
-  };
-  for (Value operand : consumer->getOperands()) {
-    if (operand.getDefiningOp() == regionOp) {
-      // If the operand is the region op directly, there is no issue.
-      continue;
-    }
-    SetVector<Operation *> slice;
-    if (failed(getBackwardSlice(operand, &slice, sliceOptions))) {
-      return false;
-    }
-    if (slice.contains(regionOp)) {
-      // This indicates that there is an operation in between the region op
-      // and the consumer in the SSA use-def chain (from regionOp -> consumer)
-      // preventing the fusion.
-      return false;
-    }
-  }
-  return true;
-}
-
 /// Create IREE::Flow::DispatchGroupsOps based on a fusion heuristic.
 static LogicalResult
 createFusionGroups(TensorDimTrackingRewriter &rewriter,
@@ -1026,13 +991,6 @@ createFusionGroups(TensorDimTrackingRewriter &rewriter,
         if (failed(IREE::Flow::simplifyDimOps(rewriter, dimOps))) {
           return failure();
         }
-      }
-
-      // Check to see if it is still legal to fuse into consumer.
-      if (!checkConsumerFusionLegality(regionOp, consumer, dominanceInfo)) {
-        // Leave the consumer as is, it will get put into its own dispatch
-        // later.
-        continue;
       }
 
       if (failed(moveOperandDefs(rewriter, consumer, regionOp, dominanceInfo,

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -1331,3 +1331,53 @@ util.func @attention_rope_fusion(%arg0: tensor<10x20x30x50xbf16>,
 //  CHECK-SAME:         ins(%[[Q]], %[[K]], %[[V]]
 //       CHECK:     flow.return %[[ATTENTION]]
 //       CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
+util.func public @avoid_illegal_consumer_fusion(%arg0: tensor<75600x5120xf32>) -> tensor<75600x1x5120xbf16> {
+  %cst0 = arith.constant 0.0 : bf16
+  %0 = tensor.empty() : tensor<75600x5120xbf16>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0 : tensor<75600x5120xf32>) outs(%0 : tensor<75600x5120xbf16>) {
+  ^bb0(%in: f32, %out: bf16):
+    %13 = arith.truncf %in : f32 to bf16
+    linalg.yield %13 : bf16
+  } -> tensor<75600x5120xbf16>
+  %2 = tensor.empty() : tensor<75600xbf16>
+  %3 = linalg.fill ins(%cst0 : bf16) outs(%2 : tensor<75600xbf16>) -> tensor<75600xbf16>
+  %4 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%1 : tensor<75600x5120xbf16>) outs(%3 : tensor<75600xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %8 = arith.addf %in, %out : bf16
+    linalg.yield %8 : bf16
+  } -> tensor<75600xbf16>
+  %expanded = tensor.expand_shape %1 [[0], [1, 2]] output_shape [75600, 1, 5120]
+      : tensor<75600x5120xbf16> into tensor<75600x1x5120xbf16>
+  %5 = tensor.empty() : tensor<75600x1x5120xbf16>
+  %6 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%expanded, %4 : tensor<75600x1x5120xbf16>, tensor<75600xbf16>)
+      outs(%5 : tensor<75600x1x5120xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %9 = arith.subf %in, %in_0 : bf16
+    linalg.yield %9 : bf16
+  } -> tensor<75600x1x5120xbf16>
+  util.return %6 : tensor<75600x1x5120xbf16>
+}
+// CHECK-LABEL: @avoid_illegal_consumer_fusion(
+//       CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.region
+//       CHECK:     %[[GENERIC0:.+]] = linalg.generic
+//       CHECK:     %[[GENERIC1:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[GENERIC0]] :
+//       CHECK:     flow.return %[[GENERIC1]], %[[GENERIC0]]
+//       CHECK:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[DISPATCH]]#1
+//       CHECK:   %[[GENERIC2:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[EXPAND_SHAPE]], %[[DISPATCH]]#0 :
+//       CHECK:   util.return %[[GENERIC2]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -1334,6 +1334,18 @@ util.func @attention_rope_fusion(%arg0: tensor<10x20x30x50xbf16>,
 
 // -----
 
+
+// Avoid fusing consumer when the producer/consumer has the following structure
+//
+// ```mlir
+// %producer = "producer_op"
+// %root = "root_op"(%producer)
+// %0 = "non_fusable_op"(%producer)
+// %1 = "consumer_op"(%producer, %root_op, %0)
+// ```
+//
+// Moving the `"producer_op"`, `"root+_op"`, and  `"consumer_op"`  into a dispatch
+// and leaving `"non_fusable_op"` out would lead to SSA violation.
 util.func public @avoid_illegal_consumer_fusion(%arg0: tensor<75600x5120xf32>) -> tensor<75600x1x5120xbf16> {
   %cst0 = arith.constant 0.0 : bf16
   %0 = tensor.empty() : tensor<75600x5120xbf16>


### PR DESCRIPTION
Consumer fusion would create illegal dispatches in presence of diamond fusion patterns when one of the operations arent fused into dispatch. For example

```
%producer = ...
%0 = "non_fused_op"(%producer)
%1 = "fused_op"(%producer, %0)
```

Moving `"fused_op"` into the same dispatch as `%producer` is a SSA violation. Avoid this fusion.

Fixes #21176 