### PR TITLE
Fixing typo in #21142 that was causing failures on MSVC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
@@ -125,7 +125,7 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
     SmallVector<tensor::ExpandShapeOp> maybeExpands(numOperands, nullptr);
     SmallVector<Value> newOperands(tiledOp.getOperands());
     SmallVector<Attribute> newPermutations;
-    if (*permutationsAttr) {
+    if (permutationsAttr) {
       newPermutations = llvm::to_vector(*permutationsAttr);
     }
 


### PR DESCRIPTION
This was not MSVC-specific, just that MSVC caught it. It was undefined behavior on other compilers.