### PR TITLE
[DT] Perform vectorization if the value is defined by scf.for

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -2,7 +2,6 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{enable-vector-masking=true vectorize-padding=true}))" --split-input-file %s | FileCheck %s -check-prefix=CHECK-MASK
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{fold-cast-into-contract=true}))" --split-input-file %s | FileCheck %s -check-prefix=CHECK-FOLD
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{vectorize-to-transfer-gather=true}))" --split-input-file %s | FileCheck %s --check-prefix=CHECK-GATHER
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{enable-vector-masking=true use-configured-vector-sizes=false}))" --split-input-file %s | FileCheck %s -check-prefix=CHECK-VAL-DEF-SCF-FOR
 
 func.func @matmul(%lhs: tensor<3x4xf16>, %rhs: tensor<4x5xf16>, %acc: tensor<3x5xf32>) -> tensor<3x5xf32> {
   %result = linalg.matmul ins(%lhs, %rhs: tensor<3x4xf16>, tensor<4x5xf16>) outs(%acc: tensor<3x5xf32>) -> tensor<3x5xf32>
@@ -393,7 +392,7 @@ func.func @generic_unpack_infer_vector_size(%arg0: tensor<?x?x16x16xf32>, %arg1:
 
 // -----
 
-// CHECK-VAL-DEF-SCF-FOR-LABEL: @val_defined_by_scf_for
+// CHECK-MASK-LABEL: @val_defined_by_scf_for
 func.func @val_defined_by_scf_for(%arg0: index, %arg1: index) -> tensor<?x?xf32> {
   %c0 = arith.constant 0 : index
   %0 = tensor.empty() : tensor<1x1x16x16xf32>
@@ -407,13 +406,13 @@ func.func @val_defined_by_scf_for(%arg0: index, %arg1: index) -> tensor<?x?xf32>
   %unpack = linalg.unpack %2 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into %1 : tensor<1x1x16x16xf32> -> tensor<?x?xf32>
   return %unpack : tensor<?x?xf32>
 }
-// CHECK-VAL-DEF-SCF-FOR: %[[EMPTY:.*]] = tensor.empty{{.*}}: tensor<?x?xf32>
-// CHECK-VAL-DEF-SCF-FOR: %[[FOR:.*]] = scf.for
-// CHECK-VAL-DEF-SCF-FOR: %[[READ:.*]] = vector.transfer_read %[[FOR]]{{.*}} vector<1x1x16x16xf32>
-// CHECK-VAL-DEF-SCF-FOR: %[[CAST:.*]] = vector.shape_cast %[[READ]]{{.*}} vector<16x16xf32>
-// CHECK-VAL-DEF-SCF-FOR: %[[MASK:.*]] = vector.create_mask
-// CHECK-VAL-DEF-SCF-FOR: %[[WRITE:.*]] = vector.transfer_write %[[CAST]], %[[EMPTY]]{{.*}}, %[[MASK]]
-// CHECK-VAL-DEF-SCF-FOR: return %[[WRITE]]
+// CHECK-MASK: %[[EMPTY:.*]] = tensor.empty{{.*}}: tensor<?x?xf32>
+// CHECK-MASK: %[[FOR:.*]] = scf.for
+// CHECK-MASK: %[[READ:.*]] = vector.transfer_read %[[FOR]]{{.*}} vector<1x1x16x16xf32>
+// CHECK-MASK: %[[CAST:.*]] = vector.shape_cast %[[READ]]{{.*}} vector<16x16xf32>
+// CHECK-MASK: %[[MASK:.*]] = vector.create_mask
+// CHECK-MASK: %[[WRITE:.*]] = vector.transfer_write %[[CAST]], %[[EMPTY]]{{.*}}, %[[MASK]]
+// CHECK-MASK: return %[[WRITE]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1664,6 +1664,14 @@ bool isFullSlice(OffsetSizeAndStrideOpInterface sliceLoadStoreOp,
 // Utility functions for vector size inference for dynamic shapes
 //===----------------------------------------------------------------------===//
 
+std::optional<VectorizationTileSizes> inferSizesFromIR(scf::ForOp forOp,
+                                                       OpResult opResult) {
+  LDBG() << "Inferring sizes for: " << forOp;
+  unsigned resultNumber = opResult.getResultNumber();
+  LDBG() << " where OpResult.resultNumber = " << resultNumber;
+  return inferSizesFromIR(forOp.getInitsMutable()[resultNumber].get());
+}
+
 std::optional<VectorizationTileSizes>
 inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult) {
   LDBG() << "Inferring sizes for: " << linalgOp;
@@ -1846,6 +1854,8 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(Value val) {
   std::optional<VectorizationTileSizes> result;
   LDBG() << "Inferring sizes for: " << val;
   TypeSwitch<Operation *, void>(val.getDefiningOp())
+      .Case<scf::ForOp>(
+          [&](auto op) { result = inferSizesFromIR(op, cast<OpResult>(val)); })
       .Case<linalg::LinalgOp>(
           [&](auto op) { result = inferSizesFromIR(op, cast<OpResult>(val)); })
       .Case<linalg::PackOp>([&](auto op) { result = inferSizesFromIR(op); })

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1854,11 +1854,11 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(Value val) {
   std::optional<VectorizationTileSizes> result;
   LDBG() << "Inferring sizes for: " << val;
   TypeSwitch<Operation *, void>(val.getDefiningOp())
-      .Case<scf::ForOp>(
-          [&](auto op) { result = inferSizesFromIR(op, cast<OpResult>(val)); })
       .Case<linalg::LinalgOp>(
           [&](auto op) { result = inferSizesFromIR(op, cast<OpResult>(val)); })
       .Case<linalg::PackOp>([&](auto op) { result = inferSizesFromIR(op); })
+      .Case<scf::ForOp>(
+          [&](auto op) { result = inferSizesFromIR(op, cast<OpResult>(val)); })
       .Case<tensor::ExtractSliceOp, tensor::EmptyOp>([&](auto op) {
         // tensor::ExtractSliceOp is not vectorizable, so only `destShape` has
         // the values.

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -324,6 +324,11 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(linalg::PackOp op);
 std::optional<VectorizationTileSizes>
 inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult);
 
+/// Tries to infer the vector sizes from an IR using ValueBounds analysis.
+/// Returns std::nullopt if vector sizes can't be inferred.
+std::optional<VectorizationTileSizes> inferSizesFromIR(scf::ForOp forOp,
+                                                       OpResult opResult);
+
 /// Returns the underlying index if the given value is a constant index.
 std::optional<int64_t> getConstantIndex(Value value);
 


### PR DESCRIPTION
-- This commit adds scf.for op into the vector size inference list
   to perform vectorization if the value is defined by scf.for.
-- Resolves https://github.com/iree-org/iree/issues/21235

Signed-off-by: Abhishek Varma <abhvarma@amd.com>