### PR TITLE
[Codegen] Add canonicalizer with IREE codegen specific patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -133,6 +133,7 @@ iree_compiler_cc_library(
         "GenericVectorization.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "HoistUnrolledVectorExtractInsertSlice.cpp",
+        "IREECodegenCanonicalizer.cpp",
         "IREEComprehensiveBufferizePass.cpp",
         "IREEExpandStridedMetadata.cpp",
         "IREEInjectAssumeAlignment.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -125,6 +125,7 @@ iree_cc_library(
     "GenericVectorization.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "HoistUnrolledVectorExtractInsertSlice.cpp"
+    "IREECodegenCanonicalizer.cpp"
     "IREEComprehensiveBufferizePass.cpp"
     "IREEExpandStridedMetadata.cpp"
     "IREEInjectAssumeAlignment.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
@@ -1,0 +1,137 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-canonicalizer"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_IREECODEGENCANONICALIZERPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+/// Helper method to check if a `subview` operation is trivially a no-op. This
+/// is the case if the all offsets are zero, all strides are 1, and the source
+/// shape is same as the size of the subview. In such cases, the subview can
+/// be folded into its source.
+static bool isTrivialSubViewOp(memref::SubViewOp subviewOp) {
+  if (subviewOp.getSourceType().getRank() != subviewOp.getType().getRank())
+    return false;
+
+  if (!areAllConstantIntValue(subviewOp.getMixedOffsets(), 0) ||
+      !areAllConstantIntValue(subviewOp.getMixedStrides(), 1)) {
+    return false;
+  }
+
+  // Check all size values match the source sizes.
+  ArrayRef<int64_t> sourceShape = subviewOp.getSourceType().getShape();
+  if (areConstantIntValues(subviewOp.getMixedSizes(), sourceShape)) {
+    return true;
+  }
+
+  // If the sizes are dynamic, traverse the IR to find a ShapeAwareOpInterface
+  // to get the dynamic sizes of the source.
+  auto opResult = dyn_cast<OpResult>(subviewOp.getSource());
+  while (opResult) {
+    Operation *owner = opResult.getOwner();
+    if (isa<IREE::Util::ShapeAwareOpInterface>(owner)) {
+      break;
+    }
+    // Only continue traversing operands that don't affect the type
+    if (!owner->hasTrait<OpTrait::SameOperandsAndResultType>()) {
+      return false;
+    }
+    // SameOperandsAndResultType guarantees 1 operand.
+    opResult = dyn_cast<OpResult>(owner->getOperand(0));
+  }
+  if (!opResult) {
+    return false;
+  }
+  auto shapeAwareProducer =
+      cast<IREE::Util::ShapeAwareOpInterface>(opResult.getOwner());
+  if (!shapeAwareProducer) {
+    return false;
+  }
+  SmallVector<Value> sourceDynamicSizes =
+      shapeAwareProducer.getResultDynamicDimsFromValue(opResult);
+  SmallVector<OpFoldResult> sourceMixedSizes =
+      getMixedValues(sourceShape, sourceDynamicSizes, subviewOp.getContext());
+  return llvm::equal(sourceMixedSizes, subviewOp.getMixedSizes());
+}
+
+/// Canonicalize subview ops that are no-ops, using Util::ShapeAwareOpInterface
+/// to check dynamic subviews.
+/// TODO(Max191): Fold this pattern into TrivialSubViewOpFolder in llvm-project
+/// once there is an appropriate interface for dynamic shape retrieval. The
+/// existing interface (ReifyRankedShapedTypeOpInterface) can mutate the IR,
+/// so it is not viable for canonicalizers.
+class DynamicTrivialSubViewOpFolder final
+    : public OpRewritePattern<memref::SubViewOp> {
+public:
+  using OpRewritePattern<memref::SubViewOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::SubViewOp subViewOp,
+                                PatternRewriter &rewriter) const override {
+    if (!isTrivialSubViewOp(subViewOp))
+      return failure();
+    if (subViewOp.getSourceType() == subViewOp.getType()) {
+      rewriter.replaceOp(subViewOp, subViewOp.getSource());
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<memref::CastOp>(subViewOp, subViewOp.getType(),
+                                                subViewOp.getSource());
+    return success();
+  }
+};
+
+struct IREECodegenCanonicalizerPass final
+    : impl::IREECodegenCanonicalizerPassBase<IREECodegenCanonicalizerPass> {
+public:
+  using impl::IREECodegenCanonicalizerPassBase<
+      IREECodegenCanonicalizerPass>::IREECodegenCanonicalizerPassBase;
+  /// Initialize the canonicalizer by building the set of patterns used during
+  /// execution.
+  LogicalResult initialize(MLIRContext *context) override {
+    // Inherit the same config defaults from the upstream canonicalizer pass.
+    config.setUseTopDownTraversal().setRegionSimplificationLevel(
+        GreedySimplifyRegionLevel::Normal);
+
+    RewritePatternSet owningPatterns(context);
+    for (auto *dialect : context->getLoadedDialects())
+      dialect->getCanonicalizationPatterns(owningPatterns);
+    for (RegisteredOperationName op : context->getRegisteredOperations()) {
+      if (op.getStringRef() == memref::CopyOp::getOperationName()) {
+        owningPatterns.add<DynamicTrivialSubViewOpFolder>(context);
+      }
+      op.getCanonicalizationPatterns(owningPatterns, context);
+    }
+
+    patterns =
+        std::make_shared<FrozenRewritePatternSet>(std::move(owningPatterns));
+    return success();
+  }
+
+  void runOnOperation() override {
+    // Canonicalization is best-effort. Non-convergence is not a pass failure.
+    LogicalResult didConverge =
+        applyPatternsGreedily(getOperation(), *patterns, config);
+    if (this->testConvergence && failed(didConverge)) {
+      getOperation()->emitError("Canonicalizer failed to converge");
+      return signalPassFailure();
+    }
+  }
+  GreedyRewriteConfig config;
+  std::shared_ptr<const FrozenRewritePatternSet> patterns;
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -288,12 +288,12 @@ createIREEComprehensiveBufferizePass(
 void addIREEPostBufferizationPasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createIREEInjectAssumeAlignmentPass());
   funcPassManager.addPass(memref::createResolveShapedTypeResultDimsPass());
-  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createIREECodegenCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   // There are redundant memcpy (with linalg.generic form) ops created, which
   // can be deleted by canonicalizer. We have to run it again because the
   // memrefs are unified in CSE pass, so we can truely remove redundant memcpy.
-  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createIREECodegenCanonicalizerPass());
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -493,6 +493,15 @@ def IREEBufferizeConstantsPass :
   let summary = "Convert from arith.constant on tensors to buffers";
 }
 
+def IREECodegenCanonicalizerPass :
+    Pass<"iree-codegen-canonicalize", ""> {
+  let summary = "Codegen canonicalization pass with IREE specific patterns";
+  let options = [
+    Option<"testConvergence", "test-convergence", "bool",
+           /*default=*/"false", "Fails if the patterns fail to converge">
+  ];
+}
+
 def IREEComprehensiveBufferizePass :
     InterfacePass<"iree-codegen-iree-comprehensive-bufferize", "mlir::FunctionOpInterface"> {
   let summary = "Convert from to Linalg ops on tensors to buffers";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -62,6 +62,7 @@ iree_lit_test_suite(
             "generic_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "hoist_unrolled_vector_extract_insert_slice.mlir",
+            "iree_codegen_canonicalize.mlir",
             "iree_comprehensive_bufferize.mlir",
             "iree_expand_strided_metadata_with_subview_expansion.mlir",
             "iree_expand_strided_metadata.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -58,6 +58,7 @@ iree_lit_test_suite(
     "generic_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "hoist_unrolled_vector_extract_insert_slice.mlir"
+    "iree_codegen_canonicalize.mlir"
     "iree_comprehensive_bufferize.mlir"
     "iree_expand_strided_metadata.mlir"
     "iree_expand_strided_metadata_with_subview_expansion.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_codegen_canonicalize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_codegen_canonicalize.mlir
@@ -15,3 +15,18 @@ func.func @fold_dynamic_trivial_subview(%size: index) -> memref<?xf32, #hal.desc
 //       CHECK:   %[[ASSUME_ALIGN:.+]] = memref.assume_alignment %[[SUBSPAN]]
 //   CHECK-NOT:   memref.subview
 //       CHECK:   return %[[ASSUME_ALIGN]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @no_fold_dynamic_real_subview(%size: index, %slice_size: index) -> memref<?xf32, #hal.descriptor_type<storage_buffer>> {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%size}
+  %assume_align = memref.assume_alignment %0, 64 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  %subview = memref.subview %assume_align[0] [%slice_size] [1] : memref<?xf32, #hal.descriptor_type<storage_buffer>> to memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  return %subview : memref<?xf32, #hal.descriptor_type<storage_buffer>>
+}
+// CHECK-LABEL: @no_fold_dynamic_real_subview
+//       CHECK:   %[[SUBVIEW:.+]] = memref.subview
+//       CHECK:   return %[[SUBVIEW]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_codegen_canonicalize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_codegen_canonicalize.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-canonicalize))" %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @fold_dynamic_trivial_subview(%size: index) -> memref<?xf32, #hal.descriptor_type<storage_buffer>> {
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%size}
+  %assume_align = memref.assume_alignment %0, 64 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  %subview = memref.subview %assume_align[0] [%size] [1] : memref<?xf32, #hal.descriptor_type<storage_buffer>> to memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  return %subview : memref<?xf32, #hal.descriptor_type<storage_buffer>>
+}
+// CHECK-LABEL: @fold_dynamic_trivial_subview
+//  CHECK-SAME:   %[[SIZE:.+]]: index
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan{{.*}} binding(0)
+//       CHECK:   %[[ASSUME_ALIGN:.+]] = memref.assume_alignment %[[SUBSPAN]]
+//   CHECK-NOT:   memref.subview
+//       CHECK:   return %[[ASSUME_ALIGN]]


### PR DESCRIPTION
Adds a new canonicalizer pass called `IREECodegenCanonicalizerPass`, which can have additional IREE specific patterns. The only extra pattern so far is an extension of the memref.subview folder for full subviews, using the Util::ShapeAwareOpInterface to look at dynamic sizes. The pattern is IREE specific because the interface exists in IREE.

The new pass is currently only used in post-bufferization passes, since this is where the dynamic subview folder is useful, but it could be used in place of other canonicalizers in the future as well.

fixes https://github.com/iree-org/iree/issues/21417