### PR TITLE
[LinalgExt] Use IndexingMapOpInterface for attention

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -169,10 +169,7 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
         return deriveIm2colOpThreadTileSizes(im2colOp, numThreads);
       })
       .Case([&](IREE::LinalgExt::ScatterOp scatterOp) -> SmallVector<int64_t> {
-        int64_t loopDepth = scatterOp.getLoopIteratorTypes().size();
-        SmallVector<int64_t> loopBounds =
-            scatterOp.getStaticLoopRanges().value_or(
-                SmallVector<int64_t>(loopDepth, ShapedType::kDynamic));
+        SmallVector<int64_t> loopBounds = scatterOp.getStaticLoopRanges();
         int64_t elemBits = scatterOp.getOriginalType().getElementTypeBitWidth();
         int64_t vectorSize = kPreferredCopyNumBits / elemBits;
         return getVectorTileSizesFromLoopRanges(loopBounds, numThreads,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -1018,8 +1018,7 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
   // Various problem parameters.
   int64_t loopDepth = scatter.getLoopIteratorTypes().size();
   int64_t elemBits = scatter.getOriginalType().getElementTypeBitWidth();
-  SmallVector<int64_t> loopBounds = scatter.getStaticLoopRanges().value_or(
-      SmallVector<int64_t>(loopDepth, ShapedType::kDynamic));
+  SmallVector<int64_t> loopBounds = scatter.getStaticLoopRanges();
 
   // Configurations we need to decide.
   int64_t flatWorkgroupSize = target.getPreferredSubgroupSize();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1343,21 +1343,29 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
           op.getQueryMap(), op.getKeyMap(), op.getValueMap(), op.getOutputMap())
           .value();
 
-  int64_t mDim = opInfo.getMDims().back();
-  int64_t k1Dim = opInfo.getK1Dims().back();
-  int64_t k2Dim = opInfo.getK2Dims().back();
-  int64_t nDim = opInfo.getNDims().back();
+  auto getDimAndSize = [&bounds](ArrayRef<int64_t> dims)
+      -> std::pair<std::optional<int64_t>, int64_t> {
+    std::optional<int64_t> dim;
+    int64_t size = 1;
+    if (!dims.empty()) {
+      dim = dims.back();
+      size = bounds[dim.value()];
+    }
+    return {dim, size};
+  };
+  auto [mDim, mDimSize] = getDimAndSize(opInfo.getMDims());
+  auto [k1Dim, k1DimSize] = getDimAndSize(opInfo.getK1Dims());
+  auto [k2Dim, k2DimSize] = getDimAndSize(opInfo.getK2Dims());
+  auto [nDim, nDimSize] = getDimAndSize(opInfo.getNDims());
 
   // Dynamic dims are expected to be taken care of earlier in the pipeline.
-  if (ShapedType::isDynamic(bounds[mDim]) ||
-      ShapedType::isDynamic(bounds[k1Dim]) ||
-      ShapedType::isDynamic(bounds[k2Dim]) ||
-      ShapedType::isDynamic(bounds[nDim])) {
+  if (ShapedType::isDynamic(mDimSize) || ShapedType::isDynamic(k1DimSize) ||
+      ShapedType::isDynamic(k2DimSize) || ShapedType::isDynamic(nDimSize)) {
     return failure();
   }
 
   // Bail out on skinny attention.
-  if (bounds[mDim] <= kVerySkinnyDimThreshold) {
+  if (mDimSize <= kVerySkinnyDimThreshold) {
     return failure();
   }
 
@@ -1400,16 +1408,16 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   Type vElementType = getElementTypeOrSelf(vMatrix);
   Type f32Type = b.getF32Type();
   GPUMatmulShapeType qkMatmul{
-      /*m=*/bounds[mDim],
-      /*n=*/bounds[k2Dim],
-      /*k=*/bounds[k1Dim],
+      /*m=*/mDimSize,
+      /*n=*/k2DimSize,
+      /*k=*/k1DimSize,
       /*lhsType=*/qElementType,
       /*rhsType=*/kElementType,
       /*accType=*/f32Type,
   };
-  GPUMatmulShapeType pvMatmul{/*m=*/bounds[mDim],
-                              /*n=*/bounds[nDim],
-                              /*k=*/bounds[k2Dim],
+  GPUMatmulShapeType pvMatmul{/*m=*/mDimSize,
+                              /*n=*/nDimSize,
+                              /*k=*/k2DimSize,
                               /*lhsType=*/vElementType,
                               /*rhsType=*/vElementType,
                               /*accType=*/f32Type};
@@ -1492,12 +1500,20 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   }
 
   // Compute the M/N dimension tile size by multiply subgroup information.
-  workgroupTileSizes[mDim] = pvSchedule.mSubgroupCounts[0] *
-                             pvSchedule.mTileSizes[0] * pvSchedule.mSize;
-  workgroupTileSizes[nDim] = pvSchedule.nSubgroupCounts[0] *
-                             pvSchedule.nTileSizes[0] * pvSchedule.nSize;
-
-  reductionTileSizes[k2Dim] = pvSchedule.kTileSizes[0] * pvSchedule.kSize;
+  if (mDim.has_value()) {
+    workgroupTileSizes[mDim.value()] = pvSchedule.mSubgroupCounts[0] *
+                                       pvSchedule.mTileSizes[0] *
+                                       pvSchedule.mSize;
+  }
+  if (nDim.has_value()) {
+    workgroupTileSizes[nDim.value()] = pvSchedule.nSubgroupCounts[0] *
+                                       pvSchedule.nTileSizes[0] *
+                                       pvSchedule.nSize;
+  }
+  if (k2Dim.has_value()) {
+    reductionTileSizes[k2Dim.value()] =
+        pvSchedule.kTileSizes[0] * pvSchedule.kSize;
+  }
 
   SmallVector<NamedAttribute, 2> attrs = {
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -135,12 +135,12 @@ def LinalgFusionInterface : OpInterface<"LinalgFusionOpInterface"> {
       /*desc=*/[{
         Return the static loop ranges.
       }],
-      /*retTy=*/"FailureOr<SmallVector<int64_t>>",
+      /*retTy=*/"SmallVector<int64_t>",
       /*methodName=*/"getStaticLoopRanges",
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return failure();
+        llvm_unreachable("not implemented");
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -806,6 +806,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
      DeclareOpInterfaceMethods<LinalgFusionInterface,
       ["getIndexingMapsForResults", "getIndexingMapsForOperands",
        "getStaticLoopRanges"]>,
+     DeclareOpInterfaceMethods<IndexingMapOpInterface, ["getMatchingIndexingMap"]>,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<AggregatedOpInterface, ["decomposeOperation"]>,
      DeclareOpInterfaceMethods<TilingInterface,
@@ -852,13 +853,17 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
 
   let builders = [
     OpBuilder<(ins "TypeRange":$results,
-    "Value":$query,
-    "Value":$key,
-    "Value":$value,
-    "Value":$scale,
-    "Value":$output,
-    "ArrayAttr":$indexing_maps,
-    CArg<"std::optional<Value>", "std::nullopt">:$mask)>
+      "Value":$query,
+      "Value":$key,
+      "Value":$value,
+      "Value":$scale,
+      "Value":$output,
+      "ArrayAttr":$indexing_maps,
+      CArg<"std::optional<Value>", "std::nullopt">:$mask)>,
+    OpBuilder<(ins "TypeRange":$results,
+      "ValueRange":$inputOperands,
+      "ValueRange":$initOperands,
+      "ArrayAttr":$indexing_maps)>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -41,79 +41,6 @@ namespace mlir::iree_compiler::DispatchCreation {
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct FoldAttentionMaskUnitDim final
-    : public OpRewritePattern<IREE::LinalgExt::AttentionOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(IREE::LinalgExt::AttentionOp attentionOp,
-                                PatternRewriter &rewriter) const override {
-    TypedValue<ShapedType> mask = attentionOp.getMask();
-    if (!mask) {
-      return failure();
-    }
-    auto detail = IREE::LinalgExt::AttentionOpDetail::get(
-                      attentionOp.getQueryMap(), attentionOp.getKeyMap(),
-                      attentionOp.getValueMap(), attentionOp.getOutputMap())
-                      .value();
-    auto mDims = detail.getMDims();
-    auto maskShape = mask.getType().getShape();
-    AffineMap maskMap = attentionOp.getMaskMap().value();
-    if (!mDims.size()) {
-      return failure();
-    }
-
-    llvm::DenseMap<int64_t, int64_t> loopToMaskDim;
-    for (auto [i, result] : llvm::enumerate(maskMap.getResults())) {
-      loopToMaskDim[cast<AffineDimExpr>(result).getPosition()] = i;
-    }
-
-    // Find unit M dims in the mask map.
-    llvm::DenseSet<int64_t> loopsToDrop;
-    for (int64_t dim : mDims) {
-      auto it = loopToMaskDim.find(dim);
-      if (it != loopToMaskDim.end() && maskShape[it->second] == 1) {
-        loopsToDrop.insert(dim);
-      }
-    }
-    if (loopsToDrop.size() == 0) {
-      return rewriter.notifyMatchFailure(attentionOp, "no unit M dim");
-    }
-
-    // Compute the reassociation to remove unit dims and the new shape.
-    ReassociationIndices indices;
-    SmallVector<ReassociationIndices> reassoc;
-    SmallVector<int64_t> resultShape;
-    llvm::SmallBitVector resultsToDrop(maskShape.size());
-    for (auto [i, size] : llvm::enumerate(maskShape)) {
-      int64_t loop = maskMap.getDimPosition(i);
-      if (!loopsToDrop.contains(loop)) {
-        resultShape.push_back(size);
-        if (indices.size())
-          reassoc.emplace_back(std::move(indices));
-      } else {
-        resultsToDrop.set(i);
-      }
-      indices.push_back(i);
-    }
-    if (indices.size()) {
-      reassoc.emplace_back(std::move(indices));
-    }
-
-    auto loc = attentionOp.getLoc();
-    auto collapseOp = rewriter.create<tensor::CollapseShapeOp>(
-        loc, mask.getType().clone(resultShape), mask, reassoc);
-
-    rewriter.modifyOpInPlace(attentionOp, [&]() {
-      attentionOp.getMaskMutable().assign(collapseOp);
-      AffineMap newMap = maskMap.dropResults(resultsToDrop);
-      auto newMaps = attentionOp.getIndexingMapsArray();
-      newMaps[attentionOp.getMaskMutable().begin()->getOperandNumber()] =
-          newMap;
-      attentionOp.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr(newMaps));
-    });
-    return success();
-  }
-};
-
 /// Simplify collapse_shape(expand_shape) by removing unneeded unit dimensions
 /// that get expanded and subsequently collapsed.
 ///
@@ -296,9 +223,8 @@ populatefoldUnitDimsPatterns(RewritePatternSet &foldUnitDimsPatterns) {
   IREE::LinalgExt::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns,
                                                       options);
   linalg::populateMoveInitOperandsToInputPattern(foldUnitDimsPatterns);
-  foldUnitDimsPatterns
-      .insert<FoldAttentionMaskUnitDim, DropUnitDimsFromCollapseOfExpand>(
-          foldUnitDimsPatterns.getContext());
+  foldUnitDimsPatterns.insert<DropUnitDimsFromCollapseOfExpand>(
+      foldUnitDimsPatterns.getContext());
 }
 
 static LogicalResult

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -156,14 +156,16 @@ util.func public @attention_mask_multi_m_dims(%arg0: tensor<8x4x1x128xf32>, %arg
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG4]]
 //  CHECK-SAME:     tensor<8x4x1x?x32xf32> into tensor<8x4x?x32xf32>
 //       CHECK:   %[[ATTN:.+]] = iree_linalg_ext.attention
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d5, d6, d0, d4)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d5, d6, d0, d3)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d5, d6)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5, d0, d3)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5, d0, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
 //  CHECK-SAME:     ins({{.+}}, %[[COLLAPSED]]
-//       CHECK:   util.return %[[ATTN]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ATTN]]
+//  CHECK-SAME:     tensor<8x4x128xf32> into tensor<8x4x1x128xf32>
+//       CHECK:   util.return %[[EXPAND]]
 
 
 // -----
@@ -194,14 +196,16 @@ util.func public @attention_mask_single_m_dim(%arg0 : tensor<32x1x128xf16>, %arg
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG4]]
 //  CHECK-SAME:     tensor<32x1x?xf16> into tensor<32x?xf16>
 //       CHECK:   %[[ATTN:.+]] = iree_linalg_ext.attention
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> ()>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d4)>,
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> ()>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d3)>,
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 //  CHECK-SAME:     ins({{.+}}, %[[COLLAPSED]]
-//       CHECK:   util.return %[[ATTN]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ATTN]]
+//  CHECK-SAME:     tensor<32x128xf16> into tensor<32x1x128xf16>
+//       CHECK:   util.return %[[EXPAND]]
 
 // -----
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -44,8 +44,7 @@ public:
     return (llvm::cast<ConcreteType>(op).getNumLoops());
   }
 
-  FailureOr<SmallVector<int64_t>>
-  getStaticLoopRanges(mlir::Operation *op) const {
+  SmallVector<int64_t> getStaticLoopRanges(mlir::Operation *op) const {
     return SmallVector<int64_t>(
         llvm::cast<ConcreteType>(op).getStaticLoopRanges());
   }
@@ -91,7 +90,7 @@ public:
         }));
   }
 
-  FailureOr<SmallVector<int64_t>> getStaticLoopRanges(Operation *op) const {
+  SmallVector<int64_t> getStaticLoopRanges(Operation *op) const {
     auto softmaxOp = cast<linalg::SoftmaxOp>(op);
     // Softmax loop range is the input shape.
     return SmallVector<int64_t>(softmaxOp.getInputOperandType().getShape());


### PR DESCRIPTION
Use `IndexingMapOpInterface` for attention which allows using the upstream function to drop the unit dims. 

- Added pattern to drop all attention unit dims & erased old one that only dropped dims on the mask.
- `getStaticLoopRanges` return type was modified to match the `IndexingMapOpInterface`
- Fix `KernelConfig.cpp` to handle non-existent M dims. 