### PR TITLE
[Codegen] Fix TileLargeTensors handling of dynamic reduction dims

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -62,8 +62,9 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
   // because outputs should reflect the full parallel iteration space.
   int64_t staticNumTrips = 1;
   for (auto [size, type] : llvm::zip_equal(staticTileSizes, iteratorTypes)) {
-    // Skip reduction iterators.
+    // Skip tiling of reduction iterators.
     if (type == utils::IteratorType::reduction) {
+      size = 0;
       continue;
     }
     if (ShapedType::isDynamic(size)) {


### PR DESCRIPTION
When setting up tile sizes, currently it leaves reduction dimensions alone to avoid tiling them. If the reduction dim is dynamic, however, this will result in a tile size of ShapedType::kDynamic. Set the tile size to 0 instead.