### PR TITLE
[codegen][gpu] Guard `vector.trasfer_write` with conditional in vector distribute if not distributed

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -463,6 +463,23 @@ struct DistributeTransferWrite final
           writeOp, "warp or thread tiles have overlapping strides");
     }
 
+    // If the write op is not distributed to threads, modify the op to be
+    // guarded by a conditional to avoid multiple threads writing the same
+    // address.
+    // NOTE[1]: This makes the assumption that before distributing the `write`
+    // op, none of the indices of the op are thread dependent.
+    // NOTE[2]: Currently this assumes that all the fields in the layout have
+    // the same rank. This is ensured by the verifier of the attribute, but if
+    // that changes, this needs to be updated.
+    // NOTE[3]: This assumes that the value to be written is held by thread 0.
+    if (vectorLayout.getThreadTile().empty()) {
+      auto cmpOp = arith::CmpIOp::create(
+          rewriter, writeOp.getLoc(), arith::CmpIPredicate::eq, threadId,
+          arith::ConstantIndexOp::create(rewriter, writeOp.getLoc(), 0));
+      auto ifOp = scf::IfOp::create(rewriter, writeOp.getLoc(), cmpOp);
+      rewriter.setInsertionPoint(ifOp.thenYield());
+    }
+
     Value distributedVector =
         getDistributed(rewriter, writeOp.getValueToStore(), vectorLayout);
 
@@ -483,7 +500,6 @@ struct DistributeTransferWrite final
       SmallVector<Value> slicedIndices = getTransferIndicesFromNestedLayout(
           rewriter, indices, offsets, vectorLayout, permMap, warpIndices,
           threadIndices);
-
       // Extract the "element vector" from the inner most dimensions. All outer
       // dimensions are either unrolled or distributed such that this is a
       // contiguous slice.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -58,6 +58,7 @@ struct LLVMGPUVectorDistributePass final
     registry.insert<affine::AffineDialect>();
     registry.insert<amdgpu::AMDGPUDialect>();
     registry.insert<gpu::GPUDialect>();
+    registry.insert<scf::SCFDialect>();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
This patch guards `vector.transfer_write` operations with a conditional if they are not being distributed by vector distribution. This solves an issue when handling reductions using the vector distribution pipeline, where all threads write the same final reduction value to memory.

```mlir
func.func @undistributed_write(%out: memref<f32, #amdgpu.address_space<fat_raw_buffer>>, %v: vector<f32>) {
  vector.transfer_write %v, %out[] : vector<f32>, memref<f32, #amdgpu.address_space<fat_raw_buffer>>
  return
}
// After vector distribution.
func.func @undistributed_write(%arg0: memref<f32, #amdgpu.address_space<fat_raw_buffer>>, %arg1: vector<f32>) {
  %c0 = arith.constant 0 : index
  %thread_id_x = gpu.thread_id  x
  %0 = arith.cmpi eq, %thread_id_x, %c0 : index
  scf.if %0 {
    %1 = iree_vector_ext.to_simt %arg1 : vector<f32> -> vector<f32>
    %2 = vector.extract %1[] : f32 from vector<f32>
    %3 = vector.broadcast %2 : f32 to vector<f32>
    vector.transfer_write %3, %arg0[] : vector<f32>, memref<f32, #amdgpu.address_space<fat_raw_buffer>>
  }
  return
}
```

The following assumptions were made:
- That before distributing the `write` op, none of the indices of the op are thread dependent.
- That all the fields in the layout have the same rank. This is ensured by the verifier of the attribute, but if that changes, this needs to be updated.
- That the value to be written is held by thread 0.