### PR TITLE
Integrate LLVM at llvm/llvm-project@1381ad497b9a.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -312,20 +312,20 @@ struct ConvertBf16ToUInt16BuffersPass final
       // changes. Also handle amdgpu buffer casts:
       target.addDynamicallyLegalOp<
           amdgpu::FatRawBufferCastOp, vector::BroadcastOp, vector::ShuffleOp,
-          vector::ExtractElementOp, vector::ExtractOp, vector::InsertElementOp,
-          vector::InsertOp, vector::ScalableInsertOp, vector::ScalableExtractOp,
-          vector::InsertStridedSliceOp, vector::ExtractStridedSliceOp,
-          vector::TransferReadOp, vector::TransferWriteOp, vector::LoadOp,
-          vector::StoreOp, vector::MaskedLoadOp, vector::MaskedStoreOp,
-          vector::GatherOp, vector::ScatterOp, vector::ExpandLoadOp,
-          vector::CompressStoreOp, vector::ShapeCastOp, vector::ConstantMaskOp,
-          vector::CreateMaskOp, vector::MaskOp, vector::TransposeOp,
-          vector::YieldOp>([&typeConverter](Operation *op) {
-        bool legal = typeConverter.isLegal(op);
-        LLVM_DEBUG(if (!legal) llvm::dbgs()
-                   << "Bf16Emulation: illegal op: " << *op << "\n");
-        return legal;
-      });
+          vector::ExtractOp, vector::InsertOp, vector::ScalableInsertOp,
+          vector::ScalableExtractOp, vector::InsertStridedSliceOp,
+          vector::ExtractStridedSliceOp, vector::TransferReadOp,
+          vector::TransferWriteOp, vector::LoadOp, vector::StoreOp,
+          vector::MaskedLoadOp, vector::MaskedStoreOp, vector::GatherOp,
+          vector::ScatterOp, vector::ExpandLoadOp, vector::CompressStoreOp,
+          vector::ShapeCastOp, vector::ConstantMaskOp, vector::CreateMaskOp,
+          vector::MaskOp, vector::TransposeOp, vector::YieldOp>(
+          [&typeConverter](Operation *op) {
+            bool legal = typeConverter.isLegal(op);
+            LLVM_DEBUG(if (!legal) llvm::dbgs()
+                       << "Bf16Emulation: illegal op: " << *op << "\n");
+            return legal;
+          });
 
       RewritePatternSet patterns(ctx);
       populateIreeBf16EmulationPatterns(patterns, typeConverter);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/vector_reduction_to_gpu.mlir
@@ -91,8 +91,8 @@ module {
     %c384 = arith.constant 384 : index
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) offset(%c0) : memref<1xvector<4xi32>, #hal.descriptor_type<uniform_buffer>>
     %1 = memref.load %0[%c0] : memref<1xvector<4xi32>, #hal.descriptor_type<uniform_buffer>>
-    %2 = vector.extractelement %1[%c0 : index] : vector<4xi32>
-    %3 = vector.extractelement %1[%c1 : index] : vector<4xi32>
+    %2 = vector.extract %1[%c0] : i32 from vector<4xi32>
+    %3 = vector.extract %1[%c1] : i32 from vector<4xi32>
     %4 = arith.index_castui %2 : i32 to index
     %5 = arith.index_castui %3 : i32 to index
     %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%4) : memref<128x384xf32>
@@ -114,11 +114,10 @@ module {
 
 //   CHECK-LABEL: func.func @reduce_uniform_buffer_offset()
 //     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //         CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
 //         CHECK:   %[[LOAD:.+]] = memref.load %[[SUBSPAN]][%[[C0]]]
-//         CHECK:   %[[EXT0:.+]] = vector.extractelement %[[LOAD]][%[[C0]] : index] : vector<4xi32>
-//         CHECK:   %[[EXT1:.+]] = vector.extractelement %[[LOAD]][%[[C1]] : index] : vector<4xi32>
+//         CHECK:   %[[EXT0:.+]] = vector.extract %[[LOAD]][0] : i32 from vector<4xi32>
+//         CHECK:   %[[EXT1:.+]] = vector.extract %[[LOAD]][1] : i32 from vector<4xi32>
 //         CHECK:   %[[OFFSET0:.+]] = arith.index_castui %[[EXT0]] : i32 to index
 //         CHECK:   %[[OFFSET1:.+]] = arith.index_castui %[[EXT1]] : i32 to index
 //         CHECK:   hal.interface.binding.subspan layout({{.+}}) binding(0) alignment(64) offset(%[[OFFSET0]])
@@ -150,8 +149,8 @@ module {
     %c384 = arith.constant 384 : index
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : memref<1xvector<4xi32>, #hal.descriptor_type<storage_buffer>>
     %1 = memref.load %0[%c0] : memref<1xvector<4xi32>, #hal.descriptor_type<storage_buffer>>
-    %2 = vector.extractelement %1[%c0 : index] : vector<4xi32>
-    %3 = vector.extractelement %1[%c1 : index] : vector<4xi32>
+    %2 = vector.extract %1[%c0] : i32 from vector<4xi32>
+    %3 = vector.extract %1[%c1] : i32 from vector<4xi32>
     %4 = arith.index_castui %2 : i32 to index
     %5 = arith.index_castui %3 : i32 to index
     %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%4) : memref<128x384xf32>
@@ -173,11 +172,10 @@ module {
 
 //   CHECK-LABEL: func.func @reduce_storage_buffer_offset()
 //     CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //         CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
 //         CHECK:   %[[LOAD:.+]] = memref.load %[[SUBSPAN]][%[[C0]]]
-//         CHECK:   %[[EXT0:.+]] = vector.extractelement %[[LOAD]][%[[C0]] : index] : vector<4xi32>
-//         CHECK:   %[[EXT1:.+]] = vector.extractelement %[[LOAD]][%[[C1]] : index] : vector<4xi32>
+//         CHECK:   %[[EXT0:.+]] = vector.extract %[[LOAD]][0] : i32 from vector<4xi32>
+//         CHECK:   %[[EXT1:.+]] = vector.extract %[[LOAD]][1] : i32 from vector<4xi32>
 //         CHECK:   %[[OFFSET0:.+]] = arith.index_castui %[[EXT0]] : i32 to index
 //         CHECK:   %[[OFFSET1:.+]] = arith.index_castui %[[EXT1]] : i32 to index
 //         CHECK:   hal.interface.binding.subspan layout({{.+}}) binding(0) alignment(64) offset(%[[OFFSET0]])

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_bf16_arith_to_f32.mlir
@@ -97,27 +97,23 @@ func.func @extf_scalar_noop(%arg0 : vector<bf16>) -> vector<bf16> {
 
 func.func @store_reduction_bf16(%arg0 : vector<3xbf16>, %arg1 : vector<3xbf16>, %arg2 : memref<bf16>) {
   %cst = arith.constant dense<1.000000e+00> : vector<bf16>
-  %5 = vector.extractelement %cst[] : vector<bf16>
+  %5 = vector.extract %cst[] : bf16 from vector<bf16>
   %6 = arith.mulf %arg0, %arg1 : vector<3xbf16>
   %7 = vector.reduction <add>, %6, %5 : vector<3xbf16> into bf16
   %8 = vector.broadcast %7 : bf16 to vector<bf16>
-  %9 = vector.extractelement %8[] : vector<bf16>
+  %9 = vector.extract %8[] : bf16 from vector<bf16>
   memref.store %9, %arg2[] : memref<bf16>
   return
 }
 
 // CHECK-LABEL: @store_reduction_bf16
-// CHECK:      %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<bf16>
+// CHECK-DAG:  %[[CST:.+]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:  %[[VAL0:.+]] = arith.extf %arg0 : vector<3xbf16> to vector<3xf32>
 // CHECK-DAG:  %[[VAL1:.+]] = arith.extf %arg1 : vector<3xbf16> to vector<3xf32>
-// CHECK:      %[[VAL2:.+]] = vector.extractelement %[[CST]][] : vector<bf16>
-// CHECK:      %[[VAL3:.+]] = arith.extf %[[VAL2]] : bf16 to f32
 // CHECK:      %[[VAL4:.+]] = arith.mulf %[[VAL0]], %[[VAL1]] : vector<3xf32>
-// CHECK:      %[[VAL5:.+]] = vector.reduction <add>, %[[VAL4]], %[[VAL3]] : vector<3xf32> into f32
+// CHECK:      %[[VAL5:.+]] = vector.reduction <add>, %[[VAL4]], %[[CST]] : vector<3xf32> into f32
 // CHECK:      %[[VAL6:.+]] = arith.truncf %[[VAL5]] : f32 to bf16
-// CHECK:      %[[VAL7:.+]] = vector.broadcast %[[VAL6]] : bf16 to vector<bf16>
-// CHECK:      %[[VAL8:.+]] = vector.extractelement %[[VAL7]][] : vector<bf16>
-// CHECK:      memref.store %[[VAL8]], %arg2[] : memref<bf16>
+// CHECK:      memref.store %[[VAL6]], %arg2[] : memref<bf16>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -809,7 +809,7 @@ builtin.module attributes { transform.with_named_sequence } {
       %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
       // expected-remark @above {{element_tile = [16, 8]}}
       %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
-      %init = vector.extractelement %arg1[] : vector<f16>
+      %init = vector.extract %arg1[] : f16 from vector<f16>
       %root_red = vector.multi_reduction<add>, %rootl, %init [0, 1]  : vector<16x16xf16> to f16
       %c = vector.broadcast %root_red : f16 to vector<f16>
       scf.yield %c : vector<f16>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -99,12 +99,8 @@ Operation *stripElementBitPatternPreservingParents(Value op) {
             .Case<vector::BroadcastOp>([](vector::BroadcastOp broadcast) {
               return broadcast.getVector();
             })
-            .Case<vector::ExtractOp, vector::ExtractElementOp,
-                  vector::ExtractStridedSliceOp>(
+            .Case<vector::ExtractOp, vector::ExtractStridedSliceOp>(
                 [](auto extract) { return extract.getVector(); })
-            .Case<vector::InsertElementOp>([](vector::InsertElementOp insert) {
-              return insert.getSource();
-            })
             .Case<vector::InsertOp, vector::InsertStridedSliceOp>(
                 [](auto insert) { return insert.getValueToStore(); })
             .Case<vector::TransposeOp>([](vector::TransposeOp transpose) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -943,8 +943,7 @@ struct ScalarizeVectorTransferWrite final
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
-        Value scalar =
-            b.create<vector::ExtractElementOp>(loc, writeOp.getVector());
+        Value scalar = b.create<vector::ExtractOp>(loc, writeOp.getVector());
         b.create<memref::StoreOp>(loc, scalar, writeOp.getBase(),
                                   writeOp.getIndices());
         return Value();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -121,7 +121,7 @@ hal.executable private @resource_bindings_in_same_func {
         %10 = arith.addf %5, %6 : f32
         %11 = arith.addf %7, %9 : f32
         %12 = arith.addf %10, %11 : f32
-        %13 = vector.extractelement %8[%c0 : index] : vector<4xf32>
+        %13 = vector.extract %8[%c0] : f32 from vector<4xf32>
         %14 = arith.addf %12, %13 : f32
 
         return %14 : f32
@@ -162,7 +162,7 @@ hal.executable private @resource_bindings_in_multi_entry_func {
         %2 = memref.load %0[%c0, %c0] : memref<4x4xf32, #spirv.storage_class<StorageBuffer>>
         %3 = memref.load %1[%c0] : memref<4xvector<4xf32>, #spirv.storage_class<StorageBuffer>>
 
-        %4 = vector.extractelement %3[%c0 : index] : vector<4xf32>
+        %4 = vector.extract %3[%c0] : f32 from vector<4xf32>
         %5 = arith.addf %2, %4 : f32
 
         return %5 : f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -349,7 +349,7 @@ func.func @scalarize_0d_transfer_write(%val: vector<f32>, %memory: memref<4xf32>
   return
 }
 
-// CHECK: %[[S:.+]] = vector.extractelement %[[V]][] : vector<f32>
+// CHECK: %[[S:.+]] = vector.extract %[[V]][] : f32 from vector<f32>
 // CHECK: memref.store %[[S]], %[[MEM]][%[[I]]] : memref<4xf32>
 
 // -----

--- a/tests/e2e/math/BUILD.bazel
+++ b/tests/e2e/math/BUILD.bazel
@@ -49,6 +49,10 @@ testcases = [
     deps = [
         "gen_math_ops_%s.mlir" % backend,
     ],
+    tags = [
+        # TODO(#21512): Reenable tests for RISCV targets.
+        "noriscv",
+    ] if (backend == "llvm-cpu") else []
 ) for backend, driver in [
     ("llvm-cpu", "local-task"),
     ("rocm", "hip"),

--- a/tests/e2e/math/BUILD.bazel
+++ b/tests/e2e/math/BUILD.bazel
@@ -45,14 +45,14 @@ testcases = [
     srcs = ["//tests/e2e/math:math_ops_%s.mlir" % backend],
     compiler_flags = ["--iree-llvmcpu-target-cpu=generic"] if backend == "llvm-cpu" else [],
     driver = driver,
+    tags = [
+        # TODO(#21512): Reenable tests for RISCV targets.
+        "noriscv",
+    ] if (backend == "llvm-cpu") else [],
     target_backend = backend,
     deps = [
         "gen_math_ops_%s.mlir" % backend,
     ],
-    tags = [
-        # TODO(#21512): Reenable tests for RISCV targets.
-        "noriscv",
-    ] if (backend == "llvm-cpu") else []
 ) for backend, driver in [
     ("llvm-cpu", "local-task"),
     ("rocm", "hip"),

--- a/tests/e2e/math/CMakeLists.txt
+++ b/tests/e2e/math/CMakeLists.txt
@@ -45,6 +45,8 @@ iree_check_single_backend_test_suite(
     "local-task"
   COMPILER_FLAGS
     "--iree-llvmcpu-target-cpu=generic"
+  LABELS
+    "noriscv"
   DEPS
     "gen_math_ops_llvm-cpu.mlir"
 )
@@ -59,6 +61,8 @@ iree_check_single_backend_test_suite(
   DRIVER
     "hip"
   COMPILER_FLAGS
+
+  LABELS
 
   DEPS
     "gen_math_ops_rocm.mlir"

--- a/tests/e2e/tosa_ops/if.mlir
+++ b/tests/e2e/tosa_ops/if.mlir
@@ -2,7 +2,7 @@ func.func @if_true_test() {
   %0 = util.unfoldable_constant dense<true> : tensor<i1>
   %1 = util.unfoldable_constant dense<10> : tensor<i32>
   %path = util.unfoldable_constant 1 : i32
-  %2 = tosa.cond_if %0 -> (tensor<i32>) {
+  %2 = tosa.cond_if %0 : tensor<i1> -> tensor<i32> {
     check.expect_true(%path) : i32
     %3 = util.unfoldable_constant dense<10> : tensor<i32>
     %4 = tosa.add %1, %3 : (tensor<i32>, tensor<i32>) -> tensor<i32>
@@ -19,7 +19,7 @@ func.func @if_false_test() {
   %0 = util.unfoldable_constant dense<false> : tensor<i1>
   %1 = util.unfoldable_constant dense<10> : tensor<i32>
   %path = util.unfoldable_constant 0 : i32
-  %2 = tosa.cond_if %0 -> (tensor<i32>) {
+  %2 = tosa.cond_if %0 : tensor<i1> -> tensor<i32> {
     check.expect_true(%path) : i32
     tosa.yield %1 : tensor<i32>
   } else {


### PR DESCRIPTION
Most of the changes are the fixes for https://github.com/llvm/llvm-project/commit/33465bb2bb75f26b7ad42ab87ccb2464c0245476.

The `InsertElementToBroadcast` pattern seems not used, so it is removed in the revision.

It disables math ops e2e tests for RISC-V targets: https://github.com/iree-org/iree/issues/21512