### PR TITLE
[Codegen] Add SwapExtractWithCollapsePattern

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -291,6 +291,7 @@ void GPUApplyTilingLevelPass::runOnOperation() {
 
   // Swap `collapse_shape` with `extract_slice` to enable more loop fusion
   // opportunity. Currently this is only needed for convolution IGEMM path.
+  // TODO(vivian): Move the pattern to `GPUFuseAndHoistParallelLoopsPass`.
   if (normalizeLoops) {
     funcOp->walk(
         [&](scf::ForOp forOp) { (void)normalizeLoopBounds(rewriter, forOp); });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -326,7 +326,9 @@ def GPUApplyTilingLevelPass :
            )}]>,
     Option<"allowZeroSlices", "allow-zero-slices", "bool",
            /*default=*/"true",
-           "Allow pad fusion to generate zero size slices">
+           "Allow pad fusion to generate zero size slices">,
+    Option<"normalizeLoops", "normalize-loops", "bool", "false",
+           "Enable normalization for scf loops">
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -3,6 +3,7 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level{tiling-level=thread}, canonicalize, cse))" %s | FileCheck %s --check-prefix=THREAD
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level{tiling-level=subgroup}, canonicalize, cse))" %s | FileCheck %s --check-prefix=SUBGROUP
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level{tiling-level=partial_reduction}, canonicalize, cse))" %s | FileCheck %s --check-prefix=PARTRED
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level{normalize-loops}, canonicalize, cse))" %s | FileCheck %s --check-prefix=NORM-REDUCTION
 
 #config = #iree_gpu.lowering_config<{thread = [2, 16], subgroup = [2, 16]}>
 #map = affine_map<(d0, d1) -> (d0, d1)>
@@ -536,3 +537,67 @@ func.func @partial_reduction(%3: tensor<?x?xf32>) -> tensor<?xf32> {
 //       PARTRED:   scf.yield
 //       PARTRED:   linalg.reduce ins(%[[OUT]] : tensor<?x8xf32>)
 //  PARTRED-SAME:                 outs(%[[FULL]] : tensor<?xf32>)
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 32]}>
+func.func @swap_collapse_shape_with_extract_slice(%arg0: tensor<32x3x3x288xf32>) -> tensor<32x2592xf32> {
+  %collapsed = tensor.collapse_shape %arg0 [[0], [1, 2, 3]] : tensor<32x3x3x288xf32> into tensor<32x2592xf32>
+  %empty = tensor.empty() : tensor<32x2592xf32>
+  %0 = linalg.copy {lowering_config = #config} ins(%collapsed : tensor<32x2592xf32>) outs(%empty : tensor<32x2592xf32>) -> tensor<32x2592xf32>
+  return %0: tensor<32x2592xf32>
+}
+
+// NORM-REDUCTION-LABEL: func.func @swap_collapse_shape_with_extract_slice
+//   NORM-REDUCTION-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   NORM-REDUCTION-DAG:   %[[C81:.+]] = arith.constant 81 : index
+//   NORM-REDUCTION-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//       NORM-REDUCTION:   scf.for %[[ARG1:.+]] = %[[C0]] to %[[C81]] step %[[C1]]
+//       NORM-REDUCTION:     %[[APPLY:.+]] = affine.apply affine_map<(d0) -> (d0 * 32)>(%[[ARG1]])
+//       NORM-REDUCTION:     %[[IDX:.+]]:3 = affine.delinearize_index %[[APPLY]] into (3, 3, 288) : index, index, index
+//       NORM-REDUCTION:     %[[SLICE:.+]] = tensor.extract_slice %{{.*}}[0, %[[IDX]]#0, %[[IDX]]#1, %[[IDX]]#2] [32, 1, 1, 32] [1, 1, 1, 1] : tensor<32x3x3x288xf32> to tensor<32x1x1x32xf32>
+//       NORM-REDUCTION:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SLICE]] {{\[}}[0], [1, 2, 3]] : tensor<32x1x1x32xf32> into tensor<32x32xf32>
+//       NORM-REDUCTION:     linalg.copy {{.*}} ins(%[[COLLAPSE]]
+
+// Without loop normalization, no swap would happen.
+//                CHECK:   tensor.collapse_shape
+//                CHECK:   scf.for
+//                CHECK:     tensor.extract_slice
+//            CHECK-NOT:     tensor.collapse_shape
+//                CHECK:     linalg.copy
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 30]}>
+func.func @no_swap_collapse_shape_with_extract_slice(%arg0: tensor<32x3x3x288xf32>) -> tensor<32x2592xf32> {
+  %collapsed = tensor.collapse_shape %arg0 [[0], [1, 2, 3]] : tensor<32x3x3x288xf32> into tensor<32x2592xf32>
+  %empty = tensor.empty() : tensor<32x2592xf32>
+  %0 = linalg.copy {lowering_config = #config} ins(%collapsed : tensor<32x2592xf32>) outs(%empty : tensor<32x2592xf32>) -> tensor<32x2592xf32>
+  return %0: tensor<32x2592xf32>
+}
+
+// No swap would happen when collapsed size is not divisible by offset multiplier.
+// NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice
+//       NORM-REDUCTION:   tensor.collapse_shape
+//       NORM-REDUCTION:   scf.for
+//       NORM-REDUCTION:     tensor.extract_slice
+//   NORM-REDUCTION-NOT:     tensor.collapse_shape
+//       NORM-REDUCTION:     linalg.copy
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 32]}>
+func.func @no_swap_collapse_shape_with_extract_slice_2(%arg0: tensor<32x2x2x16xf32>) -> tensor<32x64xf32> {
+  %collapsed = tensor.collapse_shape %arg0 [[0], [1, 2, 3]] : tensor<32x2x2x16xf32> into tensor<32x64xf32>
+  %empty = tensor.empty() : tensor<32x64xf32>
+  %0 = linalg.copy {lowering_config = #config} ins(%collapsed : tensor<32x64xf32>) outs(%empty : tensor<32x64xf32>) -> tensor<32x64xf32>
+  return %0: tensor<32x64xf32>
+}
+
+// No swap would happen when the last expanded size is not divisible by collapse size.
+// NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice_2
+//       NORM-REDUCTION:   tensor.collapse_shape
+//       NORM-REDUCTION:   scf.for
+//       NORM-REDUCTION:     tensor.extract_slice
+//   NORM-REDUCTION-NOT:     tensor.collapse_shape
+//       NORM-REDUCTION:     linalg.copy

--- a/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -86,8 +87,7 @@ emitNormalizedLoopBounds(RewriterBase &rewriter, Location loc, Block *body,
 /// into a 0-based loop with step 1
 ///   for %ii = 0 to ceildiv(%ub - %lb, %s) step 1
 /// Insert an `affine.apply` operation to compute the denormalized index value.
-static LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
-                                         scf::ForOp forOp) {
+LogicalResult normalizeLoopBounds(RewriterBase &rewriter, scf::ForOp forOp) {
   OpBuilder::InsertionGuard g(rewriter);
   // Return if already normalized.
   std::optional<int64_t> lbInt = getConstantIntValue(forOp.getLowerBound());
@@ -135,8 +135,8 @@ static LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
 /// into a 0-based loop with step 1 (normalized)
 ///   forall (%i, %j) in (ceildiv(%ub0 - %lb0, %s0), ceildiv(%ub1 - %lb1, %s1))
 /// Insert `affine.apply` operations to compute the denormalized index values.
-static LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
-                                         scf::ForallOp forallOp) {
+LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
+                                  scf::ForallOp forallOp) {
   OpBuilder::InsertionGuard g(rewriter);
   if (forallOp.isNormalized())
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -483,9 +483,9 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
         }
 
         AffineMap map = applyOp.getAffineMap();
-        if (map.getNumInputs() != 1 || map.getNumResults() != 1) {
+        if (map.getNumResults() != 1) {
           return rewriter.notifyMatchFailure(
-              sliceOp, "affine.apply must have one input and one result");
+              sliceOp, "affine.apply must have only one result");
         }
 
         auto maybeStaticSize = getConstantIntValue(collapsedSize);

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -359,4 +359,342 @@ void populateSwapExtractWithExpandPattern(RewritePatternSet &patterns) {
   patterns.add<SwapExpandShapeWithSlicePattern>(patterns.getContext());
 }
 
+/// Note the following pattern is adapted from the upstream pattern
+/// `BubbleUpCollapseShapeThroughExtractSlice` by allowing some special cases.
+///
+/// Converts `tensor.extract_slice(tensor.collapse_shape)` to
+///          `tensor.collapse_shape(tensor.extract_slice)`.
+///
+/// For this transformation to be possible - after bubbling up, the extraction
+/// of the contiguous slice must be representable as a single slice obtained via
+/// tensor.extract_slice within each reassociation group of the src.
+///
+/// In case the size and offset extracted are static then this is possible if
+/// the following conditions are met within each reassociation group:
+/// Let T be a tensor of shape [A0, A1, ..., An] (these are the sizes of the
+/// dimensions in the reassociation group), and let S = [S0, S1, ..., Sn] be the
+/// shape of a desired slice. A slice of shape S can be extracted as a
+/// contiguous span of elements if and only if there exists an index k in {0, 1,
+/// ..., n} such that:
+///      S_i = 1 for all i < k (that is, all leading dimensions are singleton),
+///      1 <= S_k <= A_k (that is, non trivial slicing occurs along exactly
+///                       one dimension),
+///      S_i = A_i for all i > k (that is, all trailing dimensions are preserved
+///      in full).
+/// In other words, the slice shape S must be of the form:
+/// [ 1, 1, ..., 1, Sk, Ak + 1, Ak + 2, ...,An ]
+///
+/// In case the size and/or offset extracted are dynamic then this is possible
+/// only if there is single dimension in the reassociation group that has a size
+/// not equal to 1.
+/// In other words, the tensor shape must be of the form:
+/// [ 1, 1, ..., 1, A, 1, ...,1 ]
+/// Note - it might be possible to enable this pattern for more cases when the
+/// size/offset are dynamic via performing an analysis of the possible values
+/// that could be given to the size/offset.
+///
+/// Example:
+/// The transformation is possible because each reassociation group can be
+/// represented as a contiguous slice (i.e., [8x16->2x16], [1x7->1x?],
+/// [20->10]).
+/// ```
+/// BEFORE:
+/// %collapse = tensor.collapse_shape %src [[0, 1], [2, 3], [4]] ...
+///     tensor<8x16x1x7x20f32> to tensor<128x7x20xf32>
+/// %slice = tensor.extract_slice %slice [0, 0, 0][32, %size, 10][1, 1, 1]
+///     tensor<128x7x20xf32> to tensor<32x?x10xf32>
+///
+/// AFTER:
+/// %slice = tensor.extract_slice %src [0, 0, 0, 0, 0][2, 16, 1, %size, 10]
+//           [1, 1, 1, 1, 1] : tensor<8x16x1x7x20f32> to tensor<2x16x1x?x10xf32>
+/// %collapse = tensor.collapse_shape %slice [[0, 1], [2, 3], [4]] ...
+///     tensor<2x16x1x?x10xf32> to tensor<32x?x10xf32>
+/// ```
+///
+/// Negative example:
+/// The transformation is not possible because we cannot use a single slice to
+/// represent the reassociation group [2x3x10->???]. If we would want the
+/// collapse to be after the extraction, we would need to extract multiple
+/// slices and concat them together.
+/// ```
+/// %collapse = tensor.collapse_shape %src [[0, 1, 2]] : tensor<2x3x10xf32> into
+/// tensor<60xf32> %extract = tensor.extract_slice %collapse[0][15][1] :
+///                                      tensor<60xf32> to tensor<15xf32>
+/// ```
+/// If we would want the collapse to be after the extraction, a possible
+/// alternate transformation could be to extract multiple slices and concat them
+/// together:
+/// ```
+/// %extract_1 = tensor.extract_slice %src[0, 0, 0][1, 1, 10] :
+///                               tensor<2x3x10xf32> to tensor <1x1x10xf32>
+/// %extract_2 = tensor.extract_slice %src[0, 1, 0][1, 1, 5] :
+///                               tensor<2x3x10xf32> to tensor <1x1x5xf32>
+/// %concat = tosa.concat %extract_1, %extract_2 {axis = 0 : i32} :
+///                    (<1x1x10xf32>, <1x1x5xf32>) -> <1x1x15xf32>
+/// %collapse = tensor.collapse_shape %concat [[0, 1, 2]] : tensor<1x1x15xf32>
+///                                                       to tensor<15xf32>
+/// ```
+/// But this is not the intended purpose of the transformation.
+static LogicalResult
+swapCollapseShapeWithSlice(RewriterBase &rewriter,
+                           tensor::CollapseShapeOp collapseShapeOp,
+                           tensor::ExtractSliceOp sliceOp) {
+  // The tensor.extract_slice before applying the pattern works on the result
+  // of the tensor.collapse_shape, so variables (i.e. inputs for
+  // ExtractSliceOp) referring to the state before applying the pattern are
+  // named with the prefix "collapsed", and ones referring to the state after
+  // applying the pattern are named with the prefix "expanded".
+  SmallVector<OpFoldResult> collapsedOffsets = sliceOp.getMixedOffsets();
+  SmallVector<OpFoldResult> collapsedSizes = sliceOp.getMixedSizes();
+
+  if (static_cast<size_t>(sliceOp.getResultType().getRank()) !=
+      collapsedSizes.size()) {
+    return rewriter.notifyMatchFailure(sliceOp,
+                                       "unimplemented: rank reducing slice");
+  }
+
+  ArrayRef<int64_t> srcShape = collapseShapeOp.getSrcType().getShape();
+  SmallVector<ReassociationIndices, 4> reassociationIndices =
+      collapseShapeOp.getReassociationIndices();
+
+  // Compute new offsets, sizes, and strides for tensor.extract_slice.
+  // The new tensor.extract_slice will work on a tensor that has has a rank
+  // equal to the rank of the src of the collapse_shape. In each iteration of
+  // the loop, the offsets and sizes will be computed per reassociation group.
+  SmallVector<OpFoldResult> expandedOffsets, expandedSizes;
+  SmallVector<OpFoldResult> expandedStrides(srcShape.size(),
+                                            rewriter.getIndexAttr(1));
+
+  for (auto [collapsedSize, collapsedOffset, reassocIndices] :
+       llvm::zip_equal(collapsedSizes, collapsedOffsets,
+                       collapseShapeOp.getReassociationIndices())) {
+    // CASE #1 - size and/or offset are dynamic.
+    if (isa<Value>(collapsedSize) || isa<Value>(collapsedOffset)) {
+      // Special case especially for collapse shape of convolution filter in
+      // IGEMM, while the offset is dynamic and the size is static.
+      if (isa<Attribute>(collapsedSize) && isa<Value>(collapsedOffset) &&
+          reassocIndices.size() != 1) {
+        // Check if offset is from affine.apply of form (d0 * K) or (K * d0).
+        auto applyOp = collapsedOffset.dyn_cast<Value>()
+                           .getDefiningOp<affine::AffineApplyOp>();
+        if (!applyOp) {
+          return rewriter.notifyMatchFailure(sliceOp,
+                                             "offset is not from affine.apply");
+        }
+
+        AffineMap map = applyOp.getAffineMap();
+        if (map.getNumInputs() != 1 || map.getNumResults() != 1) {
+          return rewriter.notifyMatchFailure(
+              sliceOp, "affine.apply map is not of form (d0 * K)");
+        }
+
+        AffineExpr expr = map.getResult(0);
+        int64_t multiplier;
+        if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
+          multiplier = 1;
+        } else if (auto binOp = dyn_cast<AffineBinaryOpExpr>(expr)) {
+          if (!binOp || binOp.getKind() != AffineExprKind::Mul) {
+            return rewriter.notifyMatchFailure(
+                sliceOp, "affine.apply is not a multiplication");
+          }
+          auto constExpr = isa<AffineConstantExpr>(binOp.getLHS())
+                               ? dyn_cast<AffineConstantExpr>(binOp.getLHS())
+                               : dyn_cast<AffineConstantExpr>(binOp.getRHS());
+          if (!constExpr) {
+            return rewriter.notifyMatchFailure(
+                sliceOp, "affine.apply must multiply by a constant");
+          }
+          multiplier = constExpr.getValue();
+        } else {
+          return rewriter.notifyMatchFailure(sliceOp,
+                                             "unable to get the multiplier");
+        }
+
+        auto maybeStaticSize = getConstantIntValue(collapsedSize);
+        if (!maybeStaticSize) {
+          return rewriter.notifyMatchFailure(sliceOp,
+                                             "collapsed size must be static");
+        }
+        if (maybeStaticSize.value() % multiplier != 0) {
+          return rewriter.notifyMatchFailure(
+              sliceOp, "collapsed size is not divisible by offset multiplier");
+        }
+        unsigned lastReassocSize = srcShape[reassocIndices.back()];
+        if (lastReassocSize % maybeStaticSize.value() != 0) {
+          return rewriter.notifyMatchFailure(
+              sliceOp,
+              "the last expanded size is not divisible by collapse size");
+        }
+
+        // Calculate expanded offsets and sizes.
+        SmallVector<OpFoldResult> expandedBasis;
+        for (auto dimIdx : reassocIndices) {
+          expandedBasis.push_back(rewriter.getIndexAttr(srcShape[dimIdx]));
+        }
+        auto delinearizeOp = rewriter.create<affine::AffineDelinearizeIndexOp>(
+            sliceOp.getLoc(), cast<Value>(collapsedOffset), expandedBasis);
+        ValueRange offsets = delinearizeOp.getResults();
+        expandedOffsets.append(offsets.begin(), offsets.end());
+
+        for (auto i = 0; i < reassocIndices.size() - 1; i++) {
+          expandedSizes.push_back(rewriter.getIndexAttr(1));
+        }
+        expandedSizes.push_back(collapsedSize);
+        continue;
+      }
+
+      // In other general case, the slice can be represented as a contiguous
+      // slice only if there is a single dimension in the reassociation group
+      // that has a size not equal to 1.
+      int nonUnitSizeCount = 0;
+      for (int64_t expandedShapeIdx : reassocIndices) {
+        if (srcShape[expandedShapeIdx] != 1) {
+          nonUnitSizeCount++;
+          expandedSizes.push_back(collapsedSize);
+          expandedOffsets.push_back(collapsedOffset);
+          continue;
+        }
+
+        expandedSizes.push_back(rewriter.getIndexAttr(1));
+        expandedOffsets.push_back(rewriter.getIndexAttr(0));
+      }
+
+      if (nonUnitSizeCount != 1) {
+        return rewriter.notifyMatchFailure(
+            sliceOp, "unsupported: slice cannot be verified to be contiguous");
+      }
+      continue;
+    }
+
+    // CASE #2 = size and offset are static.
+    // Verify that the slice can be represented as a contiguous slice of the
+    // src of the collapse_shape.
+    // Checking this is done on order of most internal dimensions first,
+    // so traversal is done in reverse order of the reassociation group.
+    // If the expected slice shape is [1, 1, ..., 1, Sk, Ak + 1, Ak + 2,
+    // ...,An] then we first find the size and offset for n...k+1 then for k
+    // and then for k-1...0.
+
+    // currentCollapsedsize and currentCollapsedOffset are initialized with
+    // the original collapsed size and offset and divided by the expanded
+    // shape size in each dimension as we go along the reassociation group.
+    // In essence we are spreading the original collapsed size and offset over
+    // the various expanded slice dimensions.
+    // The variables are used both to check the validity of the slice and to
+    // compute the expanded sizes and offsets.
+    int64_t currentCollapsedsize = getConstantIntValue(collapsedSize).value();
+    int64_t currentCollapsedOffset =
+        getConstantIntValue(collapsedOffset).value();
+
+    SmallVector<OpFoldResult> groupExpandedSizes, groupExpandedOffsets;
+
+    ReassociationIndices reversedReassocIndices(reassocIndices.rbegin(),
+                                                reassocIndices.rend());
+    int64_t idx = 0;
+    int64_t reassocGroupSize = reassocIndices.size();
+
+    // First handle the trailing dimensions where the slice size should be
+    // equal to the tensor shape and the offset should be 0 (n...k+1).
+    for (; idx < reassocGroupSize; ++idx) {
+      int64_t expandedShapeSize = srcShape[reversedReassocIndices[idx]];
+
+      if (currentCollapsedsize < expandedShapeSize)
+        break;
+
+      // We need to make sure that the slice size can be set to the shape size
+      // and the offset to 0.
+      if ((currentCollapsedsize % expandedShapeSize) != 0 ||
+          (currentCollapsedOffset % expandedShapeSize) != 0) {
+        return rewriter.notifyMatchFailure(
+            sliceOp, "unsupported: cannot be extracted as a contiguous slice "
+                     "of the src of the collapse_shape");
+      }
+
+      groupExpandedSizes.push_back(rewriter.getIndexAttr(expandedShapeSize));
+      groupExpandedOffsets.push_back(rewriter.getIndexAttr(0));
+
+      currentCollapsedsize /= expandedShapeSize;
+      currentCollapsedOffset /= expandedShapeSize;
+    }
+
+    // Now handle the first dim where slicing occurs on (k).
+    if (idx < reassocGroupSize) {
+      int64_t expandedShapeSize = srcShape[reversedReassocIndices[idx]];
+      int64_t offsetInDim = currentCollapsedOffset % expandedShapeSize;
+      // We need to make sure that the slice size in this dim + offset will
+      // not exceed the shape size.
+      if ((currentCollapsedsize + offsetInDim) >= expandedShapeSize) {
+        return rewriter.notifyMatchFailure(
+            sliceOp, "unsupported: slice cannot be extracted as a contiguous "
+                     "slice of the src of the collapse_shape");
+      }
+
+      groupExpandedSizes.push_back(rewriter.getIndexAttr(currentCollapsedsize));
+      groupExpandedOffsets.push_back(rewriter.getIndexAttr(offsetInDim));
+
+      currentCollapsedOffset /= expandedShapeSize;
+    }
+
+    // Now handle the leading dimensions where the slice size is equal to 1
+    // (k-1...0).
+    // The size for these dimensions must be 1 because of how we constructed
+    // the slice size of the expanded shape. We spread the original collapsed
+    // size over the expanded shape sizes until we reached dimension k where
+    // the remaining size was smaller than the expanded shape size, and spread
+    // the remaining size on it. So, now we are left with only 1s.
+    for (idx++; idx < reassocGroupSize; ++idx) {
+      int64_t expandedShapeSize = srcShape[reversedReassocIndices[idx]];
+      int64_t offsetInDim = currentCollapsedOffset % expandedShapeSize;
+      groupExpandedSizes.push_back(rewriter.getIndexAttr(1));
+      groupExpandedOffsets.push_back(rewriter.getIndexAttr(offsetInDim));
+      currentCollapsedOffset /= expandedShapeSize;
+    }
+
+    expandedSizes.append(groupExpandedSizes.rbegin(),
+                         groupExpandedSizes.rend());
+    expandedOffsets.append(groupExpandedOffsets.rbegin(),
+                           groupExpandedOffsets.rend());
+  }
+
+  Value newSliceOp = rewriter.create<tensor::ExtractSliceOp>(
+      collapseShapeOp->getLoc(), collapseShapeOp.getSrc(), expandedOffsets,
+      expandedSizes, expandedStrides);
+  rewriter.replaceOpWithNewOp<tensor::CollapseShapeOp>(
+      sliceOp, sliceOp.getResultType(), newSliceOp,
+      collapseShapeOp.getReassociationIndices());
+
+  return success();
+}
+
+namespace {
+
+struct SwapCollapseShapeWithSlicePattern
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    auto collapseOp =
+        sliceOp.getSource().getDefiningOp<tensor::CollapseShapeOp>();
+    if (!collapseOp) {
+      return rewriter.notifyMatchFailure(
+          sliceOp,
+          "tensor.extract_slice source not produced by tensor.collapse_shape");
+    }
+
+    if (!sliceOp.hasUnitStride()) {
+      return rewriter.notifyMatchFailure(sliceOp,
+                                         "unsupported: non-unit stride");
+    }
+
+    return swapCollapseShapeWithSlice(rewriter, collapseOp, sliceOp);
+  }
+};
+
+} // namespace
+
+void populateSwapExtractWithCollapsePattern(RewritePatternSet &patterns) {
+  patterns.add<SwapCollapseShapeWithSlicePattern>(patterns.getContext());
+}
+
 } // namespace mlir::iree_compiler


### PR DESCRIPTION
This PR adds a pattern to swap the `collapse_shape` with the `extract_slice` op to enable more loop fusion opportunity. Note this pattern is adapted from the upstream[ `BubbleUpCollapseShapeThroughExtractSlice`](https://github.com/llvm/llvm-project/blob/ffb453989b0e95d85b6cfa543b65fec23b65649d/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp#L322) by allowing some special cases we've seen through the IGEMM path.

The special case is processed under `CASE #1` session with the corresponding tests mainly focusing on the changes. Note that some strict conditions are added to match the special case for convolutions which maybe not general and robust enough to add to upstream. In addition, we break the [upstream single pattern](https://github.com/llvm/llvm-project/blob/ffb453989b0e95d85b6cfa543b65fec23b65649d/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp#L767) into two separate ones to be able to apply them separately in different passes.