### PR TITLE
[NFC][LLVMGPU] Move intrinsic sorting to deduceMMASchedule

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -123,54 +123,6 @@ LogicalResult setDataTiledMultiMmaLoweringConfig(
       workgroupSize, targetSubgroupSize, pipelineConfig);
 }
 
-/// Sort the MMA intrinsics by following precedence rules:
-///   1) k-alignment. We prefer intrinsics that can evenly divide the K
-///   dimension of the problem.
-///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M and N
-///   dimensions of the problem.
-///   3) Intrinsic with larger gemm size.
-///   4) Intrinsic with larger K size.
-static void sortMMAIntrinsics(GPUMatmulShapeType problem,
-                              SmallVector<GPUIntrinsicType> &intrinsics) {
-  llvm::sort(intrinsics, [&](const GPUMatmulShapeType &lhs,
-                             const GPUMatmulShapeType &rhs) {
-    // Prefer K-aligned intrinsics.
-    int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
-    int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
-    if (lhsKAligned != rhsKAligned) {
-      return lhsKAligned > rhsKAligned;
-    }
-
-    // If K alignment is the same, prefer the intrinsic that aligns M and N.
-    int lhsMNAligned = (problem.mSizes.back() % lhs.mSizes.back() == 0 &&
-                        problem.nSizes.back() % lhs.nSizes.back() == 0)
-                           ? 1
-                           : 0;
-    int rhsMNAligned = (problem.mSizes.back() % rhs.mSizes.back() == 0 &&
-                        problem.nSizes.back() % rhs.nSizes.back() == 0)
-                           ? 1
-                           : 0;
-    if (lhsMNAligned != rhsMNAligned) {
-      return lhsMNAligned > rhsMNAligned;
-    }
-
-    auto intrinsicArea = [&](const GPUMatmulShapeType &intrinsic) {
-      return (ShapedType::getNumElements(intrinsic.mSizes) +
-              ShapedType::getNumElements(intrinsic.nSizes)) *
-             ShapedType::getNumElements(intrinsic.kSizes);
-    };
-    int64_t lhsArea = intrinsicArea(lhs);
-    int64_t rhsArea = intrinsicArea(rhs);
-    if (lhsArea != rhsArea) {
-      return lhsArea > rhsArea;
-    }
-
-    // Finally if everything else is the same, prefer large K size.
-    return ShapedType::getNumElements(lhs.kSizes) >
-           ShapedType::getNumElements(rhs.kSizes);
-  });
-}
-
 /// Given a target and a matmul problem, try to find an MMA schedule for the
 /// problem based on the available mma intrinsics.
 static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
@@ -192,7 +144,6 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
   }
   if (intrinsics.empty())
     return std::nullopt;
-  sortMMAIntrinsics(problem, intrinsics);
 
   GPUMMAHeuristicSeeds seeds;
   assert(problem.aType == problem.bType &&


### PR DESCRIPTION
No test changes because the intrinsics are already sorted in a good order. This will be further used for attention intrinsic sorting in future patches.