### PR TITLE
[Encoding] Remove ambiguity from encoding propagation interface methods

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -345,19 +345,20 @@ def IREEEncoding_PropagationAttrInterface :
   AttrInterface<"EncodingPropagationAttrInterface"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
-    Interface used to query new encoding attributes that can be propagated to
-    the operands and result of the operation.
+    Interface used to query new encoding attributes resulting from propagation
+    to the operands and results of operations.
   }];
 
   let methods = [
     InterfaceMethod<
         [{
-          Returns true if the encodings can be propagated across the operation.
+          Returns true if the encoding can be propagated down through the
+          target's owner operation.
         }],
         /*retTy=*/"bool",
-        /*methodName=*/"isPropagable",
+        /*methodName=*/"isPropagableDown",
         /*args=*/(ins
-          "::mlir::Value":$target
+          "::mlir::OpOperand *":$target
         ),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{
@@ -366,14 +367,47 @@ def IREEEncoding_PropagationAttrInterface :
     >,
     InterfaceMethod<
         [{
-          Returns the new encodings for operand and result types for the given
+          Returns true if the encoding can be propagated up through the
+          target's owner operation.
+        }],
+        /*retTy=*/"bool",
+        /*methodName=*/"isPropagableUp",
+        /*args=*/(ins
+          "::mlir::OpResult":$target
+        ),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+            return false;
+        }]
+    >,
+    InterfaceMethod<
+        [{
+          Returns the new encodings for operand and result types for the
+          target's owner operation after propagating the encoding down through
+          the operation.
+        }],
+        /*retTy=*/
+        "llvm::FailureOr<::mlir::iree_compiler::IREE::Encoding::PropagationEncoding>",
+        /*methodName=*/"generateSinkingEncodings",
+        /*args=*/(ins
+          "::mlir::OpOperand *":$target
+        ),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+          return failure();
+      }]
+    >,
+    InterfaceMethod<
+        [{
+          Returns the new encodings for operand and result types for the
+          target's owner operation after propagating the encoding up through the
           operation.
         }],
         /*retTy=*/
         "llvm::FailureOr<::mlir::iree_compiler::IREE::Encoding::PropagationEncoding>",
-        /*methodName=*/"generateEncodings",
+        /*methodName=*/"generateBubblingEncodings",
         /*args=*/(ins
-          "::mlir::Value":$target
+          "::mlir::OpResult":$target
         ),
         /*methodBody=*/"",
         /*defaultImplementation=*/[{

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -70,9 +70,9 @@ struct PropagationResult {
   // the propagation.
   SmallVector<Operation *> generatedEncodingOps;
 
-  // The new corresponding result that is created by the propagation. It is
-  // returned to the caller for further transformation or replacement.
-  Value replacement;
+  // The new results created after propagating an encoding through an operation.
+  // It is returned to the caller for further transformation or replacement.
+  SmallVector<Value> replacements;
 };
 
 } // namespace mlir::iree_compiler::IREE::Encoding


### PR DESCRIPTION
The `EncodingPropagationAttrInterface` has shared methods for propagation upwards and downwards, and the methods only take a `Value` parameter, which is not enough to determine (1) Which operation to propagate through, or (2) Which direction to propagate. This PR splits the interface methods into separate methods for upwards and downwards propagation. The upwards propagation methods now take an `OpResult`, and the downwards propagation methods take an `OpOperand *`, to indicate for which operation/operand the propagation is happening for.

There are no test changes, because the propagation interface methods are already tested in `DispatchCreation/test/propagate_encodings.mlir`.