### PR TITLE
[WIP][Codegen] Lower preference for warp reduction pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -3210,10 +3210,6 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       LDBG() << "Vector Distribution Subgroup Reduction Config";
       return success();
     }
-    if (succeeded(setWarpReductionConfig(target, entryPointFn, linalgOp))) {
-      LDBG() << "Warp Reduction Config";
-      return success();
-    }
     if (succeeded(setConvolutionConfig(target, entryPointFn, linalgOp, 16))) {
       LDBG() << "Convolution Config";
       return success();
@@ -3233,6 +3229,15 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
         LDBG() << "Tile and Fuse Config";
         return success();
       }
+    }
+    if (succeeded(IREE::GPU::setMatmulLoweringConfig(
+            target, entryPointFn, computeOp, clUseDirectLoad))) {
+      LDBG() << "Tile and fuse matmul config";
+      return success();
+    }
+    if (succeeded(setWarpReductionConfig(target, entryPointFn, linalgOp))) {
+      LDBG() << "Warp Reduction Config";
+      return success();
     }
   }
   return TypeSwitch<Operation *, LogicalResult>(computeOp)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -431,19 +431,11 @@ func.func @dynamic_parallel_dims(%dynsize : index, %input : tensor<4x?x4096xf16>
     } -> tensor<4x?xf32>
   return %2 : tensor<4x?xf32>
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 64]{{\]}}
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//      CHECK: func @dynamic_parallel_dims
-// CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//      CHECK:   linalg.generic
-// CHECK-SAME:       lowering_config = #[[CONFIG]]
 
-//  CDNA3-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 32]{{\]}}
-//  CDNA3-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [32, 1, 1] subgroup_size = 32>
-//      CDNA3: func @dynamic_parallel_dims
-// CDNA3-SAME:     translation_info = #[[TRANSLATION]]
-//      CDNA3:   linalg.generic
-// CDNA3-SAME:       lowering_config = #[[CONFIG]]
+
+//  CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+//  CDNA3: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
 
 // -----
 
@@ -480,9 +472,6 @@ func.func @test_dyn_reduction(%arg0: tensor<128x?x32xf8E4M3FNUZ>, %arg1: tensor<
   } -> tensor<128x128xf8E4M3FNUZ>
   return %4 : tensor<128x128xf8E4M3FNUZ>
 }
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 1, 64]{{\]}}>
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//       CHECK: func.func @test_dyn_reduction
-//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+
+
+// CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_softmax_rocm.mlir
@@ -98,5 +98,4 @@ func.func @dynamic_softmax() {
 
 // Finer details of this lowering are captured by the spirv pipeline test. Just
 // verify that warp reduction triggers.
-//    CHECK-LABEL: func.func @dynamic_softmax
-// CHECK-COUNT-10: gpu.shuffle  xor {{.*}} : i32
+// CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>


### PR DESCRIPTION
This PR gets us closer to being able to remove warp-reduction. It changes the pipeline selection strategy from 

```
START (highest priority strategy)
...
...
setWarpReductionConfig
... 
...
END (lowest priority strategy)
```

to 

```
START (highest priority strategy)
...
...
... 
setMatmulLoweringConfig
setWarpReductionConfig
END (lowest priority strategy)
```

i.e. it moves warp-reduction selection to the very end, with one last attempt at configuring a matmul (with tile-and-fuse) before it. 

This change means that some workloads that were going to warp-reduction now go to tile-and-fuse. 

As a later step, I will change the pipeline again so that the dynamic softmax doesn't go to ile-and-fuse, but goes to vector-distribute. 