### PR TITLE
Reapply "[Codegen] Don't fold workgroup loops during workgroup tiling (#21137)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -25,8 +25,6 @@
 
 namespace mlir::iree_compiler {
 
-#define CEILDIV(a, b) ((a + b - 1) / b)
-
 #define GEN_PASS_DEF_TILEANDDISTRIBUTETOWORKGROUPSUSINGFORALLOPPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
@@ -120,10 +118,18 @@ getTiledAndDistributionInfo(RewriterBase &rewriter,
     }
     OpFoldResult zero = rewriter.getIndexAttr(0);
     SmallVector<int64_t> tileSizesInt = tilableOpConfig.getWorkgroupTileSizes();
-    for (auto loopId : llvm::seq<unsigned>(0, tileSizesInt.size())) {
+    int numNonZero = tileSizesInt.size() - llvm::count(tileSizesInt, 0);
+    for (auto loopId :
+         llvm::reverse(llvm::seq<unsigned>(0, tileSizesInt.size()))) {
+      // Do not set all sizes to 0, or else the distribution loop will not be
+      // created.
+      if (numNonZero <= 1) {
+        break;
+      }
       if (loopId < staticLoopSizes.size() &&
           staticLoopSizes[loopId] == tileSizesInt[loopId]) {
         tileSizes[loopId] = zero;
+        --numNonZero;
       }
     }
   }
@@ -160,64 +166,6 @@ static SmallVector<Attribute> getMapping(MLIRContext *context,
 // Post tiling cleanup patterns
 //===---------------------------------------------------------------------===//
 
-/// Prune the values corresponding to the dropped loops.
-static SmallVector<OpFoldResult>
-pruneDroppedLoops(ArrayRef<OpFoldResult> inputs,
-                  const llvm::SmallDenseSet<int> &droppedLoops) {
-  SmallVector<OpFoldResult> prunedInputs;
-  for (auto [index, input] : llvm::enumerate(inputs)) {
-    if (droppedLoops.contains(index)) {
-      continue;
-    }
-    prunedInputs.push_back(input);
-  }
-  return prunedInputs;
-}
-
-/// Prune the mapping attributes corresponding to the dropped loops.
-/// Note that we cant just drop them. We need to rebalance the
-/// attributes so that the workgroup attributes are perfectly ordered.
-/// For example, if the attribute list is
-///
-/// ```
-/// [workgroup_mapping<x>, workgroup_mapping<z:1>,
-///  workgroup_mapping<z>, workgroup_mapping<y>,
-///  workgroup_mapping<z:3>, workgroup_mapping<z:2>]
-/// ```
-///
-/// and the droppedloops are `{1, 3}`, then the new mapping should be
-///
-/// ```
-/// [workgroup_mapping<x>, workgroup_mapping<y>,
-///  workgroup_mapping<z:1>, workgroup_mapping<z>]
-/// ```
-SmallVector<Attribute>
-pruneDroppedLoops(ArrayRef<Attribute> inputs,
-                  const llvm::SmallDenseSet<int> &droppedLoops) {
-  SmallVector<IREE::Codegen::WorkgroupMappingAttr> droppedMappings;
-  SmallVector<Attribute> prunedAttrs;
-  for (auto [index, input] : llvm::enumerate(inputs)) {
-    if (droppedLoops.contains(index)) {
-      droppedMappings.push_back(
-          cast<IREE::Codegen::WorkgroupMappingAttr>(input));
-    } else {
-      prunedAttrs.push_back(input);
-    }
-  }
-  for (auto droppedMapping : droppedMappings) {
-    for (auto [index, prunedAttr] : llvm::enumerate(prunedAttrs)) {
-      auto prunedMappingAttr =
-          cast<IREE::Codegen::WorkgroupMappingAttr>(prunedAttr);
-      if (droppedMapping < prunedMappingAttr) {
-        prunedAttrs[index] =
-            IREE::Codegen::WorkgroupMappingAttr::getAttributeFromMappingId(
-                prunedAttr.getContext(), prunedMappingAttr.getMappingId() - 1);
-      }
-    }
-  }
-  return prunedAttrs;
-}
-
 /// Checks whether we have static dimension for all the loop bounds and steps.
 /// This is a requirement if the reordering strategy is set to `transpose`.
 static bool areAllStaticLoopBounds(scf::ForallOp forallOp) {
@@ -235,77 +183,6 @@ static bool areAllStaticLoopBounds(scf::ForallOp forallOp) {
     }
   }
   return true;
-}
-
-/// Find dimensions of the loop that are unit-trip count and drop them from the
-/// distributed dimensions.
-static FailureOr<scf::ForallOp>
-dropUnitDistributedDims(RewriterBase &rewriter, scf::ForallOp forallOp) {
-  SmallVector<OpFoldResult> mixedLbs = forallOp.getMixedLowerBound();
-  SmallVector<OpFoldResult> mixedUbs = forallOp.getMixedUpperBound();
-  SmallVector<OpFoldResult> mixedSteps = forallOp.getMixedStep();
-
-  // Find the index of loops to be dropped.
-  llvm::SmallDenseSet<int> droppedLoops;
-  for (auto [index, lb, ub, step] :
-       llvm::enumerate(mixedLbs, mixedUbs, mixedSteps)) {
-
-    std::optional<int64_t> lbVal = getConstantIntValue(lb);
-    std::optional<int64_t> ubVal = getConstantIntValue(ub);
-    std::optional<int64_t> stepVal = getConstantIntValue(step);
-
-    if (!(lbVal && ubVal && stepVal)) {
-      continue;
-    }
-
-    if (CEILDIV(ubVal.value() - lbVal.value(), stepVal.value()) == 1) {
-      droppedLoops.insert(index);
-    }
-  }
-  if (droppedLoops.empty()) {
-    return forallOp;
-  }
-
-  OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(forallOp);
-  SmallVector<OpFoldResult> newLbs =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedLbs), droppedLoops);
-  SmallVector<OpFoldResult> newUbs =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedUbs), droppedLoops);
-  SmallVector<OpFoldResult> newSteps =
-      pruneDroppedLoops(ArrayRef<OpFoldResult>(mixedSteps), droppedLoops);
-  std::optional<ArrayAttr> newMapping;
-  if (auto currMapping = forallOp.getMapping()) {
-    SmallVector<Attribute> newMappingAttrs =
-        pruneDroppedLoops(currMapping.value().getValue(), droppedLoops);
-    newMapping = rewriter.getArrayAttr(newMappingAttrs);
-  }
-
-  Value zero = rewriter.create<arith::ConstantIndexOp>(forallOp.getLoc(), 0);
-  auto newForallOp = rewriter.create<scf::ForallOp>(
-      forallOp.getLoc(), newLbs, newUbs, newSteps, forallOp.getInits(),
-      newMapping, [](OpBuilder &, Location, ValueRange) {});
-
-  SmallVector<Value> argReplacements;
-  int newLoopBlockArgNum = 0;
-  auto newLoopBodyArgs = newForallOp.getInductionVars();
-  for (auto [index, oldBlockArg] :
-       llvm::enumerate(forallOp.getInductionVars())) {
-    if (droppedLoops.contains(index)) {
-      argReplacements.push_back(zero);
-    } else {
-      argReplacements.push_back(newLoopBodyArgs[newLoopBlockArgNum++]);
-    }
-  }
-  argReplacements.append(newForallOp.getRegionIterArgs().begin(),
-                         newForallOp.getRegionIterArgs().end());
-
-  Block *oldLoopBody = forallOp.getBody();
-  Block *newLoopBody = newForallOp.getBody();
-  rewriter.mergeBlocks(oldLoopBody, newLoopBody, argReplacements);
-
-  rewriter.replaceOp(forallOp, newForallOp.getResults());
-  return newForallOp;
 }
 
 //===---------------------------------------------------------------------===//
@@ -444,24 +321,17 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
       return signalPassFailure();
     }
 
-    auto forallOp =
-        dropUnitDistributedDims(rewriter, cast<scf::ForallOp>(tilingLoops[0]));
-    if (failed(forallOp)) {
-      tilingLoops[0]->emitOpError("failed to drop unit dimensions");
-      return signalPassFailure();
-    }
-
     // Reorder the workgroups if the strategy is set to `transpose`.
     // This just transposes the first two dimensions of the workgroup i.e., the
     // #iree.codegen.workgroup_id_x and #iree.codegen.workgroup_id_y.
     // Only reorders if the loop bounds are static.
+    auto forallOp = cast<scf::ForallOp>(tilingLoops[0]);
     if (transposeWorkgroup) {
-      SmallVector<Attribute> mappingAttrs(
-          forallOp->getMappingAttr().getValue());
+      SmallVector<Attribute> mappingAttrs(forallOp.getMappingAttr().getValue());
       int64_t mappingSize = mappingAttrs.size();
-      if (areAllStaticLoopBounds(*forallOp) && mappingSize >= 2) {
+      if (areAllStaticLoopBounds(forallOp) && mappingSize >= 2) {
         std::swap(mappingAttrs[mappingSize - 1], mappingAttrs[mappingSize - 2]);
-        forallOp->setMappingAttr(ArrayAttr::get(context, mappingAttrs));
+        forallOp.setMappingAttr(ArrayAttr::get(context, mappingAttrs));
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -136,19 +136,6 @@ func.func @gemm_unit_N(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x1xf32>,
 
 // -----
 
-func.func @gemm_unit_M_unit_N(%arg0 : tensor<1x1xf32>, %arg1 : tensor<1x1xf32>,
-    %arg2 : tensor<1x1xf32>) -> tensor<1x1xf32> {
-  %0 = linalg.matmul {
-      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>}
-      ins(%arg0, %arg1 : tensor<1x1xf32>, tensor<1x1xf32>)
-      outs(%arg2 : tensor<1x1xf32>) -> tensor<1x1xf32>
-  return %0 : tensor<1x1xf32>
-}
-// CHECK-LABEL: func.func @gemm_unit_M_unit_N(
-//   CHECK-NOT:   scf.forall
-
-// -----
-
 func.func @generic_unit_dims(%arg0 : tensor<1x?x1x1x?x?x1x?xf32>) -> tensor<1x?x1x1x?x?x1x?xf32> {
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
@@ -388,25 +375,6 @@ func.func @set_size_to_tilesize_when_divisible(
 //       CHECK:     scf.forall.in_parallel
 //       CHECK:       tensor.parallel_insert_slice %[[GENERIC]]
 //  CHECK-SAME:           tensor<1x16x128xf16> into tensor<?x16x4096xf16>
-
-// -----
-
-// This just verifies that constant dim propagation works as expected after tiling.
-func.func @generate_no_distribution(%arg0 : tensor<16xf16>) -> tensor<16xf16> {
-   %empty = tensor.empty() : tensor<16xf16>
-   %0 = linalg.generic {
-      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
-      iterator_types = ["parallel"]}
-      ins(%arg0 : tensor<16xf16>) outs(%empty : tensor<16xf16>)
-      attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[16]]>} {
-    ^bb0(%b0: f16, %b1: f16):
-      %1 = arith.mulf %b0, %b0 : f16
-      linalg.yield %1 : f16
-  } -> tensor<16xf16>
-  return %0 : tensor<16xf16>
-}
-// CHECK-LABEL: func @generate_no_distribution(
-//   CHECK-NOT:   scf.forall
 
 // -----
 
@@ -1021,7 +989,7 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
       iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
       ins(%3 : tensor<3x?x32x32xf32>) outs(%5 : tensor<3x?x32xf32>)
-      attrs = {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 4], thread = [1, 1, 1, 0], workgroup = [1, 1, 64, 0]}>} {
+      attrs = {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 4], thread = [1, 1, 1, 0], workgroup = [1, 1, 32, 0]}>} {
   ^bb0(%in: f32, %out: f32):
     %8 = math.fpowi %in, %c2_i64 : f32, i64
     %9 = arith.addf %8, %out : f32
@@ -1048,8 +1016,6 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 // CHECK-LABEL: func @multi_slice_fusion_broadcast
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<3x?x32xi64>
 //  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<32xf32>
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty
 //       CHECK:    %[[RESULT:.+]]:2 = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]])
 //  CHECK-SAME:        shared_outs(%[[INIT0:[a-zA-Z0-9]+]] = %[[EMPTY]], %[[INIT1:[a-zA-Z0-9]+]] = %[[EMPTY]])
@@ -1058,7 +1024,6 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 //       CHECK:      %[[GENERIC0:.+]] = linalg.generic
 //  CHECK-SAME:          ins(%[[ARG1_SLICE]] :
 //  CHECK-SAME:          outs(%[[INIT0_SLICE]] :
-//       CHECK:      %[[CAST0:.+]] = tensor.cast %[[GENERIC0]]
 //       CHECK:      %[[EMPTYTILE:.+]] = tensor.empty() : tensor<1x1x32xf32>
 //       CHECK:      %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:          outs(%[[EMPTYTILE]] :
@@ -1069,7 +1034,19 @@ func.func @multi_slice_fusion_broadcast(%arg0: index, %arg1: tensor<3x?x32xi64>,
 //       CHECK:      %[[GENERIC2:.+]] = linalg.generic
 //  CHECK-SAME:          ins(%[[ARG3]], %[[GENERIC0]], %[[GENERIC1]] :
 //  CHECK-SAME:          outs(%[[INIT1_SLICE]] :
-//       CHECK:      %[[CAST1:.+]] = tensor.cast %[[GENERIC2]]
-//   CHECK-DAG:      tensor.parallel_insert_slice %[[CAST0]] into %[[INIT0]][%[[IV0]], %[[IV1]], %[[C0]], 0] [1, 1, %[[C32]], 32]
-//   CHECK-DAG:      tensor.parallel_insert_slice %[[CAST1]] into %[[INIT1]][%[[IV0]], %[[IV1]], %[[C0]], 0] [1, 1, %[[C32]], 32]
+//   CHECK-DAG:      tensor.parallel_insert_slice %[[GENERIC0]] into %[[INIT0]][%[[IV0]], %[[IV1]], 0, 0] [1, 1, 32, 32]
+//   CHECK-DAG:      tensor.parallel_insert_slice %[[GENERIC2]] into %[[INIT1]][%[[IV0]], %[[IV1]], 0, 0] [1, 1, 32, 32]
 //       CHECK:    return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+// Verify that the scf.forall is still generated when only one worker is needed
+// for distribution.
+func.func @single_trip_forall(%0 : tensor<64x64xf32>, %1 : tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %2 = linalg.copy {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>}
+      ins(%0 : tensor<64x64xf32>)
+      outs(%1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+  return %2 : tensor<64x64xf32>
+}
+//   CHECK-LABEL: func @single_trip_forall
+//         CHECK:   scf.forall

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -149,7 +149,7 @@ hal.executable private @main {
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//          CHECK:   scf.forall ({{.*}}) in (17, 81) {
+//          CHECK:   scf.forall ({{.*}}) in (17, 1, 81) {
 //          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C721]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
 //          CHECK:       gpu.barrier
 //      CHECK-DAG:       %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4xf16>
@@ -159,4 +159,4 @@ hal.executable private @main {
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
 //       CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
-//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1534,6 +1534,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1563,6 +1564,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1592,6 +1594,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1618,9 +1621,11 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling"
+    "--iree-opt-data-tiling=false"
     "--iree-hip-enable-ukernels=multi_mma"
+    "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1650,6 +1655,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1679,6 +1685,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1708,6 +1715,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1738,6 +1746,7 @@ iree_generated_e2e_runner_test(
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
     "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
Undo the revert of https://github.com/iree-org/iree/commit/887d75a6062d894baee58ca19aaca0988638f496 and https://github.com/iree-org/iree/commit/7f35ecfe4bb85c1b3a7dc3efb75fbafc59e85345 now that the failure is fixed by https://github.com/iree-org/iree/pull/21334