### PR TITLE
[Codegen] Fix return of non-owning reference in CombineLayoutTransformation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -429,7 +429,7 @@ bool isSupportedRelayoutOp(Operation *op) {
 /// over whether or not to insert a map_scatter op.
 struct InsertMapScatterOpPattern : public RewritePattern {
   InsertMapScatterOpPattern(MLIRContext *context,
-                            CombineRelayoutOpsControlFn controlFn = nullptr,
+                            CombineRelayoutOpsControlFnRef controlFn = nullptr,
                             PatternBenefit benefit = 1)
       : RewritePattern(MatchAnyOpTypeTag(), benefit, context),
         controlFn(controlFn) {}
@@ -456,13 +456,13 @@ struct InsertMapScatterOpPattern : public RewritePattern {
   }
 
 private:
-  CombineRelayoutOpsControlFn controlFn;
+  CombineRelayoutOpsControlFnRef controlFn;
 };
 
 LogicalResult
 combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
                             PadDistributionConfigFn padDistributionConfigFn,
-                            CombineRelayoutOpsControlFn controlFn) {
+                            CombineRelayoutOpsControlFnRef controlFn) {
   // Sink relayout operations to the end of the funcOp.
   RewritePatternSet propagationPatterns(ctx);
   tensor::populateFoldTensorEmptyPatterns(propagationPatterns);

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -36,7 +36,8 @@ using PadDistributionConfigFn = function_ref<SmallVector<DistributionConfig>(
 /// Control function type for layout transformation combination. The control
 /// function takes a leaf of a relayout op chain, and returns a bool indicating
 /// whether to combine the relayout op chain, starting from the leaf.
-using CombineRelayoutOpsControlFn = function_ref<bool(OpResult leaf)>;
+using CombineRelayoutOpsControlFnRef = function_ref<bool(OpResult leaf)>;
+using CombineRelayoutOpsControlFn = std::function<bool(OpResult leaf)>;
 
 namespace IREE::Codegen {
 /// Enum defining the scope of the CombineLayoutTransformationPass.
@@ -93,7 +94,7 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
 LogicalResult
 combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
                             PadDistributionConfigFn padDistributionConfigFn,
-                            CombineRelayoutOpsControlFn controlFn = nullptr);
+                            CombineRelayoutOpsControlFnRef controlFn = nullptr);
 
 } // namespace mlir::iree_compiler
 #endif // IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_


### PR DESCRIPTION
There was a function returning a `CombineRelayoutOpsControlFn` type, which is defined as `llvm::function_ref`. The function should return `std::function` instead. This PR changes the name of the type alias to `CombineRelayoutOpsControlFnRef`, and adds a separate `std::function` version as `CombineRelayoutOpsControlFn` so these bugs won't show up in the future. A test is also added that will fail if the control function is not returned properly.