### PR TITLE
[build] Add GFX ARCH type to bitcode file names

### DIFF
--- a/build_tools/cmake/iree_amdgpu_binary.cmake
+++ b/build_tools/cmake/iree_amdgpu_binary.cmake
@@ -74,7 +74,7 @@ function(iree_amdgpu_binary)
   set(_BITCODE_FILES)
   foreach(_SRC ${_RULE_SRCS})
     get_filename_component(_BITCODE_SRC_PATH "${_SRC}" REALPATH)
-    string(REGEX REPLACE "[.]c$" ".bc" _BITCODE_FILE ${_SRC})
+    string(REGEX REPLACE "[.]c$" "--${_RULE_ARCH}.bc" _BITCODE_FILE ${_SRC})
     list(APPEND _BITCODE_FILES ${_BITCODE_FILE})
     add_custom_command(
       OUTPUT


### PR DESCRIPTION
Adds GFX arch to bc files in iree_amdgpu_binary.cmake. Without this generated binaries would contain invalid instruction data for all but the first listed arch type.