### PR TITLE
Migrate existing mi300 runners to new mi325 capacity.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -52,11 +52,11 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi250')
     uses: ./.github/workflows/pkgci_test_amd_mi250.yml
 
-  test_amd_mi300:
-    name: Test AMD MI300
+  test_amd_mi325:
+    name: Test AMD MI325
     needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi300')
-    uses: ./.github/workflows/pkgci_test_amd_mi300.yml
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi325')
+    uses: ./.github/workflows/pkgci_test_amd_mi325.yml
 
   test_amd_w7900:
     name: Test AMD W7900
@@ -127,7 +127,7 @@ jobs:
       - build_packages
       - unit_test
       - test_amd_mi250
-      - test_amd_mi300
+      - test_amd_mi325
       - test_amd_w7900
       # - test_nvidia_t4
       - test_android

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_mi300:
-    runs-on: linux-mi300-1gpu-ossci-iree-org
+    runs-on: linux-mi325-1gpu-ossci-iree-org
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -18,7 +18,7 @@ on:
         default: ""
 
 jobs:
-  test_mi300:
+  test_mi325:
     runs-on: linux-mi325-1gpu-ossci-iree-org
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages

--- a/.github/workflows/pkgci_test_amd_mi325.yml
+++ b/.github/workflows/pkgci_test_amd_mi325.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: PkgCI Test AMD MI300
+name: PkgCI Test AMD MI325
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -53,7 +53,7 @@ jobs:
             iree_test_files: /shark-cache/data/iree-regression-cache
             sku: mi300
             target: target_hip
-            runs-on: linux-mi300-1gpu-ossci-iree-org
+            runs-on: linux-mi325-1gpu-ossci-iree-org
           - name: amdgpu_rocm_mi308_gfx942
             rocm-chip: gfx942
             backend: rocm


### PR DESCRIPTION
Runner capacity is shifting from MI300 to MI325 machines. These machines are compatible enough for testing, though benchmarks will need new baselines.