### PR TITLE
Pinning ninja on the Windows CI to 1.12.1 due to a 1.13.0 bug.

### DIFF
--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           choco install sccache
           choco install cmake
-          choco install ninja
+          # ninja pinned due to a bug in the 1.13.0 release:
+          # https://github.com/ninja-build/ninja/issues/2616
+          choco install ninja --version 1.12.1
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
       - name: "Building IREE"


### PR DESCRIPTION
https://github.com/ninja-build/ninja/issues/2616