### PR TITLE
[Codegen][GPU] Redirect transfer read lowering to masked load lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -127,7 +127,6 @@ struct LLVMGPUVectorLoweringPass final
     populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
                                           vectorToSCFOptions);
     memref::populateFoldMemRefAliasOpPatterns(vectorToLoopsPatterns);
-    amdgpu::populateAmdgpuTransferReadToLoadPatterns(vectorToLoopsPatterns);
     vector::populateVectorTransferLoweringPatterns(vectorToLoopsPatterns);
     if (failed(
             applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Conversion/ComplexToStandard/ComplexToStandard.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
@@ -1169,6 +1170,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createExpandGPUOpsPass)
       // Barrier elimination before we reach unstructured control flow.
       .addPass(createGpuEliminateBarriers);
+
+  if (forROCDL) {
+    funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);
+  }
 
   // This pass needs to run before SCF -> CF.
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -37,21 +37,3 @@ module {
 // CHECK: %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
 // CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
 // CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
-
-// -----
-
-module {
-  func.func @transfer_read_lowering(%arg0: memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, %idx : index, %mask: vector<4xi1>) -> vector<4xf32> {
-    %cst_0 = arith.constant 0.000000e+00 : f32
-    %v = vector.transfer_read %arg0[%idx, %idx], %cst_0, %mask {in_bounds = [true]} : memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<4xf32>
-    return %v : vector<4xf32>
-  }
-}
-
-// CHECK-LABEL: func.func @transfer_read_lowering(
-// CHECK-SAME: %[[ARG0:.+]]: memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>,
-// CHECK-SAME: %[[ARG1:.+]]: index,
-// CHECK-SAME: %[[MASK:.+]]: vector<4xi1>
-// CHECK: %[[CST:.+]] = arith.constant dense<0.000000e+00>
-// CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]][%[[ARG1]], %[[ARG1]]]
-// CHECK: %[[SELECT:.+]] = arith.select %[[MASK]], %[[LOAD]], %[[CST]]


### PR DESCRIPTION
This needs to be bundled with https://github.com/llvm/llvm-project/pull/146705.

With the upstream PR, I'm able to move transfer read lowering pass from a target independent pipeline to rocDL specific pipeline. This is to address feedbacks from @kuhar and @Groverkss. 

I'm posting this as a review so this can go through CI regressions and can be cherry-picked with next llvm upstream integration PR.