### PR TITLE
Register `VectorExt` Dialect in LLVMCPUTarget

### DIFF
--- a/compiler/plugins/target/LLVMCPU/BUILD.bazel
+++ b/compiler/plugins/target/LLVMCPU/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",

--- a/compiler/plugins/target/LLVMCPU/CMakeLists.txt
+++ b/compiler/plugins/target/LLVMCPU/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Encoding::IR

--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -226,6 +227,7 @@ public:
     registry.insert<IREE::Codegen::IREECodegenDialect,
                     IREE::CPU::IREECPUDialect,
                     IREE::LinalgExt::IREELinalgExtDialect,
+                    IREE::VectorExt::IREEVectorExtDialect,
                     mlir::transform::TransformDialect,
                     pdl::PDLDialect,
                     pdl_interp::PDLInterpDialect,


### PR DESCRIPTION
Without this change, if we compile the below MLIR using `iree-compile --mlir-disable-threading --mlir-print-ir-after-all --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu-features=host`. We get the error: `LLVM ERROR: Building op iree_vector_ext.transfer_gather but it isn't known in this MLIRContext: the dialect may not be loaded or this operation hasn't been added by the dialect`. The error occurs in `iree-codegen-generic-vectorization` when it tries to vectorize `iree_linalg_ext_gather` op.

The codegen lowering uses dynamic pipeline, so we need to register all the dialects in `LLVMCPUTarget.cpp`.

```MLIR
hal.executable public @decode_bs1$async_dispatch_24 {
  hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {cpu = "znver2", cpu_features = "+prfchw,-cldemote,+avx,+aes,+sahf,+pclmul,-xop,+crc32,-amx-fp8,+xsaves,-avx512fp16,-usermsr,-sm4,-egpr,+sse4.1,-avx512ifma,+xsave,+sse4.2,-tsxldtrk,-sm3,-ptwrite,-widekl,-movrs,-invpcid,+64bit,+xsavec,-avx10.1-512,-avx512vpopcntdq,+cmov,-avx512vp2intersect,-avx512cd,+movbe,-avxvnniint8,-ccmp,-amx-int8,-kl,-avx10.1-256,-sha512,-avxvnni,-rtm,+adx,+avx2,-hreset,-movdiri,-serialize,-vpclmulqdq,-avx512vl,-uintr,-cf,+clflushopt,-raoint,-cmpccxadd,+bmi,-amx-tile,+sse,-avx10.2-256,-gfni,-avxvnniint16,-amx-fp16,-zu,-ndd,+xsaveopt,+rdrnd,-avx512f,-amx-bf16,-avx512bf16,-avx512vnni,-push2pop2,+cx8,-avx512bw,+sse3,-pku,-nf,-amx-tf32,-amx-avx512,+fsgsbase,+clzero,+mwaitx,-lwp,+lzcnt,+sha,-movdir64b,-ppx,+wbnoinvd,-enqcmd,-amx-transpose,-avx10.2-512,-avxneconvert,-tbm,-pconfig,-amx-complex,+ssse3,+cx16,+bmi2,+fma,+popcnt,-avxifma,+f16c,-avx512bitalg,+rdpru,+clwb,+mmx,+sse2,+rdseed,-avx512vbmi2,-prefetchi,-amx-movrs,+rdpid,-fma4,-avx512vbmi,-shstk,-vaes,-waitpkg,-sgx,+fxsr,-avx512dq,+sse4a", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, max_stack_allocation_size = 32768 : i64, native_vector_size = 32 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>) {
    hal.executable.export public @decode_bs1$async_dispatch_24_attention_Dx8x32x64xf16_dispatch_tensor_store ordinal(0) layout(#hal.pipeline.layout<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
      hal.return %x, %y, %z : index, index, index
    }
    builtin.module {
      func.func @decode_bs1$async_dispatch_24_attention_Dx8x32x64xf16_dispatch_tensor_store() {
        %c32_i64 = arith.constant 32 : i64
        %cst = arith.constant 1.250000e-01 : f16
        %c0 = arith.constant 0 : index
        %c8256 = arith.constant 8256 : index
        %c33558784 = arith.constant 33558784 : index
        %0 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
        %1 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
        %2 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
        %3 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
        %4 = arith.index_castui %0 : i32 to index
        %5 = arith.extui %1 : i32 to i64
        %6 = arith.extui %2 : i32 to i64
        %7 = arith.shli %6, %c32_i64 : i64
        %8 = arith.ori %5, %7 : i64
        %9 = arith.index_castui %8 : i64 to index
        %10 = arith.index_castui %3 : i32 to index
        %11:3 = util.assume.int
            %4<umin = 1, umax = 4095>,
            %9<umin = 1, umax = 9007199254740991>,
            %10<umin = 1, umax = 4095>
          : index, index, index
        %12 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c8256) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4x64xf16>>
        %13 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x4x64xf16>>
        %14 = iree_tensor_ext.dispatch.workload.ordinal %11#0, 0 : index
        %15 = iree_tensor_ext.dispatch.workload.ordinal %11#1, 1 : index
        %16 = iree_tensor_ext.dispatch.workload.ordinal %11#2, 2 : index
        %17 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x16x2x8x32x64xf16>>{%15}
        %18 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xi64>>{%14}
        %19 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c33558784) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4x?x32xf16>>{%16}
        %20 = iree_tensor_ext.dispatch.tensor.load %18, offsets = [0], sizes = [%14], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?xi64>>{%14} -> tensor<?xi64>
        %21 = iree_tensor_ext.dispatch.tensor.load %12, offsets = [0, 0, 0], sizes = [8, 4, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4x64xf16>> -> tensor<8x4x64xf16>
        %22 = iree_tensor_ext.dispatch.tensor.load %19, offsets = [0, 0, 0, 0], sizes = [8, 4, %16, 32], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4x?x32xf16>>{%16} -> tensor<8x4x?x32xf16>
        %23 = tensor.empty() : tensor<8x4x64xf16>
        %24 = tensor.empty(%14) : tensor<?x8x32x64xf16>
        %25 = iree_tensor_ext.dispatch.tensor.load %17, offsets = [0, 0, 1, 0, 0, 0], sizes = [%15, 1, 1, 8, 32, 64], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x16x2x8x32x64xf16>>{%15} -> tensor<?x8x32x64xf16>
        %26 = iree_tensor_ext.dispatch.tensor.load %17, offsets = [0, 0, 0, 0, 0, 0], sizes = [%15, 1, 1, 8, 32, 64], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x16x2x8x32x64xf16>>{%15} -> tensor<?x8x32x64xf16>
        %27 = iree_linalg_ext.gather dimension_map = [0] ins(%26, %20 : tensor<?x8x32x64xf16>, tensor<?xi64>) outs(%24 : tensor<?x8x32x64xf16>) -> tensor<?x8x32x64xf16>
        %28 = iree_linalg_ext.gather dimension_map = [0] ins(%25, %20 : tensor<?x8x32x64xf16>, tensor<?xi64>) outs(%24 : tensor<?x8x32x64xf16>) -> tensor<?x8x32x64xf16>
        %29 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d0, d5, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d0, d5, d2)>, affine_map<(d0, d1, d2, d3, d4, d5) -> ()>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d4, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>]} ins(%21, %27, %28, %cst, %22 : tensor<8x4x64xf16>, tensor<?x8x32x64xf16>, tensor<?x8x32x64xf16>, f16, tensor<8x4x?x32xf16>) outs(%23 : tensor<8x4x64xf16>) {
        ^bb0(%arg0: f32):
          iree_linalg_ext.yield %arg0 : f32
        } -> tensor<8x4x64xf16>
        iree_tensor_ext.dispatch.tensor.store %29, %13, offsets = [0, 0, 0], sizes = [8, 4, 64], strides = [1, 1, 1] : tensor<8x4x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x4x64xf16>>
        return
      }
    }
  }
}
```