### PR TITLE
[CPU][NFCI] Drop the use of TilingConfig from pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -69,7 +69,7 @@ public:
 static LoweringConfigAttrInterface
 getRootLoweringConfig(FunctionOpInterface funcOp) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  for (auto op : computeOps) {
+  for (Operation *op : computeOps) {
     LoweringConfigAttrInterface loweringConfig = getLoweringConfig(op);
     if (loweringConfig && loweringConfig.hasWorkgroupTilingLevel()) {
       return loweringConfig;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "iree/compiler/Codegen/Utils/CPUUtils.h"
@@ -25,7 +26,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
 
-using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttr;
+using mlir::iree_compiler::IREE::Codegen::LoweringConfigAttrInterface;
 
 namespace mlir::iree_compiler {
 
@@ -65,15 +66,16 @@ public:
 };
 } // namespace
 
-static std::unique_ptr<TilingConfig>
-getTilingConfigForPipeline(FunctionOpInterface funcOp) {
+static LoweringConfigAttrInterface
+getRootLoweringConfig(FunctionOpInterface funcOp) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
-  if (failed(rootOp) || !rootOp.value()) {
-    return nullptr;
+  for (auto op : computeOps) {
+    LoweringConfigAttrInterface loweringConfig = getLoweringConfig(op);
+    if (loweringConfig && loweringConfig.hasWorkgroupTilingLevel()) {
+      return loweringConfig;
+    }
   }
-  auto config = iree_compiler::getLoweringConfig(rootOp.value());
-  return TilingConfig::create(config);
+  return nullptr;
 }
 
 void LLVMCPULowerExecutableTargetPass::runOnOperation() {
@@ -90,16 +92,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     return;
   }
 
-  auto maybeTilingConfig = getTilingConfigForPipeline(funcOp);
+  LoweringConfigAttrInterface loweringConfig = getRootLoweringConfig(funcOp);
   auto pipeline = translationInfo.getDispatchLoweringPassPipeline();
-  if (!maybeTilingConfig &&
-      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault &&
-      pipeline != IREE::Codegen::DispatchLoweringPassPipeline::None) {
-    funcOp.emitOpError("Tiling Config is necessary for ")
-        << stringifyEnum(pipeline) << " pipeline.";
-    return signalPassFailure();
-  }
-
   LLVMCPUPipelineOptions pipelineOpts;
   if (isX86(target) || isRISCV(target)) {
     pipelineOpts.useConfiguredVectorSizes = false;
@@ -114,8 +108,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
       isAArch64(target) && hasAnySVEFeature(target) && hasSMEFeature(target);
   pipelineOpts.enableAArch64I8mm = isAArch64(target) && hasI8mmFeature(target);
   pipelineOpts.enablePeeling = isOptEnabled(funcOp, getEnableLoopPeelingStr());
-  if (maybeTilingConfig &&
-      llvm::all_of(maybeTilingConfig->getDistributionTileSizes(),
+  if (loweringConfig &&
+      llvm::all_of(loweringConfig.getWorkgroupTileSizes(),
                    [](int64_t tileSize) { return tileSize == 0; })) {
     pipelineOpts.disableDistribution = true;
   }
@@ -126,39 +120,35 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::None:
     return;
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault: {
-    addCPUDefaultPassPipeline(passManager, maybeTilingConfig, pipelineOpts);
+    addCPUDefaultPassPipeline(passManager, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUBufferOpsTileAndVectorize: {
-    addCPUBufferOpsTileAndVectorizePipeline(passManager, *maybeTilingConfig,
-                                            pipelineOpts);
+    addCPUBufferOpsTileAndVectorizePipeline(passManager, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDoubleTilingExpert: {
-    addMultiTilingExpertPassPipeline(passManager, *maybeTilingConfig,
-                                     pipelineOpts);
+    assert(loweringConfig && "expected a valid lowering config");
+    addMultiTilingExpertPassPipeline(passManager, loweringConfig, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
-    addConvTileAndDecomposeExpertPassPipeline(passManager, *maybeTilingConfig,
-                                              pipelineOpts);
+    addConvTileAndDecomposeExpertPassPipeline(passManager, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert: {
-    addMmt4dTilingExpertPassPipeline(passManager, *maybeTilingConfig,
-                                     pipelineOpts);
+    addMmt4dTilingExpertPassPipeline(passManager, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling: {
-    addCPUDataTilingPipeline(passManager, *maybeTilingConfig, pipelineOpts);
+    addCPUDataTilingPipeline(passManager, pipelineOpts);
     break;
   }
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPULinalgExtTileAndVectorize: {
-    addCPULinalgExtTileAndVectorizePipeline(passManager, *maybeTilingConfig,
-                                            pipelineOpts);
+    addCPULinalgExtTileAndVectorizePipeline(passManager, pipelineOpts);
     break;
   }
   default:

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -10,6 +10,8 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
@@ -364,14 +366,13 @@ void buildLLVMCPUVectorLoweringPipeline(
 }
 
 void addCPUBufferOpsTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   // Skip tiling reduction loops because this is expected to apply on copy ops
   // only.
   funcPassManager.addPass(createLLVMCPUTilePass(
-      tilingConfig.getVectorCommonParallelLevel(), /*skipRootOp=*/false));
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles, /*skipRootOp=*/false));
   funcPassManager.addPass(createLLVMCPUPeelPass());
   {
     GenericVectorizationPassOptions options;
@@ -400,13 +401,14 @@ void addCPUBufferOpsTileAndVectorizePipeline(
   }
 }
 
-void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      TilingConfig &tilingConfig,
-                                      LLVMCPUPipelineOptions &pipelineOpt) {
+void addMultiTilingExpertPassPipeline(
+    OpPassManager &funcPassManager,
+    IREE::Codegen::LoweringConfigAttrInterface loweringConfig,
+    LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   for (int i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e; ++i) {
     auto level = static_cast<IREE::CPU::TilingLevel>(i);
-    if (!tilingConfig.isValidLevel(level)) {
+    if (!loweringConfig.hasTilingLevel(level)) {
       continue;
     }
 
@@ -500,8 +502,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
 }
 
 void addConvTileAndDecomposeExpertPassPipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
@@ -559,7 +560,6 @@ void addConvTileAndDecomposeExpertPassPipeline(
 }
 
 void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      TilingConfig &tilingConfig,
                                       LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
@@ -609,7 +609,6 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
 }
 
 void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
-                              TilingConfig &tilingConfig,
                               LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
@@ -620,7 +619,7 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
       createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
 
   funcPassManager.addPass(createLLVMCPUTilePass(
-      tilingConfig.getVectorCommonParallelLevel(), /*skipRootOp=*/false));
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles, /*skipRootOp=*/false));
   if (pipelineOpt.decomposePackUnPackOps) {
     funcPassManager.addPass(createDecomposePackUnPackOpsPass());
   }
@@ -652,8 +651,7 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
 }
 
 void addCPULinalgExtTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
       IREE::CPU::TilingLevel::VectorCommonParallelTiles));
@@ -694,13 +692,10 @@ void addCPULinalgExtTileAndVectorizePipeline(
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               std::unique_ptr<TilingConfig> &tilingConfig,
                                LLVMCPUPipelineOptions &pipelineOpt) {
-  if (tilingConfig && tilingConfig->getNumTilingLevels() > 1) {
-    addTileAndDistributePasses(funcPassManager, pipelineOpt);
-    funcPassManager.addPass(createLLVMCPUTileAndFusePass(
-        tilingConfig->getVectorCommonParallelLevel()));
-  }
+  addTileAndDistributePasses(funcPassManager, pipelineOpt);
+  funcPassManager.addPass(createLLVMCPUTileAndFusePass(
+      IREE::CPU::TilingLevel::VectorCommonParallelTiles));
   addCPUBufferizePasses(funcPassManager);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -89,38 +89,33 @@ struct LLVMCPUPipelineOptions {
 /// pipeline is only used for dispatches that just copy data from input
 /// interfaces to output interface.
 void addCPUBufferOpsTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
-                              TilingConfig &tilingConfig,
                               LLVMCPUPipelineOptions &pipelineOpt);
 
 void addCPULinalgExtTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower scalars and unknown tensor op (i.e. linalg op
 /// that is not specialized by any pipeline). Adds an additional level of tiling
 /// and converts to memrefs.
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               std::unique_ptr<TilingConfig> &tilingConfig,
                                LLVMCPUPipelineOptions &pipelineOpt);
 
 void addConvTileAndDecomposeExpertPassPipeline(
-    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
-    LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize
 /// lowering of linalg ops on tensors to vectors operations.
 void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      TilingConfig &tilingConfig,
                                       LLVMCPUPipelineOptions &pipelineOpt);
 
-void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      TilingConfig &tilingConfig,
-                                      LLVMCPUPipelineOptions &pipelineOpt);
+void addMultiTilingExpertPassPipeline(
+    OpPassManager &funcPassManager,
+    IREE::Codegen::LoweringConfigAttrInterface loweringConfig,
+    LLVMCPUPipelineOptions &pipelineOpt);
 
 void addTensorToVectorsPassPipeline(OpPassManager &funcPassManager,
                                     bool lowerToVectors = true);


### PR DESCRIPTION
All the passes use `IREE::CPU::TilingLevel`, so we no longer need the `TilingConfig` to verify if a level is valid or not. Instead, we can pass the `LoweringConfigAttrInterface` when needed.

Most of the pipelines do not need the information, so it is dropped in many pipelines.