### PR TITLE
Integrate LLVM at llvm/llvm-project@1194353

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -13,8 +13,7 @@ module {
 //  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x32xf16>)
 //  CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]]{{.*}} : memref<4096x32xf16>
 //  CHECK: %[[ELEM:.+]] = vector.extract %[[LOAD]][0] : f16 from vector<1xf16>
-//  CHECK: %[[SPLAT:.+]] = vector.splat %[[ELEM]] : vector<8xf16>
-//  CHECK: %[[INSERT:.+]] = vector.broadcast %[[SPLAT]] : vector<8xf16> to vector<1x8xf16>
+//  CHECK: %[[INSERT:.+]] = vector.broadcast %[[ELEM]] : f16 to vector<1x8xf16>
 //  CHECK: return %[[INSERT]]
 
 // -----
@@ -34,8 +33,8 @@ module {
 // CHECK: %[[RHS_CAST:.+]] = arith.extf %[[RHS_EXTRACT]] : vector<2xf16> to vector<2xf32>
 // CHECK: %[[LHS_CAST:.+]] = arith.extf %[[LHS_EXTRACT]] : f16 to f32
 // CHECK: %[[MASK_EXTRACT:.+]] = vector.extract %[[MASK]][0] : vector<2xi1> from vector<3x2xi1>
-// CHECK: %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
-// CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
+// CHECK: %[[LHS_BROADCAST:.+]] = vector.broadcast %[[LHS_CAST]] : f32 to vector<2xf32>
+// CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_BROADCAST]], %[[ACC]] : vector<2xf32>
 // CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matvec.mlir
@@ -53,11 +53,11 @@ func.func @i4_dequant_matvec_f32() {
 //         CHECK:     %[[EXTEND:.+]] = arith.extui %[[READ0]] : vector<4xi4> to vector<4xi32>
 //         CHECK:     %[[CVT:.+]] = arith.uitofp %[[EXTEND]] : vector<4xi32> to vector<4xf32>
 //         CHECK:     %[[EXTRACT0:.+]] = vector.extract %[[READ1]][0] : f32 from vector<1xf32>
-//         CHECK:     %[[SPLAT0:.+]] = vector.splat %[[EXTRACT0]] : vector<4xf32>
-//         CHECK:     %[[SUB:.+]] = arith.subf %[[CVT]], %[[SPLAT0]] : vector<4xf32>
+//         CHECK:     %[[BROADCAST0:.+]] = vector.broadcast %[[EXTRACT0]] : f32 to vector<4xf32>
+//         CHECK:     %[[SUB:.+]] = arith.subf %[[CVT]], %[[BROADCAST0]] : vector<4xf32>
 //         CHECK:     %[[EXTRACT1:.+]] = vector.extract %[[READ2]][0] : f32 from vector<1xf32>
-//         CHECK:     %[[SPLAT1:.+]] = vector.splat %[[EXTRACT1]] : vector<4xf32>
-//         CHECK:     %[[MUL0:.+]] = arith.mulf %[[SUB]], %[[SPLAT1]] : vector<4xf32>
+//         CHECK:     %[[BROADCAST1:.+]] = vector.broadcast %[[EXTRACT1]] : f32 to vector<4xf32>
+//         CHECK:     %[[MUL0:.+]] = arith.mulf %[[SUB]], %[[BROADCAST1]] : vector<4xf32>
 //         CHECK:     %[[MUL1:.+]] = arith.mulf %[[READ3]], %[[MUL0]] : vector<4xf32>
 //         CHECK:     %[[EXTRACT2:.+]] = vector.extract %arg1[0] : vector<4xf32> from vector<1x4xf32>
 //         CHECK:     %[[ADD:.+]] = arith.addf %[[MUL1]], %[[EXTRACT2]] : vector<4xf32>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -68,7 +68,7 @@ func.func @warp_reduction_dispatch_0() attributes {hal.executable.target = #exec
 //         CHECK:    %[[R8:.+]] = arith.addf %[[R7]], %[[S6]] : f32
 //         CHECK:    %[[S7:.+]], %{{.*}} = gpu.shuffle  idx %[[R8]], %[[C0I]], %[[C32]] : f32
 //         CHECK:    %[[R12:.+]] = arith.addf %[[S7]], %[[CF]] : f32
-//         CHECK:    %[[R13:.+]] = vector.splat %[[R12]] : vector<1xf32>
+//         CHECK:    %[[R13:.+]] = vector.broadcast %[[R12]] : f32 to vector<1xf32>
 //         CHECK:    %[[TID0:.+]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
 //         CHECK:    scf.if %[[TID0]] {
 //         CHECK:      vector.transfer_write %[[R13]], %{{.*}}[%{{.*}}] {in_bounds = [true]} : vector<1xf32>, memref<512xf32, #hal.descriptor_type<storage_buffer>>
@@ -144,15 +144,15 @@ func.func @warp_reduction_dispatch_1() attributes {hal.executable.target = #exec
 //         CHECK:    %[[TRUNC:.+]] = arith.trunci %{{.+}} : i32 to i16
 //         CHECK:    %[[BCAST:.+]] = arith.bitcast %[[TRUNC]] : i16 to f16
 //         CHECK:    %[[ADD1:.+]] = arith.addf %[[BCAST]], %[[F0]] : f16
-//         CHECK:    %[[SPLAT:.+]] = vector.splat %[[ADD1]] : vector<4xf16>
+//         CHECK:    %[[BROADCAST:.+]] = vector.broadcast %[[ADD1]] : f16 to vector<4xf16>
 //         CHECK:    scf.for %[[IV:.+]] = %[[C0]] to %[[C9216]] step %[[C1024]] {
 //         CHECK:      %[[OFFSET:.+]] = affine.apply {{.*}}(%[[IV]])[%[[TIDX]]]
 //         CHECK:      %[[READ:.+]] = vector.transfer_read %[[SPAN0]][%[[WGIDY]], %[[WGIDX]], %[[OFFSET]]], %[[PV]] {in_bounds = [true]} : memref<10x9216x9216xf16{{.*}}>, vector<8xf16>
 //         CHECK:      %[[SLICE0:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [0], sizes = [4], strides = [1]}
-//         CHECK:      %[[DIV0:.+]] = arith.divf %[[SLICE0]], %[[SPLAT]] : vector<4xf16>
+//         CHECK:      %[[DIV0:.+]] = arith.divf %[[SLICE0]], %[[BROADCAST]] : vector<4xf16>
 //         CHECK:      %[[SLICE1:.+]] = vector.insert_strided_slice %[[DIV0]], %cst {offsets = [0], strides = [1]}
 //         CHECK:      %[[SLICE2:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [4], sizes = [4], strides = [1]}
-//         CHECK:      %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[SPLAT]] : vector<4xf16>
+//         CHECK:      %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[BROADCAST]] : vector<4xf16>
 //         CHECK:      %[[SLICE3:.+]] = vector.insert_strided_slice %[[DIV1]], %[[SLICE1]] {offsets = [4], strides = [1]}
 //         CHECK:      vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
 //         CHECK:    }
@@ -210,7 +210,7 @@ func.func @softmax() attributes {hal.executable.target = #executable_target_vulk
 //         CHECK:    arith.maxnumf
 //         CHECK:    gpu.shuffle  xor
 //         CHECK:    arith.maxnumf
-//         CHECK:    vector.splat %{{.*}} : vector<4xf32>
+//         CHECK:    vector.broadcast %{{.*}} : f32 to vector<4xf32>
 //         CHECK:    scf.for {{.*}} -> (vector<4xf32>) {
 //         CHECK:      vector.transfer_read
 //         CHECK:      arith.subf
@@ -236,8 +236,8 @@ func.func @softmax() attributes {hal.executable.target = #executable_target_vulk
 //         CHECK:    gpu.shuffle  xor
 //         CHECK:    arith.addf
 //         CHECK:    arith.addf
-//         CHECK:    vector.splat
-//         CHECK:    vector.splat
+//         CHECK:    vector.broadcast
+//         CHECK:    vector.broadcast
 //         CHECK:    scf.for
 //         CHECK:      vector.transfer_read
 //         CHECK:      arith.subf
@@ -327,8 +327,8 @@ func.func @dynamic_softmax() attributes {hal.executable.target = #executable_tar
 // CHECK:         gpu.subgroup_reduce  add {{.*}} : (f16) -> f16
 // CHECK:         arith.addf {{.*}} : f16
 // CHECK:         gpu.subgroup_reduce  maxnumf {{.*}} : (f16) -> f16
-// CHECK:         vector.splat {{.*}} : vector<1xf16>
-// CHECK:         vector.splat {{.*}} : vector<1xf16>
+// CHECK:         vector.broadcast {{.*}} : f16 to vector<1xf16>
+// CHECK:         vector.broadcast {{.*}} : f16 to vector<1xf16>
 
 // Store the result back to global memory in a loop, recomputing the
 // elementwise part.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -23,16 +23,16 @@ func.func @matmul_1x4x4(%lhs: tensor<1x4xf32>, %rhs: tensor<4x4xf32>, %init: ten
 //       CHECK:   %[[RHS_3_VECTOR:.+]] = vector.transfer_read %[[RHS]][%[[C3]], %[[C0]]], %[[PAD]]
 //       CHECK:   %[[INIT_VECTOR:.+]] = vector.transfer_read %[[INIT]][%[[C0]], %[[C0]]], %[[PAD]]
 //       CHECK:   %[[LHS_0_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][0]
-//       CHECK:   %[[LHS_0_VECTOR:.+]] = vector.splat %[[LHS_0_SCALAR]] : vector<4xf32>
+//       CHECK:   %[[LHS_0_VECTOR:.+]] = vector.broadcast %[[LHS_0_SCALAR]] : f32 to vector<4xf32>
 //       CHECK:   %[[FMA_0:.+]] = vector.fma %[[LHS_0_VECTOR]], %[[RHS_0_VECTOR]], %[[INIT_VECTOR]] : vector<4xf32>
 //       CHECK:   %[[LHS_1_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][1]
-//       CHECK:   %[[LHS_1_VECTOR:.+]] = vector.splat %[[LHS_1_SCALAR]] : vector<4xf32>
+//       CHECK:   %[[LHS_1_VECTOR:.+]] = vector.broadcast %[[LHS_1_SCALAR]] : f32 to vector<4xf32>
 //       CHECK:   %[[FMA_1:.+]] = vector.fma %[[LHS_1_VECTOR]], %[[RHS_1_VECTOR]], %[[FMA_0]] : vector<4xf32>
 //       CHECK:   %[[LHS_2_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][2]
-//       CHECK:   %[[LHS_2_VECTOR:.+]] = vector.splat %[[LHS_2_SCALAR]] : vector<4xf32>
+//       CHECK:   %[[LHS_2_VECTOR:.+]] = vector.broadcast %[[LHS_2_SCALAR]] : f32 to vector<4xf32>
 //       CHECK:   %[[FMA_2:.+]] = vector.fma %[[LHS_2_VECTOR]], %[[RHS_2_VECTOR]], %[[FMA_1]] : vector<4xf32>
 //       CHECK:   %[[LHS_3_SCALAR:.+]] = vector.extract %[[LHS_VECTOR]][3]
-//       CHECK:   %[[LHS_3_VECTOR:.+]] = vector.splat %[[LHS_3_SCALAR]] : vector<4xf32>
+//       CHECK:   %[[LHS_3_VECTOR:.+]] = vector.broadcast %[[LHS_3_SCALAR]] : f32 to vector<4xf32>
 //       CHECK:   %[[FMA_3:.+]] = vector.fma %[[LHS_3_VECTOR]], %[[RHS_3_VECTOR]], %[[FMA_2]] : vector<4xf32>
 //       CHECK:   vector.transfer_write %[[FMA_3]], %[[INIT]][%[[C0]], %[[C0]]]
 
@@ -137,7 +137,7 @@ func.func @matmul_broadcast_add(%init: tensor<1x8xf32>, %a: tensor<1x8xf32>, %b:
 
 //          CHECK:   %[[READ:.+]] = vector.transfer_read %[[BIAS]]
 //          CHECK:   %[[EXT0:.+]] = vector.extract %[[READ]][0] : f32 from vector<1xf32>
-//          CHECK:   %[[BCST0:.+]] = vector.splat %[[EXT0]] : vector<4xf32>
+//          CHECK:   %[[BCST0:.+]] = vector.broadcast %[[EXT0]] : f32 to vector<4xf32>
 //          CHECK:   %[[ADD0:.+]] = arith.addf %{{.+}}, %[[BCST0]] : vector<4xf32>
 //          CHECK:   %[[ADD1:.+]] = arith.addf %{{.+}}, %[[BCST0]] : vector<4xf32>
 //          CHECK:   %[[WRITE0:.+]] = vector.transfer_write %[[ADD0]], %[[INIT]][%[[C0]], %[[C0]]]
@@ -247,11 +247,11 @@ func.func @matmul_4x4x4_i8_to_i32(%lhs: tensor<4x4xi8>, %rhs : tensor<4x4xi8>) -
 // CHECK-NEXT:    %[[RHS2E:.+]]  = arith.extsi %[[RHS2]] : vector<4xi8> to vector<4xi32>
 // CHECK-NEXT:    %[[RHS3E:.+]]  = arith.extsi %[[RHS3]] : vector<4xi8> to vector<4xi32>
 // CHECK:         %[[EXT0:.+]]   = vector.extract %[[LHS0E]][0]
-// CHECK-NEXT:    %[[SPLT:.+]]   = vector.splat %[[EXT0]] : vector<4xi32>
-// CHECK-NEXT:    %[[MUL0:.+]]   = arith.muli %[[SPLT]], %[[RHS0E]]
+// CHECK-NEXT:    %[[BROADCAST:.+]]   = vector.broadcast %[[EXT0]] : i32 to vector<4xi32>
+// CHECK-NEXT:    %[[MUL0:.+]]   = arith.muli %[[BROADCAST]], %[[RHS0E]]
 // CHECK:         %[[EXT1:.+]]   = vector.extract %[[LHS0E]][1]
-// CHECK-NEXT:    %[[SPLT:.+]]   = vector.splat %[[EXT1]] : vector<4xi32>
-// CHECK-NEXT:    %[[MUL1:.+]]   = arith.muli %[[SPLT]], %[[RHS1E]]
+// CHECK-NEXT:    %[[BROADCAST:.+]]   = vector.broadcast %[[EXT1]] : i32 to vector<4xi32>
+// CHECK-NEXT:    %[[MUL1:.+]]   = arith.muli %[[BROADCAST]], %[[RHS1E]]
 // CHECK-NEXT:    %[[ADD0:.+]]   = arith.addi %[[MUL1]], %[[MUL0]]
 //
 // CHECK:         %[[W0:.+]]     = vector.transfer_write %{{.+}}, %{{.+}}[%[[IDX0]], %[[IDX0]]]

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -163,7 +163,7 @@ util.func public @main(%dynamic_arg: i32) -> !stream.timepoint attributes {
 }
 
 // -----
-// expected-warning@-2 {{multiple devices in the module}}
+// expected-warning@-1 {{multiple devices in the module}}
 
 // Tests that multiple devices fail today.
 // We should be creating one benchmark per executable with only the dispatches

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
@@ -4,7 +4,7 @@
 
 // -----
 // Must be rank-0 or rank-1.
-// expected-error @-3 {{conversion to util failed}}
+// expected-error @-2 {{conversion to util failed}}
 util.func @verify_invalid_rank_2(%buffer: memref<4x2xf32>, %idx: index) -> f32{
   // expected-error @below {{failed to legalize operation 'memref.load'}}
   %0 = memref.load %buffer[%idx, %idx] : memref<4x2xf32>
@@ -13,7 +13,7 @@ util.func @verify_invalid_rank_2(%buffer: memref<4x2xf32>, %idx: index) -> f32{
 
 // -----
 // Must have an identity map.
-// expected-error @-3 {{conversion to util failed}}
+// expected-error @-2 {{conversion to util failed}}
 #map = affine_map<(d0)[s0] -> (d0 * s0)>
 util.func @verify_invalid_non_identity_map(%buffer: memref<4xf32, #map>, %idx: index) -> f32 {
   // expected-error @below {{failed to legalize operation 'memref.load'}}


### PR DESCRIPTION
Drops the revert needed in the previous integrate (https://github.com/llvm/llvm-project/commit/b6a98b934f63431243ba062aa9e07a52aae05f70) because a fix landed in https://github.com/llvm/llvm-project/pull/151499.