### PR TITLE
[DispatchCreation] Fuse reshape op chains along with set_encoding ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -16,7 +16,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
@@ -83,16 +84,18 @@ struct FuseEncodingOpsIntoDispatchRegionsPass
 
     for (IREE::Encoding::SetEncodingOp encodingOp : encodingOps) {
       OpOperand &operand = encodingOp.getSourceMutable();
-      auto producerDispatch =
-          operand.get().getDefiningOp<IREE::Flow::DispatchRegionOp>();
+      std::optional<std::pair<OpResult, SmallVector<Operation *>>>
+          producerChain = getProducerDispatchValueAndOpChain(operand.get());
       // Nothing to fuse with, so wrap the `encodingOp` in its own dispatch.
-      if (!producerDispatch) {
+      if (!producerChain) {
         continue;
       }
 
       // Find producer operation inside of the dispatch region to determine if
       // fusion is possible.
-      auto result = cast<OpResult>(operand.get());
+      OpResult result = producerChain->first;
+      auto producerDispatch =
+          result.getDefiningOp<IREE::Flow::DispatchRegionOp>();
       auto dispatchReturnOp = cast<IREE::Flow::ReturnOp>(
           producerDispatch.getBody().front().getTerminator());
       auto producerInRegion = dyn_cast<OpResult>(
@@ -107,10 +110,18 @@ struct FuseEncodingOpsIntoDispatchRegionsPass
           !isFusableWithSetEncoding(producerInRegion.getOwner())) {
         continue;
       }
-      // Fuse the `encodingOp` into the producer dispatch region.
-      if (failed(moveFollowingOpIntoDispatchRegion(rewriter, encodingOp,
-                                                   producerDispatch))) {
-        return signalPassFailure();
+      // Fuse the `encodingOp` and the producer chain into the dispatch.
+      SmallVector<Operation *> dispatchConsumers(
+          llvm::reverse(producerChain->second));
+      dispatchConsumers.push_back(encodingOp);
+      for (Operation *consumer : dispatchConsumers) {
+        FailureOr<IREE::Flow::DispatchRegionOp> fusedDispatch =
+            moveFollowingOpIntoDispatchRegion(rewriter, consumer,
+                                              producerDispatch);
+        if (failed(fusedDispatch)) {
+          return signalPassFailure();
+        }
+        producerDispatch = fusedDispatch.value();
       }
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -9,10 +9,12 @@
 
 #include "compiler/src/iree/compiler/DispatchCreation/FusionUtils.h"
 #include "compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/RegionUtils.h"
 
 namespace mlir::iree_compiler::DispatchCreation {
@@ -175,6 +177,55 @@ LogicalResult moveOperandDefs(RewriterBase &rewriter,
     rewriter.moveOpBefore(op, insertionPoint);
   }
   return success();
+}
+
+std::optional<std::pair<OpResult, SmallVector<Operation *>>>
+getProducerDispatchValueAndOpChain(Value operand) {
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+  if (!operandType || operandType.getRank() == 0) {
+    return std::nullopt;
+  }
+
+  SmallVector<Operation *> opChain;
+  auto producerValue = dyn_cast<OpResult>(operand);
+  while (producerValue &&
+         !isa<IREE::Flow::DispatchRegionOp>(producerValue.getOwner())) {
+    if (!llvm::hasSingleElement(producerValue.getUses())) {
+      return std::nullopt;
+    }
+
+    // If it is an operation that we want to look past, add it to the chain
+    // and update the `producerValue`.
+    Operation *currOperation = producerValue.getOwner();
+    if (isa<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(currOperation)) {
+      opChain.push_back(currOperation);
+      producerValue = dyn_cast<OpResult>(currOperation->getOperand(0));
+      continue;
+    }
+
+    // Conservative, bail out.
+    return std::nullopt;
+  }
+
+  if (!producerValue) {
+    return std::nullopt;
+  }
+
+  auto producerDispatch =
+      dyn_cast<IREE::Flow::DispatchRegionOp>(producerValue.getOwner());
+  // TODO(MaheshRavishankar): Multi-result producer dispatches can be supported.
+  // Will require to move the consumer dispatch immediately after the producer
+  // instead of what is done below and move other operands of the consumer
+  // dispatch before the producer dispatch.
+  if (!producerDispatch ||
+      !llvm::hasSingleElement(producerDispatch.getBody()) ||
+      producerDispatch->getNumResults() != 1) {
+    return std::nullopt;
+  }
+  if (!llvm::hasSingleElement(producerValue.getUses())) {
+    return std::nullopt;
+  }
+  return std::make_pair(producerValue, opChain);
 }
 
 } // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
@@ -34,4 +34,11 @@ LogicalResult moveOperandDefs(RewriterBase &rewriter,
                               DominanceInfo &dominanceInfo,
                               ArrayRef<Operation *> ignoreOperations = {});
 
+/// Returns the closest producer dispatch region op result and the chain of
+/// operations being looked past during the traversal to find the producer
+/// dispatch. Returns std::nullopt if the dispatch or any ops in the chain have
+/// multiple uses.
+std::optional<std::pair<OpResult, SmallVector<Operation *>>>
+getProducerDispatchValueAndOpChain(Value operand);
+
 } // namespace mlir::iree_compiler::DispatchCreation


### PR DESCRIPTION
There can be reshape ops in between set_encoding ops and their producer dispatch region ops when we fuse encoding ops into dispatches, so this PR pulls any reshape op chains into the producer dispatch along with the set_encoding op. This enables more producer fusions for set_encoding in the data tiling fusion path.