### PR TITLE
[Codegen] Add XOR-based Swizzle Attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -201,7 +201,6 @@ static void resolveHintOp(RewriterBase &rewriter,
       if (accessBitWidth != transferBitWidth) {
         return;
       }
-
       gatherToLDSOps.push_back(gatherToLDSOp);
       continue;
     }

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -227,7 +227,7 @@ static void resolveHintOp(RewriterBase &rewriter,
       if (isGatherToLDSDstOperand(memRefSubviewOp))
         continue;
     }
-    // Warning if we can't rewrite all users.
+    // Throw if we can't rewrite all users.
     hintOp.emitError()
         << "At least one of the SwizzleHintOp users is not supported. ";
     return;

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -191,25 +191,23 @@ static void resolveHintOp(RewriterBase &rewriter,
       // subgroup contiguously in order of lane ID
       if (gatherToLDSOp.getDst() == hintOp) {
         continue;
-      } else {
-        int64_t accessBitWidth = cast<MemRefType>(hintOp.getOperand().getType())
-                                     .getElementTypeBitWidth() *
-                                 accessWidth;
-        auto transferBitWidth = [&]() -> int64_t {
-          if (auto vectorType =
-                  dyn_cast<VectorType>(gatherToLDSOp.getTransferType())) {
-            return vectorType.getElementTypeBitWidth() *
-                   vectorType.getNumElements();
-          }
-          return gatherToLDSOp.getTransferType().getIntOrFloatBitWidth();
-        }();
-        if (accessBitWidth != transferBitWidth) {
-          return;
-        }
-        gatherToLDSOps.push_back(gatherToLDSOp);
-
-        continue;
       }
+      int64_t accessBitWidth = cast<MemRefType>(hintOp.getOperand().getType())
+                                   .getElementTypeBitWidth() *
+                               accessWidth;
+      auto transferBitWidth = [&]() -> int64_t {
+        if (auto vectorType =
+                dyn_cast<VectorType>(gatherToLDSOp.getTransferType())) {
+          return vectorType.getElementTypeBitWidth() *
+                 vectorType.getNumElements();
+        }
+        return gatherToLDSOp.getTransferType().getIntOrFloatBitWidth();
+      }();
+      if (accessBitWidth != transferBitWidth) {
+        return;
+      }
+      gatherToLDSOps.push_back(gatherToLDSOp);
+      continue;
     }
     // Throw if we can't rewrite all users.
     hintOp.emitError() << "unsupported SwizzleHintOp user: "

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -210,8 +210,7 @@ static void resolveHintOp(RewriterBase &rewriter,
       continue;
     }
     // Throw if we can't rewrite all users.
-    hintOp.emitError() << "unsupported SwizzleHintOp user: "
-                       << user->getName().getStringRef();
+    hintOp.emitError() << "unsupported SwizzleHintOp user: " << user;
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -212,7 +212,7 @@ static void resolveHintOp(RewriterBase &rewriter,
       }
     }
     // Throw if we can't rewrite all users.
-    hintOp.emitError() << "The following SwizzleHintOp user is not supported : "
+    hintOp.emitError() << "unsupported SwizzleHintOp user: "
                        << user->getName().getStringRef();
     return;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -254,7 +254,7 @@ func.func @swizzle_load_xor(%src: memref<?xi8>) -> vector<16xi8> {
   return %1: vector<16xi8>
 }
 
-// CHECK-LABEL: func @swizzle_load
+// CHECK-LABEL: func @swizzle_load_xor
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xi8>
 //       CHECK:   %[[SWOFF:.+]] = arith.constant 2000 : index
 //       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]
@@ -270,7 +270,7 @@ func.func @swizzle_load_xor_phase2(%src: memref<?xi8>) -> vector<16xi8> {
   return %1: vector<16xi8>
 }
 
-// CHECK-LABEL: func @swizzle_load
+// CHECK-LABEL: func @swizzle_load_xor_phase2
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xi8>
 //       CHECK:   %[[SWOFF:.+]] = arith.constant 1120 : index
 //       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-resolve-swizzle-hints, canonicalize, cse))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-resolve-swizzle-hints, canonicalize, cse))" --verify-diagnostics \
 // RUN:   --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 func.func @swizzle_load(%src: memref<?xf32>) -> vector<4xf32> {
@@ -70,6 +70,7 @@ func.func @swizzle_both(%src: memref<?xf32>) {
 // -----
 
 func.func @drop_swizzle_non_access_user(%src: memref<?xf32>) -> (memref<?xf32>, vector<4xf32>) {
+  // expected-error @+1 {{The following SwizzleHintOp user is not supported}}
   %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
   %offset = arith.constant 68 : index
   %1 = vector.load %0[%offset] : memref<?xf32>, vector<4xf32>
@@ -300,3 +301,25 @@ func.func @swizzle_raw_buffer_to_lds(%global : memref<32768xi8, #amdgpu.address_
 //       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[LDSOFFSET]]]
 
 // -----
+
+
+func.func @swizzle_raw_buffer_to_lds_ignore_dst_op(%global : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  //1 row, 3rd tile : 1*8192+2*128 = 8448 -> (0 XOR 1)*16+8448 = 8464
+  %offset = arith.constant 8448 : index
+  %lds = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
+  %ldsSwizzle = iree_codegen.swizzle_hint %lds[#iree_codegen.xor_shuffle<128, 16>] : memref<32768xi8, #gpu.address_space<workgroup>>
+  %globalSwizzle = iree_codegen.swizzle_hint %global[#iree_codegen.xor_shuffle<128, 16, 8192>] : memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>
+  amdgpu.gather_to_lds %globalSwizzle[%offset], %ldsSwizzle[%c0]
+    : vector<16xi8>, memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>, memref<32768xi8, #gpu.address_space<workgroup>>
+
+  func.return
+}
+
+// CHECK-LABEL: func @swizzle_raw_buffer_to_lds_ignore_dst_op
+//  CHECK-SAME:   %[[SRC:.+]]: memref<32768xi8, #amdgpu.address_space<fat_raw_buffer>>
+//   CHECK:   %[[SWOFF:.+]] = arith.constant 8464 : index
+//   CHECK:   %[[LDSOFFSET:.+]] = arith.constant 0 : index
+//       CHECK:   %[[LDS:.+]] = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
+//       CHECK:   amdgpu.gather_to_lds %[[SRC]][%[[SWOFF]]], %[[LDS]][%[[LDSOFFSET]]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -70,7 +70,7 @@ func.func @swizzle_both(%src: memref<?xf32>) {
 // -----
 
 func.func @drop_swizzle_non_access_user(%src: memref<?xf32>) -> (memref<?xf32>, vector<4xf32>) {
-  // expected-error @+1 {{The following SwizzleHintOp user is not supported}}
+  // expected-error @+1 {{unsupported SwizzleHintOp user}}
   %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
   %offset = arith.constant 68 : index
   %1 = vector.load %0[%offset] : memref<?xf32>, vector<4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -679,7 +679,7 @@ XORShuffleAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   if (rowWidth % accessWidth != 0) {
     return emitError() << "expected access width to divide row width";
   }
-  auto maxPhase = rowWidth / accessWidth;
+  int64_t maxPhase = rowWidth / accessWidth;
   if (perPhase > maxPhase) {
     return emitError() << "per_phase must be smaller than max_phase";
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -677,7 +677,6 @@ LogicalResult
 XORShuffleAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        int64_t rowWidth, int64_t accessWidth, int64_t rowStride,
                        int64_t perPhase) {
-
   if (rowWidth % accessWidth != 0) {
     return emitError() << "expected access width to divide row width";
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -638,15 +638,15 @@ OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
   // Number of elements per group.
   Value accessWidthVal =
       b.create<arith::ConstantIndexOp>(loc, getAccessWidth());
-  // Number of rows per phase
+  // Number of rows per phase.
   Value perPhaseVal = b.create<arith::ConstantIndexOp>(loc, perPhase);
 
   Value idVal = getValueOrCreateConstantIndexOp(b, loc, id);
 
-  // Col and row indexes in overall memref
+  // Col and row indexes in overall memref.
   auto col = b.create<arith::RemUIOp>(loc, idVal, rowAlignmentVal);
   auto row = b.create<arith::DivUIOp>(loc, idVal, rowStrideVal);
-  // Futur base id. We swizzle only within accessWidth
+  // Futur base id. We swizzle only within accessWidth.
   auto swizzledBase = b.create<arith::SubIOp>(loc, idVal, col);
   auto colElements = b.create<arith::DivUIOp>(loc, col, accessWidthVal);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -620,7 +620,6 @@ SymbolicUKernelProviderAttr::getMLIRUKernel(StringRef name, DictionaryAttr,
 OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
                                            OpFoldResult offset,
                                            Value src) const {
-
   int64_t rotationInvariant =
       getRowWidth() * (getRowWidth() / getAccessWidth());
   int64_t rowStride =

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -613,7 +613,6 @@ SymbolicUKernelProviderAttr::getMLIRUKernel(StringRef name, DictionaryAttr,
   return symbolTable.lookup(name);
 }
 
-
 //===---------------------------------------------------------------------===//
 // iree_codegen.xor_shuffle
 //===---------------------------------------------------------------------===//
@@ -643,14 +642,17 @@ OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
   auto col = b.create<arith::RemUIOp>(loc, idVal, rowAlignmentVal);
   auto row = b.create<arith::DivUIOp>(loc, idVal, rowAlignmentVal);
   auto rowPhase = b.create<arith::DivUIOp>(loc, row, perPhase);
-  auto rowModPhase = b.create<arith::RemUIOp>(loc, rowPhase, rowAccessAlignmentVal);
-  auto colElements = b.create<arith::DivUIOp>(loc,col,accessWidthVal);
+  auto rowModPhase =
+      b.create<arith::RemUIOp>(loc, rowPhase, rowAccessAlignmentVal);
+  auto colElements = b.create<arith::DivUIOp>(loc, col, accessWidthVal);
 
-  auto colSwizzled  = b.create<arith::XOrIOp>(loc,rowModPhase,colElements);
-  auto colSwizzledBytes  = b.create<arith::MulIOp>(loc,colSwizzled,accessWidthVal);
+  auto colSwizzled = b.create<arith::XOrIOp>(loc, rowModPhase, colElements);
+  auto colSwizzledBytes =
+      b.create<arith::MulIOp>(loc, colSwizzled, accessWidthVal);
 
-  auto swizzledBase  = b.create<arith::MulIOp>(loc,row,rowAlignmentVal);
-  auto swizzledId  = b.create<arith::AddIOp>(loc,swizzledBase,colSwizzledBytes);
+  auto swizzledBase = b.create<arith::MulIOp>(loc, row, rowAlignmentVal);
+  auto swizzledId =
+      b.create<arith::AddIOp>(loc, swizzledBase, colSwizzledBytes);
 
   Value diff = b.create<arith::SubIOp>(loc, swizzledId, idVal);
   return b
@@ -665,20 +667,19 @@ int64_t XORShuffleAttr::getAccessElementCount() const {
 
 LogicalResult
 XORShuffleAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                       int64_t rowWidth, int64_t accessWidth, int64_t perPhase) {
+                       int64_t rowWidth, int64_t accessWidth,
+                       int64_t perPhase) {
 
-  
   if (rowWidth % accessWidth != 0) {
     return emitError() << "expected access width to divide row width";
   }
-  auto maxPhase = rowWidth/accessWidth;
+  auto maxPhase = rowWidth / accessWidth;
   if (perPhase > maxPhase) {
     return emitError() << "per_phase must be smaller than max_phase";
   }
-  
+
   return success();
 }
-
 
 //===----------------------------------------------------------------------===//
 // Initialize attributes

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -659,7 +659,6 @@ OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
   auto colSwizzledBytes =
       b.create<arith::MulIOp>(loc, colSwizzled, accessWidthVal);
 
-  // auto swizzledBase = b.create<arith::MulIOp>(loc, row, rowStrideVal);
   auto swizzledId =
       b.create<arith::AddIOp>(loc, swizzledBase, colSwizzledBytes);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -617,6 +617,50 @@ SymbolicUKernelProviderAttr::getMLIRUKernel(StringRef name, DictionaryAttr,
 // iree_codegen.xor_shuffle
 //===---------------------------------------------------------------------===//
 
+/// Extract column index for XOR swizzling.
+/// ((id%rowStride) / accessWidth)
+static Value extractCol(OpBuilder &builder, Location loc, OpFoldResult id,
+                        OpFoldResult rowAlignment, OpFoldResult accessWidth) {
+  AffineExpr d0, s0, s1;
+  bindDims(builder.getContext(), d0);
+  bindSymbols(builder.getContext(), s0, s1);
+  AffineExpr result = (d0 % s0).floorDiv(s1);
+  return getValueOrCreateConstantIndexOp(
+      builder, loc,
+      affine::makeComposedFoldedAffineApply(builder, loc, result,
+                                            {id, rowAlignment, accessWidth}));
+}
+
+/// Extract row index for XOR swizzling.
+/// row = ((id/rowStride) / perPhase ) % rowAccessAlignment
+static Value extractRow(OpBuilder &builder, Location loc, OpFoldResult id,
+                        OpFoldResult rowStride, OpFoldResult perPhase,
+                        OpFoldResult rowAccessAlignment) {
+  AffineExpr d0, s0, s1, s2;
+  bindDims(builder.getContext(), d0);
+  bindSymbols(builder.getContext(), s0, s1, s2);
+  AffineExpr result = (d0.floorDiv(s0).floorDiv(s1)) % s2;
+  return getValueOrCreateConstantIndexOp(
+      builder, loc,
+      affine::makeComposedFoldedAffineApply(
+          builder, loc, result, {id, rowStride, perPhase, rowAccessAlignment}));
+}
+
+/// Swizzle column on id.
+/// new_id = id-id%rowAlignmentVal+colSwizzled*accessWidthVal
+static Value updateCol(OpBuilder &builder, Location loc, OpFoldResult id,
+                       Value colSwizzled, OpFoldResult rowAlignment,
+                       OpFoldResult accessWidth) {
+  AffineExpr d0, d1, s0, s1;
+  bindDims(builder.getContext(), d0, d1);
+  bindSymbols(builder.getContext(), s0, s1);
+  AffineExpr result = d0 - d0 % s0 + d1 * s1;
+  return getValueOrCreateConstantIndexOp(
+      builder, loc,
+      affine::makeComposedFoldedAffineApply(
+          builder, loc, result, {id, colSwizzled, rowAlignment, accessWidth}));
+}
+
 OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
                                            OpFoldResult offset,
                                            Value src) const {
@@ -628,40 +672,30 @@ OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
 
   OpFoldResult id =
       getMinimumConstantOffsetValue(b, loc, offset, rotationInvariant);
+  Value idVal = getValueOrCreateConstantIndexOp(b, loc, id);
 
-  Value rowStrideVal = b.create<arith::ConstantIndexOp>(loc, rowStride);
   // Number of elements per row.
   Value rowAlignmentVal = b.create<arith::ConstantIndexOp>(loc, getRowWidth());
-  // Number of contiguous groups of elements per row (swizzled together).
-  Value rowAccessAlignmentVal =
-      b.create<arith::ConstantIndexOp>(loc, getRowWidth() / getAccessWidth());
   // Number of elements per group.
   Value accessWidthVal =
       b.create<arith::ConstantIndexOp>(loc, getAccessWidth());
   // Number of rows per phase.
   Value perPhaseVal = b.create<arith::ConstantIndexOp>(loc, perPhase);
+  // Buffer stride.
+  Value rowStrideVal = b.create<arith::ConstantIndexOp>(loc, rowStride);
+  // Number of contiguous groups of elements per row (swizzled together).
+  Value rowAccessAlignmentVal =
+      b.create<arith::ConstantIndexOp>(loc, getRowWidth() / getAccessWidth());
 
-  Value idVal = getValueOrCreateConstantIndexOp(b, loc, id);
+  Value colVal = extractCol(b, loc, idVal, rowAlignmentVal, accessWidthVal);
+  Value rowVal = extractRow(b, loc, idVal, rowStrideVal, perPhaseVal,
+                            rowAccessAlignmentVal);
+  auto colSwizzled = b.create<arith::XOrIOp>(loc, rowVal, colVal);
 
-  // Col and row indexes in overall memref.
-  auto col = b.create<arith::RemUIOp>(loc, idVal, rowAlignmentVal);
-  auto row = b.create<arith::DivUIOp>(loc, idVal, rowStrideVal);
-  // Futur base id. We swizzle only within accessWidth.
-  auto swizzledBase = b.create<arith::SubIOp>(loc, idVal, col);
-  auto colElements = b.create<arith::DivUIOp>(loc, col, accessWidthVal);
-
-  auto rowPhase = b.create<arith::DivUIOp>(loc, row, perPhaseVal);
-  auto rowModPhase =
-      b.create<arith::RemUIOp>(loc, rowPhase, rowAccessAlignmentVal);
-
-  auto colSwizzled = b.create<arith::XOrIOp>(loc, rowModPhase, colElements);
-  auto colSwizzledBytes =
-      b.create<arith::MulIOp>(loc, colSwizzled, accessWidthVal);
-
-  auto swizzledId =
-      b.create<arith::AddIOp>(loc, swizzledBase, colSwizzledBytes);
-
-  Value diff = b.create<arith::SubIOp>(loc, swizzledId, idVal);
+  // Update colSwizzled to initial id
+  Value swizzledIdVal =
+      updateCol(b, loc, idVal, colSwizzled, rowAlignmentVal, accessWidthVal);
+  Value diff = b.create<arith::SubIOp>(loc, swizzledIdVal, idVal);
   return b
       .create<arith::AddIOp>(
           loc, getValueOrCreateConstantIndexOp(b, loc, offset), diff)

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -609,11 +609,11 @@ def IREECodegen_XORShuffleAttr  :
   let parameters = (ins
     AttrParameter<"int64_t", "">:$row_width,
     AttrParameter<"int64_t", "">:$access_width,
-    AttrParameter<"int64_t", "">:$per_phase,
-    OptionalParameter<"int64_t", "row stride. Default to row_width">:$row_stride
+    OptionalParameter<"int64_t", "row stride. Default to row_width">:$row_stride,
+    OptionalParameter<"int64_t", "Default to 1">:$per_phase
   );
   let assemblyFormat = [{
-    `<` $row_width `,` $access_width `,` $per_phase (`,` $row_stride^)? `>`
+    `<` $row_width `,` $access_width  (`,` $row_stride^)? (`,` $per_phase^)? `>`
   }];
   let genVerifyDecl = 1;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -562,7 +562,7 @@ def IREECodegen_XORShuffleAttr  :
       ]>
     ]> {
   let mnemonic = "xor_shuffle";
-  let summary = [{An attribute that describes a XOR-based swizzling pattern.}];
+  let summary = "An attribute that describes an XOR-based swizzling pattern.";
   let description = [{
     Shuffles accesses of |access_width| within rows of size
     |row_width|. For any given access into logical memref of shape

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -567,10 +567,10 @@ def IREECodegen_XORShuffleAttr  :
     This attribute shuffle accesses of |access_width| within rows of size
     |row_width|. For any given access into logical memref of shape
     `memref<...xNx|access_width|x!eltype>` where `N = row_width / access_width`
-    at position `(i, j, 0)` is shuffled to `(i, ((i/per_hase) %N) XOR j , 0)`. For example,
+    at position `(i, j, 0)` is shuffled to `(i, ((i/per_phase) %N) XOR j , 0)`. For example,
 
     ```
-    row_width = 16, access_width = 4, per_hase = 1
+    row_width = 16, access_width = 4, per_phase = 1
 
     0000 1111 2222 3333 /// 0 1 2 3
     4444 5555 6666 7777 /// 0 1 2 3
@@ -588,7 +588,7 @@ def IREECodegen_XORShuffleAttr  :
     |access_width| allows to keep the same shuffling accross multiple rows. For example,
 
     ```
-    row_width = 16, access_width = 4, per_hase = 2
+    row_width = 16, access_width = 4, per_phase = 2
 
     0000 1111 2222 3333 /// 0 1 2 3
     4444 5555 6666 7777 /// 0 1 2 3
@@ -609,10 +609,11 @@ def IREECodegen_XORShuffleAttr  :
   let parameters = (ins
     AttrParameter<"int64_t", "">:$row_width,
     AttrParameter<"int64_t", "">:$access_width,
-    AttrParameter<"int64_t", "">:$per_phase
+    AttrParameter<"int64_t", "">:$per_phase,
+    OptionalParameter<"int64_t", "row stride. Default to row_width">:$row_stride
   );
   let assemblyFormat = [{
-    `<` $row_width `,` $access_width `,` $per_phase `>`
+    `<` $row_width `,` $access_width `,` $per_phase (`,` $row_stride^)? `>`
   }];
   let genVerifyDecl = 1;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -549,4 +549,72 @@ def IREECodegen_UKernelDescriptorAttr  :
   }];
 }
 
+
+//===---------------------------------------------------------------------===//
+// iree_codegen.xor_shuffle
+//===---------------------------------------------------------------------===//
+
+def IREECodegen_XORShuffleAttr  :
+    AttrDef<IREECodegen_Dialect, "XORShuffle", [
+    DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
+        "swizzleOffset",
+        "getAccessElementCount"
+      ]>
+    ]> {
+  let mnemonic = "xor_shuffle";
+  let summary = [{An attribute that describes a XOR-based swizzling pattern.}];
+  let description = [{
+    This attribute shuffle accesses of |access_width| within rows of size
+    |row_width|. For any given access into logical memref of shape
+    `memref<...xNx|access_width|x!eltype>` where `N = row_width / access_width`
+    at position `(i, j, 0)` is shuffled to `(i, ((i/per_hase) %N) XOR j , 0)`. For example,
+
+    ```
+    row_width = 16, access_width = 4, per_hase = 1
+
+    0000 1111 2222 3333 /// 0 1 2 3
+    4444 5555 6666 7777 /// 0 1 2 3
+    8888 9999 AAAA BBBB /// 0 1 2 3
+    CCCC DDDD EEEE FFFF /// 0 1 2 3
+    ```
+
+    is swizzled to
+    ```
+    0000 1111 2222 3333 /// 0 1 2 3
+    7777 4444 5555 6666 /// 1 0 3 2
+    BBBB AAAA 8888 9999 /// 2 3 0 1
+    FFFF EEEE DDDD CCCC /// 3 2 1 0
+    ```
+    |access_width| allows to keep the same shuffling accross multiple rows. For example,
+
+    ```
+    row_width = 16, access_width = 4, per_hase = 2
+
+    0000 1111 2222 3333 /// 0 1 2 3
+    4444 5555 6666 7777 /// 0 1 2 3
+    8888 9999 AAAA BBBB /// 0 1 2 3
+    CCCC DDDD EEEE FFFF /// 0 1 2 3
+    ```
+
+    is swizzled to
+    ```
+    0000 1111 2222 3333 /// 0 1 2 3
+    7777 4444 5555 6666 /// 0 1 2 3
+    BBBB AAAA 8888 9999 /// 1 0 3 2
+    FFFF EEEE DDDD CCCC /// 1 0 3 2
+    ```
+
+    The pattern repeats for subsequent rows.
+  }];
+  let parameters = (ins
+    AttrParameter<"int64_t", "">:$row_width,
+    AttrParameter<"int64_t", "">:$access_width,
+    AttrParameter<"int64_t", "">:$per_phase    
+  );
+  let assemblyFormat = [{
+    `<` $row_width `,` $access_width `,` $per_phase `>`
+  }];
+  let genVerifyDecl = 1;
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -609,7 +609,7 @@ def IREECodegen_XORShuffleAttr  :
   let parameters = (ins
     AttrParameter<"int64_t", "">:$row_width,
     AttrParameter<"int64_t", "">:$access_width,
-    AttrParameter<"int64_t", "">:$per_phase    
+    AttrParameter<"int64_t", "">:$per_phase
   );
   let assemblyFormat = [{
     `<` $row_width `,` $access_width `,` $per_phase `>`

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -564,7 +564,7 @@ def IREECodegen_XORShuffleAttr  :
   let mnemonic = "xor_shuffle";
   let summary = [{An attribute that describes a XOR-based swizzling pattern.}];
   let description = [{
-    This attribute shuffle accesses of |access_width| within rows of size
+    Shuffles accesses of |access_width| within rows of size
     |row_width|. For any given access into logical memref of shape
     `memref<...xNx|access_width|x!eltype>` where `N = row_width / access_width`
     at position `(i, j, 0)` is shuffled to `(i, ((i/per_phase) %N) XOR j , 0)`. For example,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1208,6 +1208,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
 
   if (forROCDL) {
     funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);
+    // This pass needs to be done before the ResolveSwizzleHints Pass
+    funcPassManager.addPass(amdgpu::createAmdgpuFoldMemRefOpsPass);
   }
 
   // This pass needs to run before SCF -> CF.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1208,7 +1208,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
 
   if (forROCDL) {
     funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);
-    // This pass needs to be done before the ResolveSwizzleHints Pass
+    // This pass needs to run before the ResolveSwizzleHints pass.
     funcPassManager.addPass(amdgpu::createAmdgpuFoldMemRefOpsPass);
   }
 


### PR DESCRIPTION
This PR adds a new swizzle attribute : xor_shuffle. 
It swizzles a element in `(row, col)` into `(row, col_swizzled)` with `col_swizzled = ((row/perPhase) % maxPhase) ^ (col )`.

Definition is : 
`#iree_codegen.xor_shuffle<row_width, access_width, row_stride, per_phase>`

By default, row_stride == row_width and per_phase=1
Example usage :
```
%alloc = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
        %alloc_swizzle = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<128, 16>] : memref<32768xi8, #gpu.address_space<workgroup>>
```

To do reverse swizzling on GMEM loads using global_to_lds:
`%val = iree_codegen.swizzle_hint %rawBuffer[#iree_codegen.xor_shuffle<128, 16, 8192>] : memref<?xi8, strided<[1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>`