### PR TITLE
[Codegen] Fix multiple function support in materialize user configs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -230,7 +230,7 @@ struct MaterializeUserConfigsPass final
       IREE::Codegen::TranslationInfoAttr translationInfo =
           getTranslationInfo(funcOp);
       if (translationInfo) {
-        return;
+        continue;
       }
 
       /// First, apply all user configs.
@@ -256,13 +256,13 @@ struct MaterializeUserConfigsPass final
           translationInfo.getDispatchLoweringPassPipeline() !=
               IREE::Codegen::DispatchLoweringPassPipeline::
                   TransformDialectCodegen) {
-        return;
+        continue;
       }
 
       std::optional<SymbolRefAttr> strategyName =
           translationInfo.getCodegenSpec();
       if (!strategyName || *strategyName == SymbolRefAttr()) {
-        return;
+        continue;
       }
 
       /// If we have a symbol, verify the existence of the symbol within the


### PR DESCRIPTION
When verifying symbol imports, it was returning from the pass instead of continuing to the next function, causing us to only apply user configs to the first function.