### PR TITLE
Move all producing uses of flow.bitcast to tensor_ext

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/BitCastTensor.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BitCastTensor.cpp
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -73,7 +73,7 @@ public:
       }
     }
 
-    Value flowBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+    Value flowBitcast = rewriter.create<IREE::TensorExt::BitCastOp>(
         loc, rType, builtinCast, inDynamicDims, outDynamicDims);
 
     auto torchCast =
@@ -110,7 +110,7 @@ public:
       }
     }
 
-    Value flowBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+    Value flowBitcast = rewriter.create<IREE::TensorExt::BitCastOp>(
         loc, rType, builtinCast, dynDims, dynDims);
 
     auto torchCast =
@@ -184,7 +184,7 @@ public:
             loc, rhsType.toBuiltinTensor(), rhs);
 
     // No dynamic dims because we are bitcasting a constant.
-    auto flowBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+    auto flowBitcast = rewriter.create<IREE::TensorExt::BitCastOp>(
         loc, bitCastTargetType, builtinCast, ValueRange(), ValueRange());
 
     // Cast back to the (un)signed torch tensor type to inform later lowerings.
@@ -209,7 +209,7 @@ namespace {
 class BitCastTensorPass final
     : public impl::BitCastTensorPassBase<BitCastTensorPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<IREE::TensorExt::IREETensorExtDialect>();
     registry.insert<torch::Torch::TorchDialect>();
     registry.insert<torch::TorchConversion::TorchConversionDialect>();
   }

--- a/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
@@ -58,5 +58,6 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Stream::IR
+    iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )

--- a/compiler/plugins/input/Torch/InputConversion/test/bitcast_tensor.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/bitcast_tensor.mlir
@@ -9,7 +9,7 @@ func.func @forward(%arg0: !torch.vtensor<[1,1,8],f16>) -> !torch.vtensor<[1,1,8]
   %bit_width = torch.constant.int 4
   %group_size = torch.constant.int 2
   // CHECK: %[[TOBUILTIN:.*]] = torch_c.to_builtin_tensor %[[C0]] : !torch.vtensor<[8,4],ui8> -> tensor<8x4xui8>
-  // CHECK: %[[BITCAST:.*]] = flow.tensor.bitcast %[[TOBUILTIN]] : tensor<8x4xui8> -> tensor<8x8xi4>
+  // CHECK: %[[BITCAST:.*]] = iree_tensor_ext.bitcast %[[TOBUILTIN]] : tensor<8x4xui8> -> tensor<8x8xi4>
   // CHECK: %[[TOTORCH:.*]] = torch_c.from_builtin_tensor %[[BITCAST]] : tensor<8x8xi4> -> !torch.vtensor<[8,8],ui4>
   %output = torch.operator "quant.matmul_rhs_group_quant"(%arg0, %q_rhs, %scales, %zps, %bit_width, %group_size) : (!torch.vtensor<[1,1,8],f16>, !torch.vtensor<[8,4],ui8>, !torch.vtensor<[8,4,1],f16>, !torch.vtensor<[8,4,1],f16>, !torch.int, !torch.int) -> !torch.vtensor<[1,1,8],f16>
   return %output : !torch.vtensor<[1,1,8],f16>
@@ -20,7 +20,7 @@ func.func @forward(%arg0: !torch.vtensor<[1,1,8],f16>) -> !torch.vtensor<[1,1,8]
 // CHECK-LABEL: @view_type0
 func.func @view_type0(%arg0 : !torch.vtensor<[295501824],ui8>) -> !torch.vtensor<[147750912],si16> {
   %int4 = torch.constant.int 4
-  // CHECK: flow.tensor.bitcast %[[IN:.+]] : tensor<295501824xi8> -> tensor<147750912xi16>
+  // CHECK: iree_tensor_ext.bitcast %[[IN:.+]] : tensor<295501824xi8> -> tensor<147750912xi16>
   %0 = torch.aten.view.dtype %arg0, %int4 : !torch.vtensor<[295501824],ui8>, !torch.int -> !torch.vtensor<[147750912],si16>
   return %0 : !torch.vtensor<[147750912],si16>
 }
@@ -34,7 +34,7 @@ func.func @view_type1(%arg0 : !torch.vtensor<[?],ui8>) -> !torch.vtensor<[?],si1
   //  CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
   //      CHECK: %[[DIM:.+]] = tensor.dim %[[IN:.+]], %[[C0]] : tensor<?xi8>
   //      CHECK: %[[OUT:.+]] = arith.muli %[[DIM]], %[[C2]]
-  //      CHECK: flow.tensor.bitcast %[[IN]] :
+  //      CHECK: iree_tensor_ext.bitcast %[[IN]] :
   // CHECK-SAME:   tensor<?xi8>{%[[DIM]]} -> tensor<?xi16>{%[[OUT]]}
   %0 = torch.aten.view.dtype %arg0, %int4 : !torch.vtensor<[?],ui8>, !torch.int -> !torch.vtensor<[?],si16>
   return %0 : !torch.vtensor<[?],si16>
@@ -49,7 +49,7 @@ func.func @view_type2(%arg0 : !torch.vtensor<[?],f64>) -> !torch.vtensor<[?],f16
   //  CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
   //      CHECK: %[[DIM:.+]] = tensor.dim %[[IN:.+]], %[[C0]] : tensor<?xf64>
   //      CHECK: %[[OUT:.+]] = arith.divsi %[[DIM]], %[[C4]] : index
-  //      CHECK: flow.tensor.bitcast %[[IN]] :
+  //      CHECK: iree_tensor_ext.bitcast %[[IN]] :
   // CHECK-SAME:   tensor<?xf64>{%[[DIM]]} -> tensor<?xf16>{%[[OUT]]}
   %0 = torch.aten.view.dtype %arg0, %int4 : !torch.vtensor<[?],f64>, !torch.int -> !torch.vtensor<[?],f16>
   return %0 : !torch.vtensor<[?],f16>
@@ -62,7 +62,7 @@ func.func @view_type3(%arg0 : !torch.vtensor<[?,295501824],ui8>) -> !torch.vtens
   %int4 = torch.constant.int 4
   //      CHECK: %[[C0:.+]] = arith.constant 0 : index
   //      CHECK: %[[DIM:.+]] = tensor.dim %[[IN:.+]], %[[C0]] : tensor<?x295501824xi8>
-  //      CHECK: flow.tensor.bitcast %[[IN]] :
+  //      CHECK: iree_tensor_ext.bitcast %[[IN]] :
   // CHECK-SAME:   tensor<?x295501824xi8>{%[[DIM]]} -> tensor<?x147750912xi16>{%[[DIM]]}
   %0 = torch.aten.view.dtype %arg0, %int4 : !torch.vtensor<[?,295501824],ui8>, !torch.int -> !torch.vtensor<[?,147750912],si16>
   return %0 : !torch.vtensor<[?,147750912],si16>
@@ -72,7 +72,7 @@ func.func @view_type3(%arg0 : !torch.vtensor<[?,295501824],ui8>) -> !torch.vtens
 
 // CHECK-LABEL: @view_as_complex
 func.func @view_as_complex(%arg0 : !torch.vtensor<[128,2],f32>) -> !torch.vtensor<[128], complex<f32>> {
-  // CHECK: flow.tensor.bitcast %[[IN:.+]] : tensor<128x2xf32> -> tensor<128xcomplex<f32>>
+  // CHECK: iree_tensor_ext.bitcast %[[IN:.+]] : tensor<128x2xf32> -> tensor<128xcomplex<f32>>
   %0 = torch.aten.view_as_complex %arg0 : !torch.vtensor<[128,2],f32> -> !torch.vtensor<[128],complex<f32>>
   return %0 : !torch.vtensor<[128],complex<f32>>
 }
@@ -81,7 +81,7 @@ func.func @view_as_complex(%arg0 : !torch.vtensor<[128,2],f32>) -> !torch.vtenso
 
 // CHECK-LABEL: @view_as_real
 func.func @view_as_real(%arg0 : !torch.vtensor<[128], complex<f32>>) -> !torch.vtensor<[128,2],f32> {
-  // CHECK: flow.tensor.bitcast %[[IN:.+]] : tensor<128xcomplex<f32>> -> tensor<128x2xf32>
+  // CHECK: iree_tensor_ext.bitcast %[[IN:.+]] : tensor<128xcomplex<f32>> -> tensor<128x2xf32>
   %0 = torch.aten.view_as_real %arg0 : !torch.vtensor<[128],complex<f32>> -> !torch.vtensor<[128,2],f32>
   return %0 : !torch.vtensor<[128,2],f32>
 }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/DispatchCreation/Passes.h"
 
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
@@ -185,7 +186,7 @@ void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
   IREE::Util::ExprHoistingOptions options;
   options.maxSizeIncreaseThreshold = 0;
   options.registerDependentDialectsFn = [](DialectRegistry &registry) {
-    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<IREE::TensorExt::IREETensorExtDialect>();
   };
   passManager.addPass(IREE::Util::createHoistIntoGlobalsPass(options));
   FunctionLikeNest(passManager)
@@ -263,7 +264,7 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
   IREE::Util::ExprHoistingOptions hoistingOptions;
   hoistingOptions.maxSizeIncreaseThreshold = 0;
   hoistingOptions.registerDependentDialectsFn = [](DialectRegistry &registry) {
-    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<IREE::TensorExt::IREETensorExtDialect>();
   };
   passManager.addPass(IREE::Util::createHoistIntoGlobalsPass(hoistingOptions));
 }

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -94,6 +94,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/DFX",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -104,6 +104,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils
+    iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::Analysis::Attributes
     iree::compiler::Dialect::Util::Analysis::DFX

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRIR
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -6,7 +6,7 @@
 
 #include "iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.h"
 
-#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -24,8 +24,8 @@ static Value bitcastToStaticTypeImpl(OpBuilder &b, Location loc,
     return global;
   }
   // No dynamic dims because we are always bitcasting constants.
-  return b.create<IREE::Flow::TensorBitCastOp>(loc, targetType, global,
-                                               ValueRange(), ValueRange());
+  return b.create<IREE::TensorExt::BitCastOp>(loc, targetType, global,
+                                              ValueRange(), ValueRange());
 }
 
 struct HoistableTensorTypeInterface

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/GlobalOptimization/Passes.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "iree/compiler/Modules/IO/Parameters/Transforms/Passes.h"
@@ -82,7 +82,7 @@ void buildGlobalOptExprHoistingPassPipeline(
   options.maxSizeIncreaseThreshold =
       transformOptions.options.constExprMaxSizeIncreaseThreshold;
   options.registerDependentDialectsFn = [](DialectRegistry &registry) {
-    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<IREE::TensorExt::IREETensorExtDialect>();
   };
   passManager.addPass(IREE::Util::createHoistIntoGlobalsPass(options));
 }


### PR DESCRIPTION
All places where we currently construct flow.bitcast happen before
dispatch formation and instead should use tensor_ext.bitcast.