### PR TITLE
[Codegen][IGEMM] Fix pre-padding for group convolutions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -187,3 +187,35 @@ func.func @conv_chwn_chwf_unaligned(%arg0: tensor<16x193x129x40xbf16>, %arg1: te
 //  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0]
 
 //    PAD-CONV:     padding_conv = [16, 1, 1, 16, 0, 0, 0]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0 + d4, d1 + d5, d2, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d2, d3, d4, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+func.func @group_conv_unaligned(%arg0: tensor<61x93x16x56xbf16>, %arg1: tensor<16x56x3x3x56xbf16>, %arg2: tensor<59x91x16x56xf32>) -> tensor<59x91x16x56xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<61x93x16x56xbf16>, tensor<16x56x3x3x56xbf16>) outs(%arg2 : tensor<59x91x16x56xf32>) {
+    ^bb0(%in: bf16, %in_4: bf16, %out: f32):
+      %10 = arith.extf %in : bf16 to f32
+      %11 = arith.extf %in_4 : bf16 to f32
+      %12 = arith.mulf %10, %11 : f32
+      %13 = arith.addf %out, %12 : f32
+      linalg.yield %13 : f32
+    } -> tensor<59x91x16x56xf32>
+  return %0 : tensor<59x91x16x56xf32>
+}
+
+// CHECK-LABEL: func.func @group_conv_unaligned
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false
+//  CHECK-SAME:   use_igemm_convolution = true
+
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
+//  CHECK-SAME:     padding = [1, 32, 1, 64, 32]
+//  CHECK-SAME:     promote_operands = [0, 1, 2]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 2]
+//  CHECK-SAME:     subgroup = [1, 2, 0, 1, 0]
+//  CHECK-SAME:     workgroup = [1, 32, 1, 64, 0]
+
+//    PAD-CONV:     padding_conv = [1, 32, 1, 64, 0, 0, 32]


### PR DESCRIPTION
The depth (group) dimension is a batch dimension in IGEMM. This PR added the support for group convolutions when padding before converting to IGEMM.