### PR TITLE
Adding `iree-hal-drivers-amdgpu-tests` target.

### DIFF
--- a/build_tools/bazel/build_defs.oss.bzl
+++ b/build_tools/bazel/build_defs.oss.bzl
@@ -138,7 +138,7 @@ def iree_runtime_cc_library(deps = [], **kwargs):
         **kwargs
     )
 
-def iree_runtime_cc_test(deps = [], **kwargs):
+def iree_runtime_cc_test(deps = [], group = None, **kwargs):
     """Used for cc_test targets within the //runtime tree.
 
     This is a pass-through to the native cc_test which adds specific

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -460,6 +460,7 @@ class BuildFileFunctions(object):
         args=None,
         tags=None,
         includes=None,
+        group=None,
         **kwargs,
     ):
         if self._should_skip_target(tags=tags, **kwargs):
@@ -475,6 +476,7 @@ class BuildFileFunctions(object):
         labels_block = self._convert_string_list_block("LABELS", tags)
         timeout_block = self._convert_timeout_arg_block("TIMEOUT", timeout)
         includes_block = self._convert_includes_block(includes)
+        group_block = self._convert_string_arg_block("GROUP", group)
 
         self._converter.body += (
             f"iree_cc_test(\n"
@@ -489,6 +491,7 @@ class BuildFileFunctions(object):
             f"{labels_block}"
             f"{timeout_block}"
             f"{includes_block}"
+            f"{group_block}"
             f")\n\n"
         )
 

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -15,12 +15,13 @@
 #     Note: flag passing is only enforced through CTest, so manually running
 #     the test binaries (such as under a debugger) will _not_ pass any
 #     arguments without extra setup.
-# SRCS: List of source files for the binary
-# DATA: List of other targets and files required for this binary
-# DEPS: List of other libraries to be linked in to the binary targets
-# COPTS: List of private compile options
-# DEFINES: List of public defines
-# LINKOPTS: List of link options
+# SRCS: List of source files for the binary.
+# DATA: List of other targets and files required for this binary.
+# DEPS: List of other libraries to be linked in to the binary targets.
+# COPTS: List of private compile options.
+# DEFINES: List of public defines.
+# LINKOPTS: List of link options.
+# GROUP: Optional test group to add the target to.
 # LABELS: Additional labels to apply to the test. The package path is added
 #     automatically.
 #
@@ -58,7 +59,7 @@ function(iree_cc_test)
     _RULE
     ""
     "NAME"
-    "ARGS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;LABELS;TIMEOUT"
+    "ARGS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;LABELS;GROUP;TIMEOUT"
     ${ARGN}
   )
 
@@ -197,11 +198,21 @@ function(iree_cc_test)
 
   set_property(TEST ${_NAME_PATH} APPEND PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
 
-  if (NOT DEFINED _RULE_TIMEOUT)
+  if(NOT DEFINED _RULE_TIMEOUT)
     set(_RULE_TIMEOUT 60)
   endif()
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+
+  if(_RULE_GROUP)
+    if(NOT TARGET ${_RULE_GROUP})
+      add_custom_target(${_RULE_GROUP}
+        COMMENT
+          "Building IREE unit tests for ${_RULE_GROUP}"
+      )
+    endif()
+    add_dependencies(${_RULE_GROUP} "${_NAME}")
+  endif()
 endfunction()

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -62,6 +62,8 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:synchronization",
+        "//runtime/src/iree/base/internal:threading",
         "//runtime/src/iree/base/internal/flatcc:parsing",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/amdgpu/device:binaries",
@@ -119,6 +121,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "buffer_pool_test",
     srcs = ["buffer_pool_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -139,6 +142,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "host_service_test",
     srcs = ["host_service_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -147,6 +151,8 @@ iree_runtime_cc_test(
         ":amdgpu",
         ":headers",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu/device:headers",
         "//runtime/src/iree/hal/drivers/amdgpu/util",
         "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
         "//runtime/src/iree/hal/drivers/amdgpu/util:topology",
@@ -158,6 +164,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "semaphore_pool_test",
     srcs = ["semaphore_pool_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -178,6 +185,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "system_test",
     srcs = ["system_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -57,6 +57,8 @@ iree_cc_library(
     iree::base::internal
     iree::base::internal::arena
     iree::base::internal::flatcc::parsing
+    iree::base::internal::synchronization
+    iree::base::internal::threading
     iree::hal
     iree::hal::drivers::amdgpu::device::binaries
     iree::hal::drivers::amdgpu::device::headers
@@ -124,6 +126,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -135,6 +139,8 @@ iree_cc_test(
     ::amdgpu
     ::headers
     iree::base
+    iree::hal
+    iree::hal::drivers::amdgpu::device::headers
     iree::hal::drivers::amdgpu::util
     iree::hal::drivers::amdgpu::util::libhsa
     iree::hal::drivers::amdgpu::util::topology
@@ -143,6 +149,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -163,6 +171,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -182,6 +192,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/drivers/amdgpu/host_service_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_service_test.cc
@@ -6,6 +6,8 @@
 
 #include "iree/hal/drivers/amdgpu/host_service.h"
 
+#include <thread>
+
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/amdgpu/device/host_client.h"

--- a/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
@@ -39,6 +39,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "libhsa_test",
     srcs = ["libhsa_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -68,6 +69,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "topology_test",
     srcs = ["topology_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -121,6 +123,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "bitmap_test",
     srcs = ["bitmap_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     deps = [
         ":util",
         "//runtime/src/iree/base",
@@ -132,6 +135,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "block_pool_test",
     srcs = ["block_pool_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -148,6 +152,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "device_library_test",
     srcs = ["device_library_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -164,6 +169,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "kfd_test",
     srcs = ["kfd_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",
@@ -181,6 +187,7 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "vmem_test",
     srcs = ["vmem_test.cc"],
+    group = "iree-hal-drivers-amdgpu-tests",
     tags = [
         "driver=amdgpu",
         "nodocker",

--- a/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
@@ -41,6 +41,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_library(
@@ -70,6 +72,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_library(
@@ -113,6 +117,8 @@ iree_cc_test(
     iree::base
     iree::testing::gtest
     iree::testing::gtest_main
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -129,6 +135,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -145,6 +153,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -162,6 +172,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 iree_cc_test(
@@ -179,6 +191,8 @@ iree_cc_test(
   LABELS
     "driver=amdgpu"
     "nodocker"
+  GROUP
+    "iree-hal-drivers-amdgpu-tests"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
This makes it easy to build all of the AMDGPU HAL tests at once as part of an IDE action. This is accomplished by adding an optional `group` to cc_test rules that appends each test to a custom target.