### PR TITLE
[DispatchCreation] Add pass to cast away unsupported element types

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -20,6 +20,7 @@ package(
 iree_compiler_cc_library(
     name = "DispatchCreation",
     srcs = [
+        "BitcastUnsupportedElementTypes.cpp",
         "BubbleUpExpandShapes.cpp",
         "CloneProducersIntoDispatchRegions.cpp",
         "CollapseDimensions.cpp",

--- a/compiler/src/iree/compiler/DispatchCreation/BitcastUnsupportedElementTypes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BitcastUnsupportedElementTypes.cpp
@@ -138,7 +138,9 @@ bitcastWorkgroupsInputs(RewriterBase &rewriter,
     operand.assign(inputBitcast);
 
     blockArg.setType(castedDispatchType);
-    for (auto user : blockArg.getUsers()) {
+    // Copy the list of users since they will be updated while bitcasting.
+    SmallVector<Operation *> users(blockArg.getUsers());
+    for (auto user : users) {
       if (failed(bitcastBlockArgUser(rewriter, workgroupsOp, user, blockArg,
                                      tensorType, castedTensorType))) {
         return failure();
@@ -207,7 +209,8 @@ bitcastWorkgroupsOutputs(RewriterBase &rewriter,
 
     // Update the type of the block argument and bitcast all load/store users.
     blockArg.setType(castedDispatchType);
-    for (auto user : blockArg.getUsers()) {
+    SmallVector<Operation *> users(blockArg.getUsers());
+    for (auto user : users) {
       if (failed(bitcastBlockArgUser(rewriter, workgroupsOp, user, blockArg,
                                      tensorType, castedTensorType))) {
         return failure();

--- a/compiler/src/iree/compiler/DispatchCreation/BitcastUnsupportedElementTypes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BitcastUnsupportedElementTypes.cpp
@@ -1,0 +1,282 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_BITCASTUNSUPPORTEDELEMENTTYPESPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+/// Helper to get the target type for bitcasting if required. Returns failure
+/// if bitcasting is not possible, and returns a null type if not required.
+static FailureOr<RankedTensorType>
+getBitcastRequiredType(Builder &b, Operation *root,
+                       RankedTensorType tensorType) {
+  // All integer and byte aligned types are legal. DispatchTensorType
+  // only allows int and float element types so this check is safe.
+  Type elementType = tensorType.getElementType();
+  int64_t bitwidth = elementType.getIntOrFloatBitWidth();
+  if (elementType.isInteger() || bitwidth % 8 == 0) {
+    return RankedTensorType();
+  }
+
+  int64_t innerSize = tensorType.getShape().back();
+  int64_t innerNumBits = innerSize * bitwidth;
+  if (ShapedType::isDynamic(innerSize) || innerNumBits % 8 != 0) {
+    return root->emitOpError(
+        "Unsupported tensor type unable to pack to bytes.");
+  }
+
+  SmallVector<int64_t> newShape(tensorType.getShape());
+  newShape.back() = innerNumBits / 8;
+  return RankedTensorType::get(newShape, b.getI8Type());
+}
+
+static LogicalResult bitcastBlockArgUser(RewriterBase &rewriter,
+                                         Operation *root, Operation *user,
+                                         Value arg,
+                                         RankedTensorType originalType,
+                                         RankedTensorType targetType) {
+  int64_t innerSize = originalType.getShape().back();
+  if (auto load = dyn_cast<IREE::TensorExt::DispatchTensorLoadOp>(user)) {
+    SmallVector<int64_t> newSizes(load.getStaticSizes());
+    if (newSizes.back() != innerSize || load.getStaticOffsets().back() != 0) {
+      return root->emitOpError("non-full load of unsupported element type.");
+    }
+    newSizes.back() = targetType.getShape().back();
+
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(load);
+
+    // Load in the new type -> bitcast back to the original type.
+    auto newLoad = rewriter.create<IREE::TensorExt::DispatchTensorLoadOp>(
+        load.getLoc(), targetType, arg, load.getSourceDims(), load.getOffsets(),
+        load.getSizes(), load.getStrides(), load.getStaticOffsets(), newSizes,
+        load.getStaticStrides());
+    rewriter.replaceOpWithNewOp<IREE::TensorExt::BitCastOp>(
+        load, originalType, newLoad, load.getSizes(), load.getSizes());
+    return success();
+  } else if (auto store =
+                 dyn_cast<IREE::TensorExt::DispatchTensorStoreOp>(user)) {
+    SmallVector<int64_t> newSizes(store.getStaticSizes());
+    if (newSizes.back() != innerSize || store.getStaticOffsets().back() != 0) {
+      return root->emitOpError("non-full store of unsupported element type.");
+    }
+    newSizes.back() = targetType.getShape().back();
+
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(store);
+
+    auto bitcast = rewriter.create<IREE::TensorExt::BitCastOp>(
+        store.getLoc(), targetType, store.getValue(), store.getSizes(),
+        store.getSizes());
+    // Bitcast to the target type -> store in the new type.
+    rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorStoreOp>(
+        store, TypeRange{}, bitcast, arg, store.getTargetDims(),
+        store.getOffsets(), store.getSizes(), store.getStrides(),
+        store.getStaticOffsets(), newSizes, store.getStaticStrides());
+    return success();
+  }
+
+  return root->emitOpError(
+      "non-tensor load or store user of unsupported element type.");
+}
+
+/// Bitcast unsupported input tensor types to i8s in place. Bitcasts inside the
+/// dispatch use `iree_tensor_ext.bitcast` and outside it uses
+/// `flow.tensor.bitcast`.
+static LogicalResult
+bitcastWorkgroupsInputs(RewriterBase &rewriter,
+                        IREE::Flow::DispatchWorkgroupsOp workgroupsOp) {
+  for (auto [index, operand] :
+       llvm::enumerate(workgroupsOp.getArgumentsMutable())) {
+    // Skip tied operands. They will be processed separately.
+    if (workgroupsOp.isOperandTied(operand.getOperandNumber())) {
+      continue;
+    }
+
+    auto tensorType = dyn_cast<RankedTensorType>(operand.get().getType());
+    // TODO: Figure out what to do about encodings.
+    if (!tensorType || tensorType.getEncoding()) {
+      continue;
+    }
+
+    auto maybeCastedTensorType =
+        getBitcastRequiredType(rewriter, workgroupsOp, tensorType);
+    if (failed(maybeCastedTensorType)) {
+      return failure();
+    }
+
+    RankedTensorType castedTensorType = *maybeCastedTensorType;
+    if (!castedTensorType) {
+      continue;
+    }
+
+    BlockArgument blockArg = workgroupsOp.getInputBlockArgument(index);
+    auto dispatchType =
+        cast<IREE::TensorExt::DispatchTensorType>(blockArg.getType());
+
+    auto castedDispatchType = IREE::TensorExt::DispatchTensorType::get(
+        dispatchType.getAccess(), castedTensorType);
+
+    rewriter.setInsertionPoint(workgroupsOp);
+    ValueRange sourceDims =
+        workgroupsOp.getOperandDynamicDims(operand.getOperandNumber());
+    auto inputBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+        workgroupsOp.getLoc(), castedTensorType, operand.get(), sourceDims,
+        sourceDims);
+    operand.assign(inputBitcast);
+
+    blockArg.setType(castedDispatchType);
+    for (auto user : blockArg.getUsers()) {
+      if (failed(bitcastBlockArgUser(rewriter, workgroupsOp, user, blockArg,
+                                     tensorType, castedTensorType))) {
+        return failure();
+      }
+    }
+  }
+  return success();
+}
+
+/// Bitcast unsupported output and tied input tensor types to bytes.
+static LogicalResult
+bitcastWorkgroupsOutputs(RewriterBase &rewriter,
+                         IREE::Flow::DispatchWorkgroupsOp workgroupsOp) {
+  // Try to keep the check for whether bitcasting is required fast as that is
+  // the dramatically more common case.
+  SmallVector<std::pair<int64_t, RankedTensorType>> resultsToCast;
+  for (OpResult result : workgroupsOp->getOpResults()) {
+    auto tensorType = dyn_cast<RankedTensorType>(result.getType());
+    // TODO: Figure out what to do about encodings.
+    if (!tensorType || tensorType.getEncoding()) {
+      continue;
+    }
+
+    auto maybeCastedTensorType =
+        getBitcastRequiredType(rewriter, workgroupsOp, tensorType);
+    if (failed(maybeCastedTensorType)) {
+      return failure();
+    }
+
+    RankedTensorType castedTensorType = *maybeCastedTensorType;
+    if (castedTensorType) {
+      resultsToCast.emplace_back(result.getResultNumber(), castedTensorType);
+    }
+  }
+
+  // Nothing to do.
+  if (resultsToCast.empty()) {
+    return success();
+  }
+
+  SmallVector<Type> newResultTypes(workgroupsOp->getResultTypes());
+  for (auto [resultIndex, castedTensorType] : resultsToCast) {
+    OpResult originalResult = workgroupsOp->getOpResult(resultIndex);
+    auto tensorType = cast<RankedTensorType>(originalResult.getType());
+    newResultTypes[resultIndex] = castedTensorType;
+
+    BlockArgument blockArg = workgroupsOp.getOutputBlockArgument(resultIndex);
+    auto dispatchType =
+        cast<IREE::TensorExt::DispatchTensorType>(blockArg.getType());
+    auto castedDispatchType = IREE::TensorExt::DispatchTensorType::get(
+        dispatchType.getAccess(), castedTensorType);
+
+    // Cast the input to the dispatch if the corresponding result is tied.
+    if (OpOperand *tiedOperand =
+            workgroupsOp.getTiedResultOpOperand(originalResult)) {
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPoint(workgroupsOp);
+      ValueRange dynamicDims =
+          workgroupsOp.getOperandDynamicDims(tiedOperand->getOperandNumber());
+
+      auto inputBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+          workgroupsOp.getLoc(), castedTensorType, tiedOperand->get(),
+          dynamicDims, dynamicDims);
+      tiedOperand->assign(inputBitcast);
+    }
+
+    // Update the type of the block argument and bitcast all load/store users.
+    blockArg.setType(castedDispatchType);
+    for (auto user : blockArg.getUsers()) {
+      if (failed(bitcastBlockArgUser(rewriter, workgroupsOp, user, blockArg,
+                                     tensorType, castedTensorType))) {
+        return failure();
+      }
+    }
+  }
+
+  // Clone the op with new result types and steal the body.
+  rewriter.setInsertionPoint(workgroupsOp);
+  auto newWorkgroupsOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
+      workgroupsOp->getLoc(), workgroupsOp.getWorkload(), newResultTypes,
+      workgroupsOp.getResultDims(), workgroupsOp.getArguments(),
+      workgroupsOp.getArgumentDims(),
+      workgroupsOp.getTiedResultOperandIndices(), workgroupsOp->getAttrs());
+  newWorkgroupsOp->setDialectAttrs(workgroupsOp->getDialectAttrs());
+  auto &newBody = newWorkgroupsOp.getClosureBodyRegion();
+  newBody.takeBody(workgroupsOp.getClosureBodyRegion());
+
+  // Copy the workgroup_count region.
+  auto &workgroupCountRegion = workgroupsOp.getWorkgroupCount();
+  if (!workgroupCountRegion.empty()) {
+    auto &newWorkgroupCountRegion = newWorkgroupsOp.getWorkgroupCount();
+    newWorkgroupCountRegion.takeBody(workgroupCountRegion);
+  }
+
+  // Bitcast back to the original types for replacement.
+  SmallVector<Value> replacements(newWorkgroupsOp.getResults());
+  for (auto [resultIndex, castedTensorType] : resultsToCast) {
+    auto originalType =
+        cast<RankedTensorType>(workgroupsOp.getResult(resultIndex).getType());
+    ValueRange dynamicDims = newWorkgroupsOp.getResultDynamicDims(resultIndex);
+    replacements[resultIndex] = rewriter.create<IREE::Flow::TensorBitCastOp>(
+        workgroupsOp.getLoc(), originalType, replacements[resultIndex],
+        dynamicDims, dynamicDims);
+  }
+
+  rewriter.replaceOp(workgroupsOp, replacements);
+  return success();
+}
+
+namespace {
+struct BitcastUnsupportedElementTypesPass
+    : public impl::BitcastUnsupportedElementTypesPassBase<
+          BitcastUnsupportedElementTypesPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+void BitcastUnsupportedElementTypesPass::runOnOperation() {
+  Operation *op = getOperation();
+
+  IRRewriter rewriter(&getContext());
+
+  WalkResult res = op->walk([&](IREE::Flow::DispatchWorkgroupsOp workgroupsOp) {
+    // First update bitcast all non-tied input operands in place.
+    if (failed(bitcastWorkgroupsInputs(rewriter, workgroupsOp))) {
+      return WalkResult::interrupt();
+    }
+    // Bitcast all required outputs (including tied operands).
+    if (failed(bitcastWorkgroupsOutputs(rewriter, workgroupsOp))) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (res.wasInterrupted()) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "FusionUtils.h"
     "Passes.h"
   SRCS
+    "BitcastUnsupportedElementTypes.cpp"
     "BubbleUpExpandShapes.cpp"
     "CloneProducersIntoDispatchRegions.cpp"
     "CollapseDimensions.cpp"

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -335,6 +335,10 @@ void buildDispatchCreationPassPipeline(
       ///   to map the captured operand to the position in the workload list.
       .addPass(
           DispatchCreation::createMaterializeDefaultWorkgroupCountRegionPass)
+      /// Bitcasts away all unsupported element types. We rely on folders to
+      /// elide cancelling bitcasts on the host side dropping all such types.
+      /// This only handles the dispatch boundary.
+      .addPass(DispatchCreation::createBitcastUnsupportedElementTypesPass)
       .addPass(createCSEPass)
       .addPass(IREE::Flow::createCanonicalizePass);
 }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -23,6 +23,15 @@ include "mlir/Pass/PassBase.td"
 // - Reshape propagation passes
 //===---------------------------------------------------------------------===//
 
+def BitcastUnsupportedElementTypesPass :
+    Pass<"iree-dispatch-creation-bitcast-unsupported-element-types"> {
+  let summary = "Bitcasts tensor element types unsupported by the HAL";
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+    "IREE::TensorExt::IREETensorExtDialect",
+  ];
+}
+
 def BubbleUpExpandShapesPass :
     Pass<"iree-dispatch-creation-bubble-up-expand-shapes"> {
   let summary = "Propagate expand_shapes up the program (and collapse_shapes down).";

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "bitcast_unsupported_element_types.mlir",
             "clone_producers_into_dispatch_regions.mlir",
             "collapse_dimensions.mlir",
             "collapse_linalg_generic_on_tensors.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "bitcast_unsupported_element_types.mlir"
     "bubble_up_expand_shapes.mlir"
     "bubble_up_extract_slice.mlir"
     "clone_producers_into_dispatch_regions.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/bitcast_unsupported_element_types.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bitcast_unsupported_element_types.mlir
@@ -1,0 +1,183 @@
+// RUN: iree-opt --split-input-file --mlir-print-local-scope \
+// RUN:   --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bitcast-unsupported-element-types, canonicalize))" \
+// RUN:   --allow-unregistered-dialect --verify-diagnostics %s | FileCheck %s
+
+util.func private @f4_input_tensor(%arg0: tensor<1024xf4E2M1FN>, %arg1: tensor<?x1024xf4E2M1FN>, %arg2: index) -> tensor<1024xi8> {
+  %0 = flow.dispatch.workgroups[%arg2](%arg0, %arg1, %arg2)
+    : (tensor<1024xf4E2M1FN>, tensor<?x1024xf4E2M1FN>{%arg2}, index) -> tensor<1024xi8> = (
+        %arg3: !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024xf4E2M1FN>>,
+        %arg4: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x1024xf4E2M1FN>>,
+        %arg5: index,
+        %arg6: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024xi8>>
+      ) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg3, offsets = [0], sizes = [1024], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024xf4E2M1FN>> -> tensor<1024xf4E2M1FN>
+    %2 = iree_tensor_ext.dispatch.tensor.load %arg4, offsets = [0, 0], sizes = [%arg5, 1024], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x1024xf4E2M1FN>>{%arg5} -> tensor<?x1024xf4E2M1FN>
+    %3 = "dispatch.body"(%1, %2) : (tensor<1024xf4E2M1FN>, tensor<?x1024xf4E2M1FN>) -> (tensor<1024xi8>)
+    iree_tensor_ext.dispatch.tensor.store %3, %arg6, offsets = [0], sizes = [1024], strides = [1]
+      : tensor<1024xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024xi8>>
+    flow.return
+  }
+  util.return %0 : tensor<1024xi8>
+}
+
+// CHECK-LABEL: @f4_input_tensor
+
+// CHECK-SAME:    %[[ARG0:[A-Za-z0-9]+]]: tensor<1024xf4E2M1FN>
+// CHECK-SAME:    %[[ARG1:[A-Za-z0-9]+]]: tensor<?x1024xf4E2M1FN>
+// CHECK-SAME:    %[[ARG2:[A-Za-z0-9]+]]: index
+
+// CHECK-DAG:     %[[B0:.+]] = flow.tensor.bitcast %[[ARG0]] : tensor<1024xf4E2M1FN> -> tensor<512xi8>
+// CHECK-DAG:     %[[B1:.+]] = flow.tensor.bitcast %[[ARG1]] : tensor<?x1024xf4E2M1FN>{%[[ARG2]]} -> tensor<?x512xi8>{%[[ARG2]]}
+
+// CHECK:         flow.dispatch.workgroups[%[[ARG2]]](%[[B0]], %[[B1]], %[[ARG2]])
+// CHECK-NEXT:      (%[[ARG3:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<512xi8>>
+// CHECK-SAME:       %[[ARG4:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x512xi8>>
+// CHECK-SAME:       %[[ARG5:[A-Za-z0-9]+]]: index
+
+// CHECK-DAG:       %[[L0:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG3]], offsets = [0], sizes = [512]
+// CHECK-DAG:       %[[B2:.+]] = iree_tensor_ext.bitcast %[[L0]] : tensor<512xi8> -> tensor<1024xf4E2M1FN>
+// CHECK-DAG:       %[[L1:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG4]], offsets = [0, 0], sizes = [%[[ARG5]], 512]
+// CHECK-DAG:       %[[B3:.+]] = iree_tensor_ext.bitcast %[[L1]] : tensor<?x512xi8>{%[[ARG5]]} -> tensor<?x1024xf4E2M1FN>{%[[ARG5]]}
+
+// CHECK:           "dispatch.body"(%[[B2]], %[[B3]])
+
+// -----
+
+util.func private @f6_input_tensor(%arg0: tensor<960xf6E3M2FN>) -> tensor<960xi8> {
+  %0 = flow.dispatch.workgroups(%arg0)
+    : (tensor<960xf6E3M2FN>) -> tensor<960xi8> = (
+        %arg1: !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>>,
+        %arg2: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+      ) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets = [0], sizes = [960], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>> -> tensor<960xf6E3M2FN>
+    %2 = "dispatch.body"(%1) : (tensor<960xf6E3M2FN>) -> (tensor<960xi8>)
+    iree_tensor_ext.dispatch.tensor.store %2, %arg2, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+    flow.return
+  }
+  util.return %0 : tensor<960xi8>
+}
+
+// CHECK-LABEL: @f6_input_tensor
+// CHECK-SAME:    %[[ARG0:[A-Za-z0-9]+]]: tensor<960xf6E3M2FN>
+// CHECK:         %[[B0:.+]] = flow.tensor.bitcast %[[ARG0]] : tensor<960xf6E3M2FN> -> tensor<720xi8>
+// CHECK:         flow.dispatch.workgroups(%[[B0]])
+// CHECK-NEXT:      %[[ARG1:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<720xi8>>
+// CHECK-DAG:       %[[L0:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG1]], offsets = [0], sizes = [720]
+// CHECK-DAG:       %[[B1:.+]] = iree_tensor_ext.bitcast %[[L0]] : tensor<720xi8> -> tensor<960xf6E3M2FN>
+// CHECK:           "dispatch.body"(%[[B1]])
+
+// -----
+
+util.func private @unsupported_dynamic_cast(%arg0: tensor<?xf6E3M2FN>, %arg1: index) -> tensor<960xi8> {
+  // expected-error@+1 {{Unsupported tensor type unable to pack to bytes.}}
+  %0 = flow.dispatch.workgroups[%arg1](%arg0, %arg1)
+    : (tensor<?xf6E3M2FN>{%arg1}, index) -> tensor<960xi8> = (
+        %arg2: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf6E3M2FN>>,
+        %arg3: index,
+        %arg4: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+      ) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg2, offsets = [0], sizes = [%arg3], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xf6E3M2FN>>{%arg3} -> tensor<?xf6E3M2FN>
+    %2 = "dispatch.body"(%1) : (tensor<?xf6E3M2FN>) -> (tensor<960xi8>)
+    iree_tensor_ext.dispatch.tensor.store %2, %arg4, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+    flow.return
+  }
+  util.return %0 : tensor<960xi8>
+}
+
+// -----
+
+util.func private @f6_output_tensor(%arg0: tensor<960xi8>) -> tensor<960xf6E3M2FN> {
+  %0 = flow.dispatch.workgroups(%arg0)
+    : (tensor<960xi8>) -> tensor<960xf6E3M2FN> = (
+        %arg1: !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xi8>>,
+        %arg2: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xf6E3M2FN>>
+      ) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets = [0], sizes = [960], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xi8>> -> tensor<960xi8>
+    %2 = "dispatch.body"(%1) : (tensor<960xi8>) -> (tensor<960xf6E3M2FN>)
+    iree_tensor_ext.dispatch.tensor.store %2, %arg2, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xf6E3M2FN> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xf6E3M2FN>>
+    flow.return
+  }
+  util.return %0 : tensor<960xf6E3M2FN>
+}
+
+// CHECK-LABEL: @f6_output_tensor
+// CHECK:         %[[DISPATCH:.+]] = flow.dispatch.workgroups
+// CHECK-NEXT:      %[[ARG2:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<720xi8>>
+// CHECK:           %[[BODY:.+]] = "dispatch.body"
+// CHECK:           %[[B0:.+]] = iree_tensor_ext.bitcast %[[BODY]] : tensor<960xf6E3M2FN> -> tensor<720xi8>
+// CHECK:           iree_tensor_ext.dispatch.tensor.store %[[B0]], %[[ARG2]], offsets = [0], sizes = [720]
+// CHECK:         %[[B1:.+]] = flow.tensor.bitcast %[[DISPATCH]] : tensor<720xi8> -> tensor<960xf6E3M2FN>
+
+// -----
+
+util.func private @bitcast_chain_tied(%arg0: tensor<960xf6E3M2FN>) -> tensor<960xf6E3M2FN> {
+  %0 = flow.dispatch.workgroups(%arg0)
+    : (tensor<960xf6E3M2FN>) -> tensor<960xf6E3M2FN> = (
+        %arg1: !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>>,
+        %arg2: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xf6E3M2FN>>
+      ) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets = [0], sizes = [960], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>> -> tensor<960xf6E3M2FN>
+    %2 = "dispatch0.body"(%1) : (tensor<960xf6E3M2FN>) -> (tensor<960xf6E3M2FN>)
+    iree_tensor_ext.dispatch.tensor.store %2, %arg2, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xf6E3M2FN> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xf6E3M2FN>>
+    flow.return
+  }
+  %3 = flow.dispatch.workgroups(%0) : (tensor<960xf6E3M2FN>) -> %0 = (
+        %arg3: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<960xf6E3M2FN>>
+      ) {
+    %4 = iree_tensor_ext.dispatch.tensor.load %arg3, offsets = [0], sizes = [960], strides = [1]
+      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<960xf6E3M2FN>> -> tensor<960xf6E3M2FN>
+    %5 = "dispatch1.body"(%4) : (tensor<960xf6E3M2FN>) -> (tensor<960xf6E3M2FN>)
+    iree_tensor_ext.dispatch.tensor.store %5, %arg3, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xf6E3M2FN> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<960xf6E3M2FN>>
+    flow.return
+  }
+  util.return %3 : tensor<960xf6E3M2FN>
+}
+
+// CHECK-LABEL: @bitcast_chain_tied
+// CHECK-SAME:    %[[ARG0:[A-Za-z0-9]+]]: tensor<960xf6E3M2FN>
+// CHECK:         %[[B0:.+]] = flow.tensor.bitcast %[[ARG0]] : tensor<960xf6E3M2FN> -> tensor<720xi8>
+// CHECK:         %[[D0:.+]] = flow.dispatch.workgroups(%[[B0]])
+// CHECK-NEXT:      %[[ARG1:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<720xi8>>
+// CHECK-SAME:      %[[ARG2:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<720xi8>>
+// CHECK-DAG:       %[[L0:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG1]], offsets = [0], sizes = [720]
+// CHECK-DAG:       %[[B1:.+]] = iree_tensor_ext.bitcast %[[L0]] : tensor<720xi8> -> tensor<960xf6E3M2FN>
+// CHECK:           %[[BODY0:.+]] = "dispatch0.body"(%[[B1]])
+// CHECK:           %[[B2:.+]] = iree_tensor_ext.bitcast %[[BODY0]] : tensor<960xf6E3M2FN> -> tensor<720xi8>
+// CHECK:           iree_tensor_ext.dispatch.tensor.store %[[B2]], %[[ARG2]], offsets = [0], sizes = [720]
+// CHECK:         %[[D1:.+]] = flow.dispatch.workgroups(%[[D0]])
+// CHECK-NEXT:      %[[ARG3:[A-Za-z0-9]+]]: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<720xi8>>
+// CHECK:           %[[L1:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG3]], offsets = [0], sizes = [720]
+// CHECK:           %[[B3:.+]] = iree_tensor_ext.bitcast %[[L1]] : tensor<720xi8> -> tensor<960xf6E3M2FN>
+// CHECK:           %[[BODY1:.+]] = "dispatch1.body"(%[[B3]])
+// CHECK:           %[[B4:.+]] = iree_tensor_ext.bitcast %[[BODY1]] : tensor<960xf6E3M2FN> -> tensor<720xi8>
+// CHECK:           iree_tensor_ext.dispatch.tensor.store %[[B4]], %[[ARG3]], offsets = [0], sizes = [720]
+// CHECK:         %[[B5:.+]] = flow.tensor.bitcast %[[D1]] : tensor<720xi8> -> tensor<960xf6E3M2FN>
+// CHECK:         util.return %[[B5]]
+
+// -----
+
+util.func private @unsupported_other_user(%arg0: tensor<960xf6E3M2FN>) -> tensor<960xi8> {
+  // expected-error@+1 {{non-tensor load or store user of unsupported element type.}}
+  %0 = flow.dispatch.workgroups(%arg0)
+    : (tensor<960xf6E3M2FN>) -> tensor<960xi8> = (
+        %arg1: !iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>>,
+        %arg2: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+      ) {
+    %1 = "unsupported.other_user"(%arg1) : (!iree_tensor_ext.dispatch.tensor<readonly:tensor<960xf6E3M2FN>>) -> (tensor<960xi8>)
+    iree_tensor_ext.dispatch.tensor.store %1, %arg2, offsets = [0], sizes = [960], strides = [1]
+      : tensor<960xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<960xi8>>
+    flow.return
+  }
+  util.return %0 : tensor<960xi8>
+}


### PR DESCRIPTION
Tensor element types unsupported by the HAL need to be casted to bytes before then. This adds a pass that supports cases where the inner most dimension of such tensors can be evenly bitcasted to bytes, and causes an earlier compiler failure in other cases where we know both the HAL and codegen won't be able to support it.