### PR TITLE
[Codegen] Combine layout transformation after GPUFuseAndHoistParallelLoops 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -137,6 +137,7 @@ void GPUPackToIntrinsicsPass::runOnOperation() {
   };
 
   linalg::populateDataLayoutPropagationPatterns(patterns, control);
+  linalg::UnPackOp::getCanonicalizationPatterns(patterns, context);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -121,6 +121,9 @@ void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns);
 /// Populate patterns to fold relayout operations into map_scatter ops.
 void populateCombineRelayoutOpPatterns(RewritePatternSet &patterns);
 
+/// Populate patterns to fuse tilable consumers of forall ops into it.
+void populateFuseTilableForallConsumersPattern(RewritePatternSet &patterns);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -272,3 +272,36 @@ func.func @propagate_relayout_ops(%source : tensor<?x?x128x128xf32>,
 //  CHECK-SAME:     outs(%[[INIT]] : tensor<?x?x128x128xf16>)
 //       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter %[[COMPUTE_OP]]
 //       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]]
+
+// -----
+
+func.func @insert_in_workgroup_forall(%2 : tensor<196608x35xbf16>, %3 : tensor<196608x35xbf16>, %9 : tensor<8x16x1x16xbf16>, %10 : tensor<8x16x1x16xbf16>) -> (tensor<196608x35xbf16>, tensor<196608x35xbf16>){
+  %6:2 = scf.forall (%arg0, %arg1) = (0, 0) to (196608, 35) step (128, 16) shared_outs(%arg2 = %2, %arg3 = %3) -> (tensor<196608x35xbf16>, tensor<196608x35xbf16>) {
+    %collapsed = tensor.collapse_shape %9 [[0, 1], [2, 3]] : tensor<8x16x1x16xbf16> into tensor<128x16xbf16>
+    %collapsed_1 = tensor.collapse_shape %10 [[0, 1], [2, 3]] : tensor<8x16x1x16xbf16> into tensor<128x16xbf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %collapsed into %arg2[%arg0, %arg1] [128, 16] [1, 1] : tensor<128x16xbf16> into tensor<196608x35xbf16>
+      tensor.parallel_insert_slice %collapsed_1 into %arg3[%arg0, %arg1] [128, 16] [1, 1] : tensor<128x16xbf16> into tensor<196608x35xbf16>
+    }
+  } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+  return %6#0, %6#1  : tensor<196608x35xbf16>, tensor<196608x35xbf16>
+}
+
+// CHECK-LABEL: @insert_in_workgroup_forall
+//       CHECK:   %[[MAP_SCATTER1:.+]] = iree_linalg_ext.map_scatter
+//       CHECK:   %[[MAP_SCATTER2:.+]] = iree_linalg_ext.map_scatter
+//       CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+func.func @no_insert_in_non_workgroup_forall(%2 : tensor<196608x35xbf16>, %9 : tensor<8x16x1x16xbf16>) -> tensor<196608x35xbf16>{
+  %6 = scf.forall (%arg0, %arg1) = (0, 0) to (196608, 35) step (128, 16) shared_outs(%arg2 = %2) -> (tensor<196608x35xbf16>) {
+    %collapsed = tensor.collapse_shape %9 [[0, 1], [2, 3]] : tensor<8x16x1x16xbf16> into tensor<128x16xbf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %collapsed into %arg2[%arg0, %arg1] [128, 16] [1, 1] : tensor<128x16xbf16> into tensor<196608x35xbf16>
+    }
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return %6 : tensor<196608x35xbf16>
+}
+// CHECK-LABEL: @no_insert_in_non_workgroup_forall
+//   CHECK-NOT:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -522,6 +522,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(createGPUFuseAndHoistParallelLoopsPass());
+  funcPassManager.addPass(createCombineLayoutTransformationPass());
   funcPassManager.addPass(createGPUGreedilyDistributeToThreadsPass());
   funcPassManager.addPass(createTileLargeTensorsPass());
   funcPassManager.addPass(createCanonicalizerPass());


### PR DESCRIPTION
The CombineLayoutTransform pass is now able to insert an identity `iree_linalg_ext.map_scatter` op on detecting a `scf.forall` op having workgroup mapping. This change introduces the `map_scatter` op after the `GPUFuseAndHoist` Pass helping `map_scatter` fold any remaining reshape ops. The `map_scatter` op then gets fused into the thread mapped `scf.forall`. 