### PR TITLE
[Codegen][Tuner] Better lowering config for batch matvec

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -2735,6 +2735,31 @@ transform.named_sequence
 }
 
 transform.named_sequence
+@match_matvec_4x16384x6656_f16_f16_f32(%matmul: !transform.any_op {transform.readonly})
+  -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul)
+    : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<4x16384xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<6656x16384xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+    lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 512], 
+                                                 subgroup_basis = [[1, 1, 1], [0, 1, 2]], 
+                                                 thread = [0, 0, 8], 
+                                                 thread_basis = [[1, 1, 64], [0, 1, 2]], 
+                                                 workgroup = [4, 1, 0]
+                                                 }>,
+    translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+      workgroup_size = [64, 1, 1] subgroup_size = 64,
+      {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>}>
+  > -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence
 @__kernel_config(%variant_op: !transform.any_op {transform.consumed}) -> !transform.any_op
   attributes { iree_codegen.tuning_spec_entrypoint } {
   %res = transform.foreach_match in %variant_op
@@ -2752,7 +2777,10 @@ transform.named_sequence
 
     // Expected speedup: 1.22x.
     @match_attention_2x10x4096x64x64x64_f16 -> @apply_attn_op_config,
-    @match_mmt_2048x1280x5120_f16_f16_f32 -> @apply_op_config
+    @match_mmt_2048x1280x5120_f16_f16_f32 -> @apply_op_config,
+
+    // Batched matvec variants: expected speedup: 1.2 - 1.3x
+    @match_matvec_4x16384x6656_f16_f16_f32 -> @apply_op_config
     : (!transform.any_op) -> !transform.any_op
   transform.yield %res : !transform.any_op
 }

--- a/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
+++ b/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
@@ -85,6 +85,7 @@
 // MERGE-NEXT:      @match_attention_2x10x4096x64x64x64_f16 -> @apply_attn_op_config,
 // MERGE-NEXT:      @match_mmt_2048x1280x5120_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config,
 // MERGE-NEXT:      @match_matvec_4x16384x6656_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config
+// MERGE-NEXT:      @match_matvec_4x6656x16384_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config
 
 // NOTE: The order matters above because `foreach_match` ops performs matching from top to bottom.
 

--- a/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
+++ b/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
@@ -83,7 +83,8 @@
 // MERGE-NEXT:      @match_mmt_bf16_bf16_f32_medium_expanded -> @apply_expanded_bf16_medium_pingpong_op_config,
 // MERGE-NEXT:      @match_mmt_f8_f8_f32_medium_expanded -> @apply_expanded_f8_medium_pingpong_op_config,
 // MERGE-NEXT:      @match_attention_2x10x4096x64x64x64_f16 -> @apply_attn_op_config,
-// MERGE-NEXT:      @match_mmt_2048x1280x5120_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config
+// MERGE-NEXT:      @match_mmt_2048x1280x5120_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config,
+// MERGE-NEXT:      @match_matvec_4x16384x6656_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config
 
 // NOTE: The order matters above because `foreach_match` ops performs matching from top to bottom.
 


### PR DESCRIPTION
WIP. Lowering config heuristics for batch matvec size 4, initially for consideration w.r.t llama 405b ([Issue #21300](https://github.com/iree-org/iree/issues/21300)) . Config is v3 from [spreadsheet](https://docs.google.com/spreadsheets/d/1KD7uGoWjCinW9RToIPGpALGYLIbpAtNFuUabcYPV5JA/edit?usp=sharing). Still under investigation. 