### PR TITLE
Toggle the default option to false for pre-padding convolution flag

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -126,7 +126,7 @@ static llvm::cl::opt<bool>
 llvm::cl::opt<bool> clGPUPadConvolution(
     "iree-codegen-llvmgpu-igemm-pad-convolution",
     llvm::cl::desc("enable pre-padding for convolutions in igemm path"),
-    llvm::cl::init(true));
+    llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
     clUseDirectLoad("iree-llvmgpu-use-direct-load",


### PR DESCRIPTION
If a lot of BOO shapes got regression because of pre-padding convolutions, then set the option default to false. And only turn it on for certain unaligned k cases. NO NEED to merge if there's no performance regression.