### PR TITLE
[CPU] Use scf.forall for TileRootAndFuseProducerConsumer by default.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -37,11 +37,11 @@ namespace mlir::iree_compiler {
 /// the root operation and fuse the producers of the root operation then
 /// consumers (finds any missing fusion opportunities, then apply producer
 /// fusion). If `onlyFuseProducerInputOperands` is set, only fuse producer input
-/// operands. If `tileUsingForall` is set, creates `scf.forall`, rather than
-/// `scf.for` loops during tiling.
-static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
-    IRRewriter &rewriter, TilingInterface rootOp, int64_t tilingLevel,
-    bool onlyFuseProducerInputOperands, bool tileUsingForall) {
+/// operands.
+static FailureOr<Operation *>
+tileRootAndFuseProducerConsumer(IRRewriter &rewriter, TilingInterface rootOp,
+                                int64_t tilingLevel,
+                                bool onlyFuseProducerInputOperands) {
   auto *context = rewriter.getContext();
   mlir::DominanceInfo dominanceInfo(rootOp);
   llvm::SmallDenseSet<Operation *> tiledAndFusedOps;
@@ -88,7 +88,7 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
   tilingOptions.setTileSizes(tileSizes);
 
   // onlyFuseProducerInputOperands implies reduction tiling.
-  if (tileUsingForall && !onlyFuseProducerInputOperands) {
+  if (!onlyFuseProducerInputOperands) {
     tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
   }
 
@@ -218,7 +218,7 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
 
   if (failed(tileRootAndFuseProducerConsumer(
           rewriter, cast<TilingInterface>(rootOp.value()), tilingLevel,
-          onlyFuseProducerInputOperands, tileUsingForall))) {
+          onlyFuseProducerInputOperands))) {
     funcOp.emitError() << "tiling of level " << tilingLevel.getValue()
                        << " failed\n";
     return signalPassFailure();
@@ -242,12 +242,10 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
 } // namespace
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel,
-                                             bool tileUsingForAll) {
+createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel) {
   LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
   options.tilingLevel = tilingLevel;
   options.onlyFuseProducerInputOperands = false;
-  options.tileUsingForall = tileUsingForAll;
   return std::make_unique<LLVMCPUTileRootAndFuseProducerConsumer>(options);
 }
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
@@ -255,7 +253,6 @@ createLLVMCPUTileRootAndFuseInputOperands(int64_t tilingLevel) {
   LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
   options.tilingLevel = tilingLevel;
   options.onlyFuseProducerInputOperands = true;
-  options.tileUsingForall = false;
   return std::make_unique<LLVMCPUTileRootAndFuseProducerConsumer>(options);
 }
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -532,8 +532,7 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
   addTileAndDistributePasses(funcPassManager);
 
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumer(
-      static_cast<int64_t>(tilingConfig.getVectorCommonParallelLevel()),
-      /*tileUsingForall=*/true));
+      static_cast<int64_t>(tilingConfig.getVectorCommonParallelLevel())));
   // The below two passes are nop if the "mmt4d" is explicitly excluded in the
   // ukernels attribute.
   funcPassManager.addPass(createCPUPrepareUkernelsPass());
@@ -647,6 +646,7 @@ void addCPULinalgExtTileAndVectorizePipeline(
   funcPassManager.addPass(
       IREE::LinalgExt::createDecomposeWinogradTransformPass());
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeAttentionPass());
+  funcPassManager.addPass(iree_compiler::createForallToForPass());
 
   {
     GenericVectorizationPassOptions options;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -43,8 +43,7 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUTileAndFusePass(int64_t tilingLevel);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel,
-                                             bool tileUsingForall);
+createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUTileRootAndFuseInputOperands(int64_t tilingLevel);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -160,10 +160,7 @@ def LLVMCPUTileRootAndFuseProducerConsumerPass
               "only-fuse-producer-input-operands", "bool",
               /*default=*/"false",
               "Specifies if we only want to fuse producer's input operands. "
-              "This is helpful to tile&fuse in case of reduction dimensions.">,
-       Option<"tileUsingForall", "tile-using-forall", "bool",
-              /*default=*/"false",
-              "Tile parallel dimensions using `scf.forall` instead of `scf.for`. Reduction dimension defaults to `scf.for`.">];
+              "This is helpful to tile&fuse in case of reduction dimensions.">];
 }
 
 def LLVMCPUVerifyVectorSizeLegalityPass :


### PR DESCRIPTION
The revision drops the option and switch to scf.forall by default, when tile and fuse the parallel dimensions.

To finish the migration, it updates the LinalgExt pipeline and adds the ForallToFor pass before vectorization.