### PR TITLE
Revert "[Codegen] Don't fold workgroup loops during workgroup tiling (#21137)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -136,6 +136,19 @@ func.func @gemm_unit_N(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x1xf32>,
 
 // -----
 
+func.func @gemm_unit_M_unit_N(%arg0 : tensor<1x1xf32>, %arg1 : tensor<1x1xf32>,
+    %arg2 : tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %0 = linalg.matmul {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>}
+      ins(%arg0, %arg1 : tensor<1x1xf32>, tensor<1x1xf32>)
+      outs(%arg2 : tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %0 : tensor<1x1xf32>
+}
+// CHECK-LABEL: func.func @gemm_unit_M_unit_N(
+//   CHECK-NOT:   scf.forall
+
+// -----
+
 func.func @generic_unit_dims(%arg0 : tensor<1x?x1x1x?x?x1x?xf32>) -> tensor<1x?x1x1x?x?x1x?xf32> {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
@@ -375,6 +388,25 @@ func.func @set_size_to_tilesize_when_divisible(
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:       tensor.parallel_insert_slice %[[GENERIC]]
 //  CHECK-SAME:           tensor<1x16x128xf16> into tensor<?x16x4096xf16>
+
+// -----
+
+// This just verifies that constant dim propagation works as expected after tiling.
+func.func @generate_no_distribution(%arg0 : tensor<16xf16>) -> tensor<16xf16> {
+   %empty = tensor.empty() : tensor<16xf16>
+   %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<16xf16>) outs(%empty : tensor<16xf16>)
+      attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[16]]>} {
+    ^bb0(%b0: f16, %b1: f16):
+      %1 = arith.mulf %b0, %b0 : f16
+      linalg.yield %1 : f16
+  } -> tensor<16xf16>
+  return %0 : tensor<16xf16>
+}
+// CHECK-LABEL: func @generate_no_distribution(
+//   CHECK-NOT:   scf.forall
 
 // -----
 
@@ -989,7 +1021,7 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
       iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
       ins(%3 : tensor<3x?x32x32xf32>) outs(%5 : tensor<3x?x32xf32>)
-      attrs = {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 4], thread = [1, 1, 1, 0], workgroup = [1, 1, 32, 0]}>} {
+      attrs = {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 4], thread = [1, 1, 1, 0], workgroup = [1, 1, 64, 0]}>} {
   ^bb0(%in: f32, %out: f32):
     %8 = math.fpowi %in, %c2_i64 : f32, i64
     %9 = arith.addf %8, %out : f32
@@ -1016,6 +1048,8 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 // CHECK-LABEL: func @multi_slice_fusion_broadcast
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<3x?x32xi64>
 //  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<32xf32>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty
 //       CHECK:    %[[RESULT:.+]]:2 = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]])
 //  CHECK-SAME:        shared_outs(%[[INIT0:[a-zA-Z0-9]+]] = %[[EMPTY]], %[[INIT1:[a-zA-Z0-9]+]] = %[[EMPTY]])
@@ -1024,6 +1058,7 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 //       CHECK:      %[[GENERIC0:.+]] = linalg.generic
 //  CHECK-SAME:          ins(%[[ARG1_SLICE]] :
 //  CHECK-SAME:          outs(%[[INIT0_SLICE]] :
+//       CHECK:      %[[CAST0:.+]] = tensor.cast %[[GENERIC0]]
 //       CHECK:      %[[EMPTYTILE:.+]] = tensor.empty() : tensor<1x1x32xf32>
 //       CHECK:      %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:          outs(%[[EMPTYTILE]] :
@@ -1034,19 +1069,7 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 //       CHECK:      %[[GENERIC2:.+]] = linalg.generic
 //  CHECK-SAME:          ins(%[[ARG3]], %[[GENERIC0]], %[[GENERIC1]] :
 //  CHECK-SAME:          outs(%[[INIT1_SLICE]] :
-//   CHECK-DAG:      tensor.parallel_insert_slice %[[GENERIC0]] into %[[INIT0]][%[[IV0]], %[[IV1]], 0, 0] [1, 1, 32, 32]
-//   CHECK-DAG:      tensor.parallel_insert_slice %[[GENERIC2]] into %[[INIT1]][%[[IV0]], %[[IV1]], 0, 0] [1, 1, 32, 32]
+//       CHECK:      %[[CAST1:.+]] = tensor.cast %[[GENERIC2]]
+//   CHECK-DAG:      tensor.parallel_insert_slice %[[CAST0]] into %[[INIT0]][%[[IV0]], %[[IV1]], %[[C0]], 0] [1, 1, %[[C32]], 32]
+//   CHECK-DAG:      tensor.parallel_insert_slice %[[CAST1]] into %[[INIT1]][%[[IV0]], %[[IV1]], %[[C0]], 0] [1, 1, %[[C32]], 32]
 //       CHECK:    return %[[RESULT]]#0, %[[RESULT]]#1
-
-// -----
-
-// Verify that the scf.forall is still generated when only one worker is needed
-// for distribution.
-func.func @single_trip_forall(%0 : tensor<64x64xf32>, %1 : tensor<64x64xf32>) -> tensor<64x64xf32> {
-  %2 = linalg.copy {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>}
-      ins(%0 : tensor<64x64xf32>)
-      outs(%1 : tensor<64x64xf32>) -> tensor<64x64xf32>
-  return %2 : tensor<64x64xf32>
-}
-//   CHECK-LABEL: func @single_trip_forall
-//         CHECK:   scf.forall

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -149,7 +149,7 @@ hal.executable private @main {
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//          CHECK:   scf.forall ({{.*}}) in (17, 1, 81) {
+//          CHECK:   scf.forall ({{.*}}) in (17, 81) {
 //          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C721]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
 //          CHECK:       gpu.barrier
 //      CHECK-DAG:       %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4xf16>
@@ -159,4 +159,4 @@ hal.executable private @main {
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
 //       CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
-//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1534,7 +1534,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1564,7 +1563,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1594,7 +1592,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1621,11 +1618,9 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
+    "--iree-opt-data-tiling"
     "--iree-hip-enable-ukernels=multi_mma"
-    "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1655,7 +1650,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1685,7 +1679,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1715,7 +1708,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1746,7 +1738,6 @@ iree_generated_e2e_runner_test(
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
     "--iree-hip-encoding-layout-resolver=data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
This reverts the commit https://github.com/iree-org/iree/commit/887d75a6062d894baee58ca19aaca0988638f496 which caused a failure compiling LLaMa 8b downstream.

Also reverts dependent commit: https://github.com/iree-org/iree/commit/7f35ecfe4bb85c1b3a7dc3efb75fbafc59e85345