### PR TITLE
[DispatchCreation] Add pass to hoist scalar ops out of dispatch regions

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "FusionPreprocessing.cpp",
         "FusionUtils.cpp",
         "HoistEncodingOps.cpp",
+        "HoistUniformScalarCompute.cpp",
         "MaterializeDefaultWorkgroupCountRegion.cpp",
         "Passes.cpp",
         "PropagateEncodings.cpp",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     "FusionPreprocessing.cpp"
     "FusionUtils.cpp"
     "HoistEncodingOps.cpp"
+    "HoistUniformScalarCompute.cpp"
     "MaterializeDefaultWorkgroupCountRegion.cpp"
     "Passes.cpp"
     "PropagateEncodings.cpp"

--- a/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
@@ -1,0 +1,91 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_HOISTUNIFORMSCALARCOMPUTEPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+static bool isUniformScalarForDispatch(Operation *op, Operation *dispatch) {
+  assert(op->getParentOp() == dispatch &&
+         "hoist target is not direct child of dispatch");
+  if (!mlir::isPure(op)) {
+    return false;
+  }
+
+  auto isScalarOrVector = [](Type t) {
+    return t.isIntOrIndexOrFloat() || isa<VectorType>(t);
+  };
+  auto isOutsideDispatch = [&](Value v) {
+    return v.getParentRegion()->getParentOp() != dispatch;
+  };
+
+  // Check that all operands are defined outside the dispatch and all operand
+  // and result types are scalars or vectors.
+  return llvm::all_of(op->getOperands(), isOutsideDispatch) &&
+         llvm::all_of(op->getOperandTypes(), isScalarOrVector) &&
+         llvm::all_of(op->getResultTypes(), isScalarOrVector);
+}
+
+namespace {
+
+struct HoistUniformScalarComputePass
+    : public DispatchCreation::impl::HoistUniformScalarComputePassBase<
+          HoistUniformScalarComputePass> {
+  void runOnOperation() override {
+    mlir::FunctionOpInterface funcOp = getOperation();
+    MLIRContext *context = &getContext();
+    IRRewriter rewriter(context);
+
+    funcOp.walk([&](IREE::Flow::DispatchRegionOp dispatch) {
+      for (Block &body : dispatch.getBody()) {
+        SmallVector<Operation *> ops = llvm::map_to_vector(
+            body.getOperations(), [](Operation &op) { return &op; });
+        for (Operation *op : ops) {
+          if (isUniformScalarForDispatch(op, dispatch)) {
+            op->moveBefore(dispatch);
+          }
+        }
+      }
+
+      llvm::SetVector<Operation *> constantsToClone;
+      mlir::visitUsedValuesDefinedAbove(
+          dispatch.getBody(), dispatch.getBody(), [&](OpOperand *operand) {
+            Value v = operand->get();
+            auto constant = v.getDefiningOp<arith::ConstantOp>();
+            if (!constant || (!v.getType().isIntOrIndexOrFloat() &&
+                              !isa<VectorType>(v.getType()))) {
+              return;
+            }
+            constantsToClone.insert(constant);
+          });
+      for (Operation *constant : constantsToClone) {
+        if (constant->hasOneUse()) {
+          constant->moveBefore(&dispatch.getBody().front().front());
+        } else {
+          if (failed(IREE::Flow::clonePrecedingOpIntoDispatchRegion(
+                  rewriter, constant, dispatch))) {
+            return WalkResult::interrupt();
+          }
+        }
+      }
+      return WalkResult::interrupt();
+    });
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
@@ -47,7 +47,6 @@ struct HoistUniformScalarComputePass
     mlir::FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
     IRRewriter rewriter(context);
-    Dialect *arithDialect = context->getLoadedDialect<arith::ArithDialect>();
 
     WalkResult walkResult =
         funcOp.walk([&](IREE::Flow::DispatchRegionOp dispatch) {
@@ -57,7 +56,7 @@ struct HoistUniformScalarComputePass
             // flow/stream/hal.dispatch.workgroups.count/id ops.
             // TODO: Add an op trait to tie count/id ops to region ops.
             for (Operation &op : body.getOperations()) {
-              if (op.getDialect() == arithDialect) {
+              if (isa<arith::ArithDialect>(op.getDialect())) {
                 ops.push_back(&op);
               }
             }

--- a/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistUniformScalarCompute.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/RegionUtils.h"
@@ -21,7 +22,7 @@ namespace mlir::iree_compiler::DispatchCreation {
 static bool isUniformScalarForDispatch(Operation *op, Operation *dispatch) {
   assert(op->getParentOp() == dispatch &&
          "hoist target is not direct child of dispatch");
-  if (!mlir::isPure(op)) {
+  if (!mlir::isPure(op) || op->hasTrait<OpTrait::IsTerminator>()) {
     return false;
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -231,7 +231,10 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
                 options.enableAggressiveFusion});
       })
       // Collapse dimensions of linalg Ops.
-      .addPass(DispatchCreation::createCollapseDimensionsPass);
+      .addPass(DispatchCreation::createCollapseDimensionsPass)
+      // Hoist scalar compute introduced from collapsing dimensions to
+      // increase CSE and deduplication opportunities.
+      .addPass(DispatchCreation::createHoistUniformScalarComputePass);
 
   // Experimental data tiling path. The intent of this path is to set encodings
   // after fusion decisions have already been made, so encodings can be

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -342,7 +342,9 @@ void buildDispatchCreationPassPipeline(
       /// `iree_tensor_ext.dispatch.workload.ordinal`
       ///   to map the captured operand to the position in the workload list.
       .addPass(
-          DispatchCreation::createMaterializeDefaultWorkgroupCountRegionPass);
+          DispatchCreation::createMaterializeDefaultWorkgroupCountRegionPass)
+      .addPass(createCSEPass)
+      .addPass(IREE::Flow::createCanonicalizePass);
 }
 
 namespace {

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -271,7 +271,6 @@ def FuseEncodingOpsIntoDispatchRegionsPass :
     "IREE::Encoding::IREEEncodingDialect",
   ];
 }
-
 def HoistEncodingOpsPass :
     InterfacePass<"iree-dispatch-creation-hoist-encoding-ops", "mlir::FunctionOpInterface"> {
   let summary = "Hoists tensor encoding ops out of flow dispatch regions.";
@@ -284,6 +283,11 @@ def HoistEncodingOpsPass :
     "IREE::Flow::FlowDialect",
     "IREE::Encoding::IREEEncodingDialect",
   ];
+}
+
+def HoistUniformScalarComputePass :
+    InterfacePass<"iree-dispatch-creation-hoist-uniform-scalar-compute", "mlir::FunctionOpInterface"> {
+  let summary = "Hoists scalar (computation) out of dispatch regions.";
 }
 
 def PropagateEncodingsPass :

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -31,6 +31,7 @@ iree_lit_test_suite(
             "form_dispatch_workgroups.mlir",
             "dispatch_linalg_ext_fusion.mlir",
             "hoist_encoding_ops.mlir",
+            "hoist_uniform_scalar_compute.mlir",
             "dispatch_linalg_on_tensors_default.mlir",
             "dispatch_linalg_on_tensors_fusion_with_transpose.mlir",
             "form_scalar_dispatches.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_lit_test_suite(
     "fuse_multiuse_elementwise_producer.mlir"
     "fusion_preprocessing.mlir"
     "hoist_encoding_ops.mlir"
+    "hoist_uniform_scalar_compute.mlir"
     "pad_fusion_with_consumer.mlir"
     "pad_fusion_with_producer.mlir"
     "pipeline_tests.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_uniform_scalar_compute.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_uniform_scalar_compute.mlir
@@ -1,0 +1,70 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-hoist-uniform-scalar-compute))" --split-input-file %s | FileCheck %s
+
+util.func public @no_hoist_constants(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %m: index, %n: index) -> tensor<?x?xf32> {
+  %0 = flow.dispatch.region -> (tensor<?x?xf32>{%m, %n}) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+    %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %1 = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %2 = linalg.matmul
+        ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %2 : tensor<?x?xf32>
+  }
+  util.return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @no_hoist_constants
+// CHECK:       flow.dispatch.region
+// CHECK-DAG:     arith.constant 0.0{{0+}}e+00 : f32
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[D0:.+]] = tensor.dim %{{.*}}, %[[C0]]
+// CHECK-DAG:     %[[D1:.+]] = tensor.dim %{{.*}}, %[[C1]]
+// CHECK:         tensor.empty(%[[D0]], %[[D1]])
+// CHECK:         flow.return
+
+// -----
+
+util.func public @hoist_arithmetic(%m: index, %n: index) -> tensor<?x?xf32> {
+  %0 = flow.dispatch.region -> (tensor<?x?xf32>{%m, %n}) {
+    %c3 = arith.constant 3 : index
+    %mul = arith.muli %m, %c3 : index
+    %1 = tensor.empty(%mul, %n) : tensor<?x?xf32>
+    flow.return %1 : tensor<?x?xf32>
+  }
+  util.return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @hoist_arithmetic
+// CHECK:       %[[C3:.+]] = arith.constant 3
+// CHECK:       %[[MUL:.+]] = arith.muli %{{.*}}, %[[C3]]
+// CHECK:       flow.dispatch.region
+// CHECK:         tensor.empty(%[[MUL]]
+// CHECK:         flow.return
+
+// -----
+
+util.func public @no_hoist_dep_inside_dispatch(%arg0: tensor<?xf32>, %m: index) -> tensor<?xf32> {
+  %0 = flow.dispatch.region -> (tensor<?xf32>{%m}) {
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %arg0, %c0 : tensor<?xf32>
+    %c3 = arith.constant 3 : index
+    %mul = arith.muli %d0, %c3 : index
+    %1 = tensor.empty(%mul) : tensor<?xf32>
+    flow.return %1 : tensor<?xf32>
+  }
+  util.return %0 : tensor<?xf32>
+}
+
+// CHECK-LABEL: @no_hoist_dep_inside_dispatch
+// CHECK:       flow.dispatch.region
+// CHECK-DAG:     arith.constant 0
+// CHECK-DAG:     arith.constant 3
+// CHECK:         tensor.dim
+// CHECK:         arith.muli
+// CHECK:         tensor.empty
+// CHECK:         flow.return

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-attr-based-pipeline, iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-attr-based-pipeline, iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline, cse, canonicalize)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d1)>
@@ -356,3 +356,42 @@ util.func public @single_gather(%source : tensor<20x20x100xi32>, %indices : tens
 //       CHECK:     %[[GATHER:.+]] = iree_linalg_ext.gather
 //       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[GATHER]]
 //       CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
+// Check that we end up with a single copy of the workload when collapsing
+// dynamic dims.
+
+#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+util.func public @collapse_dynamic_matmul(%arg0: tensor<4x?x2048xbf16>, %arg1: tensor<1024x2048xbf16>) -> tensor<4x?x1024xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c1 = arith.constant 1 : index
+    %1 = tensor.dim %arg0, %c1 : tensor<4x?x2048xbf16>
+    %2 = tensor.empty(%1) : tensor<4x?x1024xf32>
+    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<4x?x1024xf32>) -> tensor<4x?x1024xf32>
+    %4 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : tensor<4x?x2048xbf16>, tensor<1024x2048xbf16>) outs(%3 : tensor<4x?x1024xf32>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+      %9 = arith.extf %in : bf16 to f32
+      %10 = arith.extf %in_0 : bf16 to f32
+      %11 = arith.mulf %9, %10 : f32
+      %12 = arith.addf %out, %11 : f32
+      linalg.yield %12 : f32
+    } -> tensor<4x?x1024xf32>
+    util.return %4 : tensor<4x?x1024xf32>
+  }
+
+// CHECK-LABEL: util.func public @collapse_dynamic_matmul
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<4x?x2048xbf16>
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+//   CHECK-DAG:   %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//   CHECK-DAG:   %[[MUL4:.+]] = arith.muli %[[DIM]], %[[C4]]
+//       CHECK:   flow.tensor.reshape %[[ARG0]] : {{.*}} -> tensor<?x2048xbf16>{%[[MUL4]]}
+//       CHECK:   flow.dispatch.workgroups[%[[MUL4]]](%[[MUL4]]
+//  CHECK-NEXT:     (%[[ARG2:[A-Za-z0-9]+]]: index
+
+//       CHECK:   %[[W:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ARG2]], 0
+//       CHECK:   tensor.empty(%[[W]])

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-attr-based-pipeline, iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline, cse, canonicalize)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-attr-based-pipeline, iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d1)>


### PR DESCRIPTION
CollapseDimensions pass introduces operations on dimension sizes both inside and outside a dispatch that should be able to CSE. Because we don't run CSE until after dispatch workgroups conversion, this results in redundant workload values we can't fold away.

To avoid such redundancies, this patch introduces a new pass that hoists scalar compute ops out of dispatch region. To keep behavior similar in all other cases constants are cloned back into the dispatch.