### PR TITLE
[Codegen] Rename `thread_basis`  to `lane_basis`. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -69,12 +69,14 @@ void setSubgroupNCount(MLIRContext *context,
 }
 
 const StringLiteral kSubgroupBasisName = "subgroup_basis";
-const StringLiteral kThreadBasisName = "thread_basis";
+const StringLiteral kLaneBasisName = "lane_basis";
 
 static StringLiteral getBasisLevelName(IREE::GPU::TilingLevel level) {
   switch (level) {
   case GPU::TilingLevel::Thread:
-    return kThreadBasisName;
+    // We use the term 'lane_basis' here in the context of thread distribution
+    // because of the strict nesting of 'lane_basis' within 'subgroup_basis'.
+    return kLaneBasisName;
   case GPU::TilingLevel::Subgroup:
     return kSubgroupBasisName;
   default:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -419,14 +419,14 @@ getVectorDistributeReductionConfig(
     ArrayAttr subgroupBasisAttr = b.getArrayAttr(
         {b.getI64ArrayAttr(subGroupCounts), b.getI64ArrayAttr(mapping)});
 
-    ArrayAttr threadBasisAttr = b.getArrayAttr(
+    ArrayAttr laneBasisAttr = b.getArrayAttr(
         {b.getI64ArrayAttr(threadCounts), b.getI64ArrayAttr(mapping)});
 
     NamedAttribute configAttrs[] = {
         NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
         NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes)),
         NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
-        NamedAttribute("thread_basis", threadBasisAttr),
+        NamedAttribute("lane_basis", laneBasisAttr),
         NamedAttribute("subgroup_basis", subgroupBasisAttr)};
 
     auto configDict = b.getDictionaryAttr(configAttrs);
@@ -501,12 +501,12 @@ getVectorDistributeReductionConfig(
   ArrayAttr threadBasisAttr = b.getArrayAttr(
       {b.getI64ArrayAttr(threadCounts), b.getI64ArrayAttr(mapping)});
 
-  SmallVector<NamedAttribute, 5> configAttrs = {
+  NamedAttribute configAttrs[] = {
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
       NamedAttribute("partial_reduction",
                      b.getI64ArrayAttr(partialReductionTileSizes)),
       NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
-      NamedAttribute("thread_basis", threadBasisAttr),
+      NamedAttribute("lane_basis", threadBasisAttr),
       NamedAttribute("subgroup_basis", subgroupBasisAttr)};
 
   auto configDict = b.getDictionaryAttr(configAttrs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -112,7 +112,7 @@ hal.executable private @matvec_dispatch_0 {
         %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
         %5 = tensor.empty() : tensor<32000x2xf32>
         %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 4], [0, 1, 2]], thread = [0, 0, 4], thread_basis = [[1, 1, 32], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 4], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 32], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
         ^bb0(%in: f16, %in_0: f16, %out: f32):
           %8 = arith.extf %in : f16 to f32
           %9 = arith.extf %in_0 : f16 to f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -1178,7 +1178,7 @@ hal.executable private @matvec_dispatch_0 {
         %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
         %5 = tensor.empty() : tensor<32000x2xf32>
         %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], thread_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
         ^bb0(%in: f16, %in_0: f16, %out: f32):
           %8 = arith.extf %in : f16 to f32
           %9 = arith.extf %in_0 : f16 to f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx950.mlir
@@ -549,7 +549,7 @@ hal.executable private @matvec_dispatch_0 {
         %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>> -> tensor<2x4096xf16>
         %5 = tensor.empty() : tensor<32000x2xf32>
         %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32000x2xf32>) -> tensor<32000x2xf32>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], thread_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<32000x4096xf16>, tensor<2x4096xf16>) outs(%6 : tensor<32000x2xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], subgroup_basis = [[1, 1, 2], [0, 1, 2]], thread = [0, 0, 4], lane_basis = [[1, 1, 64], [0, 1, 2]], workgroup = [16, 1, 0]}>} {
         ^bb0(%in: f16, %in_0: f16, %out: f32):
           %8 = arith.extf %in : f16 to f32
           %9 = arith.extf %in_0 : f16 to f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -7,7 +7,7 @@
                                       reduction = [0, 0, 128],
                                       thread = [0, 0, 8],
                                       subgroup_basis = [[1, 1, 1], [0, 1, 2]],
-                                      thread_basis   = [[1, 4, 16], [0, 1, 2]]}
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
                                                workgroup_size = [64, 1, 1]
@@ -64,7 +64,7 @@ hal.executable private @matvec_fp16 {
                                       reduction = [0, 0, 512],
                                       thread = [0, 0, 8],
                                       subgroup_basis = [[1, 4, 1], [0, 1, 2]],
-                                      thread_basis   = [[1, 1, 64], [0, 1, 2]]}
+                                      lane_basis = [[1, 1, 64], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
                                                workgroup_size = [256, 1, 1]
@@ -121,7 +121,7 @@ hal.executable private @matvec_fp16_parallel_subgroup {
                                       reduction = [0, 0, 512],
                                       thread = [0, 0, 8],
                                       subgroup_basis = [[1, 4, 1], [0, 1, 2]],
-                                      thread_basis   = [[1, 1, 64], [0, 1, 2]],
+                                      lane_basis = [[1, 1, 64], [0, 1, 2]],
                                       promote_operands = [1]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
@@ -193,12 +193,12 @@ hal.executable private @matvec_fp16_promote_rhs {
                                      promote_operands = [1, 2]}>
 
 #qk_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 2, 3]],
-                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
                                         thread         = [0, 0, 32, 4],
                                         promote_operands = [1]}>
 
 #pv_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 3, 4]],
-                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
                                         thread         = [0, 0, 4, 4],
                                         promote_operands = [1]}>
 
@@ -287,12 +287,12 @@ hal.executable private @attention_20x1x64x4096x64 {
                                      promote_operands = [1, 2]}>
 
 #qk_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 2, 3]],
-                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
                                         thread         = [0, 0, 32, 4],
                                         promote_operands = [1]}>
 
 #pv_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 3, 4]],
-                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
+                                        lane_basis = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
                                         thread         = [0, 0, 4, 4],
                                         promote_operands = [1]}>
 
@@ -377,7 +377,7 @@ hal.executable private @attention_20x1x64x4096x64 {
                                       reduction = [0, 0, 128],
                                       thread = [0, 0, 4],
                                       subgroup_basis = [[1, 1, 2], [0, 1, 2]],
-                                      thread_basis   = [[1, 4, 16], [0, 1, 2]]}
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
                                                workgroup_size = [64, 1, 1]
@@ -435,7 +435,7 @@ hal.executable private @matvec_fp16 {
                                       partial_reduction = [0, 0, 128],
                                       thread = [0, 0, 8],
                                       subgroup_basis = [[1, 1, 1], [0, 1, 2]],
-                                      thread_basis   = [[1, 4, 16], [0, 1, 2]]}
+                                      lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
                                                workgroup_size = [64, 1, 1]
@@ -495,8 +495,8 @@ hal.executable private @matvec_fp16_unaligned {
 /// Paged attention reduction distribution to multiple subgroups.
 /// Distribute 8x32 reduction dims across 4 subbroups with 2x32 threads shape per subgroup.
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64>
-#pv_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], thread_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
-#qk_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], thread_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
+#pv_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], lane_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
+#qk_attrs_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 1, 4, 1], [4, 3, 2, 1, 5, 6]], thread = [0, 0, 0, 8, 0, 0], lane_basis = [[1, 1, 1, 1, 1, 2, 32], [2, 1, 0, 4, 5, 6]]}>
 #attention_lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 0, 0, 0, 8, 0], workgroup = [1, 1, 1, 0, 0, 0, 0]}>
 
 hal.executable private @attention_4xDx1x32x128xf16 {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -78,9 +78,10 @@ func.func @vmt1() attributes {hal.executable.target = #executable_target_rocm_hs
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 0, 512],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
-//  CHECK-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 8],
 //  CHECK-SAME:               workgroup = [1, 8, 0]
 
 
@@ -120,9 +121,10 @@ func.func @matvec_like_no_m_dim() attributes {hal.executable.target = #executabl
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
 //  CHECK-SAME:               partial_reduction = [0, 512],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
-//  CHECK-SAME:               thread = [0, 8], thread_basis = {{\[}}[1, 64], [0, 1]],
+//  CHECK-SAME:               thread = [0, 8],
 //  CHECK-SAME:               workgroup = [8, 0]
 
 // -----
@@ -161,9 +163,10 @@ func.func @matvec_unit_n_dim() attributes {hal.executable.target = #executable_t
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 0, 512],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
-//  CHECK-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 8],
 //  CHECK-SAME:               workgroup = [8, 1, 0]
 
 // -----
@@ -204,9 +207,10 @@ func.func @vmt2() attributes {hal.executable.target = #executable_target_rocm_hs
 //  CDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //       CDNA3:   linalg.generic
 //  CDNA3-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CDNA3-SAME:               lane_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
 //  CDNA3-SAME:               partial_reduction = [0, 0, 512],
 //  CDNA3-SAME:               subgroup_basis = {{\[}}[1, 1, 2], [0, 1, 2]],
-//  CDNA3-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
+//  CDNA3-SAME:               thread = [0, 0, 8],
 //  CDNA3-SAME:               workgroup = [1, 8, 0]
 
 // -----
@@ -263,9 +267,10 @@ func.func @i4_dequant_matvec() {
 //       CHECK:   linalg.generic
 //       CHECK:   linalg.generic
 //  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 1, 128],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
-//  CHECK-SAME:               thread = [0, 1, 2], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 1, 2],
 //  CHECK-SAME:               workgroup = [8, 0, 0]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -349,7 +349,7 @@ func.func @dynamic_infer_sizes(%in : tensor<4x32x?x128xf16>) -> tensor<1x1x?x128
 
 #lowering_config = #iree_gpu.lowering_config<{
     subgroup_basis = [[1, 1, 2, 2], [0, 1, 2, 3]],
-    thread_basis = [[1, 1, 8, 8], [0, 1, 2, 3]],
+    lane_basis = [[1, 1, 8, 8], [0, 1, 2, 3]],
     thread = [0, 0, 8, 8]
 }>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -704,7 +704,8 @@ func.func @i4_dequant_matvec() {
 //       CHECK:   linalg.generic
 //       CHECK:   linalg.generic
 //  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 0, 256],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 2], [0, 1, 2]],
-//  CHECK-SAME:               thread = [0, 0, 4], thread_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 4],
 //  CHECK-SAME:               workgroup = [1, 1, 0]


### PR DESCRIPTION
Thread IDs are within a workgroup and lane IDs are within a subgroup. Because `thread_basis` is used together in `lowering_configs` with `subgroup_basis`, rename it to `lane_basis` to better communicate that it's disjoint from `subgroup_basis`.

The tiling level remains called `thread`, since there should be no confusion about overlap/IDs.