### PR TITLE
[docs] Correct default values in optimization options.

### DIFF
--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -104,7 +104,7 @@ functions, not free-standing operations in the program which may produce
 constant-derived results. See `--iree-opt-const-expr-hoisting` for options to
 optimize these.
 
-### Constant expression hoisting (`--iree-opt-const-expr-hoisting` (off))
+### Constant expression hoisting (`--iree-opt-const-expr-hoisting` (on))
 
 Identifies all trees of constant expressions in the program and uses a
 heuristic to determine which would be profitable to hoist into global


### PR DESCRIPTION
The default value is `on`, see

https://github.com/iree-org/iree/blob/4c394272161ba0294fb15adf0e5160ec036c7efe/compiler/src/iree/compiler/Pipelines/Options.h#L127-L128

Fixes https://github.com/iree-org/iree/issues/21306