### PR TITLE
[CPU] Skip distribution passes if the tile sizes are known as zeros.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -86,8 +86,18 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
 
   IREE::Codegen::TranslationInfoAttr translationInfo =
       getTranslationInfo(funcOp);
-  if (!translationInfo)
+  if (!translationInfo) {
     return;
+  }
+
+  auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
+  auto pipeline = translationInfo.getDispatchLoweringPassPipeline();
+  if (!maybeTilingConfig &&
+      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault) {
+    funcOp.emitOpError("Tiling Config is necessary for ")
+        << stringifyEnum(pipeline) << " pipeline.";
+    return signalPassFailure();
+  }
 
   LLVMCPUPipelineOptions pipelineOpts;
   if (isX86(target) || isRISCV(target)) {
@@ -103,82 +113,50 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
       isAArch64(target) && hasAnySVEFeature(target) && hasSMEFeature(target);
   pipelineOpts.enableAArch64I8mm = isAArch64(target) && hasI8mmFeature(target);
   pipelineOpts.enablePeeling = isOptEnabled(funcOp, getEnableLoopPeelingStr());
+  if (maybeTilingConfig &&
+      llvm::all_of(maybeTilingConfig->getDistributionTileSizes(),
+                   [](int64_t tileSize) { return tileSize == 0; })) {
+    pipelineOpts.disableDistribution = true;
+  }
 
-  OpPassManager pipeline(func::FuncOp::getOperationName());
-  switch (translationInfo.getDispatchLoweringPassPipeline()) {
+  OpPassManager passManager(func::FuncOp::getOperationName());
+  switch (pipeline) {
   // No pipleline specified, nothing to do.
   case IREE::Codegen::DispatchLoweringPassPipeline::None:
     return;
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    addCPUDefaultPassPipeline(pipeline, maybeTilingConfig);
+    addCPUDefaultPassPipeline(passManager, maybeTilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUBufferOpsTileAndVectorize: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError("Tiling Config is necessary for "
-                         "CPUBufferOpsTileAndVectorize pipeline.");
-      return signalPassFailure();
-    }
-    addCPUBufferOpsTileAndVectorizePipeline(pipeline, *maybeTilingConfig,
+    addCPUBufferOpsTileAndVectorizePipeline(passManager, *maybeTilingConfig,
                                             pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDoubleTilingExpert: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError(
-          "Tiling Config is necessary for CPUDoubleTilingExpert pipeline.");
-      return signalPassFailure();
-    }
-    addMultiTilingExpertPassPipeline(pipeline, *maybeTilingConfig,
+    addMultiTilingExpertPassPipeline(passManager, *maybeTilingConfig,
                                      pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError("Tiling Config is necessary for "
-                         "CPUConvTileAndDecomposeExpert pipeline.");
-      return signalPassFailure();
-    }
-    addConvTileAndDecomposeExpertPassPipeline(pipeline, *maybeTilingConfig,
+    addConvTileAndDecomposeExpertPassPipeline(passManager, *maybeTilingConfig,
                                               pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError(
-          "Tiling Config is necessary for Mmt4dTilingExpert pipeline.");
-      return signalPassFailure();
-    }
-    addMmt4dTilingExpertPassPipeline(pipeline, *maybeTilingConfig,
+    addMmt4dTilingExpertPassPipeline(passManager, *maybeTilingConfig,
                                      pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError(
-          "Tiling Config is necessary for CPUDataTiling pipeline.");
-      return signalPassFailure();
-    }
-    addCPUDataTilingPipeline(pipeline, *maybeTilingConfig, pipelineOpts);
+    addCPUDataTilingPipeline(passManager, *maybeTilingConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPULinalgExtTileAndVectorize: {
-    auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
-    if (!maybeTilingConfig) {
-      funcOp.emitOpError("Tiling Config is necessary for "
-                         "CPULinalgExtTileAndVectorize pipeline.");
-      return signalPassFailure();
-    }
-    addCPULinalgExtTileAndVectorizePipeline(pipeline, *maybeTilingConfig,
+    addCPULinalgExtTileAndVectorizePipeline(passManager, *maybeTilingConfig,
                                             pipelineOpts);
     break;
   }
@@ -187,7 +165,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  if (failed(runPipeline(pipeline, funcOp))) {
+  if (failed(runPipeline(passManager, funcOp))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -93,7 +93,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
   auto pipeline = translationInfo.getDispatchLoweringPassPipeline();
   if (!maybeTilingConfig &&
-      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault) {
+      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault &&
+      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::None) {
     funcOp.emitOpError("Tiling Config is necessary for ")
         << stringifyEnum(pipeline) << " pipeline.";
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -75,6 +75,7 @@ void populateVectorContractCustomKernelsPatterns(
 //----------------------------------------------------------------------------//
 
 struct LLVMCPUPipelineOptions {
+  bool disableDistribution = false;
   bool decomposePackUnPackOps = true;
   bool useConfiguredVectorSizes = true;
   bool enablePeeling = false;
@@ -104,7 +105,8 @@ void addCPULinalgExtTileAndVectorizePipeline(
 /// that is not specialized by any pipeline). Adds an additional level of tiling
 /// and converts to memrefs.
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               std::unique_ptr<TilingConfig> &tilingConfig);
+                               std::unique_ptr<TilingConfig> &tilingConfig,
+                               LLVMCPUPipelineOptions &pipelineOpt);
 
 void addConvTileAndDecomposeExpertPassPipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "illegal_configuration.mlir",
             "peel.mlir",
             "pipeline_arm_sme_streaming_mode_tests.mlir",
+            "pipeline_disable_distribution_tests.mlir",
             "pipeline_pack_unpack_tests.mlir",
             "pipeline_pad_conv_tests.mlir",
             "pipeline_pad_tests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "illegal_configuration.mlir"
     "peel.mlir"
     "pipeline_arm_sme_streaming_mode_tests.mlir"
+    "pipeline_disable_distribution_tests.mlir"
     "pipeline_pack_unpack_tests.mlir"
     "pipeline_pad_conv_tests.mlir"
     "pipeline_pad_tests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
@@ -1,7 +1,10 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target, iree-llvmcpu-check-ir-before-llvm-conversion))' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
 
 // Test that iree_linalg_ext.map_scatter op is not generated when distribution
-// is disabled.
+// is disabled. The op is used in the fallback solution when the pack op is not
+// fusible in consumer fusion. We do not expect the op if the distribution is
+// disabled. For more details, see
+// https://github.com/iree-org/iree/issues/20723#issuecomment-3006445505
 
 #executable_target_embedded_elf_arm_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu = "generic", cpu_features = "+reserve-x18", max_stack_allocation_size = 32768 : i64, native_vector_size = 16 : i64, target_triple = "aarch64-unknown-unknown-eabi-elf"}>
 func.func @pack_without_distribution() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64} {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_disable_distribution_tests.mlir
@@ -1,0 +1,20 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy, func.func(iree-llvmcpu-lower-executable-target, iree-llvmcpu-check-ir-before-llvm-conversion))' --iree-llvmcpu-disable-distribution --split-input-file %s | FileCheck %s
+
+// Test that iree_linalg_ext.map_scatter op is not generated when distribution
+// is disabled.
+
+#executable_target_embedded_elf_arm_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu = "generic", cpu_features = "+reserve-x18", max_stack_allocation_size = 32768 : i64, native_vector_size = 16 : i64, target_triple = "aarch64-unknown-unknown-eabi-elf"}>
+func.func @pack_without_distribution() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1980x192xf32>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<248x192x8x1xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1980, 192], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1980x192xf32>> -> tensor<1980x192xf32>
+  %3 = tensor.empty() : tensor<248x192x8x1xf32>
+  %pack = linalg.pack %2 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<1980x192xf32> -> tensor<248x192x8x1xf32>
+  iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [248, 192, 8, 1], strides = [1, 1, 1, 1] : tensor<248x192x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<248x192x8x1xf32>>
+  return
+}
+// CHECK-LABEL: func.func @pack_without_distribution
+// CHECK-NOT:     scf.forall
+// CHECK-NOT:     iree_linalg_ext.map_scatter


### PR DESCRIPTION
The revision adds an option to `LLVMCPUPipelineOptions` that describes if distribution is disabled or not.

It may be okay to run the passes, but it causes maintenance burdens. E.g., https://github.com/iree-org/iree/issues/21504

It is better to not run the passes at all, if we already know that distribution is disabled. It also saves compilation time as fewer passes are run.

Fixes https://github.com/iree-org/iree/issues/21504