### PR TITLE
[Codegen] Add AMDGPU specific narrow type emulation pass for AMDGPUDialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -188,6 +188,7 @@ iree_compiler_cc_library(
     hdrs = [
         "BufferizationAnalysis.h",
         "CombineLayoutTransformation.h",
+        "EmulateNarrowType.h",
         "EncodingUtils.h",
         "ExtractAddressComputation.h",
         "FastMathPatterns.h",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
   HDRS
     "BufferizationAnalysis.h"
     "CombineLayoutTransformation.h"
+    "EmulateNarrowType.h"
     "EncodingUtils.h"
     "ExtractAddressComputation.h"
     "FastMathPatterns.h"

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -623,15 +623,13 @@ LogicalResult emulateNarrowType(
   }
 
   if (failed(applyPartialConversion(root, target, std::move(patterns)))) {
-    root->emitOpError("failed to emulate bit width");
-    return failure();
+    return root->emitOpError("failed to emulate bit width");
   }
 
   RewritePatternSet sinkBroadcast(ctx);
   vector::populateSinkVectorOpsPatterns(sinkBroadcast);
   if (failed(applyPatternsGreedily(root, std::move(sinkBroadcast)))) {
-    root->emitOpError("failed in sinking of broadcasts");
-    return failure();
+    return root->emitOpError("failed in sinking of broadcasts");
   }
 
   // Also do the `bitcast -> extui/extsi` rewrite.

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/EmulateNarrowType.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
@@ -576,61 +577,70 @@ struct EmulateNarrowTypePass final
   }
 
   void runOnOperation() override {
-    // The number of bits used in a load/store op.
-    constexpr unsigned kLoadStoreEmulateBitwidth = 8;
-    static_assert(
-        llvm::isPowerOf2_32(kLoadStoreEmulateBitwidth) &&
-        "only power of 2 is supported for narrow type load/store emulation");
-
-    MLIRContext *ctx = &getContext();
-
-    arith::NarrowTypeEmulationConverter typeConverter(
-        kLoadStoreEmulateBitwidth);
-    memref::populateMemRefNarrowTypeEmulationConversions(typeConverter);
-
-    ConversionTarget target(*ctx);
-    target.addDynamicallyLegalOp<func::FuncOp>([&typeConverter](Operation *op) {
-      return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
-    });
-    auto opLegalCallback = [&typeConverter](Operation *op) {
-      return typeConverter.isLegal(op);
-    };
-    target.addDynamicallyLegalOp<func::CallOp, func::ReturnOp>(opLegalCallback);
-    target.addDynamicallyLegalDialect<
-        arith::ArithDialect, vector::VectorDialect, memref::MemRefDialect,
-        affine::AffineDialect, IREE::HAL::HALDialect>(opLegalCallback);
-
-    RewritePatternSet patterns(ctx);
-    patterns.insert<IREEConvertVectorStore>(ctx, /*disableAtomicRMW=*/false,
-                                            /*benefit=*/100);
-    arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
-    memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
-    populateIREEResolveExtractStridedMetadataPatterns(patterns);
-    vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns);
-    populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
-
-    if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns)))) {
-      getOperation()->emitOpError("failed to emulate bit width");
-      return signalPassFailure();
-    }
-
-    RewritePatternSet sinkBroadcast(ctx);
-    vector::populateSinkVectorOpsPatterns(sinkBroadcast);
-    if (failed(
-            applyPatternsGreedily(getOperation(), std::move(sinkBroadcast)))) {
-      getOperation()->emitOpError("failed in sinking of broadcasts");
-      return signalPassFailure();
-    }
-
-    // Also do the `bitcast -> extui/extsi` rewrite.
-    RewritePatternSet foldExtPatterns(ctx);
-    vector::populateVectorNarrowTypeRewritePatterns(foldExtPatterns);
-    if (failed(applyPatternsGreedily(getOperation(),
-                                     std::move(foldExtPatterns)))) {
+    if (failed(emulateNarrowType(getOperation()))) {
       return signalPassFailure();
     }
   }
 };
 } // namespace
+
+LogicalResult emulateNarrowType(
+    Operation *root,
+    std::optional<NarrowTypeConversionPopulationFn> populateCallback) {
+  // The number of bits used in a load/store op.
+  constexpr unsigned kLoadStoreEmulateBitwidth = 8;
+  static_assert(
+      llvm::isPowerOf2_32(kLoadStoreEmulateBitwidth) &&
+      "only power of 2 is supported for narrow type load/store emulation");
+
+  MLIRContext *ctx = root->getContext();
+
+  arith::NarrowTypeEmulationConverter typeConverter(kLoadStoreEmulateBitwidth);
+  memref::populateMemRefNarrowTypeEmulationConversions(typeConverter);
+
+  ConversionTarget target(*ctx);
+  target.addDynamicallyLegalOp<func::FuncOp>([&typeConverter](Operation *op) {
+    return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
+  });
+  auto opLegalCallback = [&typeConverter](Operation *op) {
+    return typeConverter.isLegal(op);
+  };
+  target.addDynamicallyLegalOp<func::CallOp, func::ReturnOp>(opLegalCallback);
+  target.addDynamicallyLegalDialect<
+      arith::ArithDialect, vector::VectorDialect, memref::MemRefDialect,
+      affine::AffineDialect, IREE::HAL::HALDialect>(opLegalCallback);
+
+  RewritePatternSet patterns(ctx);
+  patterns.insert<IREEConvertVectorStore>(ctx, /*disableAtomicRMW=*/false,
+                                          /*benefit=*/100);
+  arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
+  memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
+  populateIREEResolveExtractStridedMetadataPatterns(patterns);
+  vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns);
+  populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
+  if (populateCallback) {
+    populateCallback.value()(typeConverter, patterns, target);
+  }
+
+  if (failed(applyPartialConversion(root, target, std::move(patterns)))) {
+    root->emitOpError("failed to emulate bit width");
+    return failure();
+  }
+
+  RewritePatternSet sinkBroadcast(ctx);
+  vector::populateSinkVectorOpsPatterns(sinkBroadcast);
+  if (failed(applyPatternsGreedily(root, std::move(sinkBroadcast)))) {
+    root->emitOpError("failed in sinking of broadcasts");
+    return failure();
+  }
+
+  // Also do the `bitcast -> extui/extsi` rewrite.
+  RewritePatternSet foldExtPatterns(ctx);
+  vector::populateVectorNarrowTypeRewritePatterns(foldExtPatterns);
+  if (failed(applyPatternsGreedily(root, std::move(foldExtPatterns)))) {
+    return failure();
+  }
+  return success();
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
@@ -1,4 +1,4 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2025 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.h
@@ -1,0 +1,22 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef IREE_COMPILER_CODEGEN_COMMON_EMULATENARROWTYPE_H_
+#define IREE_COMPILER_CODEGEN_COMMON_EMULATENARROWTYPE_H_
+
+#include "mlir/Dialect/Arith/Transforms/NarrowTypeEmulationConverter.h"
+#include "mlir/IR/PatternMatch.h"
+
+using namespace mlir;
+
+namespace mlir::iree_compiler {
+using NarrowTypeConversionPopulationFn =
+    std::function<void(arith::NarrowTypeEmulationConverter &,
+                       RewritePatternSet &, ConversionTarget &)>;
+LogicalResult emulateNarrowType(Operation *root,
+                                std::optional<NarrowTypeConversionPopulationFn>
+                                    populateCallback = std::nullopt);
+} // namespace mlir::iree_compiler
+#endif // IREE_COMPILER_CODEGEN_COMMON_EMULATENARROWTYPE_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -1,0 +1,80 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/EmulateNarrowType.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/Transforms/NarrowTypeEmulationConverter.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_AMDGPUEMULATENARROWTYPEPASS
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
+
+namespace {
+
+struct ConvertRawBufferCast final
+    : OpConversionPattern<amdgpu::FatRawBufferCastOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(amdgpu::FatRawBufferCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type newTy = getTypeConverter()->convertType(op.getResult().getType());
+    if (!newTy) {
+      return rewriter.notifyMatchFailure(
+          op->getLoc(), llvm::formatv("failed to convert memref type: {0}",
+                                      op.getResult().getType()));
+    }
+    if (newTy == op.getResult().getType()) {
+      // Nothing to do.
+      return failure();
+    }
+
+    // |validBytes| and |cacheSwizzleStride| are independent of element type
+    // and don't need to be updated.
+    rewriter.replaceOpWithNewOp<amdgpu::FatRawBufferCastOp>(
+        op, newTy, adaptor.getSource(), adaptor.getValidBytes(),
+        adaptor.getCacheSwizzleStride(), adaptor.getBoundsCheck(),
+        adaptor.getResetOffset());
+    return success();
+  }
+};
+
+struct AMDGPUEmulateNarrowTypePass final
+    : impl::AMDGPUEmulateNarrowTypePassBase<AMDGPUEmulateNarrowTypePass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, func::FuncDialect,
+                    memref::MemRefDialect, vector::VectorDialect,
+                    affine::AffineDialect, IREE::HAL::HALDialect>();
+  }
+
+  void runOnOperation() override {
+    auto populateAMDGPUPatterns =
+        [](arith::NarrowTypeEmulationConverter &typeConverter,
+           RewritePatternSet &patterns, ConversionTarget &target) {
+          auto opLegalCallback = [&typeConverter](Operation *op) {
+            return typeConverter.isLegal(op);
+          };
+          target.addDynamicallyLegalDialect<amdgpu::AMDGPUDialect>(
+              opLegalCallback);
+          patterns.add<ConvertRawBufferCast>(typeConverter,
+                                             patterns.getContext());
+        };
+    if (failed(emulateNarrowType(getOperation(), populateAMDGPUPatterns))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -90,6 +90,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "LLVMGPU",
     srcs = [
+        "AMDGPUEmulateNarrowType.cpp",
         "ConvertToLLVM.cpp",
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     "ROCDLKernelConfig.h"
     "ROCDLPasses.h"
   SRCS
+    "AMDGPUEmulateNarrowType.cpp"
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1220,7 +1220,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
         options.allowSubviewExpansion = true;
         return createIREEExpandStridedMetadataPass(options);
       })
-      .addPass(createEmulateNarrowTypePass)
+      .addPass(forROCDL ? createAMDGPUEmulateNarrowTypePass
+                        : createEmulateNarrowTypePass)
       .addPass(affine::createAffineExpandIndexOpsPass)
       .addPass(createLowerAffinePass);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -13,6 +13,11 @@ include "mlir/Pass/PassBase.td"
 // LLVMGPU Passes (keep alphabetical)
 //------------------------------------------------------------------------------
 
+def AMDGPUEmulateNarrowTypePass :
+    Pass<"iree-amdgpu-emulate-narrow-type", ""> {
+  let summary = "Emulate narrow integer operations including amdgpu operations";
+}
+
 // TODO: Bring the argument in line with the names used elsewhere.
 def ConvertToNVVMPass :
     Pass<"iree-convert-to-nvvm", "ModuleOp"> {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "amdgpu_emulate_narrow_type.mlir",
             "assign_constant_ordinals.mlir",
             "conv_pipeline_test_cuda.mlir",
             "convert_to_nvvm.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "amdgpu_emulate_narrow_type.mlir"
     "assign_constant_ordinals.mlir"
     "cast_address_space_function.mlir"
     "cast_type_to_fit_mma.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_emulate_narrow_type.mlir
@@ -1,0 +1,12 @@
+// RUN: iree-opt --iree-amdgpu-emulate-narrow-type --split-input-file %s | FileCheck %s
+
+func.func @memref_memory_space_cast_i4(%arg0: memref<32x128xi4>) -> memref<32x128xi4, #amdgpu.address_space<fat_raw_buffer>> {
+  %cast = amdgpu.fat_raw_buffer_cast %arg0 resetOffset : memref<32x128xi4> to memref<32x128xi4, #amdgpu.address_space<fat_raw_buffer>>
+  return %cast : memref<32x128xi4, #amdgpu.address_space<fat_raw_buffer>>
+}
+
+// CHECK-LABEL:   func.func @memref_memory_space_cast_i4(
+//  CHECK-SAME:   %[[ARG0:.*]]: memref<2048xi8>
+//       CHECK:     %[[CAST:.*]] = amdgpu.fat_raw_buffer_cast %[[ARG0]] resetOffset
+//  CHECK-SAME:       : memref<2048xi8> to memref<2048xi8, #amdgpu.address_space<fat_raw_buffer>>
+//       CHECK:     return %[[CAST]]


### PR DESCRIPTION
The alternative is to add a dialect interface, but that's overkill for now. Splits out
the pass implementation to a separate function to avoid an AMDGPU dep in Codegen/Common.