### PR TITLE
Convert nanobind into a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "third_party/hsa-runtime-headers"]
 	path = third_party/hsa-runtime-headers
 	url = https://github.com/iree-org/hsa-runtime-headers.git
+[submodule "third_party/nanobind"]
+	path = third_party/nanobind
+	url = https://github.com/wjakob/nanobind.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,13 +839,7 @@ if(IREE_BUILD_PYTHON_BINDINGS)
   if(IREE_USE_SYSTEM_DEPS)
     find_package(nanobind REQUIRED)
   else()
-    include(FetchContent)
-    FetchContent_Declare(
-        nanobind
-        GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-        GIT_TAG        0f9ce749b257fdfe701edb3cf6f7027ba029434a # v2.4.0
-    )
-    FetchContent_MakeAvailable(nanobind)
+    add_subdirectory(third_party/nanobind EXCLUDE_FROM_ALL)
   endif()
 endif()
 

--- a/build_tools/scripts/git/runtime_submodules.txt
+++ b/build_tools/scripts/git/runtime_submodules.txt
@@ -5,6 +5,7 @@ third_party/googletest
 third_party/hip-build-deps
 third_party/hsa-runtime-headers
 third_party/musl
+third_party/nanobind
 third_party/spirv_cross
 third_party/tracy
 third_party/vulkan_headers


### PR DESCRIPTION
The motivation for this change was the need to cherry-pick nanobind@3a33b85 to build w/ recent versions of Clang. While experimenting w/ getting a build to pass locally, I found it easier to tweak a submodule than messing w/ a patchfile + FetchContent.