### PR TITLE
[Codegen] Introduce lowering config interface methods for vectorization.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
-#include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -37,14 +38,23 @@ namespace {
 static std::optional<SizesAndScalableFlags>
 getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
   // Get vector sizes from the lowering config, if available in the op itself.
-  std::unique_ptr<TilingConfig> tilingConfig =
-      TilingConfig::create(getLoweringConfig(op));
-  if (useConfiguredVectorSizes && tilingConfig) {
+  IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
+      getLoweringConfig(op);
+  if (useConfiguredVectorSizes && loweringConfig) {
     LDBG() << "Use configured vector sizes from lowering config";
-    auto [vectorSizes, scalableFlags] = tilingConfig->getVectorTileSizes();
-    // Replace zeros in canonical vector shape to turn it into a valid shape.
-    std::replace(vectorSizes.begin(), vectorSizes.end(), 0, 1);
-    return std::make_pair(vectorSizes, scalableFlags);
+    std::optional<SmallVector<int64_t>> vectorSizes =
+        loweringConfig.getVectorSizes();
+    std::optional<SmallVector<bool>> scalableFlags =
+        loweringConfig.getVectorScalableFlags();
+    if (vectorSizes) {
+      if (!scalableFlags || scalableFlags->empty()) {
+        scalableFlags->assign(vectorSizes->size(), false);
+      }
+      // Replace zeros in canonical vector shape to turn it into a valid shape.
+      std::replace(vectorSizes->begin(), vectorSizes->end(), 0, 1);
+      return std::make_pair(*vectorSizes, *scalableFlags);
+    }
+    LDBG() << "Failed to get configured vector sizes, fall back to inference";
   }
 
   // Try to infer the vector sizes from the IR.

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -44,15 +44,14 @@ getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
     LDBG() << "Use configured vector sizes from lowering config";
     std::optional<SmallVector<int64_t>> vectorSizes =
         loweringConfig.getVectorSizes();
-    std::optional<SmallVector<bool>> scalableFlags =
-        loweringConfig.getVectorScalableFlags();
+    SmallVector<bool> scalableFlags = loweringConfig.getVectorScalableFlags();
     if (vectorSizes) {
-      if (!scalableFlags || scalableFlags->empty()) {
-        scalableFlags->assign(vectorSizes->size(), false);
+      if (scalableFlags.empty()) {
+        scalableFlags.assign(vectorSizes->size(), false);
       }
       // Replace zeros in canonical vector shape to turn it into a valid shape.
       std::replace(vectorSizes->begin(), vectorSizes->end(), 0, 1);
-      return std::make_pair(*vectorSizes, *scalableFlags);
+      return std::make_pair(*vectorSizes, scalableFlags);
     }
     LDBG() << "Failed to get configured vector sizes, fall back to inference";
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -10,11 +10,9 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 
 namespace mlir::iree_compiler {
-
-using SizesAndScalableFlags =
-    std::pair<SmallVector<int64_t>, SmallVector<bool>>;
 
 /// Provides unified API to get access to all the tile size needed during the
 /// CPU lowering process, while abstracting the representation and verification

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -523,7 +523,7 @@ func.func @dynamic_fill_with_scalable_tiling_infer_remainder_vector_size(%arg0: 
 // -----
 
 #aarch64_sve = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", target_triple = "aarch64-none-elf"}>
-#config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0, 0], [1, 4, [4], 0], [0, 0, 0, 3], [0, 0, 0, 0]]>
+#config = #iree_cpu.lowering_config<vector_common_parallel = [1, 4, [4], 0], vector_reduction = [0, 0, 0, 3]>
 #map = affine_map<()[s0] -> (-(96 mod s0) + 96)>
 #map1 = affine_map<(d0) -> (d0 * 2)>
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -207,6 +207,54 @@ Attribute LoweringConfigAttr::getTilingLevelAttr(unsigned level) const {
   return config.get(key);
 }
 
+constexpr std::array vectorTilingLevels{TilingLevel::VectorCommonParallelTiles,
+                                        TilingLevel::VectorReductionTiles,
+                                        TilingLevel::VectorInnerParallelTiles};
+
+std::optional<SmallVector<int64_t>> LoweringConfigAttr::getVectorSizes() const {
+  SmallVector<int64_t> result;
+  for (auto level : vectorTilingLevels) {
+    if (!hasTilingLevel(level)) {
+      continue;
+    }
+    auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        getTilingLevelAttr(level));
+    if (result.empty()) {
+      result.resize(attr.getSizes().size(), 0);
+    }
+    for (auto [idx, size] : llvm::enumerate(attr.getSizes())) {
+      if (size == 0) {
+        continue;
+      }
+      if (result[idx] != 0) {
+        return std::nullopt;
+      }
+      result[idx] = size;
+    }
+  }
+  return result;
+}
+
+std::optional<SmallVector<bool>>
+LoweringConfigAttr::getVectorScalableFlags() const {
+  SmallVector<bool> result;
+  for (auto level : vectorTilingLevels) {
+    if (!hasTilingLevel(level)) {
+      continue;
+    }
+    auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        getTilingLevelAttr(level));
+    ArrayRef<bool> scalableFlags = attr.getScalableFlags();
+    if (result.empty() && !scalableFlags.empty()) {
+      result.resize(attr.getSizes().size(), false);
+    }
+    for (auto [idx, flag] : llvm::enumerate(scalableFlags)) {
+      result[idx] |= flag;
+    }
+  }
+  return result;
+}
+
 //===----------------------------------------------------------------------===//
 // Attribute Registration
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -235,8 +235,7 @@ std::optional<SmallVector<int64_t>> LoweringConfigAttr::getVectorSizes() const {
   return result;
 }
 
-std::optional<SmallVector<bool>>
-LoweringConfigAttr::getVectorScalableFlags() const {
+SmallVector<bool> LoweringConfigAttr::getVectorScalableFlags() const {
   SmallVector<bool> result;
   for (auto level : vectorTilingLevels) {
     if (!hasTilingLevel(level)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -25,6 +25,8 @@ def IREECPU_LoweringConfigAttr :
         "getNumTilingLevels",
         "getStaticTilingLevelSizes",
         "getTilingLevelAttr",
+        "getVectorSizes",
+        "getVectorScalableFlags",
       ]>
     ]> {
   let mnemonic = "lowering_config";

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -50,6 +50,12 @@ def IREECPU_LoweringConfigAttr :
       >
 
     For more details, see the implementation in IREECPUAttrs.cpp.
+
+    Note that it is undefined if more than one of vector tiling levels set a
+    value on a dimension. They are expected to be disjoint. It is not enforced
+    in the verifier, because we want to keep the flexibility when something is
+    wrong in a lowering config. E.g., some transformations still work even if
+    they are not disjoint.
   }];
   let parameters = (ins
     AttrParameter<"DictionaryAttr",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -392,14 +392,15 @@ def IREECodegen_LoweringConfigAttrInterface :
         Returns the vector scalable flags sizes for all the vector dimensions.
         Similar to the `getVectorSizes` method, but it is for scalable flags.
 
-        Returns std::nullopt if it fails to construct vector tile sizes.
+        The default implementation returns an empty list, which means that there
+        are no scalable flags at all.
       }],
-      /*retTy=*/"::std::optional<::llvm::SmallVector<bool>>",
+      /*retTy=*/"::llvm::SmallVector<bool>",
       /*methodName=*/"getVectorScalableFlags",
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return ::std::nullopt;
+        return {};
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -369,6 +369,41 @@ def IREECodegen_LoweringConfigAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns the tile sizes of all the vector level tiling, including
+        parallel and reduction dimensions.
+
+        Usually, the tile sizes for parallel dimensions and reduction dimensions
+        are split for different tiling and fusion purposes. The interface method
+        returns the tile sizes for vector level, as only lowering config knows
+        how to compose the list.
+
+        Returns std::nullopt if it fails to construct vector tile sizes.
+      }],
+      /*retTy=*/"::std::optional<::llvm::SmallVector<int64_t>>",
+      /*methodName=*/"getVectorSizes",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::std::nullopt;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the vector scalable flags sizes for all the vector dimensions.
+        Similar to the `getVectorSizes` method, but it is for scalable flags.
+
+        Returns std::nullopt if it fails to construct vector tile sizes.
+      }],
+      /*retTy=*/"::std::optional<::llvm::SmallVector<bool>>",
+      /*methodName=*/"getVectorScalableFlags",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::std::nullopt;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Gets the name of the custom lowering strategy to apply to the annotated
         operation.
       }],

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
@@ -58,7 +58,7 @@ func.func @vectorize_matmul_dyn_parallel(%A: tensor<?x64xf32>,
   %BL = iree_vector_ext.to_layout %B to layout(#layout) : tensor<64x?xf32>
   %CL = iree_vector_ext.to_layout %C to layout(#layout) : tensor<?x?xf32>
   %matmul = linalg.matmul ins(%AL, %BL : tensor<?x64xf32>, tensor<64x?xf32>)
-                          outs(%CL: tensor<?x?xf32>) {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0], [64, 64, 0], [0, 0, 64]]>}
+                          outs(%CL: tensor<?x?xf32>) {lowering_config = #iree_cpu.lowering_config<vector_common_parallel = [64, 64, 0], vector_reduction = [0, 0, 64]>}
                           -> tensor<?x?xf32>
   return %matmul : tensor<?x?xf32>
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -297,6 +297,9 @@ bool isFullSlice(OffsetSizeAndStrideOpInterface sliceLoadStoreOp,
 // Utility functions for vector size inference for dynamic shapes
 //===----------------------------------------------------------------------===//
 
+using SizesAndScalableFlags =
+    std::pair<SmallVector<int64_t>, SmallVector<bool>>;
+
 struct VectorizationTileSizes {
   SmallVector<int64_t> destShape;
   SmallVector<int64_t> vectorSizes;


### PR DESCRIPTION
It is user's choice about how to provide input vector sizes to the vectorizer. It can either be inferred or queried from lowering config.

We used to rely on TilingConfig to provide the pre-configured vector sizes, but it is CPU specific in fact. The revision introduces two interface method to serve the need, and it drops the dependency from TilingConfig.

- `getVectorSizes()`: Returns the tile sizes of all the vector level tiling.
- `getVectorScalableFlags()`: Returns the vector scalable flags sizes for all the vector dimensions.