### PR TITLE
[Codegen] Fix dynamic tensor ukernel descriptor lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_tensor_descriptor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_tensor_descriptor.mlir
@@ -34,6 +34,44 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
 
 // -----
 
+// CHECK-LABEL: @ukernel_impl_dynamic
+// CHECK-LABEL: @replace_generic_with_ukernel_impl_and_cast
+// CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+// CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]: tensor<16x32xf32>
+// CHECK-NOT:     linalg.generic
+// CHECK:         %[[FILL:.+]] = linalg.fill
+// CHECK:         %[[CAST_LHS:.+]] = tensor.cast %[[LHS]] : tensor<16x32xf32> to tensor<?x?xf32>
+// CHECK:         %[[CAST_RHS:.+]] = tensor.cast %[[RHS]] : tensor<16x32xf32> to tensor<?x?xf32>
+// CHECK:         %[[CAST_FILL:.+]] = tensor.cast %[[FILL]] : tensor<16x16xf32> to tensor<?x?xf32>
+// CHECK:         %[[CALL:.+]] = call @ukernel_impl_dynamic(%[[CAST_LHS]], %[[CAST_RHS]], %[[CAST_FILL]]) : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[CAST_CALL:.+]] = tensor.cast %[[CALL]] : tensor<?x?xf32> to tensor<16x16xf32>
+// CHECK:         return %[[CAST_CALL]]
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.ukernel_provider = #iree_codegen.symbolic_ukernel_provider}>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  func.func private @ukernel_impl_dynamic(tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  func.func @test(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %0 = call @ukernel_impl_dynamic(%arg0, %arg1, %arg2) : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+    return %0 : tensor<?x?xf32>
+  }
+  func.func @replace_generic_with_ukernel_impl_and_cast(%arg0: tensor<16x32xf32>, %arg1: tensor<16x32xf32>) -> tensor<16x16xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<16x16xf32>
+    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<16x16xf32>) -> tensor<16x16xf32>
+    %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<16x32xf32>, tensor<16x32xf32>) outs(%1 : tensor<16x16xf32>) attrs =  {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"test", tensor>} {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %3 = arith.mulf %in, %in_0 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<16x16xf32>
+    return %2 : tensor<16x16xf32>
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @no_ops_to_convert
 // CHECK:         linalg.fill
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb">


### PR DESCRIPTION
Contains small fixes for inlining ukernels with dynamic shapes, requiring casts to be inserted. I should have added this test in the original PR..