### PR TITLE
[Integrate] Drop revert for vectorization API change

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -277,7 +277,11 @@ vectorizeCopyToWorkgroupMemoryOps(mlir::FunctionOpInterface funcOp) {
 
   funcOp.walk([&](linalg::GenericOp op) {
     if (succeeded(filter.checkAndNotify(rewriter, op))) {
-      (void)linalg::vectorize(rewriter, op);
+      FailureOr<linalg::VectorizationResult> result =
+          linalg::vectorize(rewriter, op);
+      if (succeeded(result)) {
+        rewriter.replaceOp(op, result->replacements);
+      }
     }
   });
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -171,8 +171,11 @@ void GenericVectorizationPass::runOnOperation() {
       (void)IREE::VectorExt::vectorizeLinalgExtGatherToTransferGather(rewriter,
                                                                       gatherOp);
     } else {
-      (void)linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
-                              vectorizeGatherAccesses);
+      FailureOr<linalg::VectorizationResult> result = linalg::vectorize(
+          rewriter, op, vectorSizes, scalableVecDims, vectorizeGatherAccesses);
+      if (succeeded(result)) {
+        rewriter.replaceOp(op, result->replacements);
+      }
     }
   };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -365,8 +365,13 @@ LogicalResult vectorizeGatherLikeGenericToTransferGather(
 
   // If no extract op was found, call generic vectorization.
   if (!extractOp) {
-    return linalg::vectorize(rewriter, linalgOp, vectorSizes, scalableVecDims,
-                             vectorizeNDExtract);
+    FailureOr<linalg::VectorizationResult> result = linalg::vectorize(
+        rewriter, linalgOp, vectorSizes, scalableVecDims, vectorizeNDExtract);
+    if (failed(result)) {
+      return failure();
+    }
+    rewriter.replaceOp(linalgOp, result->replacements);
+    return success();
   }
 
   Location loc = linalgOp->getLoc();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -43,7 +43,11 @@ static void vectorizeLinalgOps(mlir::FunctionOpInterface funcOp) {
             op)) {
       return WalkResult::advance();
     }
-    (void)linalg::vectorize(rewriter, op);
+    FailureOr<linalg::VectorizationResult> result =
+        linalg::vectorize(rewriter, op);
+    if (succeeded(result)) {
+      rewriter.replaceOp(op, result->replacements);
+    }
     return WalkResult::advance();
   });
 }


### PR DESCRIPTION
Drops a revert of https://github.com/llvm/llvm-project/pull/144158 in llvm-project, which changed the linalg::vectorize api to return vectorized values instead of replacing the source op.