### PR TITLE
[CPU] Use rootOp in distribution for mmt4d pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
     srcs = [
         "CPULowerToUKernels.cpp",
         "CPUPrepareUkernels.cpp",
+        "CPUTileAndDistributeToWorkgroups.cpp",
         "Passes.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
   SRCS
     "CPULowerToUKernels.cpp"
     "CPUPrepareUkernels.cpp"
+    "CPUTileAndDistributeToWorkgroups.cpp"
     "Passes.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUTileAndDistributeToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUTileAndDistributeToWorkgroups.cpp
@@ -1,0 +1,184 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/CPU/Passes.h"
+#include "iree/compiler/Codegen/Common/TileAndFuseUtils.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_CPUTILEANDDISTRIBUTETOWORKGROUPSPASS
+#include "iree/compiler/Codegen/Common/CPU/Passes.h.inc"
+
+namespace {
+struct CPUTileAndDistributeToWorkgroupsPass final
+    : public impl::CPUTileAndDistributeToWorkgroupsPassBase<
+          CPUTileAndDistributeToWorkgroupsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+void CPUTileAndDistributeToWorkgroupsPass::runOnOperation() {
+  auto funcOp = getOperation();
+  auto *context = &getContext();
+  SmallVector<Operation *> computeOps = getComputeOps(funcOp);
+  IRRewriter rewriter(context);
+  FailureOr<TilingInfo> tilingInfo =
+      getTiledAndDistributionInfo(rewriter, getCPURootOperation(computeOps));
+  if (failed(tilingInfo)) {
+    return signalPassFailure();
+  }
+  auto tilableOp = dyn_cast_or_null<TilingInterface>(tilingInfo->tilableOp);
+  if (!tilableOp) {
+    // Did not find a tileable op. So do nothing.
+    return;
+  }
+  mlir::DominanceInfo dominanceInfo(tilableOp);
+  llvm::SmallDenseSet<Operation *> tiledAndFusedOps;
+  collectTiledAndFusedOps(tilableOp, tiledAndFusedOps);
+  bool useWARForConsumerFusionSSAViolation =
+      warForConsumerFusionSSAViolation(tilableOp, tiledAndFusedOps);
+
+  llvm::DenseSet<Operation *> yieldReplacementsFor;
+  for (auto op : tiledAndFusedOps) {
+    // If tiledAndFused ops doesn't contain the user; add an replacement
+    // for that.
+    if (llvm::any_of(op->getUsers(), [&](Operation *user) {
+          return dominanceInfo.properlyDominates(tilableOp, user) &&
+                 !tiledAndFusedOps.contains(user);
+        })) {
+      yieldReplacementsFor.insert(op);
+    }
+  }
+  scf::SCFTilingOptions tilingOptions;
+  tilingOptions.setTileSizes(tilingInfo->tileSizes);
+  tilingOptions.setInterchange(tilingInfo->interchange);
+  tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
+  SmallVector<Attribute> deviceMappingAttribute =
+      getDistributionMapping(context, tilingInfo->tileSizes);
+  if (failed(IREE::Codegen::WorkgroupMappingAttr::verifyAttrList(
+          context, funcOp.getLoc(), deviceMappingAttribute))) {
+    return signalPassFailure();
+  }
+  tilingOptions.setMapping(deviceMappingAttribute);
+
+  scf::SCFTileAndFuseOptions tileAndFuseOptions;
+  tileAndFuseOptions.setTilingOptions(tilingOptions);
+  RewritePatternSet cleanupPatterns(context);
+  tensor::ExtractSliceOp::getCanonicalizationPatterns(cleanupPatterns, context);
+  tensor::DimOp::getCanonicalizationPatterns(cleanupPatterns, context);
+  tensor::populateMergeConsecutiveInsertExtractSlicePatterns(cleanupPatterns);
+  // When fusing pads we do not want to generate zeroSliceGuards when doing
+  // workgroup tiling.
+  cleanupPatterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
+      context, [](tensor::ExtractSliceOp) { return /*zeroSliceGuard=*/false; });
+  tileAndFuseOptions.cleanupPatterns =
+      FrozenRewritePatternSet(std::move(cleanupPatterns));
+
+  // The control function that determines whether a tiled producer should yield
+  // its replacement.
+  scf::SCFTileAndFuseOptions::ControlFnTy controlFn =
+      [&](tensor::ExtractSliceOp candidateSliceOp, OpResult originalProducer,
+          bool isDestinationOperand)
+      -> std::optional<scf::SCFTileAndFuseOptions::ControlFnResult> {
+    Operation *owner = originalProducer.getOwner();
+    if (isa<tensor::PadOp>(owner)) {
+      return std::nullopt;
+    }
+    bool yieldProducerReplacement = yieldReplacementsFor.contains(owner);
+    return scf::SCFTileAndFuseOptions::ControlFnResult{
+        yieldProducerReplacement};
+    return std::nullopt;
+  };
+  tileAndFuseOptions.setFusionControlFn(controlFn);
+  rewriter.setInsertionPoint(tilableOp);
+
+  // If the `tilableOp` is a `memref` op, then just tile the operation.
+  SmallVector<LoopLikeOpInterface> tilingLoops;
+  if (tilableOp->getNumResults() == 0) {
+    FailureOr<scf::SCFTilingResult> tilingResult =
+        scf::tileUsingSCF(rewriter, tilableOp, tilingOptions);
+    if (failed(tilingResult)) {
+      funcOp.emitOpError("tiling failed");
+      return signalPassFailure();
+    }
+    rewriter.eraseOp(tilableOp);
+    std::swap(tilingResult->loops, tilingLoops);
+  } else {
+    FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
+        scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilableOp,
+                                                  tileAndFuseOptions);
+    if (failed(tileAndFuseResult)) {
+      funcOp.emitOpError("tile and fuse greedily failed");
+      return signalPassFailure();
+    }
+    for (auto [origValue, replacement] : tileAndFuseResult->replacements) {
+      rewriter.replaceAllUsesWith(origValue, replacement);
+    }
+    std::swap(tileAndFuseResult->loops, tilingLoops);
+    Operation *rootTiledOp = tileAndFuseResult->tiledAndFusedOps.front();
+    FailureOr<std::queue<Operation *>> newFusionOpportunities =
+        fuseConsumersIntoLoops(rewriter, rootTiledOp, tilingLoops,
+                               useWARForConsumerFusionSSAViolation);
+    if (failed(newFusionOpportunities)) {
+      rootTiledOp->emitOpError("failed to fuse consumers");
+      return signalPassFailure();
+    }
+
+    // Because we restrict to at most a single tilable consumer for yielding
+    // a replacement, no new fusion opportunities will yield a replacement,
+    // meaning there is no need to run consumer fusion again afterwards.
+    // TODO: run producer and consumer fusion in one worklist.
+    fuseProducersOfSlices(rewriter, *newFusionOpportunities, tileAndFuseOptions,
+                          tilingLoops);
+  }
+  if (!tilingLoops.empty()) {
+    if (tilingLoops.size() != 1 || !isa<scf::ForallOp>(tilingLoops[0])) {
+      funcOp.emitOpError(
+          "expected tiling to produce a single `scf.forall` loop");
+      return signalPassFailure();
+    }
+
+    auto forallOp =
+        dropUnitDistributedDims(rewriter, cast<scf::ForallOp>(tilingLoops[0]));
+    if (failed(forallOp)) {
+      tilingLoops[0]->emitOpError("failed to drop unit dimensions");
+      return signalPassFailure();
+    }
+  }
+
+  // Cleanup patterns for tile and distribute
+  {
+    RewritePatternSet patterns(context);
+    linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+    tensor::populateFoldTensorEmptyPatterns(patterns);
+    context->getOrLoadDialect<tensor::TensorDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    context->getOrLoadDialect<IREE::LinalgExt::IREELinalgExtDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+    scf::ForallOp::getCanonicalizationPatterns(patterns, context);
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      funcOp.emitOpError("tiling canonicalization failed");
+      return signalPassFailure();
+    }
+  }
+
+  return;
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.td
@@ -30,4 +30,24 @@ def CPUPrepareUkernelsPass :
                 "For example, batch_mmt4d ops are decomposed to mmt4d ops";
 }
 
+def CPUTileAndDistributeToWorkgroupsPass :
+    InterfacePass<"iree-codegen-cpu-tile-and-distribute-to-workgroups",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Tile and distribute operations to workgroups using scf.forall op.";
+  let description = [{
+    Tile and distribute operations to workgroups using scf.forall op. Different
+    from the shared TileAndDistributeToWorkgroupsUsingForallOpPass, the CPU
+    version starts the tiling with the root op.
+  }];
+
+  let dependentDialects = [
+    "affine::AffineDialect",
+    "IREE::Codegen::IREECodegenDialect",
+    "IREE::LinalgExt::IREELinalgExtDialect",
+    "scf::SCFDialect",
+    "tensor::TensorDialect",
+  ];
+}
+
+
 #endif  // IREE_CODEGEN_COMMON_CPU_PASSES

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
         [
             "lower_to_ukernel_ops.mlir",
             "prepare_ukernels.mlir",
+            "tile_and_distribute_to_workgroups.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "lower_to_ukernel_ops.mlir"
     "prepare_ukernels.mlir"
+    "tile_and_distribute_to_workgroups.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/tile_and_distribute_to_workgroups.mlir
@@ -1,0 +1,37 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-cpu-tile-and-distribute-to-workgroups, cse))" --mlir-print-local-scope --split-input-file %s | FileCheck %s
+
+#config1 = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 0, 0, 0, 0], [1, 1, 0, 16, 16, 0], [0, 0, 1, 0, 0, 1]]>
+#config2 = #iree_codegen.lowering_config<tile_sizes = [[0, 0], [0, 0], [0, 0], [0, 0]]>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1) -> (d0)>
+func.func @mmt4d_unpack_elementwise(
+    %lhs: tensor<?x?x16x1xf32>, %rhs: tensor<?x?x16x1xf32>, %acc: tensor<?x?x16x16xf32>,
+    %unpack_dest: tensor<?x?xf32>, %elementwise_input: tensor<?xf32>,
+    %dest: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.mmt4d {lowering_config = #config1} ins(%lhs, %rhs : tensor<?x?x16x1xf32>, tensor<?x?x16x1xf32>) outs(%acc : tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32>
+  %unpack = linalg.unpack %0
+    outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16]
+    into %unpack_dest {lowering_config = #config2}
+    : tensor<?x?x16x16xf32> -> tensor<?x?xf32>
+  %1 = linalg.generic {
+    indexing_maps = [#map1, #map2, #map1],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%unpack, %elementwise_input : tensor<?x?xf32>, tensor<?xf32>)
+    outs(%dest : tensor<?x?xf32>)
+    attrs = {lowering_config = #config2} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %2 = arith.addf %in, %in_0 : f32
+    linalg.yield %2 : f32
+  } -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// If the mmt4d op is selected as a root op, scf.forall is generated. Otherwise,
+// it is a nop pass because the other config uses zero values. It checks the
+// in_parallel op at the end which ensures that all the ops are fused into the
+// forall op.
+// CHECK-LABEL: @mmt4d_unpack_elementwise(
+// CHECK:         scf.forall
+// CHECK:           linalg.mmt4d
+// CHECK:           linalg.unpack
+// CHECK:           linalg.generic
+// CHECK:         scf.forall.in_parallel

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -105,12 +105,6 @@ createTileAndDistributeToWorkgroupsPass(
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createTileAndDistributeToWorkgroupsWithReordering(bool transposeWorkgroup);
 
-// Pass to tile and distribute using scf.forall with rootOp control function.
-using GetTilingRootOpFn = std::function<Operation *(ArrayRef<Operation *>)>;
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createTileAndDistributeToWorkgroupsUsingForallOpPassWithRootOpControl(
-    GetTilingRootOpFn getRootOpFn);
-
 //----------------------------------------------------------------------------//
 // CodeGen Common Patterns
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -105,6 +105,12 @@ createTileAndDistributeToWorkgroupsPass(
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createTileAndDistributeToWorkgroupsWithReordering(bool transposeWorkgroup);
 
+// Pass to tile and distribute using scf.forall with rootOp control function.
+using GetTilingRootOpFn = std::function<Operation *(ArrayRef<Operation *>)>;
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createTileAndDistributeToWorkgroupsUsingForallOpPassWithRootOpControl(
+    GetTilingRootOpFn getRootOpFn);
+
 //----------------------------------------------------------------------------//
 // CodeGen Common Patterns
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -783,7 +783,15 @@ def TileAndDistributeToWorkgroupsPass :
 def TileAndDistributeToWorkgroupsUsingForallOpPass :
     InterfacePass<"iree-codegen-tile-and-distribute-to-workgroups-using-forall-op",
                   "mlir::FunctionOpInterface"> {
-  let summary = "Tile and distribute operation to workgroups (using scf.forall op)";
+  let summary = "Tile and distribute operations to workgroups (using scf.forall op)";
+  let description = [{
+    Tile and distribute operations to workgroups using scf.forall op. The pass
+    itself holds GetTilingRootOpFn function to determine which operation is the
+    root op. I.e., the operation is used in start of tiling in the algorithm. If
+    the function is not provided, it selects the last compute op that has
+    workgroup tiling level.
+  }];
+
   let dependentDialects = [
     "affine::AffineDialect",
     "IREE::Codegen::IREECodegenDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -100,6 +100,35 @@ FailureOr<std::queue<Operation *>>
 fuseConsumersIntoLoops(RewriterBase &rewriter, Operation *tiledOp,
                        MutableArrayRef<LoopLikeOpInterface> loops,
                        bool useWARForConsumerFusionSSAViolation);
+
+//===---------------------------------------------------------------------===//
+// Distribution Utilities.
+//===---------------------------------------------------------------------===//
+
+struct TilingInfo {
+  Operation *tilableOp;
+  SmallVector<OpFoldResult> tileSizes;
+  SmallVector<int64_t> interchange;
+};
+
+/// Find the lowering config from `tileableOp` to use for getting the tile
+/// sizes.
+FailureOr<TilingInfo> getTiledAndDistributionInfo(RewriterBase &rewriter,
+                                                  Operation *tilableOp);
+
+/// Helper function to return the mapping attribute to use given the tile sizes.
+SmallVector<Attribute> getDistributionMapping(MLIRContext *context,
+                                              ArrayRef<OpFoldResult> tileSizes);
+
+/// Checks whether we have static dimension for all the loop bounds and steps.
+/// This is a requirement if the reordering strategy is set to `transpose`.
+bool areAllStaticLoopBounds(scf::ForallOp forallOp);
+
+/// Find dimensions of the loop that are unit-trip count and drop them from the
+/// distributed dimensions.
+FailureOr<scf::ForallOp> dropUnitDistributedDims(RewriterBase &rewriter,
+                                                 scf::ForallOp forallOp);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -7,12 +7,8 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TileAndFuseUtils.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
-#include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
-#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -24,8 +20,6 @@
 #define DEBUG_TYPE "tile-and-distribute-to-workgroups-using-forall-op"
 
 namespace mlir::iree_compiler {
-
-#define CEILDIV(a, b) ((a + b - 1) / b)
 
 #define GEN_PASS_DEF_TILEANDDISTRIBUTETOWORKGROUPSUSINGFORALLOPPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
@@ -52,262 +46,14 @@ private:
 
 } // namespace
 
-/// Find the lowering config to use for getting the tile sizes.
-// TODO: For now this is taking the "last op" in the dispatch, but
-// ideally this should take the "root op" that gets tiled and everything
-// gets fused with it. For now to keep consistent with the legacy
-// tile-and-distribute it is still looking for the "last compute operation".
-struct TilingInfo {
-  Operation *tilableOp;
-  SmallVector<OpFoldResult> tileSizes;
-  SmallVector<int64_t> interchange;
-};
-
-static FailureOr<TilingInfo> getTiledAndDistributionInfo(RewriterBase &rewriter,
-                                                         Operation *tilableOp) {
-  if (!tilableOp) {
-    // There is no lowering config. Return `null`.
-    return TilingInfo{nullptr, {}, {}};
-  }
-
-  IREE::Codegen::LoweringConfigAttrInterface tilableOpConfig =
-      getLoweringConfig(tilableOp);
-  if (!tilableOpConfig) {
-    return tilableOp->emitOpError("unable to find configuration of root op to "
-                                  "define workgroup count region");
-  }
-  auto tileSizes = llvm::map_to_vector(
-      tilableOpConfig.getWorkgroupTileSizes(),
-      [&](int64_t t) -> OpFoldResult { return rewriter.getIndexAttr(t); });
-  SmallVector<int64_t> interchange = tilableOpConfig.getWorkgroupInterchange();
-
-  // Avoid distributing unit-trip count loops.
-
-  // Set tile sizes for non-partitioned loops to zero.
-  if (auto partitionableLoopsInterface =
-          dyn_cast<PartitionableLoopsInterface>(tilableOp)) {
-    SmallVector<unsigned> partitionableLoops =
-        partitionableLoopsInterface.getPartitionableLoops(std::nullopt);
-    llvm::SmallDenseSet<unsigned> partitionableLoopsSet(
-        partitionableLoops.begin(), partitionableLoops.end());
-    OpFoldResult zero = rewriter.getIndexAttr(0);
-    for (auto loopId : llvm::seq<unsigned>(0, tileSizes.size())) {
-      if (partitionableLoopsSet.count(loopId)) {
-        continue;
-      }
-      tileSizes[loopId] = zero;
-    }
-  }
-
-  // Set tile sizes for full tiles to zero. This prevents single trip loops from
-  // being created, which can sometimes block certain cleanup patterns from
-  // applying during producer fusion.
-  if (auto tilingInterfaceOp = dyn_cast<TilingInterface>(tilableOp)) {
-    OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPoint(tilingInterfaceOp);
-    SmallVector<Range> bounds = tilingInterfaceOp.getIterationDomain(rewriter);
-    SmallVector<int64_t> staticLoopSizes;
-    SmallVector<Value> d;
-    for (Range bound : bounds) {
-      dispatchIndexOpFoldResult(bound.size, d, staticLoopSizes);
-    }
-    OpFoldResult zero = rewriter.getIndexAttr(0);
-    SmallVector<int64_t> tileSizesInt = tilableOpConfig.getWorkgroupTileSizes();
-    for (auto loopId : llvm::seq<unsigned>(0, tileSizesInt.size())) {
-      if (loopId < staticLoopSizes.size() &&
-          staticLoopSizes[loopId] == tileSizesInt[loopId]) {
-        tileSizes[loopId] = zero;
-      }
-    }
-  }
-
-  return TilingInfo{tilableOp, tileSizes, interchange};
-}
-
-/// Helper function to return the mapping attribute to use given the tile sizes.
-static SmallVector<Attribute> getMapping(MLIRContext *context,
-                                         ArrayRef<OpFoldResult> tileSizes) {
-  SmallVector<Attribute> mapping;
-  mapping.reserve(tileSizes.size());
-  for (auto tileSize : llvm::reverse(tileSizes)) {
-    if (isZeroInteger(tileSize)) {
-      continue;
-    }
-    uint64_t currSize = mapping.size();
-    switch (currSize) {
-    case 0:
-    case 1:
-    case 2:
-      mapping.push_back(IREE::Codegen::WorkgroupMappingAttr::get(
-          context, IREE::Codegen::symbolizeWorkgroupId(currSize).value()));
-      break;
-    default:
-      mapping.push_back(IREE::Codegen::WorkgroupMappingAttr::get(
-          context, IREE::Codegen::WorkgroupId::IdZ, currSize - 2));
-    }
-  }
-  return llvm::to_vector(llvm::reverse(mapping));
-}
-
-//===---------------------------------------------------------------------===//
-// Post tiling cleanup patterns
-//===---------------------------------------------------------------------===//
-
-/// Prune the values corresponding to the dropped loops.
-static SmallVector<OpFoldResult>
-pruneDroppedLoops(ArrayRef<OpFoldResult> inputs,
-                  const llvm::SmallDenseSet<int> &droppedLoops) {
-  SmallVector<OpFoldResult> prunedInputs;
-  for (auto [index, input] : llvm::enumerate(inputs)) {
-    if (droppedLoops.contains(index)) {
-      continue;
-    }
-    prunedInputs.push_back(input);
-  }
-  return prunedInputs;
-}
-
-/// Prune the mapping attributes corresponding to the dropped loops.
-/// Note that we cant just drop them. We need to rebalance the
-/// attributes so that the workgroup attributes are perfectly ordered.
-/// For example, if the attribute list is
-///
-/// ```
-/// [workgroup_mapping<x>, workgroup_mapping<z:1>,
-///  workgroup_mapping<z>, workgroup_mapping<y>,
-///  workgroup_mapping<z:3>, workgroup_mapping<z:2>]
-/// ```
-///
-/// and the droppedloops are `{1, 3}`, then the new mapping should be
-///
-/// ```
-/// [workgroup_mapping<x>, workgroup_mapping<y>,
-///  workgroup_mapping<z:1>, workgroup_mapping<z>]
-/// ```
-SmallVector<Attribute>
-pruneDroppedLoops(ArrayRef<Attribute> inputs,
-                  const llvm::SmallDenseSet<int> &droppedLoops) {
-  SmallVector<IREE::Codegen::WorkgroupMappingAttr> droppedMappings;
-  SmallVector<Attribute> prunedAttrs;
-  for (auto [index, input] : llvm::enumerate(inputs)) {
-    if (droppedLoops.contains(index)) {
-      droppedMappings.push_back(
-          cast<IREE::Codegen::WorkgroupMappingAttr>(input));
-    } else {
-      prunedAttrs.push_back(input);
-    }
-  }
-  for (auto droppedMapping : droppedMappings) {
-    for (auto [index, prunedAttr] : llvm::enumerate(prunedAttrs)) {
-      auto prunedMappingAttr =
-          cast<IREE::Codegen::WorkgroupMappingAttr>(prunedAttr);
-      if (droppedMapping < prunedMappingAttr) {
-        prunedAttrs[index] =
-            IREE::Codegen::WorkgroupMappingAttr::getAttributeFromMappingId(
-                prunedAttr.getContext(), prunedMappingAttr.getMappingId() - 1);
-      }
-    }
-  }
-  return prunedAttrs;
-}
-
-/// Checks whether we have static dimension for all the loop bounds and steps.
-/// This is a requirement if the reordering strategy is set to `transpose`.
-static bool areAllStaticLoopBounds(scf::ForallOp forallOp) {
-
-  for (auto [lb, ub, step] : llvm::zip_equal(forallOp.getMixedLowerBound(),
-                                             forallOp.getMixedUpperBound(),
-                                             forallOp.getMixedStep())) {
-
-    std::optional<int64_t> lbVal = getConstantIntValue(lb);
-    std::optional<int64_t> ubVal = getConstantIntValue(ub);
-    std::optional<int64_t> stepVal = getConstantIntValue(step);
-
-    if (!(lbVal && ubVal && stepVal)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/// Find dimensions of the loop that are unit-trip count and drop them from the
-/// distributed dimensions.
-static FailureOr<scf::ForallOp>
-dropUnitDistributedDims(RewriterBase &rewriter, scf::ForallOp forallOp) {
-  SmallVector<OpFoldResult> mixedLbs = forallOp.getMixedLowerBound();
-  SmallVector<OpFoldResult> mixedUbs = forallOp.getMixedUpperBound();
-  SmallVector<OpFoldResult> mixedSteps = forallOp.getMixedStep();
-
-  // Find the index of loops to be dropped.
-  llvm::SmallDenseSet<int> droppedLoops;
-  for (auto [index, lb, ub, step] :
-       llvm::enumerate(mixedLbs, mixedUbs, mixedSteps)) {
-
-    std::optional<int64_t> lbVal = getConstantIntValue(lb);
-    std::optional<int64_t> ubVal = getConstantIntValue(ub);
-    std::optional<int64_t> stepVal = getConstantIntValue(step);
-
-    if (!(lbVal && ubVal && stepVal)) {
-      continue;
-    }
-
-    if (CEILDIV(ubVal.value() - lbVal.value(), stepVal.value()) == 1) {
-      droppedLoops.insert(index);
-    }
-  }
-  if (droppedLoops.empty()) {
-    return forallOp;
-  }
-
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(forallOp);
-  SmallVector<OpFoldResult> newLbs =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedLbs), droppedLoops);
-  SmallVector<OpFoldResult> newUbs =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedUbs), droppedLoops);
-  SmallVector<OpFoldResult> newSteps =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedSteps), droppedLoops);
-  std::optional<ArrayAttr> newMapping;
-  if (auto currMapping = forallOp.getMapping()) {
-    SmallVector<Attribute> newMappingAttrs =
-        pruneDroppedLoops(currMapping.value().getValue(), droppedLoops);
-    newMapping = rewriter.getArrayAttr(newMappingAttrs);
-  }
-
-  Value zero = rewriter.create<arith::ConstantIndexOp>(forallOp.getLoc(), 0);
-  auto newForallOp = rewriter.create<scf::ForallOp>(
-      forallOp.getLoc(), newLbs, newUbs, newSteps, forallOp.getInits(),
-      newMapping, [](OpBuilder &, Location, ValueRange) {});
-
-  SmallVector<Value> argReplacements;
-  int newLoopBlockArgNum = 0;
-  auto newLoopBodyArgs = newForallOp.getInductionVars();
-  for (auto [index, oldBlockArg] :
-       llvm::enumerate(forallOp.getInductionVars())) {
-    if (droppedLoops.contains(index)) {
-      argReplacements.push_back(zero);
-    } else {
-      argReplacements.push_back(newLoopBodyArgs[newLoopBlockArgNum++]);
-    }
-  }
-  argReplacements.append(newForallOp.getRegionIterArgs().begin(),
-                         newForallOp.getRegionIterArgs().end());
-
-  Block *oldLoopBody = forallOp.getBody();
-  Block *newLoopBody = newForallOp.getBody();
-  rewriter.mergeBlocks(oldLoopBody, newLoopBody, argReplacements);
-
-  rewriter.replaceOp(forallOp, newForallOp.getResults());
-  return newForallOp;
-}
-
-//===---------------------------------------------------------------------===//
-// Pass implementation.
-//===---------------------------------------------------------------------===//
-
 void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   auto funcOp = getOperation();
   auto *context = &getContext();
+
+  // TODO: For now this is taking the "last op" in the dispatch, but
+  // ideally this should take the "root op" that gets tiled and everything
+  // gets fused with it. For now to keep consistent with the legacy
+  // tile-and-distribute it is still looking for the "last compute operation".
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   if (!getRootOpFn) {
     getRootOpFn = [](ArrayRef<Operation *> computeOps) -> Operation * {
@@ -355,7 +101,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   tilingOptions.setInterchange(tilingInfo->interchange);
   tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
   SmallVector<Attribute> deviceMappingAttribute =
-      getMapping(context, tilingInfo->tileSizes);
+      getDistributionMapping(context, tilingInfo->tileSizes);
   if (failed(IREE::Codegen::WorkgroupMappingAttr::verifyAttrList(
           context, funcOp.getLoc(), deviceMappingAttribute))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3186,12 +3186,8 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
       return failure();
   }
 
-  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
-  if (failed(rootOp))
-    return failure();
-  Operation *rootOperation = rootOp.value();
-
   // Handle the case with no known root operation.
+  Operation *rootOperation = getCPURootOperation(computeOps);
   if (!rootOperation) {
     return lowerUsingDefaultPipeline(entryPointFn);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -67,13 +67,13 @@ public:
 static FailureOr<TilingConfig>
 getTilingConfigForPipeline(FunctionOpInterface funcOp) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
-  if (failed(rootOp) || !rootOp.value()) {
+  Operation *rootOp = getCPURootOperation(computeOps);
+  if (!rootOp) {
     return failure();
   }
   auto rootLoweringConfig =
       iree_compiler::getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(
-          rootOp.value());
+          rootOp);
   if (!rootLoweringConfig) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -196,15 +196,15 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
   IRRewriter rewriter(funcOp);
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
+  Operation *rootOp = getCPURootOperation(computeOps);
 
-  if (failed(rootOp) || !rootOp.value()) {
+  if (!rootOp) {
     LDBG("unable to find the root operation");
     return;
   }
 
   IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
-      getLoweringConfig(rootOp.value());
+      getLoweringConfig(rootOp);
 
   if (!loweringConfig) {
     LDBG("unable to find the attached lowering config");
@@ -217,7 +217,7 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
   }
 
   if (failed(tileRootAndFuseProducerConsumer(
-          rewriter, cast<TilingInterface>(rootOp.value()), tilingLevel,
+          rewriter, cast<TilingInterface>(rootOp), tilingLevel,
           onlyFuseProducerInputOperands, tileUsingForall))) {
     funcOp.emitError() << "tiling of level " << tilingLevel.getValue()
                        << " failed\n";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -116,9 +116,7 @@ static llvm::cl::opt<bool> clForceArmStreaming(
 // TODO: Enable `TileDispatchUsingForall` for every pipeline.
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   if (clTileDispatchUsingForall) {
-    funcPassManager.addPass(
-        createTileAndDistributeToWorkgroupsUsingForallOpPassWithRootOpControl(
-            getCPURootOperation));
+    funcPassManager.addPass(createCPUTileAndDistributeToWorkgroupsPass());
   } else {
     funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
     funcPassManager.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
@@ -116,7 +117,8 @@ static llvm::cl::opt<bool> clForceArmStreaming(
 static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   if (clTileDispatchUsingForall) {
     funcPassManager.addPass(
-        createTileAndDistributeToWorkgroupsUsingForallOpPass());
+        createTileAndDistributeToWorkgroupsUsingForallOpPassWithRootOpControl(
+            getCPURootOperation));
   } else {
     funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass());
     funcPassManager.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -19,7 +19,7 @@
 
 namespace mlir::iree_compiler {
 
-FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
+Operation *getCPURootOperation(ArrayRef<Operation *> computeOps) {
   Operation *rootOperation = nullptr;
   for (auto op : llvm::reverse(computeOps)) {
     if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -19,7 +19,8 @@ namespace mlir::iree_compiler {
 ///   3. An operation that implements TilingInterface.
 /// If there are multiple operations meeting the same priority, the one closer
 /// to the end of the function is the root op.
-FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
+/// Returns nullptr if any root op is not found.
+Operation *getCPURootOperation(ArrayRef<Operation *> computeOps);
 
 /// Creates a string attribute containing the name of the attribute that is
 /// used to enable decomposition.

--- a/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/KernelDispatch.cpp
@@ -98,13 +98,8 @@ setConfigForKernel(mlir::FunctionOpInterface entryPointFn) {
     return lowerUsingVMVXDefaultPipeline(entryPointFn);
   }
 
-  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
-  if (failed(rootOp)) {
-    return failure();
-  }
-
   // Handle the case with no known root operation.
-  Operation *rootOperation = rootOp.value();
+  Operation *rootOperation = getCPURootOperation(computeOps);
   if (!rootOperation) {
     return lowerUsingVMVXDefaultPipeline(entryPointFn);
   }


### PR DESCRIPTION
The revision allows users passing a GetRootOpFn function to the pass, so it can decide to start with the determined root op. It makes sure that we can always start with the root op that defined by a backend for tiling and distribution.

The revision renames `getRootOperation` as `getCPURootOperation`, since the logic is CPU specific. Furthermore, it removes the `FailureOr` from the return type because nullptr can already represent a failure.

To verify that it fixes the issue, the stack allocation check is added to pipeline tests, which makes sure all the pipeline tests are generating valid IRs.

It is a step towards https://github.com/iree-org/iree/issues/21197

Fixes https://github.com/iree-org/iree/issues/20786