### PR TITLE
[CodeGen][NFC] Retire native_vector_sizes from LoweringConfigAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -117,9 +117,7 @@ computeDecomposedLoweringConfig(ArrayRef<Operation *> computeOps,
   // 4. Create and return a new lowering config attribute.
   auto newTilingLevels = IREE::Codegen::LoweringConfigTilingLevelsAttr::get(
       context, newTilingLevelsList);
-  return IREE::Codegen::LoweringConfigAttr::get(
-      context, newTilingLevels,
-      loweringConfigAttr.value().getNativeVectorSize());
+  return IREE::Codegen::LoweringConfigAttr::get(context, newTilingLevels);
 }
 
 class DecomposeConvolutionToLowerDimOpsPass final

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -153,8 +153,7 @@ TilingConfig::getLoweringConfigWithNewVectorSizes(
   // Create a new `lowering_config` attribute.
   auto newTilingLevels = IREE::Codegen::LoweringConfigTilingLevelsAttr::get(
       context, newTilingLevelsList);
-  return IREE::Codegen::LoweringConfigAttr::get(
-      context, newTilingLevels, loweringConfig.getNativeVectorSize());
+  return IREE::Codegen::LoweringConfigAttr::get(context, newTilingLevels);
 }
 
 /// Returns a list with the tiling levels that can be fused for this

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -129,9 +129,6 @@ public:
   SmallVector<int64_t> getTileInterchangeSizes(unsigned level) {
     return loweringConfig.getTileInterchangeVals(level);
   }
-  SmallVector<int64_t> getNativeVectorSizes() {
-    return loweringConfig.getNativeVectorSizeVals();
-  }
 
 private:
   SizesAndScalableFlags getVectorSizesForLevel(unsigned level) {

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
@@ -37,8 +37,7 @@ protected:
     auto newTilingLevels = IREE::Codegen::LoweringConfigTilingLevelsAttr::get(
         &ctx, newTilingLevelsList);
     loweringConfig =
-        IREE::Codegen::LoweringConfigAttr::get(&ctx, newTilingLevels,
-                                               /*nativeVectorSize=*/4);
+        IREE::Codegen::LoweringConfigAttr::get(&ctx, newTilingLevels);
   }
 
   ~TileSizeSelection() override {}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -306,24 +306,19 @@ def IREECodegen_LoweringConfigAttr :
   }];
 
   let assemblyFormat = [{
-    `<` `tile_sizes` `=` $tilingLevels
-      (`,` `native_vector_size` `=` `[` $nativeVectorSize^ `]`)? `>`
+    `<` `tile_sizes` `=` $tilingLevels `>`
   }];
 
   let parameters = (ins
     AttrParameter<"LoweringConfigTilingLevelsAttr",
-        "The lowering config at different levels">:$tilingLevels,
-    OptionalArrayRefParameter<"int64_t",
-        "The native vector size to use for the given operation">:$nativeVectorSize
+        "The lowering config at different levels">:$tilingLevels
   );
   let builders = [
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
-        CArg<"TileSizesListTypeRef", "{}">:$tileInterchange,
-        CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize)>,
+        CArg<"TileSizesListTypeRef", "{}">:$tileInterchange)>,
     AttrBuilder<(ins "TileSizesListTypeRef":$tileSizes,
         "ScalableTileFlagsListTypeRef":$scalableTileFlags,
-        CArg<"TileSizesListTypeRef", "{}">:$tileInterchange,
-        CArg<"ArrayRef<int64_t>", "{}">:$nativeVectorSize)>
+        CArg<"TileSizesListTypeRef", "{}">:$tileInterchange)>
   ];
   let extraClassDeclaration = [{
     // Returns the tile sizes for all levels set for the op.
@@ -344,11 +339,6 @@ def IREECodegen_LoweringConfigAttr :
     // Returns true if there are no tile interchange values (this means that
     // interchange can be ignored).
     bool isInterchangeEmpty();
-
-    // Returns the native vector size to use.
-    SmallVector<int64_t> getNativeVectorSizeVals() {
-      return SmallVector<int64_t>(getNativeVectorSize());
-    }
   }];
 
   let genVerifyDecl = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/lowering_config_attr.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/lowering_config_attr.mlir
@@ -22,11 +22,11 @@ module {
 
 module {
   func.func @test() attributes {
-      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [10]], native_vector_size = [32, 32]>} {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [10]]>} {
     return
   }
 }
-// CHECK: #config = #iree_codegen.lowering_config<tile_sizes = {{\[}}[], [10]{{\]}}, native_vector_size = [32, 32]>
+// CHECK: #config = #iree_codegen.lowering_config<tile_sizes = {{\[}}[], [10]{{\]}}>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -226,12 +226,6 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
              << level;
     }
   }
-
-  // Verify that native vector size is empty.
-  SmallVector<int64_t> nativeVectorSize = tilingConfig.getNativeVectorSizes();
-  if (!nativeVectorSize.empty()) {
-    return op->emitOpError("native_vector_size must be empty");
-  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -12,18 +12,6 @@ func.func @illegal_empty_tiling(%0: memref<4x8xf32>, %1: memref<8x16xf32>, %2: m
 
 // -----
 
-#config = #iree_codegen.lowering_config<tile_sizes = [[4, 8], [8, 8, 0], [0, 0, 8], [0, 0, 0]], native_vector_size = [0, 0, 4]>
-#translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
-func.func @illegal_native_vector_size(%0: memref<4x8xf32>, %1: memref<8x16xf32>, %2: memref<4x16xf32>) attributes {
-  translation_info = #translation
-} {
-  // expected-error @+1 {{native_vector_size must be empty}}
-  linalg.matmul {lowering_config = #config} ins(%0, %1 : memref<4x8xf32>, memref<8x16xf32>) outs(%2 : memref<4x16xf32>)
-  return
-}
-
-// -----
-
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [8, 32, 16], [0, 0, 16], [0, 0, 0]]>
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 func.func @illegal_parallel_tile_sizes_config(%0: memref<4x8xf32>, %1: memref<8x16xf32>, %2: memref<4x16xf32>) attributes {


### PR DESCRIPTION
It's a legacy field for CPU and the native vector size can be queried in executable_target attributes.

It is a step towards https://github.com/iree-org/iree/issues/21297