### PR TITLE
[CPU] Teach TilingConfig::getVectorTileSizes about CPU lowering config.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -20,7 +20,8 @@ using SizesAndScalableFlags =
 /// CPU lowering process, while abstracting the representation and verification
 /// details of such information in the IR.
 ///
-/// We currently support the following scenarios:
+/// We currently support the following scenarios, if
+/// IREE::Codegen::LoweringConfigAttr is used:
 ///   1. [[distribution]]
 ///   2. [[distribution], [vector-common-parallel]]
 ///   3. [[distribution], [vector-common-parallel], [vector-reduction]]
@@ -34,7 +35,10 @@ public:
   /// a subset of them may be available in a valid configuration.
   using TilingLevel = IREE::CPU::TilingLevel;
 
-  explicit TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc);
+  static std::unique_ptr<TilingConfig>
+  create(IREE::Codegen::LoweringConfigAttrInterface lc);
+  TilingConfig() = delete;
+  ~TilingConfig() {}
 
   /// Returns the number of tiling levels of the configuration.
   unsigned getNumTilingLevels() const {
@@ -47,10 +51,14 @@ public:
   /// Returns the number of dimensions of the configuration. All the tiling
   /// levels must have the same number of dimensions.
   unsigned getNumDimensions() {
-    return getNumTilingLevels() > 0
-               ? loweringConfig.getStaticTilingLevelSizes(0, /*target=*/nullptr)
-                     .size()
-               : 0;
+    for (auto level : tilingLevelToActualLevelMap) {
+      if (level == TilingLevel::InvalidLevel) {
+        continue;
+      }
+      return loweringConfig.getStaticTilingLevelSizes(level, /*target=*/nullptr)
+          .size();
+    }
+    return 0;
   }
 
   /// Returns the number of parallel dimensions to tile at vector level.
@@ -184,6 +192,7 @@ public:
 private:
   // Initialize the TilingConfig with given LoweringConfigAttr attribute
   // details.
+  explicit TilingConfig(IREE::Codegen::LoweringConfigAttrInterface lc);
   void initFromCodegenLoweringConfig(IREE::Codegen::LoweringConfigAttr lc);
   void initFromCPULoweringConfig(IREE::CPU::LoweringConfigAttr lc);
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -51,7 +51,7 @@ public:
   /// Returns the number of dimensions of the configuration. All the tiling
   /// levels must have the same number of dimensions.
   unsigned getNumDimensions() {
-    for (auto level : tilingLevelToActualLevelMap) {
+    for (unsigned level : tilingLevelToActualLevelMap) {
       if (level == TilingLevel::InvalidLevel) {
         continue;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2799,8 +2799,9 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
     return success();
   IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
       getLoweringConfig(linalgOp);
-  TilingConfig tilingConfig(loweringConfig);
-  TileSizesListType tileSizesList = tilingConfig.getTileSizes();
+  std::unique_ptr<TilingConfig> tilingConfig =
+      TilingConfig::create(loweringConfig);
+  TileSizesListType tileSizesList = tilingConfig->getTileSizes();
 
   bool foundUnPackOp = false;
   SmallVector<int64_t> alignedSizes(linalgOp.getNumLoops(), 1);
@@ -2835,7 +2836,7 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
 
   // Fixup for making tileSizes be multiple of inner_tile_sizes.
   SmallVector<IREE::CPU::LoweringConfigLevelInfo> tilingInfo =
-      tilingConfig.getTilingLevelInfo();
+      tilingConfig->getTilingLevelInfo();
   for (IREE::CPU::LoweringConfigLevelInfo &info : tilingInfo) {
     SmallVector<int64_t> &tileSizes = info.sizes;
     for (auto idx : llvm::seq<int64_t>(0, tileSizes.size())) {
@@ -2991,15 +2992,16 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
   }
 
   auto rootLoweringConfig = getLoweringConfig(rootOperation);
-  TilingConfig tilingConfig(rootLoweringConfig);
+  std::unique_ptr<TilingConfig> tilingConfig =
+      TilingConfig::create(rootLoweringConfig);
   SmallVector<int64_t> distTileSizes, parallelVecTileSizes;
   SmallVector<bool> distScalableTileSizes, parallelVecScalableTileSizes;
-  if (tilingConfig.getNumTilingLevels() > 0) {
-    distTileSizes = tilingConfig.getDistributionTileSizes();
+  if (tilingConfig->getNumTilingLevels() > 0) {
+    distTileSizes = tilingConfig->getDistributionTileSizes();
   }
-  if (tilingConfig.getNumTilingLevels() > 1) {
+  if (tilingConfig->getNumTilingLevels() > 1) {
     std::tie(parallelVecTileSizes, parallelVecScalableTileSizes) =
-        tilingConfig.getVectorCommonParallelSizes();
+        tilingConfig->getVectorCommonParallelSizes();
   }
 
   size_t maxLoopNums = 0;
@@ -3130,10 +3132,10 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
     // For root op, we patch the adjusted tile sizes on its original tiling
     // config.
     if (op == rootOperation) {
-      newTilingInfo = tilingConfig.getTilingLevelInfo();
+      newTilingInfo = tilingConfig->getTilingLevelInfo();
       updateOrAddTilingLevelInfo(newTilingInfo, IREE::CPU::DistributionTiles,
                                  distTileSizes, distScalableTileSizes);
-      if (tilingConfig.getNumTilingLevels() > 1) {
+      if (tilingConfig->getNumTilingLevels() > 1) {
         updateOrAddTilingLevelInfo(
             newTilingInfo, IREE::CPU::VectorCommonParallelTiles,
             commonVecTileSizes, commonVecScalableTileFlags);
@@ -3152,7 +3154,7 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
           TypeSwitch<Operation *, bool>(op)
               .Case<linalg::PackOp>([&](auto packOp) {
                 for (ArrayRef<bool> flags :
-                     tilingConfig.getScalableTileFlags()) {
+                     tilingConfig->getScalableTileFlags()) {
                   // TODO: Handle scalable flags
                   if (llvm::any_of(flags, [&](bool flag) { return flag; }))
                     return false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -122,8 +122,9 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
     if (!loweringConfigAttr)
       continue;
 
-    TilingConfig tilingConfig(loweringConfigAttr);
-    auto [vectorSizes, scalableFlags] = tilingConfig.getVectorTileSizes();
+    std::unique_ptr<TilingConfig> tilingConfig =
+        TilingConfig::create(loweringConfigAttr);
+    auto [vectorSizes, scalableFlags] = tilingConfig->getVectorTileSizes();
     auto numScalableDims = llvm::count(scalableFlags, true);
 
     if (numScalableDims <= 1)
@@ -154,7 +155,7 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
       return failure();
 
     // 3. Update the lowering config of the new tiled operations.
-    auto newLoweringConfig = tilingConfig.getLoweringConfigWithNewVectorSizes(
+    auto newLoweringConfig = tilingConfig->getLoweringConfigWithNewVectorSizes(
         vectorSizes, newScalableFlags);
     for (auto *newOp : tilingResult->tiledOps) {
       if (isa<TilingInterface>(newOp))

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -65,18 +65,15 @@ public:
 };
 } // namespace
 
-static FailureOr<TilingConfig>
+static std::unique_ptr<TilingConfig>
 getTilingConfigForPipeline(FunctionOpInterface funcOp) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   FailureOr<Operation *> rootOp = getRootOperation(computeOps);
   if (failed(rootOp) || !rootOp.value()) {
-    return failure();
+    return nullptr;
   }
   auto config = iree_compiler::getLoweringConfig(rootOp.value());
-  if (!config) {
-    return failure();
-  }
-  return TilingConfig(config);
+  return TilingConfig::create(config);
 }
 
 void LLVMCPULowerExecutableTargetPass::runOnOperation() {
@@ -120,7 +117,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUBufferOpsTileAndVectorize: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError("Tiling Config is necessary for "
                          "CPUBufferOpsTileAndVectorize pipeline.");
       return signalPassFailure();
@@ -131,7 +128,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDoubleTilingExpert: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError(
           "Tiling Config is necessary for CPUDoubleTilingExpert pipeline.");
       return signalPassFailure();
@@ -143,7 +140,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError("Tiling Config is necessary for "
                          "CPUConvTileAndDecomposeExpert pipeline.");
       return signalPassFailure();
@@ -154,7 +151,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError(
           "Tiling Config is necessary for Mmt4dTilingExpert pipeline.");
       return signalPassFailure();
@@ -165,7 +162,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError(
           "Tiling Config is necessary for CPUDataTiling pipeline.");
       return signalPassFailure();
@@ -176,7 +173,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPULinalgExtTileAndVectorize: {
     auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (failed(maybeTilingConfig)) {
+    if (!maybeTilingConfig) {
       funcOp.emitOpError("Tiling Config is necessary for "
                          "CPULinalgExtTileAndVectorize pipeline.");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <memory>
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
@@ -52,8 +53,11 @@ verifyLoweringConfiguration(FunctionOpInterface funcOp,
         getLoweringConfig(op);
     if (!loweringConfig)
       return WalkResult::advance();
-    TilingConfig tilingConfig(loweringConfig);
-    return verificationFn(op, tilingConfig, translationInfo,
+    std::unique_ptr<TilingConfig> tilingConfig =
+        TilingConfig::create(loweringConfig);
+    if (!tilingConfig)
+      return WalkResult::interrupt();
+    return verificationFn(op, *tilingConfig, translationInfo,
                           ArrayRef<int64_t>{});
   });
   return failure(walkResult.wasInterrupted());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -193,9 +193,10 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
       LDBG("can't find lowering_config, skip SplitReduction");
       continue;
     }
-    TilingConfig tilingConfig(maybeLoweringConfig);
+    std::unique_ptr<TilingConfig> tilingConfig =
+        TilingConfig::create(maybeLoweringConfig);
     auto [reductionSizes, scalableDims] =
-        tilingConfig.getVectorReductionSizes();
+        tilingConfig->getVectorReductionSizes();
     if (scalableDims.back()) {
       LDBG("scalable reduction dimensions not yet supported, skip "
            "SplitReduction");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -664,12 +664,11 @@ void addCPULinalgExtTileAndVectorizePipeline(
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               FailureOr<TilingConfig> &tilingConfig) {
-  if (succeeded(tilingConfig) &&
-      tilingConfig.value().getNumTilingLevels() > 1) {
+                               std::unique_ptr<TilingConfig> &tilingConfig) {
+  if (tilingConfig && tilingConfig->getNumTilingLevels() > 1) {
     addTileAndDistributePasses(funcPassManager);
     funcPassManager.addPass(createLLVMCPUTileAndFusePass(
-        tilingConfig.value().getVectorCommonParallelLevel()));
+        tilingConfig->getVectorCommonParallelLevel()));
   }
   addCPUBufferizePasses(funcPassManager);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -104,7 +104,7 @@ void addCPULinalgExtTileAndVectorizePipeline(
 /// that is not specialized by any pipeline). Adds an additional level of tiling
 /// and converts to memrefs.
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               FailureOr<TilingConfig> &tilingConfig);
+                               std::unique_ptr<TilingConfig> &tilingConfig);
 
 void addConvTileAndDecomposeExpertPassPipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,


### PR DESCRIPTION
The revision updates the static constructor with unique_ptr because there are invalid states. E.g., the config does not recognize GPU lowering config and different structured Codegen lowering configs. In this context, we prefer factory functions to initializer methods. See https://abseil.io/tips/42 for more details.

Furthermore, it updates the logic of `getVectorTileSizes`, which uses the mapping level index to get the right list. Ideally, we can implement an interface method for all the specific lowering config, but we still need the generic lowering config being able to handle the case. Thus, we only update `TilingConfig` logic now, and we will do the interface way later.