### PR TITLE
[LLVMCPU] Tracks the dimension mapping for multi lowering config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -145,6 +145,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:IndexToLLVM",
+        "@llvm-project//mlir:IndexingMapOpInterface",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -114,6 +114,7 @@ iree_cc_library(
     MLIRFunctionInterfaces
     MLIRIR
     MLIRIndexToLLVM
+    MLIRIndexingMapOpInterface
     MLIRLLVMCommonConversion
     MLIRLLVMDialect
     MLIRLinalgDialect


### PR DESCRIPTION
This adds `IterationDimTracker` to determine dimension mappings both within individual operations and across multiple operations. 

The tracker assigns a global dimension index to all loop dimensions encountered (where “local” refers to an individual operation and “global” refers to all target operations). By analyzing producer-consumer relationships of SSA values, dimensions that are considered equivalent are assigned the same global dimension index.

It is currently used to improve lowering configuration propagation by identifying loop dimensions that are common across all target operations.