### PR TITLE
[CodeGen] Make TilingConfig compatible with LoweringConfigAttrInterface.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -132,7 +132,7 @@ TilingConfig::getLoweringConfigWithNewVectorSizes(
 
   MLIRContext *context = loweringConfig.getContext();
   SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> tilingLevels;
-  for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+  for (unsinged i = 0, e = getNumTilingLevels(); i < e; ++i) {
     tilingLevels.push_back(cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
         loweringConfig.getTilingLevelAttr(i)));
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -6,13 +6,12 @@
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 
 namespace mlir::iree_compiler {
 
-TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc)
+TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
     : loweringConfig(lc) {
   assert(lc && "Expected a valid lowering config");
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -6,12 +6,13 @@
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 
 namespace mlir::iree_compiler {
 
-TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
+TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc)
     : loweringConfig(lc) {
   assert(lc && "Expected a valid lowering config");
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -30,7 +30,7 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   //   5. [[distribution], [cache-parallel], [cache-reduction],
   //       [vector-common-parallel], [vector-reduction],
   //       [vector-inner-parallel]]
-  int numTileLevels = getNumTilingLevels();
+  unsigned numTileLevels = getNumTilingLevels();
   switch (numTileLevels) {
   case 4:
     tilingLevelToActualLevelMap[VectorInnerParallelTiles] = 3;
@@ -91,7 +91,7 @@ SizesAndScalableFlags TilingConfig::getVectorTileSizes() {
   SmallVector<int64_t> vectorSizes(numDims, 0);
   SmallVector<bool> scalableFlags(numDims, false);
   SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> tilingLevels;
-  for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+  for (unsigned i = 0, e = getNumTilingLevels(); i < e; ++i) {
     tilingLevels.push_back(cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
         loweringConfig.getTilingLevelAttr(i)));
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 
@@ -29,7 +30,7 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   //   5. [[distribution], [cache-parallel], [cache-reduction],
   //       [vector-common-parallel], [vector-reduction],
   //       [vector-inner-parallel]]
-  int numTileLevels = loweringConfig.getTilingLevels().size();
+  int numTileLevels = getNumTilingLevels();
   switch (numTileLevels) {
   case 4:
     tilingLevelToActualLevelMap[VectorInnerParallelTiles] = 3;
@@ -61,11 +62,11 @@ TilingConfig::getTilingLevelForVectorDimPosition(unsigned dimPos) const {
                                           VectorReductionTiles,
                                           VectorInnerParallelTiles};
   std::optional<unsigned> foundLevel;
-  auto tilingLevels = loweringConfig.getTilingLevels();
+  auto tilingLevels = getTileSizes();
   for (TilingLevel level : vectorTilingLevels) {
     auto tilingLevelIndex = tilingLevelToActualLevelMap[level];
     if (tilingLevelIndex != InvalidLevel &&
-        tilingLevels[tilingLevelIndex].getSizes()[dimPos] != 0) {
+        tilingLevels[tilingLevelIndex][dimPos] != 0) {
       assert(!foundLevel.has_value() &&
              "expected at most one tile size to be non-zero");
       foundLevel = tilingLevelIndex;
@@ -89,7 +90,11 @@ SizesAndScalableFlags TilingConfig::getVectorTileSizes() {
   unsigned numDims = getNumDimensions();
   SmallVector<int64_t> vectorSizes(numDims, 0);
   SmallVector<bool> scalableFlags(numDims, false);
-  auto tilingLevels = loweringConfig.getTilingLevels();
+  SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> tilingLevels;
+  for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+    tilingLevels.push_back(cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(i)));
+  }
   for (int dimPos = 0; dimPos < numDims; ++dimPos) {
     auto dimTilingLevel = getTilingLevelForVectorDimPosition(dimPos);
     if (!dimTilingLevel.has_value())
@@ -126,7 +131,11 @@ TilingConfig::getLoweringConfigWithNewVectorSizes(
   }
 
   MLIRContext *context = loweringConfig.getContext();
-  auto tilingLevels = loweringConfig.getTilingLevels();
+  SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> tilingLevels;
+  for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+    tilingLevels.push_back(cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(i)));
+  }
   SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> newTilingLevelsList(
       tilingLevels.begin(), tilingLevels.end());
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -132,7 +132,7 @@ TilingConfig::getLoweringConfigWithNewVectorSizes(
 
   MLIRContext *context = loweringConfig.getContext();
   SmallVector<IREE::Codegen::LoweringConfigTilingLevelAttr> tilingLevels;
-  for (unsinged i = 0, e = getNumTilingLevels(); i < e; ++i) {
+  for (unsigned i = 0, e = getNumTilingLevels(); i < e; ++i) {
     tilingLevels.push_back(cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
         loweringConfig.getTilingLevelAttr(i)));
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -32,7 +32,10 @@ public:
 
   /// Returns the number of tiling levels of the configuration.
   unsigned getNumTilingLevels() const {
-    return loweringConfig.getNumTilingLevels();
+    std::optional<unsigned> maybeResult = loweringConfig.getNumTilingLevels();
+    assert(maybeResult.has_value() &&
+           "invalid loweringConfig that fails to get number of tiling levels");
+    return maybeResult.value();
   };
 
   /// Returns the number of dimensions of the configuration. All the tiling
@@ -57,7 +60,7 @@ public:
   /// Returns all the tile sizes of all the levels of the configuration.
   TileSizesListType getTileSizes() const {
     TileSizesListType result;
-    for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+    for (unsigned i = 0, e = getNumTilingLevels(); i < e; ++i) {
       result.push_back(
           loweringConfig.getStaticTilingLevelSizes(i, /*target=*/nullptr));
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -28,7 +28,7 @@ using SizesAndScalableFlags =
 ///       [vector-parallel], [vector-reduction]]
 class TilingConfig {
 public:
-  TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc);
+  TilingConfig(IREE::Codegen::LoweringConfigAttr lc);
 
   /// Returns the number of tiling levels of the configuration.
   unsigned getNumTilingLevels() const {

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -8,7 +8,6 @@
 #define IREE_COMPILER_CODEGEN_LLVMCPU_TILESIZESELECTION_H_
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
-#include "mlir/IR/BuiltinOps.h"
 
 namespace mlir::iree_compiler {
 
@@ -32,15 +31,16 @@ public:
   TilingConfig(IREE::Codegen::LoweringConfigAttr lc);
 
   /// Returns the number of tiling levels of the configuration.
-  unsigned getNumTilingLevels() {
-    return loweringConfig.getTilingLevels().size();
+  unsigned getNumTilingLevels() const {
+    return loweringConfig.getNumTilingLevels();
   };
 
   /// Returns the number of dimensions of the configuration. All the tiling
   /// levels must have the same number of dimensions.
   unsigned getNumDimensions() {
     return getNumTilingLevels() > 0
-               ? loweringConfig.getTilingLevels()[0].getSizes().size()
+               ? loweringConfig.getStaticTilingLevelSizes(0, /*target=*/nullptr)
+                     .size()
                : 0;
   }
 
@@ -49,9 +49,19 @@ public:
     unsigned parallelLevel = getVectorCommonParallelLevel();
     if (parallelLevel <= getNumTilingLevels())
       return 0;
-    return llvm::count_if(
-        loweringConfig.getTilingLevels()[parallelLevel].getSizes(),
-        [](int64_t tileSize) { return tileSize != 0; });
+    return llvm::count_if(loweringConfig.getStaticTilingLevelSizes(
+                              parallelLevel, /*target=*/nullptr),
+                          [](int64_t tileSize) { return tileSize != 0; });
+  }
+
+  /// Returns all the tile sizes of all the levels of the configuration.
+  TileSizesListType getTileSizes() const {
+    TileSizesListType result;
+    for (int i = 0, e = getNumTilingLevels(); i < e; ++i) {
+      result.push_back(
+          loweringConfig.getStaticTilingLevelSizes(i, /*target=*/nullptr));
+    }
+    return result;
   }
 
   /// Returns the tiling level for cache parallel dimensions.
@@ -85,9 +95,6 @@ public:
   unsigned getVectorReductionLevel() {
     return getActualLevel(VectorReductionTiles);
   }
-
-  /// Returns all the tile sizes of all the levels of the configuration.
-  TileSizesListType getTileSizes() { return loweringConfig.getTileSizeVals(); }
 
   /// Returns the distribution tile sizes of the configuration.
   SmallVector<int64_t> getDistributionTileSizes() {
@@ -127,17 +134,21 @@ public:
 
   // TODO(dcaballe): Revisit if these features are ever used.
   SmallVector<int64_t> getTileInterchangeSizes(unsigned level) {
-    return loweringConfig.getTileInterchangeVals(level);
+    auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(level));
+    return SmallVector<int64_t>(attr.getInterchange());
   }
 
 private:
   SizesAndScalableFlags getVectorSizesForLevel(unsigned level) {
-    return std::make_pair(loweringConfig.getTileSizeVals(level),
-                          loweringConfig.getScalableTileFlagVals(level));
+    auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(level));
+    return {SmallVector<int64_t>(attr.getSizes()),
+            SmallVector<bool>(attr.getScalableFlags())};
   }
 
   SmallVector<int64_t> getTileSizesForLevel(unsigned level) {
-    return loweringConfig.getTileSizeVals(level);
+    return loweringConfig.getStaticTilingLevelSizes(level, /*target=*/nullptr);
   }
 
   /// Returns the tiling level that contains the vector dim at `dimPos` (which
@@ -162,7 +173,7 @@ private:
   unsigned getActualLevel(TilingLevel level);
 
   /// Holds the lowering config that provides the configuration.
-  IREE::Codegen::LoweringConfigAttr loweringConfig;
+  IREE::Codegen::LoweringConfigAttrInterface loweringConfig;
 
   /// Maps `TilingLevel`'s to the actual number of levels in this configuration.
   std::array<unsigned, TilingLevel::MaxNumTileLevels>

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -28,7 +28,7 @@ using SizesAndScalableFlags =
 ///       [vector-parallel], [vector-reduction]]
 class TilingConfig {
 public:
-  TilingConfig(IREE::Codegen::LoweringConfigAttr lc);
+  TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc);
 
   /// Returns the number of tiling levels of the configuration.
   unsigned getNumTilingLevels() const {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -304,10 +304,18 @@ SmallVector<int64_t> LoweringConfigAttr::getWorkgroupInterchange() const {
   return getTileInterchangeVals(0);
 }
 
+int64_t LoweringConfigAttr::getNumTilingLevels() const {
+  return getTilingLevels().size();
+}
+
 SmallVector<int64_t>
 LoweringConfigAttr::getStaticTilingLevelSizes(unsigned level,
                                               Operation *) const {
   return getTileSizeVals(level);
+}
+
+Attribute LoweringConfigAttr::getTilingLevelAttr(unsigned level) const {
+  return getTilingLevels()[level];
 }
 
 SmallVector<OpFoldResult>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -304,7 +304,7 @@ SmallVector<int64_t> LoweringConfigAttr::getWorkgroupInterchange() const {
   return getTileInterchangeVals(0);
 }
 
-int64_t LoweringConfigAttr::getNumTilingLevels() const {
+std::optional<unsigned> LoweringConfigAttr::getNumTilingLevels() const {
   return getTilingLevels().size();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -284,7 +284,9 @@ def IREECodegen_LoweringConfigAttr :
       DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
         "getWorkgroupTileSizes",
         "getWorkgroupInterchange",
+        "getNumTilingLevels",
         "getStaticTilingLevelSizes",
+        "getTilingLevelAttr",
         "getTilingLevelSizes",
         "hasTilingLevel",
         "hasWorkgroupTilingLevel",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -271,6 +271,19 @@ def IREECodegen_LoweringConfigAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns the number of tiling levels of the configuration. Returns -1 if
+        it is unknown.
+      }],
+      /*retTy=*/"int64_t",
+      /*methodName=*/"getNumTilingLevels",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return -1;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Returns true if the lowering config specifies tile sizes for the given
         tiling level.
       }],
@@ -301,8 +314,8 @@ def IREECodegen_LoweringConfigAttrInterface :
         interpretation of |level| is attribute and backend dependent. The
         |target| is the operation this lowering configuration annotates.
 
-        returns an empty list if sizes are not specified for this level. dynamic
-        sizes are specified with `shapedtype::kdynamicsize`.
+        Returns an empty list if sizes are not specified for this level. Dynamic
+        sizes are specified with `ShapedType::kDynamicSize`.
       }],
       /*retTy=*/"::llvm::SmallVector<int64_t>",
       /*methodName=*/"getStaticTilingLevelSizes",
@@ -313,6 +326,25 @@ def IREECodegen_LoweringConfigAttrInterface :
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return ::llvm::SmallVector<int64_t>();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the tile sizes in Attribute types for the specified tiling
+        level. The interpretation of |level| is attribute and backend dependent.
+        Different from `getStaticTilingLevelSizes`, it returns the whole
+        attribute, so users can parse the attribute with their backend specifics.
+
+        Returns NULL if the information is not specified for this level.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getTilingLevelAttr",
+      /*args=*/(ins
+        "unsigned":$level
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return {};
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -271,15 +271,15 @@ def IREECodegen_LoweringConfigAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Returns the number of tiling levels of the configuration. Returns -1 if
-        it is unknown.
+        Returns the number of tiling levels of the configuration. Returns
+        std::nullopt if it is unknown.
       }],
-      /*retTy=*/"int64_t",
+      /*retTy=*/"std::optional<unsigned>",
       /*methodName=*/"getNumTilingLevels",
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return -1;
+        return std::nullopt;
       }]
     >,
     InterfaceMethod<


### PR DESCRIPTION
The revision uses `LoweringConfigAttrInterface` in `TilingConfig`, and adds a couple interface methods to `LoweringConfigAttrInterface`:

- `unsigned getNumTilingLevels()`: Returns the number of tiling levels of the configuration. Returns -1 if it is unknown.
- `SmallVector<Attribute> getStaticTilingLevelSizes(unsigned, Operation*)`: Similar to `getStaticTilingLevelSizes`, but it returns a list of attributes that allow users to parse attributes with their backend specifics.

It also fixes the lowercase issues in `getStaticTilingLevelSizes`'s doc.

No additional tests are added because we have [unittest](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp) for the helper class, and the pipeline tests already serve the needs.

It is a step towards https://github.com/iree-org/iree/issues/21297