### PR TITLE
[Codegen][LLVMGPU] Remove math scalarization patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -207,7 +207,6 @@ class TestLLVMGPULegalizeOpPass final
   }
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    populateScalarizeMathOps(patterns);
     populateConvertSharedMemoryAllocOps(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
@@ -666,19 +665,6 @@ void populateLLVMConversionPatterns(MLIRContext *context,
   converter.addConversion([context](IREE::Codegen::NullPointerType type) {
     return LLVM::LLVMPointerType::get(context);
   });
-}
-
-void populateScalarizeMathOps(RewritePatternSet &patterns) {
-  patterns.add<ScalarizeMathOp<math::SqrtOp>, ScalarizeMathOp<math::AbsFOp>,
-               ScalarizeMathOp<math::AtanOp>, ScalarizeMathOp<math::Atan2Op>,
-               ScalarizeMathOp<math::CeilOp>, ScalarizeMathOp<math::CosOp>,
-               ScalarizeMathOp<math::ExpOp>, ScalarizeMathOp<math::Exp2Op>,
-               ScalarizeMathOp<math::ExpM1Op>, ScalarizeMathOp<math::FloorOp>,
-               ScalarizeMathOp<math::LogOp>, ScalarizeMathOp<math::Log1pOp>,
-               ScalarizeMathOp<math::Log10Op>, ScalarizeMathOp<math::Log2Op>,
-               ScalarizeMathOp<math::PowFOp>, ScalarizeMathOp<math::RsqrtOp>,
-               ScalarizeMathOp<math::SinOp>, ScalarizeMathOp<math::SqrtOp>,
-               ScalarizeMathOp<math::TanhOp>>(patterns.getContext());
 }
 
 void populateConvertSharedMemoryAllocOps(RewritePatternSet &patterns) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
@@ -19,8 +19,6 @@ void populateLLVMConversionPatterns(MLIRContext *context,
                                     RewritePatternSet &patterns,
                                     LLVMTypeConverter &converter);
 
-void populateScalarizeMathOps(RewritePatternSet &patterns);
-
 /// Lower hal.interface ops to the equivalent gpu ops.
 void populateLowerHALInterfaceOp(RewritePatternSet &patterns);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -99,7 +99,6 @@ struct ConvertToNVVMPass final
       populateVectorToSCFConversionPatterns(
           patterns, VectorTransferToSCFOptions().enableFullUnroll());
       populateDropSharedMemoryDeallocOpPatterns(patterns);
-      populateScalarizeMathOps(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateVectorBroadcastLoweringPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -251,7 +251,6 @@ struct ConvertToROCDLPass final
       populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);
-      populateScalarizeMathOps(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateBubbleVectorBitCastOpPatterns(patterns);
       vector::populateVectorBroadcastLoweringPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/legalize.mlir
@@ -1,42 +1,5 @@
 // RUN: iree-opt --iree-test-llvmgpu-legalize-ops --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: func.func @scalarize
-func.func @scalarize(
-  %arg0: vector<3x1x2xf32>,%arg1: vector<2xf32>, %arg2: vector<2xf32>)
-  -> (vector<3x1x2xf32>, vector<2xf32>) {
-// CHECK: %[[E_0_0:.+]] = vector.extract %{{.*}}[0, 0, 0] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_0_0:.+]] = math.sqrt %[[E_0_0]] : f32
-// CHECK: vector.insert %[[S_0_0]], %{{.*}} [0, 0, 0] : f32 into vector<3x1x2xf32>
-// CHECK: %[[E_1_0:.+]] = vector.extract %{{.*}}[1, 0, 0] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_1_0:.+]] = math.sqrt %[[E_1_0]] : f32
-// CHECK: vector.insert %[[S_1_0]], %{{.*}} [1, 0, 0] : f32 into vector<3x1x2xf32>
-// CHECK: %[[E_2_0:.+]] = vector.extract %{{.*}}[2, 0, 0] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_2_0:.+]] = math.sqrt %[[E_2_0]] : f32
-// CHECK: vector.insert %[[S_2_0]], %{{.*}} [2, 0, 0] : f32 into vector<3x1x2xf32>
-// CHECK: %[[E_0_1:.+]] = vector.extract %{{.*}}[0, 0, 1] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_0_1:.+]] = math.sqrt %[[E_0_1]] : f32
-// CHECK: vector.insert %[[S_0_1]], %{{.*}} [0, 0, 1] : f32 into vector<3x1x2xf32>
-// CHECK: %[[E_1_1:.+]] = vector.extract %{{.*}}[1, 0, 1] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_1_1:.+]] = math.sqrt %[[E_1_1]] : f32
-// CHECK: vector.insert %[[S_1_1]], %{{.*}} [1, 0, 1] : f32 into vector<3x1x2xf32>
-// CHECK: %[[E_2_1:.+]] = vector.extract %{{.*}}[2, 0, 1] : f32 from vector<3x1x2xf32>
-// CHECK: %[[S_2_1:.+]] = math.sqrt %[[E_2_1]] : f32
-// CHECK: vector.insert %[[S_2_1]], %{{.*}} [2, 0, 1] : f32 into vector<3x1x2xf32>
-  %0 = math.sqrt %arg0 : vector<3x1x2xf32>
-// CHECK: %[[E0:.+]] = vector.extract %{{.*}}[0] : f32 from vector<2xf32>
-// CHECK: %[[E1:.+]] = vector.extract %{{.*}}[0] : f32 from vector<2xf32>
-// CHECK: %[[P0:.+]] = math.powf %[[E0]], %[[E1]] : f32
-// CHECK: vector.insert %[[P0]], %{{.*}} [0] : f32 into vector<2xf32>
-// CHECK: %[[E2:.+]] = vector.extract %{{.*}}[1] : f32 from vector<2xf32>
-// CHECK: %[[E3:.+]] = vector.extract %{{.*}}[1] : f32 from vector<2xf32>
-// CHECK: %[[P1:.+]] = math.powf %[[E2]], %[[E3]] : f32
-// CHECK: vector.insert %[[P1]], %{{.*}} [1] : f32 into vector<2xf32>
-  %1 = math.powf %arg1, %arg2 : vector<2xf32>
-  return %0, %1 : vector<3x1x2xf32>, vector<2xf32>
-}
-
-// -----
-
 // CHECK: memref.global "private" @__shared_memory__ : memref<16x16xf32, #gpu.address_space<workgroup>>
 // CHECK: func.func @allocation
 // CHECK:   %[[A:.*]] = memref.get_global @__shared_memory__ : memref<16x16xf32, #gpu.address_space<workgroup>>


### PR DESCRIPTION
All the lowerings for math.* ops (both MathToLLVM and MathToROCDL) that are used in LLVMGPU can handle vector inputs/outputs and will do their own scalarization if needed. Furthermore, LLVM backetds will generally scalarize a math intrinsic if needed (while the LLVM middle end will generally not vectorize it). When the scalarization isn't needed, this can improve codegen (for example, AMDGPU takes fabs.v2f16 to & 0x7fff7fff).

These scalarization patterns seem to be a workaround for a problem that no longer exists.