### PR TITLE
[CodeGen][NFC] Delete DeadMemAlloc patterns.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -385,7 +385,6 @@ void BlockDynamicDimensionsPass::runOnOperation() {
     // operations.
     memref::populateResolveRankedShapedTypeResultDimsPatterns(
         bubbleExpandShapePatterns);
-    populateRemoveDeadMemAllocPatterns(bubbleExpandShapePatterns);
     if (failed(applyPatternsGreedily(operation,
                                      std::move(bubbleExpandShapePatterns)))) {
       operation->emitOpError(

--- a/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
@@ -37,7 +37,6 @@ struct CleanupBufferAllocViewPass final
     RewritePatternSet patterns(&getContext());
     populateReshapeToInterfaceTensorPatterns(patterns);
     populateFoldTensorReshapeIntoBufferPatterns(patterns);
-    populateRemoveDeadMemAllocPatterns(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -284,7 +284,6 @@ void IREEExpandStridedMetadataPass::runOnOperation() {
   RewritePatternSet patterns(context);
   populateIREEResolveExtractStridedMetadataPatterns(patterns,
                                                     allowSubviewExpansion);
-  populateRemoveDeadMemAllocPatterns(patterns);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -220,7 +220,8 @@ static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
   modulePassManager.addPass(createFlattenMemRefSubspanPass());
 
   FunctionLikeNest(modulePassManager)
-      .addPass(createSPIRVEraseStorageBufferStaticShapePass);
+      .addPass(createSPIRVEraseStorageBufferStaticShapePass)
+      .addPass(createCSEPass);
 }
 
 /// Adds passes to perform the final SPIR-V conversion.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -119,14 +119,6 @@ void EraseStorageBufferStaticShapePass::runOnOperation() {
     replaceMemrefUsesAndPropagateType(rewriter, subspanOp.getLoc(), subspanOp,
                                       newSubspanOp);
   }
-
-  {
-    RewritePatternSet patterns(&getContext());
-    populateRemoveDeadMemAllocPatterns(patterns);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      return signalPassFailure();
-    }
-  }
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/erase_storage_buffer_static_shape.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/erase_storage_buffer_static_shape.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-spirv-erase-storage-buffer-static-shape))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-spirv-erase-storage-buffer-static-shape, cse))" %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -99,9 +99,6 @@ using GetMinMaxExprFn =
 /// single iteration loops based on the range returned ValueBoundsOpInterface.
 void populateRemoveSingleIterationLoopPattern(RewritePatternSet &patterns);
 
-/// Populate patterns that remove dead allocations
-void populateRemoveDeadMemAllocPatterns(RewritePatternSet &patterns);
-
 // Group of Alloc operations that have overlapping liveranges.
 using AliasGroup = SmallVector<Operation *>;
 


### PR DESCRIPTION
With the memref.assume_alignment upstream change, it now can be DCE-ed, so we no longer need these patterns.

SPIRVEraseStorageBufferStaticShape could create duplicated bindings and constants, so we run CSE in the lit test and add the CSE pass to the pipeline.

Fixes https://github.com/iree-org/iree/issues/20949