### PR TITLE
[DT] Improve encoding hoisting pass.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -66,6 +66,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/TensorExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes",
+        "//compiler/src/iree/compiler/Dialect/Util/Analysis/Constant",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/DFX",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     iree::compiler::Dialect::TensorExt::Transforms
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::Analysis::Attributes
+    iree::compiler::Dialect::Util::Analysis::Constant
     iree::compiler::Dialect::Util::Analysis::DFX
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -234,9 +234,10 @@ void HoistEncodingOpsPass::runOnOperation() {
     }
 
     bool isHoistable = true;
-    SetVector<Operation *> opsWithinDispatch;
+    SetVector<Operation *> opsWithinDispatch, seen;
     std::queue<Operation *> worklist;
     worklist.push(setEncodingOp);
+    seen.insert(setEncodingOp);
     while (!worklist.empty()) {
       Operation *op = worklist.front();
       worklist.pop();
@@ -245,11 +246,12 @@ void HoistEncodingOpsPass::runOnOperation() {
         auto inputOp = input.getDefiningOp();
         if (inputOp &&
             inputOp->getParentOfType<IREE::Flow::DispatchRegionOp>() &&
-            !opsWithinDispatch.contains(inputOp)) {
+            !seen.contains(inputOp)) {
           if (!isHoistableOp(inputOp)) {
             isHoistable = false;
           }
           worklist.push(inputOp);
+          seen.insert(inputOp);
         }
       }
     }

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -4,12 +4,18 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cassert>
+#include <queue>
+
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "llvm/ADT/STLExtras.h"
@@ -31,6 +37,8 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-dispatch-creation-hoist-encoding-ops"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::DispatchCreation {
 #define GEN_PASS_DEF_HOISTENCODINGOPSPASS
@@ -135,6 +143,21 @@ static LogicalResult bubbleUpSetEncoding(RewriterBase &rewriter,
   return bubbleUpSetEncodingThroughGenericOp(rewriter, setEncoding, producer);
 }
 
+static bool isHoistableOp(Operation *op) {
+  if (auto sliceOp = dyn_cast<tensor::ExtractSliceOp>(op)) {
+    SmallVector<OpFoldResult> offsets = sliceOp.getMixedOffsets();
+    SmallVector<OpFoldResult> sizes = sliceOp.getMixedSizes();
+    SmallVector<OpFoldResult> strides = sliceOp.getMixedStrides();
+    ArrayRef<int64_t> srcShape = sliceOp.getSourceType().getShape();
+    return IREE::Flow::isOffsetSizeAndStrideMappableToFlow(offsets, sizes,
+                                                           strides, srcShape);
+  }
+
+  // Compute ops are not hoistable after dispatch formation.
+  return !isa<linalg::LinalgDialect, IREE::LinalgExt::IREELinalgExtDialect>(
+      op->getDialect());
+}
+
 namespace {
 /// Pass declaration.
 struct HoistEncodingOpsPass
@@ -187,7 +210,14 @@ void HoistEncodingOpsPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  SmallVector<IREE::Encoding::SetEncodingOp> candidates;
+  const auto &constExprs = getAnalysis<IREE::Util::ConstExprAnalysis>();
+  IREE::Util::ConstExprHoistingPolicy policy(constExprs, /*threshold=*/0);
+  policy.initialize();
+
+  // Each element indicates ops that are expected to be hoisted. It is valid to
+  // follow the order in the vector to hoist the ops. The last operation is
+  // expected to be the corresponding SetEncoding op.
+  SmallVector<SmallVector<Operation *>> candidates;
   funcOp->walk([&](IREE::Encoding::SetEncodingOp setEncodingOp) {
     if (!setEncodingOp->getParentOfType<IREE::Flow::DispatchRegionOp>()) {
       return;
@@ -197,28 +227,55 @@ void HoistEncodingOpsPass::runOnOperation() {
     if (isa_and_nonnull<IREE::Encoding::PaddingAttr>(encoding)) {
       return;
     }
-    Operation *src = setEncodingOp.getSource().getDefiningOp();
-    if (!hoistEncodingsForConstExpr && src &&
-        (isa<IREE::Util::GlobalLoadOp>(src) ||
-         src->hasTrait<OpTrait::ConstantLike>())) {
+
+    bool isHoistable = true;
+    SetVector<Operation *> opsWithinDispatch;
+    std::queue<Operation *> worklist;
+    worklist.push(setEncodingOp);
+    while (!worklist.empty()) {
+      Operation *op = worklist.front();
+      worklist.pop();
+      opsWithinDispatch.insert(op);
+      for (auto input : op->getOperands()) {
+        if (auto inputOp = input.getDefiningOp();
+            inputOp &&
+            inputOp->getParentOfType<IREE::Flow::DispatchRegionOp>() &&
+            !opsWithinDispatch.contains(inputOp)) {
+          if (!isHoistableOp(inputOp)) {
+            inputOp->dump();
+            isHoistable = false;
+          }
+          worklist.push(inputOp);
+        }
+      }
+    }
+    if (isHoistable) {
+      candidates.push_back(llvm::to_vector(llvm::reverse(opsWithinDispatch)));
       return;
     }
-    candidates.push_back(setEncodingOp);
-  });
-  IRRewriter rewriter(ctx);
-  for (auto setEncodingOp : candidates) {
-    // TODO: Hoist the entire slice of IR up to the root if there is a ConstExpr
-    // root op.
-    Operation *src = setEncodingOp.getSource().getDefiningOp();
-    if (src && src->hasTrait<OpTrait::ConstantLike>() &&
-        src->getParentOfType<IREE::Flow::DispatchRegionOp>() &&
-        failed(IREE::Flow::hoistOutOfDispatch(rewriter, src))) {
-      src->emitOpError("failed to hoist the source out of dispatch");
-      return signalPassFailure();
+
+    // The ops are hoistable if they are const-exprs.
+    auto *constInfo = constExprs.lookup(setEncodingOp.getSource());
+    if (!constInfo) {
+      LDBG("Non-hoistable op (failed to get constInfo): " << setEncodingOp);
+      return;
     }
-    if (failed(IREE::Flow::hoistOutOfDispatch(rewriter, setEncodingOp))) {
-      setEncodingOp.emitOpError("failed to hoist the op out of dispatch");
-      return signalPassFailure();
+    if (policy.getDecision(constInfo)->getOutcome() ==
+        IREE::Util::ConstExprHoistingPolicy::ENABLE_HOIST) {
+      candidates.push_back(llvm::to_vector(llvm::reverse(opsWithinDispatch)));
+      return;
+    }
+    LDBG("Non-hoistable op: " << setEncodingOp);
+  });
+
+  IRRewriter rewriter(ctx);
+  for (auto hoistableOps : candidates) {
+    LDBG("Hoisting the ops for " << *hoistableOps.back());
+    for (auto op : hoistableOps) {
+      if (failed(IREE::Flow::hoistOutOfDispatch(rewriter, op))) {
+        op->emitOpError("failed to hoist the op out of dispatch");
+        return signalPassFailure();
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -271,13 +271,9 @@ def FuseEncodingOpsIntoDispatchRegionsPass :
     "IREE::Encoding::IREEEncodingDialect",
   ];
 }
-def HoistEncodingOpsPass :
-    InterfacePass<"iree-dispatch-creation-hoist-encoding-ops", "mlir::FunctionOpInterface"> {
+
+def HoistEncodingOpsPass : Pass<"iree-dispatch-creation-hoist-encoding-ops", "mlir::ModuleOp"> {
   let summary = "Hoists tensor encoding ops out of flow dispatch regions.";
-  let options = [
-    Option<"hoistEncodingsForConstExpr", "hoist-encodings-for-constexpr", "bool", /*default=*/"true",
-           "Enable the hoisting when the source is a ConstExpr.">,
-  ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "IREE::Flow::FlowDialect",


### PR DESCRIPTION
The revision runs ConstExprHoistingPolicy and hoist the chain ops outside dispatch if they are const-exprs. Furthermore, it allows hoisting tensor.extract_slice ops when they are mappable into Flow ops. It also allows constant-like ops because the ConstExpr analysis has an assumption that any root op is already hoisted to initializers. The rest of operations are not allowed to be hoisted out atm.

The hoistEncodingsForConstExpr is dropped because it is no longer needed. It was created for padding strategy.

The pass is changed to ModuleOp scope because it requires the analysis for const-exprs. Otherwise, it causes a thread race condition.

Fixes https://github.com/iree-org/iree/issues/21100