### PR TITLE
[GPU] Sort intrinsic pairs for attention configuration

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -418,8 +418,12 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
 ///   1) k-alignment. We prefer intrinsics that can evenly divide the K
 ///   dimension of the problem.
 ///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M
-///   and N dimensions of the problem. 3) Intrinsic with larger gemm size.
+///   and N dimensions of the problem.
+///   3) Intrinsic with larger gemm size.
 ///   4) Intrinsic with larger K size.
+///
+/// This function acts as a comparison function object for std::sort, which
+/// returns true if the lhs is ordered before rhs.
 bool compareIntrinsics(const GPUMatmulShapeType &problem,
                        const GPUMatmulShapeType &lhs,
                        const GPUMatmulShapeType &rhs) {
@@ -745,7 +749,7 @@ FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
                               pvSchedule->kTileSizes[0],
                               qkMatmul.kSizes[0] / intrinsicAK};
 
-    return std::make_pair(qkSchedule, pvSchedule.value());
+    return std::pair(qkSchedule, pvSchedule.value());
   }
 
   return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 
 #include <cstdint>
 
@@ -22,6 +23,8 @@ using llvm::APIntOps::GreatestCommonDivisor;
 
 namespace mlir::iree_compiler {
 
+using IREE::GPU::getSingleSubgroupLayout;
+
 // Threshold used to determine whether a matmul dimension is 'very skinny'.
 constexpr int64_t kVerySkinnyDimThreshold = 4;
 
@@ -33,6 +36,7 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const GPUMMASchedule &schedule) {
+  os << "mmaKind " << schedule.mmaKind << ", ";
   os << "mSizes: " << schedule.mSize << ", ";
   os << "nSizes: " << schedule.nSize << ", ";
   os << "kSizes: " << schedule.kSize << ", ";
@@ -168,7 +172,7 @@ static bool isValidMMASchedule(const GPUMatmulShapeType &problem,
 /// found. The schedule sizes are reduced in the order of mTileSizes,
 /// nTileSizes, kTileSizes, mSubgroupCounts, nSubgroupCounts.
 static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
-    GPUMatmulShapeType intrinsic, GPUMMASchedule schedule,
+    GPUMMASchedule schedule,
     llvm::function_ref<bool(const GPUMMASchedule &schedule)> isScheduleValid) {
 
   while (!isScheduleValid(schedule)) {
@@ -410,54 +414,59 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
       mTileSizes,          nTileSizes,          kTileSizes};
 }
 
-/// Sort the MMA intrinsics by following precedence rules:
+/// Compare the MMA intrinsics by following precedence rules:
 ///   1) k-alignment. We prefer intrinsics that can evenly divide the K
 ///   dimension of the problem.
-///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M and N
-///   dimensions of the problem.
-///   3) Intrinsic with larger gemm size.
+///   2) M/N-alignment. We prefer intrinsics that can evenly divide the M
+///   and N dimensions of the problem. 3) Intrinsic with larger gemm size.
 ///   4) Intrinsic with larger K size.
+bool compareIntrinsics(const GPUMatmulShapeType &problem,
+                       const GPUMatmulShapeType &lhs,
+                       const GPUMatmulShapeType &rhs) {
+  // Prefer K-aligned intrinsics.
+  int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
+  int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
+  if (lhsKAligned != rhsKAligned) {
+    return lhsKAligned > rhsKAligned;
+  }
+
+  // If K alignment is the same, prefer the intrinsic that aligns M and N.
+  int lhsMNAligned = (problem.mSizes.back() % lhs.mSizes.back() == 0 &&
+                      problem.nSizes.back() % lhs.nSizes.back() == 0)
+                         ? 1
+                         : 0;
+  int rhsMNAligned = (problem.mSizes.back() % rhs.mSizes.back() == 0 &&
+                      problem.nSizes.back() % rhs.nSizes.back() == 0)
+                         ? 1
+                         : 0;
+  if (lhsMNAligned != rhsMNAligned) {
+    return lhsMNAligned > rhsMNAligned;
+  }
+
+  auto intrinsicArea = [&](const GPUMatmulShapeType &intrinsic) {
+    return (ShapedType::getNumElements(intrinsic.mSizes) +
+            ShapedType::getNumElements(intrinsic.nSizes)) *
+           ShapedType::getNumElements(intrinsic.kSizes);
+  };
+  int64_t lhsArea = intrinsicArea(lhs);
+  int64_t rhsArea = intrinsicArea(rhs);
+  if (lhsArea != rhsArea) {
+    return lhsArea > rhsArea;
+  }
+
+  // Finally if everything else is the same, prefer large K size.
+  return ShapedType::getNumElements(lhs.kSizes) >
+         ShapedType::getNumElements(rhs.kSizes);
+}
+
 static SmallVector<GPUIntrinsicType>
 sortMMAIntrinsics(GPUMatmulShapeType problem,
                   ArrayRef<GPUIntrinsicType> intrinsics) {
   SmallVector<GPUIntrinsicType> sortedIntrinsics;
-  llvm::sort(sortedIntrinsics, [&](const GPUMatmulShapeType &lhs,
-                                   const GPUMatmulShapeType &rhs) {
-    // Prefer K-aligned intrinsics.
-    int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
-    int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
-    if (lhsKAligned != rhsKAligned) {
-      return lhsKAligned > rhsKAligned;
-    }
-
-    // If K alignment is the same, prefer the intrinsic that aligns M and N.
-    int lhsMNAligned = (problem.mSizes.back() % lhs.mSizes.back() == 0 &&
-                        problem.nSizes.back() % lhs.nSizes.back() == 0)
-                           ? 1
-                           : 0;
-    int rhsMNAligned = (problem.mSizes.back() % rhs.mSizes.back() == 0 &&
-                        problem.nSizes.back() % rhs.nSizes.back() == 0)
-                           ? 1
-                           : 0;
-    if (lhsMNAligned != rhsMNAligned) {
-      return lhsMNAligned > rhsMNAligned;
-    }
-
-    auto intrinsicArea = [&](const GPUMatmulShapeType &intrinsic) {
-      return (ShapedType::getNumElements(intrinsic.mSizes) +
-              ShapedType::getNumElements(intrinsic.nSizes)) *
-             ShapedType::getNumElements(intrinsic.kSizes);
-    };
-    int64_t lhsArea = intrinsicArea(lhs);
-    int64_t rhsArea = intrinsicArea(rhs);
-    if (lhsArea != rhsArea) {
-      return lhsArea > rhsArea;
-    }
-
-    // Finally if everything else is the same, prefer large K size.
-    return ShapedType::getNumElements(lhs.kSizes) >
-           ShapedType::getNumElements(rhs.kSizes);
-  });
+  llvm::sort(sortedIntrinsics,
+             [&](const GPUMatmulShapeType &lhs, const GPUMatmulShapeType &rhs) {
+               return compareIntrinsics(problem, lhs, rhs);
+             });
   return sortedIntrinsics;
 }
 
@@ -505,7 +514,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
 
       return isAligned && sharedMemoryUsed <= sharedMemLimitInBytes;
     };
-    return fitScheduleInSharedMemory(intrinsic, schedule, isValidSchedule);
+    return fitScheduleInSharedMemory(schedule, isValidSchedule);
   }
   return failure();
 }
@@ -585,7 +594,13 @@ getOptimalAttentionPVSchedule(const GPUMatmulShapeType &problem,
       mTileSizes,          nTileSizes,          kTileSizes};
 }
 
-FailureOr<GPUMMASchedule> deduceAttentionSchedule(
+struct ChainedMMAIntrinsics {
+  GPUIntrinsicType intrinsicA;
+  GPUIntrinsicType intrinsicB;
+  bool canReuseAOutputForB;
+};
+
+FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
     const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
     ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,
@@ -595,40 +610,87 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
          pvMatmul.kSizes.size() == 1 && qkMatmul.mSizes.size() == 1 &&
          qkMatmul.nSizes.size() == 1 && qkMatmul.kSizes.size() == 1 &&
          "unimplemented: multi M/N/K attention schedule");
-  for (const GPUIntrinsicType &intrinsic : intrinsics) {
-    if (failed(canTargetIntrinsic(qkMatmul, intrinsic, subgroupSize,
-                                  canUpcastAcc, mustBeAligned))) {
-      continue;
+
+  std::vector<ChainedMMAIntrinsics> intrinsicPairs;
+
+  for (const GPUIntrinsicType &intrinsicA : intrinsics) {
+    for (const GPUIntrinsicType &intrinsicB : intrinsics) {
+      if (failed(canTargetIntrinsic(qkMatmul, intrinsicA, subgroupSize,
+                                    canUpcastAcc, mustBeAligned))) {
+        continue;
+      }
+
+      if (failed(canTargetIntrinsic(pvMatmul, intrinsicB, subgroupSize,
+                                    canUpcastAcc, mustBeAligned))) {
+        continue;
+      }
+      // Check if we can reuse the output of intrinsicA for lhs/rhs of
+      // intrinsicB.
+      auto matchLayout =
+          [](IREE::GPU::MMASingleSubgroupLayout layoutA,
+             IREE::GPU::MMASingleSubgroupLayout layoutB) -> bool {
+        return (layoutA.element == layoutB.element) &&
+               (layoutA.thread == layoutB.thread) &&
+               (layoutA.tstrides == layoutB.tstrides);
+      };
+      bool canReuseAOutForBLhs =
+          matchLayout(getSingleSubgroupLayout(intrinsicA.mmaKind,
+                                              IREE::GPU::MMAFragment::Acc),
+                      getSingleSubgroupLayout(intrinsicB.mmaKind,
+                                              IREE::GPU::MMAFragment::Lhs));
+      bool canReuseAOutForBRhs =
+          matchLayout(getSingleSubgroupLayout(intrinsicA.mmaKind,
+                                              IREE::GPU::MMAFragment::Acc),
+                      getSingleSubgroupLayout(intrinsicB.mmaKind,
+                                              IREE::GPU::MMAFragment::Rhs));
+      intrinsicPairs.push_back(
+          {intrinsicA, intrinsicB, canReuseAOutForBLhs || canReuseAOutForBRhs});
+    }
+  }
+
+  llvm::sort(intrinsicPairs, [&](const ChainedMMAIntrinsics &lhs,
+                                 const ChainedMMAIntrinsics &rhs) {
+    if (lhs.canReuseAOutputForB && !rhs.canReuseAOutputForB) {
+      return true;
+    }
+    if (!lhs.canReuseAOutputForB && rhs.canReuseAOutputForB) {
+      return false;
     }
 
-    if (failed(canTargetIntrinsic(pvMatmul, intrinsic, subgroupSize,
-                                  canUpcastAcc, mustBeAligned))) {
-      continue;
+    if (lhs.intrinsicA.mmaKind != rhs.intrinsicA.mmaKind) {
+      return compareIntrinsics(qkMatmul, lhs.intrinsicA, rhs.intrinsicA);
     }
+    return compareIntrinsics(pvMatmul, lhs.intrinsicB, rhs.intrinsicB);
+  });
+
+  for (ChainedMMAIntrinsics intrinsics : intrinsicPairs) {
+    // Structured bindings cannot be captured in C++ < 20.
+    GPUIntrinsicType intrinsicA = intrinsics.intrinsicA;
+    GPUIntrinsicType intrinsicB = intrinsics.intrinsicB;
+    bool canReuseAOutput = intrinsics.canReuseAOutputForB;
 
     GPUMMASchedule schedule =
-        getOptimalAttentionPVSchedule(pvMatmul, intrinsic, pvMatmulSeeds);
+        getOptimalAttentionPVSchedule(pvMatmul, intrinsicB, pvMatmulSeeds);
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
       llvm::dbgs() << "  " << schedule << "\n";
     });
-
-    int64_t intrinsicK = intrinsic.kSizes[0];
+    int64_t intrinsicAK = intrinsicA.kSizes[0];
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
       // Create a mma schedule for qkMatmul in attention.
       // qkMatmul.M = pvMatmul.M
       // qkMatmul.N = pvMatmul.K
       // qkMatmul.K = problem.K
-      GPUMMASchedule qkSchedule{schedule.mmaKind,
+      GPUMMASchedule qkSchedule{intrinsicA.mmaKind,
                                 schedule.mSize,
                                 schedule.kSize,
-                                intrinsicK,
+                                intrinsicAK,
                                 /*mSubgroupCount=*/schedule.mSubgroupCounts[0],
                                 /*nSubgroupCount=*/1,
                                 schedule.mTileSizes[0],
                                 schedule.kTileSizes[0],
-                                qkMatmul.kSizes[0] / intrinsicK};
+                                qkMatmul.kSizes[0] / intrinsicAK};
 
       bool isQKAligned =
           isValidMMASchedule(qkMatmul, qkSchedule, mustBeAligned, subgroupSize,
@@ -639,12 +701,18 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
       bool isPVAligned = isValidMMASchedule(pvMatmul, schedule, mustBeAligned,
                                             subgroupSize, false, transposedV);
 
-      int64_t lhsBitwidth = intrinsic.aType.getIntOrFloatBitWidth();
-      int64_t rhsBitwidth = intrinsic.bType.getIntOrFloatBitWidth();
+      int64_t lhsABitwidth = intrinsicA.aType.getIntOrFloatBitWidth();
+      int64_t rhsABitwidth = intrinsicA.bType.getIntOrFloatBitWidth();
+      int64_t rhsBBitwidth = intrinsicB.bType.getIntOrFloatBitWidth();
+      // We don't need to use shared memory for lhsB if we can reuse A intrinsic
+      // output.
+      int64_t lhsBBitwidth =
+          canReuseAOutput ? 0 : intrinsicB.aType.getIntOrFloatBitWidth();
+
       int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
-                                     qkSchedule, lhsBitwidth, rhsBitwidth) +
+                                     qkSchedule, lhsABitwidth, rhsABitwidth) +
                                  calculateOperandsSharedMemoryUsedInBytes(
-                                     schedule, lhsBitwidth, rhsBitwidth);
+                                     schedule, lhsBBitwidth, rhsBBitwidth);
 
       LLVM_DEBUG({
         llvm::dbgs() << "Available Shared Memory: ";
@@ -657,7 +725,27 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
              sharedMemoryUsed <= sharedMemLimitInBytes;
     };
 
-    return fitScheduleInSharedMemory(intrinsic, schedule, isValidSchedule);
+    FailureOr<GPUMMASchedule> pvSchedule =
+        fitScheduleInSharedMemory(schedule, isValidSchedule);
+    if (failed(pvSchedule)) {
+      return failure();
+    }
+
+    // Create a mma schedule for qkMatmul in attention.
+    // qkMatmul.M = pvMatmul.M
+    // qkMatmul.N = pvMatmul.K
+    // qkMatmul.K = problem.K
+    GPUMMASchedule qkSchedule{intrinsicA.mmaKind,
+                              pvSchedule->mSize,
+                              pvSchedule->kSize,
+                              intrinsicAK,
+                              /*mSubgroupCount=*/schedule.mSubgroupCounts[0],
+                              /*nSubgroupCount=*/1,
+                              pvSchedule->mTileSizes[0],
+                              pvSchedule->kTileSizes[0],
+                              qkMatmul.kSizes[0] / intrinsicAK};
+
+    return std::make_pair(qkSchedule, pvSchedule.value());
   }
 
   return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -110,7 +110,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
 /// Returns a schedule for the pvMatmul in attention using one of the given MMA
 /// |intrinsics| to target the given attention matmul problems, |qkMatmul|
 /// and |pvMatmul|. Returns std::nullopt if we cannot find such a schedule.
-FailureOr<GPUMMASchedule> deduceAttentionSchedule(
+FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
     const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
     ArrayRef<GPUIntrinsicType> intrinsics,
     const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -274,6 +274,50 @@ func.func @attention_20x4096x64x4096x64() {
 // CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-NOT:   prefetch_shared_memory = true
 
+// CHECK-LABEL: func.func @attention_20x4096x64x4096x64_f8()
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @attention_20x4096x64x4096x64_f8() {
+  %cst = arith.constant 1.250000e-01 : f8E4M3FNUZ
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf8E4M3FNUZ>> -> tensor<20x4096x64xf8E4M3FNUZ>
+  %7 = tensor.empty() : tensor<20x4096x64xf8E4M3FNUZ>
+  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, tensor<20x4096x64xf8E4M3FNUZ>, f8E4M3FNUZ) outs(%7 : tensor<20x4096x64xf8E4M3FNUZ>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x4096x64xf8E4M3FNUZ>
+  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x4096x64xf8E4M3FNUZ>>
+  return
+}
+
+// CHECK:      VMFMA_F32_16x16x32_F8E4M3FNUZ
+// CHECK-SAME: MFMA_F32_16x16x32_F8E4M3FNUZ
+// CHECK-SAME: subgroup_m_count = 4
+// CHECK-SAME: subgroup_n_count = 1
+// CHECK-SAME: reduction =  [0, 0, 0, 128, 0]
+// CHECK-SAME: workgroup =  [1, 64, 0, 0, 64]
+
+// -----
+
+// CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK-NOT:   prefetch_shared_memory = true
+
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 
 // Test to check if having a large head dim, which would lead to high shared

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -229,11 +229,12 @@ func.func @attention_20x4096x64x4096x64() {
   return
 }
 
-// CHECK:                #iree_gpu.lowering_config
-// CHECK-SAME:                           subgroup_m_count = 4
-// CHECK-SAME:                           subgroup_n_count = 1
-// CHECK-SAME:                           reduction =  [0, 0, 0, 128, 0]
-// CHECK-SAME:                           workgroup =  [1, 64, 0, 0, 64]
+// CHECK:      MFMA_F32_16x16x16_F16
+// CHECK-SAME: MFMA_F32_16x16x32_F16
+// CHECK-SAME: subgroup_m_count = 4
+// CHECK-SAME: subgroup_n_count = 1
+// CHECK-SAME: reduction =  [0, 0, 0, 64, 0]
+// CHECK-SAME: workgroup =  [1, 64, 0, 0, 64]
 
 // -----
 
@@ -275,8 +276,9 @@ func.func @attention_large_head_dim_shared_mem() {
   return
 }
 
-// CHECK:                #iree_gpu.lowering_config
-// CHECK-SAME:                           subgroup_m_count = 4
-// CHECK-SAME:                           subgroup_n_count = 1
-// CHECK-SAME:                           reduction =  [0, 0, 64, 0]
-// CHECK-SAME:                           workgroup =  [64, 0, 0, 16]
+// CHECK:      MFMA_F32_16x16x16_F16
+// CHECK-SAME: MFMA_F32_16x16x32_F16
+// CHECK-SAME: subgroup_m_count = 4
+// CHECK-SAME: subgroup_n_count = 1
+// CHECK-SAME: reduction =  [0, 0, 64, 0]
+// CHECK-SAME: workgroup =  [64, 0, 0, 64]


### PR DESCRIPTION
This patch takes into account intrinsic reuse while setting intrinsics for attention. This patch also allows the configuration to choose different intrinsics for QK and PV matmul. The F8 test shows the configuration selecting a good intrinsic combination (with VMFMA and MFMA intrinsic mix) and the gfx950 test shows a combination of wide width MFMA and lower width MFMA to allow intrinsic reuse.