### PR TITLE
[DT] Implement TiedOpInterface for IREE::Encoding::UnsetEncodingOp.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -853,7 +853,7 @@ def Util_TiedOpInterface : OpInterface<"TiedOpInterface"> {
       /*args=*/(ins "unsigned":$resultIndex),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
-        return IREE::Util::TiedOpInterface::findTiedBaseValue($_op.getResult(resultIndex));
+        return IREE::Util::TiedOpInterface::findTiedBaseValue($_op->getResult(resultIndex));
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -245,6 +245,19 @@ struct GenericNumericCastExternalModel {
 // TiedOpInterface
 //===----------------------------------------------------------------------===//
 
+struct UnsetEncodingOpTiedOpInterface
+    : public IREE::Util::TiedOpInterface::ExternalModel<
+          UnsetEncodingOpTiedOpInterface, IREE::Encoding::UnsetEncodingOp> {
+  ::std::optional<unsigned>
+  getTiedResultOperandIndex(Operation *op, unsigned resultIndex) const {
+    return {0}; // source
+  }
+
+  SmallVector<int64_t> getTiedResultOperandIndices(Operation *op) const {
+    return {0}; // source
+  }
+};
+
 struct InsertSliceOpTiedOpInterface
     : public IREE::Util::TiedOpInterface::ExternalModel<
           InsertSliceOpTiedOpInterface, tensor::InsertSliceOp> {
@@ -469,6 +482,12 @@ void registerUtilExternalModels(DialectRegistry &registry) {
     IREE::Codegen::InnerTiledOp::attachInterface<InnerTiledOpTiedOpInterface>(
         *context);
   });
+
+  registry.addExtension(
+      +[](MLIRContext *context, IREE::Encoding::IREEEncodingDialect *dialect) {
+        IREE::Encoding::UnsetEncodingOp::attachInterface<
+            UnsetEncodingOpTiedOpInterface>(*context);
+      });
 
   registry.addExtension(
       +[](MLIRContext *context, linalg::LinalgDialect *dialect) {


### PR DESCRIPTION
In the data-tiling fusion pipeline, we form `matmul`, followed by `unset_encoding`, into the same dispatch. The revision implements the TiedOpInterface for UnsetEncodingOp, so they can use the same buffer. Otherwise, there are four arguments. One is readonly for MatmulOp's init operands and the other is writeonly for the final result.

The revision also updates the default implementation for `getTiedResult` because not all the operations have multiple result. In this context, it only has `getResult()` method. The revision forces it to use the `getResult(idx)` method from `Operation *`.