### PR TITLE
[Integrate] Update bufferization related codes for upstream custom types support.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -78,7 +78,12 @@ class EliminateEmptyTensorsPass final
     : public impl::EliminateEmptyTensorsPassBase<EliminateEmptyTensorsPass> {
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<tensor::TensorDialect>();
+    // BufferizationDialect is needed for using type interfaces, like
+    // TensorLikeType. Because the builtin types, e.g., RankedTensorType, etc.,
+    // implement the type interface in
+    // bufferization::BufferizationDialect::initialize().
+    registry
+        .insert<bufferization::BufferizationDialect, tensor::TensorDialect>();
   }
 
   void runOnOperation() override;

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -44,6 +44,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:BufferizationInterfaces",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -8,6 +8,9 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizationTypeInterfaces.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 
 namespace mlir::iree_compiler {
@@ -62,6 +65,39 @@ struct EncodingTypeExternalModel
   }
 };
 
+struct BuiltinTensorExternalModel
+    : bufferization::TensorLikeType::ExternalModel<
+          BuiltinTensorExternalModel, IREE::TensorExt::DispatchTensorType> {
+  llvm::FailureOr<bufferization::BufferLikeType> getBufferType(
+      mlir::Type type, const bufferization::BufferizationOptions &options,
+      llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
+    auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
+    auto tensorType = cast<TensorType>(dispatchTensorType.asRankedTensorType());
+    auto memSpace = options.defaultMemorySpaceFn(tensorType);
+    if (!memSpace.has_value())
+      return emitError() << "could not infer memory space";
+
+    return cast<bufferization::BufferLikeType>(
+        getMemRefType(tensorType, options, /*layout=*/{}, *memSpace));
+  }
+
+  mlir::LogicalResult verifyCompatibleBufferType(
+      mlir::Type type, bufferization::BufferLikeType bufferType,
+      llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
+    auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
+    assert(isa<BaseMemRefType>(bufferType) && "expected memref type");
+    auto memrefType = cast<ShapedType>(bufferType);
+
+    if (dispatchTensorType.getShape() != memrefType.getShape())
+      return emitError() << "shapes do not match";
+
+    if (dispatchTensorType.getBoundElementType() != memrefType.getElementType())
+      return emitError() << "element types do not match";
+
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 void registerTensorExtExternalModels(DialectRegistry &registry) {
@@ -72,7 +108,7 @@ void registerTensorExtExternalModels(DialectRegistry &registry) {
         IREE::TensorExt::DispatchWorkloadOrdinalOp::attachInterface<
             WorkloadOrdinalOpInterface>(*ctx);
         IREE::TensorExt::DispatchTensorType::attachInterface<
-            EncodingTypeExternalModel>(*ctx);
+            EncodingTypeExternalModel, BuiltinTensorExternalModel>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -68,33 +68,33 @@ struct EncodingTypeExternalModel
 struct BuiltinTensorExternalModel
     : bufferization::TensorLikeType::ExternalModel<
           BuiltinTensorExternalModel, IREE::TensorExt::DispatchTensorType> {
-  llvm::FailureOr<bufferization::BufferLikeType> getBufferType(
-      mlir::Type type, const bufferization::BufferizationOptions &options,
+  FailureOr<bufferization::BufferLikeType> getBufferType(
+      Type type, const bufferization::BufferizationOptions &options,
       llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
     auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
     auto tensorType = cast<TensorType>(dispatchTensorType.asRankedTensorType());
     auto memSpace = options.defaultMemorySpaceFn(tensorType);
-    if (!memSpace.has_value())
+    if (!memSpace.has_value()) {
       return emitError() << "could not infer memory space";
-
+    }
     return cast<bufferization::BufferLikeType>(
         getMemRefType(tensorType, options, /*layout=*/{}, *memSpace));
   }
 
-  mlir::LogicalResult verifyCompatibleBufferType(
-      mlir::Type type, bufferization::BufferLikeType bufferType,
+  LogicalResult verifyCompatibleBufferType(
+      Type type, bufferization::BufferLikeType bufferType,
       llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
     auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
     assert(isa<BaseMemRefType>(bufferType) && "expected memref type");
     auto memrefType = cast<ShapedType>(bufferType);
-
-    if (dispatchTensorType.getShape() != memrefType.getShape())
+    if (dispatchTensorType.getShape() != memrefType.getShape()) {
       return emitError() << "shapes do not match";
-
-    if (dispatchTensorType.getBoundElementType() != memrefType.getElementType())
+    }
+    if (dispatchTensorType.getBoundElementType() !=
+        memrefType.getElementType()) {
       return emitError() << "element types do not match";
-
-    return mlir::success();
+    }
+    return success();
   }
 };
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -65,9 +65,9 @@ struct EncodingTypeExternalModel
   }
 };
 
-struct BuiltinTensorExternalModel
+struct TensorLikeTypeExternalModel
     : bufferization::TensorLikeType::ExternalModel<
-          BuiltinTensorExternalModel, IREE::TensorExt::DispatchTensorType> {
+          TensorLikeTypeExternalModel, IREE::TensorExt::DispatchTensorType> {
   FailureOr<bufferization::BufferLikeType> getBufferType(
       Type type, const bufferization::BufferizationOptions &options,
       llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
@@ -108,7 +108,7 @@ void registerTensorExtExternalModels(DialectRegistry &registry) {
         IREE::TensorExt::DispatchWorkloadOrdinalOp::attachInterface<
             WorkloadOrdinalOpInterface>(*ctx);
         IREE::TensorExt::DispatchTensorType::attachInterface<
-            EncodingTypeExternalModel, BuiltinTensorExternalModel>(*ctx);
+            EncodingTypeExternalModel, TensorLikeTypeExternalModel>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -159,6 +159,9 @@ def TransposeMatmulPass : Pass<"iree-preprocessing-transpose-matmul-pass"> {
            )}]>
   ];
   let dependentDialects = [
+    // TODO(hanchung): Remove the dep after switching upstream patterns to not
+    // use bufferization::hasTensorSemantics method.
+    "mlir::bufferization::BufferizationDialect",
     "mlir::linalg::LinalgDialect",
   ];
 }


### PR DESCRIPTION
The revision drops two reverts:

- https://github.com/iree-org/llvm-project/commit/0f3edc6051e3c69cafeaac10e22e795647c761e4
- https://github.com/iree-org/llvm-project/commit/20a3487ee98805e675e032ecc026609c53c88830

In the upstream change, it updates `isaTensor` to check whether the type implements TensorLikeType or not. Thus, the revision implements the interface for DispatchTensorType, so bufferization can recognize the case. It also registers the bufferization dialect in EliminateEmptyTensors pass. Otherwise, the opt tool does not register the external models for the builtin types. See https://github.com/llvm/llvm-project/blob/ff4faaa660e1e9e844f8d6d15f55d810411d9642/mlir/lib/Dialect/Bufferization/IR/BufferizationDialect.cpp#L102-L122

No additional tests are added because they are all covered by the [existing eliminate_empty_tensors.mlir test](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir).

The revision adds a workaround for upstream mis-use of `bufferization::hasTensorSemantics`. The commit is not cherry-picked because we already carry many reverts now. It will be fixed in a separate PR.