### PR TITLE
[Codegen][Tuner] remove decomposition attr for attention op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -79,10 +79,10 @@ struct StripAttentionOpCompilationInfo final
                    attr.getName() !=
                        IREE::LinalgExt::AttentionOp::getPVAttrStr();
           }));
-      if (!newConfig.empty()) {
-        attentionOp.setDecompositionConfigAttr(newConfig);
-      } else {
+      if (newConfig.empty()) {
         attentionOp.removeDecompositionConfigAttr();
+      } else {
+        attentionOp.setDecompositionConfigAttr(newConfig);
       }
     }
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -79,7 +79,11 @@ struct StripAttentionOpCompilationInfo final
                    attr.getName() !=
                        IREE::LinalgExt::AttentionOp::getPVAttrStr();
           }));
-      attentionOp.setDecompositionConfigAttr(newConfig);
+      if (!newConfig.empty()) {
+        attentionOp.setDecompositionConfigAttr(newConfig);
+      } else {
+        attentionOp.removeDecompositionConfigAttr();
+      }
     }
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -120,3 +120,34 @@ func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>
 // CHECK-NOT:   translation_info =
 // CHECK-NOT:   lowering_config =
 // CHECK-NOT:   decomposition_config =
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+#config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
+#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [16, 8, 1] subgroup_size = 64>
+#compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
+func.func @attention_2(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
+  %init = tensor.empty() : tensor<2x10x6x4xf16>
+  %result = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {x}, qk_attrs = {y}}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+        ^bb0(%arg: f32):
+          iree_linalg_ext.yield %arg : f32
+        } -> tensor<2x10x6x4xf16>
+  return %result : tensor<2x10x6x4xf16>
+}
+
+// CHECK-LABEL: func.func @attention_2
+// CHECK:       iree_linalg_ext.attention
+// CHECK-NOT:   iree_codegen.compilation_info
+// CHECK-NOT:   iree_codegen.lowering_config
+// CHECK-NOT:   iree_codegen.translation_info
+// CHECK-NOT:   compilation_info =
+// CHECK-NOT:   translation_info =
+// CHECK-NOT:   lowering_config =
+// CHECK-NOT:   decomposition_config =


### PR DESCRIPTION
This PR is a follow-up fix to https://github.com/iree-org/iree/pull/20081. 

We observed that the generated TD spec includes `decomposition_config = {}`, which enforces the input model MLIR to also contain an explicitly empty `decomposition_config` for matching. However, since `decomposition_config` is an **optional** attribute for the attention op, it should be removed entirely when empty.

This fix ensures that empty `decomposition_config` attributes are stripped to ensure applying td-spec during tuning.

Detailed discussion can be found in: https://discordapp.com/channels/689900678990135345/1255609343689097318/1393245935852847224 