### PR TITLE
Adding IREE_ENABLE_RUNTIME_COVERAGE cmake mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,9 +530,21 @@ if(IREE_ENABLE_CCACHE)
   endif()
 endif()
 
-set (CMAKE_POSITION_INDEPENDENT_CODE ${IREE_ENABLE_POSITION_INDEPENDENT_CODE})
+set(CMAKE_POSITION_INDEPENDENT_CODE ${IREE_ENABLE_POSITION_INDEPENDENT_CODE})
 
 option(IREE_DEV_MODE "Configure settings to optimize for IREE development (as opposed to CI or release)" OFF)
+
+option(IREE_ENABLE_RUNTIME_COVERAGE "Enable LLVM code coverage of the runtime" OFF)
+set(IREE_RUNTIME_COVERAGE_OBJECTS "" CACHE STRING "List of archives (.a), objects (.o), or binaries to use as coverage data sources.")
+set_property(GLOBAL PROPERTY IREE_RUNTIME_COVERAGE_TARGETS "")
+
+# Verify we are in debug mode (coverage doesn't work well without it).
+# Coverage is possible (though very inaccurate) in other configurations but
+# optimizations must be disabled to get anything useful (otherwise source lines
+# and instrumented execution don't line up enough).
+if(IREE_ENABLE_RUNTIME_COVERAGE AND NOT _UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  message(FATAL_ERROR "IREE_ENABLE_*_COVERAGE requires building in Debug")
+endif()
 
 #-------------------------------------------------------------------------------
 # IREE assertions
@@ -1111,6 +1123,99 @@ endif()
 if(IREE_BUILD_TESTS)
   iree_create_ctest_customization()
 endif()
+
+#-------------------------------------------------------------------------------
+# Code coverage support
+#-------------------------------------------------------------------------------
+
+# LLVM coverage targets:
+#
+# - iree-runtime-coverage-export
+#   Merge and export coverage data to `coverage/runtime.lcov.info`.
+#   All of `coverage/runtime/*.profraw` files will be merged as if they had been
+#   produced in the same run, written to `coverage/runtime.profdata`, and then
+#   exported into LCOV format.
+#
+# - iree-runtime-coverage-clear-all
+#   Erases all `coverage/runtime*` files (*.profraw/*.profdata/*.info).
+#   Invoke this to completely clear all collected coverage data.
+#
+# - iree-runtime-coverage-clear-artifacts
+#   Erases only merged `coverage/runtime.*` files (*.profdata/*.info).
+#   Invoke this after adding more *.profraw files to update the coverage.
+#
+# To collect the source *.profraw files use the LLVM_PROFILE_FILE environment
+# variable on each invocation; tests run via ctest do this automatically:
+#  LLVM_PROFILE_FILE=coverage/runtime/binary_target_name[.whatever].profraw \
+#     my_binary_to_run --other --flags
+# The base name before the first `.` must be the target name for the tooling to
+# automatically detect the binaries used. Any additional `.foo` up to the
+# extension will be ignored and allow for multiple runs to be accumulated before
+# exporting. If the name is not target-name based then the
+# IREE_RUNTIME_COVERAGE_OBJECTS CMake variable must be populated with binaries,
+# archives (.a), or object files (.o).
+#
+# VSCode can be configured with these targets/artifacts to show coverage
+# information by adding the following workspace configuration:
+#   // Accumulate over multiple test runs:
+#   "cmake.preRunCoverageTarget": "iree-runtime-coverage-clear-artifacts",
+#   // Or only show coverage for the tests run in a single batch:
+#   "cmake.preRunCoverageTarget": "iree-runtime-coverage-clear-all",
+#   "cmake.postRunCoverageTarget": "iree-runtime-coverage-export",
+#   "cmake.coverageInfoFiles": [
+#     "${command:cmake.buildDirectory}/coverage/runtime.lcov.info"
+#  ],
+if(IREE_ENABLE_RUNTIME_COVERAGE)
+  set(_RUNTIME_COVERAGE_BASE "${IREE_BINARY_DIR}/coverage/runtime")
+  if(Python3_FOUND)
+    get_property(_RUNTIME_COVERAGE_TARGETS GLOBAL PROPERTY IREE_RUNTIME_COVERAGE_TARGETS)
+    file(GENERATE
+      OUTPUT
+        ${_RUNTIME_COVERAGE_BASE}.target.list
+      CONTENT
+        "${_RUNTIME_COVERAGE_TARGETS}"
+    )
+    add_custom_target(iree-runtime-coverage-export
+      COMMAND
+        ${Python3_EXECUTABLE}
+        ${IREE_ROOT_DIR}/build_tools/scripts/export_profdata_lcov.py
+        --base=${_RUNTIME_COVERAGE_BASE}
+        --objects=${IREE_RUNTIME_COVERAGE_OBJECTS}
+        --targets=${_RUNTIME_COVERAGE_BASE}.target.list
+        --output=${_RUNTIME_COVERAGE_BASE}.lcov.info
+        --llvm-profdata=${IREE_LLVM_PROFDATA_BINARY}
+        --llvm-cov=${IREE_LLVM_COV_BINARY}
+      BYPRODUCTS
+        ${_RUNTIME_COVERAGE_BASE}.lcov.info
+      DEPENDS
+        ${IREE_LLVM_COV_BINARY}
+        ${IREE_LLVM_PROFCOV_BINARY}
+      COMMENT
+        "Exporting runtime coverage data to ${_RUNTIME_COVERAGE_BASE}.lcov.info"
+    )
+  else()
+    message(WARNING "IREE_ENABLE_*_COVERAGE requires Python3 to export automatically via the iree-runtime-coverage-export target; coverage is still enabled but must be manually processed")
+  endif()
+  add_custom_target(iree-runtime-coverage-clear-all
+    COMMAND
+      ${CMAKE_COMMAND}
+      -E rm -f
+      "${_RUNTIME_COVERAGE_BASE}.profdata"
+      "${_RUNTIME_COVERAGE_BASE}.lcov.info"
+      "${_RUNTIME_COVERAGE_BASE}/*.profraw"
+    COMMENT
+      "Clearing ${_RUNTIME_COVERAGE_BASE}/* and related source coverage data"
+  )
+  add_custom_target(iree-runtime-coverage-clear-artifacts
+    COMMAND
+      ${CMAKE_COMMAND}
+      -E rm -f
+      "${_RUNTIME_COVERAGE_BASE}.profdata"
+      "${_RUNTIME_COVERAGE_BASE}.lcov.info"
+    COMMENT
+      "Clearing merged ${_RUNTIME_COVERAGE_BASE}.* files only"
+  )
+endif(IREE_ENABLE_RUNTIME_COVERAGE)
 
 #-------------------------------------------------------------------------------
 # Install/exports

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -84,6 +84,11 @@ macro(iree_llvm_configure_bundled)
   set(IREE_LLD_BINARY "$<TARGET_FILE:${IREE_LLD_TARGET}>")
   set(IREE_CLANG_BINARY "$<TARGET_FILE:${IREE_CLANG_TARGET}>")
   set(IREE_CLANG_BUILTIN_HEADERS_PATH "${LLVM_BINARY_DIR}/lib/clang/${LLVM_VERSION_MAJOR}/include/")
+
+  if(IREE_ENABLE_RUNTIME_COVERAGE)
+    set(IREE_LLVM_COV_BINARY "$<TARGET_FILE:${IREE_LLVM_COV_TARGET}>")
+    set(IREE_LLVM_PROFDATA_BINARY "$<TARGET_FILE:${IREE_LLVM_PROFDATA_TARGET}>")
+  endif()
 endmacro()
 
 macro(iree_llvm_configure_installed)
@@ -119,6 +124,11 @@ macro(iree_llvm_configure_installed)
   set(IREE_CLANG_BUILTIN_HEADERS_PATH "${LLVM_LIBRARY_DIR}/clang/${LLVM_VERSION_MAJOR}/include")
   if(NOT EXISTS "${IREE_CLANG_BUILTIN_HEADERS_PATH}")
     message(WARNING "Could not find installed clang-resource-headers (tried ${IREE_CLANG_BUILTIN_HEADERS_PATH})")
+  endif()
+
+  if(IREE_ENABLE_RUNTIME_COVERAGE)
+    set(IREE_LLVM_COV_BINARY "$<TARGET_FILE:llvm-cov>")
+    set(IREE_LLVM_PROFDATA_BINARY "$<TARGET_FILE:llvm-profdata>")
   endif()
 endmacro()
 
@@ -182,6 +192,14 @@ macro(iree_llvm_set_bundled_cmake_options)
 
   # Unconditionally enable mlir.
   list(APPEND LLVM_ENABLE_PROJECTS mlir)
+
+  # Coverage tools.
+  set(IREE_LLVM_COV_TARGET)
+  set(IREE_LLVM_PROFDATA_TARGET)
+  if(IREE_ENABLE_RUNTIME_COVERAGE)
+    set(IREE_LLVM_COV_TARGET llvm-cov)
+    set(IREE_LLVM_PROFDATA_TARGET llvm-profdata)
+  endif()
 
   # Configure LLVM based on enabled IREE target backends.
   message(STATUS "IREE compiler target backends:")

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -17,7 +17,6 @@ else()
   set(IREE_HOST_EXECUTABLE_SUFFIX "")
 endif()
 
-
 #-------------------------------------------------------------------------------
 # IREE_ARCH: identifies the target CPU architecture. May be empty when this is
 # ill-defined, such as multi-architecture builds.
@@ -593,7 +592,6 @@ function(iree_symlink_tool)
   set(_FROM_TOOL_TARGET ${_RULE_FROM_TOOL_TARGET})
   set(_TO_TOOL_PATH "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_TO_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
   get_filename_component(_TO_TOOL_DIR "${_TO_TOOL_PATH}" DIRECTORY)
-
 
   add_custom_command(
     TARGET "${_TARGET}"

--- a/build_tools/scripts/export_profdata_lcov.py
+++ b/build_tools/scripts/export_profdata_lcov.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+"""Produces an LCOV file from a directory of LLVM .profraw files.
+
+Finds all .profraw files in a source directory specified as {--base}/ and merges
+them into a single .profdata file using llvm-profdata. An optional objects list
+specifying absolute paths for .a, .o, or executable binaries will be used to
+find the coverage metadata for the collected profiles.
+
+If available a list of CMake targets and their corresponding object file will be
+used to try to infer the objects based on the filenames of the .profraw files as
+`cmake_target[.optional-extra-discriminators].profraw`. Objects can also be
+explicitly specified for any profiles not matching a target.
+The `--targets=` file is a ; delimited dictionary of target=path items.
+e.g. `cmake_target_a=/bin/a;cmake_target_b=/bin/b`
+
+The paths for llvm-profdata and llvm-cov can be explicitly specified as flags
+and otherwise must be available on PATH.
+
+Usage:
+  ./build_tools/scripts/export_profdata_lcov.py \\
+      --base=../build/coverage/runtime \\
+      --targets=../build/coverage/runtime.target.list \\
+      --output=../build/coverage/runtime.lcov.info
+"""
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import os
+
+
+def parse_arguments(argv):
+    parser = argparse.ArgumentParser(
+        prog="export_profdata_lcov",
+        usage=__doc__,
+    )
+    parser.add_argument(
+        "--base",
+        required=True,
+        type=Path,
+        help="Root source directory containing .profraw files.",
+    )
+    parser.add_argument(
+        "--objects",
+        type=str,
+        help="Optional list of absolute paths for .a, .o, or executable binaries used to find coverage metadata for collected profiles.",
+    )
+    parser.add_argument(
+        "--targets",
+        type=str,
+        help="Optional semicolon (;) delimited list of [CMake Target]=[path] items, e.g. `cmake_target_a=/bin/a;cmake_target_b=/bin/b`.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output file (e.g. ../build/covarge/runtime.lcov.info).",
+    )
+    parser.add_argument(
+        "--llvm-profdata",
+        type=Path,
+        default="llvm-profdata",
+        help="Path to the llvm-profdata tool (may be relative if on PATH).",
+    )
+    parser.add_argument(
+        "--llvm-cov",
+        type=Path,
+        default="llvm-cov",
+        help="Path to the llvm-cov tool (may be relative if on PATH).",
+    )
+    args = parser.parse_args(argv)
+    return args
+
+
+def main(args):
+    # Erase existing artifacts, if any.
+    output_path = args.output
+    if output_path.exists():
+        print(f"Removing existing {output_path} file")
+        output_path.unlink()
+    profdata_path = args.base.with_suffix(".profdata")
+    if profdata_path.exists():
+        print(f"Removing existing {profdata_path} file")
+        profdata_path.unlink()
+
+    # Find all .profraw files in the source directory.
+    source_dir = Path(f"{args.base}{os.path.sep}")
+    if not source_dir.is_dir():
+        print(f"WARNING: source directory {source_dir} not found, skipping run")
+        sys.exit(0)
+    source_files = list(source_dir.glob("*.profraw"))
+    if not source_files:
+        print(f"No sources profraw files found in {source_dir}, skipping run")
+        sys.exit(0)
+
+    # Merge all source profraw files together into a single profdata file.
+    print(f"Merging from source files in {source_dir} to {profdata_path}:")
+    for source_file in source_files:
+        print(f"- {source_file}")
+    subprocess.check_call(
+        [
+            args.llvm_profdata,
+            "merge",
+            "--sparse",
+            f"--output={profdata_path}",
+        ]
+        + source_files
+    )
+
+    # Add any explicitly specified objects first.
+    objects = []
+    if args.objects:
+        objects.append([object for object in args.objects.split(";")])
+
+    # Read target map, if specified.
+    # This may not be needed if objects are also specified and is allowed to
+    # fail. The file is a ; delimited dictionary of target=path items.
+    # e.g. cmake_target_a=/bin/a;cmake_target_b=/bin/b
+    target_map = {}
+    if args.targets:
+        with open(args.targets, "r") as targets_file:
+            for target, object in [
+                item.split("=", 1) for item in targets_file.read().split(";")
+            ]:
+                target_map[target] = object
+
+    # Try to automatically add target objects from the source files.
+    for source_file in source_files:
+        target_name = source_file.stem
+        target_object = target_map[target_name]
+        if target_object:
+            objects.append(target_object)
+
+    if not objects:
+        print(f"WARNING: no objects specified/discovered, skipping export")
+        print(f"Merged profiling data available in {profdata_path}")
+        sys.exit(0)
+
+    # Export the lcov file.
+    print(f"Exporting {profdata_path} to {output_path} using objects:")
+    for object in objects:
+        print(f"- {object}")
+    with open(output_path, "wb") as output_file:
+        subprocess.check_call(
+            [
+                args.llvm_cov,
+                "export",
+                "-format=lcov",
+                f"-instr-profile={profdata_path}",
+            ]
+            + [f"-object={object}" for object in objects],
+            stdout=output_file,
+            text=False,
+        )
+
+    print(f"LCOV file written: {output_path}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main(parse_arguments(sys.argv[1:]))

--- a/docs/website/docs/developers/building/cmake-options.md
+++ b/docs/website/docs/developers/building/cmake-options.md
@@ -179,6 +179,51 @@ the current build type is Debug and the compiler supports it.
 Enable [undefiend behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
 if the current build type is Debug and the compiler supports it.
 
+### `IREE_ENABLE_RUNTIME_COVERAGE`
+
+* type: BOOL
+
+Enable LLVM code coverage for the runtime code. All runtime libraries and
+binaries will be compiled with instrumentation and CMake targets will be exposed
+for performing common coverage tasks.
+
+#### `iree-runtime-coverage-export`
+
+Merges and export coverage data to `coverage/runtime.lcov.info`.
+All of `coverage/runtime/*.profraw` files will be merged as if they had been
+produced in the same run, written to `coverage/runtime.profdata`, and then
+exported into LCOV format.
+
+#### `iree-runtime-coverage-clear-all`
+
+Erases all `coverage/runtime*` files (*.profraw/*.profdata/*.info).
+Invoke this to completely clear all collected coverage data.
+
+#### `iree-runtime-coverage-clear-artifacts`
+
+Erases only merged `coverage/runtime.*` files (*.profdata/*.info).
+Invoke this after adding more *.profraw files to update the coverage.
+
+#### VSCode Coverage Integration
+
+VSCode can be configured with these targets/artifacts to show coverage
+information by adding the following workspace configuration:
+
+```json
+"cmake.preRunCoverageTarget": "iree-runtime-coverage-clear-all",
+"cmake.postRunCoverageTarget": "iree-runtime-coverage-export",
+"cmake.coverageInfoFiles": [
+  "${command:cmake.buildDirectory}/coverage/runtime.lcov.info"
+],
+```
+
+Coverage runs with the Test Explorer will clear, accumulate coverage for each
+test selected, and then export an LCOV file that will be rendered in the
+coverage panel/overlay.
+
+See the [VSCode Testing Documentation](https://code.visualstudio.com/docs/debugtest/testing#_test-coverage)
+for more information.
+
 ## Cross-compilation
 
 When cross compiling (using a toolchain file like

--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -196,6 +196,15 @@ There are other more specific test targets, such as `iree_hal_cts_test_suite`,
 which are designed to test specific runtime support with template configuration
 and is not supported by Bazel rules.
 
+### Code Coverage
+
+Use the [IREE_ENABLE_RUNTIME_COVERAGE](../../building/cmake-options/#iree_enable_runtime_coverage)
+CMake option to enable code coverage instrumentation and add synthetic targets
+for managing profiling state. Tests run with coverage enabled with automatically
+write profiles to the build directory and then the
+`iree-runtime-coverage-export` target can be built to export LCOV information
+for tooling/IDEs.
+
 ## IREE core end-to-end (e2e) tests
 
 Here "end-to-end" means from the input accepted by the IREE core compiler

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -10,4 +10,27 @@ iree_setup_c_src_root(
   IMPLICIT_DEFS_TARGET iree_defs
 )
 
+# Enable LLVM coverage for the runtime libraries.
+# All object archives under runtime/src/ will contain coverage information and
+# binaries will be will produce profraw files when requested.
+#
+# TODO(benvanik): ideally we have iree_runtime_cc_library/binary and do this
+# there - today we use the same macros for both compiler and runtime and this
+# is the best way to scope coverage codegen to only the runtime.
+if(IREE_ENABLE_RUNTIME_COVERAGE)
+  message(WARNING
+    "IREE_ENABLE_RUNTIME_COVERAGE enabling coverage in all runtime libraries. "
+    "All runtime binaries are instrumented and should not be used for"
+    "benchmarking."
+  )
+  add_compile_options(
+    "-fprofile-instr-generate"
+    "-fcoverage-mapping"
+  )
+  add_link_options(
+    "-fprofile-instr-generate"
+    "-fcoverage-mapping"
+  )
+endif(IREE_ENABLE_RUNTIME_COVERAGE)
+
 add_subdirectory(iree)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_binary(
     iree::tooling::device_util
     iree::tooling::function_io
     iree::vm
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -95,6 +96,7 @@ iree_cc_binary(
     iree::tooling::device_util
     iree::tooling::function_io
     iree::vm
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -115,6 +117,7 @@ iree_cc_binary(
     iree::vm
     iree::vm::bytecode::module
   TESTONLY
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
 )
 
 iree_cc_binary(
@@ -131,6 +134,7 @@ iree_cc_binary(
     iree::io::parameter_index
     iree::io::scope_map
     iree::tooling::parameter_util
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -143,6 +147,7 @@ iree_cc_binary(
     iree::base
     iree::base::internal::cpu
     iree::schemas::cpu_data
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -160,6 +165,7 @@ iree_cc_binary(
     iree::io::parameter_index
     iree::io::scope_map
     iree::io::stream
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -175,6 +181,7 @@ iree_cc_binary(
     iree::base::internal::flatcc::parsing
     iree::schemas::instruments
     iree::schemas::instruments::dispatch_def_c_fbs
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -192,6 +199,7 @@ iree_cc_binary(
     iree::base::internal::flatcc::parsing
     iree::schemas::bytecode_module_def_c_fbs
     iree::vm::bytecode::module
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -207,6 +215,7 @@ iree_cc_binary(
     iree::io::parameter_index
     iree::io::scope_map
     iree::tooling::parameter_util
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 
@@ -225,6 +234,7 @@ iree_cc_binary(
     iree::base::internal::file_io
     iree::base::internal::path
     iree::hal::local::elf::elf_module
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 endif()  # IREE_HAL_EXECUTABLE_*_EMBEDDED_ELF
@@ -241,6 +251,7 @@ iree_cc_binary(
     iree::tooling::context_util
     iree::tooling::run_module
     iree::vm
+  COVERAGE ${IREE_ENABLE_RUNTIME_COVERAGE}
   INSTALL_COMPONENT IREETools-Runtime
 )
 


### PR DESCRIPTION
This enables LLVM coverage information for all runtime libraries, test binaries, and some specific runtime tools. We may want to extend this to support the compiler in the future so everything has been left runtime-prefixed. Additionally, a script and some cmake targets are provided to convert captured coverage data into LCOV info files for tooling. The implementation focuses on automating coverage on CI (in the future), producing LCOV reports, and integrating with IDE tooling.

As noted in the documentation this is roughly shaped to fit in with VSCode's cmake-tools coverage support. Prior to a coverage run triggered from the UI all profiling information is cleared via the `iree-runtime-coverage-clear-all` target, cmake-tools runs the chosen tests and collects new information, and then the LCOV file is exported via the `iree-runtime-coverage-export` target. Users can build these targets themselves to handle one-shot coverage or accumulating many coverage runs from different ctest or manual invocations.

The major point of complexity here is around LLVM not being able to resolve a .profraw output from a tool to the source objects it was compiled with. If doing a full build, full test, and then single export that works ok but if trying to subset it falls over fast due to the performance of llvm-cov with many inputs: it can take a minute or more to handle all of the runtime object files if passed together. To make the common interactive coverage case faster we export a map of CMake targets to their corresponding output binary and use a naming convention on the .profraw files to help the export script subset the target list. Users can also specify their own objects to inspect in addition to the automatic ones with the `IREE_RUNTIME_COVERAGE_OBJECTS` variable pointed at one or more .o, .a, or executable binaries.

Example running two tests with coverage and the resulting coverage tree/inline coverage overlay:
![image](https://github.com/user-attachments/assets/cede4b4e-7dd3-4f0e-87d1-55f9aebb75d2)
![image](https://github.com/user-attachments/assets/ee96e1fb-8604-4769-8e94-d4ff760bdd74)

VSCode workspace configuration:
```json
    "cmake.configureArgs": ["-DIREE_ENABLE_RUNTIME_COVERAGE=ON"],
    "cmake.preRunCoverageTarget": "iree-runtime-coverage-clear-all",
    "cmake.postRunCoverageTarget": "iree-runtime-coverage-export",
    "cmake.coverageInfoFiles": [
      "${command:cmake.buildDirectory}/coverage/runtime.lcov.info"
    ],
```

Beyond basic manual/CI/IDE support everything else is left to future work (aforementioned compiler coverage, PGO, other export formats like gcov, other compilers like gcc, etc).