### PR TITLE
Add support for split-reduction-tiling of multiple reduction dimensions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -716,7 +716,7 @@ hal.executable private @split_reduction_executable {
           scf.forall (%arg1, %arg2, %arg3) in (%3, %4, %5) {
             "use2"(%arg1, %arg2, %arg3) : (index, index, index) -> ()
           } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
         return
       }
     }
@@ -776,7 +776,7 @@ hal.executable private @only_split_reduction_executable {
         %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
         scf.forall (%arg0) = (%0) to (%1) step (%2) {
           "use1"(%arg0) : (index) -> ()
-        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
         return
       }
     }
@@ -804,3 +804,129 @@ hal.executable private @only_split_reduction_executable {
 //       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_NPROCS]], %[[ORIGCOUNTX]])
 //       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]]]
 //       CHECK:     "use1"(%[[SPLITIVREPLACEMENT]])
+
+// -----
+
+// Test resolution of split reduction loop with rank > 1.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @split_reduction_2d_executable {
+  hal.executable.variant public @split_reduction_2d_variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @split_reduction_2d layout(#pipeline_layout) count(
+        %arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5
+      %return_x, %return_y, %return_z =
+          iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg1, %arg2, %arg3, %arg4, %arg5
+      hal.return %return_x, %return_y, %return_z : index, index, index
+    }
+    builtin.module {
+      func.func @split_reduction_2d() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        scf.forall (%arg0, %arg1) in (%0, %1) {
+          "use1"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall (%arg2, %arg3, %arg4) in (%2, %3, %4) {
+            "use2"(%arg2, %arg3, %arg4) : (index, index, index) -> ()
+          } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<1>, #iree_linalg_ext.split_reduction_mapping<0>]}
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> ((((s3 * s4) * s2) * s1) * s0)>
+//       CHECK: @split_reduction_2d_variant
+//       CHECK:   hal.executable.export
+//  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG5]], %[[ARG4]]]
+//       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
+//       CHECK:   func @split_reduction_2d()
+//   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   CHECK-DAG:     %[[SPLIT_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   CHECK-DAG:     %[[WG_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   CHECK-DAG:     %[[WG_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   CHECK-DAG:     %[[WG_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   CHECK-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//       CHECK:     %[[DELINEARIZE:.+]]:5 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_UB0]], %[[SPLIT_UB1]], %[[WG_UB0]], %[[WG_UB1]], %[[WG_UB2]])
+//       CHECK:     "use1"(%[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1)
+//       CHECK:     "use2"(%[[DELINEARIZE]]#2, %[[DELINEARIZE]]#3, %[[DELINEARIZE]]#4)
+
+// -----
+
+// Test resolution of split reduction loop with permuted mappings.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @split_reduction_2d_permuted_mapping_executable {
+  hal.executable.variant public @split_reduction_2d_permuted_mapping_variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @split_reduction_2d_permuted_mapping layout(#pipeline_layout) count(
+        %arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      %return_x, %return_y, %return_z =
+          iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %return_x, %return_y, %return_z : index, index, index
+    }
+    builtin.module {
+      func.func @split_reduction_2d_permuted_mapping() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %cst5 = hal.interface.constant.load layout(#pipeline_layout) ordinal(5) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %cst5, 5 : index
+        scf.forall (%arg0, %arg1, %arg2) in (%0, %1, %2) {
+          "use1"(%arg0, %arg1, %arg2) : (index, index, index) -> ()
+          scf.forall (%arg3, %arg4, %arg5) in (%3, %4, %5) {
+            "use2"(%arg3, %arg4, %arg5) : (index, index, index) -> ()
+          } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>, #iree_linalg_ext.split_reduction_mapping<2>, #iree_linalg_ext.split_reduction_mapping<1>]}
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((((s4 * s5) * s3) * s2) * s1) * s0)>
+//       CHECK: @split_reduction_2d_permuted_mapping_variant
+//       CHECK:   hal.executable.export
+//  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]], %[[ARG3]], %[[ARG1]], %[[ARG5]], %[[ARG4]], %[[ARG6]]]
+//       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
+//       CHECK:   func @split_reduction_2d_permuted_mapping()
+//   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   CHECK-DAG:     %[[SPLIT_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   CHECK-DAG:     %[[SPLIT_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   CHECK-DAG:     %[[WG_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   CHECK-DAG:     %[[WG_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   CHECK-DAG:     %[[WG_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
+//   CHECK-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//       CHECK:     %[[DELINEARIZE:.+]]:6 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_UB1]], %[[SPLIT_UB2]], %[[SPLIT_UB0]], %[[WG_UB1]], %[[WG_UB2]], %[[WG_UB0]])
+//       CHECK:     "use1"(%[[DELINEARIZE]]#2, %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1)
+//       CHECK:     "use2"(%[[DELINEARIZE]]#5, %[[DELINEARIZE]]#3, %[[DELINEARIZE]]#4)

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_legacy_resolve_split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_legacy_resolve_split_reduction.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info{fold-split-reduction-loop-into-workgroup-mapping-loop=false}, canonicalize, cse)))" %s --verify-diagnostics --allow-unregistered-dialect | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info{fold-split-reduction-loop-into-workgroup-mapping-loop=false}, canonicalize, cse)))" %s --verify-diagnostics --allow-unregistered-dialect | FileCheck %s --enable-var-scope
 
 // Test that the legacy approach to split-reduction loop resolution works.
 
@@ -33,7 +33,7 @@ hal.executable private @split_reduction_executable {
           scf.forall (%arg1, %arg2, %arg3) in (%3, %4, %5) {
             "use2"(%arg1, %arg2, %arg3) : (index, index, index) -> ()
           } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
         return
       }
     }
@@ -54,7 +54,7 @@ hal.executable private @split_reduction_executable {
 //   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG4]], %[[ARG6]], %[[ARG5]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
-//       CHECK:   func @split_reduction
+//       CHECK:   func @split_reduction()
 //   CHECK-DAG:     %[[SPLIT_LB:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
 //   CHECK-DAG:     %[[SPLIT_UB:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
 //   CHECK-DAG:     %[[SPLIT_STEP:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
@@ -71,3 +71,139 @@ hal.executable private @split_reduction_executable {
 //       CHECK:     %[[OTHERIVREPLACEMENTS:.+]]:3 = affine.delinearize_index %[[DELINEARIZE]]#1
 //  CHECK-SAME:       into (%[[ORIG_UB0]], %[[ORIG_UB1]], %[[ORIG_UB2]]
 //       CHECK:     "use2"(%[[OTHERIVREPLACEMENTS]]#0, %[[OTHERIVREPLACEMENTS]]#1, %[[OTHERIVREPLACEMENTS]]#2)
+
+// -----
+
+// Test resolution of split reduction loop with rank > 1.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @split_reduction_2d_executable {
+  hal.executable.variant public @split_reduction_2d_variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @split_reduction_2d layout(#pipeline_layout) count(
+        %arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5
+      %return_x, %return_y, %return_z =
+          iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg1, %arg2, %arg3, %arg4, %arg5
+      hal.return %return_x, %return_y, %return_z : index, index, index
+    }
+    builtin.module {
+      func.func @split_reduction_2d() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        scf.forall (%arg0, %arg1) in (%0, %1) {
+          "use1"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall (%arg2, %arg3, %arg4) in (%2, %3, %4) {
+            "use2"(%arg2, %arg3, %arg4) : (index, index, index) -> ()
+          } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<1>, #iree_linalg_ext.split_reduction_mapping<0>]}
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> ((s3 * s4) * ((s1 * s2) * s0))>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2] -> (s0 floordiv (s1 * s2))>
+//       CHECK: @split_reduction_2d_variant
+//       CHECK:   hal.executable.export
+//  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG3]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]]]
+//       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
+//       CHECK:   func @split_reduction_2d()
+//   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   CHECK-DAG:     %[[SPLIT_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   CHECK-DAG:     %[[ORIG_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   CHECK-DAG:     %[[ORIG_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   CHECK-DAG:     %[[ORIG_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   CHECK-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//   CHECK-DAG:     %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
+//   CHECK-DAG:     %[[ORIG_COUNTX:.+]] = affine.apply #[[MAP1]]()[%[[COUNTX]], %[[SPLIT_UB0]], %[[SPLIT_UB1]]]
+//       CHECK:     %[[DELINEARIZE:.+]]:3 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_UB0]], %[[SPLIT_UB1]], %[[ORIG_COUNTX]]
+//       CHECK:     "use1"(%[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1)
+//       CHECK:     %[[OTHERIVREPLACEMENTS:.+]]:3 = affine.delinearize_index %[[DELINEARIZE]]#2
+//  CHECK-SAME:       into (%[[ORIG_UB0]], %[[ORIG_UB1]], %[[ORIG_UB2]]
+//       CHECK:     "use2"(%[[OTHERIVREPLACEMENTS]]#0, %[[OTHERIVREPLACEMENTS]]#1, %[[OTHERIVREPLACEMENTS]]#2)
+
+// -----
+
+// Test resolution of split reduction loop with permuted mappings.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">,
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @split_reduction_2d_permuted_mapping_executable {
+  hal.executable.variant public @split_reduction_2d_permuted_mapping_variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @split_reduction_2d_permuted_mapping layout(#pipeline_layout) count(
+        %arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      %return_x, %return_y, %return_z =
+          iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier(%x, %y, %z), %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %return_x, %return_y, %return_z : index, index, index
+    }
+    builtin.module {
+      func.func @split_reduction_2d_permuted_mapping() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %cst5 = hal.interface.constant.load layout(#pipeline_layout) ordinal(5) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %cst5, 5 : index
+        scf.forall (%arg0, %arg1, %arg2) in (%0, %1, %2) {
+          "use1"(%arg0, %arg1, %arg2) : (index, index, index) -> ()
+          scf.forall (%arg3, %arg4, %arg5) in (%3, %4, %5) {
+            "use2"(%arg3, %arg4, %arg5) : (index, index, index) -> ()
+          } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>, #iree_linalg_ext.split_reduction_mapping<2>, #iree_linalg_ext.split_reduction_mapping<1>]}
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s3 * s4) * s5) * ((s1 * s2) * s0))>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 floordiv ((s1 * s2) * s3))>
+//       CHECK: @split_reduction_2d_permuted_mapping_variant
+//       CHECK:   hal.executable.export
+//  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG5]], %[[ARG4]], %[[ARG6]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
+//       CHECK:   func @split_reduction_2d_permuted_mapping()
+//   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   CHECK-DAG:     %[[SPLIT_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   CHECK-DAG:     %[[SPLIT_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   CHECK-DAG:     %[[ORIG_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   CHECK-DAG:     %[[ORIG_UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   CHECK-DAG:     %[[ORIG_UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
+//   CHECK-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//   CHECK-DAG:     %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
+//   CHECK-DAG:     %[[ORIG_COUNTX:.+]] = affine.apply #[[MAP1]]()[%[[COUNTX]], %[[SPLIT_UB0]], %[[SPLIT_UB1]], %[[SPLIT_UB2]]]
+//       CHECK:     %[[DELINEARIZE:.+]]:4 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_UB0]], %[[SPLIT_UB1]], %[[SPLIT_UB2]], %[[ORIG_COUNTX]]
+//       CHECK:     "use1"(%[[DELINEARIZE]]#2, %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1)
+//       CHECK:     %[[OTHERIVREPLACEMENTS:.+]]:3 = affine.delinearize_index %[[DELINEARIZE]]#3
+//  CHECK-SAME:       into (%[[ORIG_UB1]], %[[ORIG_UB2]], %[[ORIG_UB0]]
+//       CHECK:     "use2"(%[[OTHERIVREPLACEMENTS]]#2, %[[OTHERIVREPLACEMENTS]]#0, %[[OTHERIVREPLACEMENTS]]#1)

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -194,7 +194,7 @@ hal.executable private @split_reduction_executable {
           scf.forall (%arg1, %arg2, %arg3) in (%3, %4, %5) {
             "use2"(%arg1, %arg2, %arg3) : (index, index, index) -> ()
           } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
         return
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize_legacy_resolve_split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize_legacy_resolve_split_reduction.mlir
@@ -194,7 +194,7 @@ hal.executable private @split_reduction_executable {
           scf.forall (%arg1, %arg2, %arg3) in (%3, %4, %5) {
             "use2"(%arg1, %arg2, %arg3) : (index, index, index) -> ()
           } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-        } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+        } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
         return
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_workgroup_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_workgroup_distribution.mlir
@@ -48,7 +48,7 @@ func.func @nested_split_reduction_and_workgroup_forall(%arg0 : i32,
     scf.forall (%iv1) in (32) {
       memref.store %arg0, %out[%iv0, %iv1] : memref<?x?xi32, #hal.descriptor_type<storage_buffer>>
     } {mapping = [#iree_codegen.workgroup_mapping<x>]}
-  } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+  } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
   return
 }
 // CHECK-LABEL: func @nested_split_reduction_and_workgroup_forall

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -416,7 +416,7 @@ LogicalResult WorkgroupMappingAttr::verifyAttrList(MLIRContext *context,
   for (auto attr : attrs) {
     auto typedAttr =
         ::mlir::dyn_cast_or_null<IREE::Codegen::WorkgroupMappingAttr>(attr);
-    if (!attr) {
+    if (!typedAttr) {
       return emitError() << "expected all the mapping attribute to be of "
                             "`WorkgroupMappingAttr` type";
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -642,9 +642,12 @@ checkDispatchForVectorDistribution(Operation *parentOp) {
   }
   if (forallOp) {
     std::optional<ArrayAttr> mapping = forallOp->getMapping();
-    if (!mapping || mapping->size() != 1 ||
-        !isa<IREE::LinalgExt::SplitReductionMappingAttr>(
-            mapping->getValue().front())) {
+    if (!mapping) {
+      return failure();
+    }
+    if (failed(IREE::LinalgExt::SplitReductionMappingAttr::verifyAttrList(
+            forallOp->getContext(), forallOp->getLoc(), mapping->getValue(),
+            /*emitDiagnosticErrors =*/false))) {
       return failure();
     }
     if (foundLinalgOp) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -325,7 +325,7 @@ func.func @split_reduction_config(%arg0 : tensor<?x131072xf32>,
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %7 into %arg2[0, %5] [%1, 1] [1, 1] : tensor<?xf32> into tensor<?x1024xf32>
     }
-  } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+  } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
   iree_tensor_ext.dispatch.tensor.store %3, %result,
       offsets = [0, 0], sizes = [%1, 1024], strides = [1, 1]
       : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%1}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -68,14 +68,26 @@ def SplitReductionMappingAttr :
     AttrDef<IREELinalgExt_Dialect, "SplitReductionMapping", [
       DeclareAttrInterfaceMethods<DeviceMappingAttrInterface, []>]> {
   let mnemonic = "split_reduction_mapping";
-  let parameters = (ins);
-  let assemblyFormat = "";
+  let parameters = (ins
+    "int64_t":$dimension
+  );
+  let assemblyFormat = "`<` $dimension `>`";
   let description = [{
     Mapping attribute to indicate distribution for split-reduction.
 
     This attribute indicates that the `scf.forall` represent parallel partial
     reductions generated through the use of
     `ReductionTilingStrategy::PartialReductionOuterParallel`.
+  }];
+  let extraClassDeclaration = [{
+    // Checks that a list of attributes is well-defined.
+    static LogicalResult verifyAttrList(::mlir::MLIRContext *context,
+        Location loc, ArrayRef<Attribute> attrs, bool emitDiagnosticErrors = true);
+
+    // Less than operator for easy comparison.
+    bool operator<(
+        const ::mlir::iree_compiler::IREE::LinalgExt::SplitReductionMappingAttr &rhs)
+        const;
   }];
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -2090,11 +2090,17 @@ func.func @custom_op_index(%arg0 : tensor<?x?xindex>) -> tensor<?x?xindex> {
 
 // -----
 
-func.func @split_reduction_mapping(%arg0 : index) {
-  scf.forall (%iv) in (%arg0) {
+func.func @split_reduction_mapping(%arg0 : index,
+    %arg1 : index, %arg2 : index) {
+  scf.forall (%iv0, %iv1, %iv2) in (%arg0, %arg1, %arg2) {
 
-  } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+  } {mapping = [#iree_linalg_ext.split_reduction_mapping<1>,
+                #iree_linalg_ext.split_reduction_mapping<0>,
+                #iree_linalg_ext.split_reduction_mapping<2>]}
   return
 }
 // CHECK-LABEL: func @split_reduction_mapping
-//       CHECK:   mapping = [#iree_linalg_ext.split_reduction_mapping]
+//       CHECK:   mapping = [
+//  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<1>,
+//  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<0>,
+//  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<2>]

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -18,8 +18,8 @@ util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf3
   } -> tensor<?xf32>
   util.return %2 : tensor<?xf32>
 }
-// CHECK-LABEL:  util.func public @split_reduction_dynamic
-//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-LABEL:  @split_reduction_dynamic
+//  CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //       CHECK:    %[[EMPTY0:.+]] = tensor.empty(%{{.+}}) : tensor<?xf32>
 //       CHECK:    %[[FILL0:.+]] = linalg.fill
 //  CHECK-SAME:        outs(%[[EMPTY0]] :
@@ -33,15 +33,16 @@ util.func public @split_reduction_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?xf3
 //       CHECK:        %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:            outs(%[[FILL1]] :
 //       CHECK:        tensor.parallel_insert_slice %[[GENERIC]] into %[[INIT]]
-//       CHECK:      } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+//       CHECK:      } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
 //       CHECK:      flow.return %[[FORALL]] : tensor<?x?xf32>
-//       CHECK:    %[[REDUCE:.+]] = linalg
-//  CHECK-SAME:      ins(%[[DISPATCH]] :
-//  CHECK-SAME:      outs(%[[FILL0]] :
+//       CHECK:    %[[REDUCE:.+]] = linalg.reduce
+//  CHECK-SAME:        ins(%[[DISPATCH]] :
+//  CHECK-SAME:        outs(%[[FILL0]] :
+//  CHECK-SAME:        dimensions = [1]
 //       CHECK:    util.return %[[REDUCE]]
 
 // Check that count region contains splitk modifier.
-// WORKGROUP-LABEL:   util.func public @split_reduction_dynamic
+// WORKGROUP-LABEL:   @split_reduction_dynamic(
 //       WORKGROUP:     count(
 //       WORKGROUP:       iree_tensor_ext.dispatch.workgroup_count_from_slice
 //       WORKGROUP:       iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier
@@ -64,18 +65,75 @@ util.func public @split_reduction_static(%arg0: tensor<64x4096xf32>) -> tensor<6
   } -> tensor<64xf32>
   util.return %2 : tensor<64xf32>
 }
-// CHECK-LABEL:  util.func public @split_reduction_static
-//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<64x4096xf32>
+// CHECK-LABEL:  @split_reduction_static(
+//  CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<64x4096xf32>
 //       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
 //       CHECK:      %[[FORALL:.+]] = scf.forall
 //       CHECK:        linalg.generic
 //       CHECK:      flow.return %[[FORALL]] : tensor<64x32xf32>
-//       CHECK:    %[[REDUCE:.+]] = linalg
-//  CHECK-SAME:      ins(%[[DISPATCH]] :
+//       CHECK:    %[[REDUCE:.+]] = linalg.reduce
+//  CHECK-SAME:        ins(%[[DISPATCH]] :
+//  CHECK-SAME:        dimensions = [1]
 //       CHECK:    util.return %[[REDUCE]]
 
 // Check that count region contains splitk modifier.
-// WORKGROUP-LABEL:   util.func public @split_reduction_static
+// WORKGROUP-LABEL:   @split_reduction_static
 //       WORKGROUP:     count(
 //       WORKGROUP:       iree_tensor_ext.dispatch.workgroup_count_from_slice
 //       WORKGROUP:       iree_tensor_ext.dispatch.workgroup_count_split_reduction_modifier
+
+// -----
+
+// Test multiple reduction dimensions.
+
+util.func public @split_reduction_multiple_dims(%arg0: tensor<?x?x?xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?x?xf32>
+  %0 = tensor.empty(%dim) : tensor<?xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<?xf32>) -> tensor<?xf32>
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>],
+      iterator_types = ["parallel", "reduction", "reduction"],
+      iree_linalg_ext.split_reduction = [128, 16]}
+      ins(%arg0 : tensor<?x?x?xf32>) outs(%1 : tensor<?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %3 = arith.addf %in, %out : f32
+    linalg.yield %3 : f32
+  } -> tensor<?xf32>
+  util.return %2 : tensor<?xf32>
+}
+// CHECK-LABEL:  @split_reduction_multiple_dims(
+//  CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?xf32>
+//   CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:    %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:    %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//   CHECK-DAG:    %[[D2:.+]] = tensor.dim %[[ARG0]], %[[C2]]
+//   CHECK-DAG:    %[[PARTIAL_D1:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%[[D1]]]
+//   CHECK-DAG:    %[[PARTIAL_D2:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 16)>()[%[[D2]]]
+//       CHECK:    %[[EMPTY:.+]] = tensor.empty(%[[D0]], %[[PARTIAL_D1]], %[[PARTIAL_D2]]) : tensor<?x?x?xf32>
+//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:      %[[FORALL:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]]) =
+//  CHECK-SAME:          (0, 0) to (%[[D1]], %[[D2]]) step (128, 16)
+//  CHECK-SAME:          shared_outs(%[[INIT:.+]] = %[[EMPTY]]) -> (tensor<?x?x?xf32>) {
+//   CHECK-DAG:        %[[T1:.+]] = affine.min affine_map<(d0)[s0] -> (-d0 + s0, 128)>(%[[IV0]])[%[[D1]]]
+//   CHECK-DAG:        %[[T2:.+]] = affine.min affine_map<(d0)[s0] -> (-d0 + s0, 16)>(%[[IV1]])[%[[D2]]]
+//       CHECK:        %[[INPUT_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[IV0]], %[[IV1]]] [%[[D0]], %[[T1]], %[[T2]]]
+//   CHECK-DAG:        %[[OUT_OFFSET0:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 128)>()[%[[IV0]]]
+//   CHECK-DAG:        %[[OUT_OFFSET1:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 16)>()[%[[IV1]]]
+//       CHECK:        %[[INIT_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, %[[OUT_OFFSET0]], %[[OUT_OFFSET1]]] [%[[D0]], 1, 1]
+//       CHECK:        %[[FILL:.+]] = linalg.fill
+//  CHECK-SAME:            outs(%[[INIT_SLICE]] :
+//       CHECK:        %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:            iterator_types = ["parallel", "reduction", "reduction"]
+//  CHECK-SAME:            ins(%[[INPUT_SLICE]] :
+//  CHECK-SAME:            outs(%[[FILL]] :
+//       CHECK:        tensor.parallel_insert_slice %[[GENERIC]] into %[[INIT]]
+//       CHECK:      } {mapping = [#iree_linalg_ext.split_reduction_mapping<1>, #iree_linalg_ext.split_reduction_mapping<0>]}
+//       CHECK:      flow.return %[[FORALL]] : tensor<?x?x?xf32>
+//       CHECK:    %[[REDUCE:.+]] = linalg.reduce
+//  CHECK-SAME:        ins(%[[DISPATCH]] :
+//  CHECK-SAME:        dimensions = [1, 2]
+//       CHECK:    util.return %[[REDUCE]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/materialize_default_workgroup_count_region.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/materialize_default_workgroup_count_region.mlir
@@ -63,7 +63,7 @@ util.func @test_split_reduction_modified(%arg0 : index, %arg1 : index, %arg2 : i
         tensor.parallel_insert_slice %3 into %init[0, 0] [%arg0_capture, %arg1_capture] [1, 1]
             : tensor<?x?xf32> into tensor<?x?xf32>
       }
-    } {mapping = [#iree_linalg_ext.split_reduction_mapping]}
+    } {mapping = [#iree_linalg_ext.split_reduction_mapping<0>]}
     iree_tensor_ext.dispatch.tensor.store %2, %output,
         offsets = [0, 0], sizes = [%arg0_capture, %arg1_capture], strides = [1, 1]
         : tensor<?x?xf32> ->

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -426,3 +426,34 @@ util.func @split_reduction_by_tiling(%arg0 : tensor<?x131072xf32>) -> tensor<?xf
 //       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[FORALL]]
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups[%[[D0]]](%[[DISPATCH0]], %[[D0]])
 //       CHECK:   return %[[DISPATCH1]]
+
+// -----
+
+util.func @split_reduction_2d_by_tiling(%arg0 : tensor<?x2048x128xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x2048x128xf32>
+  %empty = tensor.empty(%d0) : tensor<?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?xf32>) -> tensor<?xf32>
+  %reduce = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0)>],
+      iterator_types = ["parallel", "reduction", "reduction"],
+      iree_linalg_ext.split_reduction = [128, 64]}
+      ins(%arg0 : tensor<?x2048x128xf32>) outs(%fill : tensor<?xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<?xf32>
+  util.return %reduce : tensor<?xf32>
+}
+// CHECK-LABEL: @split_reduction_2d_by_tiling
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x2048x128xf32>
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.workgroups
+//  CHECK-SAME:       [%[[D0]]](%[[ARG0]], %[[D0]])
+//       CHECK:     %[[FORALL:.+]] = scf.forall
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[FORALL]]
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups[%[[D0]]](%[[DISPATCH0]], %[[D0]])
+//       CHECK:   return %[[DISPATCH1]]

--- a/tests/e2e/regression/split_reduction_using_tiling.mlir
+++ b/tests/e2e/regression/split_reduction_using_tiling.mlir
@@ -41,3 +41,49 @@ func.func @simple_large_reduction_tiling_static() {
   check.expect_almost_eq (%normal_reduce, %split_reduction, atol 0.1) : tensor<128xf32>
   return
 }
+
+func.func @simple_large_reduction_2d_tiling_static() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f32
+  %normalize = arith.constant 131200.0 : f32
+  %input_empty = tensor.empty() : tensor<128x2048x128xf32>
+  %input = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      outs(%input_empty : tensor<128x2048x128xf32>) {
+    ^bb0(%b0 : f32):
+      %0 = linalg.index 0 : index
+      %1 = linalg.index 1 : index
+      %11 = linalg.index 2 : index
+      %2 = arith.addi %0, %1 : index
+      %21 = arith.addi %2, %11 : index
+      %3 = arith.index_cast %21 : index to i32
+      %4 = arith.uitofp %3 : i32 to f32
+      %5 = arith.divf %4, %normalize : f32
+      linalg.yield %5 : f32
+  } -> (tensor<128x2048x128xf32>)
+  %input_opt_barrier = util.optimization_barrier %input : tensor<128x2048x128xf32>
+  %empty = tensor.empty() : tensor<128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+  %normal_reduce = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0)>],
+      iterator_types = ["parallel", "reduction", "reduction"]}
+      ins(%input_opt_barrier : tensor<128x2048x128xf32>) outs(%fill : tensor<128xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<128xf32>
+  %split_reduction = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0)>],
+      iterator_types = ["parallel", "reduction", "reduction"],
+      iree_linalg_ext.split_reduction = [128, 64]}
+      ins(%input_opt_barrier : tensor<128x2048x128xf32>) outs(%fill : tensor<128xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<128xf32>
+  check.expect_almost_eq (%normal_reduce, %split_reduction, atol 0.1) : tensor<128xf32>
+  return
+}


### PR DESCRIPTION
Current implementation of split-reduction (using tiling) supported
only splitting a single-reduction dimension. This adds support for
split-reduction-tiling of multiple reduction dimensions. The main
change here is the change to the
`#iree_codegen.split_reduction_mapping` attribute that has a
`dimension` argument to specify the mapping for the multiple
dimensions of the created `scf.forall` op.

There is alos a verification method added to verify a list of
split-reduction-mapping attributes. The verification does not kick in
automatically, but is called explicitly when needed.

`ReconcileTranslationInfo` is changed to resolve the multi-dimensional
split-reduction `scf.forall` loop created.

Signed-off-by: MaheshRavishankar <mravisha@amd.com>