### PR TITLE
[LinalgExt] Add pattern to make attention more static

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -236,6 +236,156 @@ verifyGatherScatter(OpTy op, int64_t sliceRank, ShapedType originalType,
   return success();
 }
 
+/// For each of the operand in `operands` this function maps the static sizes of
+/// dimensions to their affine dim expressions.
+template <typename OpTy>
+static void populateMap(OpTy op, MutableArrayRef<OpOperand> operands,
+                        llvm::DenseMap<AffineExpr, int64_t> &affineExprToSize) {
+  for (OpOperand &opOperand : operands) {
+    if (op.isScalar(&opOperand)) {
+      continue;
+    }
+    Value src = opOperand.get();
+    auto sourceType = llvm::cast<RankedTensorType>(src.getType());
+    auto sourceMap = op.getMatchingIndexingMap(&opOperand);
+
+    // Get the `sourceShape` of the `sourceType`. If the operand is a result of
+    // `tensor.cast` operation and source of the cast operation has a static
+    // shape, then assign it to the `sourceShape`.
+    auto castOp = src.getDefiningOp<tensor::CastOp>();
+    ArrayRef<int64_t> sourceShape = sourceType.getShape();
+    if (castOp && tensor::canFoldIntoConsumerOp(castOp)) {
+      sourceShape = castOp.getSource().getType().getShape();
+    }
+
+    // If the source shape's dimension has a static shape, map the affine dim
+    // expression to the known static size.
+    for (unsigned i = 0; i < sourceShape.size(); ++i) {
+      if (sourceType.isDynamicDim(i)) {
+        continue;
+      }
+      if (auto affineDimExpr =
+              dyn_cast<AffineDimExpr>(sourceMap.getResult(i))) {
+        affineExprToSize.try_emplace(affineDimExpr, sourceShape[i]);
+      }
+    }
+  }
+}
+
+/// Creates new operand w.r.t 'opOperand' of `op` with static sizes
+/// mapped in `affineExprToSize`. New operands are created in `newOperands` and
+/// their result types is stored in `resultTypes`. If `opOperand` requires no
+/// change then `changeNeeded` is false and same operand is added in the
+/// `newOperands` list.
+template <typename OpTy>
+static void createNewOperandWithStaticSizes(
+    Location loc, PatternRewriter &rewriter, OpOperand *opOperand,
+    llvm::DenseMap<AffineExpr, int64_t> &affineExprToSize, OpTy op,
+    SmallVector<Value> &newOperands, SmallVector<Type> &resultTypes,
+    bool &changeNeeded) {
+  Value src = opOperand->get();
+  newOperands.push_back(src);
+  if (op.isScalar(opOperand)) {
+    return;
+  }
+  auto sourceType = llvm::cast<RankedTensorType>(src.getType());
+  Type resultType = sourceType;
+  ArrayRef<int64_t> sourceShape = sourceType.getShape();
+  AffineMap sourceMap = op.getMatchingIndexingMap(opOperand);
+  SmallVector<int64_t> newShape;
+
+  // If operand is updated with new shape, `newOperandNeeded` will be
+  // true.
+  bool newOperandNeeded = false;
+  for (unsigned i = 0; i < sourceShape.size(); ++i) {
+    int64_t dimShape = sourceShape[i];
+    AffineExpr dimExpr = sourceMap.getResult(i);
+    if (!affineExprToSize.contains(dimExpr) || !sourceType.isDynamicDim(i)) {
+      newShape.push_back(dimShape);
+      continue;
+    }
+    // Dimension has a dynamic shape and corresponding affine dim
+    // expression is present in the map. So assign the size for the
+    // given affine dim expression to the dimension.
+    newShape.push_back(affineExprToSize[dimExpr]);
+    newOperandNeeded = true;
+  }
+  resultType = RankedTensorType::get(newShape, sourceType.getElementType(),
+                                     sourceType.getEncoding());
+  if (newOperandNeeded) {
+    changeNeeded = true;
+    // Get the new operand value given its size and element type by
+    // casting it.
+    Value newOperand = rewriter.create<tensor::CastOp>(loc, resultType, src);
+    unsigned index = opOperand->getOperandNumber();
+    newOperands[index] = newOperand;
+  }
+  if (op.isDpsInit(opOperand)) {
+    resultTypes.push_back(resultType);
+  }
+}
+
+namespace {
+/// Pattern to make an operation more static by looking at the affine dim
+/// expressions of other, more static, operands. This requires the operation to
+/// implement the DPS interface and to have indexing maps.
+template <typename OpTy>
+struct StaticizeLinalgExtOp : public OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.hasPureTensorSemantics()) {
+      return failure();
+    }
+
+    if (llvm::any_of(op.getIndexingMapsArray(), [](AffineMap map) {
+          return !map.isProjectedPermutation();
+        })) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+
+    // For each of the affine dim expression, check if the size is known. If
+    // known add that in the map.
+    llvm::DenseMap<AffineExpr, int64_t> affineExprToSize;
+    populateMap(op, op->getOpOperands(), affineExprToSize);
+
+    SmallVector<Value> newOperands;
+    SmallVector<Type> resultTypes;
+    newOperands.reserve(op->getNumOperands());
+    resultTypes.reserve(op.getNumDpsInits());
+
+    // Iterate over all the operands and update the static sizes.
+    bool changeNeeded = false;
+    for (OpOperand &opOperand : op->getOpOperands()) {
+      createNewOperandWithStaticSizes(loc, rewriter, &opOperand,
+                                      affineExprToSize, op, newOperands,
+                                      resultTypes, changeNeeded);
+    }
+    if (!changeNeeded) {
+      return failure();
+    }
+
+    // Clone op.
+    Operation *newOp = clone(rewriter, op, resultTypes, newOperands);
+    SmallVector<Value> replacements;
+    replacements.reserve(newOp->getNumResults());
+    for (auto [oldResult, newResult] :
+         llvm::zip_equal(op->getResults(), newOp->getResults())) {
+      Type newType = newResult.getType();
+      Type oldType = oldResult.getType();
+      replacements.push_back((newType != oldType)
+                                 ? rewriter.create<tensor::CastOp>(
+                                       loc, oldType, cast<Value>(newResult))
+                                 : cast<Value>(newResult));
+    }
+    rewriter.replaceOp(op, replacements);
+    return success();
+  }
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // ScatterOp
 //===----------------------------------------------------------------------===//
@@ -1882,6 +2032,11 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsForResults() {
   return SmallVector<AffineMap>(maps.begin() + getNumDpsInputs(), maps.end());
 }
 
+void AttentionOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                              MLIRContext *ctx) {
+  patterns.insert<StaticizeLinalgExtOp<AttentionOp>>(ctx);
+}
+
 //===----------------------------------------------------------------------===//
 // OnlineAttentionOp
 //===----------------------------------------------------------------------===//
@@ -2017,6 +2172,11 @@ LogicalResult OnlineAttentionOp::reifyResultShapes(
 SmallVector<AffineMap> OnlineAttentionOp::getIndexingMapsArray() {
   return SmallVector<AffineMap>(
       getIndexingMaps().getAsValueRange<AffineMapAttr>());
+}
+
+void OnlineAttentionOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                                    MLIRContext *ctx) {
+  patterns.insert<StaticizeLinalgExtOp<OnlineAttentionOp>>(ctx);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -280,7 +280,7 @@ static void populateMap(OpTy op, MutableArrayRef<OpOperand> operands,
 template <typename OpTy>
 static void createNewOperandWithStaticSizes(
     Location loc, PatternRewriter &rewriter, OpOperand *opOperand,
-    llvm::DenseMap<AffineExpr, int64_t> &affineExprToSize, OpTy op,
+    const llvm::DenseMap<AffineExpr, int64_t> &affineExprToSize, OpTy op,
     SmallVector<Value> &newOperands, SmallVector<Type> &resultTypes,
     bool &changeNeeded) {
   Value src = opOperand->get();
@@ -307,7 +307,7 @@ static void createNewOperandWithStaticSizes(
     // Dimension has a dynamic shape and corresponding affine dim
     // expression is present in the map. So assign the size for the
     // given affine dim expression to the dimension.
-    newShape.push_back(affineExprToSize[dimExpr]);
+    newShape.push_back(affineExprToSize.at(dimExpr));
     newOperandNeeded = true;
   }
   resultType = RankedTensorType::get(newShape, sourceType.getElementType(),

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -899,6 +899,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     static StringRef getQKAttrStr() { return "qk_attrs"; }
     static StringRef getPVAttrStr() { return "pv_attrs"; }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1034,6 +1036,8 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
     static StringRef getQKAttrStr() { return "qk_attrs"; }
     static StringRef getPVAttrStr() { return "pv_attrs"; }
   }];
+
+  let hasCanonicalizer = 1;
 }
 //===----------------------------------------------------------------------===//
 // Im2col

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/reshape_fusion.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/reshape_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-linalg-ext-test-reshape-fusion, canonicalize, cse, canonicalize))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-linalg-ext-test-reshape-fusion, cse))" %s | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>


### PR DESCRIPTION
Adds pattern to make attention ops more static based on shared affine dims. This was mainly copied from the upstream Linalg canonicalization pattern with minor modifications.


Closes https://github.com/iree-org/iree/issues/21471