### PR TITLE
[CPU] Use TilingConfig for lowering_config propagation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -23,15 +23,15 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc)
     : loweringConfig(lc) {
   assert(lc && "Expected a valid lowering config");
   if (auto codegenLc = dyn_cast<IREE::Codegen::LoweringConfigAttr>(lc)) {
-    initAsCodegenLoweringConfig(codegenLc);
+    initFromCodegenLoweringConfig(codegenLc);
   } else if (auto cpuLc = dyn_cast<IREE::CPU::LoweringConfigAttr>(lc)) {
-    initAsCPULoweringConfig(cpuLc);
+    initFromCPULoweringConfig(cpuLc);
   } else {
     assert(false && "unknown lowering config is not supported");
   }
 }
 
-void TilingConfig::initAsCodegenLoweringConfig(
+void TilingConfig::initFromCodegenLoweringConfig(
     IREE::Codegen::LoweringConfigAttr lc) {
   // Initialize indices to invalid.
   std::fill(tilingLevelToActualLevelMap.begin(),
@@ -72,7 +72,7 @@ void TilingConfig::initAsCodegenLoweringConfig(
   }
 }
 
-void TilingConfig::initAsCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc) {
+void TilingConfig::initFromCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc) {
   std::fill(tilingLevelToActualLevelMap.begin(),
             tilingLevelToActualLevelMap.end(), TilingLevel::InvalidLevel);
   DictionaryAttr dictAttr = lc.getConfig();

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
 #define DEBUG_TYPE "tiling-config"
 #define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
@@ -17,10 +19,20 @@ using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 
 namespace mlir::iree_compiler {
 
-TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
+TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc)
     : loweringConfig(lc) {
   assert(lc && "Expected a valid lowering config");
+  if (auto codegenLc = dyn_cast<IREE::Codegen::LoweringConfigAttr>(lc)) {
+    initAsCodegenLoweringConfig(codegenLc);
+  } else if (auto cpuLc = dyn_cast<IREE::CPU::LoweringConfigAttr>(lc)) {
+    initAsCPULoweringConfig(cpuLc);
+  } else {
+    assert(false && "unknown lowering config is not supported");
+  }
+}
 
+void TilingConfig::initAsCodegenLoweringConfig(
+    IREE::Codegen::LoweringConfigAttr lc) {
   // Initialize indices to invalid.
   std::fill(tilingLevelToActualLevelMap.begin(),
             tilingLevelToActualLevelMap.end(), TilingLevel::InvalidLevel);
@@ -58,15 +70,20 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   default:
     break;
   }
-};
+}
 
-TilingConfig::TilingConfig(IREE::CPU::LoweringConfigAttr lc)
-    : loweringConfig(lc) {
-  assert(lc && "Expected a valid lowering config");
+void TilingConfig::initAsCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc) {
+  std::fill(tilingLevelToActualLevelMap.begin(),
+            tilingLevelToActualLevelMap.end(), TilingLevel::InvalidLevel);
+  DictionaryAttr dictAttr = lc.getConfig();
   for (size_t i = 0, e = tilingLevelToActualLevelMap.size(); i < e; ++i) {
+    if (!dictAttr || !dictAttr.contains(IREE::CPU::getTilingLevelName(
+                         static_cast<IREE::CPU::TilingLevel>(i)))) {
+      continue;
+    }
     tilingLevelToActualLevelMap[i] = i;
   }
-};
+}
 
 /// Returns the tiling level that contains the vector dim at `dimPos` (which is
 /// an index into the result of `getVectorTileSizes()`).

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -70,7 +70,7 @@ public:
       if (i == TilingLevel::InvalidLevel) {
         continue;
       }
-      auto attr = loweringConfig.getTilingLevelAttr(i);
+      Attribute attr = loweringConfig.getTilingLevelAttr(i);
       assert(attr && "failed to get tiling level attribute");
       result.emplace_back(
           cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(attr).getSizes());
@@ -86,7 +86,7 @@ public:
       if (i == TilingLevel::InvalidLevel) {
         continue;
       }
-      auto attr = loweringConfig.getTilingLevelAttr(i);
+      Attribute attr = loweringConfig.getTilingLevelAttr(i);
       assert(attr && "failed to get tiling level attribute");
       result.emplace_back(
           cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(attr)
@@ -175,8 +175,8 @@ public:
 private:
   // Initialize the TilingConfig with given LoweringConfigAttr attribute
   // details.
-  void initAsCodegenLoweringConfig(IREE::Codegen::LoweringConfigAttr lc);
-  void initAsCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc);
+  void initFromCodegenLoweringConfig(IREE::Codegen::LoweringConfigAttr lc);
+  void initFromCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc);
 
   SizesAndScalableFlags getVectorSizesForLevel(unsigned level) {
     auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 
 namespace mlir::iree_compiler {
 
@@ -33,8 +34,7 @@ public:
   /// a subset of them may be available in a valid configuration.
   using TilingLevel = IREE::CPU::TilingLevel;
 
-  TilingConfig(IREE::Codegen::LoweringConfigAttr lc);
-  TilingConfig(IREE::CPU::LoweringConfigAttr lc);
+  explicit TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc);
 
   /// Returns the number of tiling levels of the configuration.
   unsigned getNumTilingLevels() const {
@@ -66,9 +66,31 @@ public:
   /// Returns all the tile sizes of all the levels of the configuration.
   TileSizesListType getTileSizes() const {
     TileSizesListType result;
-    for (unsigned i = 0, e = getNumTilingLevels(); i < e; ++i) {
-      result.push_back(
-          loweringConfig.getStaticTilingLevelSizes(i, /*target=*/nullptr));
+    for (auto i : tilingLevelToActualLevelMap) {
+      if (i == TilingLevel::InvalidLevel) {
+        continue;
+      }
+      auto attr = loweringConfig.getTilingLevelAttr(i);
+      assert(attr && "failed to get tiling level attribute");
+      result.emplace_back(
+          cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(attr).getSizes());
+    }
+    return result;
+  }
+
+  /// Returns a list that contains all the scalable tile flags in TilingLevel
+  /// order.
+  ScalableTileFlagsListType getScalableTileFlags() const {
+    ScalableTileFlagsListType result;
+    for (auto i : tilingLevelToActualLevelMap) {
+      if (i == TilingLevel::InvalidLevel) {
+        continue;
+      }
+      auto attr = loweringConfig.getTilingLevelAttr(i);
+      assert(attr && "failed to get tiling level attribute");
+      result.emplace_back(
+          cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(attr)
+              .getScalableFlags());
     }
     return result;
   }
@@ -151,6 +173,11 @@ public:
   }
 
 private:
+  // Initialize the TilingConfig with given LoweringConfigAttr attribute
+  // details.
+  void initAsCodegenLoweringConfig(IREE::Codegen::LoweringConfigAttr lc);
+  void initAsCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc);
+
   SizesAndScalableFlags getVectorSizesForLevel(unsigned level) {
     auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
         loweringConfig.getTilingLevelAttr(level));

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -192,7 +192,7 @@ Attribute LoweringConfigAttr::getTilingLevelAttr(unsigned level) const {
          "invalid level");
   StringRef key = getTilingLevelName(static_cast<TilingLevel>(level));
   DictionaryAttr config = getConfig();
-  if (!config || config.contains(key)) {
+  if (!config || !config.contains(key)) {
     return {};
   }
   return config.get(key);

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -32,6 +32,12 @@ enum TilingLevel : unsigned {
   InvalidLevel = 7,
 };
 
+struct LoweringConfigLevelInfo {
+  IREE::CPU::TilingLevel level;
+  SmallVector<int64_t> sizes;
+  SmallVector<bool> scalableFlags;
+};
+
 /// Returns the corresponding key string for `level`.
 StringRef getTilingLevelName(TilingLevel level);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2770,8 +2770,7 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
   if (!linalgOp)
     return success();
-  auto loweringConfig = getLoweringConfig(linalgOp);
-  TilingConfig tilingConfig(loweringConfig);
+  TilingConfig tilingConfig(getLoweringConfig(linalgOp));
   TileSizesListType tileSizesList = tilingConfig.getTileSizes();
 
   bool foundUnPackOp = false;
@@ -2940,7 +2939,8 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
   }
 
   auto ctx = entryPointFn.getContext();
-  auto rootLoweringConfig = getLoweringConfig(rootOperation);
+  IREE::Codegen::LoweringConfigAttrInterface rootLoweringConfig =
+      getLoweringConfig(rootOperation);
   TilingConfig tilingConfig(rootLoweringConfig);
   SmallVector<int64_t> distTileSizes, parallelVecTileSizes;
   SmallVector<bool> distScalableTileSizes, parallelVecScalableTileSizes;
@@ -3106,7 +3106,8 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
       bool setUpOK =
           TypeSwitch<Operation *, bool>(op)
               .Case<linalg::PackOp>([&](auto packOp) {
-                for (auto flags : tilingConfig.getScalableTileFlags()) {
+                for (ScalableTileFlagsListTypeRef flags :
+                     tilingConfig.getScalableTileFlags()) {
                   // TODO: Handle scalable flags
                   if (llvm::any_of(flags, [&](bool flag) { return flag; }))
                     return false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3106,7 +3106,7 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
       bool setUpOK =
           TypeSwitch<Operation *, bool>(op)
               .Case<linalg::PackOp>([&](auto packOp) {
-                for (ScalableTileFlagsListTypeRef flags :
+                for (ArrayRef<bool> flags :
                      tilingConfig.getScalableTileFlags()) {
                   // TODO: Handle scalable flags
                   if (llvm::any_of(flags, [&](bool flag) { return flag; }))

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenEnums.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -2769,10 +2770,9 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
   if (!linalgOp)
     return success();
-
-  auto loweringConfig =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(linalgOp);
-  TileSizesListType tileSizesList = loweringConfig.getTileSizeVals();
+  auto loweringConfig = getLoweringConfig(linalgOp);
+  TilingConfig tilingConfig(loweringConfig);
+  TileSizesListType tileSizesList = tilingConfig.getTileSizes();
 
   bool foundUnPackOp = false;
   SmallVector<int64_t> alignedSizes(linalgOp.getNumLoops(), 1);
@@ -2836,8 +2836,8 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   }
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, rootOp, tileSizesList,
-      loweringConfig.getScalableTileFlagVals(), pipeline, /*workgroupSize=*/{},
+      entryPointFn, rootOp, tileSizesList, tilingConfig.getScalableTileFlags(),
+      pipeline, /*workgroupSize=*/{},
       /*subgroupSize=*/{}, pipelineConfig);
 }
 
@@ -2940,8 +2940,7 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
   }
 
   auto ctx = entryPointFn.getContext();
-  auto rootLoweringConfig =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(rootOperation);
+  auto rootLoweringConfig = getLoweringConfig(rootOperation);
   TilingConfig tilingConfig(rootLoweringConfig);
   SmallVector<int64_t> distTileSizes, parallelVecTileSizes;
   SmallVector<bool> distScalableTileSizes, parallelVecScalableTileSizes;
@@ -3083,8 +3082,8 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
     // For root op, we patch the adjusted tile sizes on its original tiling
     // config.
     if (op == rootOperation) {
-      tileSizesList = rootLoweringConfig.getTileSizeVals();
-      scalableTileFlagsList = rootLoweringConfig.getScalableTileFlagVals();
+      tileSizesList = tilingConfig.getTileSizes();
+      scalableTileFlagsList = tilingConfig.getScalableTileFlags();
       if (tilingConfig.getNumTilingLevels() > 0) {
         tileSizesList[tilingConfig.getDistributionLevel()] = distTileSizes;
         scalableTileFlagsList[tilingConfig.getDistributionLevel()] =
@@ -3107,8 +3106,7 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
       bool setUpOK =
           TypeSwitch<Operation *, bool>(op)
               .Case<linalg::PackOp>([&](auto packOp) {
-                for (auto flags :
-                     rootLoweringConfig.getScalableTileFlagVals()) {
+                for (auto flags : tilingConfig.getScalableTileFlags()) {
                   // TODO: Handle scalable flags
                   if (llvm::any_of(flags, [&](bool flag) { return flag; }))
                     return false;
@@ -3241,8 +3239,7 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
         llvm::to_vector(llvm::make_filter_range(computeOps, [](Operation *op) {
           return !isa_and_nonnull<IREE::LinalgExt::CustomOp>(
                      op->getParentOp()) ||
-                 getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op) ==
-                     nullptr;
+                 getLoweringConfig(op) == nullptr;
         }));
     if (failed(setLoweringConfigForComputeOps(entryPointFn, prunedComputeOps,
                                               rootOperation))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -73,15 +73,10 @@ getTilingConfigForPipeline(FunctionOpInterface funcOp) {
     return failure();
   }
   auto config = iree_compiler::getLoweringConfig(rootOp.value());
-  if (auto cpuLoweringConfig =
-          dyn_cast_if_present<IREE::CPU::LoweringConfigAttr>(config)) {
-    return TilingConfig(cpuLoweringConfig);
-  } else if (auto loweringConfig =
-                 dyn_cast_if_present<IREE::Codegen::LoweringConfigAttr>(
-                     config)) {
-    return TilingConfig(loweringConfig);
+  if (!config) {
+    return failure();
   }
-  return failure();
+  return TilingConfig(config);
 }
 
 void LLVMCPULowerExecutableTargetPass::runOnOperation() {


### PR DESCRIPTION
The revision adds more helpers to `TilingConfig` and use it in CPU strategy selection. It is a preparation for propagating `IREE::CPU::LoweringConfigAttr`, as it does not use the methods that are only available for `IREE::Codegen::LoweringConfigAttr`.

It also fixes a bug in `LoweringConfigAttr::getTilingLevelAttr` implementation and adds more unit tests to `TilingConfig`.

Changes in `TilingConfig`:

- Use the attribute interface (i.e., `LoweringConfigAttrInterface`) in the constructor.
- Fix the bug in `getTileSizes` that is exposed by using `IREE::CPU::LoweringConfigAttr`.
- Add `getScalableTileFlags` method to `TilingConfig`, which extracts the scalable flags.

It is a step towards https://github.com/iree-org/iree/issues/21297