### PR TITLE
[DT][NFCI] Switch SetEncoding pass to walk-based pass.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -329,6 +329,10 @@ def PropagateEncodingsPass :
 def SetEncodingPass : InterfacePass<"iree-dispatch-creation-set-encoding",
                                     "mlir::FunctionOpInterface"> {
   let summary = "Introduces tensor encoding for flow dispatch regions.";
+  let description = [{
+    Sets the encoding for compute operations to allow execution of the
+    operations in tiled/padded layouts.
+  }];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "IREE::Flow::FlowDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -4,17 +4,11 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===--------------- SetEncoding.cpp -------------------------------------===//
-// Sets the encoding for compute operations to allow execution of the
-// operations in tiled layouts.
-//===---------------------------------------------------------------------===//
-
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
-#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
@@ -23,6 +17,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -120,168 +115,156 @@ static bool hasMatmulLikeBody(linalg::LinalgOp linalgOp) {
 }
 
 /// Not all contractions are supported by data tiling, so return true if:
-///   1) linalgOp has contraction indexingMaps.
-///   2) There are not more than one of each contraction dimension
-///   3) There is and M or N dimension, and there is a K dimension
-///   4) linalgOp has the same body as an ordinary int or float matmul
+///   1) linalgOp has pure tensor semantics.
+///   2) linalgOp does not have a preset compilation info.
+///   3) The workgroup count is not present if linalgOp is wrapped within
+///      Flow::DispatchRegionOp.
+///   4) All the operands do not have encodings.
+///   5) linalgOp has contraction indexingMaps.
+///   6) There are not more than one of each contraction dimension.
+///   7) There is and M or N dimension, and there is a K dimension.
+///   8) linalgOp has the same body as an ordinary int or float matmul.
 ///
 /// These restrictions are required because data tiling currently creates
 /// an Mmt4DOp or BatchMmt4DOp on the packed inputs.
 ///
 /// TODO(#16176): Loosen restrictions on contraction ops once data tiling
 /// can support more cases.
-static LogicalResult isSupportedContractionOp(PatternRewriter &rewriter,
-                                              linalg::LinalgOp linalgOp) {
+static bool isSupportedContractionOp(linalg::LinalgOp linalgOp) {
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return false;
+  }
+  if (getCompilationInfo(linalgOp)) {
+    return false;
+  }
+  auto hasWorkgroupCounts = [](Operation *op) -> bool {
+    auto parentDispatchOp = op->getParentOfType<IREE::Flow::DispatchRegionOp>();
+    return parentDispatchOp && !parentDispatchOp.getWorkgroupCount().empty();
+  };
+  if (hasWorkgroupCounts(linalgOp)) {
+    return false;
+  }
+  auto hasEncoding = [](Value operand) -> bool {
+    auto type = llvm::dyn_cast<RankedTensorType>(operand.getType());
+    return type && type.getEncoding();
+  };
+  if (llvm::any_of(linalgOp.getDpsInputs(), hasEncoding) ||
+      llvm::any_of(linalgOp.getDpsInits(), hasEncoding)) {
+    return false;
+  }
+
   if (!linalg::isaContractionOpInterface(linalgOp)) {
-    return rewriter.notifyMatchFailure(linalgOp,
-                                       "Expected isaContractionOpInterface");
+    return false;
   }
   auto cDims = linalg::inferContractionDims(linalgOp);
   if (failed(cDims) || cDims->batch.size() > 1 || cDims->m.size() > 1 ||
       cDims->n.size() > 1 || cDims->k.size() > 1) {
-    return rewriter.notifyMatchFailure(
-        linalgOp, "Expected {|Batch|, |M|, |N|, |K|} <= 1");
+    return false;
   }
   if ((cDims->n.empty() && cDims->m.empty()) || cDims->k.empty()) {
-    return rewriter.notifyMatchFailure(
-        linalgOp, "Expected M or N dims and K dim to not be empty");
+    return false;
   }
   if (!hasMatmulLikeBody(linalgOp)) {
-    return rewriter.notifyMatchFailure(
-        linalgOp, "Expected op to have a matmul body, i.e. yield(add(out, "
-                  "mul(cast(in0), cast(in1))))");
+    return false;
   }
+  return true;
+}
+
+static SmallVector<linalg::LinalgOp>
+getDataTilingCandidates(FunctionOpInterface funcOp) {
+  SmallVector<linalg::LinalgOp> result;
+  funcOp.walk([&](linalg::LinalgOp op) {
+    if (!isSupportedContractionOp(op)) {
+      return;
+    }
+    result.push_back(op);
+  });
+  return result;
+}
+
+static LogicalResult setDataTilingEncodings(RewriterBase &rewriter,
+                                            linalg::LinalgOp linalgOp,
+                                            EncodingOptions encodingOption) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(linalgOp);
+
+  Value lhs = linalgOp.getDpsInputOperand(0)->get();
+  Value rhs = linalgOp.getDpsInputOperand(1)->get();
+  Value out = linalgOp.getDpsInitOperand(0)->get();
+  Type lhsElemType = getContractionInputTypeWithSignedness(
+      rewriter, linalgOp, linalgOp.getDpsInputOperand(0));
+  Type rhsElemType = getContractionInputTypeWithSignedness(
+      rewriter, linalgOp, linalgOp.getDpsInputOperand(1));
+  Type outElemType = getContractionInputTypeWithSignedness(
+      rewriter, linalgOp, linalgOp.getDpsInitOperand(0));
+  if (!lhsElemType || !rhsElemType || !outElemType) {
+    return failure();
+  }
+  SmallVector<Type> elemTypes = {lhsElemType, rhsElemType, outElemType};
+
+  // The `iteration_sizes` are the linalg op's static loop ranges. From the
+  // combination of `iteration_sizes` and `user_indexing_maps`, we can later
+  // derive information such as the iteration size of the M/N dimensions of a
+  // matmul-like operation for example.
+  FailureOr<SmallVector<int64_t>> maybeIterationSizes =
+      linalgOp.getStaticLoopRanges();
+  if (failed(maybeIterationSizes)) {
+    return failure();
+  }
+  SmallVector<int64_t> iterationSizes = std::move(maybeIterationSizes.value());
+
+  Location loc = linalgOp.getLoc();
+  SmallVector<AffineMap> maps = linalgOp.getIndexingMapsArray();
+
+  auto opType = IREE::Encoding::EncodingOpType::matmul;
+  auto setEncodingWrapper = [&](Value src, int64_t operandIndex) -> Value {
+    MLIRContext *ctx = linalgOp.getContext();
+    Attribute encoding;
+    switch (encodingOption) {
+    case EncodingOptions::Generic: {
+      encoding = EncodingAttr::get(ctx, operandIndex, opType, elemTypes, maps,
+                                   iterationSizes);
+      break;
+    }
+    case EncodingOptions::MatmulK: {
+      SmallVector<int32_t> kDims;
+      AffineMap indexingMap = maps[operandIndex];
+      auto cDims = linalg::inferContractionDims(linalgOp);
+      for (auto k : cDims->k) {
+        std::optional<unsigned> dimIdx =
+            indexingMap.getResultPosition(rewriter.getAffineDimExpr(k));
+        if (!dimIdx) {
+          continue;
+        }
+        kDims.push_back(dimIdx.value());
+      }
+      encoding = MatmulKAttr::get(ctx, kDims);
+      break;
+    }
+    default: {
+      assert(false && "Unsupported encoding option");
+      return Value();
+    }
+    }
+    return setEncoding(rewriter, loc, src, encoding);
+  };
+  auto encodedLhs = setEncodingWrapper(lhs, IREE::Encoding::MATMUL_LHS);
+  auto encodedRhs = setEncodingWrapper(rhs, IREE::Encoding::MATMUL_RHS);
+  auto encodedOut = setEncodingWrapper(out, IREE::Encoding::MATMUL_RESULT);
+  Value opTiled = clone(rewriter, linalgOp, encodedOut.getType(),
+                        ValueRange{encodedLhs, encodedRhs, encodedOut})
+                      ->getResult(0);
+
+  // Sizes are computed by original output size.
+  SmallVector<OpFoldResult> outSizes =
+      tensor::getMixedSizes(rewriter, loc, out);
+  Value result = unsetEncoding(rewriter, loc, opTiled, outSizes);
+
+  rewriter.replaceOp(linalgOp, result);
   return success();
 }
 
-static bool hasWorkgroupCounts(Operation *op) {
-  auto parentDispatchOp = op->getParentOfType<IREE::Flow::DispatchRegionOp>();
-  return parentDispatchOp && !parentDispatchOp.getWorkgroupCount().empty();
-}
-
 namespace {
-
-class SetContractionOpEncoding final
-    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
-public:
-  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
-  explicit SetContractionOpEncoding(MLIRContext *ctx, EncodingOptions &option)
-      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx),
-        encodingOption(option) {}
-
-  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
-                                PatternRewriter &rewriter) const override {
-
-    if (!linalgOp.hasPureTensorSemantics()) {
-      return failure();
-    }
-    if (getCompilationInfo(linalgOp)) {
-      return rewriter.notifyMatchFailure(
-          linalgOp, "the op has preset compilation strategy, skip SetEncoding");
-    }
-    if (hasWorkgroupCounts(linalgOp.getOperation())) {
-      return rewriter.notifyMatchFailure(
-          linalgOp, "the op is in a region with workgroup counts, skip "
-                    "SetEncoding");
-    }
-    if (failed(isSupportedContractionOp(rewriter, linalgOp))) {
-      return failure();
-    }
-
-    auto inputs = linalgOp.getDpsInputs();
-    auto outputs = linalgOp.getDpsInits();
-
-    auto hasEncoding = [](Value operand) -> bool {
-      auto type = llvm::dyn_cast<RankedTensorType>(operand.getType());
-      return type && type.getEncoding();
-    };
-    if (llvm::any_of(inputs, hasEncoding) ||
-        llvm::any_of(outputs, hasEncoding)) {
-      return failure();
-    }
-    Value lhs = inputs[0];
-    Value rhs = inputs[1];
-    Value out = outputs[0];
-
-    Type lhsElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInputOperand(0));
-    Type rhsElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInputOperand(1));
-    Type outElemType = getContractionInputTypeWithSignedness(
-        rewriter, linalgOp, linalgOp.getDpsInitOperand(0));
-
-    if (!lhsElemType || !rhsElemType || !outElemType) {
-      return failure();
-    }
-    SmallVector<Type> elemTypes = {lhsElemType, rhsElemType, outElemType};
-
-    // The `iteration_sizes` are the linalg op's static loop ranges. From the
-    // combination of `iteration_sizes` and `user_indexing_maps`, we can later
-    // derive information such as the iteration size of the M/N dimensions of a
-    // matmul-like operation for example.
-    FailureOr<SmallVector<int64_t>> maybeIterationSizes =
-        linalgOp.getStaticLoopRanges();
-    if (failed(maybeIterationSizes)) {
-      return failure();
-    }
-    SmallVector<int64_t> iterationSizes =
-        std::move(maybeIterationSizes.value());
-
-    Location loc = linalgOp.getLoc();
-    SmallVector<AffineMap> maps = linalgOp.getIndexingMapsArray();
-
-    auto opType = IREE::Encoding::EncodingOpType::matmul;
-    auto setEncodingWrapper = [&](Value src, int64_t operandIndex) -> Value {
-      MLIRContext *ctx = linalgOp.getContext();
-      Attribute encoding;
-      switch (encodingOption) {
-      case EncodingOptions::Generic: {
-        encoding = EncodingAttr::get(ctx, operandIndex, opType, elemTypes, maps,
-                                     iterationSizes);
-        break;
-      }
-      case EncodingOptions::MatmulK: {
-        SmallVector<int32_t> kDims;
-        AffineMap indexingMap = maps[operandIndex];
-        auto cDims = linalg::inferContractionDims(linalgOp);
-        for (auto k : cDims->k) {
-          std::optional<unsigned> dimIdx =
-              indexingMap.getResultPosition(rewriter.getAffineDimExpr(k));
-          if (!dimIdx) {
-            continue;
-          }
-          kDims.push_back(dimIdx.value());
-        }
-        encoding = MatmulKAttr::get(ctx, kDims);
-        break;
-      }
-      default: {
-        assert(false && "Unsupported encoding option");
-        return Value();
-      }
-      }
-      return setEncoding(rewriter, loc, src, encoding);
-    };
-    auto encodedLhs = setEncodingWrapper(lhs, IREE::Encoding::MATMUL_LHS);
-    auto encodedRhs = setEncodingWrapper(rhs, IREE::Encoding::MATMUL_RHS);
-    auto encodedOut = setEncodingWrapper(out, IREE::Encoding::MATMUL_RESULT);
-    Value opTiled = clone(rewriter, linalgOp, encodedOut.getType(),
-                          ValueRange{encodedLhs, encodedRhs, encodedOut})
-                        ->getResult(0);
-
-    // Sizes are computed by original output size.
-    SmallVector<OpFoldResult> outSizes =
-        tensor::getMixedSizes(rewriter, loc, out);
-    Value result = unsetEncoding(rewriter, loc, opTiled, outSizes);
-
-    rewriter.replaceOp(linalgOp, result);
-    return success();
-  }
-
-private:
-  EncodingOptions encodingOption;
-};
-
 /// Pattern to fold a `linalg.fill` -> `iree_encoding.set_encoding`
 /// operation into a `linalg.fill` of the encoded type.
 struct FoldFillWithSetEncoding final
@@ -307,10 +290,12 @@ struct FoldFillWithSetEncoding final
     return success();
   }
 };
+} // namespace
 
 //===---------------------------------------------------------------------===//
 // Set padding encodings
 //===---------------------------------------------------------------------===//
+
 struct PaddedValue {
   Value paddedValue;
   SmallVector<Value> dynamicDims;
@@ -447,7 +432,7 @@ static SmallVector<unsigned> padOperandsOfOp(RewriterBase &rewriter,
 }
 
 // Return a list of operands to be padded for each `op`.
-SmallVector<unsigned> getOperandsToPad(Operation *op) {
+static SmallVector<unsigned> getOperandsToPad(Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp || !linalg::isaContractionOpInterface(linalgOp)) {
     return {};
@@ -521,10 +506,8 @@ SmallVector<unsigned> getOperandsToPad(Operation *op) {
 
 // Main driver method to add encodings to pad. Typically these are
 // intermediate values produced by `flow.dispatch.region`.
-static LogicalResult setPaddingEncodings(MLIRContext *context,
+static LogicalResult setPaddingEncodings(RewriterBase &rewriter,
                                          FunctionOpInterface funcOp) {
-  IRRewriter rewriter(context);
-
   // Collect all operations whose operands can be padded.
   using OpListType =
       SmallVector<std::tuple<Operation *, SmallVector<unsigned>>>;
@@ -540,17 +523,6 @@ static LogicalResult setPaddingEncodings(MLIRContext *context,
     // Only pad LHS or RHS of matmul ops.
     padOperandsOfOp(rewriter, op, operandsNums);
   }
-
-  // Apply the dim resolution patterns.
-  RewritePatternSet dimResolutionPatterns(context);
-  memref::populateResolveRankedShapedTypeResultDimsPatterns(
-      dimResolutionPatterns);
-  GreedyRewriteConfig config;
-  config.enableFolding(true).setMaxIterations(GreedyRewriteConfig::kNoLimit);
-  if (failed(applyPatternsGreedily(funcOp, std::move(dimResolutionPatterns),
-                                   config))) {
-    return funcOp.emitOpError("failed to resolve tensor.dim operations");
-  }
   return success();
 }
 
@@ -558,28 +530,42 @@ static LogicalResult setPaddingEncodings(MLIRContext *context,
 // Pass definition
 //===---------------------------------------------------------------------===//
 
+namespace {
 struct SetEncodingPass final : impl::SetEncodingPassBase<SetEncodingPass> {
   using Base::Base;
   void runOnOperation() override {
     auto funcOp = getOperation();
     MLIRContext *context = &getContext();
+    IRRewriter rewriter(context);
+    RewritePatternSet postPatterns(context);
 
-    // Implement the padding encoding.
-    if (encodingOption == DispatchCreation::EncodingOptions::Padding) {
-      if (failed(setPaddingEncodings(context, funcOp))) {
+    switch (encodingOption) {
+    case EncodingOptions::Generic:
+    case EncodingOptions::MatmulK: {
+      SmallVector<linalg::LinalgOp> candidates =
+          getDataTilingCandidates(funcOp);
+      for (linalg::LinalgOp linalgOp : candidates) {
+        if (failed(
+                setDataTilingEncodings(rewriter, linalgOp, encodingOption))) {
+          return signalPassFailure();
+        }
+      }
+      linalg::FillOp::getCanonicalizationPatterns(postPatterns, context);
+      postPatterns.add<FoldFillWithSetEncoding>(context);
+      break;
+    }
+    case EncodingOptions::Padding: {
+      if (failed(setPaddingEncodings(rewriter, funcOp))) {
         return signalPassFailure();
       }
-      return;
+      break;
+    }
     }
 
-    RewritePatternSet patterns(context);
-    patterns.add<SetContractionOpEncoding>(context, encodingOption.getValue());
-    linalg::FillOp::getCanonicalizationPatterns(patterns, context);
-    patterns.add<FoldFillWithSetEncoding>(context);
-    memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(postPatterns);
     GreedyRewriteConfig config;
     config.enableConstantCSE(false);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+    if (failed(applyPatternsGreedily(getOperation(), std::move(postPatterns),
                                      config))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -122,7 +122,7 @@ static bool hasMatmulLikeBody(linalg::LinalgOp linalgOp) {
 ///   4) All the operands do not have encodings.
 ///   5) linalgOp has contraction indexingMaps.
 ///   6) There are not more than one of each contraction dimension.
-///   7) There is and M or N dimension, and there is a K dimension.
+///   7) There is an M or N dimension, and there is a K dimension.
 ///   8) linalgOp has the same body as an ordinary int or float matmul.
 ///
 /// These restrictions are required because data tiling currently creates


### PR DESCRIPTION
- Move the requirements to `isSupportedContractionOp`.
- Convert `SetContractionOpEncoding::matchAndRewrite` to `setDataTilingEncodings` method.
- Collect all the candidates, iterate and set encoding for each candidate.
- Refactor `postPatterns` for all the strategies.

It is a step towards https://github.com/iree-org/iree/issues/21246