### PR TITLE
[Codegen] Fix lhs/rhs batch offsets size in vector contract distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -155,8 +155,8 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     LLVM_DEBUG(llvm::dbgs() << "init tile: " << finalTile << "\n");
 
     // Offsets into the LHS/RHS batches.
-    SmallVector<int64_t> lhsBatchOffsets(rank, 0);
-    SmallVector<int64_t> rhsBatchOffsets(rank, 0);
+    SmallVector<int64_t> lhsBatchOffsets(lhsLayout.getRank(), 0);
+    SmallVector<int64_t> rhsBatchOffsets(rhsLayout.getRank(), 0);
 
     // Offsets into the result batches.
     ArrayRef<int64_t> resultBatches = resultLayout.getBatchTile();


### PR DESCRIPTION
I encountered this case of a vector contract with 3D inputs and 2D output in e2e Llama3 with padding and it needs the batch offsets size to be set based on the corresponding inputs' rank to avoid an index out of range.