### PR TITLE
[CPU] Use IREE::CPU::TilingLevel in TileRootAndFuseProducerConsumer pass 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/TileAndFuseUtils.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
@@ -235,14 +236,16 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
 } // namespace
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel) {
+createLLVMCPUTileRootAndFuseProducerConsumerPass(
+    IREE::CPU::TilingLevel tilingLevel) {
   LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
   options.tilingLevel = tilingLevel;
   options.onlyFuseProducerInputOperands = false;
   return std::make_unique<LLVMCPUTileRootAndFuseProducerConsumer>(options);
 }
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseInputOperands(int64_t tilingLevel) {
+createLLVMCPUTileRootAndFuseInputOperandsPass(
+    IREE::CPU::TilingLevel tilingLevel) {
   LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
   options.tilingLevel = tilingLevel;
   options.onlyFuseProducerInputOperands = true;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
@@ -404,16 +405,21 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
         continue;
       }
 
+      // TODO(#21297): How we pass TilingLevel is wrong, but it is tricky to fix
+      // if not all the lowering configs are IREE::CPU::LoweringConfigAttr. For
+      // now, leave it as it is for the transition period. They will be fixed
+      // when we close #21297.
       if (i == tilingConfig.getVectorReductionLevel()) {
         // Run SplitReductionPass before the final reduction Fuse pass, because
         // SplitReductionPass takes care of banked-tiling.
         funcPassManager.addPass(
             createLLVMCPUSplitReductionPass(clEnableReassociateFpReductions));
-        funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperands(i));
+        funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
+            static_cast<IREE::CPU::TilingLevel>(i)));
         continue;
       }
-
-      funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperands(i));
+      funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
+          static_cast<IREE::CPU::TilingLevel>(i)));
     }
   }
 
@@ -468,13 +474,13 @@ void addConvTileAndDecomposeExpertPassPipeline(
     LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
 
-  funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumer(
-      tilingConfig.getVectorCommonParallelLevel()));
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles));
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   funcPassManager.addPass(createConcretizePadResultShapePass());
 
-  funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperands(
-      tilingConfig.getVectorReductionLevel()));
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
+      IREE::CPU::TilingLevel::VectorReductionTiles));
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   funcPassManager.addPass(createConcretizePadResultShapePass());
@@ -527,15 +533,15 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
                                       LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
 
-  funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumer(
-      static_cast<int64_t>(tilingConfig.getVectorCommonParallelLevel())));
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles));
   // The below two passes are nop if the "mmt4d" is explicitly excluded in the
   // ukernels attribute.
   funcPassManager.addPass(createCPUPrepareUkernelsPass());
   funcPassManager.addPass(
       createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
-  funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperands(
-      static_cast<int64_t>(tilingConfig.getVectorReductionLevel())));
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
+      IREE::CPU::TilingLevel::VectorReductionTiles));
   funcPassManager.addPass(iree_compiler::createForallToForPass());
 
   {
@@ -619,26 +625,12 @@ void addCPULinalgExtTileAndVectorizePipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,
     LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
-
-  {
-    LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
-    options.tilingLevel = tilingConfig.getVectorCommonParallelLevel();
-    options.onlyFuseProducerInputOperands = false;
-    funcPassManager.addPass(
-        createLLVMCPUTileRootAndFuseProducerConsumerPass(options));
-  }
-
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles));
   funcPassManager.addPass(
       IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
-
-  {
-    LLVMCPUTileRootAndFuseProducerConsumerPassOptions options;
-    options.tilingLevel = tilingConfig.getVectorReductionLevel();
-    options.onlyFuseProducerInputOperands = true;
-    funcPassManager.addPass(
-        createLLVMCPUTileRootAndFuseProducerConsumerPass(options));
-  }
-
+  funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
+      IREE::CPU::TilingLevel::VectorReductionTiles));
   funcPassManager.addPass(
       IREE::LinalgExt::createDecomposeWinogradTransformPass());
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeAttentionPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -14,6 +14,7 @@
 
 #include <optional>
 
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Pass/Pass.h"
@@ -43,10 +44,12 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUTileAndFusePass(int64_t tilingLevel);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseProducerConsumer(int64_t tilingLevel);
+createLLVMCPUTileRootAndFuseProducerConsumerPass(
+    IREE::CPU::TilingLevel tilingLevel);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUTileRootAndFuseInputOperands(int64_t tilingLevel);
+createLLVMCPUTileRootAndFuseInputOperandsPass(
+    IREE::CPU::TilingLevel tilingLevel);
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUVerifyVectorSizeLegalityPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -153,9 +153,24 @@ def LLVMCPUTileRootAndFuseProducerConsumerPass
   let summary = "Pass to tile root op and fuse with producer and consumer "
                 "TilingInterface ops.";
   let options =
-      [Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-              "Use default tiling level used to retrieve the configuration "
-              "from lowering_config">,
+      [Option<"tilingLevel", "tiling-level", "IREE::CPU::TilingLevel",
+           /*default=*/"IREE::CPU::TilingLevel::VectorInnerParallelTiles",
+           "The tiling level used to retrieve the configuration from lowering_config",
+           [{llvm::cl::values(
+              clEnumValN(IREE::CPU::TilingLevel::DistributionTiles, "distribution",
+                         "Use `distribution` tile sizes."),
+              clEnumValN(IREE::CPU::TilingLevel::CacheParallelTiles, "cache_parallel",
+                         "Use `cache_parallel` tile sizes."),
+              clEnumValN(IREE::CPU::TilingLevel::CacheReductionTiles, "cache_reduction",
+                         "Use `cache_reduction` tile sizes."),
+              clEnumValN(IREE::CPU::TilingLevel::VectorCommonParallelTiles, "vector_common_parallel",
+                         "Use `vector_common_parallel` tile sizes."),
+              clEnumValN(IREE::CPU::TilingLevel::VectorReductionTiles, "vector_reduction",
+                         "Use `vector_reduction` tile sizes."),
+              clEnumValN(IREE::CPU::TilingLevel::VectorInnerParallelTiles, "vector_inner_parallel",
+                         "Use `vector_inner_parallel` tile sizes.")
+
+           )}]>,
        Option<"onlyFuseProducerInputOperands",
               "only-fuse-producer-input-operands", "bool",
               /*default=*/"false",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -340,10 +340,8 @@ func.func @dispatch() attributes {hal.executable.target = #executable_target_emb
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-#config = #iree_codegen.lowering_config<tile_sizes = [[1, 2, 0, 0], [1, 1, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0]]>
-#config1 = #iree_codegen.lowering_config<tile_sizes = [[1, 2, 0, 0, 0, 0], [1, 1, 0, 1, 128, 0], [0, 0, 1, 0, 0, 1]]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "generic", cpu_features = "+fma,+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf", ukernels = "all"}>
-func.func @unsupported_ukernel_fallback_to_vectorization() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_, translation_info = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>} {
+func.func @unsupported_ukernel_fallback_to_vectorization() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %c0 = arith.constant 0 : index
   %c1024 = arith.constant 1024 : index
   %c132096 = arith.constant 132096 : index
@@ -354,8 +352,8 @@ func.func @unsupported_ukernel_fallback_to_vectorization() attributes {hal.execu
   %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 256, 1, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x256x1x1xf32>> -> tensor<1x256x1x1xf32>
   %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [4, 256, 128, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x256x128x1xi8>> -> tensor<4x256x128x1xi8>
   %5 = tensor.empty() : tensor<1x4x1x128xf32>
-  %6 = linalg.fill {lowering_config = #config} ins(%cst : f32) outs(%5 : tensor<1x4x1x128xf32>) -> tensor<1x4x1x128xf32>
-  %7 = linalg.mmt4d {lowering_config = #config1} ins(%3, %4 : tensor<1x256x1x1xf32>, tensor<4x256x128x1xi8>) outs(%6 : tensor<1x4x1x128xf32>) -> tensor<1x4x1x128xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x4x1x128xf32>) -> tensor<1x4x1x128xf32>
+  %7 = linalg.mmt4d ins(%3, %4 : tensor<1x256x1x1xf32>, tensor<4x256x128x1xi8>) outs(%6 : tensor<1x4x1x128xf32>) -> tensor<1x4x1x128xf32>
   iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 4, 1, 128], strides = [1, 1, 1, 1] : tensor<1x4x1x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4x1x128xf32>>
   return
 }


### PR DESCRIPTION
The convention of creating a pass is having a `Pass` suffix, so the revision also fixes the names.

Signed-off-by: hanhanW <hanhan0912@gmail.com>