### PR TITLE
[Dispatch Creation] Remove assert and handle null map

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -403,6 +403,9 @@ static bool makeConsumerFusableViaInterchange(
   // indexing map in the producer, do nothing.
   AffineMap producerIndexingMap = producer.getIndexingMapMatchingResult(
       cast<OpResult>(fusableOperand.get()));
+  if (!producerIndexingMap) {
+    return false;
+  }
   producerIndexingMap = getProjectedMap(
       producerIndexingMap, getUnusedDimsBitVector(producerIndexingMap));
   AffineMap consumerIndexingMap =
@@ -481,7 +484,7 @@ static bool makeProducerFusableViaInterchange(
       producerIndexingMap, getUnusedDimsBitVector(producerIndexingMap));
   AffineMap consumerIndexingMap =
       consumer.getMatchingIndexingMap(&fusableOperand);
-  if (!consumerIndexingMap.isPermutation() ||
+  if (!consumerIndexingMap || !consumerIndexingMap.isPermutation() ||
       producerIndexingMap == consumerIndexingMap) {
     return false;
   }
@@ -805,9 +808,8 @@ isFusableWithProducer(OpOperand &operand,
     if (!makeProducerFusableViaInterchange(operand, rootOuterParallelLoops)) {
       return false;
     }
+    return areOpsFusable(producer, consumer, rootOuterParallelLoops);
   }
-
-  assert(areOpsFusable(producer, consumer, rootOuterParallelLoops));
   return true;
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -808,7 +808,6 @@ isFusableWithProducer(OpOperand &operand,
     if (!makeProducerFusableViaInterchange(operand, rootOuterParallelLoops)) {
       return false;
     }
-    return areOpsFusable(producer, consumer, rootOuterParallelLoops);
   }
   return true;
 }


### PR DESCRIPTION
Adds null handling for indexing maps obtained via `LinalgFusionOpInterface`.


Closes https://github.com/iree-org/iree/issues/21378