### PR TITLE
[Codegen] Add CPU e2e tests for fp4 conversions

### DIFF
--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -177,7 +177,6 @@ CUDA_SRCS = enforce_glob(
     # keep sorted
     [
         "conv2d.mlir",
-        "fp4_f32_conversion.mlir",
         "fp_to_subbyte.mlir",
         "subbyte_to_fp.mlir",
         # currently only enabled on cuda as it can be slow on other backends.
@@ -189,6 +188,7 @@ CUDA_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
+        "fp4_f32_conversion.mlir",
         "index.mlir",
         # https://github.com/llvm/llvm-project/issues/131386 causes
         # See bug #20294

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -22,6 +22,7 @@ LLVM_SRCS = enforce_glob(
     # keep sorted
     [
         "conv2d.mlir",
+        "fp4_f32_conversion.mlir",
         "fp_to_subbyte.mlir",
         "narrow_n_matmuls.mlir",
         "pack.mlir",
@@ -82,6 +83,7 @@ VMVX_SRCS = enforce_glob(
     include = ["*.mlir"],
     exclude = [
         "fp_to_subbyte.mlir",
+        "fp4_f32_conversion.mlir",
         "large_linalg_matmul.mlir",
         "subbyte_to_fp.mlir",
         "index.mlir",
@@ -128,6 +130,7 @@ VULKAN_SRCS = enforce_glob(
     include = ["*.mlir"],
     exclude = [
         "fp_to_subbyte.mlir",
+        "fp4_f32_conversion.mlir",
         "index.mlir",
         "large_linalg_matmul.mlir",
         "pack.mlir",
@@ -174,6 +177,7 @@ CUDA_SRCS = enforce_glob(
     # keep sorted
     [
         "conv2d.mlir",
+        "fp4_f32_conversion.mlir",
         "fp_to_subbyte.mlir",
         "subbyte_to_fp.mlir",
         # currently only enabled on cuda as it can be slow on other backends.
@@ -221,6 +225,7 @@ ROCM_SRCS = enforce_glob(
     exclude = [
         "conv2d.mlir",
         "fp_to_subbyte.mlir",
+        "fp4_f32_conversion.mlir",
         "index.mlir",
         "large_linalg_matmul.mlir",
         "narrow_n_matmuls.mlir",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_check_single_backend_test_suite(
     check_llvm-cpu_local-task
   SRCS
     "conv2d.mlir"
+    "fp4_f32_conversion.mlir"
     "fp_to_subbyte.mlir"
     "narrow_n_matmuls.mlir"
     "pack.mlir"
@@ -129,6 +130,7 @@ iree_check_single_backend_test_suite(
     check_large_linalg_matmul_cuda
   SRCS
     "conv2d.mlir"
+    "fp4_f32_conversion.mlir"
     "fp_to_subbyte.mlir"
     "large_linalg_matmul.mlir"
     "narrow_n_matmuls.mlir"

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -130,7 +130,6 @@ iree_check_single_backend_test_suite(
     check_large_linalg_matmul_cuda
   SRCS
     "conv2d.mlir"
-    "fp4_f32_conversion.mlir"
     "fp_to_subbyte.mlir"
     "large_linalg_matmul.mlir"
     "narrow_n_matmuls.mlir"

--- a/tests/e2e/linalg/fp4_f32_conversion.mlir
+++ b/tests/e2e/linalg/fp4_f32_conversion.mlir
@@ -1,0 +1,35 @@
+func.func @f4E2M1FN_scaled_to_f32() {
+  // [0, 1.0, 2.0, 0.5] : f4E2M1FN
+  %input = util.unfoldable_constant dense<[0, 2, 4, 1]> : tensor<4xi8>
+  %scale = util.unfoldable_constant dense<2.0> : tensor<4xf8E8M0FNU>
+  %init0 = tensor.empty() : tensor<4xf32>
+  %res = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+    ins(%input, %scale : tensor<4xi8>, tensor<4xf8E8M0FNU>) outs(%init0 : tensor<4xf32>) {
+  ^bb0(%in: i8, %s: f8E8M0FNU, %out: f32):
+    %0 = arith.trunci %in : i8 to i4
+    %1 = arith.bitcast %0 : i4 to f4E2M1FN
+    %2 = arith.scaling_extf %1, %s : f4E2M1FN, f8E8M0FNU to f32
+    linalg.yield %2 : f32
+  } -> tensor<4xf32>
+
+  check.expect_eq_const(%res, dense<[0.0, 2.0, 4.0, 1.0]> : tensor<4xf32>) : tensor<4xf32>
+  return
+}
+
+func.func @f32_to_f4E2M1FN_scaled() {
+  %input = util.unfoldable_constant dense<[0.0, 2.0, 4.0, 1.0]> : tensor<4xf32>
+  %scale = util.unfoldable_constant dense<2.0> : tensor<4xf8E8M0FNU>
+  %init0 = tensor.empty() : tensor<4xi8>
+  %res = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+    ins(%input, %scale : tensor<4xf32>, tensor<4xf8E8M0FNU>) outs(%init0 : tensor<4xi8>) {
+  ^bb0(%in: f32, %s: f8E8M0FNU, %out: i8):
+    %0 = arith.scaling_truncf %in, %s : f32, f8E8M0FNU to f4E2M1FN
+    %1 = arith.bitcast %0 : f4E2M1FN to i4
+    %2 = arith.extui %1 : i4 to i8
+    linalg.yield %2 : i8
+  } -> tensor<4xi8>
+
+  // [0.0, 1.0, 2.0, 0.5] : tensor<4xf4E2M1FN>
+  check.expect_eq_const(%res, dense<[0, 2, 4, 1]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}


### PR DESCRIPTION
This is a followup to #21413 that addts the requested end-to-end tests, which now compile successfully thanks to #21443