### PR TITLE
[TensorExt] Add new operation that is a placeholder for modifying number of workgroups for split reduction.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -321,6 +321,17 @@ bool DispatchTensorStoreOp::isStoreToWholeTarget() {
 }
 
 //===----------------------------------------------------------------------===//
+// dispatch.workgroup_count_splitk_modifier
+//===----------------------------------------------------------------------===//
+
+void DispatchWorkgroupCountSplitReductionModifierOp::build(
+    OpBuilder &b, OperationState &state, ValueRange workgroups,
+    ValueRange workload) {
+  assert(workgroups.size() == 3);
+  return build(b, state, workgroups[0], workgroups[1], workgroups[2], workload);
+}
+
+//===----------------------------------------------------------------------===//
 // iree_tensor_ext.dispatch.workload.ordinal
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -307,6 +307,40 @@ def IREETensorExt_DispatchWorkgroupCountFromSliceOp :
   }];
 }
 
+def IREETensorExt_DispatchWorkgroupCountSplitReductionModifierOp :
+    IREETensorExt_PureOp<"dispatch.workgroup_count_split_reduction_modifier"> {
+  let summary = [{
+    Modifies the workgroup count calculation to account for split reductions.
+  }];
+  let description = [{
+    A split reduction dispatch contains an `scf.forall` within which the
+    partial reduction computation is done. The `scf.forall` represents parallel
+    partial reduction computations. `workgroup_x`, `workgroup_y`, and
+    `workgroup_z` represent the workgroups needed to execute the inner compute
+    ops. This is combined with `workload` to determine the total number of
+    workgroups required to run the computation after accounting for the
+    `scf.forall`.
+  }];
+  let arguments = (ins
+    Index:$workgroup_x,
+    Index:$workgroup_y,
+    Index:$workgroup_z,
+    Variadic<Index>:$workload
+  );
+  let results = (outs Index:$result_x, Index:$result_y, Index:$result_z);
+
+  let assemblyFormat = [{
+    attr-dict `(` $workgroup_x `,` $workgroup_y `,` $workgroup_z `)` `,` ($workload^)?
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "ValueRange":$workgroups,
+      "ValueRange":$workload
+    )>,
+  ];
+}
+
 def IREETensorExt_DispatchWorkloadOrdinalOp :
     IREETensorExt_PureOp<"dispatch.workload.ordinal", [
       DeclareOpInterfaceMethods<InferIntDivisibilityOpInterface>,

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "dispatch_tensor_folding.mlir",
             "dispatch_workload_ordinal_folding.mlir",
+            "roundtrip.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "dispatch_tensor_folding.mlir"
     "dispatch_workload_ordinal_folding.mlir"
+    "roundtrip.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+util.func public @workgroup_count_splitk(%arg0: index, %arg1: index, %arg2: index) -> tensor<?x?x?x?x?xf32> {
+  %0 = flow.dispatch.workgroups[%arg0, %arg1, %arg2](%arg0, %arg1, %arg2) : (index, index, index) -> tensor<?x?x?x?x?xf32>{%arg0, %arg1, %arg2, %arg2, %arg0} =
+      (%arg3: index, %arg4: index, %arg5: index, %arg6: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?x?x?xf32>>) {
+    flow.return
+  } count(%arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg3, %arg4, %arg5
+    %result_x, %result_y, %result_z = iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg3, %arg4, %arg5
+    flow.return %result_x, %result_y, %result_z : index, index, index
+  }
+  util.return %0 : tensor<?x?x?x?x?xf32>
+}
+// CHECK-LABEL: util.func public @workgroup_count_splitk(
+//       CHECK:   count(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+//       CHECK:   %[[X:.+]], %[[Y:.+]], %[[Z:.+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice
+//       CHECK:   %[[X0:.+]], %[[Y0:.+]], %[[Z0:.+]] = iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier
+//  CHECK-SAME:   (%[[X]], %[[Y]], %[[Z]]), %[[ARG0]], %[[ARG1]], %[[ARG2]]


### PR DESCRIPTION
To implement split reduction, the dispatch that contains the partial reduction needs workgroups to distribute the partial reduction operation by itself. This is then multiplied by the number of workgroups needed to run the parallel partial reductions in the same kernel. Since the exact value of this is not necessarily known at dispatch formation time, but is known after translating executables, a new operation is added to represent the computation that will be materialized to compute the change in the number of workgroups needed to run the parallel partial reductions. This PR just adds this operation. Its resolution/materialization will be done in a later PR.