### PR TITLE
[CPU] Disable lowering_config propagation for Mmt4dTilingExpert pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenEnums.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -3208,8 +3209,13 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
 
   // The transform dialect codegen has differnet logics and codegen flow.
   // Ignore the tile sizes adjustment.
+  // TODO(#21297): Fix the propagation logic and use the upcoming
+  // IREE::CPU::LoweringCongigAttr for mmt4d pipelines. The current workaround
+  // is mainly to by pass existing complicated logic which makes the migration
+  // easier.
   auto pipeline = getTranslationInfo(entryPointFn).getPassPipeline().getValue();
-  if (pipeline != DispatchLoweringPassPipeline::TransformDialectCodegen) {
+  if (pipeline != DispatchLoweringPassPipeline::TransformDialectCodegen &&
+      pipeline != DispatchLoweringPassPipeline::Mmt4dTilingExpert) {
     if (failed(adjustTileSizesForUnPackOp(entryPointFn, rootOperation))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1607,6 +1607,8 @@ func.func @mmt4d_with_large_reduction() attributes {hal.executable.target = #exe
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 0, 0, 0, 0], [1, 1, 0, 2, 16, 0], [0, 0, 1, 0, 0, 1]]>
 //      CHECK: func.func @mmt4d_with_large_reduction()
+//      CHECK:   linalg.fill
+//  CHECK-NOT:     lowering_config
 //      CHECK:   linalg.mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 


### PR DESCRIPTION
To verify that it fixes the issue, the stack allocation check is added to pipeline tests, which makes sure all the pipeline tests are generating valid IRs.

It is a step towards #21197 and https://github.com/iree-org/iree/issues/21297

Fixes #20786