### PR TITLE
[Codegen] Fold bitcastss of inner dimensions into binding.subspan

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -121,6 +121,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
   // dims ops, and eliminate common sub-expressions.
   {
     RewritePatternSet patterns(ctx);
+    // NOTE: These patterns are currently load-bearing for sub-byte floats.
     populateReshapeToInterfaceTensorPatterns(patterns);
     tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
     tensor::populateFoldTensorEmptyPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -97,7 +97,7 @@ tileDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
 /// of iree_codegen.load_from_buffer or iree_codegen.store_to_buffer ops.
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns);
 
-/// Populate patterns that fold tensor.expand/collapse_shape into the source
+/// Populate patterns that fold reshaping and bitcasting ops into the source
 /// hal.interface.binding.subspan.
 void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -54,6 +54,7 @@ iree_lit_test_suite(
             "flatten_memref_subspan.mlir",
             "fold_affine_min_in_distributed_loops.mlir",
             "fold_affine_min_of_block_id.mlir",
+            "fold_bitcast_into_interface_tensor.mlir",
             "fold_reshape_into_interface_tensor.mlir",
             "fold_split_reduction_workgroup_mapping_loops.mlir",
             "fold_tensor_extract_op.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_lit_test_suite(
     "flatten_memref_subspan.mlir"
     "fold_affine_min_in_distributed_loops.mlir"
     "fold_affine_min_of_block_id.mlir"
+    "fold_bitcast_into_interface_tensor.mlir"
     "fold_reshape_into_interface_tensor.mlir"
     "fold_split_reduction_workgroup_mapping_loops.mlir"
     "fold_tensor_extract_op.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-fold-reshape-into-interface-tensor,canonicalize))" \
+// RUN:   --split-input-file %s --mlir-print-local-scope | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">], flags = Indirect>
+func.func @fold_load_from_bitcast_dynamic() -> tensor<?x32xf4E2M1FN> {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+      flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x16xi8>>{%0}
+  %2 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%0, 16], strides = [1, 1]
+      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x16xi8>>{%0} -> tensor<?x16xi8>
+  %3 = iree_tensor_ext.bitcast %2 : tensor<?x16xi8>{%0} -> tensor<?x32xf4E2M1FN>{%0}
+  return %3 : tensor<?x32xf4E2M1FN>
+}
+// CHECK-LABEL: func @fold_load_from_bitcast_dynamic()
+//       CHECK:   %[[SHAPE:.+]] = hal.interface.constant.load
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
+//       CHECK:   %[[LOAD:.+]] = iree_tensor_ext.dispatch.tensor.load %[[SUBSPAN]]
+//  CHECK-SAME:       offsets = [0, 0], sizes = [%[[SHAPE]], 32], strides = [1, 1]
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
+//   CHECK-NOT:   iree_tensor_ext.bitcast
+//       CHECK:   return %[[LOAD]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+    #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+func.func @fold_store_of_bitcast_dynamic(%arg0 : tensor<?x32xf4E2M1FN>) {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+      flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x16xi8>>{%0}
+  %2 = iree_tensor_ext.bitcast %arg0 : tensor<?x32xf4E2M1FN>{%0} -> tensor<?x16xi8>{%0}
+  iree_tensor_ext.dispatch.tensor.store %2, %1, offsets = [0, 0], sizes = [%0, 16], strides = [1, 1]
+      : tensor<?x16xi8> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x16xi8>>{%0}
+  return
+}
+// CHECK-LABEL: func @fold_store_of_bitcast_dynamic(
+//       CHECK:   %[[SHAPE:.+]] = hal.interface.constant.load
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
+//       CHECK:   iree_tensor_ext.dispatch.tensor.store %{{.+}}, %[[SUBSPAN]]
+//  CHECK-SAME:       offsets = [0, 0], sizes = [%[[SHAPE]], 32], strides = [1, 1]
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
+//   CHECK-NOT:   iree_tensor_ext.bitcast


### PR DESCRIPTION
If we do bitcast(load(subspan)) or store(bitcast(x), subspan) where the bitcast only impacts the trailing dimension of the tensor, we can handle this by creating a subspan that has the bitcast type, eliminating the need to bufferize a bitcast.