### PR TITLE
[Attention] Use multiple subgroups for memory bound attention

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -37,18 +37,18 @@ func.func @attention_20x1x64x4096x64() {
 // CHECK:      decomposition_config =
 // CHECK-SAME:  pv_attrs =
 // CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 1], [0, 1, 3, 4]{{\]}}
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 4, 3]{{\]}}
 // CHECK-SAME:      thread = [0, 0, 0, 8]
 // CHECK-SAME:      thread_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 4, 3]{{\]}}
 // CHECK-SAME:  qk_attrs =
 // CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 1], [0, 1, 2, 3]{{\]}}
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 2, 4]{{\]}}
 // CHECK-SAME:      thread = [0, 0, 8, 0]
 // CHECK-SAME:      thread_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 3, 4]{{\]}}
 // CHECK-SAME:  lowering_config =
 // CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      partial_reduction = [0, 0, 0, 64, 0]
-// CHECK-SAME:      workgroup = [1, 1, 0, 0, 0]
+// CHECK-SAME:      partial_reduction = [0, 0, 0, 512, 0]
+// CHECK-SAME:      workgroup = [1, 1, 0, 0, 16]
 
 
 // -----


### PR DESCRIPTION
Now that we properly support unaligned/dynamic shapes in vector distribute pipeline, add a configuration for attention to use multiple subgroups for memory bound attention.

Verified on MI300-X for accuracy and a speedup of 2x for sequence length ~4096 (unaligned, dynamic).