### PR TITLE
[Stream] Fix dominance error for multi-result dispatches

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -210,6 +210,10 @@ bool tryMoveProducerBefore(Value value, Operation *consumerOp) {
     // Recursively try to move each operand.
     // TODO(benvanik): change to a worklist to avoid potential stack explosion.
     for (auto operand : producerOp->getOperands()) {
+      // Can't move `producerOp` if it is defined by `consumerOp`.
+      if (operand.getDefiningOp() == consumerOp) {
+        return false;
+      }
       if (!tryMoveProducerBefore(operand, consumerOp)) {
         return false;
       }


### PR DESCRIPTION
`EmplaceAllocations` doesn't support results with multiple uses but it does support multiple results. This means that it may not always be possible to move the `updateOp` before the `dispatchOp` if `updateOp` is defined by another result of the dispatch. This wasn't handled in `tryMoveProducerBefore`.



Issue originated in SDXL unet when testing some other local dispatch creation changes. [This reproducer](https://gist.github.com/IanWood1/7255096856f60bee357b48a0bd3a05d7) is from the full model and can be run with `iree-opt --run-reproducer`