### PR TITLE
[LLVMGPU] Unroll elementwise operations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -183,6 +184,52 @@ struct SetMulAddFMF final : OpRewritePattern<vector::MultiDimReductionOp> {
   }
 };
 
+struct UnrollElementwiseOps : public RewritePattern {
+  UnrollElementwiseOps(MLIRContext *context, PatternBenefit benefit = 1)
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (!OpTrait::hasElementwiseMappableTraits(op) || op->getNumResults() != 1)
+      return failure();
+
+    Location loc = op->getLoc();
+    VectorType dstVecTy = dyn_cast<VectorType>(op->getResult(0).getType());
+    if (!dstVecTy || dstVecTy.getRank() <= 1) {
+      return failure();
+    }
+    ArrayRef<int64_t> originalSize = dstVecTy.getShape();
+
+    Value result = ub::PoisonOp::create(rewriter, loc, dstVecTy);
+    auto subVecTy =
+        VectorType::get({originalSize.back()}, dstVecTy.getElementType());
+
+    SmallVector<int64_t> tileShape(dstVecTy.getRank() - 1, 1);
+    for (SmallVector<int64_t> offsets :
+         StaticTileOffsetRange(originalSize.drop_back(), tileShape)) {
+      // Extract from each operand.
+      SmallVector<Value> operands;
+      for (Value val : op->getOperands()) {
+        // Extract subvector if the operand is a vector. This is to handle
+        // things like arith.select which take a scalar conditional but are
+        // otherwise elementwise.
+        if (isa<VectorType>(val.getType())) {
+          val = vector::ExtractOp::create(rewriter, loc, val, offsets);
+        }
+        operands.push_back(val);
+      }
+
+      Operation *clonedOp = clone(rewriter, op, subVecTy, operands);
+      Value subResult = clonedOp->getResult(0);
+      result =
+          vector::InsertOp::create(rewriter, loc, subResult, result, offsets);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -228,6 +275,7 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorMultiReductionLoweringPatterns(
           contractLoweringPatterns,
           vector::VectorMultiReductionLowering::InnerReduction);
+      contractLoweringPatterns.add<UnrollElementwiseOps>(funcOp->getContext());
       if (failed(applyPatternsGreedily(funcOp,
                                        std::move(contractLoweringPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -184,7 +184,7 @@ struct SetMulAddFMF final : OpRewritePattern<vector::MultiDimReductionOp> {
   }
 };
 
-struct UnrollElementwiseOps : public RewritePattern {
+struct UnrollElementwiseOps final : public RewritePattern {
   UnrollElementwiseOps(MLIRContext *context, PatternBenefit benefit = 1)
       : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -108,13 +108,8 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 }
 
 // CHECK-LABEL: func.func @multi_reduction_f32
-// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
-// CHECK:      %[[FMA:.+]] = math.fma %{{.*}}, %{{.*}}, %[[V0]] fastmath<contract> : vector<2x1x8xf32>
-// CHECK:      %[[E0:.+]]  = vector.extract %[[FMA]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
-// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
-// CHECK:      %[[E1:.+]]  = vector.extract %[[FMA]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
-// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32
+// CHECK-COUNT-2: math.fma
+// CHECK-COUNT-2: vector.reduction
 
 func.func @multi_reduction_no_uplift(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> vector<2x1xf32> {
   %cst_4 = arith.constant dense<0.000000e+00> : vector<2x1xf32>
@@ -126,11 +121,7 @@ func.func @multi_reduction_no_uplift(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32
 }
 
 // CHECK-LABEL: func.func @multi_reduction_no_uplift
-// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
-// CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : vector<2x1x8xf32>
-// CHECK:      %[[ADD:.+]] = arith.addf %[[MUL]], %[[V0]] : vector<2x1x8xf32>
-// CHECK:      %[[E0:.+]]  = vector.extract %[[ADD]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
-// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
-// CHECK:      %[[E1:.+]]  = vector.extract %[[ADD]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
-// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32
+// CHECK-NOT: math.fma
+// CHECK-COUNT-2: arith.mulf
+// CHECK-COUNT-2: arith.addf
+// CHECK-COUNT-2: vector.reduction


### PR DESCRIPTION
LLVM doesn't support N-D vectors. To emulate them, we pass N-D vectors as array< array < ... vector<> >>>. This heavily relies on LLVM to clean up whatever aggregates we created.  We should ideally never be doing this.

Since N-D vectors are not supported by LLVM, most of vector dialect operations, other than elementwise operations, actually unroll to 1-D vectors before lowering. This causes a weird intermediate state where vector dialect operations are working on 1-D operations, but insert into aggregates to do elementwise operations. This also prevents foldings between vector dialect operations and aggregate elementwise operations.

To fix this, we unroll all elementwise operations to 1-D vectors before lowering. Note that this is exactly what LLVM would do for us, so there should be no real performance difference, other than some more foldings running before passing to LLVM.