### PR TITLE
[DispatchCreation] Form splitk dispatches

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -294,6 +294,15 @@ reifyDynamicResultDimsImpl(OpBuilder &b, Value value,
     return success();
   }
 
+  // Case 6: Value corresponds to a dps init. Reify the dimensions of the
+  // operand.
+  if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op)) {
+    return reifyDynamicResultDimsImpl(
+        b, dpsOp.getDpsInitOperand(opResult.getResultNumber())->get(),
+        dynamicDims,
+        /*createTensorDimOps=*/true);
+  }
+
   if (!createTensorDimOps)
     return failure();
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -321,6 +321,18 @@ bool DispatchTensorStoreOp::isStoreToWholeTarget() {
 }
 
 //===----------------------------------------------------------------------===//
+// dispatch.workgroup_count_splitk_modifier
+//===----------------------------------------------------------------------===//
+
+void DispatchWorkgroupCountSplitKModifierOp::build(OpBuilder &b,
+                                                   OperationState &state,
+                                                   ValueRange workgroups,
+                                                   ValueRange workload) {
+  assert(workgroups.size() == 3);
+  return build(b, state, workgroups[0], workgroups[1], workgroups[2], workload);
+}
+
+//===----------------------------------------------------------------------===//
 // iree_tensor_ext.dispatch.workload.ordinal
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -307,7 +307,7 @@ def IREETensorExt_DispatchWorkgroupCountFromSliceOp :
   }];
 }
 
-def IREETensorExt_DispatchWorkgroupCountSplitKModifier :
+def IREETensorExt_DispatchWorkgroupCountSplitKModifierOp :
     IREETensorExt_PureOp<"dispatch.workgroup_count_splitk_modifier"> {
   let summary = [{
     Modifies the workgroup count calculation to account for split-k computation.
@@ -330,6 +330,13 @@ def IREETensorExt_DispatchWorkgroupCountSplitKModifier :
   let assemblyFormat = [{
     attr-dict `(` $workgroup_x `,` $workgroup_y `,` $workgroup_z `)` `,` ($workload^)?
   }];
+
+  let builders = [
+    OpBuilder<(ins
+      "ValueRange":$workgroups,
+      "ValueRange":$workload
+    )>,
+  ];
 }
 
 def IREETensorExt_DispatchWorkloadOrdinalOp :

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -307,6 +307,31 @@ def IREETensorExt_DispatchWorkgroupCountFromSliceOp :
   }];
 }
 
+def IREETensorExt_DispatchWorkgroupCountSplitKModifier :
+    IREETensorExt_PureOp<"dispatch.workgroup_count_splitk_modifier"> {
+  let summary = [{
+    Modifies the workgroup count calculation to account for split-k computation.
+  }];
+  let description = [{
+    A split-k dispatch contains two parts: a `scf.forall` and linalg compute ops
+    within the scf op. `workgroup_x`, `workgroup_y`, and `workgroup_z` represent the
+    workgroups needed to execute the inner compute ops. This is combined with
+    `workload` to determine the total number of workgroups required to run
+    the computation after accounting for the `scf.forall`.
+  }];
+  let arguments = (ins
+    Index:$workgroup_x,
+    Index:$workgroup_y,
+    Index:$workgroup_z,
+    Variadic<Index>:$workload
+  );
+  let results = (outs Index:$result_x, Index:$result_y, Index:$result_z);
+
+  let assemblyFormat = [{
+    attr-dict `(` $workgroup_x `,` $workgroup_y `,` $workgroup_z `)` `,` ($workload^)?
+  }];
+}
+
 def IREETensorExt_DispatchWorkloadOrdinalOp :
     IREETensorExt_PureOp<"dispatch.workload.ordinal", [
       DeclareOpInterfaceMethods<InferIntDivisibilityOpInterface>,

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "dispatch_tensor_folding.mlir",
             "dispatch_workload_ordinal_folding.mlir",
+            "roundtrip.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "dispatch_tensor_folding.mlir"
     "dispatch_workload_ordinal_folding.mlir"
+    "roundtrip.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+util.func public @workgroup_count_splitk(%arg0: index, %arg1: index, %arg2: index) -> tensor<?x?x?x?x?xf32> {
+  %0 = flow.dispatch.workgroups[%arg0, %arg1, %arg2](%arg0, %arg1, %arg2) : (index, index, index) -> tensor<?x?x?x?x?xf32>{%arg0, %arg1, %arg2, %arg2, %arg0} =
+      (%arg3: index, %arg4: index, %arg5: index, %arg6: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
+    flow.return
+  } count(%arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg3, %arg4, %arg5
+    %result_x, %result_y, %result_z = iree_tensor_ext.dispatch.workgroup_count_splitk_modifier(%x, %y, %z), %arg3, %arg4, %arg5
+    flow.return %result_x, %result_y, %result_z : index, index, index
+  }
+  util.return %0 : tensor<?x?x?x?x?xf32>
+}
+// CHECK-LABEL: util.func public @workgroup_count_splitk(
+//       CHECK:   count(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+//       CHECK:   %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice
+//       CHECK:   %[[X0:.+]], %[[Y0:.+]], %[[Z0:.+]] = iree_tensor_ext.dispatch.workgroup_count_splitk_modifier
+//  CHECK-SAME:   (%[[X]], %[[Y]], %[[Z]]), %[[ARG0]], %[[ARG1]], %[[ARG2]]

--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -30,6 +30,7 @@ iree_compiler_cc_library(
         "FoldUnitExtentDims.cpp",
         "FormDispatchRegions.cpp",
         "FormScalarDispatches.cpp",
+        "FormSplitReductionDispatches.cpp",
         "FuseEncodingOpsIntoDispatchRegions.cpp",
         "FuseHorizontalContractions.cpp",
         "FuseMultiUseElementwiseProducer.cpp",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "FoldUnitExtentDims.cpp"
     "FormDispatchRegions.cpp"
     "FormScalarDispatches.cpp"
+    "FormSplitReductionDispatches.cpp"
     "FuseEncodingOpsIntoDispatchRegions.cpp"
     "FuseHorizontalContractions.cpp"
     "FuseMultiUseElementwiseProducer.cpp"

--- a/compiler/src/iree/compiler/DispatchCreation/FormSplitReductionDispatches.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormSplitReductionDispatches.cpp
@@ -1,0 +1,109 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+#define DEBUG_TYPE "iree-dispatch-creation-form-split-reduction-dispatches"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_FORMSPLITREDUCTIONDISPATCHESPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+namespace {
+
+/// Pass declaration.
+struct FormSplitReductionDispatchesPass final
+    : public impl::FormSplitReductionDispatchesPassBase<
+          FormSplitReductionDispatchesPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+static void getReductionDims(TilingInterface op, SmallVector<unsigned> &dims) {
+  for (auto [i, loopType] : llvm::enumerate(op.getLoopIteratorTypes())) {
+    if (loopType == utils::IteratorType::reduction) {
+      dims.push_back(i);
+    }
+  }
+}
+
+static LogicalResult tileOpAndWrapInDispatch(RewriterBase &rewriter,
+                                             TilingInterface op) {
+  IRRewriter::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(op);
+
+  // Tile the operation.
+  scf::SCFTilingOptions options;
+  options.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
+  options.setReductionTilingStrategy(
+      ReductionTilingStrategy::PartialReductionOuterParallel);
+  // TODO: fix this
+  SmallVector<OpFoldResult> tileSizes;
+  for (utils::IteratorType iteratorType : op.getLoopIteratorTypes()) {
+    if (iteratorType == utils::IteratorType::parallel) {
+      tileSizes.push_back(rewriter.getIndexAttr(0));
+    } else {
+      tileSizes.push_back(rewriter.getIndexAttr(128));
+    }
+  }
+  options.setTileSizes(tileSizes);
+  SmallVector<unsigned> reductionDims;
+  getReductionDims(op, reductionDims);
+  options.setReductionDims(reductionDims);
+  FailureOr<scf::SCFTilingResult> result =
+      scf::tileUsingSCF(rewriter, op, options);
+  if (failed(result)) {
+    return op.emitOpError("failed to tile using scf.forall");
+  }
+  rewriter.replaceOp(op, result->replacements);
+
+  if (result->loops.size() != 1) {
+    return op.emitOpError("expected single tiled loop");
+  }
+
+  // Wrap loop in `flow.dispatch.region`.
+  LoopLikeOpInterface loop = result->loops[0];
+  FailureOr<IREE::Flow::DispatchRegionOp> maybeRegionOp =
+      IREE::Flow::wrapOpInDispatchRegion(rewriter, loop);
+  if (failed(maybeRegionOp)) {
+    return loop.emitOpError("failed to wrap in dispatch region");
+  }
+  return success();
+}
+
+void FormSplitReductionDispatchesPass::runOnOperation() {
+  mlir::FunctionOpInterface funcOp = getOperation();
+  MLIRContext *context = &getContext();
+  IRRewriter rewriter(context);
+
+  SmallVector<TilingInterface> reductionOps;
+  funcOp.walk([&](TilingInterface tilingOp) {
+    // TODO: implement better selection.
+    if (llvm::count(tilingOp.getLoopIteratorTypes(),
+                    utils::IteratorType::reduction)) {
+      reductionOps.push_back(tilingOp);
+    }
+  });
+
+  for (TilingInterface op : reductionOps) {
+    if (failed(tileOpAndWrapInDispatch(rewriter, op))) {
+      return signalPassFailure();
+    }
+  }
+
+  (void)context;
+}
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -265,6 +265,10 @@ def FormScalarDispatchesPass :
 def FormSplitReductionDispatchesPass :
     InterfacePass<"iree-dispatch-creation-form-split-reduction-dispatches", "mlir::FunctionOpInterface"> {
   let summary = "Partially tile reduction operations and place into dispatches";
+  let options = [
+    Option<"splitSize", "split-size", "int",
+           /*default=*/"0", "Tile size for split reduction">
+  ];
   let dependentDialects = [
     "IREE::Flow::FlowDialect",
     "IREE::TensorExt::IREETensorExtDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -262,6 +262,17 @@ def FormScalarDispatchesPass :
   ];
 }
 
+def FormSplitReductionDispatchesPass :
+    InterfacePass<"iree-dispatch-creation-form-split-reduction-dispatches", "mlir::FunctionOpInterface"> {
+  let summary = "Partially tile reduction operations and place into dispatches";
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+    "IREE::TensorExt::IREETensorExtDialect",
+    "mlir::linalg::LinalgDialect",
+    "mlir::scf::SCFDialect",
+  ];
+}
+
 def FuseEncodingOpsIntoDispatchRegionsPass :
     InterfacePass<"iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass", "mlir::FunctionOpInterface"> {
   let summary = "Fuses set_encoding ops into producer dispatch regions, or forms new dispatches around them.";

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "dispatch_linalg_on_tensors_default.mlir",
             "dispatch_linalg_on_tensors_fusion_with_transpose.mlir",
             "form_scalar_dispatches.mlir",
+            "form_split_reduction_dispatches.mlir",
             "fuse_encoding_ops_into_dispatch_regions.mlir",
             "fuse_horizontal_contractions.mlir",
             "fuse_multiuse_elementwise_producer.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "form_dispatch_regions.mlir"
     "form_dispatch_workgroups.mlir"
     "form_scalar_dispatches.mlir"
+    "form_split_reduction_dispatches.mlir"
     "fuse_encoding_ops_into_dispatch_regions.mlir"
     "fuse_horizontal_contractions.mlir"
     "fuse_multiuse_elementwise_producer.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches{split-size=128}, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf32> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -1,0 +1,48 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %0 = tensor.empty(%dim) : tensor<?xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<?xf32>) -> tensor<?xf32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%1 : tensor<?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %3 = arith.addf %in, %out : f32
+    linalg.yield %3 : f32
+  } -> tensor<?xf32>
+  util.return %2 : tensor<?xf32>
+}
+// CHECK-LABEL:  util.func public @split_reduction_dynamic
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:      %[[FORALL:.+]] = scf.forall
+//       CHECK:        linalg.generic
+//       CHECK:      flow.return %[[FORALL]] : tensor<?x?xf32>
+//       CHECK:    %[[REDUCE:.+]] = linalg
+//  CHECK-SAME:      ins(%[[DISPATCH]] :
+//       CHECK:    util.return %[[REDUCE]]
+
+// -----
+
+util.func public @split_reduction_static(%arg0: tensor<64x4096xf32>) -> tensor<64xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<64xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<64x4096xf32>) outs(%1 : tensor<64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %3 = arith.addf %in, %out : f32
+    linalg.yield %3 : f32
+  } -> tensor<64xf32>
+  util.return %2 : tensor<64xf32>
+}
+// CHECK-LABEL:  util.func public @split_reduction_static
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<64x4096xf32>
+//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:      %[[FORALL:.+]] = scf.forall
+//       CHECK:        linalg.generic
+//       CHECK:      flow.return %[[FORALL]] : tensor<64x32xf32>
+//       CHECK:    %[[REDUCE:.+]] = linalg
+//  CHECK-SAME:      ins(%[[DISPATCH]] :
+//       CHECK:    util.return %[[REDUCE]]


### PR DESCRIPTION
Adds pass tile reduction operations and then place the generated `scf.forall` into a dispatch (the generated merge op can be placed into a dispatch via normal dispatch creation). A new op `workgroup_count_splitk_modifier` is added to account for the `scf.forall` when computing workgroup sizes. This op is added to the dispatch's `count` region when it contains a `scf.forall` operation.


Also, `reifyDynamicResultDimsImpl` was changed to handle DestinationStyleOpInterface to fix dynamic dim issues with the `scf.forall` op.