### PR TITLE
[DT] Fix a bug in encoding propagation when there are scalar inputs.

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -221,8 +221,8 @@ struct GenericOpPropagationInterface
                 auto operandType =
                     dyn_cast<RankedTensorType>(operand->get().getType());
                 if (!operandType) {
-                  encodedOperands.push_back(operand->get());
                   // Scalar types do not need encodings.
+                  encodedOperands.push_back(operand->get());
                   continue;
                 }
                 auto resType = RankedTensorType::get(

--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -219,7 +219,12 @@ struct GenericOpPropagationInterface
                 }
 
                 auto operandType =
-                    cast<RankedTensorType>(operand->get().getType());
+                    dyn_cast<RankedTensorType>(operand->get().getType());
+                if (!operandType) {
+                  encodedOperands.push_back(operand->get());
+                  // Scalar types do not need encodings.
+                  continue;
+                }
                 auto resType = RankedTensorType::get(
                     operandType.getShape(), operandType.getElementType(),
                     encoding);


### PR DESCRIPTION
A linalg op can take scalars as inputs, and the encoding propagation can ignore it. It is similar to 0-D tensor, but a scalar is used.

The failure is from the result of QuantizedMatmulToMatmul pass. We can switch to 0-D tensor as a fix. However, it is a legal linalg op, so supporting the propagation on scalars is a better fix.