### PR TITLE
[Codegen] Collect slices to fuse producers of loop destinations into lane foralls.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeInnerTiledToLanes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeInnerTiledToLanes.cpp
@@ -44,6 +44,12 @@ LogicalResult fuseProducersGreedily(RewriterBase &rewriter,
     if (producer && producer->getBlock() != laneForall.getBody()) {
       candidates.push_back(extractSliceOp);
     }
+
+    // Collect slices to fuse producers of loop destinations into lane foralls.
+    if (laneForall.getRegionIterArgs()[0] == extractSliceOp.getSource() &&
+        laneForall.getOutputs()[0].getDefiningOp<TilingInterface>()) {
+      candidates.push_back(extractSliceOp);
+    }
   });
 
   SmallVector<LoopLikeOpInterface> loops = {laneForall};


### PR DESCRIPTION
This helps collect all the slices needed to be fused into lane foralls specifically those that are provided as destination for `scf.forall`. It is to help fuse in the `linalg.fill` ops that won't get fused into the thread foralls via the GPUFuseAndHoistParallelLoopsPass, when reduction tiling doesn't happen and compilation fails for such conv shapes. 