### PR TITLE
[Codegen] Refactor CombineLayoutTransformation with scope options

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -64,8 +64,15 @@ struct GPUCombineLayoutTransformationPass final
       GPUCombineLayoutTransformationPassBase;
 
   void runOnOperation() override {
+    // The GPUCombineLayoutTransformationPass provides a distribution
+    // implementation for tensor.pad ops, but pad ops can't be combined in
+    // Workgroup scope anyway, so there is no point in using the pass with
+    // Workgroup scope.
+    CombineRelayoutOpsControlFn controlFn = getCombineRelayoutOpsControlFn(
+        IREE::Codegen::RelayoutCombinationScope::Dispatch);
     if (failed(combineLayoutTransformation(&getContext(), getOperation(),
-                                           gpuPadDistributionConfigFn))) {
+                                           gpuPadDistributionConfigFn,
+                                           controlFn))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -14,6 +14,7 @@
 
 #include <limits>
 
+#include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -128,13 +128,26 @@ def CombineLayoutTransformationPass :
   let summary =
     "Combines layout transformation operations into a single map_scatter operation.";
   let description = [{
-    Starting from iree_codegen.store_to_buffer ops, iteratively combine producer
+    Starting from the specified leaf ops, iteratively combine producer
     layout/indexing transformation ops (linalg.transpose, tensor.collapse_shape,
     etc.) into a single iree_linalg_ext.map_scatter operation. For tensor.pad
     ops, the writing of pad values is distributed to workgroups, and then the
     padding values are written directly to the output buffer of the
     store_to_buffer op.
   }];
+  let options = [
+    Option<"scope", "scope",
+           "::mlir::iree_compiler::IREE::Codegen::RelayoutCombinationScope",
+           /*default=*/"IREE::Codegen::RelayoutCombinationScope::Dispatch",
+           "Specify the roots for layout transformation combination.",
+           [{
+           ::llvm::cl::values(
+             clEnumValN(IREE::Codegen::RelayoutCombinationScope::Dispatch, "dispatch",
+               "Combine relayout ops starting from iree_codegen.store_to_buffer"),
+             clEnumValN(IREE::Codegen::RelayoutCombinationScope::Workgroup, "workgroup",
+               "Combine relayout ops starting from workgroup forall terminator ops"))
+           }]>
+  ];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
     "scf::SCFDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
+#include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
@@ -525,7 +526,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(createGPUFuseAndHoistParallelLoopsPass());
-  funcPassManager.addPass(createCombineLayoutTransformationPass());
+  CombineLayoutTransformationPassOptions combineLayoutOptions;
+  combineLayoutOptions.scope =
+      IREE::Codegen::RelayoutCombinationScope::Workgroup;
+  funcPassManager.addPass(
+      createCombineLayoutTransformationPass(combineLayoutOptions));
   funcPassManager.addPass(createGPUGreedilyDistributeToThreadsPass());
   funcPassManager.addPass(createTileLargeTensorsPass());
   funcPassManager.addPass(createCanonicalizerPass());


### PR DESCRIPTION
The CombineLayoutTransformation was being used in 2 different places for 2 different purposes, and the implementations for each purpose are better left separate from each other. This PR refactors the pass to separate these implementations through a pass option. The pass option is an enum defining the scope of the pass, either `Dispatch` for layout transformation chains at the end of dispatches, or `Workgroup` for chains at the end of workgroup forall ops.