### PR TITLE
[Dispatch] Don't clone scatter's indices

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -833,17 +833,6 @@ static bool isAttentionMaskGenerator(Operation *op) {
   return false;
 }
 
-static bool isScatterIndicesGenerator(Operation *op) {
-  for (OpOperand &use : op->getUses()) {
-    if (auto scatter = dyn_cast<IREE::LinalgExt::ScatterOp>(use.getOwner())) {
-      if (scatter.getIndices() == use.get()) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 /// Operations that are cloned into dispatch regions formed with other
 /// operations as roots.
 bool isClonableIntoDispatchOp(Operation *op,
@@ -868,12 +857,6 @@ bool isClonableIntoDispatchOp(Operation *op,
   // clone it. The Attention mask is usually big, and is always generated
   // from a small tensor, so it's always good to clone it.
   if (options.aggressive && isAttentionMaskGenerator(op)) {
-    return true;
-  }
-
-  // If the operation is used for the indices computation of a scatter op, it
-  // should be cloned into the dispatch.
-  if (options.aggressive && isScatterIndicesGenerator(op)) {
     return true;
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -938,7 +938,7 @@ util.func @attention_clone_mask(%Q : tensor<?x?xf16>, %K : tensor<?x?xf16>, %V: 
 
 // -----
 
-util.func @scatter_no_index_producer_fusion(%arg0 : tensor<?x1xi64>,
+util.func @scatter_index_producer_fusion(%arg0 : tensor<?x1xi64>,
     %arg1 : index, %arg2 : tensor<?x1x32x8x128xf16>,
     %arg3 : tensor<?x32x8x128xf16>) -> tensor<?x32x8x128xf16> {
   %empty = tensor.empty(%arg1) : tensor<?x1xi32>
@@ -960,11 +960,9 @@ util.func @scatter_no_index_producer_fusion(%arg0 : tensor<?x1xi64>,
   } -> tensor<?x32x8x128xf16>
   util.return %1 : tensor<?x32x8x128xf16>
 }
-// Indices operand should be cloned.
-//
-// CHECK-LABEL: func public @scatter_no_index_producer_fusion
-//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+// CHECK-LABEL: func public @scatter_index_producer_fusion
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
 //       CHECK:     %[[SCATTER:.+]] = iree_linalg_ext.scatter
 //  CHECK-SAME:         ins(%{{.+}}, %[[GENERIC]] :
 //       CHECK:     flow.return %[[SCATTER]]


### PR DESCRIPTION
This undoes the change that forced scatter's indices to be cloned. If they are cloned, only a single linalg generic gets cloned into the dispatch. This was done to prevent a codegen failure that seems to be fixed.

Old PR: https://github.com/iree-org/iree/pull/20080