### PR TITLE
[CPU] Re-enable math tests for RISC-V targets.

### DIFF
--- a/tests/e2e/math/BUILD.bazel
+++ b/tests/e2e/math/BUILD.bazel
@@ -45,10 +45,6 @@ testcases = [
     srcs = ["//tests/e2e/math:math_ops_%s.mlir" % backend],
     compiler_flags = ["--iree-llvmcpu-target-cpu=generic"] if backend == "llvm-cpu" else [],
     driver = driver,
-    tags = [
-        # TODO(#21512): Reenable tests for RISCV targets.
-        "noriscv",
-    ] if (backend == "llvm-cpu") else [],
     target_backend = backend,
     deps = [
         "gen_math_ops_%s.mlir" % backend,

--- a/tests/e2e/math/CMakeLists.txt
+++ b/tests/e2e/math/CMakeLists.txt
@@ -45,8 +45,6 @@ iree_check_single_backend_test_suite(
     "local-task"
   COMPILER_FLAGS
     "--iree-llvmcpu-target-cpu=generic"
-  LABELS
-    "noriscv"
   DEPS
     "gen_math_ops_llvm-cpu.mlir"
 )
@@ -61,8 +59,6 @@ iree_check_single_backend_test_suite(
   DRIVER
     "hip"
   COMPILER_FLAGS
-
-  LABELS
 
   DEPS
     "gen_math_ops_rocm.mlir"


### PR DESCRIPTION
The change that causes the issue is reverted in upstream: https://github.com/llvm/llvm-project/commit/2a5ac19605ae49d6628ac3af55d6b528cb13ed2e

Fixes https://github.com/iree-org/iree/issues/21512