### PR TITLE
[Codegen] Fix undefined behavior in InnerTileOp expansion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
@@ -125,7 +125,7 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
     SmallVector<tensor::ExpandShapeOp> maybeExpands(numOperands, nullptr);
     SmallVector<Value> newOperands(tiledOp.getOperands());
     SmallVector<Attribute> newPermutations;
-    if (permutationsAttr) {
+    if (permutationsAttr.has_value() && *permutationsAttr) {
       newPermutations = llvm::to_vector(*permutationsAttr);
     }
 
@@ -134,7 +134,7 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
     for (int64_t opIndex : llvm::seq(firstOperand, lastOperand)) {
       Value operand = newOperands[opIndex];
       std::optional<ArrayRef<int64_t>> permutation;
-      if (permutationsAttr) {
+      if (permutationsAttr.has_value() && *permutationsAttr) {
         permutation =
             cast<DenseI64ArrayAttr>((*permutationsAttr)[opIndex]).asArrayRef();
       }


### PR DESCRIPTION
Not checking whether the `std::optional` contains a value leads to undefined behavior. While this accidentally seems to work in the lit tests, I am hitting the following error because of this:
```
LLVM ERROR: SmallVector unable to grow. Requested capacity (17798225728808891619) is larger than maximum value for size type (4294967295)
```