### PR TITLE
[DT][NFC] Unified DEBUG_TYPE for encoding materialization implementations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -50,7 +50,7 @@
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
-#define DEBUG_TYPE "iree-cpu-encoding-external-models"
+#define DEBUG_TYPE "iree-codegen-materialize-encoding"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -49,7 +49,9 @@
 #include <cstdint>
 #include <numeric>
 
-#define DEBUG_TYPE "iree-gpu-encoding-external-models"
+#define DEBUG_TYPE "iree-codegen-materialize-encoding"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::GPU {
 
@@ -271,10 +273,10 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   IREE::GPU::DataTiledMMAAttr mma = chooseDataTiledMMAAttr(
       resultEncoding.getElementTypesArray(), targetAttr, resultEncoding);
   if (!mma) {
-    LLVM_DEBUG(llvm::dbgs() << "expect encodings on operand types\n");
+    LDBG("expect encodings on operand types");
     return nullptr;
   }
-  LLVM_DEBUG(llvm::dbgs() << "Target MMA: " << mma << "\n");
+  LDBG("Target MMA: " << mma);
 
   MLIRContext *ctx = builder.getContext();
   SmallVector<AffineExpr> lhsExprs, rhsExprs, accExprs;


### PR DESCRIPTION
Based on debug experience, we usually want to see all the logs. Thus, having different debug types does not make sense.

The DEBUG_TYPE is switched to be as the same as the one in `MaterializeEncoding` pass.