### PR TITLE
Integrate LLVM at llvm/llvm-project@8e9a0fc0f2e5 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -921,11 +921,6 @@ TargetAttr getVulkanTargetDetails(llvm::StringRef target,
   // duplicated product or microarchitecture names among vendors, which should
   // be the case.
 
-  // For mobile GPUs we target Vulkan 1.1, which accepts SPIR-V 1.3 as the
-  // maximum. But the VK_KHR_spirv_1_4 extension is commonly available so we use
-  // SPIR-V 1.4. For non-mobile GPUs we target Vulkan 1.3, which accepts
-  // SPIR-V 1.6 as the maximum.
-
   // TODO: Add feature bits for physical storage buffer.
 
   if (std::optional<TargetDetails> details = getAMDGPUTargetDetails(target)) {
@@ -934,7 +929,7 @@ TargetAttr getVulkanTargetDetails(llvm::StringRef target,
   }
   if (std::optional<TargetDetails> details = getARMGPUTargetDetails(target)) {
     return createTargetAttr(*details, normalizeARMGPUTarget(target),
-                            /*features=*/"spirv:v1.4,cap:Shader", context);
+                            /*features=*/"spirv:v1.6,cap:Shader", context);
   }
   if (std::optional<TargetDetails> details =
           getNVIDIAGPUTargetDetails(target)) {
@@ -944,7 +939,7 @@ TargetAttr getVulkanTargetDetails(llvm::StringRef target,
   if (std::optional<TargetDetails> details =
           getQualcommGPUTargetDetails(target)) {
     return createTargetAttr(*details, target,
-                            /*features=*/"spirv:v1.4,cap:Shader", context);
+                            /*features=*/"spirv:v1.6,cap:Shader", context);
   }
 
   // Go through common profiles if not hit in the above.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -114,7 +114,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //         CHECK:    gpu.subgroup_reduce
 //         CHECK:    vector.transfer_write {{.*}} : vector<1xf32
 //         CHECK:    gpu.subgroup_reduce
-//         CHECK:    arith.divf {{.*}} : vector<1x1x4xf32>
+//         CHECK:    arith.divf {{.*}} : vector<f32>
 //         CHECK:    vector.transfer_write {{.*}} : vector<4xf32>, {{.*}}
 //         CHECK:    return
 


### PR DESCRIPTION
Carrying revert:

- https://github.com/llvm/llvm-project/commit/b6a98b934f63431243ba062aa9e07a52aae05f70: It is not clear if we should only capture the conversion failure once or not. Asking a question here: https://github.com/llvm/llvm-project/pull/150982#issuecomment-3133592198

The version numbers are bumped because of https://github.com/iree-org/llvm-project/commit/c2c864462bd2cc771b08939ac38b0ca27cc75572. The comment is dropped because don't have any recent mobile devices to test with today.