### PR TITLE
DNS - IREE fixes for LLVM 149293

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -311,8 +311,17 @@ struct VectorizationTileSizes {
 /// chain.
 std::optional<VectorizationTileSizes> inferSizesFromIR(Value val);
 
-/// Returns the result sizes and vector input sizes of the linalg.unpack op. The
-/// inferred bounding size is returned if it is dynamic shape. Returns
+/// Returns the inferred input-vector-sizes for the `op` (for read + write
+/// operations), given the provided vector sizes for the write operation.
+/// Returns std::nullopt, if it fails to compute the sizes.
+/// For now, it only supports non-scalable vectors.
+std::optional<SizesAndScalableFlags>
+getVectorInputSizesFromDestTiles(linalg::UnPackOp op,
+                                 ArrayRef<int64_t> writeVectorSizes,
+                                 ArrayRef<bool> scalableFlags);
+
+/// Returns the result sizes and vector input sizes of the linalg.unpack op.
+/// The inferred bounding size is returned if it is dynamic shape. Returns
 /// std::nullopt if the shape inference failed.
 std::optional<VectorizationTileSizes> inferSizesFromIR(linalg::UnPackOp op);
 


### PR DESCRIPTION
The revision adds the `getVectorInputSizesFromDestTiles` method that infers the input vector sizes list given the vector sizes from the write. For now, scalable vectors are not yet supported in IREE as what it is today.