### PR TITLE
[Codegen] Fix dominance issues blocking consumer fusions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -788,20 +788,26 @@ func.func @fuse_warp_and_lane_foralls_multi_result(%2: tensor<2x2x64xf32>) -> (t
 
 // -----
 
-func.func @fusion_through_non_dominating_loop_user(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> (tensor<64xf32>, tensor<64xf32>) {
+func.func @fusion_through_non_dominating_loop_user(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>, %arg2: f32) -> (tensor<64xf32>, tensor<64xf32>) {
   %empty = tensor.empty() : tensor<64xf32>
-  %result:2 = scf.forall (%arg2) in (64) shared_outs(%out0 = %empty, %out1 = %empty) -> (tensor<64xf32>, tensor<64xf32>) {
-    %out0_slice = tensor.extract_slice %out0[%arg2] [1] [1] : tensor<64xf32> to tensor<1xf32>
-    %out1_slice = tensor.extract_slice %out1[%arg2] [1] [1] : tensor<64xf32> to tensor<1xf32>
+  %result:2 = scf.forall (%arg3) in (64) shared_outs(%out0 = %empty, %out1 = %empty) -> (tensor<64xf32>, tensor<64xf32>) {
+    %out0_slice = tensor.extract_slice %out0[%arg3] [1] [1] : tensor<64xf32> to tensor<1xf32>
+    %out1_slice = tensor.extract_slice %out1[%arg3] [1] [1] : tensor<64xf32> to tensor<1xf32>
     %copied = linalg.copy ins(%arg0 : tensor<1xf32>) outs(%out0_slice : tensor<1xf32>) -> tensor<1xf32>
     %add = linalg.add ins(%copied, %arg1 : tensor<1xf32>, tensor<1xf32>) outs(%out1_slice : tensor<1xf32>) -> tensor<1xf32>
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %copied into %out0[%arg2] [1] [1] : tensor<1xf32> into tensor<64xf32>
-      tensor.parallel_insert_slice %add into %out1[%arg2] [1] [1] : tensor<1xf32> into tensor<64xf32>
+      tensor.parallel_insert_slice %copied into %out0[%arg3] [1] [1] : tensor<1xf32> into tensor<64xf32>
+      tensor.parallel_insert_slice %add into %out1[%arg3] [1] [1] : tensor<1xf32> into tensor<64xf32>
     }
   } {mapping = [#gpu.thread<linear_dim_0>]}
   %unfusable_consumer = util.optimization_barrier %result#0 : tensor<64xf32>
-  %fusable_consumer = linalg.exp ins(%result#1 : tensor<64xf32>) outs(%empty : tensor<64xf32>) -> tensor<64xf32>
+  %implicit_capture = math.exp %arg2 : f32
+  %fusable_consumer = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+      ins(%result#1 : tensor<64xf32>) outs(%empty : tensor<64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %add = arith.addf %in, %implicit_capture : f32
+    linalg.yield %add : f32
+  } -> tensor<64xf32>
   return %unfusable_consumer, %fusable_consumer : tensor<64xf32>, tensor<64xf32>
 }
 
@@ -813,8 +819,8 @@ func.func @fusion_through_non_dominating_loop_user(%arg0: tensor<1xf32>, %arg1: 
 //  CHECK-SAME:       shared_outs(%[[OUT0:.+]] = %[[EMPTY]], %[[OUT1:.+]] = %[[EMPTY]])
 //       CHECK:     %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]
 //       CHECK:     %[[ADD:.+]] = linalg.add ins(%[[COPY]], %[[ARG1]]
-//       CHECK:     %[[EXP:.+]] = linalg.exp ins(%[[ADD]]
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic{{.*}} ins(%[[ADD]]
 //   CHECK-DAG:     tensor.parallel_insert_slice %[[COPY]] into %[[OUT0]]
-//   CHECK-DAG:     tensor.parallel_insert_slice %[[EXP]] into %[[OUT1]]
+//   CHECK-DAG:     tensor.parallel_insert_slice %[[GENERIC]] into %[[OUT1]]
 //       CHECK:   %[[BARRIER:.+]] = util.optimization_barrier %[[FORALL]]#0
 //       CHECK:   return %[[BARRIER]], %[[FORALL]]#1

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
@@ -37,6 +38,9 @@ struct FuseTilableForallConsumers final
       if (!forallProducer) {
         continue;
       }
+      if (forallProducer->getBlock() != tilableOp->getBlock()) {
+        continue;
+      }
       Value iterArg = forallProducer.getTiedBlockArgument(
           forallProducer.getTiedOpOperand(cast<OpResult>(operand)));
 
@@ -64,6 +68,22 @@ struct FuseTilableForallConsumers final
         return rewriter.notifyMatchFailure(tilableOp,
                                            "unimplemented: Cannot fuse op with "
                                            "multiple uses of producer loop");
+      }
+    }
+
+    // The `tileAndFuseConsumerOfSlices` transform will fail if there are any
+    // users of the loop that do not dominate the `tilableOp`, so we move the
+    // `tilableOp` and any producers needed for dominance right after the loop.
+    llvm::SetVector<Operation *> slice;
+    BackwardSliceOptions options;
+    DominanceInfo domInfo;
+    options.filter = [&](Operation *op) {
+      return domInfo.properlyDominates(sliceOwner, op);
+    };
+    options.inclusive = true;
+    if (succeeded(getBackwardSlice(tilableOp, &slice, options))) {
+      for (Operation *op : llvm::reverse(slice)) {
+        rewriter.moveOpAfter(op, sliceOwner);
       }
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -81,6 +81,8 @@ struct FuseTilableForallConsumers final
       return domInfo.properlyDominates(sliceOwner, op);
     };
     options.inclusive = true;
+    options.omitUsesFromAbove = false;
+    options.omitBlockArguments = true;
     if (succeeded(getBackwardSlice(tilableOp, &slice, options))) {
       for (Operation *op : llvm::reverse(slice)) {
         rewriter.moveOpAfter(op, sliceOwner);


### PR DESCRIPTION
The consumer fusion utility upstream does not allow fusing consumers when the producer loop has any users that are dominated by the consumer to fuse, even if the other user comes from a different result of the loop. This seems to be a result of the way the transformation is implemented, and it would be a non-trivial refactor to support the case in upstream MLIR. Instead, this PR supports the case by moving the consumer (and any ops needed to obey dominance) to right after the loop before fusing.