### PR TITLE
[CPU] Teach TilingConfig about IREE::CPU::LoweringConfigAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -63,7 +63,7 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
 TilingConfig::TilingConfig(IREE::CPU::LoweringConfigAttr lc)
     : loweringConfig(lc) {
   assert(lc && "Expected a valid lowering config");
-  for (int i = 0, e = tilingLevelToActualLevelMap.size(); i < e; ++i) {
+  for (size_t i = 0, e = tilingLevelToActualLevelMap.size(); i < e; ++i) {
     tilingLevelToActualLevelMap[i] = i;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -6,6 +6,12 @@
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "tiling-config"
+#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(X) LLVM_DEBUG(KD_DBGS() << X << "\n")
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 
@@ -17,7 +23,7 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
 
   // Initialize indices to invalid.
   std::fill(tilingLevelToActualLevelMap.begin(),
-            tilingLevelToActualLevelMap.end(), InvalidLevel);
+            tilingLevelToActualLevelMap.end(), TilingLevel::InvalidLevel);
 
   // Map the tiling levels that are defined in the actual configuration to
   // their corresponding incremental levels. We currently support the following
@@ -33,19 +39,19 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   unsigned numTileLevels = getNumTilingLevels();
   switch (numTileLevels) {
   case 4:
-    tilingLevelToActualLevelMap[VectorInnerParallelTiles] = 3;
+    tilingLevelToActualLevelMap[TilingLevel::VectorInnerParallelTiles] = 3;
     [[fallthrough]];
   case 3:
-    tilingLevelToActualLevelMap[VectorReductionTiles] = 2;
+    tilingLevelToActualLevelMap[TilingLevel::VectorReductionTiles] = 2;
     [[fallthrough]];
   case 2:
-    tilingLevelToActualLevelMap[VectorCommonParallelTiles] = 1;
+    tilingLevelToActualLevelMap[TilingLevel::VectorCommonParallelTiles] = 1;
     [[fallthrough]];
   case 1:
-    tilingLevelToActualLevelMap[DistributionTiles] = 0;
+    tilingLevelToActualLevelMap[TilingLevel::DistributionTiles] = 0;
     break;
-  case MaxNumTileLevels:
-    for (int i = 0; i < MaxNumTileLevels; ++i) {
+  case TilingLevel::MaxNumTileLevels:
+    for (int i = 0; i < TilingLevel::MaxNumTileLevels; ++i) {
       tilingLevelToActualLevelMap[i] = i;
     }
     break;
@@ -54,18 +60,26 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   }
 };
 
+TilingConfig::TilingConfig(IREE::CPU::LoweringConfigAttr lc)
+    : loweringConfig(lc) {
+  assert(lc && "Expected a valid lowering config");
+  for (int i = 0, e = tilingLevelToActualLevelMap.size(); i < e; ++i) {
+    tilingLevelToActualLevelMap[i] = i;
+  }
+};
+
 /// Returns the tiling level that contains the vector dim at `dimPos` (which is
 /// an index into the result of `getVectorTileSizes()`).
 std::optional<unsigned>
 TilingConfig::getTilingLevelForVectorDimPosition(unsigned dimPos) const {
-  constexpr std::array vectorTilingLevels{VectorCommonParallelTiles,
-                                          VectorReductionTiles,
-                                          VectorInnerParallelTiles};
+  constexpr std::array vectorTilingLevels{
+      TilingLevel::VectorCommonParallelTiles, TilingLevel::VectorReductionTiles,
+      TilingLevel::VectorInnerParallelTiles};
   std::optional<unsigned> foundLevel;
   auto tilingLevels = getTileSizes();
   for (TilingLevel level : vectorTilingLevels) {
     auto tilingLevelIndex = tilingLevelToActualLevelMap[level];
-    if (tilingLevelIndex != InvalidLevel &&
+    if (tilingLevelIndex != TilingLevel::InvalidLevel &&
         tilingLevels[tilingLevelIndex][dimPos] != 0) {
       assert(!foundLevel.has_value() &&
              "expected at most one tile size to be non-zero");
@@ -120,7 +134,8 @@ TilingConfig::getLoweringConfigWithNewVectorSizes(
          "number of dimensions (or be empty)");
 
   // Make a map from tiling levels to vector dims at that level.
-  std::array<SmallVector<unsigned, 4>, MaxNumTileLevels> tilingLevelToDimsMap;
+  std::array<SmallVector<unsigned, 4>, TilingLevel::MaxNumTileLevels>
+      tilingLevelToDimsMap;
   for (unsigned dimPos = 0; dimPos < numDims; ++dimPos) {
     auto tilingLevelIndex = getTilingLevelForVectorDimPosition(dimPos);
     assert((tilingLevelIndex.has_value() || sizes[dimPos] == 0) &&
@@ -191,9 +206,10 @@ SmallVector<int64_t> TilingConfig::getFusableLevels() {
 
 /// Returns the actual level in the configuration for this level of tiling.
 unsigned TilingConfig::getActualLevel(TilingLevel level) {
-  assert(level < InvalidLevel && "Unexpected invalid tiling level");
+  assert(level < TilingLevel::InvalidLevel &&
+         "Unexpected invalid tiling level");
   unsigned actualLevel = tilingLevelToActualLevelMap[level];
-  assert(actualLevel != InvalidLevel &&
+  assert(actualLevel != TilingLevel::InvalidLevel &&
          "Searching for unavailable tiling level");
   return actualLevel;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/BUILD.bazel
@@ -17,8 +17,10 @@ iree_compiler_cc_test(
     srcs = ["TileSizeSelectionTest.cpp"],
     deps = [
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/testing:gtest_main",
         "@com_google_googletest//:gtest",
+        "@llvm-project//mlir:IR",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/CMakeLists.txt
@@ -16,9 +16,11 @@ iree_cc_test(
   SRCS
     "TileSizeSelectionTest.cpp"
   DEPS
+    MLIRIR
     gmock
     gtest
     iree::compiler::Codegen::Common
+    iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::testing::gtest_main
 )

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
@@ -65,9 +65,10 @@ protected:
     for (auto level : targets) {
       SmallVector<int64_t> sizes;
       SmallVector<bool> scalableFlags;
-      configItems.emplace_back(IREE::CPU::getTilingLevelName(level),
-                               IREE::CPU::LoweringConfigAttr::getTilingAttr(
-                                   &ctx, sizes, scalableFlags));
+      configItems.emplace_back(
+          IREE::CPU::getTilingLevelName(level),
+          IREE::CPU::LoweringConfigAttr::getTilingLevelAttr(&ctx, sizes,
+                                                            scalableFlags));
     }
     loweringConfig = IREE::CPU::LoweringConfigAttr::get(
         &ctx, DictionaryAttr::get(&ctx, configItems));

--- a/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/unittests/TileSizeSelectionTest.cpp
@@ -8,7 +8,10 @@
 #include <gtest/gtest.h>
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
 namespace mlir::iree_compiler {
 
@@ -47,6 +50,36 @@ protected:
   IREE::Codegen::LoweringConfigAttr loweringConfig;
 };
 
+class CPUTileSizeSelection : public ::testing::Test {
+protected:
+  CPUTileSizeSelection() {
+    reg.insert<IREE::CPU::IREECPUDialect>();
+    ctx.appendDialectRegistry(reg);
+    ctx.loadAllAvailableDialects();
+  }
+
+  // Initialize `loweringConfig` to contain the config for `targets`. The actual
+  // tile sizes are not set in each target, i.e., they are empty lists.
+  void initLoweringConfig(SmallVector<IREE::CPU::TilingLevel> targets) {
+    SmallVector<NamedAttribute> configItems;
+    for (auto level : targets) {
+      SmallVector<int64_t> sizes;
+      SmallVector<bool> scalableFlags;
+      configItems.emplace_back(IREE::CPU::getTilingLevelName(level),
+                               IREE::CPU::LoweringConfigAttr::getTilingAttr(
+                                   &ctx, sizes, scalableFlags));
+    }
+    loweringConfig = IREE::CPU::LoweringConfigAttr::get(
+        &ctx, DictionaryAttr::get(&ctx, configItems));
+  }
+
+  ~CPUTileSizeSelection() override {}
+
+  MLIRContext ctx;
+  DialectRegistry reg;
+  IREE::CPU::LoweringConfigAttr loweringConfig;
+};
+
 TEST_F(TileSizeSelection, NumTilingLevels) {
   const unsigned kMaxNumTilingLevels = 7;
 
@@ -56,6 +89,36 @@ TEST_F(TileSizeSelection, NumTilingLevels) {
   // 2. Create TilingConfig and check if the number of tiling levels match.
   TilingConfig tilingConfig(loweringConfig);
   EXPECT_EQ(tilingConfig.getNumTilingLevels(), kMaxNumTilingLevels);
+}
+
+TEST_F(CPUTileSizeSelection, WithAllFields) {
+  // Initialize Lowering Config
+  SmallVector<IREE::CPU::TilingLevel> targets = {
+      IREE::CPU::TilingLevel::DistributionTiles,
+      IREE::CPU::CacheParallelTiles,
+      IREE::CPU::CacheReductionTiles,
+      IREE::CPU::VectorCommonParallelTiles,
+      IREE::CPU::VectorReductionTiles,
+      IREE::CPU::VectorInnerParallelTiles};
+  initLoweringConfig(targets);
+
+  // Create TilingConfig and check if the number of tiling levels match.
+  TilingConfig tilingConfig(loweringConfig);
+
+  // There are no re-mapping between the TilingConfig and the original config.
+  EXPECT_EQ(tilingConfig.getNumTilingLevels(), targets.size());
+  EXPECT_EQ(tilingConfig.getDistributionLevel(),
+            IREE::CPU::TilingLevel::DistributionTiles);
+  EXPECT_EQ(tilingConfig.getCacheParallelLevel(),
+            IREE::CPU::CacheParallelTiles);
+  EXPECT_EQ(tilingConfig.getCacheReductionLevel(),
+            IREE::CPU::CacheReductionTiles);
+  EXPECT_EQ(tilingConfig.getVectorCommonParallelLevel(),
+            IREE::CPU::VectorCommonParallelTiles);
+  EXPECT_EQ(tilingConfig.getVectorReductionLevel(),
+            IREE::CPU::VectorReductionTiles);
+  EXPECT_EQ(tilingConfig.getVectorInnerParallelLevel(),
+            IREE::CPU::VectorInnerParallelTiles);
 }
 
 TEST_F(TileSizeSelection, getLevel_4_levels) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -137,15 +137,15 @@ void LoweringConfigAttr::print(AsmPrinter &printer) const {
   printer << ">";
 }
 
-Attribute LoweringConfigAttr::getTilingAttr(MLIRContext *ctx,
-                                            ArrayRef<int64_t> tileSizes) {
+Attribute LoweringConfigAttr::getTilingLevelAttr(MLIRContext *ctx,
+                                                 ArrayRef<int64_t> tileSizes) {
   return IREE::Codegen::LoweringConfigTilingLevelAttr::get(
       ctx, tileSizes, /*interchange=*/{}, /*scalableFlags=*/{});
 }
 
-Attribute LoweringConfigAttr::getTilingAttr(MLIRContext *ctx,
-                                            ArrayRef<int64_t> tileSizes,
-                                            ArrayRef<bool> scalableFlags) {
+Attribute LoweringConfigAttr::getTilingLevelAttr(MLIRContext *ctx,
+                                                 ArrayRef<int64_t> tileSizes,
+                                                 ArrayRef<bool> scalableFlags) {
   return IREE::Codegen::LoweringConfigTilingLevelAttr::get(
       ctx, tileSizes, /*interchange=*/{}, scalableFlags);
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp.inc"
@@ -136,6 +137,19 @@ void LoweringConfigAttr::print(AsmPrinter &printer) const {
   printer << ">";
 }
 
+Attribute LoweringConfigAttr::getTilingAttr(MLIRContext *ctx,
+                                            ArrayRef<int64_t> tileSizes) {
+  return IREE::Codegen::LoweringConfigTilingLevelAttr::get(
+      ctx, tileSizes, /*interchange=*/{}, /*scalableFlags=*/{});
+}
+
+Attribute LoweringConfigAttr::getTilingAttr(MLIRContext *ctx,
+                                            ArrayRef<int64_t> tileSizes,
+                                            ArrayRef<bool> scalableFlags) {
+  return IREE::Codegen::LoweringConfigTilingLevelAttr::get(
+      ctx, tileSizes, /*interchange=*/{}, scalableFlags);
+}
+
 SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
   return getTileSizes(getConfig(), DistributionTiles);
 }
@@ -157,6 +171,31 @@ bool LoweringConfigAttr::hasTilingLevel(unsigned level) const {
 
 bool LoweringConfigAttr::hasWorkgroupTilingLevel() const {
   return !getWorkgroupTileSizes().empty();
+}
+
+std::optional<unsigned> LoweringConfigAttr::getNumTilingLevels() const {
+  return llvm::count_if(getConfig(), [](NamedAttribute attr) {
+    return isLoweringConfigTilingLevelKey(attr.getName());
+  });
+}
+
+SmallVector<int64_t>
+LoweringConfigAttr::getStaticTilingLevelSizes(unsigned level,
+                                              Operation *) const {
+  assert(level < llvm::to_underlying(TilingLevel::MaxNumTileLevels) &&
+         "invalid level");
+  return getTileSizes(getConfig(), static_cast<TilingLevel>(level));
+}
+
+Attribute LoweringConfigAttr::getTilingLevelAttr(unsigned level) const {
+  assert(level < llvm::to_underlying(TilingLevel::MaxNumTileLevels) &&
+         "invalid level");
+  StringRef key = getTilingLevelName(static_cast<TilingLevel>(level));
+  DictionaryAttr config = getConfig();
+  if (!config || config.contains(key)) {
+    return {};
+  }
+  return config.get(key);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -22,6 +22,9 @@ def IREECPU_LoweringConfigAttr :
         "getTilingLevelSizes",
         "hasTilingLevel",
         "hasWorkgroupTilingLevel",
+        "getNumTilingLevels",
+        "getStaticTilingLevelSizes",
+        "getTilingLevelAttr",
       ]>
     ]> {
   let mnemonic = "lowering_config";
@@ -50,6 +53,14 @@ def IREECPU_LoweringConfigAttr :
     AttrParameter<"DictionaryAttr",
         "The configured fields, including tiling levels.">:$config
   );
+  let extraClassDeclaration = [{
+    /// Returns the attribute that indicates the tiling sizes.
+    static Attribute getTilingAttr(MLIRContext *ctx,
+                                   ArrayRef<int64_t> tileSizes);
+    static Attribute getTilingAttr(MLIRContext *ctx,
+                                   ArrayRef<int64_t> tileSizes,
+                                   ArrayRef<bool> scalableFlags);
+  }];
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -55,9 +55,9 @@ def IREECPU_LoweringConfigAttr :
   );
   let extraClassDeclaration = [{
     /// Returns the attribute that indicates the tiling sizes.
-    static Attribute getTilingAttr(MLIRContext *ctx,
+    static Attribute getTilingLevelAttr(MLIRContext *ctx,
                                    ArrayRef<int64_t> tileSizes);
-    static Attribute getTilingAttr(MLIRContext *ctx,
+    static Attribute getTilingLevelAttr(MLIRContext *ctx,
                                    ArrayRef<int64_t> tileSizes,
                                    ArrayRef<bool> scalableFlags);
   }];


### PR DESCRIPTION
It aliases the internal `TilingLevel` to `IREE::CPU::TilingLevel`, because they are expected to be the same. Otherwise, the assumption could be broken in future changes.

The revision does not perform remapping when the config is `IREE::CPU::LoweringConfig`, because it is a dictionary-based config.