### PR TITLE
[Codegen] Add padding for convolutions before IGEMM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -80,6 +80,7 @@ iree_compiler_cc_library(
         "GPUMultiBuffering.cpp",
         "GPUNestedLayoutDistributionPatterns.cpp",
         "GPUPackToIntrinsics.cpp",
+        "GPUPadConvs.cpp",
         "GPUPadOperands.cpp",
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -73,6 +73,7 @@ iree_cc_library(
     "GPUMultiBuffering.cpp"
     "GPUNestedLayoutDistributionPatterns.cpp"
     "GPUPackToIntrinsics.cpp"
+    "GPUPadConvs.cpp"
     "GPUPadOperands.cpp"
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
@@ -1,0 +1,114 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUPADCONVSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+static LogicalResult padToStaticSizes(RewriterBase &rewriter,
+                                      TilingInterface tilingInterfaceOp,
+                                      SmallVector<OpFoldResult> paddingSizes) {
+  SmallVector<Attribute> paddingValues;
+  for (Value operand : tilingInterfaceOp.getOperation()->getOperands()) {
+    paddingValues.push_back(
+        rewriter.getZeroAttr(getElementTypeOrSelf(operand.getType())));
+  }
+
+  auto options = linalg::PadTilingInterfaceOptions()
+                     .setPaddingSizes(paddingSizes)
+                     .setPaddingValues(paddingValues)
+                     .setPadToMultipleOf(true);
+
+  SmallVector<tensor::PadOp> padOps;
+  FailureOr<TilingInterface> maybePaddedOp =
+      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options, padOps);
+  if (failed(maybePaddedOp)) {
+    return tilingInterfaceOp->emitOpError("failed to pad op");
+  }
+
+  return success();
+}
+
+struct GPUPadConvsPass final : impl::GPUPadConvsPassBase<GPUPadConvsPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+
+    IRRewriter rewriter(funcOp);
+    funcOp.walk([&](TilingInterface op) {
+      auto linalgOp = dyn_cast<linalg::LinalgOp>(op.getOperation());
+      if (!linalgOp || !linalg::isaConvolutionOpInterface(linalgOp)) {
+        return;
+      }
+
+      auto loweringConfig =
+          getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
+      if (!loweringConfig) {
+        return;
+      }
+
+      // Get padding sizes from lowering_config for GEMM dimensions.
+      std::optional<SmallVector<int64_t>> paddingSizes =
+          getPaddingList(loweringConfig);
+      if (!paddingSizes) {
+        return;
+      }
+
+      // Generate padding sizes for convolution dimensions.
+      auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
+      if (failed(convDimsOrFailure)) {
+        return;
+      }
+      // No padding for filter dimensions.
+      const mlir::linalg::ConvolutionDimensions &convDims = *convDimsOrFailure;
+      auto filterDims = convDims.filterLoop;
+      llvm::sort(filterDims);
+      int64_t totalReduction = 1;
+      SmallVector<int64_t> bounds = linalgOp.getStaticLoopRanges();
+      SmallVector<int64_t> paddingConvSizes = paddingSizes.value();
+      for (unsigned dim : filterDims) {
+        assert(dim <= paddingConvSizes.size() && dim < bounds.size() &&
+               "filter dimension out of bounds");
+        paddingConvSizes.insert(paddingConvSizes.begin() + dim, 0);
+        totalReduction *= bounds[dim];
+      }
+
+      // No padding for channel dimensions if the `totalReudction` is already
+      // multiples of padding size.
+      auto channelDims = convDims.inputChannel;
+      int64_t paddingReduction = 1;
+      for (unsigned dim : channelDims) {
+        assert(dim < paddingConvSizes.size() && dim < bounds.size() &&
+               "input channel dimension out of bounds");
+        paddingReduction *= paddingConvSizes[dim];
+        totalReduction *= bounds[dim];
+      }
+      if (totalReduction % paddingReduction == 0) {
+        for (unsigned dim : channelDims) {
+          paddingConvSizes[dim] = 0;
+        }
+      }
+
+      SmallVector<OpFoldResult> padSizes =
+          getAsIndexOpFoldResult(rewriter.getContext(), paddingConvSizes);
+      rewriter.setInsertionPoint(op);
+      if (failed(padToStaticSizes(rewriter, op, padSizes))) {
+        return signalPassFailure();
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -195,6 +195,16 @@ def GPUPackToIntrinsicsPass :
   ];
 }
 
+def GPUPadConvsPass :
+    InterfacePass<"iree-codegen-gpu-pad-convs",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Pass to pad operands of a convolution with padding configuration provided.";
+  let dependentDialects = [
+    "::mlir::linalg::LinalgDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUPadOperandsPass :
     InterfacePass<"iree-codegen-gpu-pad-operands",
                   "mlir::FunctionOpInterface"> {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -45,6 +45,7 @@ iree_lit_test_suite(
             "gpu_nested_layout_vector_distribution_mask.mlir",
             "gpu_nested_layout_vector_distribution_multi_reduce.mlir",
             "gpu_nested_layout_vector_distribution_step.mlir",
+            "gpu_pad_convs.mlir",
             "gpu_pad_operands.mlir",
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_lit_test_suite(
     "gpu_nested_layout_vector_distribution_multi_reduce.mlir"
     "gpu_nested_layout_vector_distribution_step.mlir"
     "gpu_pack_to_instrinsics.mlir"
+    "gpu_pad_convs.mlir"
     "gpu_pad_operands.mlir"
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
@@ -1,0 +1,63 @@
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-pad-convs))" | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, padding = [1, 8, 32, 32, 32]}>
+func.func @conv_2d_nhwc_fhwc(%arg0: tensor<16x26x19x287xf16>, %arg1: tensor<287x3x3x287xf16>, %arg2: tensor<16x24x17x287xf32>) -> tensor<16x24x17x287xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x19x287xf16>, tensor<287x3x3x287xf16>) outs(%arg2 : tensor<16x24x17x287xf32>) attrs = {lowering_config = #lowering_config} {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<16x24x17x287xf32>
+  return %0 : tensor<16x24x17x287xf32>
+}
+
+// CHECK-LABEL: func.func @conv_2d_nhwc_fhwc
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x26x19x287xf16>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<287x3x3x287xf16>
+//  CHECK-SAME:   %[[C:[A-Za-z0-9]+]]: tensor<16x24x17x287xf32>
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 1, 16, 1]
+//       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0, 0, 0] high[1, 0, 0, 1]
+//       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[C]] low[0, 0, 0, 0] high[0, 0, 15, 1]
+//       CHECK:   %[[PADDED_RESULT:.+]] = linalg.generic
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x27x35x288xf16>, tensor<288x3x3x288xf16>)
+//  CHECK-SAME:     outs(%[[PADDED_INIT]] : tensor<16x24x32x288xf32>)
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0, 0, 0] [16, 24, 17, 287] [1, 1, 1, 1]
+//  CHECK-SAME:     : tensor<16x24x32x288xf32> to tensor<16x24x17x287xf32>
+//       CHECK:   return %[[EXTRACT]] : tensor<16x24x17x287xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5 * 2, d2 + d6 * 2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, padding = [16, 1, 1, 16, 64]}>
+func.func @conv_2d_chwn_chwf(%arg0: tensor<16x194x130x40xbf16>, %arg1: tensor<16x96x64x40xbf16>, %arg2: tensor<40x3x3x40xf32>) -> tensor<40x3x3x40xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x194x130x40xbf16>, tensor<16x96x64x40xbf16>) outs(%arg2 : tensor<40x3x3x40xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, padding = [16, 1, 1, 16, 64]}>} {
+  ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+    %1 = arith.extf %in : bf16 to f32
+    %2 = arith.extf %in_0 : bf16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<40x3x3x40xf32>
+  return %0 : tensor<40x3x3x40xf32>
+}
+
+// CHECK-LABEL: func.func @conv_2d_chwn_chwf
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x194x130x40xbf16>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<16x96x64x40xbf16>
+//  CHECK-SAME:   %[[C:[A-Za-z0-9]+]]: tensor<40x3x3x40xf32>
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 1, 1, 8]
+//       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0, 0, 0] high[0, 0, 0, 8]
+//       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[C]] low[0, 0, 0, 0] high[8, 0, 0, 8]
+//       CHECK:   %[[PADDED_RESULT:.+]] = linalg.generic
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x195x131x48xbf16>, tensor<16x96x64x48xbf16>)
+//  CHECK-SAME:     outs(%[[PADDED_INIT]] : tensor<48x3x3x48xf32>)
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0, 0, 0] [40, 3, 3, 40] [1, 1, 1, 1]
+//  CHECK-SAME:     : tensor<48x3x3x48xf32> to tensor<40x3x3x40xf32>
+//       CHECK:   return %[[EXTRACT]] : tensor<40x3x3x40xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
@@ -20,11 +20,11 @@ func.func @conv_2d_nhwc_fhwc(%arg0: tensor<16x26x19x287xf16>, %arg1: tensor<287x
 //  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x26x19x287xf16>
 //  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<287x3x3x287xf16>
 //  CHECK-SAME:   %[[C:[A-Za-z0-9]+]]: tensor<16x24x17x287xf32>
-//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 1, 16, 1]
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 0, 15, 1]
 //       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0, 0, 0] high[1, 0, 0, 1]
 //       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[C]] low[0, 0, 0, 0] high[0, 0, 15, 1]
 //       CHECK:   %[[PADDED_RESULT:.+]] = linalg.generic
-//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x27x35x288xf16>, tensor<288x3x3x288xf16>)
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x26x34x288xf16>, tensor<288x3x3x288xf16>)
 //  CHECK-SAME:     outs(%[[PADDED_INIT]] : tensor<16x24x32x288xf32>)
 //       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0, 0, 0] [16, 24, 17, 287] [1, 1, 1, 1]
 //  CHECK-SAME:     : tensor<16x24x32x288xf32> to tensor<16x24x17x287xf32>
@@ -52,11 +52,11 @@ func.func @conv_2d_chwn_chwf(%arg0: tensor<16x194x130x40xbf16>, %arg1: tensor<16
 //  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x194x130x40xbf16>
 //  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<16x96x64x40xbf16>
 //  CHECK-SAME:   %[[C:[A-Za-z0-9]+]]: tensor<40x3x3x40xf32>
-//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 1, 1, 8]
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, -1, -1, 8]
 //       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0, 0, 0] high[0, 0, 0, 8]
 //       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[C]] low[0, 0, 0, 0] high[8, 0, 0, 8]
 //       CHECK:   %[[PADDED_RESULT:.+]] = linalg.generic
-//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x195x131x48xbf16>, tensor<16x96x64x48xbf16>)
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<16x193x129x48xbf16>, tensor<16x96x64x48xbf16>)
 //  CHECK-SAME:     outs(%[[PADDED_INIT]] : tensor<48x3x3x48xf32>)
 //       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0, 0, 0] [40, 3, 3, 40] [1, 1, 1, 1]
 //  CHECK-SAME:     : tensor<48x3x3x48xf32> to tensor<40x3x3x40xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_convs.mlir
@@ -3,7 +3,7 @@
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, padding = [1, 8, 32, 32, 32]}>
+#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, padding_conv = [1, 8, 32, 32, 0, 0, 32]}>
 func.func @conv_2d_nhwc_fhwc(%arg0: tensor<16x26x19x287xf16>, %arg1: tensor<287x3x3x287xf16>, %arg2: tensor<16x24x17x287xf32>) -> tensor<16x24x17x287xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x19x287xf16>, tensor<287x3x3x287xf16>) outs(%arg2 : tensor<16x24x17x287xf32>) attrs = {lowering_config = #lowering_config} {
   ^bb0(%in: f16, %in_0: f16, %out: f32):
@@ -35,9 +35,9 @@ func.func @conv_2d_nhwc_fhwc(%arg0: tensor<16x26x19x287xf16>, %arg1: tensor<287x
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5 * 2, d2 + d6 * 2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, padding = [16, 1, 1, 16, 64]}>
-func.func @conv_2d_chwn_chwf(%arg0: tensor<16x194x130x40xbf16>, %arg1: tensor<16x96x64x40xbf16>, %arg2: tensor<40x3x3x40xf32>) -> tensor<40x3x3x40xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x194x130x40xbf16>, tensor<16x96x64x40xbf16>) outs(%arg2 : tensor<40x3x3x40xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, padding = [16, 1, 1, 16, 64]}>} {
+#lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, padding_conv = [16, 1, 1, 16, 0, 0, 0]}>
+func.func @conv_2d_chwn_chwf(%arg0: tensor<16x193x129x40xbf16>, %arg1: tensor<16x96x64x40xbf16>, %arg2: tensor<40x3x3x40xf32>) -> tensor<40x3x3x40xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x193x129x40xbf16>, tensor<16x96x64x40xbf16>) outs(%arg2 : tensor<40x3x3x40xf32>) attrs =  {lowering_config = #lowering_config} {
   ^bb0(%in: bf16, %in_0: bf16, %out: f32):
     %1 = arith.extf %in : bf16 to f32
     %2 = arith.extf %in_0 : bf16 to f32
@@ -49,10 +49,10 @@ func.func @conv_2d_chwn_chwf(%arg0: tensor<16x194x130x40xbf16>, %arg1: tensor<16
 }
 
 // CHECK-LABEL: func.func @conv_2d_chwn_chwf
-//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x194x130x40xbf16>
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<16x193x129x40xbf16>
 //  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<16x96x64x40xbf16>
 //  CHECK-SAME:   %[[C:[A-Za-z0-9]+]]: tensor<40x3x3x40xf32>
-//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, -1, -1, 8]
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0, 0, 0] high[0, 0, 0, 8]
 //       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0, 0, 0] high[0, 0, 0, 8]
 //       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[C]] low[0, 0, 0, 0] high[8, 0, 0, 8]
 //       CHECK:   %[[PADDED_RESULT:.+]] = linalg.generic

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -363,6 +363,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   // Cleanup patterns for tile and distribute
   {
     RewritePatternSet patterns(context);
+    populateSwapExtractWithCollapsePattern(patterns);
     linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     context->getOrLoadDialect<tensor::TensorDialect>()

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -494,9 +494,14 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
                                              "collapsed size must be static");
         }
 
+        // Compose all nested affine.apply chains and check if the offset is
+        // multiple of collapsed size.
+        SmallVector<Value> operands(applyOp.getOperands());
+        affine::fullyComposeAffineMapAndOperands(&map, &operands);
+        map = simplifyAffineMap(map);
         if (!map.getResult(0).isMultipleOf(maybeStaticSize.value())) {
           return rewriter.notifyMatchFailure(
-              sliceOp, "collapsed size is not divisible by offset multiplier");
+              sliceOp, "offset multiplier must be multiple of collapsed size");
         }
 
         unsigned lastReassocSize = srcShape[reassocIndices.back()];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -178,9 +178,12 @@ setPromotedOperandsList(MLIRContext *context,
 }
 
 constexpr StringLiteral kPaddingName = "padding";
+constexpr StringLiteral kPaddingConvName = "padding_conv";
 
-std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config) {
-  auto array = config.getAttributes().getAs<ArrayAttr>(kPaddingName);
+std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config,
+                                                   bool paddingConv) {
+  auto attrName = paddingConv ? kPaddingConvName : kPaddingName;
+  auto array = config.getAttributes().getAs<ArrayAttr>(attrName);
   if (!array) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -70,8 +70,9 @@ IREE::GPU::LoweringConfigAttr setPromotedOperandsList(
     ArrayRef<int64_t> operands,
     std::optional<ArrayRef<Attribute>> promotionTypes = std::nullopt);
 
-/// Helper to retrieve  list of operand to pad.
-std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config);
+/// Helper to retrieve list of operand to pad.
+std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config,
+                                                   bool paddingConv = false);
 
 IREE::GPU::UKernelConfigAttr
 getUkernelSpec(IREE::GPU::LoweringConfigAttr config);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -24,10 +24,9 @@ LogicalResult setDataTiledMultiMmaLoweringConfig(
 /// specified target.
 /// TODO: Currently this only succeeds if the target supports an mma
 /// kind. Add support for a fallback direct lowering path.
-LogicalResult
-setIGEMMConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
-                                  mlir::FunctionOpInterface entryPoint,
-                                  Operation *op, bool useDirectLoad = false);
+LogicalResult setIGEMMConvolutionLoweringConfig(
+    IREE::GPU::TargetAttr target, mlir::FunctionOpInterface entryPoint,
+    Operation *op, bool useDirectLoad = false, bool padConv = false);
 
 /// Helper for setting up a matmul config based on the specified target.
 /// TODO: Currently this only succeeds if the target supports an mma

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -123,6 +123,11 @@ static llvm::cl::opt<bool>
                       llvm::cl::desc("Enable implicit gemm for convolutions."),
                       llvm::cl::init(true));
 
+llvm::cl::opt<bool> clGPUPadConvolution(
+    "iree-codegen-llvmgpu-igemm-pad-convolution",
+    llvm::cl::desc("enable pre-padding for convolutions in igemm path"),
+    llvm::cl::init(true));
+
 static llvm::cl::opt<bool>
     clUseDirectLoad("iree-llvmgpu-use-direct-load",
                     llvm::cl::desc("Use global load DMA for direct load ops."),
@@ -3091,7 +3096,8 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
   }
   if (clLLVMGPUUseIgemm) {
     if (succeeded(IREE::GPU::setIGEMMConvolutionLoweringConfig(
-            target, entryPointFn, computeOp, clUseDirectLoad))) {
+            target, entryPointFn, computeOp, clUseDirectLoad,
+            clGPUPadConvolution))) {
       LDBG() << "Tile and fuse IGEMM config";
       return success();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -570,9 +570,9 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     options.paddingBits = 64;
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
   }
+  funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   if (forROCDL && pipelineOptions.prefetchSharedMemory) {
     funcPassManager.addPass(createFissionTransferOpsInControlFlowPass());
-    funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
     funcPassManager.addPass(createRemoveSingleIterationLoopPass());
     funcPassManager.addPass(createROCDLPrefetchSharedMemoryPass());
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -414,6 +414,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
                                    const GPUPipelineOptions &pipelineOptions,
                                    bool forROCDL) {
   if (pipelineOptions.useIgemmConvolution) {
+    funcPassManager.addPass(createGPUPadConvsPass());
     funcPassManager.addPass(createConvolutionToIGEMMPass());
   }
   // TODO (nirvedhmeshram) : Can remove this pass after
@@ -455,6 +456,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   {
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Reduction;
+    options.normalizeLoops = pipelineOptions.useIgemmConvolution ? true : false;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
@@ -484,6 +486,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   {
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Thread;
+    options.normalizeLoops = pipelineOptions.useIgemmConvolution ? true : false;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -456,7 +456,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   {
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Reduction;
-    options.normalizeLoops = pipelineOptions.useIgemmConvolution ? true : false;
+    options.normalizeLoops = pipelineOptions.useIgemmConvolution;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
@@ -486,7 +486,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   {
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Thread;
-    options.normalizeLoops = pipelineOptions.useIgemmConvolution ? true : false;
+    options.normalizeLoops = pipelineOptions.useIgemmConvolution;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -1,5 +1,8 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx942 \
-// RUN: --iree-codegen-llvmgpu-use-igemm=true --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
+// RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-igemm-pad-convolution=false --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-igemm-pad-convolution=true --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=PAD-CONV
 
 func.func @nhwc_conv_mfma() {
   %cst = arith.constant 0.000000e+00 : f32
@@ -87,6 +90,8 @@ func.func @nhwc_conv_unaligned_mfma() {
 //  CHECK-SAME:     subgroup = [2, 1, 2, 1, 0]
 //  CHECK-SAME:     workgroup = [2, 1, 32, 64, 0]
 
+//    PAD-CONV:     padding_conv = [2, 1, 32, 64, 0, 0, 0]
+
 // -----
 
 func.func @nchw_conv_unaligned_mfma() {
@@ -116,3 +121,37 @@ func.func @nchw_conv_unaligned_mfma() {
 //  CHECK-SAME:     reduction = [0, 0, 0, 0, 8]
 //  CHECK-SAME:     subgroup = [1, 2, 2, 1, 0]
 //  CHECK-SAME:     workgroup = [1, 64, 2, 32, 0]
+
+//    PAD-CONV:     padding_conv = [1, 64, 2, 32, 0, 0, 0]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+func.func @conv_nhwc_fhwc_unaligned_channel(%arg0: tensor<16x26x19x287xf16>, %arg1: tensor<287x3x3x287xf16>, %arg2: tensor<16x24x17x287xf32>) -> tensor<16x24x17x287xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x19x287xf16>, tensor<287x3x3x287xf16>) outs(%arg2 : tensor<16x24x17x287xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<16x24x17x287xf32>
+  return %0 : tensor<16x24x17x287xf32>
+}
+
+// CHECK-LABEL: func.func @conv_nhwc_fhwc_unaligned_channel
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false
+//  CHECK-SAME:   use_igemm_convolution = true
+
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+//  CHECK-SAME:     padding = [1, 8, 32, 32, 32]
+//  CHECK-SAME:     promote_operands = [0, 1, 2]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 2]
+//  CHECK-SAME:     subgroup = [1, 8, 1, 1, 0]
+//  CHECK-SAME:     workgroup = [1, 8, 32, 32, 0]
+
+//    PAD-CONV:     padding_conv = [1, 8, 32, 32, 0, 0, 32]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -61,10 +61,10 @@ hal.executable private @main {
 //      CHECK-DAG:   memref.alloc() : memref<1x4x16x36xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   memref.alloc() : memref<32x260xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      CHECK-DAG:   %[[C720:.+]] = arith.constant 720 : index
-//      CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//      CHECK-DAG:   %[[C360:.+]] = arith.constant 360 : index
+//      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //          CHECK:   scf.forall ({{.*}}) in (2, 4, 5) {
-//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C720]] step %[[C2]] {{.*}} -> (vector<1x4x1x4x4x1xf32>)
+//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C360]] step %[[C1]] {{.*}} -> (vector<1x4x1x4x4x1xf32>)
 //          CHECK:       gpu.barrier
 //      CHECK-DAG:       %[[LHS_RD:.+]] = vector.transfer_read %[[BUF0]]{{.*}} vector<8xf16>
 //      CHECK-DAG:       vector.transfer_write %[[LHS_RD]]
@@ -147,10 +147,10 @@ hal.executable private @main {
 //      CHECK-DAG:   memref.alloc() : memref<16x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   memref.alloc() : memref<2x1x32x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
+//      CHECK-DAG:   %[[C729:.+]] = arith.constant 729 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//          CHECK:   scf.forall ({{.*}}) in (17, 1, 81) {
-//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C721]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
+//          CHECK:   scf.forall ({{.*}}) in (17, 81) {
+//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C729]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
 //          CHECK:       gpu.barrier
 //      CHECK-DAG:       %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4xf16>
 //      CHECK-DAG:       %[[RHS_MM:.+]] = vector.transfer_read {{.*}} vector<4xf16>
@@ -158,8 +158,8 @@ hal.executable private @main {
 //          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4xf32>
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
-//       CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
-//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//       CHECK:        memref.copy {{.*}}#gpu.address_space<private>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -147,10 +147,10 @@ hal.executable private @main {
 //      CHECK-DAG:   memref.alloc() : memref<16x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   memref.alloc() : memref<2x1x32x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      CHECK-DAG:   %[[C729:.+]] = arith.constant 729 : index
+//      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//          CHECK:   scf.forall ({{.*}}) in (17, 81) {
-//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C729]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
+//          CHECK:   scf.forall ({{.*}}) in (17, 1, 81) {
+//          CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C721]] step %[[C1]] {{.*}} -> (vector<1x1x1x1x4x1xf32>)
 //          CHECK:       gpu.barrier
 //      CHECK-DAG:       %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4xf16>
 //      CHECK-DAG:       %[[RHS_MM:.+]] = vector.transfer_read {{.*}} vector<4xf16>
@@ -158,8 +158,8 @@ hal.executable private @main {
 //          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4xf32>
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
-//       CHECK:        memref.copy {{.*}}#gpu.address_space<private>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
-//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//          CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
+//          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1220,10 +1220,10 @@ hal.executable public @main {
 // CHECK-LABEL: func @single_pack
 // CHECK-DAG:     %[[ALLOCA:.+]] = memref.alloca() : memref<4x1xi32, #gpu.address_space<private>>
 // CHECK-DAG:     %[[C42:.+]] = arith.constant 42 : i32
+// CHECK-DAG:     %[[ALLOCA_SUBVIEW:.+]] = memref.subview %[[ALLOCA]]{{.*}} : memref<4x1xi32, #gpu.address_space<private>> to memref<4xi32, strided<[1]>, #gpu.address_space<private>>
 // CHECK:         scf.forall {{.*}} in (16, 4) {
 // CHECK:           scf.for
 // CHECK:             %[[MASK:.+]] = vector.create_mask
 // CHECK:             %[[READ0:.+]] = vector.transfer_read{{.*}} %[[MASK]]
-// CHECK-DAG:         %[[ALLOCA_SUBVIEW:.+]] = memref.subview %[[ALLOCA]]{{.*}} : memref<4x1xi32, #gpu.address_space<private>> to memref<4xi32, strided<[1]>, #gpu.address_space<private>>
 // CHECK-DAG:         %[[READ:.+]] = vector.transfer_read{{.*}}: memref<1x4xi32, strided<[4, 1]>, #gpu.address_space<private>>, vector<4xi32>
 // CHECK-DAG:         vector.transfer_write %[[READ]]{{.*}}: vector<4xi32>, memref<16x4x16x32xi32, #amdgpu.address_space<fat_raw_buffer>>


### PR DESCRIPTION
Previously for IGEMM path, we first converted convolutions to IGEMM and then padded GEMM operands using `GPUPadOperandsPass`. However, this doesn't guarantee the im2col to be vectorized after decomposition, because the reduction(K) dimension is padded after collapsing all the reduction dimensions from convolutions. The im2col input tensor on the hand still depends on the original layout of convolution and vector loads can be spanned on multiple different channel dimensions, which are not contiguous.

To solve this problem, this PR added a pass to pad convolutions before converting them to IGEMM. We directly pad the input channel dimension to be multiple of vector size, so that all vector loads from the input will be contiguous. In addition, this pass makes the use of upstream `PadTilingInterface` for padding and adapts the `padding_size` in the `lowering_config` as padding options.