### PR TITLE
[Codegen] Resolve scf.forall operations created during split-reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -171,39 +171,14 @@ getProcIdsAndNprocs(
   return std::make_pair(procId, nprocs);
 }
 
-/// Resolve scf.forall operation by using the workgroup ID and counts.
-static LogicalResult
-resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
-                       IREE::Codegen::WorkgroupId deLinearizeFrom,
-                       bool generateLoopNest) {
-  if (forallOp->getNumResults() != 0) {
-    return forallOp.emitOpError(
-        "cannot resolve for all ops with return values");
-  }
-  SmallVector<OpFoldResult> mixedLowerBound = forallOp.getMixedLowerBound();
+static LogicalResult resolveForAll(RewriterBase &rewriter,
+                                   scf::ForallOp forallOp,
+                                   ArrayRef<OpFoldResult> procIds,
+                                   ArrayRef<OpFoldResult> nProcs,
+                                   bool generateLoopNest) {
   SmallVector<OpFoldResult> mixedUpperBound = forallOp.getMixedUpperBound();
   SmallVector<OpFoldResult> mixedStep = forallOp.getMixedStep();
-  FailureOr<SmallVector<IREE::Codegen::WorkgroupMappingAttr>> workgroupMapping =
-      verifyWorkgroupMappingAttrArray(forallOp);
-  if (failed(workgroupMapping)) {
-    return failure();
-  }
-  if (workgroupMapping->size() != mixedLowerBound.size()) {
-    return forallOp.emitOpError(
-        "expected as many workgroup mapping attributes as number of loops");
-  }
-
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(forallOp);
   Location loc = forallOp.getLoc();
-
-  // Get process IDs and counts by querying hal.interface.workgroup.id/count ops
-  // and delinearizing any dimensions of the forall beyond `deLinearizeFrom`.
-  SmallVector<OpFoldResult> procIds, nProcs;
-  std::tie(procIds, nProcs) = getProcIdsAndNprocs(
-      forallOp, rewriter, loc, workgroupMapping.value(), mixedLowerBound,
-      mixedUpperBound, mixedStep, deLinearizeFrom);
-
   // Scale the process IDs and counts to account for the forall op steps. These
   // are the forall offsets for each process, and the bounds of these offsets.
   SmallVector<Value> procOffsets, procOffsetBounds;
@@ -241,6 +216,42 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
                              /*argValues=*/loopNestIvs);
   rewriter.eraseOp(forallOp);
   return success();
+}
+
+/// Resolve scf.forall operation by using the workgroup ID and counts.
+static LogicalResult
+resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
+                       IREE::Codegen::WorkgroupId deLinearizeFrom,
+                       bool generateLoopNest) {
+  if (forallOp->getNumResults() != 0) {
+    return forallOp.emitOpError(
+        "cannot resolve for all ops with return values");
+  }
+  SmallVector<OpFoldResult> mixedLowerBound = forallOp.getMixedLowerBound();
+  SmallVector<OpFoldResult> mixedUpperBound = forallOp.getMixedUpperBound();
+  SmallVector<OpFoldResult> mixedStep = forallOp.getMixedStep();
+  FailureOr<SmallVector<IREE::Codegen::WorkgroupMappingAttr>> workgroupMapping =
+      verifyWorkgroupMappingAttrArray(forallOp);
+  if (failed(workgroupMapping)) {
+    return failure();
+  }
+  if (workgroupMapping->size() != mixedLowerBound.size()) {
+    return forallOp.emitOpError(
+        "expected as many workgroup mapping attributes as number of loops");
+  }
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(forallOp);
+  Location loc = forallOp.getLoc();
+
+  // Get process IDs and counts by querying hal.interface.workgroup.id/count ops
+  // and delinearizing any dimensions of the forall beyond `deLinearizeFrom`.
+  SmallVector<OpFoldResult> procIds, nProcs;
+  std::tie(procIds, nProcs) = getProcIdsAndNprocs(
+      forallOp, rewriter, loc, workgroupMapping.value(), mixedLowerBound,
+      mixedUpperBound, mixedStep, deLinearizeFrom);
+
+  return resolveForAll(rewriter, forallOp, procIds, nProcs, generateLoopNest);
 }
 
 /// Resolve the workgroup counts for the function based on the extents of the
@@ -315,20 +326,19 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
     return success();
   }
 
-  auto forAllOps = body.getOps<scf::ForallOp>();
-  SmallVector<scf::ForallOp> workgroupForAllOps =
-      llvm::filter_to_vector(forAllOps, [&](scf::ForallOp forAllOp) {
-        auto mapping = forAllOp.getMapping();
-        if (!mapping) {
-          return false;
-        }
-        if (!llvm::all_of(mapping.value(), [](Attribute attr) {
-              return isa<IREE::Codegen::WorkgroupMappingAttr>(attr);
-            })) {
-          return false;
-        }
-        return true;
-      });
+  SmallVector<scf::ForallOp> workgroupForAllOps;
+  funcOp.walk([&workgroupForAllOps](scf::ForallOp forAllOp) {
+    auto mapping = forAllOp.getMapping();
+    if (!mapping) {
+      return;
+    }
+    if (!llvm::all_of(mapping.value(), [](Attribute attr) {
+          return isa<IREE::Codegen::WorkgroupMappingAttr>(attr);
+        })) {
+      return;
+    }
+    workgroupForAllOps.push_back(forAllOp);
+  });
 
   if (workgroupForAllOps.empty()) {
     // If there are no workgroup distribution loops, set the default
@@ -362,6 +372,191 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
     }
   }
   return success();
+}
+
+static LogicalResult
+lowerSplitReductionModifierOp(RewriterBase &rewriter,
+                              FunctionOpInterface entryPointFn,
+                              IREE::Codegen::WorkgroupId delinearizeFrom,
+                              OpFoldResult splitReductionFactor) {
+  std::optional<IREE::HAL::ExecutableExportOp> exportOp =
+      getEntryPoint(entryPointFn);
+  if (!exportOp) {
+    // not entry point.
+    return success();
+  }
+  Block *body = exportOp->getWorkgroupCountBody();
+  if (!body) {
+    return success();
+  }
+  auto splitReduceModifiers = body->getOps<
+      IREE::TensorExt::DispatchWorkgroupCountSplitReductionModifierOp>();
+  if (splitReduceModifiers.empty()) {
+    // Nothing to do.
+    return success();
+  }
+  if (!llvm::hasSingleElement(splitReduceModifiers)) {
+    return exportOp->emitOpError(
+        "unexpected multiple "
+        "iree_tensor_ext.dispatch.workgroup.splitk_modifier");
+  }
+  IREE::TensorExt::DispatchWorkgroupCountSplitReductionModifierOp
+      splitReduceModifier = *splitReduceModifiers.begin();
+  Location loc = splitReduceModifier->getLoc();
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(splitReduceModifier);
+  FailureOr<SmallVector<OpFoldResult>> materializedWorkgroupCount =
+      materializeWorkgroupCountComputation(rewriter, entryPointFn,
+                                           splitReductionFactor,
+                                           splitReduceModifier.getWorkload());
+  if (failed(materializedWorkgroupCount)) {
+    return splitReduceModifier->emitOpError(
+        "failed to materialize workgroup count computation in the entry point");
+  }
+
+  SmallVector<OpFoldResult> replacement =
+      llvm::map_to_vector(splitReduceModifier.getSourceWorkgroupCount(),
+                          [](Value v) -> OpFoldResult { return v; });
+  replacement[static_cast<uint64_t>(delinearizeFrom)] =
+      IREE::LinalgExt::mulOfrs(
+          rewriter, splitReduceModifier.getLoc(),
+          replacement[static_cast<uint64_t>(delinearizeFrom)],
+          materializedWorkgroupCount->front());
+
+  SmallVector<Value> replacementVals =
+      getValueOrCreateConstantIndexOp(rewriter, loc, replacement);
+  rewriter.replaceOp(splitReduceModifier, replacementVals);
+  return success();
+}
+
+/// Resolve scf.forall introduced by split reductions. The expectation is that
+/// there is a single such loop and its the "outermost" `scf.forall`, and this
+/// is distribute along grid axis `k`.
+///
+/// ```mlir
+/// func.func(...) {
+///   scf.forall (%iv) = %lb to %ub step %s {
+///     ... = hal.interface.workgroup.id[k]
+//    }
+/// }
+/// ```
+///
+/// `k` is assumed to be the "highest" dimension of the grid used (so has to be
+/// <= 3). To resolve the `scf.forall` the number of workgroups along `k` is
+/// increased by a factor of `%nsplit = ceildiv(%ub - %lb, %s)`. In addition
+///
+/// - All uses of `hal.interface.workgroup.id[k]` within `scf.forall` is
+///   replaced by `hal.interface.workgroup.id[k] % %orig_numworkgroups`, where
+///   `%orig_numworkgroups` is the number of workgroups along `k` that were used
+///   before the resolution of the split reduction `scf.forall`. This is same as
+///   `hal.interface.workgroup.count[k] / %nsplit`.
+/// - All uses of `%iv` is replaced by `hal.interface.workgroup.id[k] / %nsplit`
+/// ```
+///
+static LogicalResult
+resolveSplitReduceForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
+                         IREE::Codegen::WorkgroupId delinearizeFrom) {
+  Region &body = funcOp.getFunctionBody();
+  if (body.empty()) {
+    return success();
+  }
+
+  SmallVector<scf::ForallOp> splitReductionForAllOps;
+  funcOp.walk([&splitReductionForAllOps](scf::ForallOp forAllOp) {
+    auto mapping = forAllOp.getMapping();
+    if (!mapping || mapping->size() != 1 ||
+        !isa<IREE::LinalgExt::SplitReductionMappingAttr>(
+            mapping->getValue().front())) {
+      return;
+    }
+    splitReductionForAllOps.push_back(forAllOp);
+  });
+
+  if (splitReductionForAllOps.empty()) {
+    return lowerSplitReductionModifierOp(rewriter, funcOp, delinearizeFrom,
+                                         rewriter.getIndexAttr(1));
+  }
+
+  // For now support only a single split-reduction forall.
+  if (splitReductionForAllOps.size() != 1) {
+    return funcOp->emitOpError(
+        "failed to resolve multiple split-reduction loops");
+  }
+
+  scf::ForallOp forallOp = splitReductionForAllOps.front();
+  if (forallOp->getNumResults() != 0) {
+    return forallOp.emitOpError(
+        "cannot resolve for all ops with return values");
+  }
+
+  assert(forallOp.getMapping() && forallOp.getMapping()->size() == 1 &&
+         "expected forall op to have mapping of "
+         "`[#iree_codegen.split_reduction_mapping]`");
+  // Currently only support single induction variable.
+  if (forallOp.getRank() != 1) {
+    return forallOp->emitOpError("unsupported split-reduction resolution of "
+                                 "`scf.forall` op of rank greater than 1");
+  }
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(forallOp);
+  Location loc = forallOp.getLoc();
+
+  OpFoldResult lb = forallOp.getMixedLowerBound().front();
+  OpFoldResult ub = forallOp.getMixedUpperBound().front();
+  OpFoldResult step = forallOp.getMixedStep().front();
+  AffineExpr s0, s1, s2;
+  bindSymbols(rewriter.getContext(), s0, s1, s2);
+  OpFoldResult nSplitProcs = affine::makeComposedFoldedAffineApply(
+      rewriter, loc, (s1 - s0).ceilDiv(s2), {lb, ub, step});
+
+  // Lower the splitk-modifier op in the entry point.
+  if (failed(lowerSplitReductionModifierOp(rewriter, funcOp, delinearizeFrom,
+                                           nSplitProcs))) {
+    return forallOp->emitOpError("failed to lower split reduction modifier op");
+  }
+
+  auto procIdOp = rewriter.create<IREE::HAL::InterfaceWorkgroupIDOp>(
+      loc, static_cast<uint>(delinearizeFrom));
+  OpFoldResult procId = procIdOp.getResult();
+  auto nTotalProcsOp = rewriter.create<IREE::HAL::InterfaceWorkgroupCountOp>(
+      loc, static_cast<uint>(delinearizeFrom));
+  OpFoldResult nTotalProcs = nTotalProcsOp.getResult();
+  auto origNProcs = affine::makeComposedFoldedAffineApply(
+      rewriter, loc, s1.floorDiv(s0), {nTotalProcs, nSplitProcs});
+  OpFoldResult workgroupIdReplacement = affine::makeComposedFoldedAffineApply(
+      rewriter, loc, s0 % s1, {procId, origNProcs});
+  Value workgroupIdReplacementVal =
+      getValueOrCreateConstantIndexOp(rewriter, loc, workgroupIdReplacement);
+
+  // Check that all uses of `hal.interface.workgroup.id[delinearizeFrom]` are
+  // within the `scf.forall` operation.
+  auto walkResult = funcOp.walk(
+      [&](IREE::HAL::InterfaceWorkgroupIDOp workgroupIdOp) -> WalkResult {
+        if (workgroupIdOp.getDimension().getZExtValue() !=
+            static_cast<uint64_t>(delinearizeFrom)) {
+          return WalkResult::advance();
+        }
+        if (workgroupIdOp == procIdOp) {
+          return WalkResult::advance();
+        }
+        for (Operation *user : workgroupIdOp->getUsers()) {
+          auto parerntForallOp = user->getParentOfType<scf::ForallOp>();
+          if (parerntForallOp != forallOp) {
+            return user->emitOpError("expected all users of `workgroup.id` to "
+                                     "be within split reduction scf.forall op");
+          }
+        }
+        rewriter.replaceAllUsesWith(workgroupIdOp, workgroupIdReplacementVal);
+        return WalkResult::advance();
+      });
+  if (walkResult.wasInterrupted()) {
+    return failure();
+  }
+
+  return resolveForAll(rewriter, forallOp, procId, nSplitProcs,
+                       /*generateLoopNest = */ false);
 }
 
 //===---------------------------------------------------------------------===//
@@ -440,8 +635,14 @@ void ReconcileTranslationInfoPass::runOnOperation() {
     // Resolve workgroup distribution related `scf.forall` ops.
     if (failed(resolveWorkgroupForAll(rewriter, rootFuncOp, distributeAlong))) {
       variantOp.emitOpError(
-          "failed in iree-codegen-reconcile-translation-info pass");
+          "failed to resolve workgroup distribution forall ops");
       return signalPassFailure();
+    }
+
+    // Resolve split reduction distribution
+    if (failed(
+            resolveSplitReduceForAll(rewriter, rootFuncOp, distributeAlong))) {
+      variantOp.emitOpError("failed to resolve split reduction forall ops");
     }
 
     std::queue<FunctionOpInterface> nodeQueue;
@@ -526,12 +727,22 @@ void ReconcileTranslationInfoPass::runOnOperation() {
 
   // Erase all the lowering configs and translation infos after we have finished
   // processing all exported functions.
-  innerModuleOp->walk([](Operation *op) {
+  SmallVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinalOps;
+  innerModuleOp->walk([&ordinalOps](Operation *op) {
     if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {
       eraseTranslationInfo(funcOp);
     }
     eraseLoweringConfig(op);
+    if (auto ordinalOp =
+            dyn_cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(op)) {
+      ordinalOps.push_back(ordinalOp);
+    }
   });
+
+  // Discard all ordinal ops.
+  for (auto ordinalOp : ordinalOps) {
+    rewriter.replaceOp(ordinalOp, ordinalOp.getOperand());
+  }
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -732,7 +732,7 @@ hal.executable private @split_reduction_executable {
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0, s1, s2] -> (d0 * ((-s0 + s1) ceildiv s2))>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> (s0 mod (((-s2 + s3) ceildiv s4) floordiv s1))>
 //   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
-// CHECK-LABEL: @split_reduction_variant
+//       CHECK: @split_reduction_variant
 //       CHECK:   hal.executable.export
 //  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -689,3 +689,68 @@ hal.executable private @different_rank_scf_forall_ops {
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @split_reduction_executable {
+  hal.executable.variant public @split_reduction_variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @split_reduction layout(#pipeline_layout) count(
+        %arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      %return_x, %return_y, %return_z =
+          iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %return_x, %return_y, %return_z : index, index, index
+    }
+    builtin.module {
+      func.func @split_reduction() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %cst5 = hal.interface.constant.load layout(#pipeline_layout) ordinal(5) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %cst5, 5 : index
+        scf.forall (%arg0) = (%0) to (%1) step (%2) {
+          "use1"(%arg0) : (index) -> ()
+          scf.forall (%arg1, %arg2, %arg3) in (%3, %4, %5) {
+            "use2"(%arg1, %arg2, %arg3) : (index, index, index) -> ()
+          } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0, s1, s2] -> (d0 * ((-s0 + s1) ceildiv s2))>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> (s0 mod (((-s2 + s3) ceildiv s4) floordiv s1))>
+//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+// CHECK-LABEL: @split_reduction_variant
+//       CHECK:   hal.executable.export
+//  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[NUMWORKGROUPSZ:.+]] = affine.apply #[[MAP0]](%[[ARG4]])[%[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//       CHECK:     hal.return %[[ARG6]], %[[ARG5]], %[[NUMWORKGROUPSZ]]
+//       CHECK:   func @split_reduction
+//       CHECK:     %[[SPLIT_LB:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//       CHECK:     %[[SPLIT_UB:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//       CHECK:     %[[SPLIT_STEP:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//       CHECK:     %[[IDZ:.+]] = hal.interface.workgroup.id[2]
+//       CHECK:     %[[COUNTZ:.+]] = hal.interface.workgroup.count[2]
+//       CHECK:     %[[IV0REPLACEMENT:.+]] = affine.apply #[[MAP1]]()[%[[IDZ]], %[[COUNTZ]], %[[SPLIT_LB]], %[[SPLIT_UB]], %[[SPLIT_STEP]]]
+//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[IDZ]], %[[SPLIT_STEP]]]
+//       CHECK:     "use1"(%[[SPLITIVREPLACEMENT]])
+//       CHECK:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//       CHECK:     %[[IDY:.+]] = hal.interface.workgroup.id[1]
+//       CHECK:     "use2"(%[[IV0REPLACEMENT]], %[[IDY]], %[[IDX]])

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -66,9 +66,9 @@ hal.executable private @matmul_tensors {
 //      CHECK:    hal.return %[[D1]], %[[D0]], %[[C1]] : index, index, index
 //      CHECK: func.func @matmul_tensors()
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-//  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(0)
-//  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(1)
-//  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(2)
+//  CHECK-DAG:   %[[M:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0
+//  CHECK-DAG:   %[[N:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 1
+//  CHECK-DAG:   %[[K:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 2
 //  CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //  CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //  CHECK-DAG:   %[[INIT_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
@@ -321,10 +321,10 @@ hal.executable private @add_distribute4D {
 //      CHECK:    hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
 //      CHECK:    func.func @add_distribute4D()
 // CHECK-SAME:    translation_info = #[[TRANSLATION]]
-//  CHECK-DAG:      %[[D0:.*]] = hal.interface.constant.load layout({{.+}}) ordinal(0) : index
-//  CHECK-DAG:      %[[D1:.*]] = hal.interface.constant.load layout({{.+}}) ordinal(1) : index
-//  CHECK-DAG:      %[[D2:.*]] = hal.interface.constant.load layout({{.+}}) ordinal(2) : index
-//  CHECK-DAG:      %[[D3:.*]] = hal.interface.constant.load layout({{.+}}) ordinal(3) : index
+//  CHECK-DAG:      %[[D0:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0
+//  CHECK-DAG:      %[[D1:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 1
+//  CHECK-DAG:      %[[D2:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 2
+//  CHECK-DAG:      %[[D3:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 3
 //  CHECK-DAG:      %[[D4:.*]] = hal.interface.binding.subspan layout({{.+}}) binding(0) alignment(32) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%[[D0]], %[[D1]], %[[D2]], %[[D3]]}
 //  CHECK-DAG:      %[[D5:.*]] = hal.interface.binding.subspan layout({{.+}}) binding(1) alignment(32) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%[[D0]], %[[D1]], %[[D2]], %[[D3]]}
 //  CHECK-DAG:      %[[D6:.*]] = hal.interface.binding.subspan layout({{.+}}) binding(2) alignment(32) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%[[D0]], %[[D1]], %[[D2]], %[[D3]]}
@@ -632,16 +632,16 @@ hal.executable public @copy_op {
 //      CHECK:   hal.return %[[D1]], %[[D0]], %[[C1]]
 //      CHECK: func.func @copy_op()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//  CHECK-DAG:   %[[SOURCE_SIZE_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(0) : index
-//  CHECK-DAG:   %[[SOURCE_SIZE_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(1) : index
-//  CHECK-DAG:   %[[DEST_SIZE_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(2) : index
-//  CHECK-DAG:   %[[DEST_SIZE_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(3) : index
-//  CHECK-DAG:   %[[SOURCE_OFFSET_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(4) : index
-//  CHECK-DAG:   %[[SOURCE_OFFSET_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(5) : index
-//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(6) : index
-//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(7) : index
-//  CHECK-DAG:   %[[SLICE_SIZE_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(8) : index
-//  CHECK-DAG:   %[[SLICE_SIZE_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(9) : index
+//  CHECK-DAG:   %[[SOURCE_SIZE_Y:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0 : index
+//  CHECK-DAG:   %[[SOURCE_SIZE_X:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 1 : index
+//  CHECK-DAG:   %[[DEST_SIZE_Y:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 2 : index
+//  CHECK-DAG:   %[[DEST_SIZE_X:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 3 : index
+//  CHECK-DAG:   %[[SOURCE_OFFSET_Y:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 4 : index
+//  CHECK-DAG:   %[[SOURCE_OFFSET_X:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 5 : index
+//  CHECK-DAG:   %[[DEST_OFFSET_Y:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 6 : index
+//  CHECK-DAG:   %[[DEST_OFFSET_X:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 7 : index
+//  CHECK-DAG:   %[[SLICE_SIZE_Y:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 8 : index
+//  CHECK-DAG:   %[[SLICE_SIZE_X:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 9 : index
 //  CHECK-DAG:   %[[SOURCE_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //  CHECK-DAG:   %[[DEST_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //  CHECK-DAG:   %[[SOURCE:.+]] = memref.subview %[[SOURCE_BINDING]][%[[SOURCE_OFFSET_Y]], %[[SOURCE_OFFSET_X]]]
@@ -1300,7 +1300,7 @@ hal.executable private @gemm_unit_N {
 //      CHECK:   hal.return %[[D0]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func.func @gemm_unit_N()
 // CHECK-SAME:  translation_info = #[[TRANSLATION]]
-//  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load layout(#pipeline_layout) ordinal(0)
+//  CHECK-DAG:   %[[M:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0
 //  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
 //  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
 //  CHECK-DAG:   %[[LB:.+]] = affine.apply #[[MAP1]]()[%[[WG_ID_X]]]
@@ -1677,8 +1677,8 @@ hal.executable private @matmul_interchange {
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: func.func @matmul_interchange()
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-//  CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-//  CHECK-DAG:   %[[D1:.+]] = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+//  CHECK-DAG:   %[[D0:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 0 : index
+//  CHECK-DAG:   %[[D1:.+]] = iree_tensor_ext.dispatch.workload.ordinal %{{.+}}, 1 : index
 //      CHECK:   scf.for %{{.+}} = %{{.+}} to %[[D1]] step %{{.+}} {
 //      CHECK:     scf.for %{{.+}} = %{{.+}} to %[[D0]] step %{{.+}} {
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -352,15 +352,19 @@ template void hoistStaticallyBoundAllocationsInFunc<memref::AllocaOp>(
 // Lowering `iree_tensor_ext.dispatch.workgroup_count_from_slice` operation.
 //===---------------------------------------------------------------------===//
 
-LogicalResult lowerWorkgroupCountFromSliceOp(
-    RewriterBase &rewriter,
-    IREE::TensorExt::DispatchWorkgroupCountFromSliceOp workgroupCountOp,
-    mlir::FunctionOpInterface entryPointFn,
-    ArrayRef<OpFoldResult> workgroupCount, int maxWorkgroupParallelDims) {
+FailureOr<SmallVector<OpFoldResult>> materializeWorkgroupCountComputation(
+    RewriterBase &rewriter, mlir::FunctionOpInterface entryPointFn,
+    ArrayRef<OpFoldResult> workgroupCount, ValueRange workloadVals) {
   // Compute the backward slice of the workgroup count operations.
   BackwardSliceOptions options;
-  options.filter = [](Operation *op) {
-    return !isa<IREE::TensorExt::DispatchWorkloadOrdinalOp>(op);
+  SmallVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> leaves;
+  options.filter = [&leaves](Operation *op) {
+    if (auto ordinalOp =
+            dyn_cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(op)) {
+      leaves.push_back(ordinalOp);
+      return false;
+    }
+    return true;
   };
   options.inclusive = true;
   llvm::SetVector<Operation *> slice;
@@ -378,26 +382,19 @@ LogicalResult lowerWorkgroupCountFromSliceOp(
   // Insert the slice into workgroup count region with all `hal.constant.index`
   // operations replaced with arguments (drop the front argument since that is
   // `hal.device`).
-  auto workloadVals = workgroupCountOp.getOperands();
   IRMapping map;
-  // Map `flow.dispatch.constant_ordinal` op with the corresponding operand of
-  // the `flow.dispatch.workgroup_count_default` operation.
-  SmallVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinalOps;
-  entryPointFn.walk([&](IREE::TensorExt::DispatchWorkloadOrdinalOp ordinalOp) {
-    ordinalOps.push_back(ordinalOp);
-  });
-  for (auto ordinalOp : ordinalOps) {
+  for (auto ordinalOp : leaves) {
+    // Map `flow.dispatch.constant_ordinal` op with the corresponding operand of
+    // the `flow.dispatch.workgroup_count_default` operation.
     int64_t ordinal = ordinalOp.getOrdinal().getSExtValue();
     if (ordinal >= workloadVals.size()) {
-      ordinalOp.emitOpError(
+      return ordinalOp.emitOpError(
           "ordinal number is higher than the number of workloads captured in "
           "the workgroup count region");
     }
     map.map(ordinalOp.getResult(),
             workloadVals[ordinalOp.getOrdinal().getSExtValue()]);
   }
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(workgroupCountOp);
   for (auto op : slice) {
     // TODO(#13038) This is a WAR for the these ops ending up in workgroup count
     // computation. They should not. Some pre-processing at MaterializeEncoding
@@ -421,6 +418,28 @@ LogicalResult lowerWorkgroupCountFromSliceOp(
     } else {
       results.push_back(ofr);
     }
+  }
+  return results;
+}
+
+LogicalResult lowerWorkgroupCountFromSliceOp(
+    RewriterBase &rewriter,
+    IREE::TensorExt::DispatchWorkgroupCountFromSliceOp workgroupCountOp,
+    mlir::FunctionOpInterface entryPointFn,
+    ArrayRef<OpFoldResult> workgroupCount, int maxWorkgroupParallelDims) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(workgroupCountOp);
+
+  SmallVector<OpFoldResult> results;
+  {
+    FailureOr<SmallVector<OpFoldResult>> resultsOr =
+        materializeWorkgroupCountComputation(rewriter, entryPointFn,
+                                             workgroupCount,
+                                             workgroupCountOp.getOperands());
+    if (failed(resultsOr)) {
+      return failure();
+    }
+    std::swap(results, resultsOr.value());
   }
 
   // The `maxWorkgroupParallelDims` represents the maximum dimension number
@@ -452,10 +471,6 @@ LogicalResult lowerWorkgroupCountFromSliceOp(
   }
   rewriter.replaceOp(workgroupCountOp,
                      getValueOrCreateConstantIndexOp(rewriter, loc, results));
-  for (auto ordinalOp : ordinalOps) {
-    rewriter.replaceOp(ordinalOp, ordinalOp.getOperand());
-  }
-
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -119,6 +119,12 @@ void analyseAllocsForPacking(mlir::FunctionOpInterface funcOp,
 void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
                 ArrayRef<AliasGroup> aliasGroups);
 
+/// Materialize the backward slice starting at the values in `workgroupCount`
+/// at the current insertion point of the `rewriter`. The leaves of the slice
+/// are expected to be `iree_tensor_ext.workload.ordinal` ops that
+/// are replaced with the corresponding `workloadVals`. Returns the
+/// values corresponding to `workgroupCount` materialized at the insertion
+/// point.
 FailureOr<SmallVector<OpFoldResult>> materializeWorkgroupCountComputation(
     RewriterBase &rewriter, mlir::FunctionOpInterface entryPointFn,
     ArrayRef<OpFoldResult> workgroupCount, ValueRange workloadVals);

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -119,6 +119,10 @@ void analyseAllocsForPacking(mlir::FunctionOpInterface funcOp,
 void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
                 ArrayRef<AliasGroup> aliasGroups);
 
+FailureOr<SmallVector<OpFoldResult>> materializeWorkgroupCountComputation(
+    RewriterBase &rewriter, mlir::FunctionOpInterface entryPointFn,
+    ArrayRef<OpFoldResult> workgroupCount, ValueRange workloadVals);
+
 /// Lower the workgroup count region for the default code-generation path in
 /// IREE. Given the list `workgroupCount` (fastest varying dimension innermost)
 /// as computed within the `entryPointFn`, clones a backward slice of the
@@ -128,7 +132,7 @@ void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
 /// the `flow.dispatch.constant_ordinal` operations from within the
 /// `entryPointFn`. Expects the workgroup count region of the corresponding
 /// `hal.executable.export` to contain the
-/// `flow.dispatch.workgroup_count_default` operation as a placeholder for the
+/// `flow.dispatch.workgroup_count_slice` operation as a placeholder for the
 /// computation to compute the number of workgroups. In absence of this
 /// operation, this method does nothing assuming that the workgroup count
 /// computation has already been resolved.

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -339,6 +339,12 @@ def IREETensorExt_DispatchWorkgroupCountSplitReductionModifierOp :
       "ValueRange":$workload
     )>,
   ];
+
+  let extraClassDeclaration = [{
+    SmallVector<Value> getSourceWorkgroupCount() {
+      return {getWorkgroupX(), getWorkgroupY(), getWorkgroupZ()};
+    }
+  }];
 }
 
 def IREETensorExt_DispatchWorkloadOrdinalOp :

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -124,6 +124,7 @@ void buildVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
 
   buildVectorVMVXTransformPassPipeline(variantPassManager);
 
+  variantPassManager.addPass(createReconcileTranslationInfoPass());
   // ---------------------------------------------------------------------------
   // Standard/Vector/HAL/etc -> VMVX conversion
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The `FormSplitReductionDispatches` (from #21280) forms dispatches containing
`scf.forall` that represent the parallel partial reductions. These
`scf.forall` have the
`#iree_linalg_ext.split_reduction_mapping`. These loops exist in
conjunction with the loops that distribute the partial reductions by
themselves within the workgroup.

The resolution for this involves taking the workgroup mapping that was
decided by the distribution of the partial reduction op by itself and
multiplying the highest dimension along which the distribution is done
by the number of workgroups needed for executing the partial reduction
in parallel.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>