### PR TITLE
[CODEGEN] Adding pipeline path to take Direct Convolution

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -35,7 +35,7 @@ bool ireeAttributeIsAGPUPipelineOptionsAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute ireeGPUPipelineOptionsAttrGet(
     MlirContext mlirCtx, bool *prefetchSharedMemory,
     bool *noReduceSharedMemoryBankConflicts, bool *useIgemmConvolution,
-    MlirAttribute *reorderWorkgroupsStrategy);
+    bool *useDirectConvolution, MlirAttribute *reorderWorkgroupsStrategy);
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ireeGPUPipelineOptionsAttrGetPrefetchSharedMemory(MlirAttribute attr);
@@ -46,6 +46,9 @@ ireeGPUPipelineOptionsAttrGetNoReduceSharedMemoryBankConflicts(
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ireeGPUPipelineOptionsAttrGetUseIgemmConvolution(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ireeGPUPipelineOptionsAttrGetUseDirectConvolution(MlirAttribute attr);
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ireeGPUPipelineOptionsAttrGetReorderWorkgroupsStrategy(MlirAttribute attr);

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -248,6 +248,7 @@ NB_MODULE(_ireeCompilerDialects, m) {
           [](const py::object &, std::optional<bool> prefetchSharedMemory,
              std::optional<bool> noReduceSharedMemoryBankConflicts,
              std::optional<bool> useIgemmConvolution,
+             std::optional<bool> useDirectConvolution,
              std::optional<MlirAttribute> reorderWorkgroupsStrategy,
              MlirContext ctx) {
             return ireeGPUPipelineOptionsAttrGet(
@@ -259,6 +260,8 @@ NB_MODULE(_ireeCompilerDialects, m) {
                     : nullptr,
                 useIgemmConvolution.has_value() ? &*useIgemmConvolution
                                                 : nullptr,
+                useDirectConvolution.has_value() ? &*useDirectConvolution
+                                                 : nullptr,
                 reorderWorkgroupsStrategy.has_value()
                     ? &*reorderWorkgroupsStrategy
                     : nullptr);
@@ -266,6 +269,7 @@ NB_MODULE(_ireeCompilerDialects, m) {
           "cls"_a, "prefetch_shared_memory"_a = py::none(),
           "no_reduce_shared_memory_bank_conflicts"_a = py::none(),
           "use_igemm_convolution"_a = py::none(),
+          "use_direct_convolution"_a = py::none(),
           "reorder_workgroups_strategy"_a = py::none(), py::kw_only(),
           "ctx"_a = py::none(),
           "Gets an #iree_gpu.pipeline_options from parameters.")

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -22,11 +22,10 @@ bool ireeAttributeIsAGPUPipelineOptionsAttr(MlirAttribute attr) {
       unwrap(attr));
 }
 
-MlirAttribute
-ireeGPUPipelineOptionsAttrGet(MlirContext mlirCtx, bool *prefetchSharedMemory,
-                              bool *noReduceSharedMemoryBankConflicts,
-                              bool *useIgemmConvolution,
-                              MlirAttribute *reorderWorkgroupsStrategy) {
+MlirAttribute ireeGPUPipelineOptionsAttrGet(
+    MlirContext mlirCtx, bool *prefetchSharedMemory,
+    bool *noReduceSharedMemoryBankConflicts, bool *useIgemmConvolution,
+    bool *useDirectConvolution, MlirAttribute *reorderWorkgroupsStrategy) {
   mlir::MLIRContext *ctx = unwrap(mlirCtx);
   mlir::Builder b(ctx);
   auto prefetchSharedMemoryAttr = mlir::BoolAttr();
@@ -42,6 +41,10 @@ ireeGPUPipelineOptionsAttrGet(MlirContext mlirCtx, bool *prefetchSharedMemory,
   if (useIgemmConvolution) {
     useIgemmConvolutionAttr = b.getBoolAttr(*useIgemmConvolution);
   }
+  auto useDirectConvolutionAttr = mlir::BoolAttr();
+  if (useDirectConvolution) {
+    useDirectConvolutionAttr = b.getBoolAttr(*useDirectConvolution);
+  }
   auto strategyAttr =
       mlir::iree_compiler::IREE::GPU::ReorderWorkgroupsStrategyAttr();
   if (reorderWorkgroupsStrategy) {
@@ -51,7 +54,7 @@ ireeGPUPipelineOptionsAttrGet(MlirContext mlirCtx, bool *prefetchSharedMemory,
   }
   return wrap(mlir::iree_compiler::IREE::GPU::GPUPipelineOptionsAttr::get(
       ctx, prefetchSharedMemoryAttr, noReduceSharedMemoryBankConflictsAttr,
-      useIgemmConvolutionAttr, strategyAttr));
+      useIgemmConvolutionAttr, useDirectConvolutionAttr, strategyAttr));
 }
 
 MlirAttribute

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1854,6 +1854,7 @@ int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
 GPUPipelineOptionsAttr GPUPipelineOptionsAttr::get(
     MLIRContext *context, bool prefetchSharedMemory,
     bool noReduceSharedMemoryBankConflicts, bool useIgemmConvolution,
+    bool useDirectConvolution,
     std::optional<ReorderWorkgroupsStrategy> reorderWorkgroupsStrategy) {
   auto strategyAttr = ReorderWorkgroupsStrategyAttr();
   if (reorderWorkgroupsStrategy) {
@@ -1863,7 +1864,8 @@ GPUPipelineOptionsAttr GPUPipelineOptionsAttr::get(
   Builder b(context);
   return Base::get(context, b.getBoolAttr(prefetchSharedMemory),
                    b.getBoolAttr(noReduceSharedMemoryBankConflicts),
-                   b.getBoolAttr(useIgemmConvolution), strategyAttr);
+                   b.getBoolAttr(useIgemmConvolution),
+                   b.getBoolAttr(useDirectConvolution), strategyAttr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -721,6 +721,7 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
     OptionalParameter<"BoolAttr">:$prefetch_shared_memory,
     OptionalParameter<"BoolAttr">:$no_reduce_shared_memory_bank_conflicts,
     OptionalParameter<"BoolAttr">:$use_igemm_convolution,
+    OptionalParameter<"BoolAttr">:$use_direct_convolution,
     OptionalParameter<"ReorderWorkgroupsStrategyAttr">:$reorder_workgroups_strategy
   );
 
@@ -729,6 +730,7 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
         CArg<"bool", "false">:$prefetch_shared_memory,
         CArg<"bool", "false">:$no_reduce_shared_memory_bank_conflicts,
         CArg<"bool", "false">:$use_igemm_convolution,
+        CArg<"bool", "false">:$use_direct_convolution,
         CArg<"std::optional<ReorderWorkgroupsStrategy>", "{}">:$reorder_workgroups_strategy)>
   ];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -109,6 +109,7 @@ LogicalResult setDataTiledMultiMmaLoweringConfig(
       context, /*prefetchSharedMemory=*/false,
       /*no_reduce_shared_memory_bank_conflicts=*/true,
       /*use_igemm_convolution=*/false,
+      /*use_direct_convolution=*/false,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
       b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
@@ -600,6 +601,7 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
       linalgOp->getContext(), /*prefetchSharedMemory=*/true,
       /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad,
       /*use_igemm_convolution=*/true,
+      /*use_direct_convolution=*/false,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
       StringAttr::get(linalgOp->getContext(),
@@ -657,6 +659,7 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
       linalgOp->getContext(), /*prefetchSharedMemory=*/true,
       /*no_reduce_shared_memory_bank_conflicts=*/useDirectLoad,
       /*use_igemm_convolution=*/false,
+      /*use_direct_convolution=*/false,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
       StringAttr::get(linalgOp->getContext(),
@@ -1219,6 +1222,203 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
       {flatWorkgroupSize, 1, 1}, flatWorkgroupSize, DictionaryAttr());
 }
 
+LogicalResult
+setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
+                                   mlir::FunctionOpInterface entryPoint,
+                                   Operation *computeOp) {
+  auto op = dyn_cast<linalg::LinalgOp>(computeOp);
+  if (target.getWgp().getMma().empty())
+    return failure();
+
+  const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
+
+  SmallVector<int64_t> bounds = op.getStaticLoopRanges();
+  FailureOr<mlir::linalg::ConvolutionDimensions> convolutionDims =
+      mlir::linalg::inferConvolutionDims(op);
+  if (failed(convolutionDims)) {
+    return failure();
+  }
+
+  // This strategy turns non-strided/dilated convolution problems into matmul
+  // problems by tiling certain dimensions to 1:
+  //  - Batch dimensions (parallel shared by the image and output)
+  //  - Filter dimensions (reduction on the filter, and convolved on the image)
+  //  - All output image dimensions except the outermost one
+  //
+  // After this, the remaining non-unit dimensions are:
+  //  - One output image dimension corresponding to the M dimension of a matmul.
+  //  - The output channel dimension, corresponding to the N dimension.
+  //  - The input channel dimension, corresponding to the K dimension.
+
+  // TODO: Relax this condition to strictly alignment requirements.
+  if (convolutionDims->outputChannel.size() < 1 ||
+      convolutionDims->inputChannel.size() < 1 ||
+      convolutionDims->filterLoop.size() < 1 ||
+      convolutionDims->outputImage.size() < 1 ||
+      convolutionDims->depth.size() != 0) {
+    return failure();
+  }
+
+  auto isAllOnesList = [](ArrayRef<int64_t> list) {
+    return llvm::all_of(list, [](int64_t i) { return i == 1; });
+  };
+
+  // TODO: Support non-unit strides/dilations.
+  if (!isAllOnesList(convolutionDims->strides) ||
+      !isAllOnesList(convolutionDims->dilations)) {
+    return failure();
+  }
+
+  int64_t mDim = convolutionDims->outputImage.back();
+  int64_t nDim = convolutionDims->outputChannel.back();
+  // TODO: Support NCHW convolutions. This is just a matmul_transpose_a, however
+  // the distribution patterns currently do not support that variant.
+  if (mDim > nDim) {
+    return failure();
+  }
+  int64_t kDim = convolutionDims->inputChannel.back();
+
+  Value lhs = op.getDpsInputOperand(0)->get();
+  Value rhs = op.getDpsInputOperand(1)->get();
+  Value init = op.getDpsInitOperand(0)->get();
+
+  Type lhsElemType = getElementTypeOrSelf(lhs);
+  Type rhsElemType = getElementTypeOrSelf(rhs);
+  Type initElemType = getElementTypeOrSelf(init);
+
+  // TODO(Max191): Support multiple M/N/K dimension problems for MMASchedules
+  // once the pipeline is able to support it. After adding multiple dimensions,
+  // all instances of schedule->m/nSubgroupCounts[0] and
+  // schedule->m/n/kTileSizes[0] need to use the full list of sizes instead of
+  // just the first element.
+  GPUMatmulShapeType problem{bounds[mDim], bounds[nDim], bounds[kDim],
+                             lhsElemType,  rhsElemType,  initElemType};
+
+  // Helper fn to store mma information.
+  auto storeMmaInfo = [](IREE::GPU::MmaInterfaceAttr mma,
+                         SmallVector<GPUIntrinsicType> &intrinsics) {
+    auto [mSize, nSize, kSize] = mma.getMNKShape();
+    auto [aType, bType, cType] = mma.getABCElementTypes();
+    intrinsics.emplace_back(mSize, nSize, kSize, aType, bType, cType, mma);
+  };
+
+  SmallVector<GPUIntrinsicType> intrinsics;
+  intrinsics.reserve(target.getWgp().getMma().size());
+  MLIRContext *context = op.getContext();
+  for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
+    if (mma.getSubgroupSize() != targetSubgroupSize)
+      continue;
+    storeMmaInfo(mma, intrinsics);
+    // Store info on virtual intrinsics based on current mma if any
+    for (IREE::GPU::VirtualMMAIntrinsic virtualIntrinsic :
+         mma.getVirtualIntrinsics()) {
+      auto virtualMma =
+          IREE::GPU::VirtualMMAAttr::get(context, virtualIntrinsic);
+      storeMmaInfo(virtualMma, intrinsics);
+    }
+  }
+
+  if (intrinsics.empty())
+    return failure();
+
+  // Note that the following heuristic seeds are just placeholder values.
+  // We need to clean it up and make it adjusting to different targets.
+  // See https://github.com/iree-org/iree/issues/16341 for details.
+  GPUMMAHeuristicSeeds seeds{/*bestSubgroupCountPerWorkgroup=*/4,
+                             /*bestMNTileCountPerSubgroup=*/8,
+                             /*bestKTileCountPerSubgroup=*/2};
+
+  int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
+
+  std::optional<int64_t> wgpCount = std::nullopt;
+  if (IREE::GPU::TargetChipAttr chip = target.getChip()) {
+    wgpCount = chip.getWgpCount();
+  }
+
+  // First try to find a schedule with an exactly matching intrinsic.
+  FailureOr<GPUMMASchedule> schedule =
+      deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
+                        targetSubgroupSize, wgpCount);
+  if (failed(schedule)) {
+    // Then try again by allowing upcasting accumulator.
+    schedule =
+        deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
+                          targetSubgroupSize, wgpCount,
+                          /*transposedLhs*/ false, /*transposedRhs*/ false,
+                          /*canUpcastAcc=*/true);
+  }
+  if (failed(schedule)) {
+    return failure();
+  }
+
+  int64_t flatWorkgroupSize =
+      targetSubgroupSize *
+      ShapedType::getNumElements(schedule->nSubgroupCounts) *
+      ShapedType::getNumElements(schedule->mSubgroupCounts);
+  std::array<int64_t, 3> workgroupSize{flatWorkgroupSize, 1, 1};
+
+  SmallVector<int64_t> workgroupTileSizes(op.getNumLoops(), 0);
+  SmallVector<int64_t> reductionTileSizes(op.getNumLoops(), 0);
+  SmallVector<int64_t> subgroupTileSizes(op.getNumLoops(), 0);
+  SmallVector<int64_t> convTileSizes(op.getNumLoops(), 0);
+  // Tile all batch dimensions with unit size.
+  for (int64_t batch : convolutionDims->batch) {
+    workgroupTileSizes[batch] = 1;
+  }
+  // Tile all output image dimensions with unit size except the last one.
+  for (int64_t oi : llvm::drop_end(convolutionDims->outputImage)) {
+    workgroupTileSizes[oi] = 1;
+  }
+  for (int64_t oc : llvm::drop_end(convolutionDims->outputChannel)) {
+    workgroupTileSizes[oc] = 1;
+  }
+  for (int64_t ic : llvm::drop_end(convolutionDims->inputChannel)) {
+    reductionTileSizes[ic] = 1;
+  }
+  // Compute the M/N dimension tile size by multiply subgroup information.
+  workgroupTileSizes[mDim] =
+      schedule->mSubgroupCounts[0] * schedule->mTileSizes[0] * schedule->mSize;
+  subgroupTileSizes[mDim] = schedule->mTileSizes[0];
+  workgroupTileSizes[nDim] =
+      schedule->nSubgroupCounts[0] * schedule->nTileSizes[0] * schedule->nSize;
+  subgroupTileSizes[nDim] = schedule->nTileSizes[0];
+
+  reductionTileSizes[kDim] = schedule->kTileSizes[0] * schedule->kSize;
+
+  Builder b(context);
+  SmallVector<NamedAttribute, 4> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes)),
+      NamedAttribute("conv_reduction", b.getI64ArrayAttr(convTileSizes)),
+      NamedAttribute("subgroup", b.getI64ArrayAttr(subgroupTileSizes))};
+  IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1});
+  IREE::GPU::setMmaKind(context, attrs, schedule->mmaKind);
+  // IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
+  // IREE::GPU::setSubgroupNCount(context, attrs, schedule->nSubgroupCounts[0]);
+
+  auto configDict = DictionaryAttr::get(context, attrs);
+  auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
+
+  SmallVector<NamedAttribute, 1> pipelineAttrs;
+
+  // Prefetch shared memory is kept off.
+  auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+      context, /*prefetchSharedMemory=*/false,
+      /*no_reduce_shared_memory_bank_conflicts=*/false,
+      /*use_igemm_convolution=*/false,
+      /*use_direct_convolution=*/true,
+      /*reorder_workgroups_strategy=*/std::nullopt);
+  pipelineAttrs.emplace_back(
+      IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName(), pipelineOptions);
+
+  auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
+
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, loweringConfig,
+      Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse, workgroupSize,
+      targetSubgroupSize, pipelineConfig);
+}
+
 //====---------------------------------------------------------------------===//
 // Sort Pipeline Configuration
 //====---------------------------------------------------------------------===//
@@ -1332,6 +1532,11 @@ getPipelineOptions(FunctionOpInterface funcOp,
     if (useIgemmConvolution) {
       pipelineOptions.useIgemmConvolution = useIgemmConvolution.getValue();
     }
+    BoolAttr useDirectConvolution =
+        pipelineOptionsAttr.getUseDirectConvolution();
+    if (useDirectConvolution) {
+      pipelineOptions.useDirectConvolution = useDirectConvolution.getValue();
+    }
     ReorderWorkgroupsStrategyAttr reorderWorkgroupsStrategy =
         pipelineOptionsAttr.getReorderWorkgroupsStrategy();
     if (reorderWorkgroupsStrategy) {
@@ -1366,6 +1571,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
             << options.enableReduceSharedMemoryBankConflicts << ", "
             << ", prefetchSharedMemory = " << options.prefetchSharedMemory
             << ", useIgemmConvolution = " << options.useIgemmConvolution
+            << ", useDirectConvolution = " << options.useDirectConvolution
             << ", reorderWorkgroupsStrategy = " << reorderStr
             << ", enableUkernels = " << options.enableUkernels << "}";
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -51,6 +51,12 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
                             mlir::FunctionOpInterface entryPoint,
                             Operation *op);
 
+// For Direct Convolution
+LogicalResult
+setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
+                                   mlir::FunctionOpInterface entryPoint,
+                                   Operation *computeOp);
+
 //===----------------------------------------------------------------------===//
 // Pass Pipeline Options
 //===----------------------------------------------------------------------===//
@@ -61,6 +67,7 @@ struct GPUPipelineOptions {
   bool enableReduceSharedMemoryBankConflicts = true;
   bool prefetchSharedMemory = false;
   bool useIgemmConvolution = false;
+  bool useDirectConvolution = false;
   bool enableUkernels = false;
   std::optional<ReorderWorkgroupsStrategy> reorderStrategy;
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -136,6 +136,11 @@ static llvm::cl::opt<bool>
                     llvm::cl::desc("Use global load DMA for direct load ops."),
                     llvm::cl::Hidden, llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clDirectConvolution(
+    "iree-codegen-use-direct-convolution",
+    llvm::cl::desc("Use direct convolution in tile and fuse pipeline"),
+    llvm::cl::init(false));
+
 namespace {
 
 using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
@@ -1124,6 +1129,7 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
         context, /*prefetchSharedMemory=*/true,
         /*no_reduce_shared_memory_bank_conflicts=*/false,
         /*use_igemm_convolution=*/false,
+        /*use_direct_convolution=*/false,
         /*reorder_workgroups_strategy=*/std::nullopt);
     pipelineAttrs.emplace_back(
         IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName(), pipelineOptions);
@@ -1387,6 +1393,7 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
         context, /*prefetchSharedMemory=*/true,
         /*no_reduce_shared_memory_bank_conflicts=*/false,
         /*use_igemm_convolution=*/false,
+        /*use_direct_convolution=*/false,
         /*reorder_workgroups_strategy=*/std::nullopt);
     pipelineAttrs.emplace_back(
         StringAttr::get(context,
@@ -2190,6 +2197,7 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
           context, /*prefetchSharedMemory=*/false,
           /*no_reduce_shared_memory_bank_conflicts=*/true,
           /*use_igemm_convolution=*/false,
+          /*use_direct_convolution=*/false,
           /*reorder_workgroups_strategy=*/std::nullopt);
       pipelineAttrs.emplace_back(
           b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
@@ -3156,6 +3164,13 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     if (succeeded(IREE::GPU::setMatmulLoweringConfig(
             target, entryPointFn, computeOp, clUseDirectLoad))) {
       LDBG() << "Tile and fuse matmul config";
+      return success();
+    }
+  }
+  if (clDirectConvolution) {
+    if (succeeded(IREE::GPU::setDirectConvolutionLoweringConfig(
+            target, entryPointFn, computeOp))) {
+      LDBG() << "Direct Convolution Config";
       return success();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -437,21 +437,24 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // Step 1. Promote matmul operands and pack to intrinsic shapes.
   funcPassManager.addPass(createGPUPadOperandsPass());
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
-  funcPassManager.addPass(createGPUPackToIntrinsicsPass());
-  // Decompose packs and unpacks that are at the function boundary.
-  funcPassManager.addPass(createDecomposeBoundaryPackUnPackOpsPass());
 
-  // Step 1.5. Expand result shapes of MultiMmaOps before tiling, and
-  // propagate reshapes to the function boundary.
-  {
-    IREE::GPU::ExpandUndistributedInnerTilesPassOptions options;
-    options.expandInputs = false;
-    options.expandOutputs = true;
-    // Note: options not passed in was previous behavior from PR #18179.
-    funcPassManager.addPass(
-        IREE::GPU::createExpandUndistributedInnerTilesPass());
+  if (!pipelineOptions.useDirectConvolution) {
+    funcPassManager.addPass(createGPUPackToIntrinsicsPass());
+    // Decompose packs and unpacks that are at the function boundary.
+    funcPassManager.addPass(createDecomposeBoundaryPackUnPackOpsPass());
+
+    // Step 1.5. Expand result shapes of MultiMmaOps before tiling, and
+    // propagate reshapes to the function boundary.
+    {
+      IREE::GPU::ExpandUndistributedInnerTilesPassOptions options;
+      options.expandInputs = false;
+      options.expandOutputs = true;
+      // Note: options not passed in was previous behavior from PR #18179.
+      funcPassManager.addPass(
+          IREE::GPU::createExpandUndistributedInnerTilesPass());
+    }
+    funcPassManager.addPass(createPropagateReshapesByExpansionPass());
   }
-  funcPassManager.addPass(createPropagateReshapesByExpansionPass());
 
   // Step 2. Tile and fuse tileable ops to reduction loops.
   {
@@ -461,6 +464,24 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+  }
+
+  if (pipelineOptions.useDirectConvolution) {
+    funcPassManager.addPass(createGPUPackToIntrinsicsPass());
+    // Decompose packs and unpacks that are at the function boundary.
+    funcPassManager.addPass(createDecomposeBoundaryPackUnPackOpsPass());
+
+    // Step 1.5. Expand result shapes of MultiMmaOps before tiling, and
+    // propagate reshapes to the function boundary.
+    {
+      IREE::GPU::ExpandUndistributedInnerTilesPassOptions options;
+      options.expandInputs = false;
+      options.expandOutputs = true;
+      // Note: options not passed in was previous behavior from PR #18179.
+      funcPassManager.addPass(
+          IREE::GPU::createExpandUndistributedInnerTilesPass());
+    }
+    funcPassManager.addPass(createPropagateReshapesByExpansionPass());
   }
 
   // Step 3. Decompose pack and unpack ops and propagate the resulting reshapes.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -38,7 +38,7 @@ func.func @expanded_matmul_transpose_b(%lhs: tensor<2x64x2048xf16>, %rhs: tensor
 
 // CHECK-LABEL: func.func @expanded_matmul_transpose_b
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>
 
 // Verify that the fill does not have the lowering config propagated to it.
 //       CHECK:   linalg.fill ins
@@ -78,7 +78,7 @@ func.func @multi_dim_mma_schedule(%lhs: tensor<10x32x128x16xf16>, %rhs: tensor<4
 
 // CHECK-LABEL: func.func @multi_dim_mma_schedule
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
@@ -117,7 +117,7 @@ func.func @dynamic_multi_dim_mma_schedule(%lhs: tensor<?x6x16x?x16xf16>, %rhs: t
 
 // CHECK-LABEL: func.func @dynamic_multi_dim_mma_schedule
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
@@ -141,7 +141,7 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>
 
 // Verify that the fill does not have the lowering config propagated to it.
 //       CHECK:   linalg.fill ins
@@ -314,7 +314,7 @@ module {
 
 // CHECK-LABEL: func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 0, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 0]
@@ -333,7 +333,7 @@ func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x2x577xf32>, %r
 
 // LATE-LABEL: func.func @unaligned_to_intrinsic_batched_matmul
 // LATE-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
-// LATE-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
+// LATE-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>}
 //      LATE:    linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  LATE-SAME:     padding = [1, 16, 16, 4]
 //  LATE-SAME:     promote_operands = [0, 1, 2]
@@ -440,7 +440,7 @@ func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(%lhs : tensor<12x5
 
 // LATE-LABEL: func.func @unaligned_to_intrinsic_batched_matmul_tiling_check
 // LATE-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-// LATE-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
+// LATE-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false, use_direct_convolution = false>}
 //      LATE:    linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  LATE-SAME:     padding = [1, 16, 512, 4]
 //  LATE-SAME:     promote_operands = [0, 1, 2]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -26,7 +26,7 @@ func.func @scaled_matmul(
 
 // CHECK-LABEL: func.func @scaled_matmul
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1]
@@ -59,7 +59,7 @@ func.func @scaled_matmul_with_batch(
 
 // CHECK-LABEL: func.func @scaled_matmul_with_batch
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1]
@@ -120,7 +120,7 @@ func.func @small_scaled_matmul(
 
 // CHECK-LABEL: func.func @small_scaled_matmul
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -408,7 +408,7 @@ func.func @not_vmt() {
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}>
 //       CHECK: func.func @not_vmt()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -54,7 +54,7 @@ func.func @dot_dispatch_1() {
   return
 }
 
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [2, 4, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [2, 4, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}>
 //      CHECK: func.func @dot_dispatch_1
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.fill
@@ -81,7 +81,7 @@ func.func @unaligned_k() {
   return
 }
 
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}>
 //      CHECK: func.func @unaligned_k
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.fill
@@ -334,7 +334,7 @@ func.func @matmul_config_sm35() {
   return
 }
 
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}>
 //      CHECK: func.func @matmul_config_sm35()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 
@@ -617,7 +617,7 @@ func.func @_main_dispatch_15_generic_512x4x42x42x64_f32() {
   return
 }
 
-//       CHECK:  #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+//       CHECK:  #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 8, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false, use_direct_convolution = false>}>
 //       CHECK:  func.func @_main_dispatch_15_generic_512x4x42x42x64_f32()
 //  CHECK-SAME:    translation_info = #[[TRANSLATION]]
 //       CHECK:  linalg.fill


### PR DESCRIPTION
This commit adds the flag `--iree-codegen-use-direct-convolution` to the available options for selecting a lowering config to choose direct convolution for reduced shared memory utilization. 