### PR TITLE
[HAL] Allow HAL dialect to store attributes in properties structs

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchExterns.cpp
@@ -106,7 +106,7 @@ outlineDispatchExternOp(std::string name,
 
     // Add an export pointing at the entry point function.
     auto exportOp = variantBuilder.create<IREE::HAL::ExecutableExportOp>(
-        dispatchExternOp.getLoc(), dispatchExternOp.getExportAttr(),
+        dispatchExternOp.getLoc(), dispatchExternOp.getExportNameAttr(),
         targetOrdinalAttr, dispatchExternOp.getLayoutAttr(),
         dispatchExternOp.getWorkgroupSizeAttr(),
         dispatchExternOp.getSubgroupSizeAttr(),

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.td
@@ -38,7 +38,6 @@ def HAL_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 0;
-  let usePropertiesForAttributes = 0;
 }
 
 #endif // IREE_DIALECT_HAL_DIALECT

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -428,7 +428,7 @@ def HAL_DispatchExternOp : HAL_PureOp<"dispatch.extern", [
   }];
 
   let arguments = (ins
-    StrAttr:$export,
+    StrAttr:$export_name,
     Variadic<Index>:$workload,
     Variadic<AnyType>:$arguments,
     HAL_ShapeDynamicDims:$argument_dims,
@@ -452,7 +452,7 @@ def HAL_DispatchExternOp : HAL_PureOp<"dispatch.extern", [
   );
 
   let assemblyFormat = [{
-    $export
+    $export_name
     (`[` $workload^ `]`)? ``
     `(` $arguments `)` `:`
     custom<ShapedFunctionType>(ref($arguments),


### PR DESCRIPTION
This PR removes an old workaround from #14941, where the HAL dilaect was made to store inherent and discardable attributes in one big dictionary. Removing this workaround is expected to improve compile performanec a bit, though I haven't benchmarked that.

The issue was that we had an attribute named "export", which caused tablegen to generated a struct with a field named "export", which caused compiler errors because "export" is a C++ keyword.

The easy fix here, which is basically NFC, is to rename "export" to "export_name", thus dodging the problem. (An alternate fix would be to teach tablegen to mangle C++ keywords or to prefix the field names with something to de-keyword them, but this was a nice quick fix).