### PR TITLE
[CODEGEN] Remove special case logic for poison padding  

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
-#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/Dominance.h"
@@ -336,12 +335,6 @@ struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     assert(!isa<VectorType>(rPad.getType()) &&
            "search `NOTE[FoldMaskedTransferRAW]` in "
            "GenericVectorization.cpp::FoldMaskedTransferRAW for information");
-
-    // Fold to the stored value if the padding value is poison
-    if (isa_and_present<ub::PoisonOp>(rPad.getDefiningOp())) {
-      rewriter.replaceOp(op, valToStore);
-      return success();
-    }
 
     // Materialize the padding with a constant.
     auto padVal = rewriter.create<vector::BroadcastOp>(


### PR DESCRIPTION
The `arith::SelectOp` immediately following the poison will fold it away: https://github.com/llvm/llvm-project/blob/147cfc89f05e8953fa8eaff7448353c817b17cc9/mlir/lib/Dialect/Arith/IR/ArithOps.cpp#L2488