### PR TITLE
[Util] Fix assume.int operand deduplication canonicalizer

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -52,28 +52,11 @@ static LogicalResult canonicalizeAssumeIntOp(AssumeIntOp op,
   // We do a fast check for the canonical form here, making any in-place updates
   // we can and signalling needsRewrite=true when the op needs to be updated
   // to a new canonical form.
-  SmallPtrSet<Value, 4> seenOperands;
-  seenOperands.reserve(op.getNumOperands());
   for (auto [idx, operand] : llvm::enumerate(op.getOperands())) {
     // Match constant.
     if (matchPattern(operand, m_Constant())) {
       needsRewrite = true;
       rewriter.replaceAllUsesWith(op.getResult(idx), operand);
-      continue;
-    }
-
-    // Check for a duplicate.
-    auto [foundIt, inserted] = seenOperands.insert(operand);
-    if (!inserted) {
-      // This should be the non-common path: find the original index number
-      // and rewrite.
-      for (auto [seenIdx, seenOperand] : llvm::enumerate(op.getOperands())) {
-        if (seenOperand == operand) {
-          needsRewrite = true;
-          rewriter.replaceAllUsesWith(op.getResult(idx), op.getResult(seenIdx));
-          break;
-        }
-      }
       continue;
     }
 
@@ -172,7 +155,110 @@ static LogicalResult canonicalizeAssumeIntOp(AssumeIntOp op,
   return success();
 }
 
+static IntAssumptionAttr getUnionedRange(IntAssumptionAttr l,
+                                         IntAssumptionAttr r) {
+  // Min is the larger minimum between the two ranges.
+  std::optional<int64_t> newMin =
+      l.getUmin() ? std::max(r.getUmin().value_or(*l.getUmin()), *l.getUmin())
+                  : r.getUmin();
+  // Max is the smaller maximum between the two ranges.
+  std::optional<int64_t> newMax =
+      l.getUmax() ? std::min(r.getUmax().value_or(*l.getUmax()), *l.getUmax())
+                  : r.getUmax();
+  // Divisible by both means divisible by the lcm.
+  std::optional<int64_t> newDiv =
+      l.getUdiv() ? std::lcm(r.getUdiv().value_or(*l.getUdiv()), *l.getUdiv())
+                  : r.getUdiv();
+  return IntAssumptionAttr::get(l.getContext(), newMin, newMax, newDiv);
+}
+
+static ArrayAttr getZippedAssumeRange(Builder &b, ArrayAttr l, ArrayAttr r) {
+  assert(l && "unexpected null lhs");
+  if (!r || l == r) {
+    return l;
+  }
+
+  int64_t lSize = l.size();
+  int64_t rSize = r.size();
+  // Shortcut for both unit ranges.
+  if (lSize == rSize && lSize == 1) {
+    return b.getArrayAttr({getUnionedRange(cast<IntAssumptionAttr>(l[0]),
+                                           cast<IntAssumptionAttr>(r[0]))});
+  }
+
+  int64_t resultSize = std::max(lSize, rSize);
+  assert((lSize == resultSize || lSize == 1) &&
+         "invalid assume range size mismatch");
+  assert((rSize == resultSize || rSize == 1) &&
+         "invalid assume range size mismatch");
+  SmallVector<Attribute> newRanges;
+  newRanges.reserve(resultSize);
+  // At this point we're guaranteed that at least one of the ranges is non-unit.
+  // Broadcast the unit range if present by not incrementing it's iterator.
+  for (int i = 0, j = 0; i < resultSize && j < resultSize;
+       i += (lSize != 1), j += (rSize != 1)) {
+    newRanges.push_back(getUnionedRange(cast<IntAssumptionAttr>(l[i]),
+                                        cast<IntAssumptionAttr>(r[j])));
+  }
+  return b.getArrayAttr(newRanges);
+}
+
 namespace {
+
+/// Deduplicates operands, merging assume ranges along the way.
+struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
+  using OpRewritePattern<AssumeIntOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(AssumeIntOp op,
+                                PatternRewriter &rewriter) const override {
+    ArrayAttr assumptions = op.getAssumptions();
+
+    llvm::SmallDenseMap<Value, ArrayAttr> assumptionReplacements;
+    for (auto [idx, operand] : llvm::enumerate(op.getOperands())) {
+      auto currentRow = cast<ArrayAttr>(assumptions[idx]);
+      auto existingRow = dyn_cast_if_present<ArrayAttr>(
+          assumptionReplacements.lookup_or(operand, ArrayAttr()));
+      ArrayAttr zippedRow =
+          getZippedAssumeRange(rewriter, currentRow, existingRow);
+
+      // Update the entry if present and different, or add a new entry with the
+      // zippedRow == currentRow if not present.
+      if ((existingRow && existingRow != zippedRow) || !existingRow) {
+        assumptionReplacements[operand] = zippedRow;
+      }
+    }
+
+    // If the map contains an entry per operand, no duplicates present.
+    if (assumptionReplacements.size() == op->getNumOperands()) {
+      return failure();
+    }
+
+    SmallVector<ArrayAttr> newRanges;
+    SmallVector<Value> newOperands;
+    llvm::SmallDenseMap<Value, int64_t> resultReplacementMap;
+    SmallVector<Value> valuesToReplace;
+    valuesToReplace.reserve(assumptionReplacements.size());
+    for (auto [idx, operand] : llvm::enumerate(op.getOperands())) {
+      auto [existingIdx, didInsert] =
+          resultReplacementMap.insert({operand, idx});
+      if (didInsert) {
+        valuesToReplace.push_back(op.getResult(idx));
+      } else {
+        newRanges.push_back(assumptionReplacements[operand]);
+        newOperands.push_back(operand);
+        // Replace all the uses of deleted results now to avoid the need to
+        // re-iterate over results after constructing the new assume.
+        rewriter.replaceAllUsesWith(op.getResult(idx),
+                                    op.getResult(existingIdx->getSecond()));
+      }
+    }
+
+    auto newOp =
+        rewriter.create<AssumeIntOp>(op.getLoc(), newOperands, newRanges);
+    rewriter.replaceAllUsesWith(valuesToReplace, newOp.getResults());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 
 /// Folds sequences of cancelling multiplications and divisions based on
 /// assumes, i.e.
@@ -227,7 +313,7 @@ struct FoldDivMulOfAssume : public OpRewritePattern<arith::MulIOp> {
 
 void AssumeIntOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                               MLIRContext *context) {
-  results.add<FoldDivMulOfAssume>(context);
+  results.add<DeduplicateOperands, FoldDivMulOfAssume>(context);
   results.add(canonicalizeAssumeIntOp);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -242,9 +242,9 @@ struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
           resultReplacementMap.insert({operand, idx});
       if (didInsert) {
         valuesToReplace.push_back(op.getResult(idx));
-      } else {
         newRanges.push_back(assumptionReplacements[operand]);
         newOperands.push_back(operand);
+      } else {
         // Replace all the uses of deleted results now to avoid the need to
         // re-iterate over results after constructing the new assume.
         rewriter.replaceAllUsesWith(op.getResult(idx),

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/assume_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/assume_folding.mlir
@@ -120,6 +120,38 @@ util.func public @dedup_operands_multiple_groups(%arg0: index, %arg1: index) -> 
 
 // -----
 
+// CHECK-LABEL: @dedup_operands_multiple_groups_and_singleton
+util.func public @dedup_operands_multiple_groups_and_singleton(
+  %arg0: index, %arg1: index, %arg2: index) -> index, index, index, index, index {
+  // CHECK: %[[ASSUME:.*]]:3 = util.assume.int
+  // CHECK-NEXT: %arg2<udiv = 64>,
+  // CHECK-NEXT: %arg0<umin = 3>,
+  // CHECK-NEXT: %arg1<umax = 5>
+  %0:5 = util.assume.int
+    %arg2<udiv=64>,
+    %arg0<umin=2>,
+    %arg1<umax=5>,
+    %arg0<umin=3>,
+    %arg1<umax=6> : index, index, index, index, index
+  // CHECK: util.return %[[ASSUME]]#0, %[[ASSUME]]#1, %[[ASSUME]]#2, %[[ASSUME]]#1, %[[ASSUME]]#2
+  util.return %0#0, %0#1, %0#2, %0#3, %0#4 : index, index, index, index, index
+}
+
+// -----
+
+// CHECK-LABEL: @dedup_operands_three
+util.func public @dedup_operands_three(%arg0: index) -> index, index, index {
+  // CHECK: %[[ASSUME:.*]] = util.assume.int %arg0<umin = 3>
+  %0:3 = util.assume.int
+    %arg0<umin=1>,
+    %arg0<umin=2>,
+    %arg0<umin=3> : index, index, index
+  // CHECK: util.return %[[ASSUME]], %[[ASSUME]], %[[ASSUME]]
+  util.return %0#0, %0#1, %0#2 : index, index, index
+}
+
+// -----
+
 // CHECK-LABEL: @fold_assume_of_div_mul
 util.func public @fold_assume_of_div_mul(%arg0: index) -> index  {
   // CHECK-SAME: %[[ARG0:.+]]: index


### PR DESCRIPTION
Previously this canonicalization would ignore differing information when deduplicating operands. Updates the pattern to incorporate information from all available ranges.

Additionally splits the pattern out of the large canonicalization function because it became too difficult to reconcile the range combining this pattern now needs with the existing implementation.