### PR TITLE
Fix missing return in `DeviceOptimalAttr::joinOR`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -1231,6 +1231,7 @@ DeviceOptimalAttr::joinOR(IREE::Stream::AffinityAttr other) const {
         if (it == affinitySet.end()) {
           // New device entry.
           affinitySet.insert({otherDeviceAttr, affinityAttr});
+          return true;
         }
         // OR in with existing entry.
         auto joinedAttr = it->second.joinOR(other);


### PR DESCRIPTION
This code is currently using a `MapVector` iterator after insertion, which invalidates it. This _happens_ to work if the insertion doesn't trigger a reallocation.

fixes #21203