### PR TITLE
iree/runtime: iree-cpuinfo: add SME/SVE feature checks for ARM64 macOS

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -150,6 +150,66 @@ static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
           .out_field_index = 0,
           .out_field_bits = IREE_CPU_DATA0_ARM_64_BF16,
       },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SVE",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SVE,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SVE2",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SVE2,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SVE2p1",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SVE2P1,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SVE2BitPerm",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SVE2_BITPERM,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_F32MM",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_F32MM,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_F64MM",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_F64MM,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME2",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME2,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME2p1",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME2P1,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME_F16F16",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME_F16F16,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME_F64F64",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME_F64F64,
+      },
+      {
+          .sysctl_key = "hw.optional.arm.FEAT_SME_I16I64",
+          .out_field_index = 0,
+          .out_field_bits = IREE_CPU_DATA0_ARM_64_SME_I16I64,
+      },
   };
   for (int i = 0; i < IREE_ARRAYSIZE(features); ++i) {
     const feature_t* f = &features[i];


### PR DESCRIPTION
Enables additional feature checks for SME/SVE in iree-cpuinfo. Before all SME checks were reported as zero on Apple M4. Note though that not all SME/SVE features are available on Apple M4, the SVE checks are only added for completeness

On a MacBook Pro with Apple M4:
```
$ iree-cpuinfo
fp-armv8             1
lse                  1
lse128               1
fullfp16             1
fp16fml              1
dotprod              1
i8mm                 1
bf16                 1
sve                  0
sve2                 0
sve2p1               0
sve2-bitperm         0
f32mm                0
f64mm                0
sme                  1
sme2                 1
sme2p1               0
sme-f16f16           0
sme-f64f64           1
sme-i16i64           1
```