### PR TITLE
[NFC] Switch dynamic inputs to flow.tensor.dynamic_constant.

### DIFF
--- a/tests/e2e/regression/linalg_quantized_matmul_vs_linalg_matmul.mlir
+++ b/tests/e2e/regression/linalg_quantized_matmul_vs_linalg_matmul.mlir
@@ -216,8 +216,15 @@ func.func @test_quantized_matmul_as_matmul() {
   call @check_one_quantized_matmul_as_matmul_3x4x5(%lhs_3x4_2, %rhs_4x5_2, %c_plus41, %c_minus57) : (tensor<3x4xi8>, tensor<4x5xi8>, i32, i32) -> ()
   call @check_one_quantized_matmul_as_matmul_3x4x5(%lhs_3x4_2, %rhs_4x5_2, %c_minus128, %c_plus127) : (tensor<3x4xi8>, tensor<4x5xi8>, i32, i32) -> ()
 
-  %lhs_3x4_dynamic = tensor.cast %lhs_3x4_1 : tensor<3x4xi8> to tensor<?x?xi8>
-  %rhs_4x5_dynamic = tensor.cast %rhs_4x5_1 : tensor<4x5xi8> to tensor<?x?xi8>
+  %lhs_3x4_dynamic = flow.tensor.dynamic_constant dense<[
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12]]> : tensor<3x4xi8> -> tensor<?x?xi8>
+  %rhs_4x5_dynamic = flow.tensor.dynamic_constant dense<[
+      [5, 4, 3, 2, 9],
+      [1, 0, -1, -2, 8],
+      [-3, -4, -5, -6, 7],
+      [2, 3, 5, 7, 11]]> : tensor<4x5xi8> -> tensor<?x?xi8>
   call @check_one_quantized_matmul_as_matmul_dynamic(%lhs_3x4_dynamic, %rhs_4x5_dynamic, %c_minus128, %c_plus127) : (tensor<?x?xi8>, tensor<?x?xi8>, i32, i32) -> ()
 
   return


### PR DESCRIPTION
The compiler is very smart on static shape inference that can generate partially dynamic shape during the lowering. It makes data-tiling fusion very struggle because they are expected to be dynamic shape but some dimensions are inferred to static values in Stream AnnotateDispatchAssumptions pass. Because it will lead to `tensor.cast -> set_encoding -> tensor.cast` sequence in a dispatch, while we expect the bindings have encoded tensor types. E.g.,

Input IR:

```mlir
%0 = iree_tensor_ext.dispatch_load ... tensor<?x?xi8>
%1 = set_encoding %0 : tensor<?x?xi8> -> tensor<?x?xi8, #encoding>
iree_tensor_ext.dispatch_store %1, ... tensor<?x?xi8, #encoding> ->
  ... tensor<?x?xi8, #encoding>
```

After annotation:

```mlir
%0 = iree_tensor_ext.dispatch_load ... tensor<4x?xi8>
%cast = tensor.cast %0 : tensor<4x?xi8> -> tensor<?x?xi8>
%1 = set_encoding %cast : tensor<?x?xi8> -> tensor<?x?xi8, #encoding>
%cast_0 = tensor.cast %1 : tensor<?x?xi8, #encoding> to tensor<4x5xi8>
iree_tensor_ext.dispatch_store %cast_0, ... tensor<4x5xi8> ->
  ... tensor<?x?xi8, #encoding>
```

It is hard to materialize the encodings when cast op is present.

Given that the original goal is testing dynamic shape, modifying the input program is an easier fix.

The issue is observed from https://github.com/iree-org/iree/pull/21441.