### PR TITLE
[Codegen] Cater to bitwidth of largest operand in reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -31,9 +31,11 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/InterleavedRange.h"
+#include "llvm/Support/LogicalResult.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -41,6 +43,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/OperationSupport.h"
@@ -287,34 +290,80 @@ static bool hasReductionIterator(linalg::LinalgOp &op) {
          llvm::any_of(op.getIteratorTypesArray(), linalg::isReductionIterator);
 }
 
-/// The bitwidth of the init and src operands is used to determine the
-/// bitwidth of the operation. The bitwidth is minimum of the init and src
-/// operands.
-static FailureOr<int64_t> getBitWidth(linalg::LinalgOp op) {
-  Value init = op.getDpsInitOperand(0)->get();
-  Type initElemType = getElementTypeOrSelf(init);
-  Value src = op.getDpsInputOperand(0)->get();
-  Type srcElemType = getElementTypeOrSelf(src);
+struct TensorSizeEstimate {
+  int64_t elementBitwidth;
+  int64_t staticSize;
+  int64_t numDynamicDims;
+  Value value; // This field is to simplify debugging / printing, not for
+               // calculation.
+};
 
-  if (auto initOp = init.getDefiningOp<linalg::GenericOp>()) {
-    if (IREE::LinalgExt::isBitExtendOp(initOp)) {
-      initElemType = getElementTypeOrSelf(initOp.getDpsInputs()[0]);
+/// Calculates the estimated tensor value size. Looks through known bit
+/// extension ops.
+static FailureOr<TensorSizeEstimate> calculateTensorSize(Value val) {
+  if (auto genericOp = val.getDefiningOp<linalg::GenericOp>()) {
+    if (IREE::LinalgExt::isBitExtendOp(genericOp) &&
+        genericOp.getNumDpsInputs() > 0) {
+      val = genericOp.getDpsInputs()[0];
     }
   }
-
-  if (auto srcOp = src.getDefiningOp<linalg::GenericOp>()) {
-    if (IREE::LinalgExt::isBitExtendOp(srcOp)) {
-      srcElemType = getElementTypeOrSelf(srcOp.getDpsInputs()[0]);
-    }
-  }
-
-  if (!initElemType.isIntOrFloat() || !srcElemType.isIntOrFloat()) {
+  auto tensorType = dyn_cast<RankedTensorType>(val.getType());
+  if (!tensorType) {
     return failure();
   }
 
-  int64_t bitWidth = std::max(initElemType.getIntOrFloatBitWidth(),
-                              srcElemType.getIntOrFloatBitWidth());
-  return bitWidth;
+  auto elemType = getElementTypeOrSelf(tensorType);
+  if (!elemType.isIntOrIndexOrFloat()) {
+    return failure();
+  }
+
+  if (isa<IndexType>(elemType)) {
+    // On LLVMGPU, we can conservatively assume 64-bit index types.
+    elemType = IntegerType::get(val.getContext(), 64);
+  }
+
+  TensorSizeEstimate result = {};
+  result.elementBitwidth = elemType.getIntOrFloatBitWidth();
+  result.numDynamicDims = tensorType.getNumDynamicDims();
+  result.staticSize = 1;
+  result.value = val;
+  for (int64_t dim :
+       llvm::make_filter_range(tensorType.getShape(), ShapedType::isStatic)) {
+    result.staticSize *= dim;
+  }
+
+  return result;
+}
+
+/// Returns the bitwidth of the largest operand or init. We estimate this based
+/// on the known static size and the number of dynamic dimensions. This is meant
+/// to cater towards the memory bandwidth required to load the largest of the
+/// inputs.
+static FailureOr<int64_t> getBitWidth(linalg::LinalgOp op) {
+  SmallVector<FailureOr<TensorSizeEstimate>> inputSizes =
+      llvm::filter_to_vector(
+          llvm::map_range(
+              llvm::concat<Value>(op.getDpsInits(), op.getDpsInputs()),
+              calculateTensorSize),
+          succeeded);
+  if (inputSizes.empty()) {
+    return failure();
+  }
+
+  TensorSizeEstimate largestInput = *inputSizes.front();
+  for (FailureOr<TensorSizeEstimate> candidateSize :
+       llvm::drop_begin(inputSizes)) {
+    if (std::tie(candidateSize->numDynamicDims, candidateSize->staticSize,
+                 candidateSize->elementBitwidth) >
+        std::tie(largestInput.numDynamicDims, largestInput.staticSize,
+                 largestInput.elementBitwidth)) {
+      largestInput = *candidateSize;
+    }
+  }
+
+  LDBG("Largest input: " << largestInput.value);
+  LDBG("Largest input bitwidth: " << largestInput.elementBitwidth);
+  return largestInput.elementBitwidth;
 }
 
 /// Check if the reduction op has a single combiner operation.
@@ -790,19 +839,18 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   if (subgroupSize == 0)
     return failure();
 
-  auto bitWidth = getBitWidth(op);
+  FailureOr<int64_t> bitWidth = getBitWidth(op);
   if (failed(bitWidth)) {
     return failure();
   }
 
-  // Reduction distribution only supports 8/16/32 bit types now.
-  if (!llvm::is_contained({8, 16, 32}, *bitWidth)) {
+  // Reduction distribution only supports 4/8/16/32 bit types now.
+  if (!llvm::is_contained({4, 8, 16, 32}, *bitWidth)) {
     return failure();
   }
 
   const std::optional<int64_t> maxLoadBits = wgp.getMaxLoadInstructionBits();
-  const unsigned largestLoadSizeInBits =
-      maxLoadBits.has_value() ? *maxLoadBits : 128;
+  const unsigned largestLoadSizeInBits = maxLoadBits.value_or(128);
 
   unsigned threadLoads = largestLoadSizeInBits / *bitWidth;
   if (numDynamicReductionDims == 0) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -398,6 +398,9 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
+// Test that the thread vector size maximizes memory bandwidth of the largest tensor
+// operand (tensor<6656x16384xf16>). We want to emit dwordx4 load, so the vector size
+// should be 8xf16 ==> 16 bytes.
 func.func @batch_matvec_f16_f32() {
   %cst = arith.constant 0.0 : f32
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -89,8 +89,8 @@ func.func @reduction_with_no_consumer() {
 // CHECK:           lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]
 // CHECK-SAME:      partial_reduction = [0, 0, 1, 4096]
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]
-// CHECK-SAME:      thread = [0, 0, 1, 4],
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]
+// CHECK-SAME:      thread = [0, 0, 1, 8],
 // CHECK-SAME:      workgroup = [1, 1, 0, 0]
 
 // -----
@@ -154,9 +154,9 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs({{.*}}: tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:               partial_reduction = [0, 0, 1, 4096],
+// CHECK-SAME:               partial_reduction = [0, 0, 1, 8192],
 // CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
-// CHECK-SAME:               thread = [0, 0, 1, 4],
+// CHECK-SAME:               thread = [0, 0, 1, 8],
 // CHECK-SAME:               workgroup = [1, 1, 0, 0]
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
@@ -164,18 +164,18 @@ func.func @test_multiple_reduction() {
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]],
-// CHECK-SAME:              partial_reduction = [0, 0, 1, 4096],
+// CHECK-SAME:              partial_reduction = [0, 0, 1, 8192],
 // CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
-// CHECK-SAME:              thread = [0, 0, 1, 4],
+// CHECK-SAME:              thread = [0, 0, 1, 8],
 // CHECK:       %{{.*}} = linalg.generic {indexing_maps = [#map, #map1, #map1, #map],
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
 // CHECK-SAME:    ins({{.*}}, %{{.*}}, {{.*}} : tensor<2x32x10x16384xf16>, tensor<2x32xf32>, tensor<2x32xf32>)
 // CHECK-SAME:    outs(%{{.*}} : tensor<2x32x10x16384xf32>)
 // CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
 // CHECK-SAME:              lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]]
-// CHECK-SAME:              reduction = [0, 0, 1, 4096],
+// CHECK-SAME:              reduction = [0, 0, 1, 8192],
 // CHECK-SAME:              subgroup_basis = {{\[}}[1, 1, 1, 16], [0, 1, 2, 3]],
-// CHECK-SAME:              thread = [0, 0, 0, 4],
+// CHECK-SAME:              thread = [0, 0, 0, 8],
 
 // -----
 
@@ -201,15 +201,15 @@ func.func @test_dyn_reduction(%arg0: !iree_tensor_ext.dispatch.tensor<readwrite:
   iree_tensor_ext.dispatch.tensor.store %5, %arg0, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<128x128xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [8, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [2, 1, 1] subgroup_size = 64
 //       CHECK: func.func @test_dyn_reduction
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
-//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]],
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 2], [0, 1, 2, 3]],
 //  CHECK-SAME:               partial_reduction = [0, 0, 1, 32],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
-//  CHECK-SAME:               thread = [0, 0, 1, 4],
+//  CHECK-SAME:               thread = [0, 0, 1, 16],
 //  CHECK-SAME:               workgroup = [1, 1, 0, 0]
 
 // -----
@@ -376,7 +376,7 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
   iree_codegen.store_to_buffer %12, %expand_shape : tensor<?x4xf32> into memref<?x4xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64
 // CHECK-LABEL: @test_store_to_buffer
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
@@ -385,6 +385,55 @@ func.func @test_store_to_buffer(%arg0: index, %arg1: index) {
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 16], [0, 1, 2]],
-//  CHECK-SAME:               thread = [0, 0, 4],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 8], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 8],
 //  CHECK-SAME:               workgroup = [1, 1, 0]
+
+
+// -----
+
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @batch_matvec_f16_f32() {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x16384xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<6656x16384xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x6656xf32>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4, 16384], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x16384xf16>> -> tensor<4x16384xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [6656, 16384], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<6656x16384xf16>> -> tensor<6656x16384xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4, 6656], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x6656xf32>> -> tensor<4x6656xf32>
+  %7 = tensor.empty() : tensor<4x6656xf32>
+  %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<4x6656xf32>) -> tensor<4x6656xf32>
+  %mv = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ], iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%4, %5 : tensor<4x16384xf16>, tensor<6656x16384xf16>)
+  outs(%8 : tensor<4x6656xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %10 = arith.extf %in : f16 to f32
+    %11 = arith.extf %in_0 : f16 to f32
+    %12 = arith.mulf %10, %11 : f32
+    %13 = arith.addf %out, %12 : f32
+    linalg.yield %13 : f32
+  } -> tensor<4x6656xf32>
+  iree_tensor_ext.dispatch.tensor.store %mv, %2, offsets = [0, 0], sizes = [4, 6656], strides = [1, 1] : tensor<4x6656xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x6656xf32>>
+  return
+}
+
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-LABEL: @batch_matvec_f16_f32
+//       CHECK:   linalg.generic
+//  CHECK-SAME:      attrs = {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:                 lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:                 partial_reduction = [0, 0, 2048],
+//  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 4], [0, 1, 2]],
+//  CHECK-SAME:                 thread = [0, 0, 8],
+//  CHECK-SAME:                 workgroup = [2, 1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -3,7 +3,7 @@
 // RUN:  %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 \
 // RUN:  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" \
-// RUN:  %s | FileCheck %s --check-prefix=CDNA3
+// RUN:  %s | FileCheck %s --check-prefix=RDNA3
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -36,10 +36,10 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
 }
 }
 
-//         CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
-//         CDNA3: func.func @group_reduction_1d()
-//    CDNA3-SAME:    translation_info = #[[$TRANSLATION]]
-//         CDNA3:        gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
+//         RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//         RDNA3: func.func @group_reduction_1d()
+//    RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
+//         RDNA3:        gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
 
 // -----
 
@@ -132,22 +132,22 @@ hal.executable private @i4_dequant_matvec {
   }
 }
 
-//        CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
-//        CDNA3: func.func @i4_dequant_matvec()
-//   CDNA3-SAME:    translation_info = #[[$TRANSLATION]]
-//     CDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//     CDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
-//     CDNA3-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//     CDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x4xf16>
-//         CDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x4xf16>)
-//         CDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x4xi4> to vector<4x1x1x1x1x4xi32>
-//         CDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x4xi32> to vector<4x1x1x1x1x4xf16>
-//         CDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         CDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         CDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         CDNA3:   %{{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//        RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//        RDNA3: func.func @i4_dequant_matvec()
+//   RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
+//     RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//     RDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
+//     RDNA3-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x4xf16>
+//         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x4xf16>)
+//         RDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x4xi4> to vector<4x1x1x1x1x4xi32>
+//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x4xi32> to vector<4x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:   %{{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
 
-//         CDNA3:   %{{.*}} = vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x4xf16> to vector<4x1x1xf16>
+//         RDNA3:   %{{.*}} = vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x4xf16> to vector<4x1x1xf16>
 
 // -----
 
@@ -300,18 +300,18 @@ hal.executable private @matvec_fp16 {
 // Multi-row matvec with wave32.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          CDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
-//          CDNA3: func.func @matvec_fp16()
-//     CDNA3-SAME:     translation_info = #[[$TRANSLATION]]
-//      CDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      CDNA3-DAG:   %[[C512:.+]] = arith.constant 512 : index
-//      CDNA3-DAG:   %[[C4096:.+]] = arith.constant 4096 : index
-//      CDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x8xf16>
-//          CDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C512]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x8xf16>)
-//          CDNA3:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
-//          CDNA3:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
+//          RDNA3: func.func @matvec_fp16()
+//     RDNA3-SAME:     translation_info = #[[$TRANSLATION]]
+//      RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//      RDNA3-DAG:   %[[C512:.+]] = arith.constant 512 : index
+//      RDNA3-DAG:   %[[C4096:.+]] = arith.constant 4096 : index
+//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x8xf16>
+//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C512]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x8xf16>)
+//          RDNA3:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//          RDNA3:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
 
-//          CDNA3: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<8x1x1x1x1x8xf16> to vector<8x1x1xf16>
+//          RDNA3: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<8x1x1x1x1x8xf16> to vector<8x1x1xf16>
 
 // -----
 


### PR DESCRIPTION
Make the reduction vector distribution logic consider the bitwidth of the largest tensor operand, for the purpose of deciding the thread-level vector sizes. This is because we want to optimize for memory-bound operands and load these using the widest instructions supported by the target.

The old logic was also weird in another way: the comment suggested using the minimum bitwidth and contradicted the logic which used `std::max`...

Issue: https://github.com/iree-org/iree/issues/21300