### PR TITLE
[CPU][NFC] Migrate TilingConfig to interface methods in LLVMCPU2DScalableTo1DScalable pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -176,13 +176,6 @@ public:
   /// and reduction dimensions.
   SizesAndScalableFlags getVectorTileSizes();
 
-  /// Returns a new `LoweringConfigAttr`, with the tile sizes of vector
-  /// dimensions, set to `sizes`, and the corresponding scalability set to
-  /// `scalableFlags`.
-  IREE::CPU::LoweringConfigAttr
-  getLoweringConfigWithNewVectorSizes(ArrayRef<int64_t> sizes,
-                                      ArrayRef<bool> scalableFlags = {});
-
   /// Returns the `level`-th valid tiling attribute. Returns an empty vector if
   /// it does not exist.
   IREE::Codegen::LoweringConfigTilingLevelAttr

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -177,16 +177,16 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
 
     std::optional<SmallVector<int64_t>> vectorSizes =
         loweringConfigAttr.getVectorSizes();
-    std::optional<SmallVector<bool>> scalableFlags =
+    SmallVector<bool> scalableFlags =
         loweringConfigAttr.getVectorScalableFlags();
-    int64_t numScalableDims = llvm::count(*scalableFlags, true);
+    int64_t numScalableDims = llvm::count(scalableFlags, true);
     if (numScalableDims <= 1) {
       continue;
     }
 
     SmallVector<int64_t> loopTileSizes;
     SmallVector<bool> newScalableFlags;
-    for (auto [flag, size] : llvm::zip_equal(*scalableFlags, *vectorSizes)) {
+    for (auto [flag, size] : llvm::zip_equal(scalableFlags, *vectorSizes)) {
       if (flag && numScalableDims >= 2) {
         --numScalableDims;
         loopTileSizes.push_back(size);


### PR DESCRIPTION
The revision moves the implementation of `getLoweringConfigWithNewVectorSizes` to the pass file. It only updates the implementation a little that query the information from lowering config interface methods instead.

It also fixes the style and removes the number labels from the comments. Note that the number labels were already wrong because we missed the step 1.

It is a step towards to TilingConfig deprecation.