### PR TITLE
Fix for control reaches end of non-void function

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -530,6 +530,7 @@ getNextWorkgroupMapping(ArrayRef<Attribute> currentMappings) {
         lastAttr.getContext(), IREE::Codegen::WorkgroupId::IdZ,
         lastAttr.getDelinearizedDim() + 1);
   }
+  return {};
 }
 
 // Pattern to fold the `scf.forall` produced by split reduction


### PR DESCRIPTION
I am seeing following compilation error while building with gcc: 

```
iree/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp: In function ‘mlir::iree_compiler::IREE::Codegen::WorkgroupMappingAttr mlir::iree_compiler::{anonymous}::getNextWorkgroupMapping(llvm::ArrayRef<mlir::Attribute>)’:
iree/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp:533:1: error: control reaches end of non-void function
```
This was introduced in: https://github.com/iree-org/iree/pull/21422