### PR TITLE
Update the logic for resolve `scf.forall` to account for maximum number of workgroups.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -80,106 +80,6 @@ getInvertedMappingPermutation(ArrayRef<MappingAttrType> mapping) {
       getMappingPermutation<MappingAttrType>(mapping));
 }
 
-/// Return the procId and nprocs to use for each of the distributed loops,
-/// derived from `hal.interface.workgroup.id/count`s.
-static std::pair<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>>
-getProcIdsAndNprocs(
-    scf::ForallOp forallOp, RewriterBase &builder, Location loc,
-    SmallVector<IREE::Codegen::WorkgroupMappingAttr> workgroupMappings,
-    SmallVector<OpFoldResult> lowerBounds,
-    SmallVector<OpFoldResult> upperBounds, SmallVector<OpFoldResult> steps,
-    IREE::Codegen::WorkgroupId deLinearizeFrom) {
-  assert(workgroupMappings.size() == lowerBounds.size() &&
-         "expected as many workgroup mapping attributes as number of loops");
-
-  auto permutation =
-      getInvertedMappingPermutation<IREE::Codegen::WorkgroupMappingAttr>(
-          workgroupMappings);
-  applyPermutationToVector(workgroupMappings, permutation);
-  applyPermutationToVector(lowerBounds, permutation);
-  applyPermutationToVector(upperBounds, permutation);
-  applyPermutationToVector(steps, permutation);
-
-  SmallVector<OpFoldResult> procId(workgroupMappings.size(),
-                                   builder.getIndexAttr(0));
-  SmallVector<OpFoldResult> nprocs(workgroupMappings.size(),
-                                   builder.getIndexAttr(1));
-
-  AffineExpr s0, s1, s2;
-  bindSymbols(builder.getContext(), s0, s1, s2);
-  AffineExpr extentExpr = (s1 - s0).ceilDiv(s2);
-  SmallVector<OpFoldResult> loopExtents;
-  if (workgroupMappings.size() > static_cast<size_t>(deLinearizeFrom)) {
-    loopExtents.resize(workgroupMappings.size() -
-                       static_cast<size_t>(deLinearizeFrom));
-  }
-  for (int index = workgroupMappings.size() - 1; index >= 0; --index) {
-    auto workgroupMapping = workgroupMappings[index];
-    auto lowerBound = lowerBounds[index];
-    auto upperBound = upperBounds[index];
-    auto step = steps[index];
-    if (workgroupMapping.getId() < deLinearizeFrom) {
-      procId[index] =
-          builder
-              .create<IREE::HAL::InterfaceWorkgroupIDOp>(
-                  loc, static_cast<unsigned>(workgroupMapping.getId()))
-              .getResult();
-      nprocs[index] =
-          builder
-              .create<IREE::HAL::InterfaceWorkgroupCountOp>(
-                  loc, static_cast<unsigned>(workgroupMapping.getId()))
-              .getResult();
-      continue;
-    }
-    OpFoldResult extent = affine::makeComposedFoldedAffineApply(
-        builder, loc, extentExpr, {lowerBound, upperBound, step});
-    loopExtents[index] = extent;
-  }
-
-  // Delinearize the z-dim based on the loop extents.
-  if (!loopExtents.empty()) {
-    Value deLinearizedDimId =
-        builder
-            .create<IREE::HAL::InterfaceWorkgroupIDOp>(
-                loc, static_cast<unsigned>(deLinearizeFrom))
-            .getResult();
-    OpFoldResult deLinearizedNprocs =
-        builder
-            .create<IREE::HAL::InterfaceWorkgroupCountOp>(
-                loc, static_cast<unsigned>(deLinearizeFrom))
-            .getResult();
-
-    if (loopExtents.size() != 1) {
-      auto deLinearizeOp = builder.create<affine::AffineDelinearizeIndexOp>(
-          loc, deLinearizedDimId, loopExtents);
-      SmallVector<OpFoldResult> orderedDelinearizedDimIds =
-          llvm::map_to_vector(deLinearizeOp.getResults(),
-                              [](Value v) -> OpFoldResult { return v; });
-      SmallVector<OpFoldResult> orderedDelinearizedNprocs;
-      AffineMap minMap = AffineMap::get(0, 2, {s0, s1}, builder.getContext());
-      AffineExpr ceilDivExpr = s0.ceilDiv(s1);
-      for (int index = loopExtents.size() - 1; index >= 0; --index) {
-        auto extent = loopExtents[index];
-        procId[index] = deLinearizeOp->getResult(index);
-        OpFoldResult currNprocs = affine::makeComposedFoldedAffineMin(
-            builder, loc, minMap, {extent, deLinearizedNprocs});
-        nprocs[index] = currNprocs;
-        deLinearizedNprocs = affine::makeComposedFoldedAffineApply(
-            builder, loc, ceilDivExpr, {deLinearizedNprocs, currNprocs});
-      }
-    } else {
-      // If there is only one z-dim mapping, just use the ID directly.
-      procId[0] = deLinearizedDimId;
-      nprocs[0] = deLinearizedNprocs;
-    }
-  }
-
-  auto inversePermutation = invertPermutationVector(permutation);
-  applyPermutationToVector(procId, inversePermutation);
-  applyPermutationToVector(nprocs, inversePermutation);
-  return std::make_pair(procId, nprocs);
-}
-
 /// Resolve the `forallOp` by mapping the loop induction variables to
 /// processor IDs. Expected `procIds` and `nProcs` to match the number
 /// of induction variables of the loop.
@@ -187,58 +87,177 @@ static LogicalResult resolveForAll(RewriterBase &rewriter,
                                    scf::ForallOp forallOp,
                                    ArrayRef<OpFoldResult> procIds,
                                    ArrayRef<OpFoldResult> nProcs,
-                                   bool generateLoopNest) {
-  SmallVector<OpFoldResult> mixedUpperBound = forallOp.getMixedUpperBound();
-  SmallVector<OpFoldResult> mixedStep = forallOp.getMixedStep();
+                                   ArrayRef<bool> generateLoopNest) {
+  assert(generateLoopNest.size() == forallOp.getRank());
+
+  SmallVector<Value> loopNestIvs;
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(forallOp);
+
+  SmallVector<OpFoldResult> mixedLbs = forallOp.getMixedLowerBound();
+  SmallVector<OpFoldResult> mixedUbs = forallOp.getMixedUpperBound();
+  SmallVector<OpFoldResult> mixedSteps = forallOp.getMixedStep();
+  assert(mixedLbs.size() == procIds.size());
+  assert(mixedLbs.size() == nProcs.size());
   Location loc = forallOp.getLoc();
-  // Scale the process IDs and counts to account for the forall op steps. These
-  // are the forall offsets for each process, and the bounds of these offsets.
-  SmallVector<Value> procOffsets, procOffsetBounds;
-  for (auto [id, count, step] : llvm::zip_equal(procIds, nProcs, mixedStep)) {
-    Value procOffset = getValueOrCreateConstantIndexOp(
-        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, id, step));
-    Value procOffsetBound = getValueOrCreateConstantIndexOp(
-        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, count, step));
-    procOffsets.push_back(procOffset);
-    procOffsetBounds.push_back(procOffsetBound);
-  }
+  Operation *bodyInsertionPoint = forallOp;
+  for (auto [index, lb] : llvm::enumerate(mixedLbs)) {
+    OpFoldResult ub = mixedUbs[index], step = mixedSteps[index],
+                 numProc = nProcs[index], procId = procIds[index];
+    Value forLb = getValueOrCreateConstantIndexOp(
+        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, procId, step));
+    if (!generateLoopNest[index]) {
+      loopNestIvs.push_back(forLb);
+      continue;
+    }
 
-  // If a loop nest is not necessary, then just inline the body of the forall.
-  if (!generateLoopNest) {
-    rewriter.eraseOp(forallOp.getBody()->getTerminator());
-    rewriter.inlineBlockBefore(forallOp.getBody(), forallOp,
-                               /*argValues=*/procOffsets);
-    rewriter.eraseOp(forallOp);
-    return success();
+    Value forUb = getValueOrCreateConstantIndexOp(rewriter, loc, ub);
+    Value forStep = getValueOrCreateConstantIndexOp(
+        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, numProc, step));
+    auto loop = scf::ForOp::create(rewriter, loc, forLb, forUb, forStep);
+    loopNestIvs.push_back(loop.getInductionVar());
+    bodyInsertionPoint = loop.getBody()->getTerminator();
+    rewriter.setInsertionPointToStart(loop.getBody());
   }
-
-  // The bounds of process offsets may not match the bounds of the forall op, so
-  // form a loop nest iterating from the process offsets to the loop bounds, and
-  // stepping by the process offset bounds. Inline the body of the forall op
-  // into the loop nest.
-  SmallVector<Value> forallUbs =
-      getValueOrCreateConstantIndexOp(rewriter, loc, mixedUpperBound);
-  scf::LoopNest loopNest = scf::buildLoopNest(rewriter, loc, procOffsets,
-                                              forallUbs, procOffsetBounds);
-  SmallVector<Value> loopNestIvs = llvm::map_to_vector(
-      loopNest.loops, [](scf::ForOp loop) { return loop.getInductionVar(); });
-  Block *loopNestBody = loopNest.loops.back().getBody();
-  rewriter.eraseOp(forallOp.getBody()->getTerminator());
-  rewriter.inlineBlockBefore(forallOp.getBody(), loopNestBody->getTerminator(),
-                             /*argValues=*/loopNestIvs);
+  Block *forAllBody = forallOp.getBody();
+  rewriter.eraseOp(forAllBody->getTerminator());
+  rewriter.inlineBlockBefore(forAllBody, bodyInsertionPoint, loopNestIvs);
   rewriter.eraseOp(forallOp);
   return success();
 }
 
+/// Collapse all the dimensions of the `scf.forall` that have mapping ID
+/// "greater" than `delinearizeFrom` into a single dimension. This dimension
+/// is placed at the same place as the position of `delinearizeFrom` in the
+/// original loop.
+scf::ForallOp
+collapseForAllOpDimensions(RewriterBase &rewriter, scf::ForallOp forallOp,
+                           IREE::Codegen::WorkgroupId delinearizeFrom) {
+  SmallVector<OpFoldResult> mixedLbs = forallOp.getMixedLowerBound();
+  SmallVector<OpFoldResult> mixedUbs = forallOp.getMixedUpperBound();
+  SmallVector<OpFoldResult> mixedSteps = forallOp.getMixedStep();
+  auto mapping = llvm::map_to_vector(
+      forallOp.getMapping()->getValue(), [](Attribute attr) {
+        return cast<IREE::Codegen::WorkgroupMappingAttr>(attr);
+      });
+
+  // Collect all dimensions that are to be collapsed.
+  auto delinearizeFromAttr = IREE::Codegen::WorkgroupMappingAttr::get(
+      rewriter.getContext(), delinearizeFrom);
+  SmallVector<int64_t> collapsedDims;
+  SmallVector<IREE::Codegen::WorkgroupMappingAttr> collapsedAttrs;
+  for (auto [index, mappingAttr] : llvm::enumerate(mapping)) {
+    if (mappingAttr < delinearizeFromAttr) {
+      continue;
+    }
+    collapsedDims.push_back(index);
+    collapsedAttrs.push_back(mappingAttr);
+  }
+
+  AffineExpr s0, s1, s2;
+  bindSymbols(rewriter.getContext(), s0, s1, s2);
+  AffineExpr nIterExpr = (s1 - s0).ceilDiv(s2);
+  Location loc = forallOp.getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(forallOp);
+
+  SmallVector<OpFoldResult> nIters =
+      llvm::map_to_vector(collapsedDims, [&](int64_t index) {
+        return affine::makeComposedFoldedAffineApply(
+            rewriter, loc, nIterExpr,
+            {mixedLbs[index], mixedUbs[index], mixedSteps[index]});
+      });
+
+  OpFoldResult one = rewriter.getIndexAttr(1);
+  OpFoldResult combinedNIters = one;
+  // The reverse below is just to preserve some lit-test behavior.
+  for (auto nIter : llvm::reverse(nIters)) {
+    combinedNIters =
+        IREE::LinalgExt::mulOfrs(rewriter, loc, combinedNIters, nIter);
+  }
+
+  // Create the collapsed forall op.
+  SmallVector<OpFoldResult> newLbs, newUbs, newSteps;
+  SmallVector<Attribute> newMapping;
+  OpFoldResult zero = rewriter.getIndexAttr(0);
+  std::optional<int> delinearizedFromIndex;
+  for (auto [index, mappingAttr] : llvm::enumerate(mapping)) {
+    if (mappingAttr < delinearizeFromAttr) {
+      newLbs.push_back(mixedLbs[index]);
+      newUbs.push_back(mixedUbs[index]);
+      newSteps.push_back(mixedSteps[index]);
+      newMapping.push_back(mappingAttr);
+      continue;
+    }
+    if (mappingAttr == delinearizeFromAttr) {
+      newLbs.push_back(zero);
+      newUbs.push_back(combinedNIters);
+      newSteps.push_back(one);
+      newMapping.push_back(mappingAttr);
+      delinearizedFromIndex = newMapping.size() - 1;
+    }
+  }
+
+  scf::ForallOp newForOp = scf::ForallOp::create(
+      rewriter, loc, newLbs, newUbs, newSteps,
+      /*outputs = */ ValueRange{}, rewriter.getArrayAttr(newMapping));
+
+  Block *newForallBody = newForOp.getBody();
+  {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(newForallBody->getTerminator());
+    SmallVector<int64_t> invertPermutation =
+        getInvertedMappingPermutation<IREE::Codegen::WorkgroupMappingAttr>(
+            collapsedAttrs);
+    applyPermutationToVector(nIters, invertPermutation);
+    SmallVector<OpFoldResult> basis = llvm::to_vector(llvm::reverse(nIters));
+
+    std::optional<SmallVector<Value>> ivs = newForOp.getLoopInductionVars();
+    auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+        rewriter, loc, ivs.value()[delinearizedFromIndex.value()], basis);
+    auto replacementIvs =
+        llvm::to_vector(llvm::reverse(delinearizeOp.getResults()));
+    int replacementIvIndex = 0;
+    SmallVector<Value> remappedIvs;
+    AffineExpr d0, s0, s1;
+    bindDims(rewriter.getContext(), d0);
+    bindSymbols(rewriter.getContext(), s0, s1);
+    AffineExpr ivExpr = s0 + d0 * s1;
+    for (auto [index, origIV, mappingAttr] :
+         llvm::enumerate(forallOp.getInductionVars(), mapping)) {
+      if (mappingAttr < delinearizeFromAttr) {
+        remappedIvs.push_back(origIV);
+        continue;
+      }
+      OpFoldResult remappedIv = affine::makeComposedFoldedAffineApply(
+          rewriter, loc, ivExpr,
+          ArrayRef<OpFoldResult>{replacementIvs[replacementIvIndex++],
+                                 mixedLbs[index], mixedSteps[index]});
+      remappedIvs.push_back(
+          getValueOrCreateConstantIndexOp(rewriter, loc, remappedIv));
+    }
+    Block *forallBody = forallOp.getBody();
+    rewriter.eraseOp(forallBody->getTerminator());
+    rewriter.inlineBlockBefore(forallBody, newForallBody->getTerminator(),
+                               remappedIvs);
+  }
+  rewriter.eraseOp(forallOp);
+  return newForOp;
+}
+
 /// Resolve scf.forall operation by using the workgroup ID and counts.
-static LogicalResult
+static FailureOr<SmallVector<OpFoldResult>>
 resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
-                       IREE::Codegen::WorkgroupId deLinearizeFrom,
-                       bool generateLoopNest) {
+                       IREE::Codegen::WorkgroupId delinearizeFrom,
+                       bool multiForall) {
   if (forallOp->getNumResults() != 0) {
     return forallOp.emitOpError(
         "cannot resolve for all ops with return values");
   }
+  if (forallOp.getRank() > llvm::to_underlying(delinearizeFrom) + 1) {
+    forallOp = collapseForAllOpDimensions(rewriter, forallOp, delinearizeFrom);
+  }
+  assert(forallOp.getRank() <= llvm::to_underlying(delinearizeFrom) + 1);
   SmallVector<OpFoldResult> mixedLowerBound = forallOp.getMixedLowerBound();
   SmallVector<OpFoldResult> mixedUpperBound = forallOp.getMixedUpperBound();
   SmallVector<OpFoldResult> mixedStep = forallOp.getMixedStep();
@@ -256,14 +275,68 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
   rewriter.setInsertionPoint(forallOp);
   Location loc = forallOp.getLoc();
 
-  // Get process IDs and counts by querying hal.interface.workgroup.id/count ops
-  // and delinearizing any dimensions of the forall beyond `deLinearizeFrom`.
-  SmallVector<OpFoldResult> procIds, nProcs;
-  std::tie(procIds, nProcs) = getProcIdsAndNprocs(
-      forallOp, rewriter, loc, workgroupMapping.value(), mixedLowerBound,
-      mixedUpperBound, mixedStep, deLinearizeFrom);
+  std::array<int64_t, 3> maxWorkgroupCountArray =
+      getMaxWorkgroupCount(IREE::HAL::ExecutableTargetAttr::lookup(forallOp));
+  SmallVector<int64_t> maxWorkgroupCount =
+      llvm::to_vector(maxWorkgroupCountArray);
+  maxWorkgroupCount.resize(forallOp.getRank(), ShapedType::kDynamic);
 
-  return resolveForAll(rewriter, forallOp, procIds, nProcs, generateLoopNest);
+  AffineExpr s0, s1, s2;
+  bindSymbols(rewriter.getContext(), s0, s1, s2);
+  AffineExpr nItersExpr = (s1 - s0).ceilDiv(s2);
+
+  SmallVector<OpFoldResult> numWorkgroupsList, mappedProcIds, mappedNProcs;
+  SmallVector<bool> generateLoopNest(forallOp.getRank(), true);
+  numWorkgroupsList.resize(forallOp.getRank());
+  for (auto [index, mapping] : llvm::enumerate(workgroupMapping.value())) {
+    int64_t mappingID = mapping.getMappingId();
+    OpFoldResult procId = rewriter
+                              .create<IREE::HAL::InterfaceWorkgroupIDOp>(
+                                  loc, static_cast<unsigned>(mappingID))
+                              .getResult();
+    OpFoldResult nprocs = rewriter
+                              .create<IREE::HAL::InterfaceWorkgroupIDOp>(
+                                  loc, static_cast<unsigned>(mappingID))
+                              .getResult();
+
+    mappedProcIds.push_back(procId);
+    mappedNProcs.push_back(nprocs);
+
+    OpFoldResult &numWorkgroups =
+        numWorkgroupsList[numWorkgroupsList.size() - 1 - mappingID];
+    numWorkgroups = affine::makeComposedFoldedAffineApply(
+        rewriter, loc, nItersExpr,
+        {mixedLowerBound[index], mixedUpperBound[index], mixedStep[index]});
+
+    int64_t maxCount = maxWorkgroupCount[mappingID];
+    if (!multiForall) {
+      if (ShapedType::isDynamic(maxCount)) {
+        // Dynamic value indicates there is no limit.
+        generateLoopNest[index] = false;
+        continue;
+      }
+      if (std::optional<int64_t> numWorkgroupsStatic =
+              getConstantIntValue(numWorkgroups)) {
+        if (numWorkgroupsStatic.value() <= maxCount) {
+          generateLoopNest[index] = false;
+        }
+        continue;
+      }
+    }
+
+    OpFoldResult boundedNumWorkgourps = affine::makeComposedFoldedAffineMin(
+        rewriter, loc,
+        AffineMap::get(
+            0, 1, {s0, getAffineConstantExpr(maxCount, rewriter.getContext())},
+            rewriter.getContext()),
+        numWorkgroups);
+    numWorkgroups = boundedNumWorkgourps;
+  }
+  if (failed(resolveForAll(rewriter, forallOp, mappedProcIds, mappedNProcs,
+                           generateLoopNest))) {
+    return forallOp.emitOpError("failed to resolve scf.forall op");
+  }
+  return numWorkgroupsList;
 }
 
 /// Resolve the workgroup counts for the function based on the extents of the
@@ -366,10 +439,6 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
     return funcOp.emitOpError("unhandled function with multiple blocks");
   }
 
-  if (failed(resolveWorkgroupCounts(rewriter, funcOp, workgroupForAllOps,
-                                    deLinearizeFrom))) {
-    return failure();
-  }
   // If there are multiple forall ops, then the workgroup counts will be
   // flattened into the workgroup X dim.
   bool multiForall = workgroupForAllOps.size() > 1;
@@ -379,9 +448,20 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
   for (auto [idx, forallOp] : llvm::enumerate(workgroupForAllOps)) {
     // Generate a loop nest when there are multiple foralls, because the
     // workgroup counts might not match between foralls.
-    if (failed(resolveWorkgroupForAll(rewriter, forallOp, deLinearizeFrom,
-                                      /*generateLoopNest=*/multiForall))) {
+    FailureOr<SmallVector<OpFoldResult>> numWorkgroups =
+        resolveWorkgroupForAll(rewriter, forallOp, deLinearizeFrom,
+                               /*multiForall =*/multiForall);
+
+    if (failed(numWorkgroups)) {
       return failure();
+    }
+    // For the first loop resolve the number of workgroups/
+    if (idx == 0) {
+      if (failed(lowerWorkgroupCountFromSliceOp(
+              rewriter, funcOp, numWorkgroups.value(),
+              llvm::to_underlying(deLinearizeFrom) + 1))) {
+        return failure();
+      }
     }
   }
   return success();
@@ -596,8 +676,9 @@ resolveSplitReduceForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
           splitReduceMapping);
   applyPermutationToVector(splitReduceOpProcIds, mappingPermutation);
   applyPermutationToVector(numIters, mappingPermutation);
+  SmallVector<bool> generateLoopNests(forallOp.getRank(), false);
   return resolveForAll(rewriter, forallOp, splitReduceOpProcIds, numIters,
-                       /*generateLoopNest = */ false);
+                       generateLoopNests);
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/Support/Casting.h"
 #include "mlir/Analysis/CallGraph.h"
@@ -276,8 +277,10 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
   rewriter.setInsertionPoint(forallOp);
   Location loc = forallOp.getLoc();
 
+  auto gpuTarget =
+      getGPUTargetAttr(IREE::HAL::ExecutableTargetAttr::lookup(forallOp));
   std::array<int64_t, 3> maxWorkgroupCountArray =
-      getMaxWorkgroupCount(IREE::HAL::ExecutableTargetAttr::lookup(forallOp));
+      getMaxWorkgroupCount(gpuTarget);
   SmallVector<int64_t> maxWorkgroupCount =
       llvm::to_vector(maxWorkgroupCountArray);
   maxWorkgroupCount.resize(forallOp.getRank(), ShapedType::kDynamic);

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -333,7 +333,7 @@ hal.executable private @scf_forall_4D {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11] -> (((-s9 + s10) ceildiv s11) * (((-s6 + s7) ceildiv s8) * (((-s3 + s4) ceildiv s5) * ((-s0 + s1) ceildiv s2))))>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * s2)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>
 //      CHECK: hal.executable.export public @scf_forall_4D layout
 // CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
@@ -371,10 +371,10 @@ hal.executable private @scf_forall_4D {
 //  CHECK-NOT:   scf.forall
 //      CHECK:   %[[WG_IDS:.+]]:4 = affine.delinearize_index %[[WG_ID_X]]
 // CHECK-SAME:     into (%[[NITERS0]], %[[NITERS1]], %[[NITERS2]], %[[NITERS3]])
-//  CHECK-DAG:   %[[I:.+]] = affine.apply #[[MAP2]]()[%[[LB0]], %[[STEP0]], %[[WG_IDS]]#0]
-//  CHECK-DAG:   %[[J:.+]] = affine.apply #[[MAP2]]()[%[[LB1]], %[[STEP1]], %[[WG_IDS]]#1]
-//  CHECK-DAG:   %[[K:.+]] = affine.apply #[[MAP2]]()[%[[LB2]], %[[STEP2]], %[[WG_IDS]]#2]
-//  CHECK-DAG:   %[[L:.+]] = affine.apply #[[MAP2]]()[%[[LB3]], %[[STEP3]], %[[WG_IDS]]#3]
+//  CHECK-DAG:   %[[I:.+]] = affine.apply #[[MAP2]]()[%[[STEP0]], %[[LB0]], %[[WG_IDS]]#0]
+//  CHECK-DAG:   %[[J:.+]] = affine.apply #[[MAP2]]()[%[[STEP1]], %[[LB1]], %[[WG_IDS]]#1]
+//  CHECK-DAG:   %[[K:.+]] = affine.apply #[[MAP2]]()[%[[STEP2]], %[[LB2]], %[[WG_IDS]]#2]
+//  CHECK-DAG:   %[[L:.+]] = affine.apply #[[MAP2]]()[%[[STEP3]], %[[LB3]], %[[WG_IDS]]#3]
 //      CHECK:   "use"(%[[I]], %[[J]], %[[K]], %[[L]])
 
 // -----
@@ -700,7 +700,7 @@ hal.executable private @split_reduction_executable {
 }
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * (s2 * (s0 * s1)))>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>
-//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * s2)>
+//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>
 //       CHECK: @split_reduction_variant
 //       CHECK:   hal.executable.export
 //  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
@@ -722,7 +722,7 @@ hal.executable private @split_reduction_executable {
 //   CHECK-DAG:     %[[SPLIT_NPROCS:.+]] = affine.apply #[[MAP1]]()[%[[SPLIT_LB]], %[[SPLIT_UB]], %[[SPLIT_STEP]]]
 //   CHECK-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0]
 //       CHECK:     %[[DELINEARIZE:.+]]:4 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_NPROCS]], %[[ORIG_UB0]], %[[ORIG_UB1]], %[[ORIG_UB2]])
-//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[SPLIT_LB]], %[[SPLIT_STEP]], %[[DELINEARIZE]]#0]
+//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[SPLIT_STEP]], %[[SPLIT_LB]], %[[DELINEARIZE]]#0]
 //       CHECK:     "use1"(%[[SPLITIVREPLACEMENT]])
 //       CHECK:     "use2"(%[[DELINEARIZE]]#1, %[[DELINEARIZE]]#2, %[[DELINEARIZE]]#3)
 
@@ -760,7 +760,7 @@ hal.executable private @only_split_reduction_executable {
 }
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 floordiv ((-s1 + s2) ceildiv s3))>
-//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>
 //       CHECK: @only_split_reduction_variant
 //       CHECK:   hal.executable.export
 //  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
@@ -778,7 +778,7 @@ hal.executable private @only_split_reduction_executable {
 //   CHECK-DAG:     %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
 //   CHECK-DAG:     %[[ORIGCOUNTX:.+]] = affine.apply #[[MAP1]]()[%[[COUNTX]], %[[SPLIT_LB]], %[[SPLIT_UB]], %[[SPLIT_STEP]]]
 //       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_NPROCS]], %[[ORIGCOUNTX]])
-//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]]]
+//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP2]]()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]], %[[SPLIT_LB]]]
 //       CHECK:     "use1"(%[[SPLITIVREPLACEMENT]])
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_legacy_resolve_split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_legacy_resolve_split_reduction.mlir
@@ -39,10 +39,10 @@ hal.executable private @split_reduction_executable {
     }
   }
 }
-//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * ((s1 * s2) * s0))>
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * (s2 * (s0 * s1)))>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>
 //   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 floordiv ((-s1 + s2) ceildiv s3))>
-//   CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+//   CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>
 //       CHECK: @split_reduction_variant
 //       CHECK:   hal.executable.export
 //  CHECK-SAME:       %[[ARG1:[a-zA-Z0-9_]+]]: index
@@ -52,7 +52,7 @@ hal.executable private @split_reduction_executable {
 //  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
 //   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG4]], %[[ARG6]], %[[ARG5]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG6]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
 //       CHECK:   func @split_reduction()
 //   CHECK-DAG:     %[[SPLIT_LB:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
@@ -66,7 +66,7 @@ hal.executable private @split_reduction_executable {
 //   CHECK-DAG:     %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
 //   CHECK-DAG:     %[[ORIG_COUNTZ:.+]] = affine.apply #[[MAP2]]()[%[[COUNTX]], %[[SPLIT_LB]], %[[SPLIT_UB]], %[[SPLIT_STEP]]]
 //       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SPLIT_NPROCS]], %[[ORIG_COUNTZ]]
-//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP3]]()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]]]
+//       CHECK:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply #[[MAP3]]()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]], %[[SPLIT_LB]]]
 //       CHECK:     "use1"(%[[SPLITIVREPLACEMENT]])
 //       CHECK:     %[[OTHERIVREPLACEMENTS:.+]]:3 = affine.delinearize_index %[[DELINEARIZE]]#1
 //  CHECK-SAME:       into (%[[ORIG_UB0]], %[[ORIG_UB1]], %[[ORIG_UB2]]
@@ -111,7 +111,7 @@ hal.executable private @split_reduction_2d_executable {
     }
   }
 }
-//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> ((s3 * s4) * ((s1 * s2) * s0))>
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> ((s3 * s4) * (s2 * (s0 * s1)))>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2] -> (s0 floordiv (s1 * s2))>
 //       CHECK: @split_reduction_2d_variant
 //       CHECK:   hal.executable.export
@@ -121,7 +121,7 @@ hal.executable private @split_reduction_2d_executable {
 //  CHECK-SAME:       %[[ARG4:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
 //   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG3]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]]]
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG5]], %[[ARG4]], %[[ARG3]], %[[ARG1]], %[[ARG2]]]
 //       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
 //       CHECK:   func @split_reduction_2d()
 //   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
@@ -179,7 +179,7 @@ hal.executable private @split_reduction_2d_permuted_mapping_executable {
     }
   }
 }
-//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s3 * s4) * s5) * ((s1 * s2) * s0))>
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s3 * s4) * s5) * (s2 * (s0 * s1)))>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 floordiv ((s1 * s2) * s3))>
 //       CHECK: @split_reduction_2d_permuted_mapping_variant
 //       CHECK:   hal.executable.export
@@ -190,7 +190,7 @@ hal.executable private @split_reduction_2d_permuted_mapping_executable {
 //  CHECK-SAME:       %[[ARG5:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
 //   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG5]], %[[ARG4]], %[[ARG6]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//   CHECK-DAG:     %[[NUMWORKGROUPSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG6]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       CHECK:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
 //       CHECK:   func @split_reduction_2d_permuted_mapping()
 //   CHECK-DAG:     %[[SPLIT_UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -43,7 +43,7 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //    CHECK-ALL-SAME:       %[[ARG6:[a-zA-Z0-9]+]]: index
 
 //       DISTRIBUTEX:     %[[C1:.+]] = arith.constant 1 : index
-//       DISTRIBUTEX:     %[[SIZE:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s0 + s1) ceildiv s2) * ((-s3 + s4) ceildiv s5))>()
+//       DISTRIBUTEX:     %[[SIZE:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * ((-s0 + s1) ceildiv s2))>()
 //  DISTRIBUTEX-SAME:         [%[[ARG2]], %[[ARG4]], %[[ARG6]], %[[ARG1]], %[[ARG3]], %[[ARG5]]]
 //       DISTRIBUTEX:     hal.return %[[SIZE]], %[[C1]], %[[C1]]
 
@@ -69,24 +69,28 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //   DISTRIBUTEX-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG0]], %[[ARG2]], %[[ARG4]]]
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SIZE1]], %[[SIZE0]])
-//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#0, %[[ARG4]]]
-//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>()[%[[ARG4]], %[[ARG0]], %[[DELINEARIZE]]#0]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>()[%[[ARG5]], %[[ARG1]], %[[DELINEARIZE]]#1]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEY-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEY-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
 //   DISTRIBUTEY-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEY-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDY]], %[[ARG4]], %[[ARG0]]]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDX]], %[[ARG5]], %[[ARG1]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEZ-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEZ-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
 //   DISTRIBUTEZ-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEZ-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDY]], %[[ARG4]], %[[ARG0]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDX]], %[[ARG5]], %[[ARG1]]]
 //       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]])
 
 // // -----
@@ -140,25 +144,25 @@ hal.executable private @scf_forall_3D_tile_size {
 
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:3 = affine.delinearize_index %[[IDX]] into (7, 9, 13)
-//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
-//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
-//   DISTRIBUTEX-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[DELINEARIZE]]#2]
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEX-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[DELINEARIZE]]#2]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEY-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDY]] into (7, 9)
-//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
-//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
-//   DISTRIBUTEY-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEY-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[IDX]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEZ-DAG:     %[[IDZ:.+]] = hal.interface.workgroup.id[2] : index
-//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[IDZ]]]
-//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[IDY]]]
-//   DISTRIBUTEZ-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[IDZ]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[IDY]]]
+//   DISTRIBUTEZ-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[IDX]]]
 //       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 // -----
@@ -210,17 +214,17 @@ hal.executable private @split_reduction_executable {
 //    CHECK-ALL-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
 
 //   DISTRIBUTEX-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//       DISTRIBUTEX:     %[[NUMWORKGROUPSX:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((s1 * s2) * s0) * ((-s3 + s4) ceildiv s5))>
-//  DISTRIBUTEX-SAME:         [%[[ARG4]], %[[ARG6]], %[[ARG5]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//       DISTRIBUTEX:     %[[NUMWORKGROUPSX:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * (s2 * (s0 * s1)))>()
+//  DISTRIBUTEX-SAME:         [%[[ARG6]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       DISTRIBUTEX:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
 
 //   DISTRIBUTEY-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//       DISTRIBUTEY:     %[[NUMWORKGROUPSY:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4] -> ((s0 * s1) * ((-s2 + s3) ceildiv s4))>
+//       DISTRIBUTEY:     %[[NUMWORKGROUPSY:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4] -> (((-s2 + s3) ceildiv s4) * (s0 * s1))>
 //  DISTRIBUTEY-SAME:         [%[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       DISTRIBUTEY:     hal.return %[[ARG6]], %[[NUMWORKGROUPSY]], %[[C1]]
 
-//       DISTRIBUTEZ:     %[[NUMWORKGROUPSZ:.+]] = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 * ((-s1 + s2) ceildiv s3))>
-//  DISTRIBUTEZ-SAME:         ()[%[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//       DISTRIBUTEZ:     %[[NUMWORKGROUPSZ:.+]] = affine.apply affine_map<()[s0, s1, s2, s3] -> (s3 * ((-s0 + s1) ceildiv s2))>
+//  DISTRIBUTEZ-SAME:         ()[%[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]]]
 //       DISTRIBUTEZ:     hal.return %[[ARG6]], %[[ARG5]], %[[NUMWORKGROUPSZ]]
 
 //         CHECK-ALL:   func @split_reduction
@@ -249,7 +253,7 @@ hal.executable private @split_reduction_executable {
 //   DISTRIBUTEZ-DAG:     %[[IDZ:.+]] = hal.interface.workgroup.id[2]
 //   DISTRIBUTEZ-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDZ]] into (%[[SPLIT_NPROCS]], %[[WG_BOUND_Z]])
 
-//         CHECK-ALL:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]]]
+//         CHECK-ALL:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>()[%[[SPLIT_STEP]], %[[SPLIT_LB]], %[[DELINEARIZE]]#0]
 //         CHECK-ALL:     "use1"(%[[SPLITIVREPLACEMENT]])
 
 //       DISTRIBUTEX:     "use2"(%[[DELINEARIZE]]#1, %[[DELINEARIZE]]#2, %[[DELINEARIZE]]#3)

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -261,3 +261,97 @@ hal.executable private @split_reduction_executable {
 //       DISTRIBUTEY:     "use2"(%[[DELINEARIZE]]#1, %[[DELINEARIZE]]#2, %[[IDX]])
 
 //       DISTRIBUTEZ:     "use2"(%[[DELINEARIZE]]#1, %[[IDY]], %[[IDX]])
+
+// -----
+
+// Check for case where the max workgroup count is specified.
+
+#pipeline_layout = #hal.pipeline.layout<constants = 12, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @bounded_scf_forall_4D {
+  hal.executable.variant public @bounded_scf_forall_4D target(#hal.executable.target<"", "", {
+      iree.gpu.target = #iree_codegen.simple_target<max_workgroup_count = [1024, 512, 256]>}>) {
+    hal.executable.export public @bounded_scf_forall_4D layout(#pipeline_layout)
+    count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @bounded_scf_forall_4D() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        scf.forall (%arg0, %arg1, %arg2, %arg3) in (%0, %1, %2, %3) {
+          "use"(%arg0, %arg1, %arg2, %arg3) : (index, index, index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<z:1>, #iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+    }
+  }
+}
+//        CHECK-ALL: hal.executable.export public @bounded_scf_forall_4D
+//   CHECK-ALL-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+//   CHECK-ALL-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+//   CHECK-ALL-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: index
+//   CHECK-ALL-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: index
+
+//      DISTRIBUTEX:   %[[C1:.+]] = arith.constant 1 : index
+//      DISTRIBUTEX:   %[[NWGX:.+]] = affine.min affine_map<()[s0, s1, s2, s3] -> (s3 * (s2 * (s0 * s1)), 1024)>()
+// DISTRIBUTEX-SAME:       [%[[ARG4]], %[[ARG3]], %[[ARG2]], %[[ARG1]]]
+//      DISTRIBUTEX:   hal.return %[[NWGX]], %[[C1]], %[[C1]]
+
+//      DISTRIBUTEY:   %[[C1:.+]] = arith.constant 1 : index
+//      DISTRIBUTEY:   %[[NWGY:.+]] = affine.min affine_map<()[s0, s1, s2] -> (s2 * (s0 * s1), 512)>()
+// DISTRIBUTEY-SAME:       [%[[ARG3]], %[[ARG2]], %[[ARG1]]]
+//      DISTRIBUTEY:   %[[NWGX:.+]] = affine.min affine_map<()[s0] -> (1024, s0)>()[%[[ARG4]]]
+//      DISTRIBUTEY:   hal.return %[[NWGX]], %[[NWGY]], %[[C1]]
+
+//      DISTRIBUTEZ:   %[[NWGZ:.+]] = affine.min affine_map<()[s0, s1] -> (s0 * s1, 256)>()
+// DISTRIBUTEZ-SAME:       [%[[ARG2]], %[[ARG1]]]
+//      DISTRIBUTEZ:   %[[NWGY:.+]] = affine.min affine_map<()[s0] -> (512, s0)>()[%[[ARG3]]]
+//      DISTRIBUTEZ:   %[[NWGX:.+]] = affine.min affine_map<()[s0] -> (1024, s0)>()[%[[ARG4]]]
+//      DISTRIBUTEZ:   hal.return %[[NWGX]], %[[NWGY]], %[[NWGZ]]
+
+//        CHECK-ALL: func.func @bounded_scf_forall_4D()
+//    CHECK-ALL-DAG:     %[[UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//    CHECK-ALL-DAG:     %[[UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//    CHECK-ALL-DAG:     %[[UB2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//    CHECK-ALL-DAG:     %[[UB3:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+
+//      DISTRIBUTEX:   %[[NITERS:.+]] = affine.apply affine_map<()[s0, s1, s2, s3] -> (s3 * (s2 * (s0 * s1)))>()
+// DISTRIBUTEX-SAME:       [%[[UB3]], %[[UB2]], %[[UB1]], %[[UB0]]]
+//  DISTRIBUTEX-DAG:   %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//  DISTRIBUTEX-DAG:   %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
+//      DISTRIBUTEX:   scf.for %[[IV:.+]] = %[[IDX]] to %[[NITERS]] step %[[COUNTX]]
+//      DISTRIBUTEX:     %[[DELINEARIZE:.+]]:4 = affine.delinearize_index %[[IV]] into (%[[UB0]], %[[UB1]], %[[UB2]], %[[UB3]])
+//      DISTRIBUTEX:     "use"(%[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[DELINEARIZE]]#2, %[[DELINEARIZE]]#3)
+
+//      DISTRIBUTEY:   %[[NITERS:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s2 * (s0 * s1))>()
+// DISTRIBUTEY-SAME:       [%[[UB2]], %[[UB1]], %[[UB0]]]
+//  DISTRIBUTEY-DAG:   %[[IDY:.+]] = hal.interface.workgroup.id[1]
+//  DISTRIBUTEY-DAG:   %[[COUNTY:.+]] = hal.interface.workgroup.count[1]
+//  DISTRIBUTEY-DAG:   %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//  DISTRIBUTEY-DAG:   %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
+//      DISTRIBUTEY:   scf.for %[[IV0:.+]] = %[[IDY]] to %[[NITERS]] step %[[COUNTY]]
+//      DISTRIBUTEY:     scf.for %[[IV1:.+]] = %[[IDX]] to %[[UB3]] step %[[COUNTX]]
+//      DISTRIBUTEY:       %[[DELINEARIZE:.+]]:3 = affine.delinearize_index %[[IV0]] into (%[[UB0]], %[[UB1]], %[[UB2]])
+//      DISTRIBUTEY:       "use"(%[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[DELINEARIZE]]#2, %[[IV1]])
+
+//  DISTRIBUTEZ-DAG:   %[[NITERS:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[UB1]], %[[UB0]]]
+//  DISTRIBUTEZ-DAG:   %[[IDZ:.+]] = hal.interface.workgroup.id[2]
+//  DISTRIBUTEZ-DAG:   %[[COUNTZ:.+]] = hal.interface.workgroup.count[2]
+//  DISTRIBUTEZ-DAG:   %[[IDY:.+]] = hal.interface.workgroup.id[1]
+//  DISTRIBUTEZ-DAG:   %[[COUNTY:.+]] = hal.interface.workgroup.count[1]
+//  DISTRIBUTEZ-DAG:   %[[IDX:.+]] = hal.interface.workgroup.id[0]
+//  DISTRIBUTEZ-DAG:   %[[COUNTX:.+]] = hal.interface.workgroup.count[0]
+//      DISTRIBUTEZ:   scf.for %[[IV0:.+]] = %[[IDZ]] to %[[NITERS]] step %[[COUNTZ]]
+//      DISTRIBUTEZ:     scf.for %[[IV1:.+]] = %[[IDY]] to %[[UB2]] step %[[COUNTY]]
+//      DISTRIBUTEZ:       scf.for %[[IV2:.+]] = %[[IDX]] to %[[UB3]] step %[[COUNTX]]
+//      DISTRIBUTEZ:         %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IV0]] into (%[[UB0]], %[[UB1]])
+//      DISTRIBUTEZ:         "use"(%[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[IV1]], %[[IV2]])

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize_legacy_resolve_split_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize_legacy_resolve_split_reduction.mlir
@@ -43,7 +43,7 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //    CHECK-ALL-SAME:       %[[ARG6:[a-zA-Z0-9]+]]: index
 
 //       DISTRIBUTEX:     %[[C1:.+]] = arith.constant 1 : index
-//       DISTRIBUTEX:     %[[SIZE:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s0 + s1) ceildiv s2) * ((-s3 + s4) ceildiv s5))>()
+//       DISTRIBUTEX:     %[[SIZE:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * ((-s0 + s1) ceildiv s2))>()
 //  DISTRIBUTEX-SAME:         [%[[ARG2]], %[[ARG4]], %[[ARG6]], %[[ARG1]], %[[ARG3]], %[[ARG5]]]
 //       DISTRIBUTEX:     hal.return %[[SIZE]], %[[C1]], %[[C1]]
 
@@ -69,24 +69,28 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //   DISTRIBUTEX-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG0]], %[[ARG2]], %[[ARG4]]]
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SIZE1]], %[[SIZE0]])
-//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#0, %[[ARG4]]]
-//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>()[%[[ARG4]], %[[ARG0]], %[[DELINEARIZE]]#0]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s2 + s1)>()[%[[ARG5]], %[[ARG1]], %[[DELINEARIZE]]#1]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEY-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEY-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
 //   DISTRIBUTEY-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEY-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDY]], %[[ARG4]], %[[ARG0]]]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDX]], %[[ARG5]], %[[ARG1]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEZ-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEZ-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
 //   DISTRIBUTEZ-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEZ-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDY]], %[[ARG4]], %[[ARG0]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[IDX]], %[[ARG5]], %[[ARG1]]]
 //       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]])
 
 // // -----
@@ -140,25 +144,25 @@ hal.executable private @scf_forall_3D_tile_size {
 
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:3 = affine.delinearize_index %[[IDX]] into (7, 9, 13)
-//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
-//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
-//   DISTRIBUTEX-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[DELINEARIZE]]#2]
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEX-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[DELINEARIZE]]#2]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEY-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDY]] into (7, 9)
-//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
-//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
-//   DISTRIBUTEY-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEY-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[IDX]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEZ-DAG:     %[[IDZ:.+]] = hal.interface.workgroup.id[2] : index
-//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[IDZ]]]
-//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[IDY]]]
-//   DISTRIBUTEZ-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7 + 1)>()[%[[IDZ]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6 + 2)>()[%[[IDY]]]
+//   DISTRIBUTEZ-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5 + 3)>()[%[[IDX]]]
 //       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
 
 // -----
@@ -210,8 +214,8 @@ hal.executable private @split_reduction_executable {
 //    CHECK-ALL-SAME:       %[[ARG6:[a-zA-Z0-9_]+]]: index
 
 //   DISTRIBUTEX-DAG:     %[[C1:.+]] = arith.constant 1 : index
-//       DISTRIBUTEX:     %[[NUMWORKGROUPSX:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * ((s1 * s2) * s0))>
-//  DISTRIBUTEX-SAME:         [%[[ARG4]], %[[ARG6]], %[[ARG5]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
+//       DISTRIBUTEX:     %[[NUMWORKGROUPSX:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s3 + s4) ceildiv s5) * (s2 * (s0 * s1)))>
+//  DISTRIBUTEX-SAME:         [%[[ARG6]], %[[ARG5]], %[[ARG4]], %[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //       DISTRIBUTEX:     hal.return %[[NUMWORKGROUPSX]], %[[C1]], %[[C1]]
 
 //   DISTRIBUTEY-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -248,7 +252,7 @@ hal.executable private @split_reduction_executable {
 //         CHECK-ALL:     %[[ORIG_NPROCS:.+]] = affine.apply affine_map<()[s0, s1, s2, s3] -> (s0 floordiv ((-s1 + s2) ceildiv s3))>
 //    CHECK-ALL-SAME:         ()[%[[DELINEARIZE_FROM_COUNT]], %[[SPLIT_LB]], %[[SPLIT_UB]], %[[SPLIT_STEP]]]
 //         CHECK-ALL:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[DELINEARIZE_FROM_ID]] into (%[[SPLIT_NPROCS]], %[[ORIG_NPROCS]])
-//         CHECK-ALL:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]]]
+//         CHECK-ALL:     %[[SPLITIVREPLACEMENT:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[DELINEARIZE]]#0, %[[SPLIT_STEP]], %[[SPLIT_LB]]]
 //         CHECK-ALL:     "use1"(%[[SPLITIVREPLACEMENT]])
 
 //       DISTRIBUTEX:     %[[DELINEARIZE2:.+]]:3 = affine.delinearize_index %[[DELINEARIZE]]#1 into (%[[WG_BOUND_Z]], %[[WG_BOUND_Y]], %[[WG_BOUND_X]])

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -466,6 +466,32 @@ int64_t WorkgroupMappingAttr::getRelativeIndex() const {
   return getMappingId();
 }
 
+//===----------------------------------------------------------------------===//
+// iree_codegen.simple_target
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimpleTargetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                         ArrayRef<int64_t> maxWorkgroupCount) {
+  if (maxWorkgroupCount.size() > 3) {
+    return emitError()
+           << "expected `max_workgroup_count` to have atmost 3 entries";
+  }
+  return success();
+}
+
+std::array<int64_t, 3> SimpleTargetAttr::getMaximumWorkgroupCount() const {
+  std::array<int64_t, 3> maxWorkgroupCount = {
+      ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+  ArrayRef<int64_t> givenMaxWorkgroupCount = getMaxWorkgroupCount();
+  assert(givenMaxWorkgroupCount.size() <= 3 &&
+         "expected `max_workgroup_count` to have atmost 3 entries");
+  for (auto [index, value] : llvm::enumerate(givenMaxWorkgroupCount)) {
+    maxWorkgroupCount[index] = value;
+  }
+  return maxWorkgroupCount;
+}
+
 //===---------------------------------------------------------------------===//
 // iree_codegen.rotate_rows
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -195,6 +195,35 @@ def WorkgroupMappingAttr :
 }
 
 //===---------------------------------------------------------------------===//
+// iree_codegen.simple_target
+//===---------------------------------------------------------------------===//
+
+def IREECodegen_SimpleTargetAttr :
+  AttrDef<IREECodegen_Dialect, "SimpleTarget", [
+    DeclareAttrInterfaceMethods<IREECodegen_TargetInfoAttrInterface, [
+      "getMaximumWorkgroupCount"]>]> {
+  let summary = "Default implementation of TargetInfoAttrInterface";
+
+  let description = [{
+    Implements the basic information needed to satisfy the
+    `TargetInfoAttrInterface`
+  }];
+
+  let mnemonic = "simple_target";
+  let parameters = (ins
+    OptionalArrayRefParameter<"int64_t",
+      "Maximum allowed workgroup count in [x, y, z]">:$max_workgroup_count
+  );
+
+  let assemblyFormat = [{`<`
+    (`max_workgroup_count` `=` `[` $max_workgroup_count^ `]` )?
+  `>`}];
+
+  let genVerifyDecl = 1;
+}
+
+
+//===---------------------------------------------------------------------===//
 // iree_codegen.translation_info
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -552,4 +552,30 @@ def IREECodegen_UKernelProviderInterface :
   ];
 }
 
+def IREECodegen_TargetInfoAttrInterface :
+    AttrInterface<"TargetInfoAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+  let description = [{
+    An interface that allows extracting target specific information from target
+    attributes.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the maximum workgroup count allowed on the target, returned as [x, y, z].
+
+        If there is no limit, then it is expected to return ShapedType::kDynamic.
+      }],
+      /*retTy=*/"std::array<int64_t, 3>",
+      /*methodName=*/"getMaximumWorkgroupCount",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return {ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+      }]
+    >
+  ];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1683,6 +1683,17 @@ bool TargetAttr::supportsSyncMMAOps() const {
   return false;
 }
 
+std::array<int64_t, 3> TargetAttr::getMaximumWorkgroupCount() const {
+  DenseI32ArrayAttr maxWgpCount = getWgp().getMaxWorkgroupCounts();
+  assert(maxWgpCount.size() <= 3 && "expected only workgroup count for x,y,z");
+  std::array<int64_t, 3> maxWorkgroupCount = {
+      ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+  for (auto [index, value] : llvm::enumerate(maxWgpCount.asArrayRef())) {
+    maxWorkgroupCount[index] = value;
+  }
+  return maxWorkgroupCount;
+}
+
 //===----------------------------------------------------------------------===//
 // Lowering Config Attributes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -581,7 +581,7 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_TargetAttr : AttrDef<IREEGPU_Dialect, "Target", [
-  DeclareAttrInterfaceMethods<IREECodegen_TargetInfoAttrInterface,[
+  DeclareAttrInterfaceMethods<IREECodegen_TargetInfoAttrInterface, [
     "getMaximumWorkgroupCount"]>]> {
   let summary = [{Full GPU target attribute.}];
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -580,7 +580,9 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 // GPU Target Attributes
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_TargetAttr : AttrDef<IREEGPU_Dialect, "Target"> {
+def IREEGPU_TargetAttr : AttrDef<IREEGPU_Dialect, "Target", [
+  DeclareAttrInterfaceMethods<IREECodegen_TargetInfoAttrInterface,[
+    "getMaximumWorkgroupCount"]>]> {
   let summary = [{Full GPU target attribute.}];
   let description = [{
     This attributes describes a full GPU target. It contains a few fields:

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -67,70 +67,41 @@ bool isEntryPoint(mlir::FunctionOpInterface func) {
   return func.isPublic() && getEntryPoint(func);
 }
 
-std::optional<StringAttr> getConfigStringAttr(Attribute srcAttr,
-                                              StringRef stringAttr) {
-  if (!srcAttr) {
+template <typename AttrType>
+std::optional<AttrType> getConfigTypedAttr(Attribute attr, StringRef attrName) {
+  if (!attr) {
     return std::nullopt;
   }
-  auto targetAttr = dyn_cast<IREE::HAL::ExecutableTargetAttr>(srcAttr);
+  auto targetAttr = dyn_cast<IREE::HAL::ExecutableTargetAttr>(attr);
   DictionaryAttr config;
   if (targetAttr) {
     config = targetAttr.getConfiguration();
   } else {
-    config = dyn_cast<DictionaryAttr>(srcAttr);
+    config = dyn_cast<DictionaryAttr>(attr);
   }
   if (!config) {
     return std::nullopt;
   }
-  auto attr = config.getAs<StringAttr>(stringAttr);
-  if (!attr) {
+  auto configAttr = config.getAs<AttrType>(attrName);
+  if (!configAttr) {
     return std::nullopt;
   }
-  return attr;
+  return configAttr;
+}
+
+std::optional<StringAttr> getConfigStringAttr(Attribute srcAttr,
+                                              StringRef stringAttr) {
+  return getConfigTypedAttr<StringAttr>(srcAttr, stringAttr);
 }
 
 std::optional<IntegerAttr> getConfigIntegerAttr(Attribute srcAttr,
                                                 StringRef integerAttr) {
-  if (!srcAttr) {
-    return std::nullopt;
-  }
-  auto targetAttr = dyn_cast<IREE::HAL::ExecutableTargetAttr>(srcAttr);
-  DictionaryAttr config;
-  if (targetAttr) {
-    config = targetAttr.getConfiguration();
-  } else {
-    config = dyn_cast<DictionaryAttr>(srcAttr);
-  }
-  if (!config) {
-    return std::nullopt;
-  }
-  auto attr = config.getAs<IntegerAttr>(integerAttr);
-  if (!attr) {
-    return std::nullopt;
-  }
-  return attr;
+  return getConfigTypedAttr<IntegerAttr>(srcAttr, integerAttr);
 }
 
 std::optional<BoolAttr> getConfigBoolAttr(Attribute srcAttr,
                                           StringRef boolAttr) {
-  if (!srcAttr) {
-    return std::nullopt;
-  }
-  auto targetAttr = dyn_cast<IREE::HAL::ExecutableTargetAttr>(srcAttr);
-  DictionaryAttr config;
-  if (targetAttr) {
-    config = targetAttr.getConfiguration();
-  } else {
-    config = dyn_cast<DictionaryAttr>(srcAttr);
-  }
-  if (!config) {
-    return std::nullopt;
-  }
-  auto attr = config.getAs<BoolAttr>(boolAttr);
-  if (!attr) {
-    return std::nullopt;
-  }
-  return attr;
+  return getConfigTypedAttr<BoolAttr>(srcAttr, boolAttr);
 }
 
 std::optional<llvm::Triple> getTargetTriple(Attribute attr) {
@@ -291,6 +262,19 @@ bool isRISCV32(Attribute attr) {
 bool isRISCV64(Attribute attr) {
   std::optional<llvm::Triple> triple = getTargetTriple(attr);
   return triple && triple.value().isRISCV64();
+}
+
+std::array<int64_t, 3> getMaxWorkgroupCount(Attribute attr) {
+  std::array<int64_t, 3> maxWorkgroupCount = {ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+  std::optional<DenseI32ArrayAttr> workgroupCount =
+      getConfigTypedAttr<DenseI32ArrayAttr>(attr, "max_workgroup_count");
+  if (!workgroupCount) {
+    return maxWorkgroupCount;
+  }
+  for (auto [index, value] : llvm::enumerate(workgroupCount->asArrayRef())) {
+    maxWorkgroupCount[index] = value;
+  }
+  return maxWorkgroupCount;
 }
 
 bool isReadOnly(Value v) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.h"
 #include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.h"
@@ -266,12 +267,12 @@ bool isRISCV64(Attribute attr) {
 
 std::array<int64_t, 3> getMaxWorkgroupCount(Attribute attr) {
   std::array<int64_t, 3> maxWorkgroupCount = {ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
-  std::optional<DenseI32ArrayAttr> workgroupCount =
-      getConfigTypedAttr<DenseI32ArrayAttr>(attr, "max_workgroup_count");
-  if (!workgroupCount) {
+  auto gpuTarget = dyn_cast_or_null<IREE::GPU::TargetAttr>(attr);
+  if (!gpuTarget) {
     return maxWorkgroupCount;
   }
-  for (auto [index, value] : llvm::enumerate(workgroupCount->asArrayRef())) {
+  for (auto [index, value] : llvm::enumerate(
+           gpuTarget.getWgp().getMaxWorkgroupCounts().asArrayRef())) {
     maxWorkgroupCount[index] = value;
   }
   return maxWorkgroupCount;

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -86,8 +86,8 @@ bool isRISCV(Attribute attr);
 bool isRISCV32(Attribute attr);
 bool isRISCV64(Attribute attr);
 
-/// Get maximum workgroup count in [x, y, z] for target attribute if it is available.
-/// Returns ShapedType::kDynamic if it is unknown.
+/// Get maximum workgroup count in [x, y, z] for target attribute if it is
+/// available. Returns ShapedType::kDynamic if it is unknown.
 std::array<int64_t, 3> getMaxWorkgroupCount(Attribute attr);
 
 /// Checks if a tensor value is generated from a read-only object, like

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -86,6 +86,10 @@ bool isRISCV(Attribute attr);
 bool isRISCV32(Attribute attr);
 bool isRISCV64(Attribute attr);
 
+/// Get maximum workgroup count in [x, y, z] for target attribute if it is available.
+/// Returns ShapedType::kDynamic if it is unknown.
+std::array<int64_t, 3> getMaxWorkgroupCount(Attribute attr);
+
 /// Checks if a tensor value is generated from a read-only object, like
 /// and interface binding with read-only attribute or from an `arith.constant`
 /// operation.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -44,8 +44,17 @@ OpFoldResult mulOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
                      OpFoldResult b) {
   AffineExpr d0, d1;
   bindDims(builder.getContext(), d0, d1);
-  auto addMap = AffineMap::get(2, 0, {d0 * d1});
-  return affine::makeComposedFoldedAffineApply(builder, loc, addMap, {a, b});
+  auto mulMap = AffineMap::get(2, 0, {d0 * d1});
+  return affine::makeComposedFoldedAffineApply(builder, loc, mulMap, {a, b});
+}
+
+OpFoldResult mulAddOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
+                        OpFoldResult b, OpFoldResult c) {
+  AffineExpr d0, d1, d2;
+  bindDims(builder.getContext(), d0, d1, d2);
+  auto mulAddMap = AffineMap::get(3, 0, {d0 * d1 + d2});
+  return affine::makeComposedFoldedAffineApply(builder, loc, mulAddMap,
+                                               {a, b, c});
 }
 
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -21,13 +21,18 @@ struct Range;
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
-// Helper method to add 2 OpFoldResult inputs with affine.apply.
+/// Helper method to add 2 OpFoldResult inputs with affine.apply.
 OpFoldResult addOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
                      OpFoldResult b);
 
-// Helper method to multiply 2 OpFoldResult inputs with affine.apply.
+/// Helper method to multiply 2 OpFoldResult inputs with affine.apply.
 OpFoldResult mulOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
                      OpFoldResult b);
+
+/// Helper method to compute (a * b + c) with OpFoldResult inputs using
+/// affine.apply.
+OpFoldResult mulAddOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
+                        OpFoldResult b, OpFoldResult c);
 
 /// Returns a `memref.dim` or `tensor.dim` operation to get the shape of `v` at
 /// `dim`.


### PR DESCRIPTION
The existing resolution of `scf.forall` did not account for cases where the number of workgroups created would be higher than the maximum number of workgroups allowed on the hardware. To account for this, in these cases, a loop needs to be generated that goes from the lower bound of the loop to the upper bound with step of the number of workgroups.
To simplify this implementation, some changes to the logic was made. If the rank of the `scf.forall` is greater than the number of processor dimension, the processor ID was "delinearized" to get the processor ID and number of processors for each loop. Instead add a transformation that collapses all the dimensions of the `scf.forall` that are mapped to grid dimension greater than the max grid dimension used. This simplies the logic substantially.

Further, currently the maximum workgroup count is only available on the GPU backend through the `hal.executable.target` attribute in the following manner
```
hal.executable.target = #hal.executable.target<"..", "..", {..., iree.gpu.target = #iree_gpu.target<... , max_workgroup_count = [...]>}>
```
Getting the max workgroup count would require the pass to know about GPU specific target attribute (while the pass itself is architecture agnostic). To avoid that add a new Attribute Interface, `TargetInfoAttrInterface` which can be used to extract the `max_workgroup_count`. The `IREE::GPU::TargetAttr` implements this interface.

This PR also adds a new attribute `iree_codegen.simple_target` that is the simplest implementation of the `TargetInfoAttrInterface` which is useful for testing.