### PR TITLE
[DispatchCreation] Avoid hoisting set encodings on scalar tensors

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -227,6 +227,14 @@ void HoistEncodingOpsPass::runOnOperation() {
     if (!setEncodingOp->getParentOfType<IREE::Flow::DispatchRegionOp>()) {
       return;
     }
+    // Avoid hoisting set encodings on scalar tensors as they will likely not
+    // resolve into anything other than scalar values and are just broadcast
+    // ops.
+    auto inputType =
+        cast<RankedTensorType>(setEncodingOp.getSource().getType());
+    if (inputType.getRank() == 0) {
+      return;
+    }
     // Avoid hoisting set encodings that are using the padding encodings.
     Attribute encoding = setEncodingOp.getResultType().getEncoding();
     if (isa_and_nonnull<IREE::Encoding::PaddingAttr>(encoding)) {


### PR DESCRIPTION
Resolves: https://github.com/iree-org/iree/issues/21307

When hoisting encodings for a dispatch containing encodings on a scalar tensor, the hoisted set_encoding on the scalar tensor results in a new encoding dispatch and codegen for this fails in LLVM Translation with:
```
<unknown>:0: error: LLVM Translation failed for operation: builtin.unrealized_conversion_cast
```
Check the issue above for a repro.