### PR TITLE
[codegen][gpu] Add the `iree-rocdl-use-buffer-instructions` pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -117,6 +117,7 @@ iree_compiler_cc_library(
         "ROCDLLowerExecutableTarget.cpp",
         "ROCDLPrefetching.cpp",
         "ROCDLSelectLoweringStrategy.cpp",
+        "ROCDLUseBufferInstructions.cpp",
         "TestLLVMGPUQueryMMAPass.cpp",
         "Verifiers.cpp",
     ],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -97,6 +97,7 @@ iree_cc_library(
     "ROCDLLowerExecutableTarget.cpp"
     "ROCDLPrefetching.cpp"
     "ROCDLSelectLoweringStrategy.cpp"
+    "ROCDLUseBufferInstructions.cpp"
     "TestLLVMGPUQueryMMAPass.cpp"
     "Verifiers.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -866,6 +866,7 @@ static LogicalResult gpuVectorCopyFn(OpBuilder &builder, Location loc,
 
 static void addVectorBufferizePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createROCDLConfigureBufferInstructionsPass());
+  funcPassManager.addPass(createROCDLUseBufferInstructionsPass());
   BufferizationOptions::AllocationFn allocationFn = gpuAllocationFn;
   BufferizationOptions::MemCpyFn memcpyFn = gpuCopyFn;
   addIREEComprehensiveBufferizePasses(funcPassManager, allocationFn, memcpyFn);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -50,6 +50,27 @@ def ROCDLConfigureBufferInstructionsPass :
   let dependentDialects = ["::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"];
 }
 
+def ROCDLUseBufferInstructionsPass :
+    InterfacePass<"iree-rocdl-use-buffer-instructions", "mlir::FunctionOpInterface"> {
+  let summary = "Determine which buffers can be implemneted with buffer fat pointers";
+  let description = [{
+    Analyze tensors to determine whether:
+    whether
+    - The size of the tensor itself, taken as a region of memory, is under 2 GB
+     (the limit for indexing a buffer descriptor is uint32_t max, but a lot of
+     intermediate code assumes indices are signed, se this limit is conservative) and
+    - That the offset argument to the tensor op is workgroup-uniform, since it will
+     be folded into the base offset of the descriptor.
+
+    If it's determined that buffer ops can be safely used, then this pass will add
+    `iree_gpu.buffer_resource_cast` operations to the buffers.
+    Note: This pass must run before bufferization.
+
+    This pass is a no-op on non-ROCDL targets.
+  }];
+  let dependentDialects = ["::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"];
+}
+
 def ROCDLLowerExecutableTargetPass : InterfacePass<
     "iree-rocdl-lower-executable-target", "mlir::FunctionOpInterface"> {
   let summary = "Lower an IREE hal.executable.variant op using a suitable "

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLUseBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLUseBufferInstructions.cpp
@@ -1,0 +1,392 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
+
+#define DEBUG_TYPE "rocdl-use-buffer-instructions"
+#define LDBGS(X)                                                               \
+  LLVM_DEBUG((llvm::dbgs() << "[" << DEBUG_TYPE << "]") << X << "\n")
+#define ADBGS(X) LLVM_DEBUG((llvm::dbgs() << "[thread-uniform]") << X << "\n")
+#define DUMP_OP(x) '`' << x->getName() << "` [" << x << "]"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+namespace mlir::iree_compiler {
+#define GEN_PASS_DEF_ROCDLUSEBUFFERINSTRUCTIONSPASS
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h.inc"
+} // namespace mlir::iree_compiler
+
+namespace {
+//===----------------------------------------------------------------------===//
+// ThreadUniform
+//===----------------------------------------------------------------------===//
+/// Class holding the state of the sparse lattice. There are three possible
+/// states for the lattice:
+/// `uninitialized`: the state is unknown.
+/// `uniform`: the value was determined to be uniform across threads.
+/// `dependent`: the value is thread dependent.
+struct ThreadUniform {
+  ThreadUniform() = default;
+  /// Creates a dependent state.
+  static ThreadUniform getDependent() { return ThreadUniform(dependent); }
+  /// Creates a uniform state.
+  static ThreadUniform getUniform() { return ThreadUniform(uniform); }
+  /// Returns whether this state is uniform.
+  bool isUniform() const { return state == uniform; }
+  /// Compares two states.
+  bool operator==(const ThreadUniform &other) const {
+    return state == other.state;
+  }
+  /// Prints the state to a stream.
+  void print(llvm::raw_ostream &s) const {
+    s << (state == uninitialized
+              ? "uninitialized"
+              : (state == uniform ? "uniform" : "dependent"));
+  }
+  /// Joins two states, where `dependent` is the top state of dataflow.
+  static ThreadUniform join(const ThreadUniform &lhs, const ThreadUniform &rhs);
+
+private:
+  typedef enum { uninitialized, uniform, dependent } State;
+  ThreadUniform(State state) : state(state) {}
+  State state = uninitialized;
+};
+
+//===----------------------------------------------------------------------===//
+// ThreadUniformLattice
+//===----------------------------------------------------------------------===//
+/// Class holding a lattice for the sparse analysis.
+class ThreadUniformLattice : public dataflow::Lattice<ThreadUniform> {
+public:
+  using Lattice::Lattice;
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ThreadUniformLattice);
+};
+
+//===----------------------------------------------------------------------===//
+// ThreadUniformAnalysis
+//===----------------------------------------------------------------------===//
+/// The dataflow analysis computing whether a value is thread uniform or not.
+class ThreadUniformAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<ThreadUniformLattice> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  /// Sets the lattice to a pessimistic state.
+  void setToEntryState(ThreadUniformLattice *lattice) override {
+    propagateIfChanged(lattice, lattice->join(ThreadUniform::getDependent()));
+  }
+
+  /// Visits an operation and determines whether it's uniform or not.
+  LogicalResult
+  visitOperation(Operation *op, ArrayRef<const ThreadUniformLattice *> operands,
+                 ArrayRef<ThreadUniformLattice *> results) override;
+
+  /// Handles the uniformity of control-flow arguments and results.
+  void
+  visitNonControlFlowArguments(Operation *op, const RegionSuccessor &successor,
+                               ArrayRef<ThreadUniformLattice *> argLattices,
+                               unsigned firstIndex) override;
+};
+
+//===----------------------------------------------------------------------===//
+// ROCDLUseBufferInstructionsPass
+//===----------------------------------------------------------------------===//
+struct ROCDLUseBufferInstructionsPass final
+    : mlir::iree_compiler::impl::ROCDLUseBufferInstructionsPassBase<
+          ROCDLUseBufferInstructionsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// ThreadUniform
+//===----------------------------------------------------------------------===//
+
+ThreadUniform ThreadUniform::join(const ThreadUniform &lhs,
+                                  const ThreadUniform &rhs) {
+  if (lhs.state == dependent || rhs.state == dependent)
+    return getDependent();
+  return (lhs.state == uniform || rhs.state == uniform) ? getUniform()
+                                                        : ThreadUniform();
+}
+
+//===----------------------------------------------------------------------===//
+// ThreadUniformAnalysis
+//===----------------------------------------------------------------------===//
+/// This function is an overly conservative estimate ops that are safe to assume
+/// to be uniform. TODO: Encode this in an interface.
+static bool maybeDefinitelyWorkgroupUniform(Operation *op) {
+  if (op->hasTrait<OpTrait::ConstantLike>() ||
+      op->hasTrait<OpTrait::IsTerminator>())
+    return true;
+  if (isa<IREE::HAL::InterfaceBindingSubspanOp,
+          IREE::HAL::InterfaceConstantLoadOp,
+          IREE::TensorExt::DispatchTensorLoadOp, IREE::Util::AssumeIntOp,
+          IREE::TensorExt::DispatchWorkloadOrdinalOp, LoopLikeOpInterface>(op))
+    return true;
+  if (isa<affine::AffineDialect>(op->getDialect()))
+    return !isa<affine::AffineDmaStartOp, affine::AffineDmaWaitOp>(op);
+  return isa<arith::ArithDialect>(op->getDialect()) &&
+         op->getNumResults() == 1 &&
+         op->getResult(0).getType().isIntOrIndexOrFloat();
+}
+
+LogicalResult ThreadUniformAnalysis::visitOperation(
+    Operation *op, ArrayRef<const ThreadUniformLattice *> operands,
+    ArrayRef<ThreadUniformLattice *> results) {
+  // Early exit if any of the operands is already dependent.
+  if (llvm::any_of(operands, [&](const ThreadUniformLattice *lattice) {
+        return ThreadUniform::getDependent() == lattice->getValue();
+      })) {
+    for (ThreadUniformLattice *v : results) {
+      propagateIfChanged(v, v->join(ThreadUniform::getDependent()));
+    }
+    ADBGS(" dependent op: " << *op);
+    return success();
+  }
+
+  // Check if it's a uniform op.
+  if (maybeDefinitelyWorkgroupUniform(op)) {
+    ADBGS(" uniform op: " << *op);
+    for (ThreadUniformLattice *v : results)
+      propagateIfChanged(v, v->join(ThreadUniform::getUniform()));
+    return success();
+  }
+
+  ADBGS(" pessimistic dependent op: " << *op);
+  // Be pessimistic about all other ops.
+  setAllToEntryStates(results);
+  return success();
+}
+
+void ThreadUniformAnalysis::visitNonControlFlowArguments(
+    Operation *op, const RegionSuccessor &successor,
+    ArrayRef<ThreadUniformLattice *> argLattices, unsigned firstIndex) {
+  auto loop = dyn_cast<LoopLikeOpInterface>(op);
+
+  // Be pessimistic about non loop ops.
+  if (!loop) {
+    SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
+        op, successor, argLattices, firstIndex);
+    return;
+  }
+
+  // Get the induction variables, and be pessimistic if they cannot be
+  // retrieved.
+  std::optional<SmallVector<Value>> iV = loop.getLoopInductionVars();
+  if (!iV) {
+    SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
+        op, successor, argLattices, firstIndex);
+    return;
+  }
+
+  // Get the inits.
+  OperandRange inits = loop.getInits();
+  assert((iV->size() + inits.size() == argLattices.size() ||
+          inits.size() == argLattices.size()) &&
+         "unsupported loop-like op");
+
+  // Get the loop structure.
+  std::optional<SmallVector<OpFoldResult>> lb = loop.getLoopLowerBounds();
+  std::optional<SmallVector<OpFoldResult>> ub = loop.getLoopUpperBounds();
+  std::optional<SmallVector<OpFoldResult>> sv = loop.getLoopSteps();
+  assert(lb && ub && sv && "unsupported loop-like op");
+  assert((iV->front() == argLattices.front()->getAnchor() ||
+          (inits.empty() ||
+           op->getResult(0) == argLattices.front()->getAnchor())) &&
+         "unsupported loop-like op");
+
+  // Helper function to get the state of an op fold result.
+  auto getState = [&](OpFoldResult ofr) {
+    auto v = dyn_cast<Value>(ofr);
+    if (!v)
+      return ThreadUniform::getUniform();
+    return getLatticeElement(v)->getValue();
+  };
+
+  // Get whether the loop is thread uniform based on the structure.
+  ThreadUniform value;
+  for (auto [lv, uv, s] : llvm::zip(*lb, *ub, *sv)) {
+    value = ThreadUniform::join(value, getState(lv));
+    value = ThreadUniform::join(value, getState(uv));
+    value = ThreadUniform::join(value, getState(s));
+  }
+
+  // Handle `scf.forall` in a pessimistic manner.
+  if (auto forAll = dyn_cast<scf::ForallOp>(op)) {
+    bool isSafeUniform =
+        llvm::all_of(forAll.getDeviceMappingAttrs(), [](Attribute attr) {
+          return isa<gpu::GPUBlockMappingAttr,
+                     IREE::Codegen::WorkgroupMappingAttr>(attr);
+        });
+    value = isSafeUniform
+                ? ThreadUniform::join(value, ThreadUniform::getUniform())
+                : ThreadUniform::join(value, ThreadUniform::getDependent());
+  }
+
+  // This is needed because dataflow is broken, and will call this function to
+  // check the results of a control-flow op. TODO: fix dataflow upstream.
+  if (inits.size() == argLattices.size()) {
+    for (auto [lattice, operand] :
+         llvm::zip(argLattices, loop.getRegionIterArgs())) {
+      join(lattice, *getLatticeElement(operand));
+      propagateIfChanged(lattice, lattice->join(value));
+    }
+    return;
+  }
+
+  // Propagate the state.
+  for (ThreadUniformLattice *lattice : argLattices.take_front(iV->size())) {
+    propagateIfChanged(lattice, lattice->join(value));
+  }
+  for (auto [lattice, operand] :
+       llvm::zip(argLattices.drop_front(iV->size()), inits)) {
+    join(lattice, *getLatticeElement(operand));
+    propagateIfChanged(lattice, lattice->join(value));
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// ROCDLUseBufferInstructionsPass
+//===----------------------------------------------------------------------===//
+
+/// Determine whether input source of a extract slice op should be handle by the
+/// pass. Currently we only handle a very specific case to not interfere with
+/// `ROCDLConfigureBufferInstructions`. TODO: unify these 2 passes.
+static bool isValidSource(TypedValue<RankedTensorType> value) {
+  auto loadOp = dyn_cast_or_null<
+      mlir::iree_compiler::IREE::TensorExt::DispatchTensorLoadOp>(
+      value.getDefiningOp());
+  if (!loadOp)
+    return false;
+  auto subspanOp = dyn_cast_or_null<IREE::HAL::InterfaceBindingSubspanOp>(
+      loadOp.getSource().getDefiningOp());
+  if (!subspanOp)
+    return false;
+  return !subspanOp->hasAttr(
+      IREE::GPU::IREEGPUDialect::UseRocdlBufferInstructionsAttrHelper::
+          getNameStr());
+}
+
+/// Handles the slice op, possibly inserting a buffer resource cast operation if
+/// it was determined buffer ops can be safely used.
+static void handleOp(tensor::ExtractSliceOp slice) {
+  SmallVector<OpFoldResult> sizes = slice.getMixedSizes();
+  // Exit if it is a trivial tensor.
+  if (sizes.size() <= 1) {
+    LDBGS("- the slice is trivial");
+    return;
+  }
+
+  IRRewriter rewriter(slice);
+  IntegerAttr maxVal =
+      rewriter.getIndexAttr(std::numeric_limits<int32_t>::max());
+
+  // Check if all the sizes in the slice are less than 2^31.
+  if (!llvm::all_of(sizes, [&](OpFoldResult sz) {
+        return ValueBoundsConstraintSet::compare(
+            ValueBoundsConstraintSet::Variable(sz),
+            ValueBoundsConstraintSet::ComparisonOperator::LT,
+            ValueBoundsConstraintSet::Variable(OpFoldResult(maxVal)));
+      })) {
+    LDBGS("- failed to infer that the slice was within bounds");
+    return;
+  }
+
+  Type eTy = slice.getResultType().getElementType();
+  // Skip if the type is not trivial. TODO: use the data layout to get the size.
+  if (!getElementTypeOrSelf(eTy).isIntOrIndexOrFloat()) {
+    LDBGS("- this pass can only handle tensors of int, index or floats");
+    return;
+  }
+
+  // Over approximate the size of index to not require using the data layout.
+  unsigned byteSize =
+      eTy.isIntOrFloat() ? std::max(eTy.getIntOrFloatBitWidth(), 8u) / 8 : 8;
+
+  // Compute the total extent of the buffer.
+  SmallVector<AffineExpr> dims(sizes.size());
+  bindSymbolsList(slice.getContext(), MutableArrayRef<AffineExpr>(dims));
+  AffineExpr result = dims[0];
+  for (AffineExpr e : MutableArrayRef<AffineExpr>(dims).drop_front())
+    result = result * e;
+  result = result * byteSize;
+
+  // Check if the total extent is less than 2^31.
+  SmallVector<ValueBoundsConstraintSet::Variable> szVars =
+      llvm::to_vector_of<ValueBoundsConstraintSet::Variable>(sizes);
+  if (!ValueBoundsConstraintSet::compare(
+          ValueBoundsConstraintSet::Variable(
+              AffineMap::get(0, dims.size(), result), szVars),
+          ValueBoundsConstraintSet::ComparisonOperator::LT,
+          ValueBoundsConstraintSet::Variable(maxVal))) {
+    LDBGS("- failed to infer that the slice was within bounds");
+    return;
+  }
+
+  // Add the cast operation.
+  rewriter.setInsertionPointAfter(slice);
+  auto buffOp = rewriter.create<IREE::GPU::BufferResourceCastOp>(
+      slice.getLoc(), slice.getType(), slice, Value());
+  rewriter.replaceAllUsesExcept(slice, buffOp, buffOp);
+  LDBGS("- success, added cast: " << buffOp);
+}
+
+void ROCDLUseBufferInstructionsPass::runOnOperation() {
+  FunctionOpInterface func = getOperation();
+
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(func);
+  if (!target || !target.isAMD())
+    return;
+
+  // Configure and run the dataflow analysis.
+  DataFlowSolver solver;
+  solver.load<dataflow::SparseConstantPropagation>();
+  solver.load<dataflow::DeadCodeAnalysis>();
+  solver.load<ThreadUniformAnalysis>();
+
+  if (failed(solver.initializeAndRun(func)))
+    return signalPassFailure();
+
+  func.walk([&](tensor::ExtractSliceOp slice) {
+    LDBGS(" found slice op: " << slice);
+
+    // Skip invalid sources.
+    if (!isValidSource(slice.getSource())) {
+      LDBGS("- the slice doesn't come from a valid source");
+      return;
+    }
+
+    // Skip if the slice is not thread uniform.
+    if (llvm::any_of(slice.getMixedOffsets(), [&](OpFoldResult operand) {
+          auto v = dyn_cast<Value>(operand);
+          if (!v)
+            return false;
+          auto opAnalysis = solver.lookupState<ThreadUniformLattice>(v);
+          return !opAnalysis || !opAnalysis->getValue().isUniform();
+        })) {
+      LDBGS("- the slice offsets are not thread uniform");
+      return;
+    }
+
+    // Try to handle op.
+    handleOp(slice);
+  });
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "pipeline_vector_distribute_gfx950.mlir",
             "pipeline_vector_distribute_gfx1100.mlir",
             "pipeline_warp_reduction.mlir",
+            "use_configure_buffer_instructions.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "pipeline_vector_distribute_gfx950.mlir"
     "pipeline_vector_distribute_reduction_gfx942.mlir"
     "pipeline_warp_reduction.mlir"
+    "use_configure_buffer_instructions.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/use_configure_buffer_instructions.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/use_configure_buffer_instructions.mlir
@@ -1,0 +1,116 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN: --pass-pipeline="builtin.module(func.func(iree-rocdl-use-buffer-instructions))" %s \
+// RUN:  | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 \
+// RUN: -pass-pipeline="builtin.module(func.func(iree-rocdl-use-buffer-instructions))" %s \
+// RUN:  | FileCheck --check-prefix=CUDA %s
+
+// CUDA-NOT: iree_gpu.use_rocdl_buffer_instructions
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+// CHECK-LABEL: @small_dyn_buffer_small_slice
+// CHECK: iree_gpu.buffer_resource_cast
+func.func @small_dyn_buffer_small_slice() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 4095> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = tensor.extract_slice %3[0, 0] [32, 32] [1, 1] : tensor<32x?xi64> to tensor<32x32xi64>
+  return
+}
+
+// CHECK-LABEL: @big_buffer_small_slice
+// CHECK: iree_gpu.buffer_resource_cast
+func.func @big_buffer_small_slice() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = tensor.extract_slice %3[0, 0] [32, 32] [1, 1] : tensor<32x?xi64> to tensor<32x32xi64>
+  return
+}
+
+// CHECK-LABEL: @big_buffer_small_dyn_slice
+// CHECK: iree_gpu.buffer_resource_cast
+func.func @big_buffer_small_dyn_slice() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %5 = util.assume.int %1<umin = 1, umax = 8192> : index
+  %6 = tensor.extract_slice %3[0, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
+  return
+}
+
+// CHECK-LABEL: @big_buffer_big_dyn_slice
+// CHECK-NOT: iree_gpu.buffer_resource_cast
+func.func @big_buffer_big_dyn_slice() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %5 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %6 = tensor.extract_slice %3[0, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
+  return
+}
+
+// CHECK-LABEL: @dependent_offsets
+// CHECK-NOT: iree_gpu.buffer_resource_cast
+func.func @dependent_offsets() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8192> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = gpu.thread_id x
+  %5 = tensor.extract_slice %3[0, %4] [32, 32] [1, 1] : tensor<32x?xi64> to tensor<32x32xi64>
+  return
+}
+
+// CHECK-LABEL: @uniform_loop
+// CHECK: iree_gpu.buffer_resource_cast
+func.func @uniform_loop() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %5 = util.assume.int %1<umin = 1, umax = 8192> : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %iv = %c0 to %5 step %c1 {
+    %6 = tensor.extract_slice %3[%iv, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
+    scf.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @non_uniform_loop
+// CHECK-NOT: iree_gpu.buffer_resource_cast
+func.func @non_uniform_loop() {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %5 = util.assume.int %1<umin = 1, umax = 8192> : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %6 = gpu.thread_id x
+  scf.for %iv = %c0 to %6 step %c1 {
+    %7 = tensor.extract_slice %3[%iv, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
+    scf.yield
+  }
+  return
+}


### PR DESCRIPTION
This patch adds the `iree-rocdl-use-buffer-instructions` pass to cover some buffers not covered by: `iree-rocdl-configure-buffer-instructions`.

In particular this pass will look for `tensor.extact_slices` coming from a `iree_tensor_ext.dispatch.tensor.load` and if the size is less than 2GB and the offsets are uniform, then the pass adds a `iree_gpu.buffer_resource_cast` to use raw buffer ops.

This is useful when the main buffer is too big to use raw buffers, but the slices are small enough to use raw buffers.

Example:
```mlir
func.func @uniform_loop() {
  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64)
      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
  %5 = util.assume.int %1<umin = 1, umax = 8192> : index
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  scf.for %iv = %c0 to %5 step %c1 {
    %6 = tensor.extract_slice %3[%iv, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
    scf.yield
  }
  return
}
// Result of applying the pass.
func.func @uniform_loop() {
  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>
  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
  %2 = util.assume.int %1<umin = 1, umax = 8589934592> : index
  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, %2], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x?xi64>>{%1} -> tensor<32x?xi64>
  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
  %5 = util.assume.int %1<umin = 1, umax = 8192> : index
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  scf.for %arg0 = %c0 to %5 step %c1 {
    %extracted_slice = tensor.extract_slice %3[%arg0, 0] [32, %5] [1, 1] : tensor<32x?xi64> to tensor<32x?xi64>
    %6 = iree_gpu.buffer_resource_cast %extracted_slice : tensor<32x?xi64>
  }
  return
}
```

It's future work to merge `iree-rocdl-use-buffer-instructions` and`iree-rocdl-configure-buffer-instructions` into a single pass. Currently, they are mutually exclusive.