### PR TITLE
Where is padding value used

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -69,7 +69,7 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
   SmallVector<Attribute> paddingValues;
   for (Value operand : tilingInterfaceOp.getOperation()->getOperands()) {
     paddingValues.push_back(
-        rewriter.getZeroAttr(getElementTypeOrSelf(operand.getType())));
+        rewriter.getOneAttr(getElementTypeOrSelf(operand.getType())));
   }
 
   // 1.b. Special adjustment for OnlineAttention mask padding that needs to be


### PR DESCRIPTION
This hard-coded padding value is incorrect for reductions which are not sum-reductions. Where is the hard-coded '0' identity value used? Checking CI. 