### PR TITLE
Adding iree_hal_device_queue_dispatch.

### DIFF
--- a/experimental/webgpu/webgpu_device.c
+++ b/experimental/webgpu/webgpu_device.c
@@ -470,6 +470,7 @@ const iree_hal_device_vtable_t iree_hal_webgpu_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_webgpu_device_queue_read,
     .queue_write = iree_hal_webgpu_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_webgpu_device_queue_execute,
     .queue_flush = iree_hal_webgpu_device_queue_flush,
     .wait_semaphores = iree_hal_webgpu_device_wait_semaphores,

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -385,6 +385,27 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_write(
     iree_hal_file_t* target_file, uint64_t target_offset,
     iree_device_size_t length, iree_hal_write_flags_t flags);
 
+// Enqueues a dispatch over a 3D grid of workgroups.
+// The request may execute overlapped with any other queue operations. The
+// executable specified must be registered for use with the device driver owning
+// the queue it is scheduled on.
+//
+// The provided constant data and binding list will be recorded into the queue
+// and need not remain live beyond the call. Binding buffers will be retained by
+// the queue until it the operation has completed.
+//
+// All provided |bindings| must be directly specified and not reference binding
+// table slots.
+//
+// See iree_hal_command_buffer_dispatch for more information.
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_dispatch(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_executable_t* executable, int32_t entry_point,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_list_t bindings, iree_hal_dispatch_flags_t flags);
+
 // Executes a command buffer on a device queue.
 // No commands will execute until the wait fence has been reached and the signal
 // fence will be signaled when all commands have completed. If a command buffer
@@ -630,6 +651,15 @@ typedef struct iree_hal_device_vtable_t {
       iree_hal_file_t* target_file, uint64_t target_offset,
       iree_device_size_t length, iree_hal_write_flags_t flags);
 
+  iree_status_t(IREE_API_PTR* queue_dispatch)(
+      iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+      const iree_hal_semaphore_list_t wait_semaphore_list,
+      const iree_hal_semaphore_list_t signal_semaphore_list,
+      iree_hal_executable_t* executable, int32_t entry_point,
+      const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+      const iree_hal_buffer_ref_list_t bindings,
+      iree_hal_dispatch_flags_t flags);
+
   iree_status_t(IREE_API_PTR* queue_execute)(
       iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
       const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -678,6 +708,14 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_emulated_copy(
     iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length, iree_hal_copy_flags_t flags);
+
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_emulated_dispatch(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_executable_t* executable, int32_t entry_point,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_list_t bindings, iree_hal_dispatch_flags_t flags);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -1128,6 +1128,7 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_cuda_device_queue_read,
     .queue_write = iree_hal_cuda_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_cuda_device_queue_execute,
     .queue_flush = iree_hal_cuda_device_queue_flush,
     .wait_semaphores = iree_hal_cuda_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -2693,6 +2693,7 @@ static const iree_hal_device_vtable_t iree_hal_hip_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_hip_device_queue_read,
     .queue_write = iree_hal_hip_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_hip_device_queue_execute,
     .queue_flush = iree_hal_hip_device_queue_flush,
     .wait_semaphores = iree_hal_hip_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -505,6 +505,7 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_sync_device_queue_read,
     .queue_write = iree_hal_sync_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_sync_device_queue_execute,
     .queue_flush = iree_hal_sync_device_queue_flush,
     .wait_semaphores = iree_hal_sync_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -539,6 +539,7 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_task_device_queue_read,
     .queue_write = iree_hal_task_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_task_device_queue_execute,
     .queue_flush = iree_hal_task_device_queue_flush,
     .wait_semaphores = iree_hal_task_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -618,6 +618,7 @@ static const iree_hal_device_vtable_t iree_hal_metal_device_vtable = {
     .queue_copy = iree_hal_device_queue_emulated_copy,
     .queue_read = iree_hal_metal_device_queue_read,
     .queue_write = iree_hal_metal_device_queue_write,
+    .queue_dispatch = iree_hal_device_queue_emulated_dispatch,
     .queue_execute = iree_hal_metal_device_queue_execute,
     .queue_flush = iree_hal_metal_device_queue_flush,
     .wait_semaphores = iree_hal_metal_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/null/device.c
+++ b/runtime/src/iree/hal/drivers/null/device.c
@@ -458,6 +458,22 @@ static iree_status_t iree_hal_null_device_queue_write(
   return loop_status;
 }
 
+static iree_status_t iree_hal_null_device_queue_dispatch(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_executable_t* executable, int32_t entry_point,
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const iree_hal_buffer_ref_list_t bindings,
+    iree_hal_dispatch_flags_t flags) {
+  // TODO(null): if a native queue dispatch operation is available use that
+  // instead. The emulated dispatch creates a command buffer and executes it and
+  // it's best if the extra recording/upload/allocation time can be avoided.
+  return iree_hal_device_queue_emulated_dispatch(
+      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      executable, entry_point, config, constants, bindings, flags);
+}
+
 static iree_status_t iree_hal_null_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -603,6 +619,7 @@ static const iree_hal_device_vtable_t iree_hal_null_device_vtable = {
     .queue_copy = iree_hal_null_device_queue_copy,
     .queue_read = iree_hal_null_device_queue_read,
     .queue_write = iree_hal_null_device_queue_write,
+    .queue_dispatch = iree_hal_null_device_queue_dispatch,
     .queue_execute = iree_hal_null_device_queue_execute,
     .queue_flush = iree_hal_null_device_queue_flush,
     .wait_semaphores = iree_hal_null_device_wait_semaphores,

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1893,6 +1893,7 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.queue_copy=*/iree_hal_device_queue_emulated_copy,
     /*.queue_read=*/iree_hal_vulkan_device_queue_read,
     /*.queue_write=*/iree_hal_vulkan_device_queue_write,
+    /*.queue_dispatch=*/iree_hal_device_queue_emulated_dispatch,
     /*.queue_execute=*/iree_hal_vulkan_device_queue_execute,
     /*.queue_flush=*/iree_hal_vulkan_device_queue_flush,
     /*.wait_semaphores=*/iree_hal_vulkan_device_wait_semaphores,


### PR DESCRIPTION
This is emulated today by creating a command buffer with a single dispatch and executing it. HAL implementations that can more efficiently perform a single dispatch in queue order should do so. We don't want people doing queue-level fill/copy/dispatch, but they are useful for glue code and allowing users to avoid the command buffer cost for O(1) operations is worth it.

Fixes #21629.