### PR TITLE
[Codegen] Fix specialize exports never applies check

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -208,11 +208,15 @@ static void specializeExportedFunction(
         }
       }
 
-      // The range is unsatisfiable if there is no multiple of the LCM of
-      // the true divisor and the target divisor in the value's range.
+      // Any value that satisfied both ranges must be divisible by the LCM of
+      // the true value's divisibility and the requested divisibility. Find the
+      // smallest multiple of the LCM larger than the true umin. This must be
+      // smaller than both the requested maximum value and actual maximum value
+      // for the range to be satisfiable.
       int64_t divLCM = std::lcm(udiv, valueUdiv);
-      int64_t nearestUminCeil = (divLCM + valueUmin - 1) / divLCM;
-      if (umin > valueUmax || umax < valueUmin || nearestUminCeil > umax) {
+      int64_t nearestUminCeil = ((divLCM + valueUmin - 1) / divLCM) * divLCM;
+      if (umin > valueUmax || umax < valueUmin || nearestUminCeil > umax ||
+          nearestUminCeil > valueUmax) {
         neverApplies = true;
         break;
       }


### PR DESCRIPTION
The check was doing a ceildiv instead of ceil to nearest multiple of LCM. Also it was only checking the requested maximum instead of both the requested maximum and the actual maximum. Update the check and improve the comment explaining the logic.