### PR TITLE
[Codegen][LLVMGPU] Add fallback patterns for fp4/f8E8M0FNU handling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -276,7 +276,7 @@ struct ConvertToROCDLPass final
         return signalPassFailure();
       }
 
-      // TODO: remove this once ArithToAMDGPU learns to take a PatternBenefit
+      // TODO: remove this once ArithToAMDGPU learns to take a PatternBenefit.
       RewritePatternSet fallbackSmallFloatPatterns(&getContext());
       arith::populateExpandScalingExtTruncPatterns(fallbackSmallFloatPatterns);
       arith::populateExpandF4E2M1Patterns(fallbackSmallFloatPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -275,6 +275,16 @@ struct ConvertToROCDLPass final
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
+
+      // TODO: remove this once ArithToAMDGPU learns to take a PatternBenefit
+      RewritePatternSet fallbackSmallFloatPatterns(&getContext());
+      arith::populateExpandScalingExtTruncPatterns(fallbackSmallFloatPatterns);
+      arith::populateExpandF4E2M1Patterns(fallbackSmallFloatPatterns);
+      arith::populateExpandF8E8M0Patterns(fallbackSmallFloatPatterns);
+      if (failed(applyPatternsGreedily(
+              m, std::move(fallbackSmallFloatPatterns)))) {
+        return signalPassFailure();
+      }
     }
 
     LDBG("After applying in-dialect conversions\n" << m);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -283,6 +283,7 @@ struct ConvertToROCDLPass final
       arith::populateExpandF8E8M0Patterns(fallbackSmallFloatPatterns);
       if (failed(applyPatternsGreedily(
               m, std::move(fallbackSmallFloatPatterns)))) {
+        LDBG("Small float patterns failed\n" << m);
         return signalPassFailure();
       }
     }
@@ -346,8 +347,9 @@ struct ConvertToROCDLPass final
       populateMathToROCDLConversionPatterns(converter, llvmPatterns);
       ub::populateUBToLLVMConversionPatterns(converter, llvmPatterns);
 
-      if (failed(applyPartialConversion(m, target, std::move(llvmPatterns))))
-        signalPassFailure();
+      if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {
+        return signalPassFailure();
+      }
     }
 
     LDBG("After converting to rocdl\n" << m);


### PR DESCRIPTION
In case arith-to-amdgpu doesn't handle some conversions to/from fp4 (or because conversion to f8E8M0FNU isn't handled by that pass), add in the generic patterns from arith.