### PR TITLE
[DT][VMVX][NFC] Rename and update VMVX encoding materialization tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -80,6 +80,7 @@ iree_lit_test_suite(
             "materialize_encoding_into_nop.mlir",
             "materialize_encoding_into_padding.mlir",
             "materialize_encoding_riscv.mlir",
+            "materialize_encoding_vmvx.mlir",
             "materialize_encoding_x86_64.mlir",
             "materialize_tuning_specs.mlir",
             "materialize_tuning_specs_default_missing.mlir",
@@ -127,7 +128,6 @@ iree_lit_test_suite(
             "vectorize_tensor_pad.mlir",
             "verify_tuning_specs.mlir",
             "verify_workgroup_distribution.mlir",
-            "vmvx_materialize_encoding.mlir",
         ],
         include = ["*.mlir"],
         exclude = [

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -76,6 +76,7 @@ iree_lit_test_suite(
     "materialize_encoding_into_nop.mlir"
     "materialize_encoding_into_padding.mlir"
     "materialize_encoding_riscv.mlir"
+    "materialize_encoding_vmvx.mlir"
     "materialize_encoding_x86_64.mlir"
     "materialize_tuning_specs.mlir"
     "materialize_tuning_specs_default_missing.mlir"
@@ -123,7 +124,6 @@ iree_lit_test_suite(
     "vectorize_tensor_pad.mlir"
     "verify_tuning_specs.mlir"
     "verify_workgroup_distribution.mlir"
-    "vmvx_materialize_encoding.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_vmvx.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_vmvx.mlir
@@ -210,8 +210,7 @@ func.func @unset_encoding_dynamic() attributes {
       -> tensor<?x?xf32, #encoding_lhs>
   %3 = iree_encoding.unset_encoding %2
       : tensor<?x?xf32, #encoding_lhs> -> tensor<?x?xf32>{%d0, %d1}
-  %4 = tensor.extract_slice %3[0, 0] [%d0, %d1] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
+  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
       : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%d0, %d1}
   return
 }


### PR DESCRIPTION
- Rename it to `materialize_encoding_vmvx.mlir` to follow the naming convention.
- Delete the legacy `tensor.extract_slice` op from tests, because UnSetEncodingOp has slicing semantics.