### PR TITLE
[LinalgExt] Improve Attention partial tiling new batch dimension insertion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -360,12 +360,14 @@ hal.executable private @attention_20x1x64x4096x64 {
 // CHECK:           vector.multi_reduction <maximumf>
 // CHECK-COUNT-1:   gpu.subgroup_reduce  maximumf
 
-// PV Matmul
+// Sum
 // CHECK:           vector.contract
 // CHECK-SAME:      vector<1x1x4xf32>, vector<1x1x4xf32> into f32
 // CHECK-COUNT-1:   gpu.subgroup_reduce  add
 
-// CHECK:           vector.multi_reduction <add>
+// PV Matmul
+// CHECK:           vector.contract
+// CHECK-SAME:      vector<1x1x4xf32>, vector<1x2x1x1x4x4xf32> into vector<2x1x4xf32>
 // CHECK-COUNT-8:   gpu.subgroup_reduce  add
 
 
@@ -573,7 +575,7 @@ hal.executable private @attention_4xDx1x32x128xf16 {
 
 //     CHECK-LABEL: func.func @attention_4xDx1x32x128xf16
 //           CHECK:   scf.forall ({{.*}}) in (4)
-//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1xf32>, vector<16x1x1x1x1x1x8x1x1xf32>) {
+//           CHECK:     scf.for {{.*}} -> (vector<1x1x1x1x1x1xf32>, vector<1x1x1x1x1x1xf32>, vector<1x1x16x1x1x1x1x1x8xf32>) {
 //       CHECK-NOT:       gpu.subgroup_reduce
 //           CHECK:       scf.yield
 //

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -2559,10 +2559,9 @@ LogicalResult OnlineAttentionOp::getResultTilePosition(
 }
 
 static AffineMap getPartialResultMap(AffineMap map, AttentionOpDetail &opInfo) {
-  // Append K2 dimensions at end.
-  for (int dim : opInfo.getK2Dims()) {
-    map = map.insertResult(getAffineDimExpr(dim, map.getContext()),
-                           map.getNumResults());
+  // Append K2 dimensions at start.
+  for (auto [idx, dim] : llvm::enumerate(opInfo.getK2Dims())) {
+    map = map.insertResult(getAffineDimExpr(dim, map.getContext()), idx);
   }
   return map;
 }


### PR DESCRIPTION
The newly inserted partial tiled dimensions are batch dimensions. These new dimensions were being inserted as the innermost dimensions, which is weird for batch dimensions and causes innermost dimensions to be 1 post thread distribution. Instead, make these dimensions the outer most dimensions as expected by the attention op.