### PR TITLE
[Codegen] Add pass to propagate constant offsets towards accesses

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -153,6 +153,7 @@ iree_compiler_cc_library(
         "PadDynamicAlloc.cpp",
         "PassUtils.cpp",
         "Passes.cpp",
+        "PropagateConstantOffsets.cpp",
         "PropagateDispatchSizeBounds.cpp",
         "PropagateReshapesByExpansion.cpp",
         "ReconcileTranslationInfo.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -144,6 +144,7 @@ iree_cc_library(
     "PadDynamicAlloc.cpp"
     "PassUtils.cpp"
     "Passes.cpp"
+    "PropagateConstantOffsets.cpp"
     "PropagateDispatchSizeBounds.cpp"
     "PropagateReshapesByExpansion.cpp"
     "ReconcileTranslationInfo.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -665,6 +665,15 @@ def MathTransformPass :
   ];
 }
 
+def PropagateConstantOffsetsPass :
+    InterfacePass<"iree-codegen-propagate-constant-offsets", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to push constant offsets towards loads/stores";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect",
+    "::mlir::arith::ArithDialect"
+  ];
+}
+
 def PropagateDispatchSizeBoundsPass :
     InterfacePass<"iree-codegen-propagate-dispatch-size-bounds", "mlir::FunctionOpInterface"> {
   let summary = "Pass to annotate workitem and workgroup IDs with known bounds";

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
@@ -1,0 +1,316 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_PROPAGATECONSTANTOFFSETSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct PropagateConstantOffsetsPass final
+    : public impl::PropagateConstantOffsetsPassBase<
+          PropagateConstantOffsetsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+/// Helper to extract constant RHS values from a defining arith op.
+template <typename OpTy>
+static std::optional<int64_t> getValueConstantRhs(Value v) {
+  auto op = v.getDefiningOp<OpTy>();
+  if (!op) {
+    return std::nullopt;
+  }
+
+  // Folders move constant operands to the RHS so no need to check both sides.
+  llvm::APInt constant;
+  if (!matchPattern(op.getRhs(), m_ConstantInt(&constant))) {
+    return std::nullopt;
+  }
+
+  return constant.getSExtValue();
+}
+
+/// Converts applies of the form:
+/// affine.apply affine_map<expr + C>
+/// to
+/// %apply = affine.apply affine_map<expr>
+/// arith.addi %apply, C
+struct ExtractConstantApplyOffset final
+    : OpRewritePattern<affine::AffineApplyOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineApplyOp apply,
+                                PatternRewriter &rewriter) const override {
+    AffineMap map = apply.getMap();
+    // Simplify the map to move `+ c` terms to the right most (first) expression
+    // in the tree.
+    map = simplifyAffineMap(map);
+    AffineExpr resultExpr = map.getResult(0);
+    auto addExpr = llvm::dyn_cast<AffineBinaryOpExpr>(resultExpr);
+
+    // After simplification, the add should be the first expression if present.
+    if (!addExpr || addExpr.getKind() != AffineExprKind::Add) {
+      return rewriter.notifyMatchFailure(apply, "top level expr not an add");
+    }
+
+    auto constantRhs = llvm::dyn_cast<AffineConstantExpr>(addExpr.getRHS());
+    if (!constantRhs) {
+      return rewriter.notifyMatchFailure(apply, "non-const rhs");
+    }
+
+    int64_t constantOffset = constantRhs.getValue();
+
+    AffineMap newMap =
+        AffineMap::get(map.getNumDims(), map.getNumSymbols(), addExpr.getLHS());
+    Value newApply = rewriter.create<affine::AffineApplyOp>(
+        apply.getLoc(), newMap, apply.getOperands());
+    Value offset =
+        rewriter.create<arith::ConstantIndexOp>(apply.getLoc(), constantOffset);
+    rewriter.replaceOpWithNewOp<arith::AddIOp>(apply, newApply, offset);
+    return success();
+  }
+};
+
+/// Converts applies of the form:
+/// affine.apply affine_map<expr + C>
+/// to
+/// %apply = affine.apply affine_map<expr>
+/// arith.addi %apply, C
+struct FoldApplySymbolOrDimSum final : OpRewritePattern<affine::AffineApplyOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(affine::AffineApplyOp apply,
+                                PatternRewriter &rewriter) const override {
+    AffineMap map = apply.getMap();
+    SmallVector<AffineExpr> replacements;
+    replacements.reserve(map.getNumInputs());
+    int64_t numDims = map.getNumDims();
+    auto getCurrExpr = [&](int64_t i) -> AffineExpr {
+      if (i >= numDims)
+        return rewriter.getAffineSymbolExpr(i - numDims);
+      return rewriter.getAffineDimExpr(i);
+    };
+    bool didReplace = false;
+    for (int64_t i = 0, e = map.getNumInputs(); i < e; ++i) {
+      AffineExpr currExpr = getCurrExpr(i);
+      OpOperand &operand = apply->getOpOperand(i);
+      std::optional<int64_t> maybeOffset =
+          getValueConstantRhs<arith::AddIOp>(operand.get());
+      if (!maybeOffset) {
+        replacements.push_back(currExpr);
+        continue;
+      }
+      if (!didReplace) {
+        rewriter.startOpModification(apply);
+      }
+      // Replace the dim/symbol with the lhs of the producing add.
+      operand.assign(operand.get().getDefiningOp<arith::AddIOp>().getLhs());
+      replacements.push_back(currExpr +
+                             rewriter.getAffineConstantExpr(*maybeOffset));
+      didReplace = true;
+    }
+
+    if (!didReplace) {
+      return rewriter.notifyMatchFailure(
+          apply, "no constant addition operands to replace");
+    }
+
+    apply.setMap(map.replaceDimsAndSymbols(
+        ArrayRef<AffineExpr>(replacements).take_front(numDims),
+        ArrayRef<AffineExpr>(replacements).drop_front(numDims), numDims,
+        map.getNumSymbols()));
+
+    rewriter.finalizeOpModification(apply);
+    return success();
+  }
+};
+
+/// Converts constant index operands into constants added after the linearize
+/// if the linearization basis is static.
+struct PropagateConstantAddsThroughLinearize final
+    : OpRewritePattern<affine::AffineLinearizeIndexOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineLinearizeIndexOp op,
+                                PatternRewriter &rewriter) const override {
+    int64_t indexCount = op.getMultiIndex().size();
+    int64_t runningElementCount = 1;
+    int64_t runningOffset = 0;
+    Value zero = nullptr;
+    auto getZero = [&]() {
+      if (zero)
+        return zero;
+      zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      return zero;
+    };
+    bool didReplace = false;
+
+    auto matchConstantAndReplaceOperand = [&](OpOperand &operand) {
+      llvm::APInt constant;
+      Value replacement = nullptr;
+      if (matchPattern(operand.get(), m_ConstantInt(&constant)) &&
+          !constant.isZero()) {
+        // If an operand is constant and non-zero, add its total contribution
+        // to the running offset and replace the multi_index operand with 0.
+        runningOffset += constant.getSExtValue() * runningElementCount;
+        replacement = getZero();
+      } else if (std::optional<int64_t> offset =
+                     getValueConstantRhs<arith::AddIOp>(operand.get())) {
+        runningOffset += offset.value() * runningElementCount;
+        replacement = operand.get().getDefiningOp<arith::AddIOp>().getLhs();
+      }
+      if (replacement) {
+        if (!didReplace) {
+          rewriter.startOpModification(op);
+        }
+        operand.assign(replacement);
+        didReplace = true;
+      }
+    };
+
+    // Iterate the static basis in reverse and accumulate the constant offset
+    // to add.
+    for (auto [i, size] : llvm::enumerate(llvm::reverse(op.getStaticBasis()))) {
+      OpOperand &operand = op.getMultiIndexMutable()[indexCount - i - 1];
+      matchConstantAndReplaceOperand(operand);
+
+      // Update the running linearization count, or break if the next size is
+      // dynamic.
+      if (ShapedType::isDynamic(size)) {
+        runningElementCount = ShapedType::kDynamic;
+        break;
+      }
+      runningElementCount *= size;
+    }
+
+    // Repeat one more time if the basis has one fewer entry than number of
+    // indices.
+    if (indexCount != op.getStaticBasis().size() &&
+        !ShapedType::isDynamic(runningElementCount)) {
+      OpOperand &operand = op.getMultiIndexMutable()[0];
+      matchConstantAndReplaceOperand(operand);
+    }
+
+    if (!didReplace) {
+      return rewriter.notifyMatchFailure(
+          op, "no constant add multi_index operands");
+    }
+
+    rewriter.finalizeOpModification(op);
+
+    rewriter.setInsertionPointAfter(op);
+    Value offset =
+        rewriter.create<arith::ConstantIndexOp>(op.getLoc(), runningOffset);
+    auto addOp =
+        rewriter.create<arith::AddIOp>(op.getLoc(), op.getResult(), offset);
+    rewriter.replaceAllUsesExcept(op, addOp, addOp);
+    return success();
+  }
+};
+
+/// Converts constant index operands into constants added after the linearize
+/// if the linearization basis is static.
+struct FoldDivisibleConstantMulsIntoLinearize final
+    : OpRewritePattern<affine::AffineLinearizeIndexOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineLinearizeIndexOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getDynamicBasis().empty()) {
+      return rewriter.notifyMatchFailure(op, "unimplemented: dynamic basis");
+    }
+    int64_t indexCount = op.getMultiIndex().size();
+    SmallVector<Value> newMultiIndex;
+    SmallVector<int64_t> newStaticBasis;
+    Value zero = nullptr;
+    auto getZero = [&]() {
+      if (zero)
+        return zero;
+      zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      return zero;
+    };
+
+    // Iterate the static basis in reverse and accumulate the constant offset
+    // to add.
+    for (auto [i, size] : llvm::enumerate(llvm::reverse(op.getStaticBasis()))) {
+      assert(!ShapedType::isDynamic(size) &&
+             "unexpected dynamic basis element");
+      Value operand = op.getMultiIndex()[indexCount - i - 1];
+      std::optional<int64_t> coefficient =
+          getValueConstantRhs<arith::MulIOp>(operand);
+      // If the basis size is indivisible by the coefficient, splitting up the
+      // size by dividing by the coefficient isn't possible.
+      if (coefficient && size % coefficient.value() == 0) {
+        newMultiIndex.push_back(getZero());
+        newMultiIndex.push_back(
+            operand.getDefiningOp<arith::MulIOp>().getLhs());
+        newStaticBasis.push_back(coefficient.value());
+        newStaticBasis.push_back(size / coefficient.value());
+      } else {
+        newStaticBasis.push_back(size);
+        newMultiIndex.push_back(operand);
+      }
+    }
+
+    // Handle the last entry if no bound given.
+    if (indexCount != op.getStaticBasis().size()) {
+      Value operand = op.getMultiIndex()[0];
+      std::optional<int64_t> coefficient =
+          getValueConstantRhs<arith::MulIOp>(operand);
+      // Since there is no outermost size, no need to verify divisibility.
+      if (coefficient) {
+        newMultiIndex.push_back(getZero());
+        newMultiIndex.push_back(
+            operand.getDefiningOp<arith::MulIOp>().getLhs());
+        newStaticBasis.push_back(coefficient.value());
+      } else {
+        newMultiIndex.push_back(operand);
+      }
+    }
+
+    if (newMultiIndex.size() == op.getMultiIndex().size()) {
+      return rewriter.notifyMatchFailure(
+          op, "no foldable constant mul multi_index operands");
+    }
+
+    SmallVector<Value> reversedIndex(llvm::reverse(newMultiIndex));
+    SmallVector<int64_t> reversedBasis(llvm::reverse(newStaticBasis));
+
+    // Disjoint status is unaffected by this transform.
+    rewriter.replaceOpWithNewOp<affine::AffineLinearizeIndexOp>(
+        op, reversedIndex, reversedBasis, op.getDisjoint());
+    return success();
+  }
+};
+
+} // namespace
+
+void PropagateConstantOffsetsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  patterns.add<PropagateConstantAddsThroughLinearize>(context);
+  patterns.add<ExtractConstantApplyOffset>(context);
+  patterns.add<FoldApplySymbolOrDimSum>(context);
+  patterns.add<FoldDivisibleConstantMulsIntoLinearize>(context);
+  // Apply canonicalization to apply new composition opportunities.
+  affine::AffineApplyOp::getCanonicalizationPatterns(patterns, context);
+  // Add canonicalization to compose adds.
+  arith::AddIOp::getCanonicalizationPatterns(patterns, context);
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
@@ -35,7 +35,8 @@ static std::optional<int64_t> getValueConstantRhs(Value v, bool nsw) {
   }
 
   // Conditionally require nsw.
-  if (nsw && op.getOverflowFlags() != arith::IntegerOverflowFlags::nsw) {
+  if (nsw && !bitEnumContainsAll(op.getOverflowFlags(),
+                                 arith::IntegerOverflowFlags::nsw)) {
     return std::nullopt;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -87,6 +87,7 @@ iree_lit_test_suite(
             "normalize_loop_bounds.mlir",
             "optimize_tensor_insert_extract_slices.mlir",
             "pad_dynamic_alloc.mlir",
+            "propagate_constant_offsets.mlir",
             "propagate_dispatch_size_bounds.mlir",
             "propagate_reshapes_by_expansion.mlir",
             "reconcile_translation_info.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -83,6 +83,7 @@ iree_lit_test_suite(
     "normalize_loop_bounds.mlir"
     "optimize_tensor_insert_extract_slices.mlir"
     "pad_dynamic_alloc.mlir"
+    "propagate_constant_offsets.mlir"
     "propagate_dispatch_size_bounds.mlir"
     "propagate_reshapes_by_expansion.mlir"
     "reconcile_translation_info.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
@@ -1,0 +1,145 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-propagate-constant-offsets))" %s \
+// RUN:   --split-input-file --mlir-print-local-scope | FileCheck %s
+
+func.func @extract_constant_map_offset(%id: index) -> index {
+  %0 = affine.apply affine_map<()[s0] -> (s0 + 32)>()[%id]
+  return %0 : index
+}
+
+// CHECK-LABEL: func @extract_constant_map_offset
+// CHECK-SAME:    %[[ID:.+]]: index
+// CHECK:         %[[C32:.+]] = arith.constant 32 : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @extract_offset_unsimplified_map(%id: index) -> index {
+  %0 = affine.apply affine_map<()[s0] -> (32 + s0)>()[%id]
+  return %0 : index
+}
+
+// CHECK-LABEL: func @extract_offset_unsimplified_map
+// CHECK-SAME:    %[[ID:.+]]: index
+// CHECK:         %[[C32:.+]] = arith.constant 32 : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @fold_add_into_map(%id0: index, %id1: index) -> index {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %a0 = arith.addi %id0, %c1 : index
+  %a1 = arith.addi %id1, %c2 : index
+  %0 = affine.apply affine_map<(d0)[s0] -> (s0 + d0)>(%a0)[%a1]
+  return %0 : index
+}
+
+// CHECK-LABEL: func @fold_add_into_map
+// CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
+// CHECK:         %[[C3:.+]] = arith.constant 3 : index
+// CHECK:         %[[AFFINE_ADD:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%[[ID1]], %[[ID0]]]
+// CHECK:         %[[ADD:.+]] = arith.addi %[[AFFINE_ADD]], %[[C3]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @propagate_constant_offsets_through_linearize(%id0: index, %id1: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c13 = arith.constant 13 : index
+  %a0 = arith.addi %id0, %c1 : index
+  %a1 = arith.addi %id1, %c2 : index
+  %0 = affine.linearize_index [%a0, %c0, %a1, %c13] by (3, 5, 7, 11) : index
+  return %0 : index
+}
+
+// CHECK-LABEL: func @propagate_constant_offsets_through_linearize
+// CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
+
+// Total constant offset = 1 * 5 * 7 * 11 + 2 * 11 + 13 = 420
+// CHECK:         %[[C420:.+]] = arith.constant 420 : index
+// CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID0]], %c0, %[[ID1]], %c0] by (3, 5, 7, 11) : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C420]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @propagate_constant_offsets_unbounded(%id: index) -> index {
+  %c2 = arith.constant 2 : index
+  %c13 = arith.constant 13 : index
+  %a = arith.addi %id, %c2 : index
+  %0 = affine.linearize_index [%a, %c13] by (11) : index
+  return %0 : index
+}
+
+// CHECK-LABEL: func @propagate_constant_offsets_unbounded
+// CHECK-SAME:    %[[ID:[A-Za-z0-9]+]]: index
+
+// Total constant offset = 2 * 11 + 13 = 35
+// CHECK:         %[[C35:.+]] = arith.constant 35 : index
+// CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID]], %c0] by (11) : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @propagate_constant_offsets_stop_dynamic(%id0: index, %id1: index, %s1: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c13 = arith.constant 13 : index
+  %a0 = arith.addi %id0, %c1 : index
+  %a1 = arith.addi %id1, %c2 : index
+  %0 = affine.linearize_index disjoint [%a0, %c0, %a1, %c13] by (3, %s1, 7, 11) : index
+  return %0 : index
+}
+
+// CHECK-LABEL: func @propagate_constant_offsets_stop_dynamic
+// CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[S1:[A-Za-z0-9]+]]: index
+
+// Total constant offset before dynamic = 2 * 11 + 13 = 35
+// CHECK:         %[[C35:.+]] = arith.constant 35 : index
+// CHECK:         %[[ADD0:.+]] = arith.addi %[[ID0]], %c1 : index
+// CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index disjoint [%[[ADD0]], %c0, %[[ID1]], %c0] by (3, %[[S1]], 7, 11) : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] : index
+// CHECK:         return %[[ADD]]
+
+// -----
+
+func.func @fold_mul_into_linearize(%id0: index, %id1: index) -> index {
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %a0 = arith.muli %id0, %c2 : index
+  %a1 = arith.muli %id1, %c4 : index
+  %0 = affine.linearize_index disjoint [%a0, %a1] by (16) : index
+  return %0 : index
+}
+
+// CHECK-LABEL: func @fold_mul_into_linearize
+// CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
+// CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index disjoint [%[[ID0]], %c0, %[[ID1]], %c0] by (2, 4, 4) : index
+// CHECK:         return %[[LINEARIZE]]
+
+// -----
+
+func.func @nofold_mul_indivisible(%id0: index, %id1: index) -> index {
+  %c7 = arith.constant 7 : index
+  %a = arith.muli %id1, %c7 : index
+  %0 = affine.linearize_index [%id0, %a] by (16) : index
+  return %0 : index
+}
+
+// CHECK-LABEL: func @nofold_mul_indivisible
+// CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
+// CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
+// CHECK:         %[[MUL:.+]] = arith.muli %[[ID1]], %c7 : index
+// CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID0]], %[[MUL]]] by (16) : index
+// CHECK:         return %[[LINEARIZE]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
@@ -31,7 +31,7 @@ func.func @fold_add_into_map(%id0: index, %id1: index) -> index {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %a0 = arith.addi %id0, %c1 overflow<nsw> : index
-  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw, nuw> : index
   %0 = affine.apply affine_map<(d0)[s0] -> (s0 + d0)>(%a0)[%a1]
   return %0 : index
 }
@@ -52,7 +52,7 @@ func.func @propagate_constant_offsets_through_linearize(%id0: index, %id1: index
   %c2 = arith.constant 2 : index
   %c13 = arith.constant 13 : index
   %a0 = arith.addi %id0, %c1 overflow<nsw> : index
-  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw, nuw> : index
   %0 = affine.linearize_index [%a0, %c0, %a1, %c13] by (3, 5, 7, 11) : index
   return %0 : index
 }
@@ -94,7 +94,7 @@ func.func @propagate_constant_offsets_stop_dynamic(%id0: index, %id1: index, %s1
   %c2 = arith.constant 2 : index
   %c13 = arith.constant 13 : index
   %a0 = arith.addi %id0, %c1 overflow<nsw> : index
-  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw, nuw> : index
   %0 = affine.linearize_index disjoint [%a0, %c0, %a1, %c13] by (3, %s1, 7, 11) : index
   return %0 : index
 }
@@ -117,7 +117,7 @@ func.func @fold_mul_into_linearize(%id0: index, %id1: index) -> index {
   %c2 = arith.constant 2 : index
   %c4 = arith.constant 4 : index
   %a0 = arith.muli %id0, %c2 overflow<nsw> : index
-  %a1 = arith.muli %id1, %c4 overflow<nsw> : index
+  %a1 = arith.muli %id1, %c4 overflow<nsw, nuw> : index
   %0 = affine.linearize_index disjoint [%a0, %a1] by (16) : index
   return %0 : index
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_constant_offsets.mlir
@@ -9,7 +9,7 @@ func.func @extract_constant_map_offset(%id: index) -> index {
 // CHECK-LABEL: func @extract_constant_map_offset
 // CHECK-SAME:    %[[ID:.+]]: index
 // CHECK:         %[[C32:.+]] = arith.constant 32 : index
-// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -22,7 +22,7 @@ func.func @extract_offset_unsimplified_map(%id: index) -> index {
 // CHECK-LABEL: func @extract_offset_unsimplified_map
 // CHECK-SAME:    %[[ID:.+]]: index
 // CHECK:         %[[C32:.+]] = arith.constant 32 : index
-// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[ID]], %[[C32]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -30,8 +30,8 @@ func.func @extract_offset_unsimplified_map(%id: index) -> index {
 func.func @fold_add_into_map(%id0: index, %id1: index) -> index {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
-  %a0 = arith.addi %id0, %c1 : index
-  %a1 = arith.addi %id1, %c2 : index
+  %a0 = arith.addi %id0, %c1 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
   %0 = affine.apply affine_map<(d0)[s0] -> (s0 + d0)>(%a0)[%a1]
   return %0 : index
 }
@@ -41,7 +41,7 @@ func.func @fold_add_into_map(%id0: index, %id1: index) -> index {
 // CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
 // CHECK:         %[[C3:.+]] = arith.constant 3 : index
 // CHECK:         %[[AFFINE_ADD:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%[[ID1]], %[[ID0]]]
-// CHECK:         %[[ADD:.+]] = arith.addi %[[AFFINE_ADD]], %[[C3]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[AFFINE_ADD]], %[[C3]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -51,8 +51,8 @@ func.func @propagate_constant_offsets_through_linearize(%id0: index, %id1: index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c13 = arith.constant 13 : index
-  %a0 = arith.addi %id0, %c1 : index
-  %a1 = arith.addi %id1, %c2 : index
+  %a0 = arith.addi %id0, %c1 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
   %0 = affine.linearize_index [%a0, %c0, %a1, %c13] by (3, 5, 7, 11) : index
   return %0 : index
 }
@@ -64,7 +64,7 @@ func.func @propagate_constant_offsets_through_linearize(%id0: index, %id1: index
 // Total constant offset = 1 * 5 * 7 * 11 + 2 * 11 + 13 = 420
 // CHECK:         %[[C420:.+]] = arith.constant 420 : index
 // CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID0]], %c0, %[[ID1]], %c0] by (3, 5, 7, 11) : index
-// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C420]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C420]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -72,7 +72,7 @@ func.func @propagate_constant_offsets_through_linearize(%id0: index, %id1: index
 func.func @propagate_constant_offsets_unbounded(%id: index) -> index {
   %c2 = arith.constant 2 : index
   %c13 = arith.constant 13 : index
-  %a = arith.addi %id, %c2 : index
+  %a = arith.addi %id, %c2 overflow<nsw> : index
   %0 = affine.linearize_index [%a, %c13] by (11) : index
   return %0 : index
 }
@@ -83,7 +83,7 @@ func.func @propagate_constant_offsets_unbounded(%id: index) -> index {
 // Total constant offset = 2 * 11 + 13 = 35
 // CHECK:         %[[C35:.+]] = arith.constant 35 : index
 // CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID]], %c0] by (11) : index
-// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -93,8 +93,8 @@ func.func @propagate_constant_offsets_stop_dynamic(%id0: index, %id1: index, %s1
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c13 = arith.constant 13 : index
-  %a0 = arith.addi %id0, %c1 : index
-  %a1 = arith.addi %id1, %c2 : index
+  %a0 = arith.addi %id0, %c1 overflow<nsw> : index
+  %a1 = arith.addi %id1, %c2 overflow<nsw> : index
   %0 = affine.linearize_index disjoint [%a0, %c0, %a1, %c13] by (3, %s1, 7, 11) : index
   return %0 : index
 }
@@ -106,9 +106,9 @@ func.func @propagate_constant_offsets_stop_dynamic(%id0: index, %id1: index, %s1
 
 // Total constant offset before dynamic = 2 * 11 + 13 = 35
 // CHECK:         %[[C35:.+]] = arith.constant 35 : index
-// CHECK:         %[[ADD0:.+]] = arith.addi %[[ID0]], %c1 : index
+// CHECK:         %[[ADD0:.+]] = arith.addi %[[ID0]], %c1 overflow<nsw> : index
 // CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index disjoint [%[[ADD0]], %c0, %[[ID1]], %c0] by (3, %[[S1]], 7, 11) : index
-// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] : index
+// CHECK:         %[[ADD:.+]] = arith.addi %[[LINEARIZE]], %[[C35]] overflow<nsw> : index
 // CHECK:         return %[[ADD]]
 
 // -----
@@ -116,8 +116,8 @@ func.func @propagate_constant_offsets_stop_dynamic(%id0: index, %id1: index, %s1
 func.func @fold_mul_into_linearize(%id0: index, %id1: index) -> index {
   %c2 = arith.constant 2 : index
   %c4 = arith.constant 4 : index
-  %a0 = arith.muli %id0, %c2 : index
-  %a1 = arith.muli %id1, %c4 : index
+  %a0 = arith.muli %id0, %c2 overflow<nsw> : index
+  %a1 = arith.muli %id1, %c4 overflow<nsw> : index
   %0 = affine.linearize_index disjoint [%a0, %a1] by (16) : index
   return %0 : index
 }
@@ -132,7 +132,7 @@ func.func @fold_mul_into_linearize(%id0: index, %id1: index) -> index {
 
 func.func @nofold_mul_indivisible(%id0: index, %id1: index) -> index {
   %c7 = arith.constant 7 : index
-  %a = arith.muli %id1, %c7 : index
+  %a = arith.muli %id1, %c7 overflow<nsw> : index
   %0 = affine.linearize_index [%id0, %a] by (16) : index
   return %0 : index
 }
@@ -140,6 +140,6 @@ func.func @nofold_mul_indivisible(%id0: index, %id1: index) -> index {
 // CHECK-LABEL: func @nofold_mul_indivisible
 // CHECK-SAME:    %[[ID0:[A-Za-z0-9]+]]: index
 // CHECK-SAME:    %[[ID1:[A-Za-z0-9]+]]: index
-// CHECK:         %[[MUL:.+]] = arith.muli %[[ID1]], %c7 : index
+// CHECK:         %[[MUL:.+]] = arith.muli %[[ID1]], %c7 overflow<nsw> : index
 // CHECK:         %[[LINEARIZE:.+]] = affine.linearize_index [%[[ID0]], %[[MUL]]] by (16) : index
 // CHECK:         return %[[LINEARIZE]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1098,6 +1098,11 @@ addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
       // full complexity.
       .addPass(createVectorTransferLoweringPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
+      // Propagate constants close to loads/stores to improve the ability for
+      // swizzling to CSE.
+      .addPass(createPropagateConstantOffsetsPass)
+      // Propagating constants introduces CSE opportunities.
+      .addPass(createCSEPass)
       // Resolve swizzling hints before lowering affine ops but after
       // lowering vector (transfer) ops.
       .addPass(createResolveSwizzleHintsPass)
@@ -1152,7 +1157,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       // Hoist any newly static allocations from PadDynamicAlloc.
       .addPass(createHoistStaticallyBoundAllocationsPass)
 
-      .addPass(createLowerAffinePass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -49,8 +49,8 @@
 // CHECK-DAG: %[[TID_Y_IDX:.*]] = llvm.mul %[[TID_Y_TRUNC]], %[[C64]] overflow<nsw> : i32
 //
 // Match the loop invariant math on the special registers.
-// CHECK: %[[GRP_IDX:.*]] = llvm.add %[[TID_Y_IDX]], %[[LANEID_TRUNC]]  : i32
-// CHECK: %[[GRP_IDX1:.*]] = llvm.add %[[GRP_IDX]], %{{.*}}  : i32
+// CHECK: %[[GRP_IDX:.*]] = llvm.add %[[TID_Y_IDX]], %{{.*}}  : i32
+// CHECK: %[[GRP_IDX1:.*]] = llvm.add %[[GRP_IDX]], %[[LANEID_TRUNC]]  : i32
 // CHECK: %[[GRP_IDX2:.*]] = llvm.and %[[GRP_IDX1]], %[[C6]]  : i32
 // CHECK: %[[GRP_IDX3:.*]] = llvm.shl %[[GRP_IDX2]], %[[C2]]  : i32
 // CHECK: %{{.*}} = llvm.xor %[[SRC:.*]], %[[GRP_IDX3]]  : i32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -54,7 +54,7 @@
 // CHECK: %[[GRP_IDX2:.*]] = llvm.and %[[GRP_IDX1]], %[[C6]]  : i32
 // CHECK: %[[GRP_IDX3:.*]] = llvm.shl %[[GRP_IDX2]], %[[C2]]  : i32
 // CHECK: %{{.*}} = llvm.xor %[[SRC:.*]], %[[GRP_IDX3]]  : i32
-// CHECK: %[[ADJ_SRC:.*]] = llvm.add %[[SRC]], %[[C16]]  : i32
+// CHECK: %[[ADJ_SRC:.*]] = llvm.add %[[SRC]], %[[C16]] overflow<nsw> : i32
 // CHECK: %[[INV:.*]] = llvm.xor %[[ADJ_SRC]], %[[GRP_IDX3]]  : i32
 // CHECK: %[[INV_EXT:.*]] = llvm.zext %[[INV]] : i32 to i64
 //


### PR DESCRIPTION
The pass added in this patch attempts to bubble constant offsets which are typical when computing the offset of unrolled hyperdimensional memory accesses closer to the access. The motivation for this is two-fold:

1. It enables better CSE opportunities earlier on by pulling out the constant portions of [affine] arithmetic and leaving the thread/workgroup id dependent portion alone, which typically is the same across multiple accesses post vector unrolling.
2. By having constant additions be the last part of an offset calculation, it increases the chance for the backend to utilize constant offset fields for various targets.

Note that this is a problem somewhat unique to hyperdimensional code generation. When unrolling the access of a simple 1-d vectorized load, the constant offset can be easily separating from the base offset. With unrolling of accesses of greater dimensionality, a linearization step complicates extracting a shared constant offset.

This pass is added to the end of the LLVMGPU pipeline after vector lowerings (so unrolling has kicked in) and before resolving swizzle hints (the first place we expect to take advantage of the transformation done here).

Additionally there was a premature call to LowerAffine in the LLVMGPU pipeline dropped to make address computation work as expected, as affine ops are introduced after that lowering, leading to unexpected mixing of arith and affine.