### PR TITLE
[Preprocessing][NFC] Drop dependency workaround from TransposeMatmulPass.

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -159,9 +159,6 @@ def TransposeMatmulPass : Pass<"iree-preprocessing-transpose-matmul-pass"> {
            )}]>
   ];
   let dependentDialects = [
-    // TODO(hanchung): Remove the dep after switching upstream patterns to not
-    // use bufferization::hasTensorSemantics method.
-    "mlir::bufferization::BufferizationDialect",
     "mlir::linalg::LinalgDialect",
   ];
 }


### PR DESCRIPTION
The workaround was introduced in recent integrate and it's fixed by https://github.com/llvm/llvm-project/commit/42578e8586e65fb9a3f9215d0f650eab26be92f0