### PR TITLE
[ROCM] Apply inserted user configs after PDL ukernel patterns

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -10,12 +10,14 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -78,6 +80,83 @@ static LogicalResult matchContraction(PatternRewriter &rewriter,
   return success();
 }
 
+/// PDL utility that checks whether the size of the dimension of the provided
+/// value is a multiple of the divisor.
+static LogicalResult dimIsMultipleOf(PatternRewriter &rewriter, Value value,
+                                     Attribute dim, Attribute divisor) {
+  auto shapedType = dyn_cast<mlir::ShapedType>(value.getType());
+  if (!shapedType) {
+    return failure();
+  }
+  auto dimInt = dyn_cast<IntegerAttr>(dim);
+  if (!dim) {
+    return failure();
+  }
+  auto divisorInt = dyn_cast<IntegerAttr>(divisor);
+  if (!divisor) {
+    return failure();
+  }
+  ValueBoundsConstraintSet::Variable dimVar(value, dimInt.getInt());
+
+  // Check if value[dim] % size == 0. There are a couple of options for how
+  // to do this (e.g. mul(floordiv)). Affine map canonicalizations are good
+  // at dropping terms that statically divide the mod RHS so we go with this
+  // one.
+  MLIRContext *ctx = value.getContext();
+  AffineMap modMap =
+      AffineMap::get(/*dimCount=*/0, /*symbolCount=*/1,
+                     getAffineSymbolExpr(0, ctx) %
+                         getAffineConstantExpr(divisorInt.getInt(), ctx));
+  ValueBoundsConstraintSet::Variable modVar(modMap, {dimVar});
+  Builder b(ctx);
+  FailureOr<bool> maybeFailed = ValueBoundsConstraintSet::areEqual(
+      modVar, OpFoldResult{b.getIndexAttr(0)});
+  if (failed(maybeFailed) || !maybeFailed.value()) {
+    return failure();
+  }
+  return success();
+}
+
+/// PDL utility that checks whether the size of the dimension of the provided
+/// value is within the specified range.
+static LogicalResult dimIsBound(PatternRewriter &rewriter, Value value,
+                                Attribute dim, Attribute lowerBound,
+                                Attribute upperBound) {
+  auto shapedType = dyn_cast<mlir::ShapedType>(value.getType());
+  if (!shapedType) {
+    return failure();
+  }
+  auto dimInt = dyn_cast<IntegerAttr>(dim);
+  if (!dimInt) {
+    return failure();
+  }
+  if (auto lowerBoundInt = dyn_cast<IntegerAttr>(lowerBound)) {
+    FailureOr<int64_t> constantLb =
+        ValueBoundsConstraintSet::computeConstantBound(
+            presburger::BoundType::LB, {value, /*dim=*/dimInt.getInt()},
+            /*stopCondition=*/nullptr, /*closedLB=*/true);
+    if (failed(constantLb)) {
+      return failure();
+    }
+    if (lowerBoundInt.getInt() > constantLb.value()) {
+      return failure();
+    }
+  }
+  if (auto upperBoundInt = dyn_cast<IntegerAttr>(upperBound)) {
+    FailureOr<int64_t> constantUb =
+        ValueBoundsConstraintSet::computeConstantBound(
+            presburger::BoundType::UB, {value, /*dim=*/dimInt.getInt()},
+            /*stopCondition=*/nullptr, /*closedUB=*/true);
+    if (failed(constantUb)) {
+      return failure();
+    }
+    if (upperBoundInt.getInt() < constantUb.value()) {
+      return failure();
+    }
+  }
+  return success();
+}
+
 // Populate patterns from builtin.
 static LogicalResult
 populatePDLModuleFromBuiltin(MLIRContext *context, RewritePatternSet &patterns,
@@ -97,6 +176,8 @@ populatePDLModuleFromBuiltin(MLIRContext *context, RewritePatternSet &patterns,
   // Constraints are registered to the PDL module, and linking the modules
   // together is likely slower than just registering a few redundant functions.
   pdlModule.registerConstraintFunction("hasAttr", hasAttr);
+  pdlModule.registerConstraintFunction("dimIsBound", dimIsBound);
+  pdlModule.registerConstraintFunction("dimIsMultipleOf", dimIsMultipleOf);
   pdlModule.registerConstraintFunction("matchContraction", matchContraction);
   pdlModule.registerRewriteFunction("annotateOperation", annotateOperation);
   patterns.insert(std::move(pdlModule));

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/BUILD.bazel
@@ -57,6 +57,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
     ],
 )
 

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/BUILD.bazel
@@ -46,6 +46,7 @@ iree_compiler_cc_library(
         ":PassesIncGen",
         "//compiler/plugins/target/ROCM/Dialect/ROCM/IR:ROCMDialect",
         "//compiler/plugins/target/ROCM/builtins/specialization:iree_specialization_patterns_amdgpu",
+        "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Dialect/Util/IR",

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     MLIRParser
     MLIRPass
     MLIRTransformUtils
+    MLIRValueBoundsOpInterface
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Dialect::Util::IR

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     MLIRPass
     MLIRTransformUtils
     MLIRValueBoundsOpInterface
+    iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Dialect::Util::IR

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/Passes.td
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/Passes.td
@@ -9,7 +9,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ApplyBuiltinPDLPatternsPass : Pass<"iree-rocm-apply-builtin-pdl-patterns", ""> {
+def ApplyBuiltinPDLPatternsPass : InterfacePass<"iree-rocm-apply-builtin-pdl-patterns", "mlir::FunctionOpInterface"> {
   let summary = "Parse a builtin file based on the target arch containing PDL patterns and apply them as patterns";
   let options = [
     ListOption<"targets", "targets", "std::string",

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_pdl_patterns.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_pdl_patterns.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-rocm-apply-builtin-pdl-patterns{targets=gfx942 enable-specialization=true})' \
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-rocm-apply-builtin-pdl-patterns{targets=gfx942 enable-specialization=true}))' \
 // RUN:   --mlir-print-local-scope --split-input-file %s | FileCheck %s
 
 func.func @transpose_matmul_f16(%lhs : tensor<10x20xf16>, %rhs : tensor<40x20xf16>,

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
@@ -24,3 +24,112 @@ func.func @matmul_f8(%arg0: tensor<1x128x4096xf8E4M3FNUZ>, %arg1: tensor<1024x40
 // CHECK-SAME:      lowering_config =
 // CHECK-SAME:      translation_info =
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+
+// -----
+
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @negative_matmul_f8(%arg0: tensor<1x128x256xf8E4M3FNUZ>, %arg1: tensor<1024x256xf8E4M3FNUZ>) -> tensor<1x128x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<1x128x1024xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x128x1024xf32>) -> tensor<1x128x1024xf32>
+  %2 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<1x128x256xf8E4M3FNUZ>, tensor<1024x256xf8E4M3FNUZ>) outs(%1 : tensor<1x128x1024xf32>) {
+    ^bb0(%in: f8E4M3FNUZ, %in_4: f8E4M3FNUZ, %out: f32):
+      %12 = arith.extf %in : f8E4M3FNUZ to f32
+      %13 = arith.extf %in_4 : f8E4M3FNUZ to f32
+      %14 = arith.mulf %12, %13 : f32
+      %15 = arith.addf %out, %14 : f32
+      linalg.yield %15 : f32
+    } -> tensor<1x128x1024xf32>
+  return %2 : tensor<1x128x1024xf32>
+}
+// CHECK-LABEL: @negative_matmul_f8
+// CHECK-NOT:     compilation_info = #iree_codegen.compilation_info
+// CHECK-NOT:     iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+
+// -----
+
+// Through a constraint, the inner dimension is known to be a multiple of 128 and has a lower bound of 512, so should be matched.
+
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @matmul_f8_dynamic(%arg0: index) -> tensor<1x128x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = util.assume.int %arg0<umin = 512, udiv = 128> : index
+  %1 = tensor.empty(%0) : tensor<1x128x?xf8E4M3FNUZ>
+  %2 = tensor.empty(%0) : tensor<1024x?xf8E4M3FNUZ>
+  %3 = tensor.empty() : tensor<1x128x1024xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<1x128x1024xf32>) -> tensor<1x128x1024xf32>
+  %5 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%1, %2 : tensor<1x128x?xf8E4M3FNUZ>, tensor<1024x?xf8E4M3FNUZ>) outs(%4 : tensor<1x128x1024xf32>) {
+  ^bb0(%in: f8E4M3FNUZ, %in_0: f8E4M3FNUZ, %out: f32):
+    %6 = arith.extf %in : f8E4M3FNUZ to f32
+    %7 = arith.extf %in_0 : f8E4M3FNUZ to f32
+    %8 = arith.mulf %6, %7 : f32
+    %9 = arith.addf %out, %8 : f32
+    linalg.yield %9 : f32
+  } -> tensor<1x128x1024xf32>
+  return %5 : tensor<1x128x1024xf32>
+}
+// CHECK-LABEL: @matmul_f8_dynamic
+// CHECK:         linalg.generic
+// CHECK-SAME:      compilation_info = #iree_codegen.compilation_info
+// CHECK-SAME:      lowering_config =
+// CHECK-SAME:      translation_info =
+// CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+
+// -----
+
+// The dynamic dimension is not a multiple of 128.
+
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @negative_matmul_f8_dynamic_multiple_of(%arg0: tensor<1024x512xf8E4M3FNUZ>, %arg1: index) -> tensor<1x?x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = util.assume.int %arg1<udiv = 64> : index
+  %1 = tensor.empty(%0) : tensor<1x?x512xf8E4M3FNUZ>
+  %2 = tensor.empty(%0) : tensor<1x?x1024xf32>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<1x?x1024xf32>) -> tensor<1x?x1024xf32>
+  %4 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%1, %arg0 : tensor<1x?x512xf8E4M3FNUZ>, tensor<1024x512xf8E4M3FNUZ>) outs(%3 : tensor<1x?x1024xf32>) {
+  ^bb0(%in: f8E4M3FNUZ, %in_0: f8E4M3FNUZ, %out: f32):
+    %5 = arith.extf %in : f8E4M3FNUZ to f32
+    %6 = arith.extf %in_0 : f8E4M3FNUZ to f32
+    %7 = arith.mulf %5, %6 : f32
+    %8 = arith.addf %out, %7 : f32
+    linalg.yield %8 : f32
+  } -> tensor<1x?x1024xf32>
+  return %4 : tensor<1x?x1024xf32>
+}
+// CHECK-LABEL: @negative_matmul_f8_dynamic_multiple_of
+// CHECK-NOT:     compilation_info = #iree_codegen.compilation_info
+// CHECK-NOT:     iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+
+// -----
+
+// The dynamic dimension is a multiple of 128, but doesn't have a lower bound of 512.
+
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @negative_matmul_f8_dynamic_lower_bound(%arg0: index) -> tensor<1x128x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = util.assume.int %arg0<umin = 256, udiv = 128> : index
+  %1 = tensor.empty(%0) : tensor<1x128x?xf8E4M3FNUZ>
+  %2 = tensor.empty(%0) : tensor<1024x?xf8E4M3FNUZ>
+  %3 = tensor.empty() : tensor<1x128x1024xf32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<1x128x1024xf32>) -> tensor<1x128x1024xf32>
+  %5 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%1, %2 : tensor<1x128x?xf8E4M3FNUZ>, tensor<1024x?xf8E4M3FNUZ>) outs(%4 : tensor<1x128x1024xf32>) {
+  ^bb0(%in: f8E4M3FNUZ, %in_0: f8E4M3FNUZ, %out: f32):
+    %6 = arith.extf %in : f8E4M3FNUZ to f32
+    %7 = arith.extf %in_0 : f8E4M3FNUZ to f32
+    %8 = arith.mulf %6, %7 : f32
+    %9 = arith.addf %out, %8 : f32
+    linalg.yield %9 : f32
+  } -> tensor<1x128x1024xf32>
+  return %5 : tensor<1x128x1024xf32>
+}
+// CHECK-LABEL: @negative_matmul_f8_dynamic_lower_bound
+// CHECK-NOT:     compilation_info = #iree_codegen.compilation_info
+// CHECK-NOT:     iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-rocm-apply-builtin-pdl-patterns{targets=gfx942 enable-tensor-ukernels=true})' \
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-rocm-apply-builtin-pdl-patterns{targets=gfx942 enable-tensor-ukernels=true}))' \
 // RUN:   --mlir-print-local-scope --split-input-file %s | FileCheck %s
 
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
@@ -19,11 +19,10 @@ func.func @matmul_f8(%arg0: tensor<1x128x4096xf8E4M3FNUZ>, %arg1: tensor<1024x40
   return %2 : tensor<1x128x1024xf32>
 }
 // CHECK-LABEL: @matmul_f8
+// CHECK-SAME:  translation_info =
 // CHECK:         linalg.generic
-// CHECK-SAME:      compilation_info = #iree_codegen.compilation_info
-// CHECK-SAME:      lowering_config =
-// CHECK-SAME:      translation_info =
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+// CHECK-SAME:      lowering_config =
 
 // -----
 
@@ -73,11 +72,10 @@ func.func @matmul_f8_dynamic(%arg0: index) -> tensor<1x128x1024xf32> {
   return %5 : tensor<1x128x1024xf32>
 }
 // CHECK-LABEL: @matmul_f8_dynamic
+// CHECK-SAME:  translation_info =
 // CHECK:         linalg.generic
-// CHECK-SAME:      compilation_info = #iree_codegen.compilation_info
-// CHECK-SAME:      lowering_config =
-// CHECK-SAME:      translation_info =
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8_expanded", tensor>
+// CHECK-SAME:      lowering_config =
 
 // -----
 


### PR DESCRIPTION
Stacked on top of: https://github.com/iree-org/iree/pull/21578

Towards: https://github.com/iree-org/iree/issues/21407

Makes the ApplyBuiltinPDLPatternsPass a function interface pass and applies the compilation user configs inserted by the PDL ukernel matching patterns.