### PR TITLE
[Codegen] Fix 1x1 Conv2D to Matmul pass ordering

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -120,8 +120,8 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
   FunctionLikeNest(passManager)
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
       .addPass(mlir::createLinalgNamedOpConversionPass)
-      .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
       .addPass(createConvertConvToChannelsLastPass)
+      .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
       .addPass(createConvertConvFilterToChannelsLastPass);
   passManager.addPass(DispatchCreation::createFoldUnitExtentDimsPass());
   passManager.addPass(createCanonicalizerPass());


### PR DESCRIPTION
Moves Convert1X1FilterConv2DToMatmulPass after ConvertConvToChannelsLastPass to ensure channel-last layout is established before conversion. This enables the reduction dimension to be the innermost loop, improving memory access locality.

Verified the input channels are moved to the last dimension.

```
%collapsed = tensor.collapse_shape %3 [[0], [1, 2], [3], [4]] : tensor<1x1x128x128x8xf32> into tensor<1x128x128x8xf32>
%4 = linalg.fill ins(%cst : f32) outs(%collapsed : tensor<1x128x128x8xf32>) -> tensor<1x128x128x8xf32>
```

Fixes https://github.com/iree-org/iree/issues/19270
