### PR TITLE
[CPU][NFC] Update pack ops to not carry artificial padding.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -1883,15 +1883,15 @@ hal.executable private @pack_lowering {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
             : !iree_tensor_ext.dispatch.tensor<readonly:tensor<100x250xf32>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x64x8x4xf32>>
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<13x63x8x4xf32>>
         %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [100, 250], strides = [1, 1]
             : !iree_tensor_ext.dispatch.tensor<readonly:tensor<100x250xf32>> -> tensor<100x250xf32>
-        %3 = tensor.empty() : tensor<14x64x8x4xf32>
+        %3 = tensor.empty() : tensor<13x63x8x4xf32>
         %4 = linalg.pack %2 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %3
             {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[12, 12]]>}
-            : tensor<100x250xf32> -> tensor<14x64x8x4xf32>
-        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [14, 64, 8, 4], strides = [1, 1, 1, 1]
-            : tensor<14x64x8x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<14x64x8x4xf32>>
+            : tensor<100x250xf32> -> tensor<13x63x8x4xf32>
+        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [13, 63, 8, 4], strides = [1, 1, 1, 1]
+            : tensor<13x63x8x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<13x63x8x4xf32>>
         return
       }
     }
@@ -1923,15 +1923,15 @@ hal.executable private @pack_lowering {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
             : !iree_tensor_ext.dispatch.tensor<readonly:tensor<250x500xf32>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c114688)
-            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x64x8x4xf32>>
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<63x63x8x4xf32>>
         %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1]
             : !iree_tensor_ext.dispatch.tensor<readonly:tensor<250x500xf32>> -> tensor<250x500xf32>
-        %3 = tensor.empty() : tensor<64x64x8x4xf32>
+        %3 = tensor.empty() : tensor<63x63x8x4xf32>
         %4 = linalg.pack %2 padding_value(%cst : f32) outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4] into %3
             {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[12, 14]]>}
-            : tensor<250x500xf32> -> tensor<64x64x8x4xf32>
-        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [64, 64, 8, 4], strides = [1, 1, 1, 1]
-            : tensor<64x64x8x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x64x8x4xf32>>
+            : tensor<250x500xf32> -> tensor<63x63x8x4xf32>
+        iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [63, 63, 8, 4], strides = [1, 1, 1, 1]
+            : tensor<63x63x8x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<63x63x8x4xf32>>
         return
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_lowering_strategy.mlir
@@ -251,12 +251,12 @@ func.func @matmul_aarch_i8_i8_i32_dynamic() attributes {hal.executable.target = 
 func.func @pack() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x48x8x1xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 40], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf32>> -> tensor<20x40xf32>
-  %3 = tensor.empty() : tensor<4x48x8x1xf32>
-  %pack = linalg.pack %2 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<20x40xf32> -> tensor<4x48x8x1xf32>
-  iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [4, 48, 8, 1], strides = [1, 1, 1, 1] : tensor<4x48x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x48x8x1xf32>>
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x48x8x1xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 48], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf32>> -> tensor<20x48xf32>
+  %3 = tensor.empty() : tensor<3x48x8x1xf32>
+  %pack = linalg.pack %2 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<20x48xf32> -> tensor<3x48x8x1xf32>
+  iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [3, 48, 8, 1], strides = [1, 1, 1, 1] : tensor<3x48x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x48x8x1xf32>>
   return
 }
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 16], vector_common_parallel = [1, 1], vector_reduction = [0, 0]>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1052,11 +1052,11 @@ func.func @multi_root() attributes {hal.executable.target = #executable_target_e
 func.func @pack() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf32>>
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf32>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 40], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf32>> -> tensor<20x40xf32>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 48], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf32>> -> tensor<20x48xf32>
   %3 = tensor.empty() : tensor<2x48x16x1xf32>
-  %pack = linalg.pack %2 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %3 : tensor<20x40xf32> -> tensor<2x48x16x1xf32>
+  %pack = linalg.pack %2 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %3 : tensor<20x48xf32> -> tensor<2x48x16x1xf32>
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [2, 48, 16, 1], strides = [1, 1, 1, 1] : tensor<2x48x16x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf32>>
   return
 }
@@ -1077,11 +1077,11 @@ func.func @pack() attributes {hal.executable.target = #executable_target_embedde
 func.func @pack_f16() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf16>>
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf16>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf16>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 40], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x40xf16>> -> tensor<20x40xf16>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [20, 48], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x48xf16>> -> tensor<20x48xf16>
   %3 = tensor.empty() : tensor<2x48x16x1xf16>
-  %pack = linalg.pack %2 padding_value(%cst : f16) inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %3 : tensor<20x40xf16> -> tensor<2x48x16x1xf16>
+  %pack = linalg.pack %2 padding_value(%cst : f16) inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %3 : tensor<20x48xf16> -> tensor<2x48x16x1xf16>
   iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [2, 48, 16, 1], strides = [1, 1, 1, 1] : tensor<2x48x16x1xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x48x16x1xf16>>
   return
 }


### PR DESCRIPTION
The transformations can be tested without artificial padding; it is going to be disallowed in upstream.