### PR TITLE
[LLVMGPU] Add canonicalization for select(pred, true, false) -> broadcast(pred)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -199,7 +199,7 @@ struct LLVMGPUVectorLoweringPass final
     // Cleanup canonicalization for masking and other basic vector operations.
     {
       RewritePatternSet patterns(ctx);
-      vector::MaskOp::getCanonicalizationPatterns(patterns, ctx);
+      vector::CreateMaskOp::getCanonicalizationPatterns(patterns, ctx);
       vector::ConstantMaskOp::getCanonicalizationPatterns(patterns, ctx);
       vector::ExtractOp::getCanonicalizationPatterns(patterns, ctx);
       vector::BroadcastOp::getCanonicalizationPatterns(patterns, ctx);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -82,6 +82,66 @@ struct PromoteContractOperands final
   }
 };
 
+/// true: vector
+/// false: vector
+/// pred: i1
+///
+/// select(pred, true, false) -> broadcast(pred)
+/// select(pred, false, true) -> broadcast(not(pred))
+///
+/// Ideally, this would be a canonicalization pattern on arith::SelectOp, but
+/// we cannot have arith depending on vector. Also, it would implicitly force
+/// users only using arith and vector dialect to use vector dialect. Since
+/// upstream is not willing to have this pattern anywhere, we manually add it
+/// where it is needed.
+struct FoldI1SelectToBroadcast : public OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp selectOp,
+                                PatternRewriter &rewriter) const override {
+    auto vecType = dyn_cast<VectorType>(selectOp.getType());
+    if (!vecType || !vecType.getElementType().isInteger(1))
+      return failure();
+
+    // Vector conditionals do not need broadcast and are already handled by
+    // the arith.select folder.
+    Value pred = selectOp.getCondition();
+    if (isa<VectorType>(pred.getType()))
+      return failure();
+
+    std::optional<int64_t> trueInt =
+        getConstantIntValue(selectOp.getTrueValue());
+    std::optional<int64_t> falseInt =
+        getConstantIntValue(selectOp.getFalseValue());
+    if (!trueInt || !falseInt)
+      return failure();
+
+    // Redundant selects are already handled by arith.select canonicalizations.
+    if (trueInt.value() == falseInt.value()) {
+      return failure();
+    }
+
+    // The only remaining possibilities are:
+    //
+    // select(pred, true, false)
+    // select(pred, false, true)
+
+    // select(pred, false, true) -> select(not(pred), true, false)
+    if (trueInt.value() == 0) {
+      Value one = rewriter.create<arith::ConstantIntOp>(
+          selectOp.getLoc(), /*value=*/1, /*width=*/1);
+      pred = rewriter.create<arith::XOrIOp>(selectOp.getLoc(), pred, one);
+    }
+
+    /// select(pred, true, false) -> broadcast(pred)
+    rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
+        selectOp, vecType.clone(rewriter.getI1Type()), pred);
+    return success();
+
+    return failure();
+  }
+};
+
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -92,6 +152,7 @@ struct LLVMGPUVectorLoweringPass final
   }
   void runOnOperation() override {
     auto funcOp = getOperation();
+    MLIRContext *ctx = &getContext();
 
     {
       // Lower high level vector operations like contract or multidim reduce ops
@@ -121,16 +182,32 @@ struct LLVMGPUVectorLoweringPass final
       }
     }
 
-    RewritePatternSet vectorToLoopsPatterns(&getContext());
-    VectorTransferToSCFOptions vectorToSCFOptions;
-    vectorToSCFOptions.enableFullUnroll();
-    populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
-                                          vectorToSCFOptions);
-    memref::populateFoldMemRefAliasOpPatterns(vectorToLoopsPatterns);
-    vector::populateVectorTransferLoweringPatterns(vectorToLoopsPatterns);
-    if (failed(
-            applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {
-      return signalPassFailure();
+    {
+      RewritePatternSet vectorToLoopsPatterns(&getContext());
+      VectorTransferToSCFOptions vectorToSCFOptions;
+      vectorToSCFOptions.enableFullUnroll();
+      populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
+                                            vectorToSCFOptions);
+      memref::populateFoldMemRefAliasOpPatterns(vectorToLoopsPatterns);
+      vector::populateVectorTransferLoweringPatterns(vectorToLoopsPatterns);
+      if (failed(applyPatternsGreedily(funcOp,
+                                       std::move(vectorToLoopsPatterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Cleanup canonicalization for masking and other basic vector operations.
+    {
+      RewritePatternSet patterns(ctx);
+      vector::MaskOp::getCanonicalizationPatterns(patterns, ctx);
+      vector::ConstantMaskOp::getCanonicalizationPatterns(patterns, ctx);
+      vector::ExtractOp::getCanonicalizationPatterns(patterns, ctx);
+      vector::BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
+      arith::SelectOp::getCanonicalizationPatterns(patterns, ctx);
+      patterns.add<FoldI1SelectToBroadcast>(ctx);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1188,7 +1188,9 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createLLVMGPUVectorLoweringPass)
       .addPass(createExpandGPUOpsPass)
       // Barrier elimination before we reach unstructured control flow.
-      .addPass(createGpuEliminateBarriers);
+      .addPass(createGpuEliminateBarriers)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass);
 
   if (forROCDL) {
     funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -37,3 +37,31 @@ module {
 // CHECK: %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
 // CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
 // CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
+
+// -----
+
+// Test to check if masked transfer reads masked on an outer dimension lowers
+// to:
+//  cond = dim >= id
+//  vector.maskedload mem[..., id, ...] broadcast(cond)
+func.func @partial_masked_transfer_read(%mem : memref<16x?x32xf16>) -> vector<1x2x16xf16> {
+  %cst = ub.poison : f16
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
+  %dim = memref.dim %mem, %c1 : memref<16x?x32xf16>
+  %mask = vector.create_mask %c1, %dim, %c16 : vector<1x2x16xi1>
+  %read = vector.transfer_read %mem[%c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true]} : memref<16x?x32xf16>, vector<1x2x16xf16>
+  return %read : vector<1x2x16xf16>
+}
+
+// CHECK-LABEL: func.func @partial_masked_transfer_read
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[DIM:.+]] = memref.dim
+// CHECK-DAG: %[[COND:.+]] = arith.cmpi sgt, %[[DIM]], %[[C0]] : index
+// CHECK-DAG: %[[COND1:.+]] = arith.cmpi sgt, %[[DIM]], %[[C1]] : index
+// CHECK-DAG: %[[MASK:.+]] = vector.broadcast %[[COND]] : i1 to vector<16xi1>
+// CHECK-DAG: %[[MASK1:.+]] = vector.broadcast %[[COND1]] : i1 to vector<16xi1>
+// CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %[[MASK]]
+// CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C1]], %[[C0]]], %[[MASK1]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -65,3 +65,31 @@ func.func @partial_masked_transfer_read(%mem : memref<16x?x32xf16>) -> vector<1x
 // CHECK-DAG: %[[MASK1:.+]] = vector.broadcast %[[COND1]] : i1 to vector<16xi1>
 // CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %[[MASK]]
 // CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C1]], %[[C0]]], %[[MASK1]]
+
+// -----
+
+// Test to check if masked transfer reads masked on an outer dimension lowers
+// to:
+//  cond = dim >= id
+//  vector.maskedload mem[..., id, ...] broadcast(cond)
+func.func @partial_masked_transfer_read(%mem : memref<16x?x32xf16>) -> vector<1x2x16xf16> {
+  %cst = ub.poison : f16
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c16 = arith.constant 16 : index
+  %dim = memref.dim %mem, %c1 : memref<16x?x32xf16>
+  %mask = vector.create_mask %c1, %dim, %c16 : vector<1x2x16xi1>
+  %read = vector.transfer_read %mem[%c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true]} : memref<16x?x32xf16>, vector<1x2x16xf16>
+  return %read : vector<1x2x16xf16>
+}
+
+// CHECK-LABEL: func.func @partial_masked_transfer_read
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[DIM:.+]] = memref.dim
+// CHECK-DAG: %[[COND:.+]] = arith.cmpi sgt, %[[DIM]], %[[C0]] : index
+// CHECK-DAG: %[[COND1:.+]] = arith.cmpi sgt, %[[DIM]], %[[C1]] : index
+// CHECK-DAG: %[[MASK:.+]] = vector.broadcast %[[COND]] : i1 to vector<16xi1>
+// CHECK-DAG: %[[MASK1:.+]] = vector.broadcast %[[COND1]] : i1 to vector<16xi1>
+// CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %[[MASK]]
+// CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C1]], %[[C0]]], %[[MASK1]]


### PR DESCRIPTION
This patch adds a canonicalization pattern on select to convert it into a broadcast(cond) if possible. Ideally, this pattern should have landed upstream, but there are problems with causing a dependency of vector dialect on arith, so landing downstream to iterate.

Also adds a few canonicalizations and tests to ensure masked transfer reads lower to the expected form:

```
cond = dim >= id
maskedload brodcast(cond)
```

This allows further vector.maskedload patterns to get better information that the load is either a full load or an empty load.