### PR TITLE
Fix parentheses warning in ireeGPUGetSingleSubgroupLayout

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -353,9 +353,9 @@ MlirAttribute ireeGPULoweringConfigAttrGetMmaKind(MlirAttribute attr) {
 
 ireeGPUMMASingleSubgroupLayout
 ireeGPUGetSingleSubgroupLayout(MlirAttribute attr, uint32_t fragment) {
-  assert(ireeAttributeIsAGPUMMAIntrinsicAttr(attr) ||
-         ireeAttributeIsAGPUVirtualMMAIntrinsicAttr(attr) &&
-             "Expected MMA or VirtualMMA Intrinsic");
+  assert((ireeAttributeIsAGPUMMAIntrinsicAttr(attr) ||
+          ireeAttributeIsAGPUVirtualMMAIntrinsicAttr(attr)) &&
+         "Expected MMA or VirtualMMA Intrinsic");
 
   mlir::Attribute baseAttr = unwrap(attr);
   mlir::iree_compiler::IREE::GPU::MMASingleSubgroupLayout layout;


### PR DESCRIPTION
Fix for following warning which was introduced recently in https://github.com/iree-org/iree/pull/21454:
```
iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp: In function ‘ireeGPUMMASingleSubgroupLayout ireeGPUGetSingleSubgroupLayout(MlirAttribute, uint32_t)’:
iree/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp:357:59: error: suggest parentheses around ‘&&’ within ‘||’ [-Werror=parentheses]
  357 |          ireeAttributeIsAGPUVirtualMMAIntrinsicAttr(attr) &&
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  358 |              "Expected MMA or VirtualMMA Intrinsic");
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
```