### PR TITLE
Numerical tests: softmax with dynamic reduction size

### DIFF
--- a/tests/e2e/regression/linalg_ops_dynamic.mlir
+++ b/tests/e2e/regression/linalg_ops_dynamic.mlir
@@ -66,3 +66,51 @@ func.func @dynamic_matmul_dynamic_reduction_size_B2_M1_N3_K5() {
   check.expect_almost_eq(%observed, %expected, atol 1.0e-04) : tensor<2x1x3xf16>
   return
 }
+
+
+// Softmax operation with dynamic reduction size.
+// Number of samples: 2. Size of reduction dimension: 4.
+func.func @softmax_dynamic_reduction_N2_K4(){
+
+  // Computed with numpy, values of ln([[3, 2, 4, 1.],[1, 7, 1, 1]]).
+  %input = flow.tensor.dynamic_constant dense<
+            [[1.09861229, 0.69314718, 1.38629436, 0. ],
+             [0.        , 1.94591015, 0.        , 0. ]]> : tensor<2x4xf32> -> tensor<2x?xf32>
+
+  %expected = flow.tensor.dynamic_constant dense<
+               [[0.3, 0.2, 0.4, 0.1],
+                [0.1, 0.7, 0.1, 0.1]]> : tensor<2x4xf32> -> tensor<2x?xf32>
+
+  %c_1_index = arith.constant 1 : index
+  %dim_0 = tensor.dim %input, %c_1_index : tensor<2x?xf32>
+  %output = tensor.empty(%dim_0) : tensor<2x?xf32>
+
+  %sm = linalg.softmax dimension(1) ins(%input : tensor<2x?xf32>)
+                                    outs(%output : tensor<2x?xf32>) -> tensor<2x?xf32>
+
+  check.expect_almost_eq(%sm, %expected, atol 1.0e-04) : tensor<2x?xf32>
+  return
+}
+
+
+// Softmax operation with dynamic reduction size.
+// Number of samples: 65. Size of reduction dimension: 1530.
+func.func @softmax_dynamic_reduction_N65_K1530(){
+
+  %input = flow.tensor.dynamic_constant dense<-3.1415> :
+     tensor<65x1530xf32> -> tensor<65x?xf32>
+
+  // 1/1530 is 0.0006535947712418301
+  %expected = flow.tensor.dynamic_constant dense<0.0006535947712418301> :
+     tensor<65x1530xf32> -> tensor<65x?xf32>
+
+  %c_1_index = arith.constant 1 : index
+  %dim_0 = tensor.dim %input, %c_1_index : tensor<65x?xf32>
+  %output = tensor.empty(%dim_0) : tensor<65x?xf32>
+
+  %sm = linalg.softmax dimension(1) ins(%input : tensor<65x?xf32>)
+                                       outs(%output : tensor<65x?xf32>) -> tensor<65x?xf32>
+
+  check.expect_almost_eq(%sm, %expected, atol 1.0e-04) : tensor<65x?xf32>
+  return
+}

--- a/tests/e2e/regression/linalg_ops_dynamic.mlir
+++ b/tests/e2e/regression/linalg_ops_dynamic.mlir
@@ -92,17 +92,33 @@ func.func @softmax_dynamic_reduction_N2_K4(){
   return
 }
 
+// Softmax operation with dynamic reduction size.
+// Number of samples: 1. Size of reduction dimension: 1.
+func.func @softmax_dynamic_reduction_N1_K1(){
+
+  %input = flow.tensor.dynamic_constant dense<[[-77.7]]> : tensor<1x1xf32> -> tensor<1x?xf32>
+  %expected = flow.tensor.dynamic_constant dense<[[1.0]]> : tensor<1x1xf32> -> tensor<1x?xf32>
+  %c_1_index = arith.constant 1 : index
+  %dim_0 = tensor.dim %input, %c_1_index : tensor<1x?xf32>
+  %output = tensor.empty(%dim_0) : tensor<1x?xf32>
+  %sm = linalg.softmax dimension(1) ins(%input : tensor<1x?xf32>)
+                                    outs(%output : tensor<1x?xf32>) -> tensor<1x?xf32>
+
+  check.expect_almost_eq(%sm, %expected, atol 1.0e-04) : tensor<1x?xf32>
+  return
+}
+
 
 // Softmax operation with dynamic reduction size.
-// Number of samples: 65. Size of reduction dimension: 1530.
-func.func @softmax_dynamic_reduction_N65_K1530(){
+// Number of samples: 65. Size of reduction dimension: 1531.
+func.func @softmax_dynamic_reduction_N65_K1531(){
 
   %input = flow.tensor.dynamic_constant dense<-3.1415> :
-     tensor<65x1530xf32> -> tensor<65x?xf32>
+     tensor<65x1531xf32> -> tensor<65x?xf32>
 
-  // 1/1530 is 0.0006535947712418301
-  %expected = flow.tensor.dynamic_constant dense<0.0006535947712418301> :
-     tensor<65x1530xf32> -> tensor<65x?xf32>
+  // 1/1531 is 0.0006531678641410843
+  %expected = flow.tensor.dynamic_constant dense<0.0006531678641410843> :
+     tensor<65x1531xf32> -> tensor<65x?xf32>
 
   %c_1_index = arith.constant 1 : index
   %dim_0 = tensor.dim %input, %c_1_index : tensor<65x?xf32>


### PR DESCRIPTION
There is a lit test for this dynamic softmax: https://github.com/iree-org/iree/blob/f322e2b9db4aef9049df45ed662fc43e41308335/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir#L44 that uses the  warp reduction pipeline, but their is no numerical test for this case. In preparation for switching to vector distribution pipeline, I am adding these tests to ensure the later change is valid. 

Update: there actually is a numerical test in `e2e/linalg/softmax.mlir` that runs on GPU. So I could 
1) abandon this PR 
2) move these new tests to `e2e/linalg/softmax.mlir`
3) leave as is. 

I think 2 or 3 -- the current tests aren't great, as they would still pass if the compiler incorrectly did softmax on rows instead of columns, or just always used the first row (the current test uses a splat over a NxN shape...)