### PR TITLE
[Codegen] Add symbol based swizzling attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -467,6 +467,35 @@ def IREECodegen_RotateRowsAttr  :
 }
 
 //===---------------------------------------------------------------------===//
+// iree_codegen.swizzle_impl
+//===---------------------------------------------------------------------===//
+
+def IREECodegen_SwizzleImplAttr  :
+    AttrDef<IREECodegen_Dialect, "SwizzleImpl", [
+    DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
+        "swizzleOffset",
+        "getAccessElementCount",
+        "verifySymbolUses"
+      ]>
+    ]> {
+  let mnemonic = "swizzle_impl";
+  let summary = [{An attribute that describes a swizzling pattern for rotating rows.}];
+  let description = [{
+    Wrapper around a symbolic reference to a function with signature
+    (index) -> (index) that implements offset swizzling. When the swizzle hint is
+    resolved, this generates a function call per |access_width| contiguous
+    elements.
+  }];
+  let parameters = (ins
+    AttrParameter<"SymbolRefAttr", "The function to call when swizzling">:$symbol,
+    AttrParameter<"int64_t", "">:$access_width
+  );
+  let assemblyFormat = [{
+    `<` $symbol `,` $access_width `>`
+  }];
+}
+
+//===---------------------------------------------------------------------===//
 // iree_codegen.symbolic_ukernel_provider
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -445,7 +445,21 @@ def IREECodegen_SwizzleAttrInterface :
       /*retTy=*/"int64_t",
       /*methodName=*/"getAccessElementCount",
       /*args=*/(ins)
-    >
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Verifies the validity of any nested symbols.
+      }],
+      /*retTy=*/"::llvm::LogicalResult",
+      /*methodName=*/"verifySymbolUses",
+      /*args=*/(ins
+        "::mlir::SymbolTableCollection &":$symbolTable,
+        "::mlir::Operation*":$owner),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return success();
+      }]
+    >,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -127,6 +127,15 @@ void StoreToBufferOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// SwizzleHintOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SwizzleHintOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return getSwizzle().verifySymbolUses(symbolTable, *this);
+}
+
+//===----------------------------------------------------------------------===//
 // InnerTiledOp
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -14,6 +14,7 @@ include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td"
 include "mlir/Dialect/Linalg/IR/LinalgBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/TilingInterface.td"
@@ -115,7 +116,9 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
 //===----------------------------------------------------------------------===//
 
 def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
-    SameOperandsAndResultType, Pure]> {
+    SameOperandsAndResultType, Pure,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface, ["verifySymbolUses"]>,
+    ]> {
   let summary = [{Hint to swizzle accesses according to an access pattern.}];
   let description = [{
     Optimization hint to swizzle all accesses to the memref this takes a view

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -42,3 +42,29 @@ func.func @store_to_buffer_invalid_element_type(%arg0: tensor<4xf16>, %arg1: mem
   iree_codegen.store_to_buffer %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
   return
 }
+
+// -----
+
+func.func private @swizzle(%offset: index) -> i32
+func.func @symbolic_swizzle_wrong_signature(%arg0: memref<?xf32>) -> memref<?xf32> {
+  // expected-error @+1 {{Symbolic swizzle attr defining function requires single index result}}
+  %0 = iree_codegen.swizzle_hint %arg0[#iree_codegen.swizzle_impl<@swizzle, 1>] : memref<?xf32>
+  return %0 : memref<?xf32>
+}
+
+// -----
+
+func.func @symbolic_swizzle_missing_function(%arg0: memref<?xf32>) -> memref<?xf32> {
+  // expected-error @+1 {{Symbolic swizzle attr could not find defining function}}
+  %0 = iree_codegen.swizzle_hint %arg0[#iree_codegen.swizzle_impl<@swizzle, 1>] : memref<?xf32>
+  return %0 : memref<?xf32>
+}
+
+// -----
+
+util.global @swizzle : index
+func.func @symbolic_swizzle_wrong_kind(%arg0: memref<?xf32>) -> memref<?xf32> {
+  // expected-error @+1 {{Symbolic swizzle attr could not find defining function}}
+  %0 = iree_codegen.swizzle_hint %arg0[#iree_codegen.swizzle_impl<@swizzle, 1>] : memref<?xf32>
+  return %0 : memref<?xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -72,3 +72,23 @@ func.func @store_to_strided_memref(
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]:
 // CHECK:         iree_codegen.store_to_buffer %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<?x?xf32> into memref<?x?xf32, strided<[?, 1], offset: ?>>
+
+// -----
+
+func.func private @swizzle(%offset: index) -> index
+func.func @symbolic_swizzle(%arg0: memref<?xf32>) -> memref<?xf32> {
+  %0 = iree_codegen.swizzle_hint %arg0[#iree_codegen.swizzle_impl<@swizzle, 1>] : memref<?xf32>
+  return %0 : memref<?xf32>
+}
+// CHECK-LABEL: func.func @symbolic_swizzle(
+// CHECK:         iree_codegen.swizzle_hint %{{[A-Za-z0-9]*}}[#iree_codegen.swizzle_impl<@swizzle, 1>]
+
+// -----
+
+util.func private @swizzle(%offset: index) -> index
+func.func @util_func_symbolic_swizzle(%arg0: memref<?xf32>) -> memref<?xf32> {
+  %0 = iree_codegen.swizzle_hint %arg0[#iree_codegen.swizzle_impl<@swizzle, 1>] : memref<?xf32>
+  return %0 : memref<?xf32>
+}
+// CHECK-LABEL: func.func @util_func_symbolic_swizzle(
+// CHECK:         iree_codegen.swizzle_hint %{{[A-Za-z0-9]*}}[#iree_codegen.swizzle_impl<@swizzle, 1>]


### PR DESCRIPTION
This enables providing functions that implement the desired swizzling logic inline with the IR. This is useful as a catch all for any swizzling strategy that is not supported by an existing attribute. The hint op is still needed because there is a gap between when we make access pattern decisions (relatively early) and when we actually apply the swizzling to individual load offsets (after we've unrolled and flattened all memory). This attribute allows us to define the strategy early and call into it later on.