### PR TITLE
[Codegen] Materialize 0D set_encoding into no-op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -680,6 +680,10 @@ struct SetEncodingOpLoweringConversion
   LogicalResult
   matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (encodingOp.getSource().getType().getRank() == 0) {
+      rewriter.replaceOp(encodingOp, adaptor.getSource());
+      return success();
+    }
     auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
         getTypeConverter());
     auto packedValue = lowerSetEncodingOpToPackOp(


### PR DESCRIPTION
We can have set_encoding ops 0D tensors if encodings are propagated through generic ops with 0D tensor operands. If these operands are materialized normally, then 0D transpose ops get generated, which breaks the assumption of a non-0D permutation and causes an assertion error. This PR just materializes 0D tensors into a no-op, since they are just scalars, and are not affected by data tiling layouts.