### PR TITLE
[Util] Implement InferIntRangeInterface for OptimizationBarrierOp.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -418,6 +418,11 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
             createLLVMCPUSplitReductionPass(clEnableReassociateFpReductions));
         funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
             static_cast<IREE::CPU::TilingLevel>(i)));
+        // Tile all the reduction ops for target vector sizes. It is a nop for
+        // rootOp because it is already tiled with the same tile sizes. It
+        // ensures that all the dimensions are tiled in all the reduction ops.
+        funcPassManager.addPass(
+            createLLVMCPUTilePass(static_cast<IREE::CPU::TilingLevel>(i)));
         continue;
       }
       funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -579,3 +579,80 @@ func.func @pooling_nchw_max_pack_with_padding_issue_20723() attributes {hal.exec
 // CHECK:           iree_linalg_ext.map_scatter
 // CHECK:         } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
 // CHECK:         scf.forall
+
+// -----
+
+// Verify that the dispatch can be compiled without creating large vectors.
+
+#executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "znver4", cpu_features = "", max_stack_allocation_size = 32768 : i64, native_vector_size = 64 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+func.func @softmax_dynamic_with_assume_int_hints() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 0xFFC00000 : f32
+  %c1 = arith.constant 1 : index
+  %c32_i64 = arith.constant 32 : i64
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
+  %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : i32
+  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : i32
+  %5 = hal.interface.constant.load layout(#pipeline_layout) ordinal(5) : i32
+  %6 = arith.extui %0 : i32 to i64
+  %7 = arith.extui %1 : i32 to i64
+  %8 = arith.shli %7, %c32_i64 : i64
+  %9 = arith.ori %6, %8 : i64
+  %10 = arith.index_castui %9 : i64 to index
+  %11 = arith.extui %2 : i32 to i64
+  %12 = arith.extui %3 : i32 to i64
+  %13 = arith.shli %12, %c32_i64 : i64
+  %14 = arith.ori %11, %13 : i64
+  %15 = arith.index_castui %14 : i64 to index
+  %16 = arith.extui %4 : i32 to i64
+  %17 = arith.extui %5 : i32 to i64
+  %18 = arith.shli %17, %c32_i64 : i64
+  %19 = arith.ori %16, %18 : i64
+  %20 = arith.index_castui %19 : i64 to index
+  %21:3 = util.assume.int
+      %10<umin = 0, umax = 9007199254740991>,
+      %15<umin = 0, umax = 9007199254740991>,
+      %20<umin = 0, umax = 9007199254740991>
+    : index, index, index
+  %22 = iree_tensor_ext.dispatch.workload.ordinal %21#0, 0 : index
+  %23 = iree_tensor_ext.dispatch.workload.ordinal %21#1, 1 : index
+  %24 = iree_tensor_ext.dispatch.workload.ordinal %21#2, 2 : index
+  %25 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32>>{%22, %23, %24}
+  %26 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?xf32>>{%22, %23, %24}
+  %27 = iree_tensor_ext.dispatch.tensor.load %25, offsets = [0, 0, 0], sizes = [%22, %23, %24], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32>>{%22, %23, %24} -> tensor<?x?x?xf32>
+  %28 = tensor.empty(%22, %23, %24) : tensor<?x?x?xf32>
+  %dim = tensor.dim %27, %c0 : tensor<?x?x?xf32>
+  %dim_1 = tensor.dim %27, %c1 : tensor<?x?x?xf32>
+  %29 = tensor.empty(%dim, %dim_1) : tensor<?x?xf32>
+  %30 = linalg.fill ins(%cst_0 : f32) outs(%29 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %31 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%27 : tensor<?x?x?xf32>) outs(%30 : tensor<?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %35 = arith.maxnumf %in, %out : f32
+    linalg.yield %35 : f32
+  } -> tensor<?x?xf32>
+  %32 = linalg.fill ins(%cst : f32) outs(%29 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %33 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%27, %31 : tensor<?x?x?xf32>, tensor<?x?xf32>) outs(%32 : tensor<?x?xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %out: f32):
+    %35 = arith.subf %in, %in_2 : f32
+    %36 = math.exp %35 : f32
+    %37 = arith.addf %36, %out : f32
+    linalg.yield %37 : f32
+  } -> tensor<?x?xf32>
+  %34 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%27, %31, %33 : tensor<?x?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) outs(%28 : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %in_3: f32, %out: f32):
+    %35 = arith.subf %in, %in_2 : f32
+    %36 = math.exp %35 : f32
+    %37 = arith.divf %36, %in_3 : f32
+    linalg.yield %37 : f32
+  } -> tensor<?x?x?xf32>
+  iree_tensor_ext.dispatch.tensor.store %34, %26, offsets = [0, 0, 0], sizes = [%22, %23, %24], strides = [1, 1, 1] : tensor<?x?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?xf32>>{%22, %23, %24}
+  return
+}
+// CHECK-LABEL: func.func @softmax_dynamic_with_assume_int_hints(
+// CHECK-NOT:     linalg

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -1433,6 +1433,20 @@ LogicalResult OptimizationBarrierOp::verify() {
   return success();
 }
 
+void OptimizationBarrierOp::inferResultRangesFromOptional(
+    ArrayRef<IntegerValueRange> argRanges, SetIntLatticeFn setResultRange) {
+  for (Value result : getResults()) {
+    Type elemType = getElementTypeOrSelf(result);
+    if (!elemType.isIntOrIndex()) {
+      continue;
+    }
+    unsigned bitWidth = ConstantIntRanges::getStorageBitwidth(elemType);
+    setResultRange(result, IntegerValueRange(ConstantIntRanges::fromUnsigned(
+                               APInt::getZero(bitWidth),
+                               APInt::getSignedMaxValue(bitWidth))));
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // util.unfoldable_constant
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -19,6 +19,7 @@ include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
@@ -525,6 +526,7 @@ def Util_AssumeIntOp : Util_PureOp<"assume.int", [
 }
 
 def Util_OptimizationBarrierOp : Util_Op<"optimization_barrier", [
+  DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRangesFromOptional"]>,
   SameOperandsAndResultType,
 ]> {
   let summary = [{Prevents compiler optimizations across a value.}];

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/optimize_int_arithmetic.mlir
@@ -496,6 +496,38 @@ util.func @util_align_zero(%arg0 : i64) -> i64 {
 
 // -----
 
+// CHECK-LABEL: @optimization_barrier_index_min_max
+util.func @optimization_barrier_index_min_max(%arg0: index) -> (i1, i1, i1) {
+  %zero = arith.constant 0 : index
+  %max = arith.constant 9223372036854775807 : index
+  %0 = util.optimization_barrier %arg0 : index
+  %1 = arith.cmpi slt, %0, %zero : index
+  %2 = arith.cmpi uge, %0, %zero : index
+  %3 = arith.cmpi ugt, %0, %max : index
+  // CHECK-DAG: %[[FALSE:.*]] = arith.constant false
+  // CHECK-DAG: %[[TRUE:.*]] = arith.constant true
+  // CHECK: util.return %[[FALSE]], %[[TRUE]], %[[FALSE]]
+  util.return %1, %2, %3 : i1, i1, i1
+}
+
+// -----
+
+// CHECK-LABEL: @optimization_barrier_i32_min_max
+util.func @optimization_barrier_i32_min_max(%arg0: i32) -> (i1, i1, i1) {
+  %zero = arith.constant 0 : i32
+  %max = arith.constant 2147483647 : i32
+  %0 = util.optimization_barrier %arg0 : i32
+  %1 = arith.cmpi slt, %0, %zero : i32
+  %2 = arith.cmpi uge, %0, %zero : i32
+  %3 = arith.cmpi ugt, %0, %max : i32
+  // CHECK-DAG: %[[FALSE:.*]] = arith.constant false
+  // CHECK-DAG: %[[TRUE:.*]] = arith.constant true
+  // CHECK: util.return %[[FALSE]], %[[TRUE]], %[[FALSE]]
+  util.return %1, %2, %3 : i1, i1, i1
+}
+
+// -----
+
 // CHECK-LABEL: @hal_buffer_view_dim_min_max
 util.func @hal_buffer_view_dim_min_max(%bv : !hal.buffer_view) -> (i1, i1, i1) {
   %zero = arith.constant 0 : index


### PR DESCRIPTION
The issue is identified from https://github.com/iree-org/iree/issues/21359 that the existing test does not reproduce the same issue. The reason is that the `hal.buffer_view.dim` op implements the interface while the `util.optimization_barrier` op does not implement the interface.

The revision implements the interface for integer and index types, so we can have consistent behavior between using IREE Check framework and user's input programs.

Signed-off-by: hanhanW <hanhan0912@gmail.com>