### PR TITLE
[Codegen][LLVMGPU] Support `gather_to_lds` in swizzling memory access

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -729,6 +729,7 @@ def ResolveSwizzleHintsPass :
   let dependentDialects = [
     "affine::AffineDialect",
     "arith::ArithDialect",
+    "amdgpu::AMDGPUDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -135,6 +135,10 @@ static void swizzleStore(RewriterBase &rewriter, vector::StoreOp store,
   rewriter.eraseOp(store);
 }
 
+static void
+resolveSubgroupLoadSwizzleHintOp(RewriterBase &rewriter,
+                                 IREE::Codegen::SwizzleHintOp hintOp) {}
+
 /// Resolves all hints. Walks all direct users and splits them into loads and
 /// stores. If any user is not a swizzle-able load or store, bail out and
 /// silently drop the optimization hint.
@@ -191,7 +195,11 @@ void ResolveSwizzleHintsPass::runOnOperation() {
   // silently pass through for that hint.
   IRRewriter rewriter(funcOp->getContext());
   for (IREE::Codegen::SwizzleHintOp hintOp : hintOps) {
-    resolveHintOp(rewriter, hintOp);
+    if (isa<IREE::Codegen::SubgroupLoadAttr>(hintOp.getSwizzle())) {
+      resolveSubgroupLoadSwizzleHintOp(rewriter, hintOp);
+    } else {
+      resolveHintOp(rewriter, hintOp);
+    }
   }
 
   // Drop all hints.

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -146,13 +146,11 @@ resolveSubgroupLoadSwizzleHintOp(RewriterBase &rewriter,
                                  IREE::Codegen::SwizzleHintOp hintOp) {
   auto subgroupLoadAttr =
       dyn_cast<IREE::Codegen::SubgroupLoadAttr>(hintOp.getSwizzle());
-  int64_t subgroupSize = subgroupLoadAttr.getSubgroupSize();
+  [[maybe_unused]] int64_t subgroupSize = subgroupLoadAttr.getSubgroupSize();
 
   // Get the memref size and element type
   auto memrefType = cast<MemRefType>(hintOp.getOperand().getType());
-  int64_t elementSizeInBits = memrefType.getElementTypeBitWidth();
-
-  [[maybe_unused]] int64_t elementSizeInBytes = elementSizeInBits / 8;
+  int64_t elementSizeInBytes = memrefType.getElementTypeBitWidth() / 8;
 
   // find the use chain:
   // hintOp -> vector.load -> vector.store
@@ -188,8 +186,8 @@ resolveSubgroupLoadSwizzleHintOp(RewriterBase &rewriter,
     // TODO: expand it to multiple subgroup loads if the size is larger than
     // the subgroup size.
     const int64_t kNumBitsPerCopy = 16;
-    int64_t totalCopySize = targetType.getNumElements() * elementSizeInBytes;
-    assert(totalCopySize == subgroupSize * kNumBitsPerCopy &&
+    assert(targetType.getNumElements() * elementSizeInBytes ==
+               subgroupSize * kNumBitsPerCopy &&
            "Total copy size is not equal to "
            "subgroup size times element size in bytes.");
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -192,3 +192,21 @@ func.func @swizzle_adjust_add_offset(%src: memref<?xf32>, %vec: vector<4xf32>, %
 //       CHECK:   %[[STORE_SWOFF:.+]] = arith.addi %[[STORE_BASE]], %[[OFFSET_DIFF]] : index
 //       CHECK:   vector.store %[[VEC]], %[[SRC]][%[[STORE_SWOFF]]]
 //       CHECK:   return %[[VECTOR]]
+
+// -----
+
+// CHECK: @subgroup_load
+// CHECK-SAME: (%[[SRC:.*]]: memref<1024xi8>, %[[OFFSET:.*]]: index)
+func.func @subgroup_load(%src: memref<1024xi8>, %offset: index) {
+  // CHECK-NOT: iree_codegen.swizzle_hint
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.subgroup_load<64>] : memref<1024xi8>
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[LDS:.*]] = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+  // CHECK: amdgpu.gather_to_lds %[[SRC]][%[[OFFSET]]], %[[LDS]][%[[C0]]]
+  // CHECK-NOT: vector.load
+  // CHECK-NOT: vector.store
+  %lds = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+  %1 = vector.load %0[%offset] : memref<1024xi8>, vector<16xi8>
+  vector.store %1, %lds[%offset] : memref<1024xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -226,7 +226,7 @@ func.func @subgroup_load_multiple(%src: memref<2048xi8>, %offset: index) {
   // CHECK-NOT: vector.load
   // CHECK-NOT: vector.store
   %lds = memref.alloc() : memref<2048xi8, #gpu.address_space<workgroup>>
-  %1 = vector.load %0[%offset] : memref<2048xi8>, vector<16xi8>
-  vector.store %1, %lds[%offset] : memref<2048xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+  %1 = vector.load %0[%offset] : memref<2048xi8>, vector<32xi8>
+  vector.store %1, %lds[%offset] : memref<2048xi8, #gpu.address_space<workgroup>>, vector<32xi8>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -573,6 +573,14 @@ RotateRowsAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+OpFoldResult SubgroupLoadAttr::swizzleOffset(OpBuilder &b, Location loc,
+                                             OpFoldResult offset,
+                                             Value src) const {
+  return {};
+}
+
+int64_t SubgroupLoadAttr::getAccessElementCount() const { return 0; }
+
 //===----------------------------------------------------------------------===//
 // Initialize attributes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -573,12 +573,6 @@ RotateRowsAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
-OpFoldResult SubgroupLoadAttr::swizzleOffset(OpBuilder &b, Location loc,
-                                             OpFoldResult offset,
-                                             Value src) const {
-  return {};
-}
-
 int64_t SubgroupLoadAttr::getAccessElementCount() const { return 0; }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -466,4 +466,30 @@ def IREECodegen_RotateRowsAttr  :
   let genVerifyDecl = 1;
 }
 
+//===---------------------------------------------------------------------===//
+// iree_codegen.subgroup_load_swizzle
+//===---------------------------------------------------------------------===//
+
+def IREECodegen_SubgroupLoadSwizzleAttr  :
+    AttrDef<IREECodegen_Dialect, "SubgroupLoadSwizzle", [
+    DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
+        "swizzleOffset",
+        "getAccessElementCount"
+      ]>
+    ]> {
+  let mnemonic = "rotate_rows";
+  let summary = [{An attribute that describes a swizzling pattern for rotating rows.}];
+  let description = [{
+  }];
+  let parameters = (ins
+    AttrParameter<"int64_t", "">:$row_width,
+    AttrParameter<"int64_t", "">:$access_width,
+    AttrParameter<"SmallVector<int64_t>", "">:$subgroup_size
+  );
+  let assemblyFormat = [{
+    `<` $row_width `,` $access_width `, $subgroup_size `>`
+  }];
+  let genVerifyDecl = 1;
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -473,8 +473,7 @@ def IREECodegen_RotateRowsAttr  :
 def IREECodegen_SubgroupLoadAttr  :
     AttrDef<IREECodegen_Dialect, "SubgroupLoad", [
     DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
-        "swizzleOffset",
-        "getAccessElementCount"
+        "getSubgroupSize"
       ]>
     ]> {
   let mnemonic = "subgroup_load";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -467,29 +467,37 @@ def IREECodegen_RotateRowsAttr  :
 }
 
 //===---------------------------------------------------------------------===//
-// iree_codegen.subgroup_load_swizzle
+// iree_codegen.subgroup_load
 //===---------------------------------------------------------------------===//
 
-def IREECodegen_SubgroupLoadSwizzleAttr  :
-    AttrDef<IREECodegen_Dialect, "SubgroupLoadSwizzle", [
+def IREECodegen_SubgroupLoadAttr  :
+    AttrDef<IREECodegen_Dialect, "SubgroupLoad", [
     DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
         "swizzleOffset",
         "getAccessElementCount"
       ]>
     ]> {
-  let mnemonic = "rotate_rows";
-  let summary = [{An attribute that describes a swizzling pattern for rotating rows.}];
+  let mnemonic = "subgroup_load";
+  let summary = [{An attribute that describes a swizzling pattern that allows for doing subgroup loads.}];
   let description = [{
+    Hints codegen that when chained with:
+    * a load from global memory, and
+    * a store to LDS memory,
+    the load can be lowered to `amdgpu.gather_to_lds`.
+
+    The transformation will assume that the whole memref is going to be direct-loaded to LDS.
+
+    The `subgroup_size` parameter specifies the size of the subgroup.
   }];
   let parameters = (ins
-    AttrParameter<"int64_t", "">:$row_width,
-    AttrParameter<"int64_t", "">:$access_width,
-    AttrParameter<"SmallVector<int64_t>", "">:$subgroup_size
+    //AttrParameter<"int64_t", "">:$row_width,
+    //AttrParameter<"int64_t", "">:$access_width,
+    AttrParameter<"int64_t", "">:$subgroup_size
   );
   let assemblyFormat = [{
-    `<` $row_width `,` $access_width `, $subgroup_size `>`
+    `<` $subgroup_size `>`
   }];
-  let genVerifyDecl = 1;
+  //let genVerifyDecl = 1;
 }
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS


### PR DESCRIPTION
Enable direct global loads to LDS in swizzling hint. 

* added a new swizzling attr `subgroup_load`, which takes a single subgroup size as argument.
* given a `subgroup_load` attribute, it hints that a subgroup gathering direct load to workgroup memory can be formed.
* in `ResolveSwizzleHints`, find chains of `HintOp -> vector.load (from global) -> vector.store (to workgroup)` and replace it with `amdgpu.gather_to_lds`.
* The gathering offset of each thread is designated by the offsets in the thread's original `vector.load`.
* The hint assumes that the subgroup as a whole will gather and completely overwrite the destination memref.