### PR TITLE
[CPU] Switch pack/unpack disptaches to use IREE::CPU::LoweringConfigAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -57,13 +57,6 @@ void LLVMCPUTilePass::runOnOperation() {
   auto funcOp = getOperation();
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  FailureOr<IREE::Codegen::LoweringConfigAttr> rootLoweringConfig =
-      getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
-  if (failed(rootLoweringConfig)) {
-    LDBG("can't find lowering_config, skip tiling");
-    return;
-  }
-
   for (auto computeOp : computeOps) {
     auto op = dyn_cast<TilingInterface>(computeOp);
     if (!op || op.getLoopIteratorTypes().empty())
@@ -76,19 +69,20 @@ void LLVMCPUTilePass::runOnOperation() {
     if (isa<tensor::PadOp>(computeOp))
       continue;
 
-    LDBG("candidate: " << op);
-    SmallVector<int64_t> tileSizes;
-    SmallVector<bool> tileScalableFlags;
-    if (auto loweringConfig =
-            getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op)) {
-      tileSizes = loweringConfig.getTileSizeVals(tilingLevel);
-      tileScalableFlags = loweringConfig.getScalableTileFlagVals(tilingLevel);
-    } else {
-      tileSizes = rootLoweringConfig.value().getTileSizeVals(tilingLevel);
-      tileScalableFlags =
-          rootLoweringConfig.value().getScalableTileFlagVals(tilingLevel);
+    auto maybeLoweringConfig = getLoweringConfig(op);
+    if (!maybeLoweringConfig) {
+      LDBG("can't find lowering_config, skip tiling");
+      continue;
     }
 
+    LDBG("candidate: " << op);
+    auto tileSizesAttr = dyn_cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        getLoweringConfig(op).getTilingLevelAttr(tilingLevel));
+    SmallVector<int64_t> tileSizes(tileSizesAttr.getSizes());
+    SmallVector<bool> tileScalableFlags(tileSizesAttr.getScalableFlags());
+    scf::SCFTilingOptions tilingOptions;
+    setSCFTileSizes(tilingOptions, op, std::move(tileSizes),
+                    std::move(tileScalableFlags));
     if (llvm::all_of(tileSizes, [](int64_t v) { return v == 0; })) {
       LDBG("tiling sizes are all zeros, skip tiling");
       continue;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -69,7 +69,8 @@ void LLVMCPUTilePass::runOnOperation() {
     if (isa<tensor::PadOp>(computeOp))
       continue;
 
-    auto maybeLoweringConfig = getLoweringConfig(op);
+    IREE::Codegen::LoweringConfigAttrInterface maybeLoweringConfig =
+        getLoweringConfig(op);
     if (!maybeLoweringConfig) {
       LDBG("can't find lowering_config, skip tiling");
       continue;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -132,9 +132,13 @@ def LLVMCPUSynchronizeSymbolVisibilityPass :
 def LLVMCPUTilePass :
     InterfacePass<"iree-llvmcpu-tile", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile TilingInterface operations.";
+  let description = [{
+    Walk through all the TilingInterface operations and apply the tiling, if the
+    given level is found in the operation's lowering config.
+  }];
   let options = [
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering_config">
+      "Tiling level used to retrieve the configuration from lowering_config">
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -259,7 +259,7 @@ func.func @pack() attributes {hal.executable.target = #executable_target_system_
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [4, 48, 8, 1], strides = [1, 1, 1, 1] : tensor<4x48x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x48x8x1xf32>>
   return
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16], [1, 1]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 16], vector_common_parallel = [1, 1], vector_reduction = [0, 0]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling, {enable_decomposition}>
 //       CHECK: func.func @pack()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -292,7 +292,7 @@ func.func @unpack_outer_dynamic() attributes {hal.executable.target = #executabl
   iree_tensor_ext.dispatch.tensor.store %unpack, %9, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1] : tensor<?x?xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
   return
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 16]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [32, 16], vector_reduction = [0, 0]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling, {enable_decomposition}>
 //       CHECK: func.func @unpack_outer_dynamic()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -326,7 +326,7 @@ func.func @unpack_fully_dynamic() attributes {hal.executable.target = #executabl
   iree_tensor_ext.dispatch.tensor.store %unpack, %13, offsets = [0, 0], sizes = [%8, %9], strides = [1, 1] : tensor<?x?xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xi32>>{%8, %9}
   return
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [1, 1]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [1, 1], vector_reduction = [0, 0]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling>
 //       CHECK: func.func @unpack_fully_dynamic()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1060,8 +1060,7 @@ func.func @pack() attributes {hal.executable.target = #executable_target_embedde
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [2, 48, 16, 1], strides = [1, 1, 1, 1] : tensor<2x48x16x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf32>>
   return
 }
-
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8], [1, 16]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 8], vector_common_parallel = [1, 16], vector_reduction = [0, 0]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling>
 //      CHECK: func.func @pack()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1086,8 +1085,7 @@ func.func @pack_f16() attributes {hal.executable.target = #executable_target_emb
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [2, 48, 16, 1], strides = [1, 1, 1, 1] : tensor<2x48x16x1xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf16>>
   return
 }
-
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8], [1, 16]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 8], vector_common_parallel = [1, 16], vector_reduction = [0, 0]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling>
 //      CHECK: func.func @pack_f16()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1111,8 +1109,7 @@ func.func @pack_many_elements() attributes {hal.executable.target = #executable_
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [31250, 1200, 16, 1], strides = [1, 1, 1, 1] : tensor<31250x1200x16x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<31250x1200x16x1xf32>>
   return
 }
-
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[50, 3], [1, 1]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [50, 3], vector_common_parallel = [1, 1], vector_reduction = [0, 0]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling>
 //      CHECK: func.func @pack_many_elements()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1373,8 +1370,7 @@ func.func @unpack_static() attributes {hal.executable.target = #executable_targe
   iree_tensor_ext.dispatch.tensor.store %unpack, %1, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : tensor<1024x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x4096xf32>>
   return
 }
-
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [16, 16]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [16, 16], vector_reduction = [0, 0]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDataTiling>
 //      CHECK: func.func @unpack_static()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
It also updates the logic in `LLVMCPUTile` pass to use the attribute interface, so it can support `IREE::CPU::LoweringConfigAttr`.