### PR TITLE
[LLVMGPU][Codegen] Set FMF for arith.mulf + arith.addf -> math.fma

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -198,6 +198,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MathToLLVM",
         "@llvm-project//mlir:MathToROCDL",
+        "@llvm-project//mlir:MathTransforms",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefToLLVM",
         "@llvm-project//mlir:MemRefTransforms",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -140,9 +140,9 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRMathDialect
-    MLIRMathTransforms
     MLIRMathToLLVM
     MLIRMathToROCDL
+    MLIRMathTransforms
     MLIRMemRefDialect
     MLIRMemRefToLLVM
     MLIRMemRefTransforms

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -140,6 +140,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRMathDialect
+    MLIRMathTransforms
     MLIRMathToLLVM
     MLIRMathToROCDL
     MLIRMemRefDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -199,7 +199,7 @@ struct LLVMGPUVectorLoweringPass final
     // Uplift arith ops to math.fma before lowering high level vector ops.
     {
       RewritePatternSet fmaPatterns(ctx);
-      fmaPatterns.add<SetMulAddFMF>(ctx, /*benefit*/ 2);
+      fmaPatterns.add<SetMulAddFMF>(ctx, PatternBenefit(2));
       populateUpliftToFMAPatterns(fmaPatterns);
       if (failed(applyPatternsGreedily(funcOp, std::move(fmaPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -179,6 +180,7 @@ struct LLVMGPUVectorLoweringPass final
     registry.insert<memref::MemRefDialect>();
     registry.insert<vector::VectorDialect>();
     registry.insert<scf::SCFDialect>();
+    registry.insert<math::MathDialect>();
   }
   void runOnOperation() override {
     auto funcOp = getOperation();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -186,7 +186,7 @@ struct LLVMGPUVectorLoweringPass final
     auto funcOp = getOperation();
     MLIRContext *ctx = &getContext();
 
-    // Uplift arith ops to math.fma before lowering high level vector operation
+    // Uplift arith ops to math.fma before lowering high level vector operation.
     {
       RewritePatternSet fmaPatterns(ctx);
       fmaPatterns.add<SetMulAddFMF>(ctx);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -8,8 +8,6 @@
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -181,7 +179,6 @@ struct LLVMGPUVectorLoweringPass final
     registry.insert<memref::MemRefDialect>();
     registry.insert<vector::VectorDialect>();
     registry.insert<scf::SCFDialect>();
-    registry.insert<math::MathDialect>();
   }
   void runOnOperation() override {
     auto funcOp = getOperation();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -12,10 +12,8 @@
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
-#include "mlir/IR/Value.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -196,8 +196,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //   CHECK-LABEL: hal.executable public @conv2d_dispatch_0
 //         CHECK:   hal.executable.variant public @cuda
 // CHECK-COUNT-3:   llvm.load %{{.*}} : !llvm.ptr<1> -> f32
-//         CHECK:   lvm.fmul %{{.*}}, %{{.*}}  : f32
-//         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : f32
+//         CHECK:   llvm.call @__nv_fmaf(%{{.*}}, %{{.*}}, %{{.*}}) : (f32, f32, f32) -> f32
 //         CHECK:   llvm.store {{.*}} : f32, !llvm.ptr<1>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -196,7 +196,8 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //   CHECK-LABEL: hal.executable public @conv2d_dispatch_0
 //         CHECK:   hal.executable.variant public @cuda
 // CHECK-COUNT-3:   llvm.load %{{.*}} : !llvm.ptr<1> -> f32
-//         CHECK:   llvm.call @__nv_fmaf(%{{.*}}, %{{.*}}, %{{.*}}) : (f32, f32, f32) -> f32
+//         CHECK:   llvm.fmul %{{.*}}, %{{.*}}  : f32
+//         CHECK:   llvm.fadd %{{.*}}, %{{.*}}  : f32
 //         CHECK:   llvm.store {{.*}} : f32, !llvm.ptr<1>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -116,3 +116,22 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 // CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
 // CHECK:      %[[E1:.+]]  = vector.extract %[[FMA]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
 // CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32
+
+func.func @multi_reduction_no_uplift(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> vector<2x1xf32> {
+  %cst_4 = arith.constant dense<0.000000e+00> : vector<2x1xf32>
+  %cst_5 = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+  %22 = arith.mulf %a, %b fastmath<fast>: vector<2x1x8xf32>
+  %23 = arith.addf %22, %cst_5 : vector<2x1x8xf32>
+  %24 = vector.multi_reduction <add>, %23, %cst_4 [2] : vector<2x1x8xf32> to vector<2x1xf32>
+  return %24 : vector<2x1xf32>
+}
+
+// CHECK-LABEL: func.func @multi_reduction_no_uplift
+// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+// CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : vector<2x1x8xf32>
+// CHECK:      %[[ADD:.+]] = arith.addf %[[MUL]], %[[V0]] : vector<2x1x8xf32>
+// CHECK:      %[[E0:.+]]  = vector.extract %[[ADD]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
+// CHECK:      %[[E1:.+]]  = vector.extract %[[ADD]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -111,9 +111,8 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 // CHECK-LABEL: func.func @multi_reduction_f32
 // CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
-// CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} : vector<2x1x8xf32>
-// CHECK:      %[[ADD:.+]] = arith.addf %[[MUL]], %[[V0]] : vector<2x1x8xf32>
-// CHECK:      %[[E0:.+]]  = vector.extract %[[ADD]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:      %[[FMA:.+]] = math.fma %{{.*}}, %{{.*}}, %[[V0]] : vector<2x1x8xf32>
+// CHECK:      %[[E0:.+]]  = vector.extract %[[FMA]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
 // CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
-// CHECK:      %[[E1:.+]]  = vector.extract %[[ADD]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:      %[[E1:.+]]  = vector.extract %[[FMA]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
 // CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -111,7 +111,7 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 // CHECK-LABEL: func.func @multi_reduction_f32
 // CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
-// CHECK:      %[[FMA:.+]] = math.fma %{{.*}}, %{{.*}}, %[[V0]] : vector<2x1x8xf32>
+// CHECK:      %[[FMA:.+]] = math.fma %{{.*}}, %{{.*}}, %[[V0]] fastmath<contract> : vector<2x1x8xf32>
 // CHECK:      %[[E0:.+]]  = vector.extract %[[FMA]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
 // CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
 // CHECK:      %[[E1:.+]]  = vector.extract %[[FMA]][1, 0] : vector<8xf32> from vector<2x1x8xf32>


### PR DESCRIPTION
This patch sets fast math flags to `arith.mulf + arith.addf` to utilize `upliftToFMA` and emit `math.fma` in their place. The intention behind this is to teach the compiler to recognize this pattern and subsequently enable optimizations with respect to `vector.multi_reduction(fma)` via e.g chaining fmas. 

Issue: #21483