### PR TITLE
Integrate LLVM at aa1b416

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2704,7 +2704,7 @@ func.func @rocdl_buffer_memory_space_elementwise_copy() {
 //   CHECK-DAG:   %[[arg0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0) : memref<256x256xf32, #hal.descriptor_type<storage_buffer>>
 //   CHECK-DAG:   %[[arg1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1) offset(%{{.+}}) : memref<256x256xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
 //   CHECK-DAG:   amdgpu.fat_raw_buffer_cast %[[arg0]] resetOffset : memref<256x256xf32, #hal.descriptor_type<storage_buffer>> to memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
-//   CHECK-DAG:   amdgpu.fat_raw_buffer_cast %[[arg1]] resetOffset : memref<256x256xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<256x256xf32, strided<[256, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+//   CHECK-DAG:   amdgpu.fat_raw_buffer_cast %[[arg1]] resetOffset : memref<256x256xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> to memref<256x256xf32, #amdgpu.address_space<fat_raw_buffer>>
 //   CHECK-NOT:   hal.interface.binding.subspan
 //       CHECK:    return
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_expand_strided_metadata_with_subview_expansion.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_expand_strided_metadata_with_subview_expansion.mlir
@@ -3,7 +3,7 @@
 #pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @expand_subview_into_resource_cast(%offset: index) -> memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>> {
+func.func @expand_subview_into_resource_cast(%offset: index) -> memref<256x4096xf16, #amdgpu.address_space<fat_raw_buffer>> {
   %c4096_i14 = arith.constant 4096 : i14
   %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
   %1 = arith.index_castui %0 : i32 to index
@@ -12,8 +12,8 @@ func.func @expand_subview_into_resource_cast(%offset: index) -> memref<256x4096x
   %subview = memref.subview %2[%offset, 0] [256, 4096] [1, 1]
     : memref<4096x4096xf16, #gpu.address_space<global>> to memref<256x4096xf16, strided<[4096, 1], offset: ?>, #gpu.address_space<global>>
   %38 = amdgpu.fat_raw_buffer_cast %subview cacheSwizzleStride(%c4096_i14) resetOffset
-    : memref<256x4096xf16, strided<[4096, 1], offset: ?>, #gpu.address_space<global>> to memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>>
-  return %38 : memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+    : memref<256x4096xf16, strided<[4096, 1], offset: ?>, #gpu.address_space<global>> to memref<256x4096xf16, #amdgpu.address_space<fat_raw_buffer>>
+  return %38 : memref<256x4096xf16, #amdgpu.address_space<fat_raw_buffer>>
 }
 
 // CHECK-LABEL: func.func @expand_subview_into_resource_cast


### PR DESCRIPTION
Integrate https://github.com/llvm/llvm-project/commit/aa1b416065ec615e93c496bbb43c7c006a04553e.

IR/test changes to tests with amdgpu.fat_raw_buffer_cast from updates in upstream related to inferring canonical layout for resetOffset https://github.com/llvm/llvm-project/commit/9052a85da803b246fa6a6f8b3b5bcbfc2e9de7a8

No reverts or cherry-picks: dropped the former local revert since https://github.com/llvm/llvm-project/pull/149393 was landed.