### PR TITLE
[VectorDistribute] Fix buffer reduction during subgroup reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -170,6 +170,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",
+        "@llvm-project//mlir:VectorUtils",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -138,6 +138,7 @@ iree_cc_library(
     MLIRVectorDialect
     MLIRVectorToSCF
     MLIRVectorTransforms
+    MLIRVectorUtils
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::VectorLayoutAnalysis
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -183,3 +183,75 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-DAG: %[[INS1:.+]] = vector.insert %[[RED1]], %[[INS0]] [1] : f32 into vector<2xf32>
 // CHECK-DAG: %[[CAST:.+]] = vector.shape_cast %[[INS1]] : vector<2xf32> to vector<2x1x1xf32>
 // CHECK-DAG: arith.maximumf %[[CAST]], %[[ACC]] : vector<2x1x1xf32>
+
+// -----
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 3],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+  subgroup_strides = [2, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @subgroup_reduction_masked_tail_thread(%arg0: vector<16x48xf16>, %arg1: vector<16xf16>) -> vector<16xf16> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested) : vector<16x48xf16>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<16x48xf16> to vector<16xf16>
+  return %0 : vector<16xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: subgroup_reduction_masked_tail_thread
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK: vector.transfer_write
+// CHECK: gpu.barrier
+// The read will be masked, because we have 4 threads doing a subgroup reduce
+// on 3 elements.
+// CHECK: %[[MASK:.+]] = vector.create_mask %[[C1]], %{{.*}} : vector<1x1xi1>
+// CHECK: vector.transfer_read
+// CHECK-SAME: %[[MASK]]
+// CHECK: gpu.subgroup_reduce
+
+// -----
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 2],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [16, 1],
+  element_tile = [1, 4],
+  subgroup_strides = [2, 1],
+  thread_strides = [1, 0]
+>
+
+func.func @subgroup_reduction_serial_tail(%arg0: vector<16x8xf16>, %arg1: vector<16xf16>) -> vector<16xf16> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested) : vector<16x8xf16>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<16x8xf16> to vector<16xf16>
+  return %0 : vector<16xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: subgroup_reduction_serial_tail
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK: vector.transfer_write
+// CHECK: gpu.barrier
+// We should be doing a serialized reduction, because we don't know if we have
+// enough threads on the reduction dimension to do a subgroup reduce.
+// CHECK: vector.transfer_read %{{.*}}[%{{.*}}, %[[C0]]]
+// CHECK-NOT: gpu.subgroup_reduce

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -49,10 +49,9 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK:    }
 //         CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
 //         CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<10xf32, #gpu.address_space<workgroup>>
-//         CHECK:    %[[SVIEW:.+]] = memref.subview {{.*}} : memref<10xf32, #gpu.address_space<workgroup>> to memref<8xf32, strided<[1]>, #gpu.address_space<workgroup>>
-//         CHECK:    vector.transfer_write %{{.*}}, %[[SVIEW]]{{.*}} : vector<1xf32>, memref<8xf32, strided<[1]>, #gpu.address_space<workgroup>>
+//         CHECK:    vector.transfer_write %{{.*}}, %[[ALLOC]]{{.*}} : vector<1xf32>
 //         CHECK:    gpu.barrier
-//         CHECK:    vector.transfer_read %[[SVIEW]]{{.*}} : memref<8xf32,
+//         CHECK:    vector.transfer_read %[[ALLOC]]{{.*}}
 //         CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 8) : (f32) -> f32
 //         CHECK:    vector.transfer_write {{.*}} : vector<f32>, memref<512xf32, #hal.descriptor_type<storage_buffer>>
 


### PR DESCRIPTION
The old buffer reduction computation was wrong, and only worked when threads were only distributed on the reduction dimensions. Fix the implementation to find thread and thread strides to use from a reduction dimension.

The implementation also uses masking instead of inbounds, and the masked dimension always gets distributed to 1, so the mask should always convert to a scf.if { load } else { passthru } (if done properly). 