### PR TITLE
[VectorDistribute][NFC] Refactor subgroup reduction distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -981,6 +981,156 @@ struct DistributeMultiReduction final
     return res;
   }
 
+  Value getBufferForSubgroupReduction(RewriterBase &rewriter, MemRefType memTy,
+                                      Value val) const {
+    // Check if the defining op is actually in a scf.for loop, and hoist out the
+    // alloc of the scf.for loop so we can reuse the allocation and not have
+    // to worry about the compiler reasoning if we can actually do any memory
+    // reuse.
+    Operation *parentOp = val.getParentBlock()->getParentOp();
+    scf::ForOp parentFor = nullptr;
+    while (parentOp) {
+      if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        parentFor = forOp;
+        break;
+      }
+      parentOp = parentOp->getParentOp();
+    }
+    memref::AllocOp alloc;
+    {
+      OpBuilder::InsertionGuard g(rewriter);
+      if (parentFor) {
+        rewriter.setInsertionPoint(parentFor);
+      }
+      alloc = rewriter.create<memref::AllocOp>(val.getLoc(), memTy);
+    }
+    if (parentOp) {
+      // Insert gpu.barrier to make sure previous iteration of batch loop has
+      // fully read the subgroup partial reductions.
+      rewriter.create<gpu::BarrierOp>(val.getLoc());
+    }
+    return alloc;
+  }
+
+  NestedLayoutAttr
+  getLayoutForReductionFromBuffer(NestedLayoutAttr srcLayout,
+                                  ArrayRef<int64_t> reductionDims) const {
+    auto ceilToPowerOf2 = [](uint32_t x) {
+      return llvm::isPowerOf2_32(x) ? x : llvm::NextPowerOf2(x);
+    };
+    // Create new layout where the elements of a subgroup are
+    // distributed to every threads.
+    IREE::VectorExt::NestedLayoutAttr bufferReduceLayout;
+    SmallVector<int64_t> subgroupTileLens =
+        llvm::to_vector(srcLayout.getSubgroupTile());
+    SmallVector<int64_t> batchTileLens =
+        llvm::to_vector(srcLayout.getBatchTile());
+    SmallVector<int64_t> outerTileLens =
+        llvm::to_vector(srcLayout.getOuterTile());
+    SmallVector<int64_t> threadTileLens =
+        llvm::to_vector(srcLayout.getThreadTile());
+    SmallVector<int64_t> elementTileLens =
+        llvm::to_vector(srcLayout.getElementTile());
+    SmallVector<int64_t> subgroupStrides =
+        llvm::to_vector(srcLayout.getSubgroupStrides());
+    SmallVector<int64_t> threadStrides =
+        llvm::to_vector(srcLayout.getThreadStrides());
+
+    for (int64_t rDim : reductionDims) {
+      batchTileLens[rDim] = 1;
+      outerTileLens[rDim] = 1;
+      elementTileLens[rDim] = 1;
+      threadStrides[rDim] *= subgroupStrides[rDim];
+      // The size or #lanes needs to be a power of 2.
+      threadTileLens[rDim] = ceilToPowerOf2(subgroupTileLens[rDim]);
+      subgroupStrides[rDim] = 1;
+      subgroupTileLens[rDim] = 1;
+    }
+    bufferReduceLayout = IREE::VectorExt::NestedLayoutAttr::get(
+        srcLayout.getContext(), subgroupTileLens, batchTileLens, outerTileLens,
+        threadTileLens, elementTileLens, subgroupStrides, threadStrides);
+    return bufferReduceLayout;
+  }
+
+  NestedLayoutAttr
+  writePartialResultToBuffer(RewriterBase &rewriter, Location loc,
+                             VectorValue valueToWrite, Value buffer,
+                             NestedLayoutAttr srcLayout,
+                             ArrayRef<int64_t> reductionDims) const {
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    VectorType unDistributedType = valueToWrite.getType();
+    SmallVector<Value> indices(unDistributedType.getRank(), c0);
+    SmallVector<bool> inBounds(unDistributedType.getRank(), false);
+    auto write = rewriter.create<vector::TransferWriteOp>(
+        loc, valueToWrite, buffer, indices, inBounds);
+    // Set layouts signature for write.
+    // We need to set the layout on the srcVector/first operand.
+    SmallVector<int64_t> subgroupTileLens =
+        llvm::to_vector(srcLayout.getSubgroupTile());
+    SmallVector<int64_t> batchTileLens =
+        llvm::to_vector(srcLayout.getBatchTile());
+    SmallVector<int64_t> outerTileLens =
+        llvm::to_vector(srcLayout.getOuterTile());
+    SmallVector<int64_t> threadTileLens =
+        llvm::to_vector(srcLayout.getThreadTile());
+    SmallVector<int64_t> elementTileLens =
+        llvm::to_vector(srcLayout.getElementTile());
+    SmallVector<int64_t> subgroupStrides =
+        llvm::to_vector(srcLayout.getSubgroupStrides());
+    SmallVector<int64_t> threadStrides =
+        llvm::to_vector(srcLayout.getThreadStrides());
+    // Replace the reduced tiles with unit dimension.
+    for (int64_t rDim : reductionDims) {
+      batchTileLens[rDim] = 1;
+      outerTileLens[rDim] = 1;
+      threadTileLens[rDim] = 1;
+      elementTileLens[rDim] = 1;
+      threadStrides[rDim] = 0;
+    }
+    auto interSubGroupLayout = IREE::VectorExt::NestedLayoutAttr::get(
+        rewriter.getContext(), subgroupTileLens, batchTileLens, outerTileLens,
+        threadTileLens, elementTileLens, subgroupStrides, threadStrides);
+    setSignatureForRedistribution(rewriter, write, {interSubGroupLayout}, {});
+    return interSubGroupLayout;
+  }
+
+  Value doSubgroupReductionFromBuffer(
+      RewriterBase &rewriter, Location loc, Value buffer,
+      NestedLayoutAttr writeLayout, NestedLayoutAttr srcLayout,
+      VectorLayoutInterface resLayout, ArrayRef<int64_t> reductionDims,
+      vector::CombiningKind kind, Value acc) const {
+    VectorType writeTy = VectorType::get(writeLayout.getUndistributedShape(),
+                                         getElementTypeOrSelf(buffer));
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value> indices(writeLayout.getRank(), c0);
+    SmallVector<bool> inBounds(writeLayout.getRank(), false);
+    auto read = rewriter.create<vector::TransferReadOp>(
+        loc, writeTy, buffer, indices, /*padding=*/
+        arith::getZeroConstant(rewriter, loc, writeTy.getElementType()),
+        inBounds);
+
+    NestedLayoutAttr subgroupToThreadsLayout =
+        getLayoutForReductionFromBuffer(srcLayout, reductionDims);
+    setSignatureForRedistribution(rewriter, read, {},
+                                  {subgroupToThreadsLayout});
+    // A newly created reduction to complete the reduction
+    // that reduces the data that was otherwise was on
+    // different subgroups.
+    // Since the data was distributed to every thread, it will
+    // form a gpu.subgroup_reduce operation later.
+    auto secondReduction = rewriter.create<vector::MultiDimReductionOp>(
+        loc, kind, read, acc, reductionDims);
+    if (resLayout) {
+      setSignatureForRedistribution(rewriter, secondReduction,
+                                    {subgroupToThreadsLayout, resLayout},
+                                    {resLayout});
+    } else {
+      setSignatureForRedistribution(rewriter, secondReduction,
+                                    {subgroupToThreadsLayout}, {});
+    }
+    return secondReduction.getResult();
+  }
+
   // The reductions across subgroups are performed
   // as follows:
   // 1) Re-cover the subgroup-local result as the same rank as the
@@ -1030,139 +1180,25 @@ struct DistributeMultiReduction final
       // tile.
       partialReductionShape[rDim] = preDistrShape[rDim];
     }
+    VectorType unDistributedType = VectorType::get(
+        partialReductionShape, srcVector.getType().getElementType());
+    VectorValue valueToWrite = rewriter.create<IREE::VectorExt::ToSIMDOp>(
+        loc, unDistributedType, isoRankThreadReduced);
+
     auto workgroupMemoryAddressSpace = Attribute(gpu::AddressSpaceAttr::get(
         rewriter.getContext(), gpu::AddressSpace::Workgroup));
     MemRefType allocType = MemRefType::get(
         partialReductionShape, srcVector.getType().getElementType(),
         AffineMap(), workgroupMemoryAddressSpace);
-    auto alloc = rewriter.create<memref::AllocOp>(loc, allocType);
-    VectorType unDistributedType = VectorType::get(
-        partialReductionShape, srcVector.getType().getElementType());
-    Value undistrWrite = rewriter.create<IREE::VectorExt::ToSIMDOp>(
-        loc, unDistributedType, isoRankThreadReduced);
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    SmallVector<Value> indices(unDistributedType.getRank(), c0);
-    SmallVector<bool> inBounds(unDistributedType.getRank(), false);
-    // Insert gpu.barrier to make sure previuos iteration
-    // of batch loop has fully read the subgroup partial
-    // reductions.
+    auto alloc =
+        getBufferForSubgroupReduction(rewriter, allocType, valueToWrite);
+    NestedLayoutAttr writeLayout = writePartialResultToBuffer(
+        rewriter, loc, valueToWrite, alloc, srcLayout, reductionDims);
+    // Wait for writes to buffer to finish.
     rewriter.create<gpu::BarrierOp>(loc);
-    auto write = rewriter.create<vector::TransferWriteOp>(
-        loc, undistrWrite, alloc, indices, inBounds);
-    // Set layouts signature for write.
-    // We need to set the layout on the srcVector/first operand.
-    auto unitAttr = UnitAttr::get(rewriter.getContext());
-    {
-      SmallVector<int64_t> subgroupTileLens =
-          llvm::to_vector(srcLayout.getSubgroupTile());
-      SmallVector<int64_t> batchTileLens =
-          llvm::to_vector(srcLayout.getBatchTile());
-      SmallVector<int64_t> outerTileLens =
-          llvm::to_vector(srcLayout.getOuterTile());
-      SmallVector<int64_t> threadTileLens =
-          llvm::to_vector(srcLayout.getThreadTile());
-      SmallVector<int64_t> elementTileLens =
-          llvm::to_vector(srcLayout.getElementTile());
-      SmallVector<int64_t> subgroupStrides =
-          llvm::to_vector(srcLayout.getSubgroupStrides());
-      SmallVector<int64_t> threadStrides =
-          llvm::to_vector(srcLayout.getThreadStrides());
-      // Replace the reduced tiles with unit dimension.
-      for (int64_t rDim : reductionDims) {
-        batchTileLens[rDim] = 1;
-        outerTileLens[rDim] = 1;
-        threadTileLens[rDim] = 1;
-        elementTileLens[rDim] = 1;
-        threadStrides[rDim] = 0;
-      }
-      auto interSubGroupLayout = IREE::VectorExt::NestedLayoutAttr::get(
-          rewriter.getContext(), subgroupTileLens, batchTileLens, outerTileLens,
-          threadTileLens, elementTileLens, subgroupStrides, threadStrides);
-      auto writeAttrs =
-          SmallVector<Attribute>(write->getNumOperands(), unitAttr);
-      writeAttrs[0] = interSubGroupLayout;
-      ArrayAttr writeOperandsAttr =
-          ArrayAttr::get(rewriter.getContext(), writeAttrs);
-      ArrayAttr writeResultsAttr = ArrayAttr::get(rewriter.getContext(), {});
-      setSignatureForRedistribution(rewriter, write.getOperation(),
-                                    writeOperandsAttr, writeResultsAttr);
-    }
-
-    auto ceilToPowerOf2 = [](uint32_t x) {
-      return llvm::isPowerOf2_32(x) ? x : llvm::NextPowerOf2(x);
-    };
-
-    // Insert gpu.barrier
-    rewriter.create<gpu::BarrierOp>(write.getLoc());
-    auto read = rewriter.create<vector::TransferReadOp>(
-        loc, unDistributedType, alloc, indices, /*padding=*/
-        arith::getZeroConstant(rewriter, loc,
-                               unDistributedType.getElementType()),
-        inBounds);
-    // Create new layout where the elements of a subgroup are
-    // distributed to every threads.
-    IREE::VectorExt::NestedLayoutAttr subgroupToThreadsLayout;
-    {
-      // We intentionally make the subgroup tile to be 1
-      SmallVector<int64_t> subgroupTileLens =
-          llvm::to_vector(srcLayout.getSubgroupTile());
-      SmallVector<int64_t> batchTileLens =
-          llvm::to_vector(srcLayout.getBatchTile());
-      SmallVector<int64_t> outerTileLens =
-          llvm::to_vector(srcLayout.getOuterTile());
-      SmallVector<int64_t> threadTileLens =
-          llvm::to_vector(srcLayout.getThreadTile());
-      SmallVector<int64_t> elementTileLens =
-          llvm::to_vector(srcLayout.getElementTile());
-      SmallVector<int64_t> subgroupStrides =
-          llvm::to_vector(srcLayout.getSubgroupStrides());
-      SmallVector<int64_t> threadStrides =
-          llvm::to_vector(srcLayout.getThreadStrides());
-
-      for (int64_t rDim : reductionDims) {
-        batchTileLens[rDim] = 1;
-        outerTileLens[rDim] = 1;
-        elementTileLens[rDim] = 1;
-        threadStrides[rDim] *= subgroupStrides[rDim];
-        // The size or #lanes needs to be a power of 2.
-        threadTileLens[rDim] = ceilToPowerOf2(subgroupTileLens[rDim]);
-        subgroupStrides[rDim] = 1;
-        subgroupTileLens[rDim] = 1;
-      }
-      subgroupToThreadsLayout = IREE::VectorExt::NestedLayoutAttr::get(
-          rewriter.getContext(), subgroupTileLens, batchTileLens, outerTileLens,
-          threadTileLens, elementTileLens, subgroupStrides, threadStrides);
-      auto readAttrs = SmallVector<Attribute>(read->getNumOperands(), unitAttr);
-      ArrayAttr readOperandsAttr =
-          ArrayAttr::get(rewriter.getContext(), readAttrs);
-      ArrayAttr readResultsAttr =
-          ArrayAttr::get(rewriter.getContext(), {subgroupToThreadsLayout});
-      setSignatureForRedistribution(rewriter, read.getOperation(),
-                                    readOperandsAttr, readResultsAttr);
-    }
-    // A newly created reduction to complete the reduction
-    // that reduces the data that was otherwise was on
-    // different subgroups.
-    // Since the data was distributed to every thread, it will
-    // form a gpu.subgroup_reduce operation later.
-    auto secondReduction = rewriter.create<vector::MultiDimReductionOp>(
-        loc, kind, read, acc, reductionDims);
-    {
-      auto reduceAttrs =
-          SmallVector<Attribute>(secondReduction->getNumOperands(), unitAttr);
-      reduceAttrs[0] = subgroupToThreadsLayout;
-      ArrayAttr reduceResultsAttr =
-          ArrayAttr::get(rewriter.getContext(), {unitAttr});
-      if (auto dstLayout = dyn_cast_or_null<NestedLayoutAttr>(resLayout)) {
-        reduceAttrs[1] = dstLayout;
-        reduceResultsAttr = ArrayAttr::get(rewriter.getContext(), {dstLayout});
-      }
-      ArrayAttr reduceOperandsAttr =
-          ArrayAttr::get(rewriter.getContext(), reduceAttrs);
-      setSignatureForRedistribution(rewriter, secondReduction.getOperation(),
-                                    reduceOperandsAttr, reduceResultsAttr);
-    }
-    return secondReduction.getResult();
+    return doSubgroupReductionFromBuffer(rewriter, loc, alloc, writeLayout,
+                                         srcLayout, resLayout, reductionDims,
+                                         kind, acc);
   }
 
   int64_t subgroupSize;
@@ -1359,22 +1395,13 @@ struct DistributeContract final
     auto partialReduction = rewriter.create<vector::MultiDimReductionOp>(
         loc, contractOp.getKind(), undistrLocalReduced, acc,
         partialReductionDims);
-    {
-      auto unitAttr = UnitAttr::get(rewriter.getContext());
-      auto reduceAttrs =
-          SmallVector<Attribute>(partialReduction->getNumOperands(), unitAttr);
-      reduceAttrs[0] = reductionLayout;
-      ArrayAttr reduceResultsAttr =
-          ArrayAttr::get(rewriter.getContext(), {unitAttr});
-      if (auto dstLayout =
-              dyn_cast_or_null<NestedLayoutAttr>(signature[resVector])) {
-        reduceAttrs[1] = dstLayout;
-        reduceResultsAttr = ArrayAttr::get(rewriter.getContext(), {dstLayout});
-      }
-      ArrayAttr reduceOperandsAttr =
-          ArrayAttr::get(rewriter.getContext(), reduceAttrs);
-      setSignatureForRedistribution(rewriter, partialReduction.getOperation(),
-                                    reduceOperandsAttr, reduceResultsAttr);
+    if (resVector) {
+      setSignatureForRedistribution(rewriter, partialReduction,
+                                    {reductionLayout, signature[resVector]},
+                                    {signature[resVector]});
+    } else {
+      setSignatureForRedistribution(rewriter, partialReduction,
+                                    {reductionLayout}, {});
     }
     rewriter.replaceOp(contractOp, partialReduction);
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -209,9 +209,8 @@ void DistributionPattern::setSignatureForRedistribution(
     }
   }
 
-  ArrayAttr inputArrayAttr = ArrayAttr::get(rewriter.getContext(), inputAttrs);
-  ArrayAttr outputArrayAttr =
-      ArrayAttr::get(rewriter.getContext(), outputAttrs);
+  auto inputArrayAttr = ArrayAttr::get(rewriter.getContext(), inputAttrs);
+  auto outputArrayAttr = ArrayAttr::get(rewriter.getContext(), outputAttrs);
 
   Attribute signature[] = {inputArrayAttr, outputArrayAttr};
   rewriter.modifyOpInPlace(op, [&]() {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -181,10 +181,39 @@ DistributionPattern::getOpSignature(Operation *op) const {
 }
 
 void DistributionPattern::setSignatureForRedistribution(
-    PatternRewriter &rewriter, Operation *op, Attribute inputLayoutsAttr,
-    Attribute outputLayoutsAttr) const {
-  Attribute signature[] = {inputLayoutsAttr, outputLayoutsAttr};
+    RewriterBase &rewriter, Operation *op,
+    ArrayRef<VectorLayoutInterface> inputLayouts,
+    ArrayRef<VectorLayoutInterface> outputLayouts) const {
   auto unitAttr = UnitAttr::get(rewriter.getContext());
+  auto inputAttrs = SmallVector<Attribute>(op->getNumOperands(), unitAttr);
+  auto outputAttrs = SmallVector<Attribute>(op->getNumResults(), unitAttr);
+
+  auto isVectorType = [](Value x) { return isa<VectorType>(x.getType()); };
+  assert(llvm::count_if(op->getOperands(), isVectorType) ==
+         inputLayouts.size());
+  int64_t currVectorInput = 0;
+  for (auto [idx, operand] : llvm::enumerate(op->getOperands())) {
+    if (isVectorType(operand)) {
+      inputAttrs[idx] = inputLayouts[currVectorInput];
+      ++currVectorInput;
+    }
+  }
+
+  assert(llvm::count_if(op->getResults(), isVectorType) ==
+         outputLayouts.size());
+  int64_t currVectorOutput = 0;
+  for (auto [idx, result] : llvm::enumerate(op->getResults())) {
+    if (isVectorType(result)) {
+      outputAttrs[idx] = outputLayouts[currVectorOutput];
+      ++currVectorOutput;
+    }
+  }
+
+  ArrayAttr inputArrayAttr = ArrayAttr::get(rewriter.getContext(), inputAttrs);
+  ArrayAttr outputArrayAttr =
+      ArrayAttr::get(rewriter.getContext(), outputAttrs);
+
+  Attribute signature[] = {inputArrayAttr, outputArrayAttr};
   rewriter.modifyOpInPlace(op, [&]() {
     op->setAttr(kVectorLayoutFetcherStorageAttrName,
                 ArrayAttr::get(rewriter.getContext(), signature));

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -51,9 +51,10 @@ protected:
   // When "vector layout storage" and "vector layout redistribution"
   // is defined, VectorDistributionRewriter would add it to worklist
   // of operations to be distributed.
-  void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
-                                     Attribute inputLayoutsAttr,
-                                     Attribute outputLayoutsAttr) const;
+  void setSignatureForRedistribution(
+      RewriterBase &rewriter, Operation *op,
+      ArrayRef<VectorLayoutInterface> inputLayouts,
+      ArrayRef<VectorLayoutInterface> outputLayouts) const;
 
   LogicalResult replaceParentMask(PatternRewriter &rewriter,
                                   vector::MaskOp) const;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -161,6 +161,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[THREAD_RED4:.+]] = vector.shape_cast %[[THREAD_RED3]] : vector<2xf32> to vector<2x1x1xf32>
 // Subgroup reduction
 // CHECK-DAG: %[[ALLOC:.+]] = memref.alloc() : memref<32x2xf32, #gpu.address_space<workgroup>>
+// CHECK: gpu.barrier
 // CHECK-DAG: %[[SGID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64)
 // CHECK-DAG: %[[TIDX:.+]]:2 = affine.delinearize_index %thread_id_x into (16)
 // CHECK-DAG: %[[EXTRACT0:.+]] = vector.extract %[[THREAD_RED4]][0] : vector<1x1xf32> from vector<2x1x1xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -161,7 +161,6 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[THREAD_RED4:.+]] = vector.shape_cast %[[THREAD_RED3]] : vector<2xf32> to vector<2x1x1xf32>
 // Subgroup reduction
 // CHECK-DAG: %[[ALLOC:.+]] = memref.alloc() : memref<32x2xf32, #gpu.address_space<workgroup>>
-// CHECK: gpu.barrier
 // CHECK-DAG: %[[SGID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64)
 // CHECK-DAG: %[[TIDX:.+]]:2 = affine.delinearize_index %thread_id_x into (16)
 // CHECK-DAG: %[[EXTRACT0:.+]] = vector.extract %[[THREAD_RED4]][0] : vector<1x1xf32> from vector<2x1x1xf32>


### PR DESCRIPTION
The multi reduction function was getting quite big and hard to modify, this patch refactors into individual sub functions to make it easier to read / modify. Further patches will actually change the write to buffer / reduce from buffer functions.