### PR TITLE
[TensorExt] Add inliner interface

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -10,10 +10,37 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 namespace mlir::iree_compiler::IREE::TensorExt {
 
+// Used to control inlining behavior.
+namespace {
+struct IREETensorExtInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  bool isLegalToInline(Operation *call, Operation *callable,
+                       bool wouldBeCloned) const final {
+    // Sure!
+    return true;
+  }
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       IRMapping &valueMapping) const final {
+    // Sure!
+    return true;
+  }
+
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       IRMapping &valueMapping) const final {
+    // Sure!
+    return true;
+  }
+};
+
+} // namespace
+
 void IREETensorExtDialect::initialize() {
+  addInterfaces<IREETensorExtInlinerInterface>();
   addTypes<DispatchTensorType>();
 
 #define GET_OP_LIST

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "dispatch_tensor_folding.mlir",
             "dispatch_workload_ordinal_folding.mlir",
+            "inline.mlir",
             "roundtrip.mlir",
             "tensor_ext_folding.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "dispatch_tensor_folding.mlir"
     "dispatch_workload_ordinal_folding.mlir"
+    "inline.mlir"
     "roundtrip.mlir"
     "tensor_ext_folding.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/inline.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/inline.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt --inline --split-input-file %s | FileCheck %s
+
+util.func private @tensor_ext_impl(%arg0: tensor<16xi32>) -> tensor<4x8xi16> {
+  %0 = iree_tensor_ext.bitcast %arg0 : tensor<16xi32> -> tensor<4x8xi16>
+  util.return %0 : tensor<4x8xi16>
+}
+
+util.func public @tensor_ext(%arg0: tensor<16xi32>) -> tensor<4x8xi16> {
+  %0 = util.call @tensor_ext_impl(%arg0) : (tensor<16xi32>) -> (tensor<4x8xi16>)
+  util.return %0 : tensor<4x8xi16>
+}
+
+// CHECK-LABEL: util.func public @tensor_ext(
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<16xi32>
+//  CHECK-NEXT:   iree_tensor_ext.bitcast %[[ARG0]]


### PR DESCRIPTION
Interestingly the dialect already depended on InliningUtils but there was no interface added for it.