### PR TITLE
Add e2e test for split reduction using tiling.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -79,5 +79,4 @@ def SplitReductionMappingAttr :
   }];
 }
 
-
 #endif // IREE_DIALECT_LINALGEXT_BASE

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h
@@ -14,4 +14,18 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h.inc" // IWYU pragma: keep
 // clang-format on
 
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+//===---------------------------------------------------------------------===//
+// These attributes represent user-hints for certain optimizations to kick in
+//===---------------------------------------------------------------------===//
+
+/// Attribute set/get methods for specifying that the reduction dimensions
+/// of the operation are to be split to execute as parallel partial reduction
+// followed by a combined step.
+void setSplitReductionAttribute(Operation *op, ArrayRef<int64_t> splitSize);
+std::optional<SmallVector<int64_t>> getSplitReductionSizes(Operation *op);
+
+} // namespace mlir::iree_compiler::IREE::LinalgExt
+
 #endif // IREE_COMPILER_DIALECT_LINALGEXT_IR_LINALGEXTDIALECT_H_

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -275,8 +275,8 @@ def FormSplitReductionDispatchesPass :
     InterfacePass<"iree-dispatch-creation-form-split-reduction-dispatches", "mlir::FunctionOpInterface"> {
   let summary = "Partially tile reduction operations and place into dispatches";
   let options = [
-    Option<"splitSize", "split-size", "int",
-           /*default=*/"0", "Tile size for split reduction">
+    ListOption<"splitSize", "split-size", "int",
+        "Tile sizes for split reduction (innermost first)">
   ];
   let dependentDialects = [
     "IREE::Flow::FlowDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches{split-size=128}, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches{split-size=128}, iree-dispatch-creation-convert-dispatch-regions-to-workgroups, iree-dispatch-creation-materialize-default-workgroup-count-region, canonicalize))" --split-input-file --mlir-print-local-scope %s | FileCheck %s --check-prefix=WORKGROUP
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-split-reduction-dispatches, iree-dispatch-creation-convert-dispatch-regions-to-workgroups, iree-dispatch-creation-materialize-default-workgroup-count-region, canonicalize))" --split-input-file --mlir-print-local-scope %s | FileCheck %s --check-prefix=WORKGROUP
 
 util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf32> {
   %c0 = arith.constant 0 : index
@@ -7,7 +7,11 @@ util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf3
   %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %0 = tensor.empty(%dim) : tensor<?xf32>
   %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<?xf32>) -> tensor<?xf32>
-  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<?x?xf32>) outs(%1 : tensor<?xf32>) {
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"],
+      iree_linalg_ext.split_reduction = [128]}
+      ins(%arg0 : tensor<?x?xf32>) outs(%1 : tensor<?xf32>) {
   ^bb0(%in: f32, %out: f32):
     %3 = arith.addf %in, %out : f32
     linalg.yield %3 : f32
@@ -49,7 +53,11 @@ util.func public @split_reduction_static(%arg0: tensor<64x4096xf32>) -> tensor<6
   %cst = arith.constant 0.000000e+00 : f32
   %0 = tensor.empty() : tensor<64xf32>
   %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<64xf32>) -> tensor<64xf32>
-  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<64x4096xf32>) outs(%1 : tensor<64xf32>) {
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"],
+      iree_linalg_ext.split_reduction = [128]}
+      ins(%arg0 : tensor<64x4096xf32>) outs(%1 : tensor<64xf32>) {
   ^bb0(%in: f32, %out: f32):
     %3 = arith.addf %in, %out : f32
     linalg.yield %3 : f32

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -582,7 +582,8 @@ TEST_F(CheckTest, ExpectAlmostEqDifferentContents3DFullMessageFailure) {
                              /*rtol=*/iree_vm_value_make_f32(0.f)})),
       "Expected near equality of these values. Contents does not match to "
       "tolerance parameters atol=0.1, rtol=0. The first failure occurs at "
-      "index 3 as the lhs value 4 differs from the rhs value 42.\n"
+      "index 3 as the lhs value 4 differs from the rhs value 42 by "
+      "3.800e+01.\n"
       "  lhs:\n"
       "    2x2x2xf32=[[1 2][3 4]][[5 6][7 8]]\n"
       "  rhs:\n"

--- a/runtime/src/iree/modules/check/module.cc
+++ b/runtime/src/iree/modules/check/module.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -564,7 +565,9 @@ class CheckModuleState final {
         os << " Contents does not match to tolerance parameters atol=" << atol
            << ", rtol=" << rtol << ". The first failure occurs at index "
            << diagnostic.index << " as the lhs value " << diagnostic.lhs_value
-           << " differs from the rhs value " << diagnostic.rhs_value << ".";
+           << " differs from the rhs value " << diagnostic.rhs_value << " by "
+           << std::scientific << std::setprecision(3)
+           << diagnostic.rhs_value - diagnostic.lhs_value << ".";
       }
       // TODO(gcmn): Propagate original variable names.
       os << "\n"

--- a/runtime/src/iree/modules/check/test/failure.mlir
+++ b/runtime/src/iree/modules/check/test/failure.mlir
@@ -9,7 +9,7 @@ func.func @expect_true_of_false() {
 }
 
 // CHECK-LABEL: expect_almost_eq_const_f32
-// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.0001, rtol=0. The first failure occurs at index 0 as the lhs value 1 differs from the rhs value 0.999.
+// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.0001, rtol=0. The first failure occurs at index 0 as the lhs value 1 differs from the rhs value 0.999 by -1.000e-03.
 func.func @expect_almost_eq_const_f32() {
   %const0 = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0]> : tensor<5xf32>
   check.expect_almost_eq_const(%const0, dense<[0.999, 2.0, 3.0, 4.0, 5.0]> : tensor<5xf32>) : tensor<5xf32>
@@ -17,7 +17,7 @@ func.func @expect_almost_eq_const_f32() {
 }
 
 // CHECK-LABEL: expect_almost_eq_const_f64
-// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0. The first failure occurs at index 0 as the lhs value 1 differs from the rhs value 0.98.
+// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0. The first failure occurs at index 0 as the lhs value 1 differs from the rhs value 0.98 by -2.000e-02.
 func.func @expect_almost_eq_const_f64() {
   %const0 = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0]> : tensor<5xf64>
   check.expect_almost_eq_const(%const0, dense<[0.98, 2.0, 3.0, 4.0, 5.0]> : tensor<5xf64>, atol 1.0e-2) : tensor<5xf64>
@@ -25,7 +25,7 @@ func.func @expect_almost_eq_const_f64() {
 }
 
 // CHECK-LABEL: expect_almost_eq_const_f16
-// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0.01. The first failure occurs at index 0 as the lhs value 0 differs from the rhs value 0.0110016.
+// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0.01. The first failure occurs at index 0 as the lhs value 0 differs from the rhs value 0.0110016 by 1.100e-02.
 func.func @expect_almost_eq_const_f16() {
   %const0 = util.unfoldable_constant dense<[0.0, 100.0]> : tensor<2xf16>
   check.expect_almost_eq_const(%const0, dense<[0.011, 99.0]> : tensor<2xf16>, atol 1.0e-2, rtol 1.0e-2) : tensor<2xf16>
@@ -33,7 +33,7 @@ func.func @expect_almost_eq_const_f16() {
 }
 
 // CHECK-LABEL: expect_almost_eq_const_bf16
-// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0.01. The first failure occurs at index 1 as the lhs value 100 differs from the rhs value 98.
+// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.01, rtol=0.01. The first failure occurs at index 1 as the lhs value 100 differs from the rhs value 98 by -2.000e+00.
 func.func @expect_almost_eq_const_bf16() {
   %const0 = util.unfoldable_constant dense<[0.0, 100.0]> : tensor<2xbf16>
   check.expect_almost_eq_const(%const0, dense<[0.009, 98.0]> : tensor<2xbf16>, atol 1.0e-2, rtol 1.0e-2) : tensor<2xbf16>
@@ -41,7 +41,7 @@ func.func @expect_almost_eq_const_bf16() {
 }
 
 // CHECK-LABEL: expect_almost_eq_const_f8E5M2
-// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.1, rtol=0.1. The first failure occurs at index 0 as the lhs value 0 differs from the rhs value 0.25.
+// CHECK: Expected near equality of these values. Contents does not match to tolerance parameters atol=0.1, rtol=0.1. The first failure occurs at index 0 as the lhs value 0 differs from the rhs value 0.25 by 2.500e-01.
 func.func @expect_almost_eq_const_f8E5M2() {
   %const0 = util.unfoldable_constant dense<[0.0, 100.0]> : tensor<2xf8E5M2>
   check.expect_almost_eq_const(%const0, dense<[0.25, 75.0]> : tensor<2xf8E5M2>, atol 0.1, rtol 0.1) : tensor<2xf8E5M2>

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -78,6 +78,7 @@ iree_check_single_backend_test_suite(
         "layernorm.mlir",
         "lowering_config.mlir",
         "pack_pad_transpose_1x9_into_2x4x8x4_issue_12546.mlir",
+        "split_reduction_using_tiling.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
     driver = "local-task",
@@ -135,6 +136,25 @@ iree_check_single_backend_test_suite(
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_regression_hip",
+    srcs = [
+        "split_reduction_using_tiling.mlir",
+    ],
+    compiler_flags = [
+        "--iree-opt-level=O3",
+    ],
+    driver = "hip",
+    tags = [
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-amd",
+    ],
+    target_backend = "rocm",
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_check_single_backend_test_suite(
     "reduction_broadcast_elementwise.mlir"
     "scalar_computation.mlir"
     "softmax.mlir"
+    "split_reduction_using_tiling.mlir"
     "strided_slice.mlir"
     "transpose.mlir"
   TARGET_BACKEND
@@ -182,6 +183,25 @@ iree_check_single_backend_test_suite(
     "notsan"
     "noubsan"
     "requires-gpu-nvidia"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_regression_hip
+  SRCS
+    "split_reduction_using_tiling.mlir"
+  TARGET_BACKEND
+    "rocm"
+  DRIVER
+    "hip"
+  COMPILER_FLAGS
+    "--iree-opt-level=O3"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-amd"
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/regression/split_reduction_using_tiling.mlir
+++ b/tests/e2e/regression/split_reduction_using_tiling.mlir
@@ -1,4 +1,4 @@
-util.func @test() {
+func.func @simple_large_reduction_tiling_static() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f32
   %normalize = arith.constant 131200.0 : f32
@@ -39,5 +39,5 @@ util.func @test() {
       linalg.yield %0 : f32
   } -> tensor<128xf32>
   check.expect_almost_eq (%normal_reduce, %split_reduction, atol 0.1) : tensor<128xf32>
-  util.return
+  return
 }

--- a/tests/e2e/regression/split_reduction_using_tiling.mlir
+++ b/tests/e2e/regression/split_reduction_using_tiling.mlir
@@ -1,0 +1,43 @@
+util.func @test() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f32
+  %normalize = arith.constant 131200.0 : f32
+  %input_empty = tensor.empty() : tensor<128x131072xf32>
+  %input = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      outs(%input_empty : tensor<128x131072xf32>) {
+    ^bb0(%b0 : f32):
+      %0 = linalg.index 0 : index
+      %1 = linalg.index 1 : index
+      %2 = arith.addi %0, %1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.uitofp %3 : i32 to f32
+      %5 = arith.divf %4, %normalize : f32
+      linalg.yield %5 : f32
+  } -> (tensor<128x131072xf32>)
+  %input_opt_barrier = util.optimization_barrier %input : tensor<128x131072xf32>
+  %empty = tensor.empty() : tensor<128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+  %normal_reduce = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%input_opt_barrier : tensor<128x131072xf32>) outs(%fill : tensor<128xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<128xf32>
+  %split_reduction = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"],
+      iree_linalg_ext.split_reduction = [128]}
+      ins(%input_opt_barrier : tensor<128x131072xf32>) outs(%fill : tensor<128xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<128xf32>
+  check.expect_almost_eq (%normal_reduce, %split_reduction, atol 0.1) : tensor<128xf32>
+  util.return
+}


### PR DESCRIPTION
This adds end to end tests for split-reduction tiling. To facilitate testing add a new attribute that can be used to specify the reduction tile sizes for the operations on the input MLIR. This is then picked up to drive splitting reductions into two dispatches, one for the partial reduce and one for the final combination. A pipeline test to verify that this attribute works as intended is added as well.

Delete the command line option that was used to turn on split-reduction using tiling.