### PR TITLE
Integrate LLVM to llvm/llvm-project@a99fee69

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
@@ -65,7 +65,7 @@ static std::tuple<Value, OpFoldResult, SmallVector<OpFoldResult>, OpFoldResult,
                   OpFoldResult>
 getFlatOffsetAndStrides(OpBuilder &rewriter, Location loc, Value source,
                         ArrayRef<OpFoldResult> subOffsets,
-                        ArrayRef<OpFoldResult> subStrides = std::nullopt) {
+                        ArrayRef<OpFoldResult> subStrides = {}) {
   auto sourceType = cast<MemRefType>(source.getType());
   auto sourceRank = static_cast<unsigned>(sourceType.getRank());
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -2335,8 +2335,8 @@ static TypedAttr constFoldBinaryCmpFOp(Attribute rawLhs, Attribute rawRhs,
         calculate);
     if (!elementResult)
       return {};
-    auto resultType = lhs.getType().clone(
-        std::nullopt, IntegerType::get(lhs.getContext(), 32));
+    auto resultType =
+        lhs.getType().clone({}, IntegerType::get(lhs.getContext(), 32));
     return DenseElementsAttr::get(resultType, elementResult);
   } else if (auto lhs = llvm::dyn_cast_if_present<ElementsAttr>(rawLhs)) {
     auto rhs = llvm::dyn_cast_if_present<ElementsAttr>(rawRhs);
@@ -2353,8 +2353,8 @@ static TypedAttr constFoldBinaryCmpFOp(Attribute rawLhs, Attribute rawRhs,
       ++lhsIt;
       ++rhsIt;
     }
-    auto resultType = lhs.getShapedType().clone(
-        std::nullopt, IntegerType::get(lhs.getContext(), 32));
+    auto resultType =
+        lhs.getShapedType().clone({}, IntegerType::get(lhs.getContext(), 32));
     return DenseElementsAttr::get(resultType, resultAttrs);
   }
   return {};

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -121,7 +121,7 @@ void FuncOp::build(OpBuilder &builder, OperationState &result, StringRef name,
   assert(type.getNumInputs() == argAttrs.size() &&
          "expected as many argument attribute lists as arguments");
   call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
-                                            /*resultAttrs=*/std::nullopt,
+                                            /*resultAttrs=*/{},
                                             getArgAttrsAttrName(result.name),
                                             getResAttrsAttrName(result.name));
 }
@@ -290,7 +290,7 @@ ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
            << "invalid result type list";
   }
   call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
-                                            /*resultAttrs=*/std::nullopt,
+                                            /*resultAttrs=*/{},
                                             getArgAttrsAttrName(result.name),
                                             getResAttrsAttrName(result.name));
   if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes))) {
@@ -359,7 +359,7 @@ void ImportOp::build(OpBuilder &builder, OperationState &result, StringRef name,
     assert(type.getNumInputs() == argAttrs.size() &&
            "expected as many argument attribute lists as arguments");
     call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
-                                              /*resultAttrs=*/std::nullopt,
+                                              /*resultAttrs=*/{},
                                               getArgAttrsAttrName(result.name),
                                               getResAttrsAttrName(result.name));
   }

--- a/compiler/src/iree/compiler/Reducer/Framework/Oracle.cpp
+++ b/compiler/src/iree/compiler/Reducer/Framework/Oracle.cpp
@@ -73,7 +73,7 @@ bool Oracle::isInteresting(WorkItem &workItem) {
 
   std::string errMsg;
   int exitCode = llvm::sys::ExecuteAndWait(testScript, testerArgs, std::nullopt,
-                                           std::nullopt, 0, 0, &errMsg);
+                                           {}, 0, 0, &errMsg);
 
   if (exitCode < 0) {
     llvm::report_fatal_error(llvm::Twine("Failed to run oracle: ") + errMsg);


### PR DESCRIPTION
Carrying-over previous reverts:

- https://github.com/llvm/llvm-project/commit/ee070d08163ac09842d9bf0c1315f311df39faf1 and https://github.com/llvm/llvm-project/commit/a1c2a712939897251729b6fc436a2db7db6f03fc: after making the necessary C++ fixes to unbreak the build (https://gist.github.com/bjacob/a132e70ea0f7ceba4554f352a45bcd1c), these break bufferization and eliminate-empty-tensors tests that I don't understand.
Corresponding Bazel changes also reverted: https://github.com/llvm/llvm-project/commit/2a41350aabd8b7d3e406141a55ce0bb6f5e70a76, https://github.com/llvm/llvm-project/commit/8fc20bffabe7fe6cdc4a9ec1bc79202eba5f1f23.

- https://github.com/llvm/llvm-project/commit/eb694b28461fdbd5e347fca59829e8a9ad021773 and https://github.com/llvm/llvm-project/commit/e33f13ba4824d807e846e7783a48efd6c0bf58ee : these break arith.trunci with destination type i1, which occurs at least in the jit_globals.mlir test.