### PR TITLE
Fixing bool->iree_status_t cast error.

### DIFF
--- a/runtime/src/iree/base/internal/wait_handle_poll.c
+++ b/runtime/src/iree/base/internal/wait_handle_poll.c
@@ -382,7 +382,9 @@ iree_status_t iree_wait_one(iree_wait_handle_t* handle,
                             iree_time_t deadline_ns) {
   struct pollfd poll_fds;
   poll_fds.fd = iree_wait_primitive_get_read_fd(handle);
-  if (poll_fds.fd == -1) return false;
+  if (poll_fds.fd == -1) {
+    return iree_ok_status();  // no-op wait
+  }
   poll_fds.events = POLLIN;
   poll_fds.revents = 0;
 


### PR DESCRIPTION
My local compiler caught this for some reason but IIRC people do this badness in LLVM/C++ and we haven't been able to turn it on. More reason to split the cmake macros for compiler/runtime code so we can at least enable `-Werror,-Wbool-conversion` in the runtime (it is never valid).

```
[build] /home/ben/src/iree/runtime/src/iree/base/internal/wait_handle_poll.c:385:33: error: initialization of pointer of type 'iree_status_t' (aka 'struct iree_status_handle_t *') to null from a constant boolean expression [-Werror,-Wbool-conversion]
[build]   385 |   if (poll_fds.fd == -1) return false;
[build]       |                                 ^~~~~
```