### PR TITLE
[Codegen] Bubble up/down reshape operations before blocking dynamic dimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -427,3 +427,21 @@ func.func @block_dims_with_map_scatter(%size: index) -> tensor<?xf32> {
 //  CHECK-SAME:     outs(%[[EMPTY]] : tensor<?x16xf32>)
 //       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
 //       CHECK:   return %[[MAP_SCATTER]]
+
+// -----
+
+func.func @reshape_propagation_before_blocking_test(%arg0: index, %arg1: index, %arg2: tensor<?xbf16>) -> tensor<?x4096xf8E4M3FNUZ> {
+  %0 = util.assume.int %arg1<umin = 128, umax = 524160, udiv = 128> : index
+  %1 = tensor.empty(%0) : tensor<?xf8E4M3FNUZ>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg2 : tensor<?xbf16>) outs(%1 : tensor<?xf8E4M3FNUZ>) {
+  ^bb0(%in: bf16, %out: f8E4M3FNUZ):
+    %3 = arith.truncf %in : bf16 to f8E4M3FNUZ
+    linalg.yield %3 : f8E4M3FNUZ
+  } -> tensor<?xf8E4M3FNUZ>
+  %expanded = tensor.expand_shape %2 [[0, 1]] output_shape [%0, 4096] : tensor<?xf8E4M3FNUZ> into tensor<?x4096xf8E4M3FNUZ>
+  return %expanded : tensor<?x4096xf8E4M3FNUZ>
+}
+// CHECK-LABEL: func @reshape_propagation_before_blocking_test(
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty{{.*}} tensor<?x128x4096xf8E4M3FNUZ>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:     outs(%[[EMPTY]] : tensor<?x128x4096xf8E4M3FNUZ>)


### PR DESCRIPTION
The SetEncodingPass can insert reshape operations into dispatch regions and this leads to chains of reshape operations after dynamic dimension blocking. Bubbling up/down reshape operations before blocking leads to simpler IR afterwards. For example, this would result into the following generic + store:

```
%32 = tensor.empty(%26) : tensor<?x128x4096xf8E4M3FNUZ>
%33 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%31, %30 : tensor<?x128x4096xbf16>, tensor<f32>) outs(%32 : tensor<?x128x4096xf8E4M3FNUZ>) {
^bb0(%in: bf16, %in_1: f32, %out: f8E4M3FNUZ):
  %34 = arith.truncf %in_1 : f32 to bf16
  %35 = arith.divf %in, %34 : bf16
  %36 = arith.cmpf ult, %35, %cst : bf16
  %37 = arith.select %36, %cst, %35 : bf16
  %38 = arith.cmpf ugt, %37, %cst_0 : bf16
  %39 = arith.select %38, %cst_0, %37 : bf16
  %40 = arith.truncf %39 : bf16 to f8E4M3FNUZ
  linalg.yield %40 : f8E4M3FNUZ
} -> tensor<?x128x4096xf8E4M3FNUZ>
iree_tensor_ext.dispatch.tensor.store %33, %29, offsets = [0, 0, 0], sizes = [%28, 128, 4096], strides = [1, 1, 1] : tensor<?x128x4096xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x128x4224xf8E4M3FNUZ>>{%28}
```
Instead of:
```
%32 = tensor.empty(%31) : tensor<?x524288xf8E4M3FNUZ>
%33 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%30, %29 : tensor<?x524288xbf16>, tensor<f32>) outs(%32 : tensor<?x524288xf8E4M3FNUZ>) {
^bb0(%in: bf16, %in_1: f32, %out: f8E4M3FNUZ):
  %34 = arith.truncf %in_1 : f32 to bf16
  %35 = arith.divf %in, %34 : bf16
  %36 = arith.cmpf ult, %35, %cst : bf16
  %37 = arith.select %36, %cst, %35 : bf16
  %38 = arith.cmpf ugt, %37, %cst_0 : bf16
  %39 = arith.select %38, %cst_0, %37 : bf16
  %40 = arith.truncf %39 : bf16 to f8E4M3FNUZ
  linalg.yield %40 : f8E4M3FNUZ
} -> tensor<?x524288xf8E4M3FNUZ>
%collapsed = tensor.collapse_shape %33 [[0, 1]] : tensor<?x524288xf8E4M3FNUZ> into tensor<?xf8E4M3FNUZ>
%expanded = tensor.expand_shape %collapsed [[0, 1]] output_shape [%24, 4096] : tensor<?xf8E4M3FNUZ> into tensor<?x4096xf8E4M3FNUZ>
iree_tensor_ext.dispatch.tensor.store %expanded, %27, offsets = [0, 0], sizes = [%24, 4096], strides = [1, 1] : tensor<?x4096xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x4224xf8E4M3FNUZ>>{%24}
```
I encountered this in Llama3 with padding enabled and the bubbling avoids a copy being introduced in the dispatch during codegen.