### PR TITLE
[Codegen] Support inner_tiled and load_from_buffer in ConvertAccGEMMToGEMMPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -27,96 +29,94 @@ namespace mlir::iree_compiler {
 #define GEN_PASS_DEF_CONVERTACCGEMMTOGEMMPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
-namespace {
-
-struct ConvertAccGEMMtoGEMM final
-    : OpInterfaceRewritePattern<linalg::LinalgOp> {
-  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
-                                PatternRewriter &rewriter) const override {
-    if (!linalg::isaContractionOpInterface(linalgOp) &&
-        !isa<linalg::ConvolutionOpInterface>(*linalgOp)) {
-      return failure();
-    }
-    if (!linalgOp.hasPureTensorSemantics())
-      return failure();
-
-    // Nothing to do if the output tensor operand is already a fill op.
-    SmallVector<OpOperand *> outputOperands;
-    if (!linalgOp.hasPureBufferSemantics()) {
-      outputOperands = llvm::to_vector(
-          llvm::make_pointer_range(linalgOp.getDpsInitsMutable()));
-    }
-
-    Value outputOperand = outputOperands.front()->get();
-
-    auto outsDefiningOp =
-        outputOperand.getDefiningOp<IREE::TensorExt::DispatchTensorLoadOp>();
-    if (!outsDefiningOp) {
-      // If not DispatchTensorLoadOp then do nothing.
-      return failure();
-    }
-    auto outputType = cast<RankedTensorType>(outputOperand.getType());
-    if (!outputType.getElementType().isIntOrFloat())
-      return failure();
-    auto elementType = outputType.getElementType();
-
-    Location loc = linalgOp.getLoc();
-
-    // Check if the output tensor access is a projected permutation
-    if (!linalgOp.getMatchingIndexingMap(outputOperands.front())
-             .isProjectedPermutation()) {
-      return rewriter.notifyMatchFailure(
-          linalgOp, "Output indexing map must be a projected permutation.");
-    }
-
-    int64_t outputRank = outputType.getRank();
-    SmallVector<utils::IteratorType> iterators(outputRank,
-                                               utils::IteratorType::parallel);
-    SmallVector<AffineMap> maps(3, rewriter.getMultiDimIdentityMap(outputRank));
-
-    // Create a zero tensor as the new output tensor operand to the Linalg
-    // contraction op.
-    SmallVector<OpFoldResult> mixedSizes =
-        tensor::getMixedSizes(rewriter, loc, outputOperand);
-    auto initOp =
-        rewriter.create<tensor::EmptyOp>(loc, mixedSizes, elementType);
-    Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
-    Value fill =
-        rewriter.create<linalg::FillOp>(loc, zero, initOp.getResult()).result();
-
-    // Update the contraction op to use the new zero tensor as output operand.
-    rewriter.modifyOpInPlace(linalgOp,
-                             [&]() { linalgOp.setDpsInitOperand(0, fill); });
-
-    // Create a generic op to add back the original output tensor operand.
-    rewriter.setInsertionPointAfter(linalgOp);
-    auto genericOp = rewriter.create<linalg::GenericOp>(
-        loc, outputType, ValueRange{linalgOp->getResult(0), outputOperand},
-        fill, maps, iterators,
-        [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
-          Value result;
-          if (llvm::isa<FloatType>(elementType)) {
-            result = b.create<arith::AddFOp>(nestedLoc, args[0], args[1]);
-          } else {
-            result = b.create<arith::AddIOp>(nestedLoc, args[0], args[1]);
-          }
-          b.create<linalg::YieldOp>(nestedLoc, result);
-        });
-    linalgOp->getResult(0).replaceAllUsesExcept(genericOp->getResult(0),
-                                                genericOp);
-    return success();
+static bool accGemmToGemmPrecondition(Operation *op) {
+  if (auto innerTiledOp = dyn_cast<IREE::Codegen::InnerTiledOp>(op)) {
+    return isa<IREE::GPU::MmaInterfaceAttr>(innerTiledOp.getKind());
   }
-};
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) {
+    return false;
+  }
+  if (!linalg::isaContractionOpInterface(linalgOp) &&
+      !isa<linalg::ConvolutionOpInterface>(*linalgOp)) {
+    return false;
+  }
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return false;
+  }
+  return linalgOp.getMatchingIndexingMap(linalgOp.getDpsInitOperand(0))
+      .isProjectedPermutation();
+}
+
+static void convertAccGemmToGemm(RewriterBase &rewriter,
+                                 DestinationStyleOpInterface dpsOp) {
+  SmallVector<OpOperand *> outputOperands =
+      llvm::to_vector(llvm::make_pointer_range(dpsOp.getDpsInitsMutable()));
+  Value outputOperand = outputOperands.front()->get();
+  auto outsDefiningOp = outputOperand.getDefiningOp();
+  // If not DispatchTensorLoadOp or LoadFromBufferOp then do nothing.
+  if (!isa_and_nonnull<IREE::TensorExt::DispatchTensorLoadOp,
+                       IREE::Codegen::LoadFromBufferOp>(outsDefiningOp)) {
+    return;
+  }
+  auto outputType = cast<RankedTensorType>(outputOperand.getType());
+  if (!outputType.getElementType().isIntOrFloat()) {
+    return;
+  }
+  auto elementType = outputType.getElementType();
+
+  Location loc = dpsOp.getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(dpsOp);
+
+  int64_t outputRank = outputType.getRank();
+  SmallVector<utils::IteratorType> iterators(outputRank,
+                                             utils::IteratorType::parallel);
+  SmallVector<AffineMap> maps(3, rewriter.getMultiDimIdentityMap(outputRank));
+
+  // Create a zero tensor as the new output tensor operand to the Linalg
+  // contraction op.
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(rewriter, loc, outputOperand);
+  auto initOp = rewriter.create<tensor::EmptyOp>(loc, mixedSizes, elementType);
+  Value zero = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(elementType));
+  Value fill =
+      rewriter.create<linalg::FillOp>(loc, zero, initOp.getResult()).result();
+
+  // Update the contraction op to use the new zero tensor as output operand.
+  rewriter.modifyOpInPlace(dpsOp, [&]() { dpsOp.setDpsInitOperand(0, fill); });
+
+  // Create a generic op to add back the original output tensor operand.
+  rewriter.setInsertionPointAfter(dpsOp);
+  auto genericOp = rewriter.create<linalg::GenericOp>(
+      loc, outputType, ValueRange{dpsOp->getResult(0), outputOperand}, fill,
+      maps, iterators, [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+        Value result;
+        if (llvm::isa<FloatType>(elementType)) {
+          result = b.create<arith::AddFOp>(nestedLoc, args[0], args[1]);
+        } else {
+          result = b.create<arith::AddIOp>(nestedLoc, args[0], args[1]);
+        }
+        b.create<linalg::YieldOp>(nestedLoc, result);
+      });
+  dpsOp->getResult(0).replaceAllUsesExcept(genericOp->getResult(0), genericOp);
+}
+
+namespace {
 
 struct ConvertAccGEMMToGEMMPass final
     : impl::ConvertAccGEMMToGEMMPassBase<ConvertAccGEMMToGEMMPass> {
   void runOnOperation() override {
-    RewritePatternSet patterns(&getContext());
-    patterns.add<ConvertAccGEMMtoGEMM>(&getContext());
-    walkAndApplyPatterns(getOperation(), std::move(patterns));
+    FunctionOpInterface funcOp = getOperation();
+    SmallVector<Operation *> candidates = llvm::filter_to_vector(
+        llvm::make_pointer_range(funcOp.getFunctionBody().getOps()),
+        accGemmToGemmPrecondition);
+    IRRewriter rewriter(&getContext());
+    for (Operation *candidate : candidates) {
+      convertAccGemmToGemm(rewriter,
+                           cast<DestinationStyleOpInterface>(candidate));
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -83,7 +83,7 @@ def ConcretizePadResultShapePass :
 }
 
 def ConvertAccGEMMToGEMMPass :
-    Pass<"iree-convert-accgemm-to-gemm", ""> {
+    InterfacePass<"iree-convert-accgemm-to-gemm", "mlir::FunctionOpInterface"> {
   let summary = "Convert accumulating GEMMs to GEMMs post dispatch creation.";
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_accgemm_to_gemm.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_accgemm_to_gemm.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-convert-accgemm-to-gemm %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-convert-accgemm-to-gemm))" %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
@@ -33,6 +33,32 @@ func.func @accumulate_gemm(%1 : tensor<512x128xi8>, %2 : tensor<512x128xi8>) {
 //       CHECK: %[[ADD:.+]] = linalg.generic {{.+}} ins(%[[GEMM]]
 //       CHECK: iree_tensor_ext.dispatch.tensor.store %[[ADD]]
 
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+func.func @accumulate_inner_tiled(%1 : tensor<?x?x4xf16>, %2 : tensor<?x?x4xf16>, %3 : memref<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  %4 = iree_codegen.load_from_buffer %3 : memref<?x?x4xf32> -> tensor<?x?x4xf32>
+  %5 = iree_codegen.inner_tiled ins(%1, %2) outs(%4) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>,
+                     affine_map<(i, j, k) -> (k, j)>,
+                     affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %5 : tensor<?x?x4xf32>
+}
+
+// CHECK-LABEL: func.func @accumulate_inner_tiled
+//       CHECK: %[[FILL:.+]] = linalg.fill
+//       CHECK: %[[GEMM:.+]] = iree_codegen.inner_tiled {{.*}} outs(%[[FILL]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -761,6 +761,7 @@ hal.executable public @main {
 // CHECK-DAG:  %[[BUFFER_C:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_C]]
 // CHECK-DAG:  %[[A_ALLOC:.+]] = memref.alloc() : memref<1x1x8x4x4x4x4xf32, #gpu.address_space<workgroup>>
 // CHECK-DAG:  %[[B_ALLOC:.+]] = memref.alloc() : memref<1x1x4x2x4x16x4xf32, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[C_INIT:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
 // CHECK:      gpu.barrier
 // CHECK-DAG:  %[[A_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BUFFER_A]]{{.*}} vector<4xf32>
 // CHECK-DAG:  %[[B_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BUFFER_B]]{{.*}} vector<4xf32>
@@ -769,11 +770,6 @@ hal.executable public @main {
 // CHECK:      gpu.barrier
 // CHECK-DAG:  %[[A_READ:.+]] = vector.transfer_read %[[A_ALLOC]]{{.*}} vector<8x1x1x1x4xf32>
 // CHECK-DAG:  %[[B_READ:.+]] = vector.transfer_read %[[B_ALLOC]]{{.*}} vector<2x1x1x4xf32>
-// CHECK-DAG:  %[[C_READ:.+]] = vector.transfer_read %[[BUFFER_C]]{{.*}} vector<8x2x1x1x4xf32>
-// CHECK-DAG:  %[[C_00_0:.+]] = vector.extract %[[C_READ]][0, 0, 0, 0] : vector<4xf32> from vector<8x2x1x1x4xf32>
-// CHECK-DAG:  %[[C_01_0:.+]] = vector.extract %[[C_READ]][0, 1, 0, 0] : vector<4xf32> from vector<8x2x1x1x4xf32>
-// CHECK-DAG:  %[[C_70_0:.+]] = vector.extract %[[C_READ]][7, 0, 0, 0] : vector<4xf32> from vector<8x2x1x1x4xf32>
-// CHECK-DAG:  %[[C_71_0:.+]] = vector.extract %[[C_READ]][7, 1, 0, 0] : vector<4xf32> from vector<8x2x1x1x4xf32>
 // CHECK-DAG:  %[[A_EXTRACT00:.+]] = vector.extract %[[A_READ]][0, 0, 0, 0, 0] : f32 from vector<8x1x1x1x4xf32>
 // CHECK-DAG:  %[[A_EXTRACT01:.+]] = vector.extract %[[A_READ]][0, 0, 0, 0, 1] : f32 from vector<8x1x1x1x4xf32>
 // CHECK-DAG:  %[[A_EXTRACT02:.+]] = vector.extract %[[A_READ]][0, 0, 0, 0, 2] : f32 from vector<8x1x1x1x4xf32>
@@ -790,19 +786,19 @@ hal.executable public @main {
 // CHECK-DAG:  %[[B_EXTRACT11:.+]] = vector.extract %[[B_READ]][1, 0, 0, 1] : f32 from vector<2x1x1x4xf32>
 // CHECK-DAG:  %[[B_EXTRACT12:.+]] = vector.extract %[[B_READ]][1, 0, 0, 2] : f32 from vector<2x1x1x4xf32>
 // CHECK-DAG:  %[[B_EXTRACT13:.+]] = vector.extract %[[B_READ]][1, 0, 0, 3] : f32 from vector<2x1x1x4xf32>
-// CHECK-DAG:  %[[C_00_1:.+]] = amdgpu.mfma %[[A_EXTRACT00]] * %[[B_EXTRACT00]] + %[[C_00_0]]
+// CHECK-DAG:  %[[C_00_1:.+]] = amdgpu.mfma %[[A_EXTRACT00]] * %[[B_EXTRACT00]] + %[[C_INIT]]
 // CHECK-DAG:  %[[C_00_2:.+]] = amdgpu.mfma %[[A_EXTRACT01]] * %[[B_EXTRACT01]] + %[[C_00_1]]
 // CHECK-DAG:  %[[C_00_3:.+]] = amdgpu.mfma %[[A_EXTRACT02]] * %[[B_EXTRACT02]] + %[[C_00_2]]
 // CHECK-DAG:  %[[C_00_4:.+]] = amdgpu.mfma %[[A_EXTRACT03]] * %[[B_EXTRACT03]] + %[[C_00_3]]
-// CHECK-DAG:  %[[C_01_1:.+]] = amdgpu.mfma %[[A_EXTRACT00]] * %[[B_EXTRACT10]] + %[[C_01_0]]
+// CHECK-DAG:  %[[C_01_1:.+]] = amdgpu.mfma %[[A_EXTRACT00]] * %[[B_EXTRACT10]] + %[[C_INIT]]
 // CHECK-DAG:  %[[C_01_2:.+]] = amdgpu.mfma %[[A_EXTRACT01]] * %[[B_EXTRACT11]] + %[[C_01_1]]
 // CHECK-DAG:  %[[C_01_3:.+]] = amdgpu.mfma %[[A_EXTRACT02]] * %[[B_EXTRACT12]] + %[[C_01_2]]
 // CHECK-DAG:  %[[C_01_4:.+]] = amdgpu.mfma %[[A_EXTRACT03]] * %[[B_EXTRACT13]] + %[[C_01_3]]
-// CHECK-DAG:  %[[C_70_1:.+]] = amdgpu.mfma %[[A_EXTRACT70]] * %[[B_EXTRACT00]] + %[[C_70_0]]
+// CHECK-DAG:  %[[C_70_1:.+]] = amdgpu.mfma %[[A_EXTRACT70]] * %[[B_EXTRACT00]] + %[[C_INIT]]
 // CHECK-DAG:  %[[C_70_2:.+]] = amdgpu.mfma %[[A_EXTRACT71]] * %[[B_EXTRACT01]] + %[[C_70_1]]
 // CHECK-DAG:  %[[C_70_3:.+]] = amdgpu.mfma %[[A_EXTRACT72]] * %[[B_EXTRACT02]] + %[[C_70_2]]
 // CHECK-DAG:  %[[C_70_4:.+]] = amdgpu.mfma %[[A_EXTRACT73]] * %[[B_EXTRACT03]] + %[[C_70_3]]
-// CHECK-DAG:  %[[C_71_1:.+]] = amdgpu.mfma %[[A_EXTRACT70]] * %[[B_EXTRACT10]] + %[[C_71_0]]
+// CHECK-DAG:  %[[C_71_1:.+]] = amdgpu.mfma %[[A_EXTRACT70]] * %[[B_EXTRACT10]] + %[[C_INIT]]
 // CHECK-DAG:  %[[C_71_2:.+]] = amdgpu.mfma %[[A_EXTRACT71]] * %[[B_EXTRACT11]] + %[[C_71_1]]
 // CHECK-DAG:  %[[C_71_3:.+]] = amdgpu.mfma %[[A_EXTRACT72]] * %[[B_EXTRACT12]] + %[[C_71_2]]
 // CHECK-DAG:  %[[C_71_4:.+]] = amdgpu.mfma %[[A_EXTRACT73]] * %[[B_EXTRACT13]] + %[[C_71_3]]
@@ -810,6 +806,8 @@ hal.executable public @main {
 // CHECK:  vector.insert_strided_slice %[[C_01_4]], {{.*}}offsets = [0, 1, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
 // CHECK:  vector.insert_strided_slice %[[C_70_4]], {{.*}}offsets = [7, 0, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
 // CHECK:  vector.insert_strided_slice %[[C_71_4]], {{.*}}offsets = [7, 1, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
+// CHECK:  vector.transfer_read %[[BUFFER_C]]
+// CHECK:  arith.addf
 // CHECK:  vector.transfer_write
 
 // -----


### PR DESCRIPTION
Adds support for iree_codegen.inner_tiled ops in ConvertAccGEMMToGEMM, and allows iree_codegen.load_from_buffer as the source of the accumulator (instead of only iree_tensor_ext.dispatch.tensor.load). The pass is also refactored to a funcOp walk instead of a pattern rewrite to reuse more code without needing lots of unnecessary boilerplate.

This is needed for the data tiling path, since GEMMs are rewritten into inner_tiled ops as part of encoding materialization.