### PR TITLE
[codegen] use vector.broadcast instead of vector.splat

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -320,7 +320,7 @@ struct ConvertBf16ToUInt16BuffersPass final
           vector::GatherOp, vector::ScatterOp, vector::ExpandLoadOp,
           vector::CompressStoreOp, vector::ShapeCastOp, vector::ConstantMaskOp,
           vector::CreateMaskOp, vector::MaskOp, vector::TransposeOp,
-          vector::SplatOp, vector::YieldOp>([&typeConverter](Operation *op) {
+          vector::YieldOp>([&typeConverter](Operation *op) {
         bool legal = typeConverter.isLegal(op);
         LLVM_DEBUG(if (!legal) llvm::dbgs()
                    << "Bf16Emulation: illegal op: " << *op << "\n");

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -345,8 +345,8 @@ struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     }
 
     // Materialize the padding with a constant.
-    auto padVal = rewriter.create<vector::SplatOp>(rPad.getLoc(),
-                                                   valToStore.getType(), rPad);
+    auto padVal = rewriter.create<vector::BroadcastOp>(
+        rPad.getLoc(), valToStore.getType(), rPad);
     rewriter.replaceOpWithNewOp<arith::SelectOp>(op, wMask, valToStore, padVal);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -100,7 +100,7 @@ void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp) {
 
     rewriter.setInsertionPoint(readOp);
     Value selectValue = createI1And(loc, ValuesToAnd, rewriter);
-    auto constantValue = rewriter.create<vector::SplatOp>(
+    auto constantValue = rewriter.create<vector::BroadcastOp>(
         loc, readOp.getVectorType(), readOp.getPadding());
 
     auto newReadOp = rewriter.create<vector::TransferReadOp>(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -828,7 +828,8 @@ struct ScalarizeVectorTransferRead final
 
       Value scalar = predicateMaybeMaskedScalarTransfer(
           rewriter, loc, maybeMaskBit, thenCond, elseCond);
-      rewriter.replaceOpWithNewOp<vector::SplatOp>(readOp, vectorType, scalar);
+      rewriter.replaceOpWithNewOp<vector::BroadcastOp>(readOp, vectorType,
+                                                       scalar);
       return success();
     }
 
@@ -889,7 +890,8 @@ struct ScalarizeVectorLoad final : public OpRewritePattern<vector::LoadOp> {
     if (vectorType.getRank() == 0) {
       Value scalar = rewriter.create<memref::LoadOp>(loc, loadOp.getBase(),
                                                      loadOp.getIndices());
-      rewriter.replaceOpWithNewOp<vector::SplatOp>(loadOp, vectorType, scalar);
+      rewriter.replaceOpWithNewOp<vector::BroadcastOp>(loadOp, vectorType,
+                                                       scalar);
       return success();
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -337,7 +337,7 @@ func.func @scalarize_0d_transfer_read(%memory: memref<4xf32>, %i: index) -> vect
 }
 
 // CHECK: %[[S:.+]] = memref.load %[[MEM]][%[[I]]] : memref<4xf32>
-// CHECK: %[[V:.+]] = vector.splat %[[S]] : vector<f32>
+// CHECK: %[[V:.+]] = vector.broadcast %[[S]] : f32 to vector<f32>
 // CHECK: return %[[V]]
 
 // -----


### PR DESCRIPTION
vector.splat has been deprecated upstream. RFC: https://discourse.llvm.org/t/rfc-mlir-vector-deprecate-then-remove-vector-splat/87143/4 This PR replaces all `vector::SplatOp` creation and matching logic with `vector::BroadcastOp`, and then does minimal test adjustments. 