### PR TITLE
Reapply "[Codegen] Fix dominance issues blocking consumer fusions (#21551)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -597,7 +597,7 @@ getCombineRelayoutOpsControlFn(IREE::Codegen::RelayoutCombinationScope scope) {
         return false;
       }
       auto forallOp = parallelInsertOp->getParentOfType<scf::ForallOp>();
-      if (!forallOp ||
+      if (!forallOp || !forallOp.getMapping() ||
           !llvm::all_of(forallOp.getMapping().value(),
                         llvm::IsaPred<IREE::Codegen::WorkgroupMappingAttr>)) {
         return false;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -785,3 +785,42 @@ func.func @fuse_warp_and_lane_foralls_multi_result(%2: tensor<2x2x64xf32>) -> (t
 //       CHECK:     }
 //       CHECK:   } {mapping = [#gpu.thread<linear_dim_2>, #gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 //       CHECK:   return %[[THREAD_FORALL]]#0, %[[THREAD_FORALL]]#1
+
+// -----
+
+func.func @fusion_through_non_dominating_loop_user(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>, %arg2: f32) -> (tensor<64xf32>, tensor<64xf32>) {
+  %empty = tensor.empty() : tensor<64xf32>
+  %result:2 = scf.forall (%arg3) in (64) shared_outs(%out0 = %empty, %out1 = %empty) -> (tensor<64xf32>, tensor<64xf32>) {
+    %out0_slice = tensor.extract_slice %out0[%arg3] [1] [1] : tensor<64xf32> to tensor<1xf32>
+    %out1_slice = tensor.extract_slice %out1[%arg3] [1] [1] : tensor<64xf32> to tensor<1xf32>
+    %copied = linalg.copy ins(%arg0 : tensor<1xf32>) outs(%out0_slice : tensor<1xf32>) -> tensor<1xf32>
+    %add = linalg.add ins(%copied, %arg1 : tensor<1xf32>, tensor<1xf32>) outs(%out1_slice : tensor<1xf32>) -> tensor<1xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %copied into %out0[%arg3] [1] [1] : tensor<1xf32> into tensor<64xf32>
+      tensor.parallel_insert_slice %add into %out1[%arg3] [1] [1] : tensor<1xf32> into tensor<64xf32>
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  %unfusable_consumer = util.optimization_barrier %result#0 : tensor<64xf32>
+  %implicit_capture = math.exp %arg2 : f32
+  %fusable_consumer = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+      ins(%result#1 : tensor<64xf32>) outs(%empty : tensor<64xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %add = arith.addf %in, %implicit_capture : f32
+    linalg.yield %add : f32
+  } -> tensor<64xf32>
+  return %unfusable_consumer, %fusable_consumer : tensor<64xf32>, tensor<64xf32>
+}
+
+// CHECK-LABEL: func @fusion_through_non_dominating_loop_user
+//  CHECK-SAME:   %[[ARG0:.[a-zA-Z0-9]]]
+//  CHECK-SAME:   %[[ARG1:.[a-zA-Z0-9]]]
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<64xf32>
+//       CHECK:   %[[FORALL:.+]]:2 = scf.forall (%[[TID:.+]]) in (64)
+//  CHECK-SAME:       shared_outs(%[[OUT0:.+]] = %[[EMPTY]], %[[OUT1:.+]] = %[[EMPTY]])
+//       CHECK:     %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]
+//       CHECK:     %[[ADD:.+]] = linalg.add ins(%[[COPY]], %[[ARG1]]
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic{{.*}} ins(%[[ADD]]
+//   CHECK-DAG:     tensor.parallel_insert_slice %[[COPY]] into %[[OUT0]]
+//   CHECK-DAG:     tensor.parallel_insert_slice %[[GENERIC]] into %[[OUT1]]
+//       CHECK:   %[[BARRIER:.+]] = util.optimization_barrier %[[FORALL]]#0
+//       CHECK:   return %[[BARRIER]], %[[FORALL]]#1

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
@@ -38,6 +39,9 @@ struct FuseTilableForallConsumers final
       if (!forallProducer) {
         continue;
       }
+      if (forallProducer->getBlock() != tilableOp->getBlock()) {
+        continue;
+      }
       Value iterArg = forallProducer.getTiedBlockArgument(
           forallProducer.getTiedOpOperand(cast<OpResult>(operand)));
 
@@ -65,6 +69,24 @@ struct FuseTilableForallConsumers final
         return rewriter.notifyMatchFailure(tilableOp,
                                            "unimplemented: Cannot fuse op with "
                                            "multiple uses of producer loop");
+      }
+    }
+
+    // The `tileAndFuseConsumerOfSlices` transform will fail if there are any
+    // users of the loop that do not dominate the `tilableOp`, so we move the
+    // `tilableOp` and any producers needed for dominance right after the loop.
+    llvm::SetVector<Operation *> slice;
+    BackwardSliceOptions options;
+    DominanceInfo domInfo;
+    options.filter = [&](Operation *op) {
+      return domInfo.properlyDominates(sliceOwner, op);
+    };
+    options.inclusive = true;
+    options.omitUsesFromAbove = false;
+    options.omitBlockArguments = true;
+    if (succeeded(getBackwardSlice(tilableOp, &slice, options))) {
+      for (Operation *op : llvm::reverse(slice)) {
+        rewriter.moveOpAfter(op, sliceOwner);
       }
     }
 


### PR DESCRIPTION
Reapplies https://github.com/iree-org/iree/commit/9c77258d5b4cd3dd1b4f533488e7be206a68bcd4 with a bug fix for https://github.com/iree-org/iree/issues/21622. Operations were being moved by the rewriter before the FuseTilableConsumer pattern was guaranteed to succeed, which added the ops to the pattern worklist every time the pattern failed. This caused an infinite recursion of the pattern application. The fix is to move the ops without the rewriter, so they will not be added to the worklist. This op movement can also be removed once the upstream fusion transformation is refactored to properly handle multi-result scf.forall loops.