### PR TITLE
Integrate LLVM to llvm/llvm-project@5ed852f7

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -338,8 +338,8 @@ public:
 
     // Creates a new function with the update signature.
     rewriter.modifyOpInPlace(funcOp, [&] {
-      funcOp.setType(rewriter.getFunctionType(
-          signatureConverter.getConvertedTypes(), std::nullopt));
+      funcOp.setType(
+          rewriter.getFunctionType(signatureConverter.getConvertedTypes(), {}));
     });
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -630,7 +630,7 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
     SmallVector<Value> indices = {warpId};
     builder.create<scf::IfOp>(loc, lane0, [&](OpBuilder &b, Location l) {
       b.create<memref::StoreOp>(l, laneVal, alloc, indices);
-      b.create<scf::YieldOp>(l, std::nullopt);
+      b.create<scf::YieldOp>(l);
     });
     builder.create<gpu::BarrierOp>(loc);
     // Further reduce the outputs from each warps with a single warp reduce.


### PR DESCRIPTION
Carrying-over previous reverts:

- https://github.com/llvm/llvm-project/commit/eb694b28461fdbd5e347fca59829e8a9ad021773 and https://github.com/llvm/llvm-project/commit/e33f13ba4824d807e846e7783a48efd6c0bf58ee : these break arith.trunci with destination type i1, which occurs at least in the jit_globals.mlir test.

New revert:
- https://github.com/iree-org/llvm-project/commit/878d3594ed74cd1153bc5cba2cb7a449702cdf34 until this https://github.com/iree-org/iree/pull/21259 works.