### PR TITLE
[Codegen][LLVMGPU] Add a DropVectorUnitDims call

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1044,7 +1044,13 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
 
   // This pass needs to run before SCF -> CF.
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);
-  funcPassManager.addPass(createLLVMGPUVectorLoweringPass)
+  funcPassManager
+      // This goes before LLVMGPUVectorLowering to ensure
+      // that broadcasts of vector<1 x T> to vector<N x 1 xT> or
+      // vector<1 x N x T> become splats to vector<N x T>, or else
+      // scaling_truncf isn't lowered efficiently.
+      .addPass(createDropVectorUnitDimsPass)
+      .addPass(createLLVMGPUVectorLoweringPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
 


### PR DESCRIPTION
DropVectorUnitDims was factored out of the CPU pipeline last yer. Now, we have a usecase for adding it to the LLVMGPU pipeline.

Specifically, LLVMGPUVectorLowering will lower the broadcast in
```
%scale = ... : vector<1xf32>
%scale.bcast = vector.broadcast %scale : vector<1xf32> to vector<32x1xf32>
%res = arith.scaling_truncf %data, %scale_bcast : ...
```
to a series of inserts, which the later ArithToAMDGPU patterns don't recoginzies as a broadcast. This produces inefficient code.

However, if we first run the unit dimension elimination patterns, this causes the scaling truncation to run on a vector<32xf32> for the scales. Then, broadcast lowering rewrites the vector<1xf32> to vector<2xf32> broadcast into a splat, which ArithToAMDGPU does pattern-match as a uniform scale.

I also expect this to improve vectorization generally, causing some minor performance improvements overall (but thaven't had time to perf it).

ci-extra: test_torch