### PR TITLE
[Codegen][LLVMGPU] Use inner reduction lowering for multi_reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -175,7 +175,7 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMultiReductionLoweringPatterns(
           contractLoweringPatterns,
-          vector::VectorMultiReductionLowering::InnerParallel);
+          vector::VectorMultiReductionLowering::InnerReduction);
       if (failed(applyPatternsGreedily(funcOp,
                                        std::move(contractLoweringPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s --check-prefix=SM80
 
-// Verify that a simple element wise op gets lowered succefully all the way to
+// Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -278,7 +278,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 // CHECK-LABEL: hal.executable public @reduction_dispatch
 //       CHECK:   hal.executable.variant public @cuda
-//       CHECK:   llvm.fadd
+//       CHECK:     "llvm.intr.vector.reduce.fadd"({{.*}}) {{.*}} : (f32, vector<4xf32>) -> f32
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -109,7 +109,6 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 }
 
 // CHECK-LABEL: func.func @multi_reduction_f32
-// CHECK-DAG:  %[[PSN:.+]] = ub.poison : vector<2x1xf32>
 // CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
 // CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} : vector<2x1x8xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -93,3 +93,28 @@ func.func @partial_masked_transfer_read(%mem : memref<16x?x32xf16>) -> vector<1x
 // CHECK-DAG: %[[MASK1:.+]] = vector.broadcast %[[COND1]] : i1 to vector<16xi1>
 // CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C0]], %[[C0]]], %[[MASK]]
 // CHECK: vector.maskedload %{{.*}}[%[[C0]], %[[C1]], %[[C0]]], %[[MASK1]]
+
+// -----
+
+// Test multi_reduction lowering.
+// TODO(#21483): Detect reduction(fma(a, b, 0.0)) and fold it into a series of FMAs.
+
+func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> vector<2x1xf32> {
+  %cst_4 = arith.constant dense<0.000000e+00> : vector<2x1xf32>
+  %cst_5 = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+  %22 = arith.mulf %a, %b : vector<2x1x8xf32>
+  %23 = arith.addf %22, %cst_5 : vector<2x1x8xf32>
+  %24 = vector.multi_reduction <add>, %23, %cst_4 [2] : vector<2x1x8xf32> to vector<2x1xf32>
+  return %24 : vector<2x1xf32>
+}
+
+// CHECK-LABEL: func.func @multi_reduction_f32
+// CHECK-DAG:  %[[PSN:.+]] = ub.poison : vector<2x1xf32>
+// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+// CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} : vector<2x1x8xf32>
+// CHECK:      %[[ADD:.+]] = arith.addf %[[MUL]], %[[V0]] : vector<2x1x8xf32>
+// CHECK:      %[[E0:.+]]  = vector.extract %[[ADD]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
+// CHECK:      %[[E1:.+]]  = vector.extract %[[ADD]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32


### PR DESCRIPTION
`InnerReduction` lowering is more friendly for GPU targets that are more likely to benefit from 1d reductions that can be either expanded to intrinsics (e.g., dot product with splat(1)) or to further optimized to chained FMAs.

`InnerParallel` on the other hand is not the best on GPU targets as it results in transposes and is unlikely to benefit from specialized intrinsics beyond packed add instructions.

gfx950 assembly before this change (`InnerParallel`):
```
	v_pk_fma_f32 v[2:3], v[12:13], v[28:29], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[4:5], v[16:17], v[26:27], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[12:13], v[14:15], v[22:23], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[16:17], v[18:19], v[22:23], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[10:11], v[10:11], v[24:25], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[8:9], v[8:9], v[28:29], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[14:15], v[20:21], v[26:27], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[6:7], v[6:7], v[24:25], 0 op_sel_hi:[1,1,0]
	v_mov_b32_e32 v18, v12
	v_mov_b32_e32 v19, v16
	v_mov_b32_e32 v16, v13
	v_mov_b32_e32 v12, v10
	v_mov_b32_e32 v13, v6
	v_mov_b32_e32 v6, v11
	v_mov_b32_e32 v10, v4
	v_mov_b32_e32 v11, v14
	v_mov_b32_e32 v14, v5
	v_mov_b32_e32 v4, v2
	v_mov_b32_e32 v5, v8
	v_mov_b32_e32 v8, v3
	v_pk_add_f32 v[2:3], v[16:17], v[18:19]
	s_nop 0
	v_pk_add_f32 v[2:3], v[12:13], v[2:3]
	s_nop 0
	v_pk_add_f32 v[2:3], v[6:7], v[2:3]
	s_nop 0
	v_pk_add_f32 v[2:3], v[10:11], v[2:3]
	s_nop 0
	v_pk_add_f32 v[2:3], v[14:15], v[2:3]
	s_nop 0
	v_pk_add_f32 v[2:3], v[4:5], v[2:3]
	s_nop 0
	v_pk_add_f32 v[2:3], v[8:9], v[2:3]
	s_nop 1
```

and after (`InnerReduction`):
```
	v_pk_fma_f32 v[2:3], v[12:13], v[28:29], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[4:5], v[16:17], v[26:27], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[12:13], v[14:15], v[22:23], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[16:17], v[18:19], v[22:23], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[10:11], v[10:11], v[24:25], 0 op_sel_hi:[1,1,0]
	v_pk_fma_f32 v[6:7], v[6:7], v[24:25], 0 op_sel_hi:[1,1,0]
	v_add_f32_e32 v12, v12, v13
	v_add_f32_e32 v13, v16, v17
	v_add_f32_e32 v10, v12, v10
	v_add_f32_e32 v6, v13, v6
	v_pk_fma_f32 v[14:15], v[20:21], v[26:27], 0 op_sel_hi:[1,1,0]
	v_add_f32_e32 v10, v10, v11
	v_add_f32_e32 v6, v6, v7
	v_add_f32_e32 v4, v10, v4
	v_add_f32_e32 v6, v6, v14
	v_pk_fma_f32 v[8:9], v[8:9], v[28:29], 0 op_sel_hi:[1,1,0]
	v_add_f32_e32 v4, v4, v5
	v_add_f32_e32 v5, v6, v15
	v_add_f32_e32 v2, v4, v2
	v_add_f32_e32 v4, v5, v8
	v_add_f32_e32 v2, v2, v3
	v_add_f32_e32 v3, v4, v9
```

Issue: #https://github.com/iree-org/iree/issues/21483