### PR TITLE
[Codegen][GPU] Canonicalize to remove the empty extract slice in combineLayoutTransformation pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -565,6 +565,8 @@ struct CombineLayoutTransformationPass final
       RewritePatternSet patterns(context);
 
       populateFuseTilableForallConsumersPattern(patterns);
+      scf::ForallOp::getCanonicalizationPatterns(patterns, context);
+      tensor::populateFoldTensorEmptyPatterns(patterns);
       if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }


### PR DESCRIPTION
Credit to @Max191 for pointing out the this canonicalization patterns that fix performance degrade in convolution.

```mlir
%11 = tensor.empty() : tensor<2x2x16x4x16xbf16>
%12 = scf.forall (%arg3, %arg4, %arg5, %arg6) in (1, 1, 4, 64) shared_outs(%arg7 = %11) -> (tensor<2x2x16x4x16xbf16>) {
...
    %extracted_slice_2 = tensor.extract_slice %arg7[0, 0, %15, %arg5, %14#2] [2, 2, 4, 1, 1] [1, 1, 1, 1, 1] : tensor<2x2x16x4x16xbf16> to tensor<2x2x4x1x1xbf16>
    %transposed = linalg.transpose ins(%20 : tensor<2x2x1x4x1xbf16>) outs(%extracted_slice_2 : tensor<2x2x4x1x1xbf16>) permutation = [0, 1, 3, 2, 4] 
```

Here `%11` is an empty tensor, so that extract_slice can be folded into a new empty tensor. Now without the canonicalization patterns, this will results in a huge private allocation ` %alloca = memref.alloca() : memref<2x2x16x4x16xbf16, #gpu.address_space<private>>` that eventually results in register spills that kills the performance.

Note that this will only happen when input IR has two level nested `scf.forall`, this make it challenging to cleanly put it in as a combine layout transformation pass test. Therefore I'm putting it as a pipeline test instead.


