### PR TITLE
[Dispatch Creation] Run multi-use fusion after forming dispatches

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -235,6 +235,15 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
                                            /*fuseMultiReduction=*/false,
                                            /*fuseTruncateOps=*/true});
       })
+      // 5. After all the reshape propagations, fuse elementwise operations
+      //    even if the producer has multiple uses.
+      .addPass([] {
+        FuseMultiUseElementwiseProducerPassOptions options;
+        options.intraDispatch = true;
+        return DispatchCreation::createFuseMultiUseElementwiseProducerPass(
+            options);
+      })
+
       // Clone all producers into the dispatch region to perpare for being
       // isolated from above. This enables running additional transformations
       // afterwards that would need the full dispatch content but don't want to

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -137,6 +137,8 @@ def FuseMultiUseElementwiseProducerPass :
                    "mlir::FunctionOpInterface"> {
   let summary = "Fuse elementwise linalg operations on tensors when producers have multiple uses.";
   let options = [
+    Option<"intraDispatch", "intra-dispatch", "bool",
+           /*default=*/"false", "Fuse operations within a dispatch only (default is to fuse only operations outside of a dispatch)">,
     Option<"numIterations", "num-iterations", "unsigned",
            /*default=*/"2", "Number of iterations to fuse multiuse ops">
   ];

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "fuse_encoding_ops_into_dispatch_regions.mlir",
             "fuse_horizontal_contractions.mlir",
             "fuse_multiuse_elementwise_producer.mlir",
+            "fuse_multiuse_intra_dispatch.mlir",
             "fusion_preprocessing.mlir",
             "materialize_default_workgroup_count_region.mlir",
             "pad_fusion_with_consumer.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_lit_test_suite(
     "fuse_encoding_ops_into_dispatch_regions.mlir"
     "fuse_horizontal_contractions.mlir"
     "fuse_multiuse_elementwise_producer.mlir"
+    "fuse_multiuse_intra_dispatch.mlir"
     "fusion_preprocessing.mlir"
     "hoist_encoding_ops.mlir"
     "hoist_uniform_scalar_compute.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_intra_dispatch.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_intra_dispatch.mlir
@@ -1,0 +1,33 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-multi-use-elementwise-producer{intra-dispatch}))" --split-input-file %s | FileCheck %s
+
+util.func public @multi_trunc_consumers(%arg0: tensor<4x2048xi64>, %arg1: tensor<4x2048xi64>, %arg2: tensor<4x2048xi32>) -> (tensor<4x2048xi32>, tensor<4x2048xi32>) {
+  %c36_i64 = arith.constant 36 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %dispatch:2 = flow.dispatch.region -> (tensor<4x2048xi32>, tensor<4x2048xi32>){
+    %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<4x2048xi64>) outs(
+  %arg1 : tensor<4x2048xi64>) {
+    ^bb0(%in: i64, %out: i64):
+      %3 = arith.addi %in, %c36_i64 : i64
+      %4 = arith.muli %3, %c2_i64 : i64
+      linalg.yield %4 : i64
+    } -> tensor<4x2048xi64>
+    %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x2048xi64>) outs(%arg2 : tensor<4x2048xi32>) {
+    ^bb0(%in: i64, %out: i32):
+      %3 = arith.trunci %in : i64 to i32
+      linalg.yield %3 : i32
+    } -> tensor<4x2048xi32>
+    %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<4x2048xi64>) outs(%arg2 : tensor<4x2048xi32>) {
+    ^bb0(%in: i64, %out: i32):
+      %3 = arith.addi %in, %c1_i64 : i64
+      %4 = arith.trunci %3 : i64 to i32
+      linalg.yield %4 : i32
+    } -> tensor<4x2048xi32>
+    flow.return %2, %1 : tensor<4x2048xi32>, tensor<4x2048xi32>
+  }
+  util.return %dispatch#0, %dispatch#1 : tensor<4x2048xi32>, tensor<4x2048xi32>
+}
+
+// CHECK-LABEL: util.func public @multi_trunc_consumers(
+//       CHECK:   %[[GENERIC:.+]]:2 = linalg.generic
+//       CHECK:   flow.return %[[GENERIC]]#1, %[[GENERIC]]#0


### PR DESCRIPTION
This helps to simplify the IR to avoid some cases that the GPU backend can't handle when multi-use fusion is disabled before forming dispatches.