### PR TITLE
[DispatchCreation] Fold collapse(expand) unit dims

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -113,6 +113,163 @@ struct FoldAttentionMaskUnitDim final
     return success();
   }
 };
+
+/// Simplify collapse_shape(expand_shape) by removing unneeded unit dimensions
+/// that get expanded and subsequently collapsed.
+///
+/// For example:
+/// ```
+/// %0 = expand_shape ... tensor<3x3x10xf32> into tensor<3x3x5x1x2xf32>
+/// %1 = collapse_shape %1 ... tensor<3x3x5x1x2xf32> into tensor<9x5x2xf32>
+/// ```
+///
+/// simplifies to
+/// ```
+/// %0 = expand_shape ... tensor<3x3x10xf32> into tensor<3x3x5x2xf32>
+/// %1 = collapse_shape %1 ... tensor<3x3x5x2xf32> into tensor<9x5x2xf32>
+/// ```
+struct DropUnitDimsFromCollapseOfExpand
+    : OpRewritePattern<tensor::CollapseShapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::CollapseShapeOp collapseOp,
+                                PatternRewriter &rewriter) const override {
+    auto expandOp = collapseOp.getSrc().getDefiningOp<tensor::ExpandShapeOp>();
+    if (!expandOp) {
+      return failure();
+    }
+
+    const SmallVector<ReassociationIndices, 4> collapseReassoc =
+        collapseOp.getReassociationIndices();
+    ArrayRef<int64_t> interShape = expandOp.getType().getShape();
+    ArrayRef<int64_t> outShape = collapseOp.getType().getShape();
+    SmallVector<int64_t> interToOutMap(expandOp.getType().getRank());
+
+    // Step 1: construct a set of dimensions (with respect to the intermediate
+    // shape) that are unit length and get collapsed away by the final
+    // `collapse_shape` op.
+    llvm::SmallDenseSet<int64_t> toDrop;
+    for (const auto &[outDim, indices] : llvm::enumerate(collapseReassoc)) {
+      for (auto [innerIdx, inDim] : llvm::enumerate(indices)) {
+        // Can't drop this dim if it isnt statically 1 or if it isn't being
+        // combined with any other dimensions.
+        if (indices.size() == 1 || interShape[inDim] != 1) {
+          continue;
+        }
+
+        // If we are collapsing multiple unit dims together, at least 1 must be
+        // kept (prefer the first).
+        if (outShape[outDim] == 1 && innerIdx != 0) {
+          continue;
+        }
+        toDrop.insert(inDim);
+      }
+    }
+
+    // Step 2: remove dimensions from `toDrop` that weren't introduced by the
+    // `expand_shape` op.
+    const auto expandReassoc = expandOp.getReassociationIndices();
+    for (const auto &[inDim, indices] : llvm::enumerate(expandReassoc)) {
+      if (indices.size() == 1) {
+        toDrop.erase(indices[0]);
+      }
+    }
+    if (toDrop.empty()) {
+      return rewriter.notifyMatchFailure(collapseOp,
+                                         "Didn't find any unit dims to drop");
+    }
+
+    // Step 3: construct a new intermediate shape without the foldable dims.
+    SmallVector<int64_t> newInterShape;
+    SmallVector<OpFoldResult> newOutputSizes;
+    newInterShape.reserve(interShape.size() - toDrop.size());
+    newOutputSizes.reserve(interShape.size() - toDrop.size());
+    SmallVector<OpFoldResult> outputSizes = getMixedValues(
+        expandOp.getStaticOutputShape(), expandOp.getOutputShape(), rewriter);
+    for (auto [idx, ofr] : llvm::enumerate(outputSizes)) {
+      if (!toDrop.contains(idx)) {
+        std::optional<int64_t> staticDim = getConstantIntValue(ofr);
+        newInterShape.push_back(staticDim.value_or(ShapedType::kDynamic));
+        newOutputSizes.push_back(ofr);
+      }
+    }
+
+    /// Attempts to push back a new `ReassociationIndices` to `reassoc` that
+    /// does not include the dimensions in `toDrop`.
+    /// Returns true if new `ReassociationIndices` were appended to `reassoc`.
+    auto pushBackReassociation =
+        [&toDrop](SmallVectorImpl<ReassociationIndices> &reassoc, int64_t start,
+                  int64_t count, int64_t origStart) {
+          ReassociationIndices indices;
+          indices.reserve(count);
+          int64_t dim = start;
+          for (int64_t idx : llvm::seq<int64_t>(origStart, origStart + count)) {
+            if (!toDrop.contains(idx)) {
+              indices.push_back(dim++);
+            }
+          }
+          if (!indices.empty()) {
+            reassoc.push_back(std::move(indices));
+            return true;
+          }
+          return false;
+        };
+
+    auto isIdentityReassociation = [](ArrayRef<ReassociationIndices> reassoc) {
+      return llvm::all_of(reassoc,
+                          [](auto &indices) { return indices.size() == 1; });
+    };
+
+    // Step 4: construct new reassociations for the `collapse_shape` that does
+    // not include the dropped dimensions.
+    SmallVector<ReassociationIndices, 4> newCollapseReassoc;
+    int64_t collapsedDim = 0;
+    for (auto dim : llvm::seq<int64_t>(0, outShape.size())) {
+      bool changed = pushBackReassociation(newCollapseReassoc, collapsedDim,
+                                           collapseReassoc[dim].size(),
+                                           collapseReassoc[dim].front());
+      if (changed) {
+        collapsedDim += newCollapseReassoc.back().size();
+      }
+    }
+
+    // Step 5: construct new reassociations for the `expand_shape` op that does
+    // not include the dropped dimensions.
+    SmallVector<ReassociationIndices, 4> newExpandReassoc;
+    ArrayRef<int64_t> srcShape = expandOp.getSrcType().getShape();
+    int64_t expandedDim = 0;
+    for (auto dim : llvm::seq<int64_t>(0, srcShape.size())) {
+      bool changed = pushBackReassociation(newExpandReassoc, expandedDim,
+                                           expandReassoc[dim].size(),
+                                           expandReassoc[dim].front());
+      if (changed) {
+        expandedDim += newExpandReassoc.back().size();
+      }
+    }
+
+    // Step 6: construct the new `expand_shape` and `collapse_shape` ops.
+    // Note: we must handle the cases where the expand/collapse is no longer
+    // needed.
+    Value newExpanded = expandOp.getSrc();
+    if (!isIdentityReassociation(newExpandReassoc)) {
+      newExpanded = rewriter.create<tensor::ExpandShapeOp>(
+          expandOp.getLoc(),
+          RankedTensorType::get(newInterShape,
+                                expandOp.getType().getElementType()),
+          expandOp.getSrc(), newExpandReassoc, newOutputSizes);
+    }
+
+    Value result = newExpanded;
+    if (!isIdentityReassociation(newCollapseReassoc)) {
+      result = rewriter.create<tensor::CollapseShapeOp>(
+          collapseOp.getLoc(), collapseOp.getType(), newExpanded,
+          newCollapseReassoc);
+    }
+    rewriter.replaceOp(collapseOp, result);
+    return success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -139,8 +296,9 @@ populatefoldUnitDimsPatterns(RewritePatternSet &foldUnitDimsPatterns) {
   IREE::LinalgExt::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns,
                                                       options);
   linalg::populateMoveInitOperandsToInputPattern(foldUnitDimsPatterns);
-  foldUnitDimsPatterns.insert<FoldAttentionMaskUnitDim>(
-      foldUnitDimsPatterns.getContext());
+  foldUnitDimsPatterns
+      .insert<FoldAttentionMaskUnitDim, DropUnitDimsFromCollapseOfExpand>(
+          foldUnitDimsPatterns.getContext());
 }
 
 static LogicalResult

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -117,12 +117,14 @@ struct FoldAttentionMaskUnitDim final
 /// Simplify collapse_shape(expand_shape) by removing unneeded unit dimensions
 /// that get expanded and subsequently collapsed.
 ///
+/// TODO: move this upstream with the other reshape folding patterns. This can
+/// also be generalized to fold non-unit dimensions.
+///
 /// For example:
 /// ```
 /// %0 = expand_shape ... tensor<3x3x10xf32> into tensor<3x3x5x1x2xf32>
 /// %1 = collapse_shape %1 ... tensor<3x3x5x1x2xf32> into tensor<9x5x2xf32>
 /// ```
-///
 /// simplifies to
 /// ```
 /// %0 = expand_shape ... tensor<3x3x10xf32> into tensor<3x3x5x2xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -233,12 +233,12 @@ util.func @collapse_of_expand_1(%arg0: tensor<?x128xf16>, %arg1: index) -> tenso
 
 // -----
 
-util.func @collapse_of_expand_2(%arg0: tensor<?x1xf16>, %arg1: index) -> tensor<4x?x1xf16> {
+util.func @collapse_of_expand_to_expand(%arg0: tensor<?x1xf16>, %arg1: index) -> tensor<4x?x1xf16> {
   %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3, 4]] output_shape [4, %arg1, 1, 1, 1] : tensor<?x1xf16> into tensor<4x?x1x1x1xf16>
   %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x1x1xf16> into tensor<4x?x1xf16>
   util.return %collapsed : tensor<4x?x1xf16>
 }
-// CHECK-LABEL: util.func public @collapse_of_expand_2
+// CHECK-LABEL: util.func public @collapse_of_expand_to_expand
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x1xf16>, %[[ARG1:.+]]: index
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<?x1xf16> into tensor<4x?x1xf16>
@@ -246,23 +246,23 @@ util.func @collapse_of_expand_2(%arg0: tensor<?x1xf16>, %arg1: index) -> tensor<
 
 // -----
 
-util.func @collapse_of_expand_3(%arg0: tensor<?x?xf16>, %arg1: index, %arg2: index) -> tensor<?x?xf16> {
+util.func @collapse_of_expand_fully_dynamic(%arg0: tensor<?x?xf16>, %arg1: index, %arg2: index) -> tensor<?x?xf16> {
   %expanded = tensor.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [%arg1, 1, 1, %arg2] : tensor<?x?xf16> into tensor<?x1x1x?xf16>
   %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3]] : tensor<?x1x1x?xf16> into tensor<?x?xf16>
   util.return %collapsed : tensor<?x?xf16>
 }
-// CHECK-LABEL: util.func public @collapse_of_expand_3
+// CHECK-LABEL: util.func public @collapse_of_expand_fully_dynamic
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf16>
 //       CHECK:   util.return %[[ARG0]] : tensor<?x?xf16>
 
 // -----
 
-util.func @collapse_of_expand_4(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: index) -> tensor<1xf16> {
+util.func @collapse_of_expand_all_unit_dim_groups(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: index) -> tensor<1xf16> {
   %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3]] output_shape [%arg1, 1, 1, %arg2] : tensor<1x1xf16> into tensor<1x1x1x1xf16>
   %collapsed = tensor.collapse_shape %expanded [[0, 1, 2, 3]] : tensor<1x1x1x1xf16> into tensor<1xf16>
   util.return %collapsed : tensor<1xf16>
 }
-// CHECK-LABEL: util.func public @collapse_of_expand_4
+// CHECK-LABEL: util.func public @collapse_of_expand_all_unit_dim_groups
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x1xf16>
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<1x1xf16> into tensor<1xf16>
@@ -270,12 +270,12 @@ util.func @collapse_of_expand_4(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: ind
 
 // -----
 
-util.func @collapse_of_expand_5(%arg0: tensor<1x?x4x32xf16>, %arg1: index) -> tensor<?x4x32xf16> {
+util.func @collapse_of_expand_to_collapse(%arg0: tensor<1x?x4x32xf16>, %arg1: index) -> tensor<?x4x32xf16> {
   %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [1, %arg1, 4, 1, 32] : tensor<1x?x4x32xf16> into tensor<1x?x4x1x32xf16>
   %collapsed = tensor.collapse_shape %expanded [[0, 1], [2, 3], [4]] : tensor<1x?x4x1x32xf16> into tensor<?x4x32xf16>
   util.return %collapsed : tensor<?x4x32xf16>
 }
-// CHECK-LABEL: util.func public @collapse_of_expand_5
+// CHECK-LABEL: util.func public @collapse_of_expand_to_collapse
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x?x4x32xf16>
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<1x?x4x32xf16> into tensor<?x4x32xf16>

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -280,3 +280,16 @@ util.func @collapse_of_expand_5(%arg0: tensor<1x?x4x32xf16>, %arg1: index) -> te
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<1x?x4x32xf16> into tensor<?x4x32xf16>
 //       CHECK:   util.return %[[COLLAPSED]] : tensor<?x4x32xf16>
+
+// -----
+
+util.func @collapse_of_expand_to_scalar(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: index) -> tensor<f16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3]] output_shape [%arg1, 1, 1, %arg2] : tensor<1x1xf16> into tensor<1x1x1x1xf16>
+  %collapsed = tensor.collapse_shape %expanded [] : tensor<1x1x1x1xf16> into tensor<f16>
+  util.return %collapsed : tensor<f16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_to_scalar
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x1xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1x1xf16> into tensor<f16>
+//       CHECK:   util.return %[[COLLAPSED]] : tensor<f16>

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -202,3 +202,81 @@ util.func public @attention_mask_single_m_dim(%arg0 : tensor<32x1x128xf16>, %arg
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
 //  CHECK-SAME:     ins({{.+}}, %[[COLLAPSED]]
 //       CHECK:   util.return %[[ATTN]]
+
+// -----
+
+util.func @collapse_of_expand_0(%arg0: tensor<?x128xf16>, %arg1: index) -> tensor<4x?x128xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3, 4]] output_shape [4, %arg1, 1, 1, 128] : tensor<?x128xf16> into tensor<4x?x1x1x128xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x1x128xf16> into tensor<4x?x128xf16>
+  util.return %collapsed : tensor<4x?x128xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_0
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x128xf16>, %[[ARG1:.+]]: index
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<?x128xf16> into tensor<4x?x128xf16>
+//       CHECK:   util.return %[[EXPAND]] : tensor<4x?x128xf16>
+
+// -----
+
+util.func @collapse_of_expand_1(%arg0: tensor<?x128xf16>, %arg1: index) -> tensor<4x?x64xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3, 4]] output_shape [4, %arg1, 1, 2, 64] : tensor<?x128xf16> into tensor<4x?x1x2x64xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x2x64xf16> into tensor<4x?x64xf16>
+  util.return %collapsed : tensor<4x?x64xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_1
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x128xf16>, %[[ARG1:.+]]: index
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<?x128xf16> into tensor<4x?x2x64xf16>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
+//  CHECK-SAME:     tensor<4x?x2x64xf16> into tensor<4x?x64xf16>
+//       CHECK:   util.return %[[COLLAPSE]] : tensor<4x?x64xf16>
+
+// -----
+
+util.func @collapse_of_expand_2(%arg0: tensor<?x1xf16>, %arg1: index) -> tensor<4x?x1xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3, 4]] output_shape [4, %arg1, 1, 1, 1] : tensor<?x1xf16> into tensor<4x?x1x1x1xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x1x1xf16> into tensor<4x?x1xf16>
+  util.return %collapsed : tensor<4x?x1xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_2
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x1xf16>, %[[ARG1:.+]]: index
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<?x1xf16> into tensor<4x?x1xf16>
+//       CHECK:   util.return %[[EXPAND]] : tensor<4x?x1xf16>
+
+// -----
+
+util.func @collapse_of_expand_3(%arg0: tensor<?x?xf16>, %arg1: index, %arg2: index) -> tensor<?x?xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [%arg1, 1, 1, %arg2] : tensor<?x?xf16> into tensor<?x1x1x?xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3]] : tensor<?x1x1x?xf16> into tensor<?x?xf16>
+  util.return %collapsed : tensor<?x?xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_3
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf16>
+//       CHECK:   util.return %[[ARG0]] : tensor<?x?xf16>
+
+// -----
+
+util.func @collapse_of_expand_4(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: index) -> tensor<1xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3]] output_shape [%arg1, 1, 1, %arg2] : tensor<1x1xf16> into tensor<1x1x1x1xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0, 1, 2, 3]] : tensor<1x1x1x1xf16> into tensor<1xf16>
+  util.return %collapsed : tensor<1xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_4
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x1xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1x1xf16> into tensor<1xf16>
+//       CHECK:   util.return %[[COLLAPSED]] : tensor<1xf16>
+
+// -----
+
+util.func @collapse_of_expand_5(%arg0: tensor<1x?x4x32xf16>, %arg1: index) -> tensor<?x4x32xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [1, %arg1, 4, 1, 32] : tensor<1x?x4x32xf16> into tensor<1x?x4x1x32xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0, 1], [2, 3], [4]] : tensor<1x?x4x1x32xf16> into tensor<?x4x32xf16>
+  util.return %collapsed : tensor<?x4x32xf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_5
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x?x4x32xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1x?x4x32xf16> into tensor<?x4x32xf16>
+//       CHECK:   util.return %[[COLLAPSED]] : tensor<?x4x32xf16>


### PR DESCRIPTION
Folds unit dimensions that are created by an expand shape then immediately collapsed. This becomes problematic because during `BubbleUpExpandShapes` these unit dims will get propagated to the surrounding compute ops.

I previously attempted to land this on https://github.com/iree-org/iree/pull/19357



2/2 fixes for #19832