### PR TITLE
[Codegen][NFC] Switch to new LDBG macro.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -21,7 +21,6 @@
 
 #define DEBUG_TYPE "iree-codegen-combine-layout-transformation"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -364,19 +364,19 @@ combineRelayoutOpChain(RewriterBase &rewriter, MapScatterOp mapScatterOp,
   MapScatterOp combinedRelayoutOp = mapScatterOp;
   while (relayoutOp) {
     LDBG() << "Attempting to fold " << relayoutOp->getName()
-                               << " into map_scatter op:\n"
-                               << *relayoutOp;
+           << " into map_scatter op:\n"
+           << *relayoutOp;
     FailureOr<MapScatterOp> maybeCombinedRelayoutOp = foldIntoMapScatter(
         rewriter, relayoutOp, combinedRelayoutOp, padDistributionConfigFn);
     if (failed(maybeCombinedRelayoutOp)) {
       LDBG() << "Failed to fold " << relayoutOp->getName()
-                             << " into map_scatter op";
+             << " into map_scatter op";
       break;
     }
     combinedRelayoutOp = maybeCombinedRelayoutOp.value();
     LDBG() << "Successfully folded " << relayoutOp->getName()
-                                << " into map_scatter. New map_scatter op:\n"
-                                << combinedRelayoutOp;
+           << " into map_scatter. New map_scatter op:\n"
+           << combinedRelayoutOp;
     relayoutOp = combinedRelayoutOp.getInput().getDefiningOp();
   }
   if (combinedRelayoutOp.isIdentity()) {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -10,7 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -363,20 +363,20 @@ combineRelayoutOpChain(RewriterBase &rewriter, MapScatterOp mapScatterOp,
   }
   MapScatterOp combinedRelayoutOp = mapScatterOp;
   while (relayoutOp) {
-    LDBG("Attempting to fold " << relayoutOp->getName()
+    LDBG() << "Attempting to fold " << relayoutOp->getName()
                                << " into map_scatter op:\n"
-                               << *relayoutOp);
+                               << *relayoutOp;
     FailureOr<MapScatterOp> maybeCombinedRelayoutOp = foldIntoMapScatter(
         rewriter, relayoutOp, combinedRelayoutOp, padDistributionConfigFn);
     if (failed(maybeCombinedRelayoutOp)) {
-      LDBG("Failed to fold " << relayoutOp->getName()
-                             << " into map_scatter op");
+      LDBG() << "Failed to fold " << relayoutOp->getName()
+                             << " into map_scatter op";
       break;
     }
     combinedRelayoutOp = maybeCombinedRelayoutOp.value();
-    LDBG("Successfully folded " << relayoutOp->getName()
+    LDBG() << "Successfully folded " << relayoutOp->getName()
                                 << " into map_scatter. New map_scatter op:\n"
-                                << combinedRelayoutOp);
+                                << combinedRelayoutOp;
     relayoutOp = combinedRelayoutOp.getInput().getDefiningOp();
   }
   if (combinedRelayoutOp.isIdentity()) {
@@ -404,7 +404,7 @@ static MapScatterOp insertIdentityMapScatter(RewriterBase &rewriter,
       rewriter, loc, op->getOperand(0), mapScatterDest);
   rewriter.modifyOpInPlace(
       op, [&]() { op->setOperand(0, mapScatterOp.getResult(0)); });
-  LDBG("Created identity map_scatter:\n" << mapScatterOp);
+  LDBG() << "Created identity map_scatter:\n" << mapScatterOp;
   return mapScatterOp;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-combine-layout-transformation"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-fission-transfer-ops-in-control-flow"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -150,7 +150,7 @@ static void setupWriteLoop(IRRewriter &rewriter, const FissionTarget &target,
 static void splitTransferOpsFromControlFlow(IRRewriter &rewriter,
                                             const FissionTarget &target) {
   LDBG() << "Splitting transfer ops from control flow: \n"
-       << "For Op: " << target.parent << "\n";
+         << "For Op: " << target.parent << "\n";
 
   rewriter.setInsertionPoint(target.parent);
   SmallVector<memref::AllocaOp> allocaOps;

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -97,7 +97,7 @@ static void setupReadLoop(IRRewriter &rewriter, const FissionTarget &target,
                                              indices);
   }
 
-  LDBG("Read loop: \n" << readLoop << "\n");
+  LDBG() << "Read loop: \n" << readLoop << "\n";
   rewriter.setInsertionPointAfter(readLoop);
 }
 
@@ -125,7 +125,7 @@ static void setupWriteLoop(IRRewriter &rewriter, const FissionTarget &target,
         readOp, readOp.getVectorType(), allocaOp, indices, readOp.getPadding());
   }
 
-  LDBG("Write loop: \n" << writeLoop << "\n");
+  LDBG() << "Write loop: \n" << writeLoop << "\n";
 }
 
 /// Splits transfer read and write operations from a control flow Operation
@@ -149,8 +149,8 @@ static void setupWriteLoop(IRRewriter &rewriter, const FissionTarget &target,
 ///   }
 static void splitTransferOpsFromControlFlow(IRRewriter &rewriter,
                                             const FissionTarget &target) {
-  LDBG("Splitting transfer ops from control flow: \n"
-       << "For Op: " << target.parent << "\n");
+  LDBG() << "Splitting transfer ops from control flow: \n"
+       << "For Op: " << target.parent << "\n";
 
   rewriter.setInsertionPoint(target.parent);
   SmallVector<memref::AllocaOp> allocaOps;

--- a/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FissionTransferOpsInControlFlow.cpp
@@ -20,7 +20,6 @@
 
 #define DEBUG_TYPE "iree-codegen-fission-transfer-ops-in-control-flow"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -216,9 +216,9 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
                                 lhsBatchOffsets, rhsBatchOffsets, lhsMap,
                                 rhsMap);
         LDBG() << "current lhs batch offsets: "
-             << llvm::interleaved_array(lhsBatchOffsets);
+               << llvm::interleaved_array(lhsBatchOffsets);
         LDBG() << "current rhs batch offsets: "
-             << llvm::interleaved_array(rhsBatchOffsets);
+               << llvm::interleaved_array(rhsBatchOffsets);
 
         Value lhsSlice =
             rewriter.create<vector::ExtractOp>(loc, lhs, lhsBatchOffsets);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #define DEBUG_TYPE "iree-codegen-amdgpu-distribute-contract"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -8,7 +8,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -143,7 +143,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     }
 
     SmallVector<int64_t> distShape = resultLayout.getDistributedShape();
-    LDBG("distributed shape: " << llvm::interleaved_array(distShape));
+    LDBG() << "distributed shape: " << llvm::interleaved_array(distShape);
 
     // Create a zero vector with the full distributed vector shape for
     // accumulating unrolled contraction results.
@@ -215,10 +215,10 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
         fillOperandBatchOffsets(opDetail, k, resultBatchOffsets,
                                 lhsBatchOffsets, rhsBatchOffsets, lhsMap,
                                 rhsMap);
-        LDBG("current lhs batch offsets: "
-             << llvm::interleaved_array(lhsBatchOffsets));
-        LDBG("current rhs batch offsets: "
-             << llvm::interleaved_array(rhsBatchOffsets));
+        LDBG() << "current lhs batch offsets: "
+             << llvm::interleaved_array(lhsBatchOffsets);
+        LDBG() << "current rhs batch offsets: "
+             << llvm::interleaved_array(rhsBatchOffsets);
 
         Value lhsSlice =
             rewriter.create<vector::ExtractOp>(loc, lhs, lhsBatchOffsets);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-combine-layout-transformation"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -13,7 +13,6 @@
 
 #define DEBUG_TYPE "iree-codegen-gpu-combine-layout-transformation"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -365,7 +365,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     }
   }
 
-  LDBG("After fusing and hoisting loops\n" << funcOp);
+  LDBG() << "After fusing and hoisting loops\n" << funcOp;
 
   // After hoisting parallel loops, try to fuse in any newly revealed consumers
   // and destinations.
@@ -386,7 +386,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     }
   }
 
-  LDBG("After fusing new consumers\n" << funcOp);
+  LDBG() << "After fusing new consumers\n" << funcOp;
 
   // Finally try to do any new producer fusions.
   {
@@ -400,7 +400,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     }
   }
 
-  LDBG("After fusing new producers\n" << funcOp);
+  LDBG() << "After fusing new producers\n" << funcOp;
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -27,7 +27,6 @@
 
 #define DEBUG_TYPE "iree-codegen-gpu-fuse-and-hoist-parallel-loops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -26,7 +26,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-fuse-and-hoist-parallel-loops"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
@@ -42,8 +42,8 @@ static LogicalResult
 distributeLinalgCopyToThreads(RewriterBase &rewriter, linalg::CopyOp copy,
                               ArrayRef<int64_t> workgroupSize,
                               int64_t subgroupSize) {
-  LDBG("==== distributing op: ");
-  LDBG(*copy);
+  LDBG() << "==== distributing op: ";
+  LDBG() << *copy;
   Location loc = copy.getLoc();
 
   // The linalg.copy we are dealing with represents a region we need to copy to
@@ -82,13 +82,13 @@ distributeLinalgCopyToThreads(RewriterBase &rewriter, linalg::CopyOp copy,
   int64_t residualElements =
       totalCopySizePerSubgroup % (subgroupSize * elementsPerCopy);
 
-  LDBG("-- elementsPerCopy: " << elementsPerCopy);
-  LDBG("-- workgroupSize: " << workgroupSize[0]);
-  LDBG("-- numSubgroups: " << numSubgroups);
-  LDBG("-- totalCopySize: " << totalCopySize);
-  LDBG("-- totalCopySizePerSubgroup: " << totalCopySizePerSubgroup);
-  LDBG("-- numCopiesPerThread: " << numCopiesPerThread);
-  LDBG("-- residualElements: " << residualElements);
+  LDBG() << "-- elementsPerCopy: " << elementsPerCopy;
+  LDBG() << "-- workgroupSize: " << workgroupSize[0];
+  LDBG() << "-- numSubgroups: " << numSubgroups;
+  LDBG() << "-- totalCopySize: " << totalCopySize;
+  LDBG() << "-- totalCopySizePerSubgroup: " << totalCopySizePerSubgroup;
+  LDBG() << "-- numCopiesPerThread: " << numCopiesPerThread;
+  LDBG() << "-- residualElements: " << residualElements;
 
   if (residualElements != 0) {
     return rewriter.notifyMatchFailure(
@@ -158,15 +158,15 @@ static LogicalResult isEligibleForGlobalDMA(linalg::CopyOp copy) {
   auto targetType = cast<MemRefType>(copy.getOutputs().front().getType());
 
   if (!getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(copy)) {
-    LDBG("-- Op: " << *copy);
-    LDBG("-- does not have `use_global_load_dma` attribute, skipping.");
+    LDBG() << "-- Op: " << *copy;
+    LDBG() << "-- does not have `use_global_load_dma` attribute, skipping.";
     return failure();
   }
 
   if (!hasGlobalMemoryAddressSpace(sourceType) ||
       !hasSharedMemoryAddressSpace(targetType)) {
-    LDBG("-- Op: " << *copy);
-    LDBG("-- incompatible source or target memory address space.");
+    LDBG() << "-- Op: " << *copy;
+    LDBG() << "-- incompatible source or target memory address space.";
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
@@ -13,7 +13,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
@@ -30,7 +30,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-lower-to-global-loads"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -20,7 +20,6 @@
 
 #define DEBUG_TYPE "iree-codegen-gpu-pipelining"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 //====---------------------------------------------------------------------===//
 // Pass to pipeline copy to shared memory for matmul op.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -519,8 +519,8 @@ static void getNvidiaAmpereTensorCorePipeline(
   // empty schedule.
   int numKgroups = mainloop.getNumberOfKgroups();
   if (numKgroups < 2 || numStages < 3) {
-    LDBG() << "--numKgroups=" << numKgroups << "(< 2) or numStages=" << numStages
-                         << "(< 3) -> BAIL";
+    LDBG() << "--numKgroups=" << numKgroups
+           << "(< 2) or numStages=" << numStages << "(< 3) -> BAIL";
     return;
   }
 
@@ -532,7 +532,8 @@ static void getNvidiaAmpereTensorCorePipeline(
   if (!(mainloop.asyncCreateGroupOp.size() == 1) ||
       !(mainloop.asyncWaitOps.size() == 1) ||
       !(mainloop.barrierOps.size() == 2)) {
-    LDBG() << "--failed prereqs: 1 async_create, 1 async_wait, 2 barriers -> BAIL";
+    LDBG()
+        << "--failed prereqs: 1 async_create, 1 async_wait, 2 barriers -> BAIL";
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-pipelining"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 //====---------------------------------------------------------------------===//
 // Pass to pipeline copy to shared memory for matmul op.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -7,7 +7,7 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -364,7 +364,7 @@ struct MainLoopInfo {
         // Pipeline and schedule the most inner for op ,i.e., the mainloop that
         // should be a flat region.
         isSchedulable = false;
-        LDBG("-- found op with regions -> not schedulable: " << op);
+        LDBG() << "-- found op with regions -> not schedulable: " << op;
         return;
       }
       if (isa<nvgpu::DeviceAsyncCopyOp>(op)) {
@@ -412,19 +412,19 @@ struct MainLoopInfo {
     // `cp.wait_group`, `bar.sync`, `mma.sync`, `ldmatrix` or `ld.shared`) for
     // scheduling is missing, the mainloop cannot be scheduled.
     if (copyGlobalToSharedOps.empty()) {
-      LDBG("-- missing copyGlobalToSharedOps -> not schedulable");
+      LDBG() << "-- missing copyGlobalToSharedOps -> not schedulable";
       isSchedulable = false;
     } else if (asyncCreateGroupOp.empty()) {
-      LDBG("-- missing asyncCreateGroupOp -> not schedulable");
+      LDBG() << "-- missing asyncCreateGroupOp -> not schedulable";
       isSchedulable = false;
     } else if (asyncWaitOps.empty()) {
-      LDBG("-- missing asyncWaitOps -> not schedulable");
+      LDBG() << "-- missing asyncWaitOps -> not schedulable";
       isSchedulable = false;
     } else if (barrierOps.empty()) {
-      LDBG("-- missing barrierOps -> not schedulable");
+      LDBG() << "-- missing barrierOps -> not schedulable";
       isSchedulable = false;
     } else if (warpOperations.empty()) {
-      LDBG("-- missing warpOperations -> not schedulable");
+      LDBG() << "-- missing warpOperations -> not schedulable";
       isSchedulable = false;
     }
     if (!isSchedulable)
@@ -505,12 +505,12 @@ static void getNvidiaAmpereTensorCorePipeline(
     unsigned numStages) {
   // Analyze the main loop and obtain information for coarse-grained pipelining
   // and fine-grained instruction scheduling.
-  LDBG("Start getNvidiaAmpereTensorCorePipeline");
+  LDBG() << "Start getNvidiaAmpereTensorCorePipeline";
   MainLoopInfo mainloop(forOp);
 
   // If the mainloop is not schedulable, return an empty schedule.
   if (!mainloop.isSchedulable) {
-    LDBG("--main loop is not schedulable -> " << forOp);
+    LDBG() << "--main loop is not schedulable -> " << forOp;
     return;
   }
 
@@ -519,8 +519,8 @@ static void getNvidiaAmpereTensorCorePipeline(
   // empty schedule.
   int numKgroups = mainloop.getNumberOfKgroups();
   if (numKgroups < 2 || numStages < 3) {
-    LDBG("--numKgroups=" << numKgroups << "(< 2) or numStages=" << numStages
-                         << "(< 3) -> BAIL");
+    LDBG() << "--numKgroups=" << numKgroups << "(< 2) or numStages=" << numStages
+                         << "(< 3) -> BAIL";
     return;
   }
 
@@ -532,7 +532,7 @@ static void getNvidiaAmpereTensorCorePipeline(
   if (!(mainloop.asyncCreateGroupOp.size() == 1) ||
       !(mainloop.asyncWaitOps.size() == 1) ||
       !(mainloop.barrierOps.size() == 2)) {
-    LDBG("--failed prereqs: 1 async_create, 1 async_wait, 2 barriers -> BAIL");
+    LDBG() << "--failed prereqs: 1 async_create, 1 async_wait, 2 barriers -> BAIL";
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-generic-vectorization"
-#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -26,7 +26,6 @@
 
 #define DEBUG_TYPE "iree-codegen-generic-vectorization"
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -41,7 +41,7 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
   std::unique_ptr<TilingConfig> tilingConfig =
       TilingConfig::create(getLoweringConfig(op));
   if (useConfiguredVectorSizes && tilingConfig) {
-    LDBG("Use configured vector sizes from lowering config");
+    LDBG() << "Use configured vector sizes from lowering config";
     auto [vectorSizes, scalableFlags] = tilingConfig->getVectorTileSizes();
     // Replace zeros in canonical vector shape to turn it into a valid shape.
     std::replace(vectorSizes.begin(), vectorSizes.end(), 0, 1);

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -23,7 +23,6 @@
 #include "mlir/IR/Verifier.h"
 
 #define DEBUG_TYPE "iree-codegen-link-tuning-specs"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -504,14 +504,14 @@ FailureOr<NamedSequenceOp> linkTuningSpecs(ModuleOp module) {
 
   size_t numConsumedSpecs = llvm::count_if(tuningSpecs, consumesInputOp);
   if (numConsumedSpecs > 0 && numConsumedSpecs != tuningSpecs.size()) {
-    LDBG("Only " << numConsumedSpecs << " tuning specs out of "
-                 << tuningSpecs.size() << " total consume the input op");
+    LDBG() << "Only " << numConsumedSpecs << " tuning specs out of "
+                 << tuningSpecs.size() << " total consume the input op";
     return module.emitWarning() << "Expected the argument in all tuning specs "
                                    "to be consistently readonly or consumed";
   }
 
   if (tuningSpecs.empty()) {
-    LDBG("No tuning specs found, exiting without linking");
+    LDBG() << "No tuning specs found, exiting without linking";
     return NamedSequenceOp{};
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Transform/IR/TransformAttrs.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -505,7 +505,7 @@ FailureOr<NamedSequenceOp> linkTuningSpecs(ModuleOp module) {
   size_t numConsumedSpecs = llvm::count_if(tuningSpecs, consumesInputOp);
   if (numConsumedSpecs > 0 && numConsumedSpecs != tuningSpecs.size()) {
     LDBG() << "Only " << numConsumedSpecs << " tuning specs out of "
-                 << tuningSpecs.size() << " total consume the input op";
+           << tuningSpecs.size() << " total consume the input op";
     return module.emitWarning() << "Expected the argument in all tuning specs "
                                    "to be consistently readonly or consumed";
   }

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -24,7 +24,6 @@
 
 #define DEBUG_TYPE "iree-codegen-link-tuning-specs"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -61,24 +61,24 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     // pass, and remove the ad-hoc materialization pass for padding.
     if (targetConfig && targetConfig.getAs<IREE::GPU::GPUPaddingResolverAttr>(
                             IREE::Encoding::kEncodingResolverAttrName)) {
-      LDBG("Found GPUPaddingResolverAttr encoding resolver. Materialization "
-           "will be handled later.");
+      LDBG() << "Found GPUPaddingResolverAttr encoding resolver. Materialization "
+           "will be handled later.";
       return success();
     }
 
     auto getTestTargetOrNopLayout =
         [&]() -> IREE::Encoding::LayoutMaterializerAttr {
       if (testCLGPUTarget) {
-        LDBG("Select GPUEncodingResolverAttr attribute as the layout "
-             "attribute. (testCLGPUTarget)");
+        LDBG() << "Select GPUEncodingResolverAttr attribute as the layout "
+             "attribute. (testCLGPUTarget)";
         return cast<IREE::Encoding::LayoutMaterializerAttr>(
             IREE::GPU::GPUEncodingResolverAttr::get(
                 ctx,
                 DictionaryAttr::get(ctx, NamedAttribute(kGPUTargetAttrName,
                                                         getCLGPUTarget(ctx)))));
       }
-      LDBG("Select EncodingNopLayoutAttr attribute as the layout "
-           "attribute (Encoding resolver unknown or unsupported).");
+      LDBG() << "Select EncodingNopLayoutAttr attribute as the layout "
+           "attribute (Encoding resolver unknown or unsupported).";
       return cast<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Codegen::EncodingNopLayoutAttr::get(ctx));
     };
@@ -104,8 +104,8 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                   resolverAttr.cloneWithSimplifiedConfig(targetConfig))
             : getTestTargetOrNopLayout();
 
-    LDBG("Selected Encoding::LayoutMaterializerAttr with target configuration: "
-         << layoutAttrWithTargetInfo);
+    LDBG() << "Selected Encoding::LayoutMaterializerAttr with target configuration: "
+         << layoutAttrWithTargetInfo;
 
     MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo);
     MaterializeEncodingConversionTarget target(*ctx);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -19,6 +19,7 @@
 #include "iree/compiler/Dialect/HAL/Analysis/DeviceAnalysis.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -33,7 +33,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -34,7 +34,6 @@
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -61,8 +61,9 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     // pass, and remove the ad-hoc materialization pass for padding.
     if (targetConfig && targetConfig.getAs<IREE::GPU::GPUPaddingResolverAttr>(
                             IREE::Encoding::kEncodingResolverAttrName)) {
-      LDBG() << "Found GPUPaddingResolverAttr encoding resolver. Materialization "
-           "will be handled later.";
+      LDBG()
+          << "Found GPUPaddingResolverAttr encoding resolver. Materialization "
+             "will be handled later.";
       return success();
     }
 
@@ -70,7 +71,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
         [&]() -> IREE::Encoding::LayoutMaterializerAttr {
       if (testCLGPUTarget) {
         LDBG() << "Select GPUEncodingResolverAttr attribute as the layout "
-             "attribute. (testCLGPUTarget)";
+                  "attribute. (testCLGPUTarget)";
         return cast<IREE::Encoding::LayoutMaterializerAttr>(
             IREE::GPU::GPUEncodingResolverAttr::get(
                 ctx,
@@ -78,7 +79,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                                                         getCLGPUTarget(ctx)))));
       }
       LDBG() << "Select EncodingNopLayoutAttr attribute as the layout "
-           "attribute (Encoding resolver unknown or unsupported).";
+                "attribute (Encoding resolver unknown or unsupported).";
       return cast<IREE::Encoding::LayoutMaterializerAttr>(
           IREE::Codegen::EncodingNopLayoutAttr::get(ctx));
     };
@@ -104,8 +105,9 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                   resolverAttr.cloneWithSimplifiedConfig(targetConfig))
             : getTestTargetOrNopLayout();
 
-    LDBG() << "Selected Encoding::LayoutMaterializerAttr with target configuration: "
-         << layoutAttrWithTargetInfo;
+    LDBG() << "Selected Encoding::LayoutMaterializerAttr with target "
+              "configuration: "
+           << layoutAttrWithTargetInfo;
 
     MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo);
     MaterializeEncodingConversionTarget target(*ctx);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -35,7 +35,6 @@
 
 #define DEBUG_TYPE "iree-codegen-materialize-tuning-specs"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -82,7 +82,7 @@ static LogicalResult dumpFinalTuningSpecToDir(ModuleOp tuningSpec) {
     return tuningSpec->emitError()
            << "Failed to create a unique file in " << dir << "\n";
   }
-  LDBG("Linked tuning spec file path: " << dumpPath);
+  LDBG() << "Linked tuning spec file path: " << dumpPath;
 
   std::string error;
   auto file = mlir::openOutputFile(dumpPath, &error);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ToolOutputFile.h"

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -34,7 +34,6 @@
 #include "mlir/Support/FileUtilities.h"
 
 #define DEBUG_TYPE "iree-codegen-materialize-tuning-specs"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -114,8 +114,8 @@ getTransformLibraryFromPath(ModuleOp compiledModule, StringRef path) {
     return compiledModule.emitError()
            << "Failed to load transform library module: " << libraryFileName;
   }
-  LDBG("--found transform library " << libraryFileName << "@"
-                                    << entrySequenceName);
+  LDBG() << "--found transform library " << libraryFileName << "@"
+                                    << entrySequenceName;
   return TransformLibraryWithEntrypoint{*maybeTransformLibrary,
                                         entrySequenceName.str()};
 }
@@ -150,7 +150,7 @@ static LogicalResult getModuleTuningSpec(ModuleOp compiledModule,
     return compiledModule.emitError() << "Failed to parse tuning spec in "
                                       << kSerializedTuningSpecAttrName;
   }
-  LDBG("--loaded tuning spec");
+  LDBG() << "--loaded tuning spec";
   return success();
 }
 
@@ -183,7 +183,7 @@ struct MaterializeUserConfigsPass final
     // removed.
     if (moduleOp->hasAttr(kSerializedTuningSpecAttrName)) {
       moduleOp->removeAttr(kSerializedTuningSpecAttrName);
-      LDBG("--dropped the serialized tuning spec from the module");
+      LDBG() << "--dropped the serialized tuning spec from the module";
     }
 
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
@@ -200,7 +200,7 @@ struct MaterializeUserConfigsPass final
       //      "translation_info" =
       //        #iree_codegen.translation_info<pipeline = None>
       //      ```
-      LDBG("MaterializeUserConfigsPass on function: " << funcOp);
+      LDBG() << "MaterializeUserConfigsPass on function: " << funcOp;
       if (succeeded(userTransformLibrary)) {
         StringRef libraryModuleName =
             userTransformLibrary->transformLibrary.getSymName().value_or(
@@ -249,7 +249,7 @@ struct MaterializeUserConfigsPass final
       }
 
       translationInfo = getTranslationInfo(funcOp);
-      LDBG("--guaranteed unique translationInfo: " << translationInfo);
+      LDBG() << "--guaranteed unique translationInfo: " << translationInfo;
       /// We only need to resolve symbols for transform dialect based
       /// strategies.
       if (!translationInfo ||

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -20,7 +20,6 @@
 
 #define DEBUG_TYPE "iree-codegen-materialize-user-configs"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Parser/Parser.h"
 
 #define DEBUG_TYPE "iree-codegen-materialize-user-configs"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -115,7 +115,7 @@ getTransformLibraryFromPath(ModuleOp compiledModule, StringRef path) {
            << "Failed to load transform library module: " << libraryFileName;
   }
   LDBG() << "--found transform library " << libraryFileName << "@"
-                                    << entrySequenceName;
+         << entrySequenceName;
   return TransformLibraryWithEntrypoint{*maybeTransformLibrary,
                                         entrySequenceName.str()};
 }

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-optimize-tensor-insert-extract-slices"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -387,21 +387,21 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   });
 
   funcOp.walk([&](scf::ForOp forOp) { moveLoopInvariantCode(forOp); });
-  LDBG("after hoisting loop invariant code\n" << funcOp);
+  LDBG() << "after hoisting loop invariant code\n" << funcOp;
 
   moveLoopInvariantCodeFromGenericOps(funcOp);
-  LDBG("after hoisting loop invariant code out of generic ops\n" << funcOp);
+  LDBG() << "after hoisting loop invariant code out of generic ops\n" << funcOp;
 
   // TODO: walking in some reverse / inside-out order would be more efficient
   // and would capture more cases.
   funcOp.walk(
       [&](scf::ForOp forOp) { hoistLoopInvariantSubsets(rewriter, forOp); });
-  LDBG("after hoisting loop invariant subsets\n" << funcOp);
+  LDBG() << "after hoisting loop invariant subsets\n" << funcOp;
 
   funcOp.walk([&](scf::ForOp forOp) {
     hoistSubsetWithLoopInvariantTensor(rewriter, forOp);
   });
-  LDBG("after hoisting subset loop invariant tensors" << funcOp);
+  LDBG() << "after hoisting subset loop invariant tensors" << funcOp;
 
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
@@ -420,8 +420,8 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  LDBG("after folding tensor.extract_slice and vector.transfer_read Ops \n"
-       << funcOp);
+  LDBG() << "after folding tensor.extract_slice and vector.transfer_read Ops \n"
+       << funcOp;
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -23,7 +23,6 @@
 
 #define DEBUG_TYPE "iree-codegen-optimize-tensor-insert-extract-slices"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -421,7 +421,7 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   }
 
   LDBG() << "after folding tensor.extract_slice and vector.transfer_read Ops \n"
-       << funcOp;
+         << funcOp;
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-optimize-vector-transfer"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -68,7 +68,7 @@ struct OptimizeVectorTransferPass final
 
   void runOnOperation() override {
     auto funcOp = getOperation();
-    LDBG("before optimize vector transfer\n" << funcOp);
+    LDBG() << "before optimize vector transfer\n" << funcOp;
     // Generate vector.shape_cast for dropping leading one dimensions in vector
     // ops. This increases the chance that we can forward more transfer writes
     // to transfer reads.
@@ -83,7 +83,7 @@ struct OptimizeVectorTransferPass final
       }
     }
 
-    LDBG("after dropping leading unit dims\n" << funcOp);
+    LDBG() << "after dropping leading unit dims\n" << funcOp;
 
     if (redundantHoisting) {
       // Workaround, run loop invariant code motion before hoist redundant
@@ -95,7 +95,7 @@ struct OptimizeVectorTransferPass final
     IRRewriter rewriter(funcOp->getContext());
     vector::transferOpflowOpt(rewriter, funcOp);
 
-    LDBG("after folding redundant vector transfers\n" << funcOp);
+    LDBG() << "after folding redundant vector transfers\n" << funcOp;
 
     // Move bitcast inwards from loop region boundaries to increase chances to
     // cancel them.
@@ -107,7 +107,7 @@ struct OptimizeVectorTransferPass final
       }
     }
 
-    LDBG("after bubbling vector bitcasts\n" << funcOp);
+    LDBG() << "after bubbling vector bitcasts\n" << funcOp;
 
     // Second stage of patterns to flatten transfer ops.
     if (flatten) {
@@ -117,11 +117,11 @@ struct OptimizeVectorTransferPass final
         return signalPassFailure();
       }
     }
-    LDBG("after flattening vector transfers\n" << funcOp);
+    LDBG() << "after flattening vector transfers\n" << funcOp;
     // Delete potential dead alloc and associated ops after store to load
     // forwarding.
     memref::eraseDeadAllocAndStores(rewriter, funcOp);
-    LDBG("after erasing unused allocs and stores\n" << funcOp);
+    LDBG() << "after erasing unused allocs and stores\n" << funcOp;
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -21,7 +21,6 @@
 
 #define DEBUG_TYPE "iree-codegen-optimize-vector-transfer"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-debug-patch-func-ops"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
@@ -40,7 +40,7 @@ static LogicalResult getMatchedFuncOp(StringRef fileName,
     return failure();
   }
   moduleOp = *maybeModuleOp;
-  LDBG("--found patching library @" << fileName);
+  LDBG() << "--found patching library @" << fileName;
 
   for (auto candidate : moduleOp->getOps<FunctionOpInterface>()) {
     if (funcOp.getName() == candidate.getName()) {
@@ -62,7 +62,7 @@ struct PatchFuncOpsPass : public impl::PatchFuncOpsPassBase<PatchFuncOpsPass> {
 
 void PatchFuncOpsPass::runOnOperation() {
   if (clCodegenPatchedFuncOpsFileName.empty()) {
-    LDBG("skip, because no file is provided");
+    LDBG() << "skip, because no file is provided";
     return;
   }
   Operation *startOp = getOperation();
@@ -84,10 +84,10 @@ void PatchFuncOpsPass::runOnOperation() {
       return signalPassFailure();
     }
     if (!replacement) {
-      LDBG("--did not find matching funcOp" << funcOp.getName());
+      LDBG() << "--did not find matching funcOp" << funcOp.getName();
       continue;
     }
-    LDBG("--found matching funcOp" << funcOp.getName());
+    LDBG() << "--found matching funcOp" << funcOp.getName();
     // Do not use takeBody method because it drops the reference in the module
     // op that contains the patches.
     IRMapping mapper;

--- a/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PatchFuncOps.cpp
@@ -16,7 +16,6 @@
 
 #define DEBUG_TYPE "iree-codegen-debug-patch-func-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
@@ -6,7 +6,7 @@
 
 #include <numeric>
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"

--- a/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
@@ -14,7 +14,6 @@
 #include "mlir/IR/TypeUtilities.h"
 
 #define DEBUG_TYPE "iree-codegen-tile-inference-utils"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 
@@ -49,8 +48,8 @@ inferWorkgroupTileMultiplesFromPackUnPack(
   SmallVector<int64_t> innerTiles = op.getStaticTiles();
   // If the tiles are dynamic, then no inference can be made.
   if (ShapedType::isDynamicShape(innerTiles)) {
-    LLVM_DEBUG(DBGS() << "Cannot infer multiple for dynamic inner tiles."
-                         "Defaulting to all 1.");
+    LDBG() << "Cannot infer multiple for dynamic inner tiles. Defaulting to "
+              "all 1.";
     return {getDefaultValueMultiples(op.getSource()),
             getDefaultValueMultiples(op.getDest())};
   }
@@ -86,8 +85,8 @@ inferWorkgroupTileMultiplesFromPackUnPack(
       lcmInnerTileMultiple = std::lcm(
           initialPackedMultiples.value()[innerTileIdx], lcmInnerTileMultiple);
       if (lcmInnerTileMultiple != tile) {
-        LLVM_DEBUG(DBGS() << "Cannot find a compatible tile size multiple. "
-                          << "Defaulting to all 1.");
+        LDBG() << "Cannot find a compatible tile size multiple. Defaulting to "
+                  "all 1.";
         return {getDefaultValueMultiples(op.getSource()),
                 getDefaultValueMultiples(op.getDest())};
       }
@@ -130,7 +129,7 @@ static void inferWorkgroupTileMultiplesFromLinalgOp(
   auto dbgsPrintMultiples = [](SmallVector<SmallVector<int64_t>> multiples) {
     LLVM_DEBUG({
       for (auto [i, m] : llvm::enumerate(multiples)) {
-        DBGS() << "operand " << i << ": " << llvm::interleaved_array(m) << "\n";
+        LDBG() << "operand " << i << ": " << llvm::interleaved_array(m);
       }
     });
   };
@@ -195,14 +194,14 @@ expandMultiples(ArrayRef<int64_t> collapsedMultiples,
     for (int i = group.size() - 1; i >= 0; --i) {
       int64_t expandedSize = expandedShape[group[i]];
       if (ShapedType::isDynamic(expandedSize)) {
-        LLVM_DEBUG(DBGS() << "Cannot infer multiple with dynamic size. "
-                             "defaulting to all 1");
+        LDBG()
+            << "Cannot infer multiple with dynamic size. defaulting to all 1";
         expandedMultiples = SmallVector<int64_t>(expandedShape.size(), 1);
         return expandedMultiples;
       }
       if (residualMultiple % expandedSize != 0) {
-        LLVM_DEBUG(DBGS() << "Expanded size does not divide producer "
-                             "multiple. Defaulting to all 1");
+        LDBG() << "Expanded size does not divide producer multiple. Defaulting "
+                  "to all 1";
         expandedMultiples = SmallVector<int64_t>(expandedShape.size(), 1);
         return expandedMultiples;
       }

--- a/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
@@ -39,8 +39,9 @@ inferWorkgroupTileMultiplesFromPackUnPack(
         std::nullopt) {
   static_assert(llvm::is_one_of<PackOrUnPackOpTy, linalg::PackOp,
                                 linalg::UnPackOp>::value);
-  LDBG() << "Inferring workgroup tile size multiples from " << op->getName() << ":\n"
-                                                       << op;
+  LDBG() << "Inferring workgroup tile size multiples from " << op->getName()
+         << ":\n"
+         << op;
   // Initialize the list of multiples for the packed and unpack inputs.
   int64_t unPackedRank = (std::is_same<PackOrUnPackOpTy, linalg::PackOp>::value)
                              ? op.getSourceRank()
@@ -124,7 +125,8 @@ static void inferWorkgroupTileMultiplesFromLinalgOp(
     linalg::LinalgOp linalgOp, SmallVector<int64_t> &iterationMultiples,
     SmallVector<SmallVector<int64_t>> &operandMultiples,
     SmallVector<SmallVector<int64_t>> &resultMultiples) {
-  LDBG() << "Inferring workgroup tile size multiples for linalgOp:\n" << linalgOp;
+  LDBG() << "Inferring workgroup tile size multiples for linalgOp:\n"
+         << linalgOp;
   auto dbgsPrintMultiples = [](SmallVector<SmallVector<int64_t>> multiples) {
     LLVM_DEBUG({
       for (auto [i, m] : llvm::enumerate(multiples)) {
@@ -160,7 +162,8 @@ static void inferWorkgroupTileMultiplesFromLinalgOp(
     }
   }
 
-  LDBG() << "\niterationMultiples: " << llvm::interleaved_array(iterationMultiples);
+  LDBG() << "\niterationMultiples: "
+         << llvm::interleaved_array(iterationMultiples);
 }
 
 /// Given a set of multiples, and reassociations for expansion, return the
@@ -245,13 +248,13 @@ static SmallVector<int64_t> inferResultWorkgroupTileMultiples(OpResult result) {
       .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
         SmallVector<int64_t> srcMultiples = getOperandMultiples()[0];
         LDBG() << "Inferring workgroup tile size multiples for "
-             << expandOp->getName() << " result.\n";
+               << expandOp->getName() << " result.\n";
         SmallVector<int64_t> resultMultiples = expandMultiples(
             /*collapsedMultiples=*/srcMultiples,
             /*expandedShape=*/expandOp.getResultType().getShape(),
             /*reassociations=*/expandOp.getReassociationIndices());
         LDBG() << "\nInferred expand_shape result multiples: "
-             << llvm::interleaved_array(resultMultiples);
+               << llvm::interleaved_array(resultMultiples);
         return resultMultiples;
       })
       .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
@@ -271,9 +274,10 @@ static SmallVector<int64_t> inferResultWorkgroupTileMultiples(OpResult result) {
       .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
         SmallVector<SmallVector<int64_t>> operandMultiples =
             getOperandMultiples();
-        LDBG() << "Inferring workgroup tile size multiples for linalg op result #"
-             << result.getResultNumber() << ":\n"
-             << result;
+        LDBG()
+            << "Inferring workgroup tile size multiples for linalg op result #"
+            << result.getResultNumber() << ":\n"
+            << result;
         SmallVector<SmallVector<int64_t>> resultMultiples = llvm::map_to_vector(
             linalgOp->getResults(), getDefaultValueMultiples);
         SmallVector<int64_t> iterationMultiples(
@@ -296,8 +300,8 @@ static SmallVector<int64_t> inferResultWorkgroupTileMultiples(OpResult result) {
 /// slice of the `use` tensor after tiling and distributing to workgroups.
 static SmallVector<int64_t> inferUseWorkgroupTileMultiples(OpOperand *use) {
   LDBG() << "Inferring workgroup tile size multiples for operand "
-       << use->getOperandNumber() << " of user:\n"
-       << *use->getOwner();
+         << use->getOperandNumber() << " of user:\n"
+         << *use->getOwner();
   // Gather multiples for all operands from producers.
   Operation *op = use->getOwner();
   auto getResultMultiples = [&]() -> SmallVector<SmallVector<int64_t>> {
@@ -315,13 +319,13 @@ static SmallVector<int64_t> inferUseWorkgroupTileMultiples(OpOperand *use) {
       .Case<tensor::CollapseShapeOp>([&](tensor::CollapseShapeOp collapseOp) {
         SmallVector<int64_t> destMultiples = getResultMultiples()[0];
         LDBG() << "Inferring workgroup tile size multiples for "
-             << collapseOp->getName() << "source.\n";
+               << collapseOp->getName() << "source.\n";
         SmallVector<int64_t> srcMultiples = expandMultiples(
             /*collapsedMultiples=*/destMultiples,
             /*expandedShape=*/collapseOp.getSrcType().getShape(),
             /*reassociations=*/collapseOp.getReassociationIndices());
         LDBG() << "\nInferred collapse_shape source multiples: "
-             << llvm::interleaved_array(srcMultiples);
+               << llvm::interleaved_array(srcMultiples);
         return srcMultiples;
       })
       .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
@@ -355,7 +359,7 @@ static SmallVector<int64_t> lcmMultiples(ArrayRef<int64_t> a,
 
 SmallVector<int64_t> getWorkgroupSizeMultiples(TilingInterface tilingOp) {
   LDBG() << "Computing workgroup tile size multiples for: "
-       << *tilingOp.getOperation();
+         << *tilingOp.getOperation();
 
   // Get operand and result multiples for the op.
   SmallVector<SmallVector<int64_t>> operandMultiples;
@@ -384,7 +388,7 @@ SmallVector<int64_t> getWorkgroupSizeMultiples(TilingInterface tilingOp) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(tilingOp.getOperation());
   if (!linalgOp) {
     LDBG() << "Only LinalgOp and PackOp are implemented. Defaulting to all 1 "
-         "multiples.";
+              "multiples.";
     return SmallVector<int64_t>(tilingOp.getLoopIteratorTypes().size(), 1);
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileInferenceUtils.cpp
@@ -15,7 +15,6 @@
 
 #define DEBUG_TYPE "iree-codegen-tile-inference-utils"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -15,7 +15,6 @@
 #include "mlir/IR/BuiltinAttributes.h"
 
 #define DEBUG_TYPE "tiling-config"
-#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -16,7 +16,6 @@
 
 #define DEBUG_TYPE "tiling-config"
 #define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
-#define LDBG(X) LLVM_DEBUG(KD_DBGS() << X << "\n")
 
 using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -19,7 +19,7 @@
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -38,7 +38,6 @@
 
 #define DEBUG_TYPE "iree-gpu-attrs"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1052,7 +1052,8 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
         return dim.kind == TileSwizzle::Dim::Kind::Internal;
       });
 
-  LDBG() << "accCrossIntrinsicShape: " << llvm::interleaved(accCrossIntrinsicShape);
+  LDBG() << "accCrossIntrinsicShape: "
+         << llvm::interleaved(accCrossIntrinsicShape);
   LDBG() << "accInternalShape: " << llvm::interleaved(accInternalShape);
   int dstRank = accCrossIntrinsicShape.size();
   SmallVector<int64_t> strides(dstRank, 1);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -976,7 +976,7 @@ distributeMmaFragmentToIntrinsics(OpBuilder &builder, Location loc, Value value,
       sliceSwizzledShape(swizzle, [](TileSwizzle::Dim dim) {
         return dim.kind == TileSwizzle::Dim::Kind::CrossIntrinsic;
       });
-  LDBG("crossIntrinsicShape: " << llvm::interleaved(crossIntrinsicShape));
+  LDBG() << "crossIntrinsicShape: " << llvm::interleaved(crossIntrinsicShape);
   int rank = internalShape.size();
   SmallVector<int64_t> indices(rank, 0);
   SmallVector<int64_t> strides(rank, 1);
@@ -1008,20 +1008,20 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
 
   // Prepare Lhs/Rhs/Acc operand slices to feed the intrinsic.
   TileSwizzle lhsSwizzle = getSwizzle(*this, MMAFragment::Lhs);
-  LDBG("DataTiledMMAAttr::buildMmaOperation");
-  LDBG("    lhsSwizzle: " << lhsSwizzle);
+  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
+  LDBG() << "    lhsSwizzle: " << lhsSwizzle;
   SmallVector<Value> intrinsicsLhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
 
   TileSwizzle rhsSwizzle = getSwizzle(*this, MMAFragment::Rhs);
-  LDBG("DataTiledMMAAttr::buildMmaOperation");
-  LDBG("    rhsSwizzle: " << rhsSwizzle);
+  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
+  LDBG() << "    rhsSwizzle: " << rhsSwizzle;
   SmallVector<Value> intrinsicsRhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
 
   TileSwizzle accSwizzle = getSwizzle(*this, MMAFragment::Acc);
-  LDBG("DataTiledMMAAttr::buildMmaOperation");
-  LDBG("    accSwizzle: " << accSwizzle);
+  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
+  LDBG() << "    accSwizzle: " << accSwizzle;
 
   SmallVector<Value> intrinsicsAcc =
       distributeMmaFragmentToIntrinsics(builder, loc, outputs[0], accSwizzle);
@@ -1052,8 +1052,8 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
         return dim.kind == TileSwizzle::Dim::Kind::Internal;
       });
 
-  LDBG("accCrossIntrinsicShape: " << llvm::interleaved(accCrossIntrinsicShape));
-  LDBG("accInternalShape: " << llvm::interleaved(accInternalShape));
+  LDBG() << "accCrossIntrinsicShape: " << llvm::interleaved(accCrossIntrinsicShape);
+  LDBG() << "accInternalShape: " << llvm::interleaved(accInternalShape);
   int dstRank = accCrossIntrinsicShape.size();
   SmallVector<int64_t> strides(dstRank, 1);
   SmallVector<int64_t> indices(dstRank, 0);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -32,7 +32,6 @@
 #include "mlir/Support/LogicalResult.h"
 
 #define DEBUG_TYPE "iree-gpu-config-utils"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler::IREE::GPU {
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -22,7 +22,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -841,8 +841,8 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
       for (unsigned i = maxCandidate; i >= 1; i >>= 1) {
         candidates.push_back(i * workgroupTileMultiple);
       }
-      LDBG() << 
-          "Base candidate tile sizes: " << llvm::interleaved_array(candidates);
+      LDBG() << "Base candidate tile sizes: "
+             << llvm::interleaved_array(candidates);
 
       int64_t candidateWorkgroupSize = 1;
       for (int64_t candidate : candidates) {
@@ -992,7 +992,8 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
-  LDBG() << "Selected tile and fuse lowering config: " << loweringConfig << "\n";
+  LDBG() << "Selected tile and fuse lowering config: " << loweringConfig
+         << "\n";
 
   // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(
@@ -1100,7 +1101,8 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
-  LDBG() << "Selected tile and fuse lowering config: " << loweringConfig << "\n";
+  LDBG() << "Selected tile and fuse lowering config: " << loweringConfig
+         << "\n";
 
   // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -33,7 +33,6 @@
 
 #define DEBUG_TYPE "iree-gpu-config-utils"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::GPU {
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -52,7 +52,6 @@
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::CPU {
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -262,8 +262,9 @@ TileMxNxK chooseMatmulTile(ArrayRef<TileMxNxK> enumeratedTiles,
     }
     ratedTile.productMxNxK = tile.M * tile.N * tile.K;
     ratedTiles.push_back(ratedTile);
-    LDBG() << "candidate: " << llvm::interleaved(ArrayRef{tile.M, tile.N, tile.K})
-                       << " penalty:" << ratedTile.paddingPenalty;
+    LDBG() << "candidate: "
+           << llvm::interleaved(ArrayRef{tile.M, tile.N, tile.K})
+           << " penalty:" << ratedTile.paddingPenalty;
     bestPaddingPenalty = std::min(bestPaddingPenalty, ratedTile.paddingPenalty);
   }
   RatedTileMxNxK bestRatedTile;
@@ -278,10 +279,10 @@ TileMxNxK chooseMatmulTile(ArrayRef<TileMxNxK> enumeratedTiles,
   // Sanity check. This assert can only fail if there's a programming mistake
   // locally here.
   assert(bestRatedTile.paddingPenalty == bestPaddingPenalty);
-  LDBG() << "bestRatedTile: " << llvm::interleaved(ArrayRef{bestRatedTile.M,
-                                                       bestRatedTile.N,
-                                                       bestRatedTile.K})
-                         << " penalty:" << bestRatedTile.paddingPenalty;
+  LDBG() << "bestRatedTile: "
+         << llvm::interleaved(
+                ArrayRef{bestRatedTile.M, bestRatedTile.N, bestRatedTile.K})
+         << " penalty:" << bestRatedTile.paddingPenalty;
   return bestRatedTile;
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -51,7 +51,6 @@
 #include "mlir/IR/BuiltinAttributes.h"
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler::IREE::CPU {
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -71,7 +71,7 @@ getScalableTileFlags(linalg::ContractionDimensions cDims,
   // TODO(egebeysel): I think this isScalable*Enabled flag should be temporary
   // and the temporary SME flag should probably come next to it.
   if (!isAArch64(config) || !isScalableVectorizationEnabled()) {
-    LDBG("Pre-conditions to enable scalable tiling are not met!");
+    LDBG() << "Pre-conditions to enable scalable tiling are not met!";
     return failure();
   }
 
@@ -86,7 +86,7 @@ getScalableTileFlags(linalg::ContractionDimensions cDims,
   // TODO(egebeysel): Add logic for SME.
   if (mDim.has_value()) {
     if (hasFeature(config, "+sme")) {
-      LDBG("SME with data-tiling is not supported yet!");
+      LDBG() << "SME with data-tiling is not supported yet!";
       return failure();
     }
     scalableTiles.push_back(false);
@@ -262,8 +262,8 @@ TileMxNxK chooseMatmulTile(ArrayRef<TileMxNxK> enumeratedTiles,
     }
     ratedTile.productMxNxK = tile.M * tile.N * tile.K;
     ratedTiles.push_back(ratedTile);
-    LDBG("candidate: " << llvm::interleaved(ArrayRef{tile.M, tile.N, tile.K})
-                       << " penalty:" << ratedTile.paddingPenalty);
+    LDBG() << "candidate: " << llvm::interleaved(ArrayRef{tile.M, tile.N, tile.K})
+                       << " penalty:" << ratedTile.paddingPenalty;
     bestPaddingPenalty = std::min(bestPaddingPenalty, ratedTile.paddingPenalty);
   }
   RatedTileMxNxK bestRatedTile;
@@ -278,10 +278,10 @@ TileMxNxK chooseMatmulTile(ArrayRef<TileMxNxK> enumeratedTiles,
   // Sanity check. This assert can only fail if there's a programming mistake
   // locally here.
   assert(bestRatedTile.paddingPenalty == bestPaddingPenalty);
-  LDBG("bestRatedTile: " << llvm::interleaved(ArrayRef{bestRatedTile.M,
+  LDBG() << "bestRatedTile: " << llvm::interleaved(ArrayRef{bestRatedTile.M,
                                                        bestRatedTile.N,
                                                        bestRatedTile.K})
-                         << " penalty:" << bestRatedTile.paddingPenalty);
+                         << " penalty:" << bestRatedTile.paddingPenalty;
   return bestRatedTile;
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -46,7 +46,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/IR/BuiltinAttributes.h"
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -51,7 +51,6 @@
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::GPU {
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -40,7 +40,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -50,7 +50,6 @@
 #include <numeric>
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler::IREE::GPU {
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -272,10 +272,10 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   IREE::GPU::DataTiledMMAAttr mma = chooseDataTiledMMAAttr(
       resultEncoding.getElementTypesArray(), targetAttr, resultEncoding);
   if (!mma) {
-    LDBG("expect encodings on operand types");
+    LDBG() << "expect encodings on operand types";
     return nullptr;
   }
-  LDBG("Target MMA: " << mma);
+  LDBG() << "Target MMA: " << mma;
 
   MLIRContext *ctx = builder.getContext();
   SmallVector<AffineExpr> lhsExprs, rhsExprs, accExprs;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -23,7 +23,7 @@
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -45,7 +45,6 @@
 #include <numeric>
 
 #define DEBUG_TYPE "kernel-dispatch"
-#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -409,8 +409,8 @@ getMinTilingSizesForEachDim(mlir::FunctionOpInterface entryPointFn,
       }
       int64_t factor = seen ? 1LL : maxUnrollFactor;
       seen = true;
-      LDBG("Adjusted min tile sizes: " << minTileSizes[unrollDim]
-                                       << " with factor=" << factor << "\n");
+      LDBG() << "Adjusted min tile sizes: " << minTileSizes[unrollDim]
+                                       << " with factor=" << factor << "\n";
       minTileSizes[unrollDim] =
           std::min<int64_t>(minTileSizes[unrollDim], factor);
     }
@@ -897,15 +897,15 @@ getDefaultDistributedLevelTileSizes(Operation *op,
         config.vectorSizeHints.empty() ? 1 : config.vectorSizeHints[i];
   }
 
-  LDBG("Adjusted min tile sizes: " << adjustedMinTileSizes);
-  LDBG("Adjusted max tile sizes: " << adjustedMaxTileSizes);
-  LDBG("Adjusted vector size hints: " << adjustedVectorSizeHints);
+  LDBG() << "Adjusted min tile sizes: " << adjustedMinTileSizes;
+  LDBG() << "Adjusted max tile sizes: " << adjustedMaxTileSizes;
+  LDBG() << "Adjusted vector size hints: " << adjustedVectorSizeHints;
 
   SmallVector<int64_t> distributedTileSizes = getDefaultDistributionTileSizes(
       lbs, ubs, adjustedMinTileSizes, adjustedMaxTileSizes,
       adjustedVectorSizeHints);
 
-  LDBG("Distributed tile sizes before fixups: " << distributedTileSizes);
+  LDBG() << "Distributed tile sizes before fixups: " << distributedTileSizes;
 
   // Final fix up of the tile sizes to make sure that they divide the problem
   // size to make it vectorizable.
@@ -916,7 +916,7 @@ getDefaultDistributedLevelTileSizes(Operation *op,
         lbs[i], ubs[i], distributedTileSizes[i], adjustedMinTileSizes[i],
         config.allowIncompleteTile);
   }
-  LDBG("Distributed tile sizes after fixups: " << distributedTileSizes);
+  LDBG() << "Distributed tile sizes after fixups: " << distributedTileSizes;
   return distributedTileSizes;
 }
 
@@ -957,7 +957,7 @@ static void setAlwaysVectorizeSizes(linalg::LinalgOp op,
       continue;
     vecTileSizes[index] = 1;
   }
-  LDBG("Set always-vectorize sizes: " << vecTileSizes);
+  LDBG() << "Set always-vectorize sizes: " << vecTileSizes;
 }
 
 /// A helper class to record different level tiling sizes and generate
@@ -1162,8 +1162,8 @@ static LogicalResult setMatmulPeelingRootConfig(
   generator.setVectorTileSizes(vecTileSizes, vectorScalableFlags);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Final tile sizes and scalable flags for contraction: "
-       << loweringConfig);
+  LDBG() << "Final tile sizes and scalable flags for contraction: "
+       << loweringConfig;
 
   DictionaryAttr pipelineConfig =
       getPipelineConfWithPeelingAttr(op.getContext());
@@ -1212,8 +1212,8 @@ static LogicalResult setMatmulRootConfig(
   generator.setVectorTileSizes(vecTileSizes, vecScalableFlags);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Final tile sizes and scalable flags for contraction: "
-       << loweringConfig);
+  LDBG() << "Final tile sizes and scalable flags for contraction: "
+       << loweringConfig;
 
   auto pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
   return setOpConfigAndEntryPointFnTranslation(entryPointFn, op, loweringConfig,
@@ -1312,7 +1312,7 @@ static void getMatmulVectorSizesUsingFullVectorHeuristics(
       minSize = std::min<int64_t>(minSize, mmType.getIntOrFloatBitWidth());
   }
 
-  LDBG("Smallest type found: " << minSize << " bits");
+  LDBG() << "Smallest type found: " << minSize << " bits";
   assert(minSize > 0 && minSize < std::numeric_limits<int64_t>::max() &&
          "Min size couldn't be computed");
 
@@ -1503,8 +1503,8 @@ getMatmulVectorSizes(mlir::FunctionOpInterface entryPointFn,
     }
   }
 
-  LDBG("Matmul vector sizes: " << tileSizes);
-  LDBG("Matmul vector scalable flags: " << scalableTileFlags);
+  LDBG() << "Matmul vector sizes: " << tileSizes;
+  LDBG() << "Matmul vector scalable flags: " << scalableTileFlags;
   return std::make_pair(tileSizes, scalableTileFlags);
 }
 
@@ -1566,7 +1566,7 @@ setRootConfig(mlir::FunctionOpInterface entryPointFn,
   bool usePeelingPipeline =
       vecPreProcStrategy == VectorPreProcStrategy::Peeling;
 
-  LDBG("Vector pre-processing strategy: " << vecPreProcStrategy);
+  LDBG() << "Vector pre-processing strategy: " << vecPreProcStrategy;
 
   DistributionHeuristicConfig distConfig;
   distConfig.maxTileSizes.resize(numLoops, clDefaultDistTileSize);
@@ -1596,7 +1596,7 @@ setRootConfig(mlir::FunctionOpInterface entryPointFn,
   // FIXME: Apply maxTileSize modification for all targets.
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
   if (isRISCV(targetAttr) && hasAnyVFeature(targetAttr)) {
-    LDBG("RISC-V Aggressive Distribution: " << clEnableRiscvAggressiveDist);
+    LDBG() << "RISC-V Aggressive Distribution: " << clEnableRiscvAggressiveDist;
     for (auto loopNum :
          llvm::seq<unsigned>(static_cast<unsigned>(isBM), numLoops)) {
       if (clEnableRiscvAggressiveDist) {
@@ -1623,11 +1623,11 @@ setRootConfig(mlir::FunctionOpInterface entryPointFn,
   // smaller than `minTileSizes`, so we have to adjust the cache sizes again.
   cacheTileSizes = distTileSizes;
 
-  LDBG("Distribution tile sizes: " << distTileSizes);
-  LDBG("Cache tile sizes: " << cacheTileSizes);
-  LDBG("Vector tile sizes: " << vecTileSizes);
-  LDBG("Vector scalable tile flags: " << vecScalableFlags);
-  LDBG("Vector size: " << vectorSize);
+  LDBG() << "Distribution tile sizes: " << distTileSizes;
+  LDBG() << "Cache tile sizes: " << cacheTileSizes;
+  LDBG() << "Vector tile sizes: " << vecTileSizes;
+  LDBG() << "Vector scalable tile flags: " << vecScalableFlags;
+  LDBG() << "Vector size: " << vectorSize;
 
   if (usePeelingPipeline) {
     return setMatmulPeelingRootConfig(
@@ -1870,12 +1870,12 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   SmallVector<int64_t> lbs, ubs;
   getRangeBounds(attnOp, lbs, ubs);
 
-  LDBG("Attention Detail:");
-  LDBG("Batch: " << llvm::interleaved_array(opInfo.getBatchDims()));
-  LDBG("M: " << llvm::interleaved_array(opInfo.getMDims()));
-  LDBG("K1: " << llvm::interleaved_array(opInfo.getK1Dims()));
-  LDBG("K2: " << llvm::interleaved_array(opInfo.getK2Dims()));
-  LDBG("N: " << llvm::interleaved_array(opInfo.getNDims()));
+  LDBG() << "Attention Detail:";
+  LDBG() << "Batch: " << llvm::interleaved_array(opInfo.getBatchDims());
+  LDBG() << "M: " << llvm::interleaved_array(opInfo.getMDims());
+  LDBG() << "K1: " << llvm::interleaved_array(opInfo.getK1Dims());
+  LDBG() << "K2: " << llvm::interleaved_array(opInfo.getK2Dims());
+  LDBG() << "N: " << llvm::interleaved_array(opInfo.getNDims());
 
   // Batch, M and N (parallel dimensions) are distributed on workgroups.
   DistributionHeuristicConfig config;
@@ -1975,7 +1975,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(vecTileSizes);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config for attnOp: " << loweringConfig);
+  LDBG() << "Set lowering_config for attnOp: " << loweringConfig;
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, attnOp, loweringConfig,
       DispatchLoweringPassPipeline::CPULinalgExtTileAndVectorize);
@@ -2081,7 +2081,7 @@ setDefaultGenericOpRootConfig(mlir::FunctionOpInterface entryPointFn,
                               const TargetMLTransformInfo &targetMLTransInfo) {
   assert(!getLoweringConfig(genericOp) &&
          "expected lowering_config is not set");
-  LDBG("Setting default generic op root configuration");
+  LDBG() << "Setting default generic op root configuration";
 
   // If there are no loops, there is nothing to do.
   unsigned numLoops = genericOp.getNumLoops();
@@ -2100,10 +2100,10 @@ setDefaultGenericOpRootConfig(mlir::FunctionOpInterface entryPointFn,
 
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(genericOp, distConfig);
-  LDBG("Final tile sizes for distribution: " << distTileSizes);
+  LDBG() << "Final tile sizes for distribution: " << distTileSizes;
 
   auto vecPreProcStrategy = getVectorPreProcStrategy(genericOp);
-  LDBG("Vectorization pre-processing strategy " << vecPreProcStrategy);
+  LDBG() << "Vectorization pre-processing strategy " << vecPreProcStrategy;
 
   // Set the next level tile sizes.
   SmallVector<int64_t> vecTileSizes;
@@ -2119,7 +2119,7 @@ setDefaultGenericOpRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(vecTileSizes);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config: " << loweringConfig);
+  LDBG() << "Set lowering_config: " << loweringConfig;
 
   // For non-tensor based ops use the Buffer ops pipeline.
   DispatchLoweringPassPipeline passPipeline;
@@ -2231,8 +2231,8 @@ getTransposeVectorSizes(mlir::FunctionOpInterface entryPointFn,
   if (scalableFlags.empty())
     scalableFlags = SmallVector<bool>(tileSizes.size(), false);
 
-  LDBG("Transpose vector sizes: " << tileSizes);
-  LDBG("Transpose vector scalable flags: " << scalableFlags);
+  LDBG() << "Transpose vector sizes: " << tileSizes;
+  LDBG() << "Transpose vector scalable flags: " << scalableFlags;
   return std::make_pair(tileSizes, scalableFlags);
 }
 
@@ -2249,7 +2249,7 @@ setTransposeLikeOpRootConfig(mlir::FunctionOpInterface entryPointFn,
   if (!linalgOpInfo.isTranspose())
     return failure();
 
-  LDBG("Setting transpose-like op root configuration");
+  LDBG() << "Setting transpose-like op root configuration";
 
   std::optional<SizesAndScalableFlags> vecDims = getTransposeVectorSizes(
       entryPointFn, genericOp, linalgOpInfo, targetMLTransInfo);
@@ -2261,7 +2261,7 @@ setTransposeLikeOpRootConfig(mlir::FunctionOpInterface entryPointFn,
   DistributionHeuristicConfig distConfig;
   distConfig.minTileSizes = vecSizes;
   auto vecPreProcStrategy = getVectorPreProcStrategy(genericOp);
-  LDBG("Vectorization pre-processing strategy " << vecPreProcStrategy);
+  LDBG() << "Vectorization pre-processing strategy " << vecPreProcStrategy;
   if (vecPreProcStrategy != VectorPreProcStrategy::None) {
     distConfig.allowIncompleteTile = true;
   }
@@ -2273,7 +2273,7 @@ setTransposeLikeOpRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(vecSizes, vecScalableDims);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config: " << loweringConfig);
+  LDBG() << "Set lowering_config: " << loweringConfig;
 
   auto passPipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
   return setOpConfigAndEntryPointFnTranslation(entryPointFn, genericOp,
@@ -2289,7 +2289,7 @@ static LogicalResult setElementwiseGenericOpRootConfig(
     const TargetMLTransformInfo &targetMLTransInfo) {
   assert(!getLoweringConfig(genericOp) &&
          "expected lowering_config is not set");
-  LDBG("Setting elementwise generic op root configuration");
+  LDBG() << "Setting elementwise generic op root configuration";
 
   unsigned numLoops = genericOp.getNumLoops();
   if (numLoops == 0)
@@ -2336,7 +2336,7 @@ static LogicalResult setElementwiseGenericOpRootConfig(
   }
 
   auto vecPreProcStrategy = getVectorPreProcStrategy(genericOp);
-  LDBG("Vector pre-processing strategy: " << vecPreProcStrategy);
+  LDBG() << "Vector pre-processing strategy: " << vecPreProcStrategy;
 
   // Adjust tiling sizes of vector levels to avoid large unroll factors. Most of
   // the cases are f32 and i32, so we divide it by 4.
@@ -2352,7 +2352,7 @@ static LogicalResult setElementwiseGenericOpRootConfig(
   generator.setVectorTileSizes(vecTileSizes);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config for element-wise op: " << loweringConfig);
+  LDBG() << "Set lowering_config for element-wise op: " << loweringConfig;
 
   DispatchLoweringPassPipeline passPipeline;
   DictionaryAttr pipelineConfig;
@@ -2609,7 +2609,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(distConfig.vectorSizeHints);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config for tensor.pad op: " << loweringConfig);
+  LDBG() << "Set lowering_config for tensor.pad op: " << loweringConfig;
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, padOp, loweringConfig,
@@ -2636,7 +2636,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   generator.setVectorTileSizes(vecTileSizes);
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
-  LDBG("Set lowering_config for tensor.pad op: " << loweringConfig);
+  LDBG() << "Set lowering_config for tensor.pad op: " << loweringConfig;
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, op, loweringConfig,
       DispatchLoweringPassPipeline::CPUDefault);
@@ -2767,8 +2767,8 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
 
     foundUnPackOp = true;
     auto idxMap = linalgOp.getMatchingIndexingMap(opOperand);
-    LDBG("Find unpack op candidate: " << unpackOp);
-    LDBG("The corresponding indexing map is: " << idxMap);
+    LDBG() << "Find unpack op candidate: " << unpackOp;
+    LDBG() << "The corresponding indexing map is: " << idxMap;
 
     SmallVector<int64_t> innerTiles = unpackOp.getStaticTiles();
     ArrayRef<int64_t> dimPos = unpackOp.getInnerDimsPos();
@@ -2786,8 +2786,8 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   if (!foundUnPackOp)
     return success();
 
-  LDBG("The tile sizes for each dimension should be aligned to "
-       << alignedSizes);
+  LDBG() << "The tile sizes for each dimension should be aligned to "
+       << alignedSizes;
 
   // Fixup for making tileSizes be multiple of inner_tile_sizes.
   SmallVector<IREE::CPU::LoweringConfigLevelInfo> tilingInfo =
@@ -2806,8 +2806,8 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   auto pipelineConfig = tInfo.getConfiguration();
   if (isOptEnabled(entryPointFn, getEnableLoopPeelingStr())) {
     // See #16406
-    LDBG("unpack fusion does not work with peeling, falling back to "
-         "non-peeling path");
+    LDBG() << "unpack fusion does not work with peeling, falling back to "
+         "non-peeling path";
     pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
 
     // Remove the "enable_loop_peeling" attr from pipelineConfig
@@ -3037,7 +3037,7 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
     }
   }
 
-  LDBG("Parallel vector tile sizes: " << parallelVecTileSizes);
+  LDBG() << "Parallel vector tile sizes: " << parallelVecTileSizes;
 
   // Split parallel vector tile sizes into common parts and op-specific parts.
   SmallVector<int64_t> commonVecTileSizes = parallelVecTileSizes;
@@ -3238,7 +3238,7 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
     return lowerUsingDefaultPipeline(entryPointFn);
   }
 
-  LDBG("Root op: " << *rootOperation);
+  LDBG() << "Root op: " << *rootOperation;
 
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
   auto targetMLTransInfo =

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -410,7 +410,7 @@ getMinTilingSizesForEachDim(mlir::FunctionOpInterface entryPointFn,
       int64_t factor = seen ? 1LL : maxUnrollFactor;
       seen = true;
       LDBG() << "Adjusted min tile sizes: " << minTileSizes[unrollDim]
-                                       << " with factor=" << factor << "\n";
+             << " with factor=" << factor << "\n";
       minTileSizes[unrollDim] =
           std::min<int64_t>(minTileSizes[unrollDim], factor);
     }
@@ -1163,7 +1163,7 @@ static LogicalResult setMatmulPeelingRootConfig(
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
   LDBG() << "Final tile sizes and scalable flags for contraction: "
-       << loweringConfig;
+         << loweringConfig;
 
   DictionaryAttr pipelineConfig =
       getPipelineConfWithPeelingAttr(op.getContext());
@@ -1213,7 +1213,7 @@ static LogicalResult setMatmulRootConfig(
   IREE::CPU::LoweringConfigAttr loweringConfig =
       generator.generateCPULoweringConfig();
   LDBG() << "Final tile sizes and scalable flags for contraction: "
-       << loweringConfig;
+         << loweringConfig;
 
   auto pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
   return setOpConfigAndEntryPointFnTranslation(entryPointFn, op, loweringConfig,
@@ -2787,7 +2787,7 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
     return success();
 
   LDBG() << "The tile sizes for each dimension should be aligned to "
-       << alignedSizes;
+         << alignedSizes;
 
   // Fixup for making tileSizes be multiple of inner_tile_sizes.
   SmallVector<IREE::CPU::LoweringConfigLevelInfo> tilingInfo =
@@ -2807,7 +2807,7 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   if (isOptEnabled(entryPointFn, getEnableLoopPeelingStr())) {
     // See #16406
     LDBG() << "unpack fusion does not work with peeling, falling back to "
-         "non-peeling path";
+              "non-peeling path";
     pipeline = DispatchLoweringPassPipeline::CPUDoubleTilingExpert;
 
     // Remove the "enable_loop_peeling" attr from pipelineConfig

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -46,7 +46,6 @@
 
 #define DEBUG_TYPE "kernel-dispatch"
 #define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
-#define LDBG(X) LLVM_DEBUG(KD_DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -47,7 +47,7 @@ void collectLoopsToPeel(Operation *op,
     if (!loop || iree_compiler::isTiledAndDistributedLoop(loop))
       break;
 
-    LDBG("Loop to peel\n  " << *op);
+    LDBG() << "Loop to peel\n  " << *op;
     loopsToPeel.insert(loop);
   }
 }
@@ -68,12 +68,12 @@ void LLVMCPUPeelPass::runOnOperation() {
   llvm::SmallSetVector<scf::ForOp, 8> uniqueLoopsToPeel;
   funcOp.walk([&](Operation *op) {
     if (isa<linalg::LinalgOp, linalg::PackOp>(op)) {
-      LDBG("Gather loops to peel from candidate op\n  " << *op);
+      LDBG() << "Gather loops to peel from candidate op\n  " << *op;
       collectLoopsToPeel(op, uniqueLoopsToPeel);
     }
   });
 
-  LDBG("Peeling loops");
+  LDBG() << "Peeling loops";
   // Visiting the loops in outer-to-inner order will prevent loops nested in
   // partial iterations to be peeled again.
   SmallVector<scf::ForOp, 8> outerToInnerLoopsToPeel(uniqueLoopsToPeel.rbegin(),
@@ -81,7 +81,7 @@ void LLVMCPUPeelPass::runOnOperation() {
   IRRewriter rewriter(context);
   linalg::peelLoops(rewriter, outerToInnerLoopsToPeel);
 
-  LDBG("Canonicalizing loops");
+  LDBG() << "Canonicalizing loops";
   RewritePatternSet patterns(context);
   linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
   scf::populateSCFForLoopCanonicalizationPatterns(patterns);
@@ -89,7 +89,7 @@ void LLVMCPUPeelPass::runOnOperation() {
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-    LDBG("----- cleanup failed -----");
+    LDBG() << "----- cleanup failed -----";
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -18,7 +18,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-peel"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-split-reduction"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -46,40 +47,40 @@ LogicalResult splitReductionPrecondition(Operation *op,
   linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(op);
 
   if (!linalgOp.hasPureTensorSemantics()) {
-    LDBG("doesn't have tensor semantics");
+    LDBG() << "doesn't have tensor semantics";
     return failure();
   }
   if (linalgOp.getNumReductionLoops() != 1) {
-    LDBG("number of reduction loops != 1");
+    LDBG() << "number of reduction loops != 1";
     return failure();
   }
   if (linalgOp.getNumDpsInits() != 1) {
-    LDBG("doesn't have exactly 1 output");
+    LDBG() << "doesn't have exactly 1 output";
     return failure();
   }
   if (!linalgOp.hasOnlyProjectedPermutations()) {
-    LDBG("index map doesn't have only projected permutations");
+    LDBG() << "index map doesn't have only projected permutations";
     return failure();
   }
   if (!isa<linalg::GenericOp>(op)) {
-    LDBG("is not a generic op");
+    LDBG() << "is not a generic op";
     return failure();
   }
   if (linalgOp.getNumDpsInputs() != 1) {
-    LDBG("doesn't have exactly 1 input");
+    LDBG() << "doesn't have exactly 1 input";
     return failure();
   }
   // The `linalg::splitReduction` method does not work for ops with indexing
   // semantics. See https://github.com/iree-org/iree/pull/14979
   if (linalgOp.hasIndexSemantics()) {
-    LDBG("the split method used currently doesnt support indexing semantics");
+    LDBG() << "the split method used currently doesnt support indexing semantics";
     return failure();
   }
 
   auto elemType =
       getElementTypeOrSelf(linalgOp.getDpsInitOperand(0)->get().getType());
   if (!(fpReductionReordering || elemType.isIntOrIndex())) {
-    LDBG("skipped because reduction reordering on FP is not enabled.");
+    LDBG() << "skipped because reduction reordering on FP is not enabled.";
     return failure();
   }
 
@@ -90,7 +91,7 @@ LogicalResult splitReductionPrecondition(Operation *op,
   unsigned lastIdx = map.getNumResults() - 1;
   unsigned lastDim = map.getDimPosition(lastIdx);
   if (lastDim != dims[0]) {
-    LDBG("innermost dimension of the input operand is not reduction");
+    LDBG() << "innermost dimension of the input operand is not reduction";
     return failure();
   }
 
@@ -123,7 +124,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
   FailureOr<scf::SCFTilingResult> tileResFirst = scf::tileUsingSCF(
       rewriter, cast<TilingInterface>(linalgOp.getOperation()), options);
   if (failed(tileResFirst)) {
-    LDBG("failed on step 1 (SCFTiling)");
+    LDBG() << "failed on step 1 (SCFTiling)";
     return failure();
   }
   rewriter.replaceOp(linalgOp, tileResFirst->replacements);
@@ -133,7 +134,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
   FailureOr<linalg::SplitReductionResult> splitRes = splitReduction(
       rewriter, cast<linalg::LinalgOp>(tileResFirst->tiledOps.back()), fn);
   if (failed(splitRes)) {
-    LDBG("failed on step 2 (SplitReduction)");
+    LDBG() << "failed on step 2 (SplitReduction)";
     return success();
   }
 
@@ -150,7 +151,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
       rewriter, cast<TilingInterface>(splitRes->splitLinalgOp.getOperation()),
       options);
   if (failed(tileRes)) {
-    LDBG("failed on step 3 (SCFTiling)");
+    LDBG() << "failed on step 3 (SCFTiling)";
     return failure();
   }
   rewriter.replaceOp(splitRes->splitLinalgOp, tileRes->replacements);
@@ -180,7 +181,7 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
   SmallVector<linalg::GenericOp> candidates;
   funcOp.walk([&](linalg::GenericOp op) { candidates.push_back(op); });
   for (auto genericOp : candidates) {
-    LDBG("candidate: " << genericOp);
+    LDBG() << "candidate: " << genericOp;
     if (failed(splitReductionPrecondition(genericOp,
                                           enableFpReductionReordering))) {
       continue;
@@ -189,7 +190,7 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
     IREE::Codegen::LoweringConfigAttrInterface maybeLoweringConfig =
         getLoweringConfig(genericOp);
     if (!maybeLoweringConfig) {
-      LDBG("can't find lowering_config, skip SplitReduction");
+      LDBG() << "can't find lowering_config, skip SplitReduction";
       continue;
     }
     std::unique_ptr<TilingConfig> tilingConfig =
@@ -197,12 +198,12 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
     auto [reductionSizes, scalableDims] =
         tilingConfig->getVectorReductionSizes();
     if (scalableDims.back()) {
-      LDBG("scalable reduction dimensions not yet supported, skip "
-           "SplitReduction");
+      LDBG() << "scalable reduction dimensions not yet supported, skip "
+           "SplitReduction";
       continue;
     }
     if (reductionSizes.empty()) {
-      LDBG("the list of reduction tiling sizes is empty, skip SplitReduction");
+      LDBG() << "the list of reduction tiling sizes is empty, skip SplitReduction";
       continue;
     }
     int64_t size = reductionSizes.back();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -73,7 +73,8 @@ LogicalResult splitReductionPrecondition(Operation *op,
   // The `linalg::splitReduction` method does not work for ops with indexing
   // semantics. See https://github.com/iree-org/iree/pull/14979
   if (linalgOp.hasIndexSemantics()) {
-    LDBG() << "the split method used currently doesnt support indexing semantics";
+    LDBG()
+        << "the split method used currently doesnt support indexing semantics";
     return failure();
   }
 
@@ -199,11 +200,12 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
         tilingConfig->getVectorReductionSizes();
     if (scalableDims.back()) {
       LDBG() << "scalable reduction dimensions not yet supported, skip "
-           "SplitReduction";
+                "SplitReduction";
       continue;
     }
     if (reductionSizes.empty()) {
-      LDBG() << "the list of reduction tiling sizes is empty, skip SplitReduction";
+      LDBG()
+          << "the list of reduction tiling sizes is empty, skip SplitReduction";
       continue;
     }
     int64_t size = reductionSizes.back();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -23,7 +23,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-tile"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -48,7 +48,7 @@ struct LLVMCPUTilePass : impl::LLVMCPUTilePassBase<LLVMCPUTilePass> {
 
 void LLVMCPUTilePass::runOnOperation() {
   if (tilingLevel == -1) {
-    LDBG("tilingLevel not set, skip tiling");
+    LDBG() << "tilingLevel not set, skip tiling";
     return;
   }
   MLIRContext *context = &getContext();
@@ -70,17 +70,17 @@ void LLVMCPUTilePass::runOnOperation() {
     IREE::Codegen::LoweringConfigAttrInterface maybeLoweringConfig =
         getLoweringConfig(op);
     if (!maybeLoweringConfig) {
-      LDBG("can't find lowering_config, skip tiling");
+      LDBG() << "can't find lowering_config, skip tiling";
       continue;
     }
     if (!maybeLoweringConfig.hasTilingLevel(tilingLevel)) {
-      LDBG("target tiling level does not exist");
+      LDBG() << "target tiling level does not exist";
       continue;
     }
 
-    LDBG("candidate: " << op);
+    LDBG() << "candidate: " << op;
     if (skipRootOp && maybeLoweringConfig.hasWorkgroupTilingLevel()) {
-      LDBG("skip tiling on the root op");
+      LDBG() << "skip tiling on the root op";
       continue;
     }
 
@@ -92,7 +92,7 @@ void LLVMCPUTilePass::runOnOperation() {
     setSCFTileSizes(tilingOptions, op, std::move(tileSizes),
                     std::move(tileScalableFlags));
     if (llvm::all_of(tileSizes, [](int64_t v) { return v == 0; })) {
-      LDBG("tiling sizes are all zeros, skip tiling");
+      LDBG() << "tiling sizes are all zeros, skip tiling";
       continue;
     }
 
@@ -115,7 +115,7 @@ void LLVMCPUTilePass::runOnOperation() {
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-    LDBG("----- cleanup failed -----");
+    LDBG() << "----- cleanup failed -----";
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -27,7 +27,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-tile-and-fuse"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -246,12 +246,12 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
     return WalkResult::interrupt();
   });
   if (!consumerOp) {
-    LDBG("----- skip, no consumer op -----");
+    LDBG() << "----- skip, no consumer op -----";
     return;
   }
 
-  LDBG("consumerOp: " << consumerOp);
-  LDBG("tilingLevel: " << tilingLevel);
+  LDBG() << "consumerOp: " << consumerOp;
+  LDBG() << "tilingLevel: " << tilingLevel;
 
   // If `consumerOp` has its own lowering config, we prefer using it. Otherwise,
   // fallback to find a lowering_config from the root operation.
@@ -260,13 +260,13 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   if (!loweringConfig) {
     FailureOr<Operation *> rootOp = getRootOperation(getComputeOps(funcOp));
     if (failed(rootOp)) {
-      LDBG("failed to find rootOp, skip TileAndFuse");
+      LDBG() << "failed to find rootOp, skip TileAndFuse";
       return;
     }
     loweringConfig = getLoweringConfig(rootOp.value());
   }
   if (!loweringConfig) {
-    LDBG("can't find lowering_config, skip TileAndFuse");
+    LDBG() << "can't find lowering_config, skip TileAndFuse";
     return;
   }
 
@@ -278,7 +278,7 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   tileScalableFlags.assign(attr.getScalableFlags().begin(),
                            attr.getScalableFlags().end());
   if (llvm::all_of(tileSizes, [&](int64_t size) { return size == 0; })) {
-    LDBG("----- skip, all zeros -----");
+    LDBG() << "----- skip, all zeros -----";
     return;
   }
 
@@ -289,7 +289,7 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   IRRewriter rewriter(context);
   DominanceInfo dominanceInfo(funcOp);
   if (failed(applyTileAndFuse(rewriter, consumerOp, dominanceInfo, options))) {
-    LDBG("----- tile and fuse failed -----");
+    LDBG() << "----- tile and fuse failed -----";
     return signalPassFailure();
   }
 
@@ -303,7 +303,7 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-    LDBG("----- cleanup failed -----");
+    LDBG() << "----- cleanup failed -----";
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -150,7 +150,7 @@ tileRootAndFuseProducerConsumer(IRRewriter &rewriter, TilingInterface rootOp,
                                 });
 
     if (failed(newFusionOpportunities)) {
-      LDBG("failed to fuse consumers, skip");
+      LDBG() << "failed to fuse consumers, skip";
       return tiledResults->tiledAndFusedOps.front();
     }
 
@@ -213,19 +213,19 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
     rootOp = llvm::filter_to_vector(computeOps, hasRootConfig)[0];
   }
   if (failed(rootOp) || !rootOp.value()) {
-    LDBG("unable to find the root operation");
+    LDBG() << "unable to find the root operation";
     return;
   }
 
   IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
       getLoweringConfig(rootOp.value());
   if (!loweringConfig) {
-    LDBG("unable to find the attached lowering config");
+    LDBG() << "unable to find the attached lowering config";
     return;
   }
 
   if (!loweringConfig.hasTilingLevel(tilingLevel)) {
-    LDBG("unable to find the lowering config with the tiling level");
+    LDBG() << "unable to find the lowering config with the tiling level";
     return;
   }
 
@@ -248,7 +248,7 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-    LDBG("----- cleanup failed -----");
+    LDBG() << "----- cleanup failed -----";
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -30,7 +30,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-tile-root-and-fuse-producers-consumers"
-#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -39,7 +39,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-convert-to-rocdl"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -281,12 +281,12 @@ struct ConvertToROCDLPass final
       arith::populateExpandF8E8M0Patterns(fallbackSmallFloatPatterns);
       if (failed(applyPatternsGreedily(
               m, std::move(fallbackSmallFloatPatterns)))) {
-        LDBG("Small float patterns failed\n" << m);
+        LDBG() << "Small float patterns failed\n" << m;
         return signalPassFailure();
       }
     }
 
-    LDBG("After applying in-dialect conversions\n" << m);
+    LDBG() << "After applying in-dialect conversions\n" << m;
 
     {
       RewritePatternSet patterns(&getContext());
@@ -298,7 +298,7 @@ struct ConvertToROCDLPass final
       }
     }
 
-    LDBG("After applying GPU rewrite patterns\n" << m);
+    LDBG() << "After applying GPU rewrite patterns\n" << m;
 
     {
       // Convert arith::maximumf/minimumf ops on AMD gpus since the lowering
@@ -312,7 +312,7 @@ struct ConvertToROCDLPass final
       }
     }
 
-    LDBG("After converting maximumf/minimumf ops\n" << m);
+    LDBG() << "After converting maximumf/minimumf ops\n" << m;
 
     {
       RewritePatternSet llvmPatterns(&getContext());
@@ -350,7 +350,7 @@ struct ConvertToROCDLPass final
       }
     }
 
-    LDBG("After converting to rocdl\n" << m);
+    LDBG() << "After converting to rocdl\n" << m;
 
     // 16 is the maximum relevant alignment for all AMD GPUs. Unceremoniously
     // set it to 16 as all of our allocations almost always have much greater
@@ -358,7 +358,7 @@ struct ConvertToROCDLPass final
     // TODO(qedawkins): Set this much earlier when we introduce the allocations.
     setSharedMemoryAlignment(m, 16);
 
-    LDBG("After updating shared memory alignments\n" << m);
+    LDBG() << "After updating shared memory alignments\n" << m;
   }
 };
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -40,7 +40,6 @@
 
 #define DEBUG_TYPE "iree-convert-to-rocdl"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h"
 #include "mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1943,11 +1943,13 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (linalg::isaContractionOpInterface(linalgOp) ||
         IREE::LinalgExt::isaHorizontallyFusedContraction(linalgOp)) {
-      LDBG() << "VectorDistribution: trying to find a suitable contraction config";
+      LDBG()
+          << "VectorDistribution: trying to find a suitable contraction config";
       return setMatmulVectorDistributionConfig(target, entryPoint, linalgOp);
     }
     if (linalg::isaConvolutionOpInterface(linalgOp)) {
-      LDBG() << "VectorDistribution: trying to find a suitable convolution config";
+      LDBG()
+          << "VectorDistribution: trying to find a suitable convolution config";
       return setConvolutionVectorDistributionConfig(target, entryPoint,
                                                     linalgOp);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -32,7 +32,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -50,7 +50,6 @@
 
 #define DEBUG_TYPE "iree-llvmgpu-kernel-config"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 namespace mlir::iree_compiler {
 
 llvm::cl::opt<bool> clGPUEarlyTileAndFuseMatmul(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1212,7 +1212,7 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
-  LDBG("Matmul Vector Distribution Config");
+  LDBG() << "Matmul Vector Distribution Config";
 
   auto pipeline = CodeGenPipeline::LLVMGPUVectorDistribute;
 
@@ -1237,12 +1237,12 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   }
 
   if (!schedule) {
-    LDBG("Failed to deduce MMA schedule");
+    LDBG() << "Failed to deduce MMA schedule";
     return failure();
   }
 
-  LDBG("Target Subgroup size: " << targetSubgroupSize);
-  LDBG("Schedule: " << schedule);
+  LDBG() << "Target Subgroup size: " << targetSubgroupSize;
+  LDBG() << "Schedule: " << schedule;
 
   int64_t flatWorkgroupSize =
       targetSubgroupSize *
@@ -1417,7 +1417,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
                                         /*bestMNTileCountPerSubgroup=*/4,
                                         /*bestKTileCountPerSubgroup=*/4};
 
-  LDBG("Attention Vector Distribution Config");
+  LDBG() << "Attention Vector Distribution Config";
 
   // Infer if Q, K and V are transposed to help generate better schedule.
   bool transposedQ =
@@ -1446,7 +1446,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   }
 
   if (!attSchedule) {
-    LDBG("Failed to deduce Attention schedule");
+    LDBG() << "Failed to deduce Attention schedule";
     return failure();
   }
 
@@ -1460,9 +1460,9 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
     pvSchedule.nSubgroupCounts[0] = 1;
   }
 
-  LDBG("Target Subgroup size: " << targetSubgroupSize);
-  LDBG("QK Schedule: " << qkSchedule);
-  LDBG("PV Schedule: " << pvSchedule);
+  LDBG() << "Target Subgroup size: " << targetSubgroupSize;
+  LDBG() << "QK Schedule: " << qkSchedule;
+  LDBG() << "PV Schedule: " << pvSchedule;
 
   int64_t flatWorkgroupSize =
       targetSubgroupSize *
@@ -1750,20 +1750,20 @@ static LogicalResult setAttentionReductionConfig(
                                         currDim);
   }
 
-  LDBG("QK Basis");
-  LDBG("Thread Basis");
-  LDBG(llvm::interleaved(qkThreadBasis.counts));
-  LDBG(llvm::interleaved(qkThreadBasis.mapping));
-  LDBG("Subgroup Basis");
-  LDBG(llvm::interleaved(subgroupBasis.counts));
-  LDBG(llvm::interleaved(subgroupBasis.mapping));
-  LDBG("PV Basis");
-  LDBG("Thread Basis");
-  LDBG(llvm::interleaved(pvThreadBasis.counts));
-  LDBG(llvm::interleaved(pvThreadBasis.mapping));
-  LDBG("Subgroup Basis");
-  LDBG(llvm::interleaved(subgroupBasis.counts));
-  LDBG(llvm::interleaved(subgroupBasis.mapping));
+  LDBG() << "QK Basis";
+  LDBG() << "Thread Basis";
+  LDBG() << llvm::interleaved(qkThreadBasis.counts);
+  LDBG() << llvm::interleaved(qkThreadBasis.mapping);
+  LDBG() << "Subgroup Basis";
+  LDBG() << llvm::interleaved(subgroupBasis.counts);
+  LDBG() << llvm::interleaved(subgroupBasis.mapping);
+  LDBG() << "PV Basis";
+  LDBG() << "Thread Basis";
+  LDBG() << llvm::interleaved(pvThreadBasis.counts);
+  LDBG() << llvm::interleaved(pvThreadBasis.mapping);
+  LDBG() << "Subgroup Basis";
+  LDBG() << llvm::interleaved(subgroupBasis.counts);
+  LDBG() << llvm::interleaved(subgroupBasis.mapping);
 
   // Tile N parallel dimensions to value tile size fetched in a single
   // iteration.
@@ -1934,27 +1934,27 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
     return failure();
 
   if (!clGPUEnableVectorDistribution) {
-    LDBG("Vector Distribution not enabled, skipping...");
+    LDBG() << "Vector Distribution not enabled, skipping...";
     return failure();
   }
 
-  LDBG("VectorDistribution: finding a suitable config...");
+  LDBG() << "VectorDistribution: finding a suitable config...";
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (linalg::isaContractionOpInterface(linalgOp) ||
         IREE::LinalgExt::isaHorizontallyFusedContraction(linalgOp)) {
-      LDBG("VectorDistribution: trying to find a suitable contraction config");
+      LDBG() << "VectorDistribution: trying to find a suitable contraction config";
       return setMatmulVectorDistributionConfig(target, entryPoint, linalgOp);
     }
     if (linalg::isaConvolutionOpInterface(linalgOp)) {
-      LDBG("VectorDistribution: trying to find a suitable convolution config");
+      LDBG() << "VectorDistribution: trying to find a suitable convolution config";
       return setConvolutionVectorDistributionConfig(target, entryPoint,
                                                     linalgOp);
     }
   }
 
   if (auto attnOp = dyn_cast<IREE::LinalgExt::AttentionOp>(computeOp)) {
-    LDBG("VectorDistribution: trying to find a suitable attention config");
+    LDBG() << "VectorDistribution: trying to find a suitable attention config";
     if (succeeded(setAttentionIntrinsicBasedVectorDistributionConfig(
             target, entryPoint, attnOp))) {
       return success();
@@ -1962,7 +1962,7 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
     return setAttentionVectorDistributionConfig(target, entryPoint, attnOp);
   }
 
-  LDBG("VectorDistribution: failed to find a suitable config");
+  LDBG() << "VectorDistribution: failed to find a suitable config";
   return failure();
 }
 
@@ -2946,7 +2946,7 @@ static LogicalResult setConvolutionConfig(
   if (clGPUUseTileAndFuseConvolution) {
     if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(target, entryPointFn,
                                                           linalgOp))) {
-      LDBG("Tile and fuse convolution config");
+      LDBG() << "Tile and fuse convolution config";
       return success();
     }
   }
@@ -3051,27 +3051,27 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
   });
   if (succeeded(setDataTiledMultiMmaLoweringConfig(target, entryPointFn,
                                                    computeOp, ukernelConfig))) {
-    LDBG("Tile and fuse data tiled MMA inner_tiled config");
+    LDBG() << "Tile and fuse data tiled MMA inner_tiled config";
     return success();
   }
   if (clGPUEarlyTileAndFuseMatmul) {
     if (succeeded(IREE::GPU::setMatmulLoweringConfig(
             target, entryPointFn, computeOp, clUseDirectLoad))) {
-      LDBG("Tile and fuse matmul config");
+      LDBG() << "Tile and fuse matmul config";
       return success();
     }
   }
   if (clLLVMGPUUseIgemm) {
     if (succeeded(IREE::GPU::setIGEMMConvolutionLoweringConfig(
             target, entryPointFn, computeOp, clUseDirectLoad))) {
-      LDBG("Tile and fuse IGEMM config");
+      LDBG() << "Tile and fuse IGEMM config";
       return success();
     }
   }
   if (clGPUTestTileAndFuseVectorize) {
     if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(target, entryPointFn,
                                                           computeOp))) {
-      LDBG("Tile and fuse default config");
+      LDBG() << "Tile and fuse default config";
       return success();
     }
   }
@@ -3082,67 +3082,67 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
   // config becomes the default for matmul.
   if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
                                                    computeOp))) {
-    LDBG("Tile and fuse matmul config after no vector distribute config");
+    LDBG() << "Tile and fuse matmul config after no vector distribute config";
     return success();
   }
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (succeeded(setContractConfig(target, entryPointFn, linalgOp))) {
-      LDBG("Contract Config");
+      LDBG() << "Contract Config";
       return success();
     }
     if (succeeded(setReductionVectorDistributionConfig(target, entryPointFn,
                                                        linalgOp))) {
-      LDBG("Vector Distribution Subgroup Reduction Config");
+      LDBG() << "Vector Distribution Subgroup Reduction Config";
       return success();
     }
     if (succeeded(setWarpReductionConfig(target, entryPointFn, linalgOp))) {
-      LDBG("Warp Reduction Config");
+      LDBG() << "Warp Reduction Config";
       return success();
     }
     if (succeeded(setConvolutionConfig(target, entryPointFn, linalgOp, 16))) {
-      LDBG("Convolution Config");
+      LDBG() << "Convolution Config";
       return success();
     }
     auto genericOp = dyn_cast<linalg::GenericOp>(computeOp);
     if (genericOp) {
       if (succeeded(setTransposeConfig(entryPointFn, genericOp))) {
-        LDBG("Transpose Config");
+        LDBG() << "Transpose Config";
         return success();
       } else if (ukernelConfig &&
                  succeeded(setArgmaxUkernelConfig(target, entryPointFn,
                                                   genericOp, ukernelConfig))) {
-        LDBG("Argmax Ukernel Config");
+        LDBG() << "Argmax Ukernel Config";
         return success();
       } else if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(
                      target, entryPointFn, linalgOp))) {
-        LDBG("Tile and Fuse Config");
+        LDBG() << "Tile and Fuse Config";
         return success();
       }
     }
   }
   return TypeSwitch<Operation *, LogicalResult>(computeOp)
       .Case<IREE::LinalgExt::FftOp>([&](auto fftOp) {
-        LDBG("FFT Config");
+        LDBG() << "FFT Config";
         return setFftConfig(target, entryPointFn, fftOp);
       })
       .Case<IREE::LinalgExt::SortOp>([&](auto sortOp) {
-        LDBG("Sort Config");
+        LDBG() << "Sort Config";
         return IREE::GPU::setSortConfig(target, entryPointFn, sortOp);
       })
       .Case<IREE::LinalgExt::WinogradInputTransformOp,
             IREE::LinalgExt::WinogradOutputTransformOp,
             IREE::LinalgExt::WinogradFilterTransformOp>([&](auto winogradOp) {
-        LDBG("Winograd Config");
+        LDBG() << "Winograd Config";
         return setWinogradOpConfig(target, entryPointFn, winogradOp);
       })
       .Case<IREE::LinalgExt::CustomOp>([&](auto customOp) {
-        LDBG("CustomOp Config");
+        LDBG() << "CustomOp Config";
         return setDefaultCustomOpLoweringConfig(entryPointFn, customOp,
                                                 initGPULaunchConfig);
       })
       .Case<IREE::LinalgExt::ScatterOp>([&](auto scatterOp) {
-        LDBG("ScatterOp Config");
+        LDBG() << "ScatterOp Config";
         if (failed(IREE::GPU::setScatterLoweringConfig(target, entryPointFn,
                                                        scatterOp))) {
           return setRootDefaultConfig(target, entryPointFn, computeOp);
@@ -3150,13 +3150,13 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
         return success();
       })
       .Default([&](auto op) {
-        LDBG("Default Config");
+        LDBG() << "Default Config";
         if (clLLVMGPUVectorizePipeline) {
           return setRootDefaultConfig(target, entryPointFn, computeOp);
         }
         if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(
                 target, entryPointFn, computeOp))) {
-          LDBG("Tile and fuse default config");
+          LDBG() << "Tile and fuse default config";
           return success();
         }
         return setRootDefaultConfig(target, entryPointFn, computeOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -7,9 +7,9 @@
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
+
 #define DEBUG_TYPE "iree-codegen-rocdl-buffer-instructions-optimization"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -10,7 +10,6 @@
 #include "llvm/Support/Debug.h"
 #define DEBUG_TYPE "iree-codegen-rocdl-buffer-instructions-optimization"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -133,7 +133,8 @@ struct ROCDLConfigureBufferInstructionsPass final
     func.walk([&](IREE::HAL::InterfaceBindingSubspanOp binding) {
       Value offset = binding.getByteOffset();
       if (offset && !isDefinitelyWorkgroupUniform(offset)) {
-        LDBG() << "Binding offset " << offset << " not known workgroup-uniform\n";
+        LDBG() << "Binding offset " << offset
+               << " not known workgroup-uniform\n";
         return;
       }
       std::optional<int64_t> maxBytes = getSpannedBytes(binding);
@@ -143,7 +144,8 @@ struct ROCDLConfigureBufferInstructionsPass final
       }
       if (*maxBytes >=
           static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
-        LDBG() << "Size of " << binding << " too large (" << *maxBytes << " bytes)";
+        LDBG() << "Size of " << binding << " too large (" << *maxBytes
+               << " bytes)";
         return;
       }
       annotationHelper.setAttr(binding, unitAttr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -11,10 +11,10 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
-#include "llvm/Support/Debug.h"
 #define DEBUG_TYPE "iree-codegen-rocdl-configure-buffer-instructions"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -17,7 +17,6 @@
 
 #define DEBUG_TYPE "iree-codegen-rocdl-configure-buffer-instructions"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -133,17 +133,17 @@ struct ROCDLConfigureBufferInstructionsPass final
     func.walk([&](IREE::HAL::InterfaceBindingSubspanOp binding) {
       Value offset = binding.getByteOffset();
       if (offset && !isDefinitelyWorkgroupUniform(offset)) {
-        LDBG("Binding offset " << offset << " not known workgroup-uniform\n");
+        LDBG() << "Binding offset " << offset << " not known workgroup-uniform\n";
         return;
       }
       std::optional<int64_t> maxBytes = getSpannedBytes(binding);
       if (!maxBytes) {
-        LDBG("Couldn't bound binding size for " << binding);
+        LDBG() << "Couldn't bound binding size for " << binding;
         return;
       }
       if (*maxBytes >=
           static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
-        LDBG("Size of " << binding << " too large (" << *maxBytes << " bytes)");
+        LDBG() << "Size of " << binding << " too large (" << *maxBytes << " bytes)";
         return;
       }
       annotationHelper.setAttr(binding, unitAttr);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -50,7 +50,6 @@ using llvm::dbgs;
 #define DEBUG_VECTOR_TO_MMA "transform-llvmgpu-extensions-vector-to-mma"
 
 #define DBGS() (dbgs() << '[' << DEBUG_TYPE << "] ")
-#define LDBG(X) LLVM_DEBUG(dbgs() << '[' << DEBUG_TYPE << "] " << X)
 #define DBGS_ALIAS() (dbgs() << '[' << DEBUG_TYPE_ALIAS << "] ")
 #define DBGS_VECTOR_TO_MMA() (dbgs() << '[' << DEBUG_VECTOR_TO_MMA << "] ")
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -96,12 +96,13 @@ static MaskResult getMask(Operation *op) {
     if (maybeExtractOp.getStaticPosition().size() + 1 !=
         llvm::cast<VectorType>(maskOp->getResultTypes().front()).getRank()) {
       LDBG() << "----mask through extract unexpected position size -> Skip: "
-           << maybeExtractOp;
+             << maybeExtractOp;
       return MaskResult{};
     }
     if (maybeExtractOp.getStaticPosition().size() != 1) {
-      LDBG() << "----only mask through 2-D -> 1-D extract supported atm -> Skip: "
-           << maybeExtractOp;
+      LDBG()
+          << "----only mask through 2-D -> 1-D extract supported atm -> Skip: "
+          << maybeExtractOp;
       return MaskResult{};
     }
     LDBG() << "----mask through extract: " << maybeExtractOp;
@@ -176,10 +177,10 @@ static bool resultsInSupportedAsyncCopy(MemRefType memrefType,
     }
   }
   if (!supportedCopySize) {
-    LDBG() << "----> cp.async alignment failed, "
-         << numElements << " elts * " << elementType.getIntOrFloatBitWidth()
-         << "b/elem = " << numElements * elementType.getIntOrFloatBitWidth()
-         << "b is not supported by cp.async";
+    LDBG() << "----> cp.async alignment failed, " << numElements << " elts * "
+           << elementType.getIntOrFloatBitWidth()
+           << "b/elem = " << numElements * elementType.getIntOrFloatBitWidth()
+           << "b is not supported by cp.async";
     return false;
   }
 
@@ -228,7 +229,7 @@ void createAsyncGroups(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
         auto maskResult = getMask(transferRead);
         if (!maskResult.maskOp) {
           LDBG() << "----read mask is not a vector.create_mask op -> Skip: "
-               << transferRead.getMask();
+                 << transferRead.getMask();
           return WalkResult::advance();
         }
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -23,7 +23,6 @@ using namespace mlir;
 
 #define DEBUG_TYPE "llvm-gpu-utils"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -10,7 +10,7 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -22,7 +22,6 @@
 using namespace mlir;
 
 #define DEBUG_TYPE "llvm-gpu-utils"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -30,7 +30,6 @@
 
 #define DEBUG_TYPE "iree-codegen-llvmgpu-prefetch-shared-memory-copy"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -29,7 +29,6 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define DEBUG_TYPE "iree-codegen-llvmgpu-prefetch-shared-memory-copy"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -41,7 +41,7 @@ public:
   /// prefetching. Returns failure if unable to support the given |op|.
   static FailureOr<LoopPrefetcher> get(scf::ForOp op) {
     if (!op.getOps<scf::ForOp>().empty()) {
-      LDBG("Loop prefetcher does not support nested loops yet");
+      LDBG() << "Loop prefetcher does not support nested loops yet";
       return failure();
     }
 
@@ -51,12 +51,12 @@ public:
     prefetcher.lb = prefetcher.ub = prefetcher.step = 0;
 
     if (failed(prefetcher.initializeLoopInfo())) {
-      LDBG("Failed to initialize loop info (unsupported loop)");
+      LDBG() << "Failed to initialize loop info (unsupported loop)";
       return failure();
     }
 
     if (failed(prefetcher.initializeStages())) {
-      LDBG("Failed to initialize stage info (unsupported loop)");
+      LDBG() << "Failed to initialize stage info (unsupported loop)";
       return failure();
     }
 
@@ -254,7 +254,7 @@ private:
     // If `scf.yeild` is the only compute op then there is no value in doing
     // prefetching.
     if (computeDependencies.size() == 1) {
-      LDBG("Loop does not have compute so not doing prefetching." << forOp);
+      LDBG() << "Loop does not have compute so not doing prefetching." << forOp;
       return failure();
     }
 
@@ -280,9 +280,9 @@ private:
       // will be re-written.
       if (!hasStage && !isa<gpu::BarrierOp>(op)) {
         if (!isPure(&op)) {
-          LDBG("Found a non-pure loop body op not assigned to any stage "
+          LDBG() << "Found a non-pure loop body op not assigned to any stage "
                "(unsupported loop): "
-               << op);
+               << op;
           return failure();
         }
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -12,7 +12,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -281,8 +281,8 @@ private:
       if (!hasStage && !isa<gpu::BarrierOp>(op)) {
         if (!isPure(&op)) {
           LDBG() << "Found a non-pure loop body op not assigned to any stage "
-               "(unsupported loop): "
-               << op;
+                    "(unsupported loop): "
+                 << op;
           return failure();
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -789,7 +789,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
     else if (sourceType.isF32())
       mmaShapeK = 8;
     else {
-      LDBG("unsupported shape for vector.contract: ");
+      LDBG() << "unsupported shape for vector.contract: ";
       return std::nullopt;
     }
 
@@ -797,7 +797,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
     // to 1.
     SmallVector<int64_t> mmaShape(contract.getIteratorTypes().size() - 3, 1);
     mmaShape.append({mmaShapeM, mmaShapeN, mmaShapeK});
-    LDBG("shape for vector.contract: " << llvm::interleaved(mmaShape));
+    LDBG() << "shape for vector.contract: " << llvm::interleaved(mmaShape);
     return mmaShape;
   }
 
@@ -807,7 +807,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
       return std::nullopt;
     SmallVector<int64_t> outputShape(writeOp.getVectorType().getRank() - 2, 1);
     outputShape.append({mmaShapeM, mmaShapeN});
-    LDBG("shape for vector.xfer_write: " << llvm::interleaved(outputShape));
+    LDBG() << "shape for vector.xfer_write: " << llvm::interleaved(outputShape);
     return outputShape;
   }
 
@@ -820,7 +820,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
     std::optional<int> operandId =
         getVectorContractOpOperandIdForVectorReadOp(op);
     if (!operandId) {
-      LDBG("Failed to get operandId for vector::xfer_read: " << *op);
+      LDBG() << "Failed to get operandId for vector::xfer_read: " << *op;
       return std::nullopt;
     }
 
@@ -872,14 +872,14 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
       if (*operandId == 2) {
         SmallVector<int64_t> readShape;
         readShape.append({mmaShapeM, mmaShapeN});
-        LDBG("shape for vector.xfer_read: " << llvm::interleaved(readShape));
+        LDBG() << "shape for vector.xfer_read: " << llvm::interleaved(readShape);
         return readShape;
       }
       // For matrixA.
       if (*operandId == 0) {
         SmallVector<int64_t> readShape;
         readShape.append({mmaShapeM, mmaShapeK});
-        LDBG("shape for vector.xfer_read: " << llvm::interleaved(readShape));
+        LDBG() << "shape for vector.xfer_read: " << llvm::interleaved(readShape);
         return readShape;
       }
       // For matrixB.
@@ -898,13 +898,13 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
             return std::nullopt;
           sliceType = vecType;
         }
-        LDBG("shape for vector.xfer_read: "
-             << llvm::interleaved(sliceType.getShape()));
+        LDBG() << "shape for vector.xfer_read: "
+             << llvm::interleaved(sliceType.getShape());
         return llvm::to_vector(sliceType.getShape());
       }
     }
   }
-  LDBG("unsupported shape for " << op->getName().getStringRef());
+  LDBG() << "unsupported shape for " << op->getName().getStringRef();
   return std::nullopt;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -33,7 +33,6 @@
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define DBGSNL() (llvm::dbgs() << "\n")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 static constexpr unsigned kShuffleBitWidth = 32;
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -14,7 +14,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -872,14 +872,16 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
       if (*operandId == 2) {
         SmallVector<int64_t> readShape;
         readShape.append({mmaShapeM, mmaShapeN});
-        LDBG() << "shape for vector.xfer_read: " << llvm::interleaved(readShape);
+        LDBG() << "shape for vector.xfer_read: "
+               << llvm::interleaved(readShape);
         return readShape;
       }
       // For matrixA.
       if (*operandId == 0) {
         SmallVector<int64_t> readShape;
         readShape.append({mmaShapeM, mmaShapeK});
-        LDBG() << "shape for vector.xfer_read: " << llvm::interleaved(readShape);
+        LDBG() << "shape for vector.xfer_read: "
+               << llvm::interleaved(readShape);
         return readShape;
       }
       // For matrixB.
@@ -899,7 +901,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
           sliceType = vecType;
         }
         LDBG() << "shape for vector.xfer_read: "
-             << llvm::interleaved(sliceType.getShape());
+               << llvm::interleaved(sliceType.getShape());
         return llvm::to_vector(sliceType.getShape());
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -42,7 +42,6 @@
 
 #define DEBUG_TYPE "iree-codegen-utils"
 #define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
-#define LDBG(X) LLVM_DEBUG(KD_DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1701,8 +1701,8 @@ inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult) {
     if (ShapedType::isStatic(dimSize)) {
       result.vectorSizes.push_back(dimSize);
       result.vectorScalableFlags.push_back(dimScalable);
-      LDBG() << "Inferred iteration size '" << dimSize << "' for dimension '" << dim
-                                       << "'";
+      LDBG() << "Inferred iteration size '" << dimSize << "' for dimension '"
+             << dim << "'";
       continue;
     }
 
@@ -1726,9 +1726,9 @@ inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult) {
     dimScalable = maybeDimBound->scalable;
     result.vectorSizes.push_back(dimSize);
     result.vectorScalableFlags.push_back(dimScalable);
-    LDBG() << "Inferred iteration size '"
-         << dimSize << (dimScalable ? " x vscale" : "") << "' for dimension '"
-         << dim << "'";
+    LDBG() << "Inferred iteration size '" << dimSize
+           << (dimScalable ? " x vscale" : "") << "' for dimension '" << dim
+           << "'";
   }
 
   if (opResult) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -41,7 +41,6 @@
 #include "mlir/Transforms/RegionUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-utils"
-#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 namespace mlir::iree_compiler {
 


### PR DESCRIPTION
It replaces `LDBG(...);` with `LDBG() ...;`; it drops unused `DBGS()` macro.