### PR TITLE
[CPU][NFC] Improve code quality and make few methods local.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -63,7 +63,8 @@ static LogicalResult verifyMultiTilingExpertPassPipelineConfig(
     }
   }
 
-  for (int i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e; ++i) {
+  for (unsigned i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e;
+       ++i) {
     if (!loweringConfig.hasTilingLevel(i)) {
       continue;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -38,6 +38,182 @@ public:
 };
 } // namespace
 
+static bool isValidInterchange(ArrayRef<int64_t> interchange, int numLoops) {
+  if (interchange.empty()) {
+    return true;
+  }
+  return isPermutationVector(interchange) && interchange.size() == numLoops;
+}
+
+/// Verifies if the tile sizes from `loweringConfig` are valid for each level.
+static LogicalResult verifyMultiTilingExpertPassPipelineConfig(
+    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig) {
+
+  auto interfaceOp = dyn_cast_or_null<TilingInterface>(op);
+  if (!interfaceOp) {
+    return success();
+  }
+
+  // Collects parallel loops.
+  llvm::SmallDenseSet<unsigned> pLoopsSet;
+  for (auto [index, iteratorType] :
+       llvm::enumerate(interfaceOp.getLoopIteratorTypes())) {
+    if (iteratorType == utils::IteratorType::parallel) {
+      pLoopsSet.insert(index);
+    }
+  }
+
+  for (int i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e; ++i) {
+    if (!loweringConfig.hasTilingLevel(i)) {
+      continue;
+    }
+
+    auto level = static_cast<IREE::CPU::TilingLevel>(i);
+    auto tilingLevelAttr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(level));
+    switch (level) {
+    case IREE::CPU::TilingLevel::DistributionTiles:
+    case IREE::CPU::TilingLevel::CacheParallelTiles:
+    case IREE::CPU::TilingLevel::VectorCommonParallelTiles:
+    case IREE::CPU::TilingLevel::VectorInnerParallelTiles: {
+      for (auto [index, tileSize] :
+           llvm::enumerate(tilingLevelAttr.getSizes())) {
+        if (tileSize != 0 && !pLoopsSet.contains(index)) {
+          return op->emitOpError(
+                     "expected only parallel dims to be set in the ")
+                 << IREE::CPU::getTilingLevelName(level)
+                 << " tiling level, but tile size at index (" << index
+                 << ") was also set";
+        }
+      }
+      break;
+    }
+    case IREE::CPU::TilingLevel::CacheReductionTiles:
+    case IREE::CPU::TilingLevel::VectorReductionTiles: {
+      for (auto [index, tileSize] :
+           llvm::enumerate(tilingLevelAttr.getSizes())) {
+        if (tileSize != 0 && pLoopsSet.contains(index)) {
+          return op->emitOpError(
+                     "expected only reduction dims to be set in the ")
+                 << IREE::CPU::getTilingLevelName(level)
+                 << " tiling level, but tile size at index (" << index
+                 << ") was also set";
+        }
+      }
+      break;
+    }
+    case IREE::CPU::TilingLevel::MaxNumTileLevels:
+    case IREE::CPU::TilingLevel::InvalidLevel:
+      break;
+    };
+
+    ArrayRef<int64_t> interchange = tilingLevelAttr.getInterchange();
+    size_t expectedSize = tilingLevelAttr.getSizes().size();
+    if (!isValidInterchange(interchange, expectedSize)) {
+      return op->emitOpError("expected [0, ")
+             << expectedSize << ") to be set exactly once in interchange for "
+             << IREE::CPU::getTilingLevelName(level) << " tiling level";
+    }
+  }
+
+  return success();
+}
+
+/// Verifies that the given `loweringConfig` can decompose convolution ops to
+/// lower dim ops. It requires {Distribution, VectorCommonParallel,
+/// VectorReduction} tiling levels.
+static LogicalResult verifyConvTileAndDecomposeExpertConfig(
+    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig) {
+  if (!isa<linalg::ConvolutionOpInterface>(op)) {
+    return success();
+  }
+
+  auto getTileSizeAtIndex = [](ArrayRef<int64_t> sizes,
+                               ArrayRef<bool> scalableFlags,
+                               unsigned index) -> std::pair<int64_t, bool> {
+    return std::make_pair(sizes[index],
+                          index < scalableFlags.size() && scalableFlags[index]);
+  };
+
+  SmallVector<IREE::CPU::TilingLevel> requiredLevels = {
+      IREE::CPU::DistributionTiles, IREE::CPU::VectorCommonParallelTiles,
+      IREE::CPU::VectorReductionTiles};
+  linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(op);
+  SmallVector<int64_t> shapeAfterTiling = linalgOp.getStaticLoopRanges();
+  for (auto level : requiredLevels) {
+    if (!loweringConfig.hasTilingLevel(level)) {
+      return op->emitOpError("expected ")
+             << IREE::CPU::getTilingLevelName(level) << " is set";
+    }
+    auto tilingLevelAttr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        loweringConfig.getTilingLevelAttr(level));
+    for (size_t i = 0, e = tilingLevelAttr.getSizes().size(); i < e; ++i) {
+      auto [size, scalableFlag] = getTileSizeAtIndex(
+          tilingLevelAttr.getSizes(), tilingLevelAttr.getScalableFlags(), i);
+      if (scalableFlag) {
+        shapeAfterTiling[i] = ShapedType::kDynamic;
+        continue;
+      }
+      if (size == 1) {
+        shapeAfterTiling[i] = 1;
+        continue;
+      }
+      if (ShapedType::isDynamicShape(shapeAfterTiling[i]) ||
+          ShapedType::isDynamic(size) || size == 0) {
+        continue;
+      }
+      if (shapeAfterTiling[i] % size != 0) {
+        shapeAfterTiling[i] = ShapedType::kDynamic;
+      } else {
+        shapeAfterTiling[i] = size;
+      }
+    }
+  }
+
+  int64_t khSize, kwSize, ohSize, owSize;
+  auto isSizeExtracted =
+      TypeSwitch<Operation *, LogicalResult>(op)
+          .Case<linalg::Conv2DNhwcHwcfOp, linalg::DepthwiseConv2DNhwcHwcOp,
+                linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+                linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+                linalg::PoolingNhwcMinUnsignedOp>([&](auto) {
+            // shape: N, OH, OW, OC, KH, KW, (IC)
+            khSize = shapeAfterTiling[4];
+            kwSize = shapeAfterTiling[5];
+            ohSize = shapeAfterTiling[1];
+            owSize = shapeAfterTiling[2];
+            return success();
+          })
+          .Case<linalg::Conv2DNchwFchwOp>([&](auto) {
+            // shape: N, OC, OH, OW, (IC), KH, KW
+            khSize = shapeAfterTiling[5];
+            kwSize = shapeAfterTiling[6];
+            ohSize = shapeAfterTiling[2];
+            owSize = shapeAfterTiling[3];
+            return success();
+          })
+          .Case<linalg::PoolingNchwSumOp, linalg::PoolingNchwMaxOp>([&](auto) {
+            // shape: N, OC, OH, OW, KH, KW
+            khSize = shapeAfterTiling[4];
+            kwSize = shapeAfterTiling[5];
+            ohSize = shapeAfterTiling[2];
+            owSize = shapeAfterTiling[3];
+            return success();
+          })
+          .Default([&](auto) { return failure(); });
+  if (failed(isSizeExtracted)) {
+    return op->emitOpError("unsupported conv types");
+  }
+
+  bool removeH = (khSize == 1 && ohSize == 1);
+  bool removeW = (kwSize == 1 && owSize == 1);
+  if (!removeH && !removeW) {
+    return op->emitOpError("can't decompose the conv op");
+  }
+
+  return success();
+}
+
 /// Verify that valid configuration is set for all ops within the funcOp.
 template <typename F>
 static LogicalResult verifyLoweringConfiguration(FunctionOpInterface funcOp,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -148,8 +148,6 @@ addTileAndDistributePasses(OpPassManager &funcPassManager,
   funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
 }
 
-
-
 //===---------------------------------------------------------------------===//
 // Codegen pipelines.
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -148,181 +148,7 @@ addTileAndDistributePasses(OpPassManager &funcPassManager,
   funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
 }
 
-//===---------------------------------------------------------------------===//
-// Codegen configuration verifications.
-//===---------------------------------------------------------------------===//
 
-static bool isValidInterchange(ArrayRef<int64_t> interchange, int numLoops) {
-  if (interchange.empty()) {
-    return true;
-  }
-  return isPermutationVector(interchange) && interchange.size() == numLoops;
-}
-
-LogicalResult verifyMultiTilingExpertPassPipelineConfig(
-    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig) {
-
-  auto interfaceOp = dyn_cast_or_null<TilingInterface>(op);
-  if (!interfaceOp) {
-    return success();
-  }
-
-  // Collects parallel loops.
-  llvm::SmallDenseSet<unsigned> pLoopsSet;
-  for (auto [index, iteratorType] :
-       llvm::enumerate(interfaceOp.getLoopIteratorTypes())) {
-    if (iteratorType == utils::IteratorType::parallel) {
-      pLoopsSet.insert(index);
-    }
-  }
-
-  for (int i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e; ++i) {
-    if (!loweringConfig.hasTilingLevel(i)) {
-      continue;
-    }
-
-    auto level = static_cast<IREE::CPU::TilingLevel>(i);
-    auto tilingLevelAttr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
-        loweringConfig.getTilingLevelAttr(level));
-    switch (level) {
-    case IREE::CPU::TilingLevel::DistributionTiles:
-    case IREE::CPU::TilingLevel::CacheParallelTiles:
-    case IREE::CPU::TilingLevel::VectorCommonParallelTiles:
-    case IREE::CPU::TilingLevel::VectorInnerParallelTiles: {
-      for (auto [index, tileSize] :
-           llvm::enumerate(tilingLevelAttr.getSizes())) {
-        if (tileSize != 0 && !pLoopsSet.contains(index)) {
-          return op->emitOpError(
-                     "expected only parallel dims to be set in the ")
-                 << IREE::CPU::getTilingLevelName(level)
-                 << " tiling level, but tile size at index (" << index
-                 << ") was also set";
-        }
-      }
-      break;
-    }
-    case IREE::CPU::TilingLevel::CacheReductionTiles:
-    case IREE::CPU::TilingLevel::VectorReductionTiles: {
-      for (auto [index, tileSize] :
-           llvm::enumerate(tilingLevelAttr.getSizes())) {
-        if (tileSize != 0 && pLoopsSet.contains(index)) {
-          return op->emitOpError(
-                     "expected only reduction dims to be set in the ")
-                 << IREE::CPU::getTilingLevelName(level)
-                 << " tiling level, but tile size at index (" << index
-                 << ") was also set";
-        }
-      }
-      break;
-    }
-    case IREE::CPU::TilingLevel::MaxNumTileLevels:
-    case IREE::CPU::TilingLevel::InvalidLevel:
-      break;
-    };
-
-    ArrayRef<int64_t> interchange = tilingLevelAttr.getInterchange();
-    size_t expectedSize = tilingLevelAttr.getSizes().size();
-    if (!isValidInterchange(interchange, expectedSize)) {
-      return op->emitOpError("expected [0, ")
-             << expectedSize << ") to be set exactly once in interchange for "
-             << IREE::CPU::getTilingLevelName(level) << " tiling level";
-    }
-  }
-
-  return success();
-}
-
-LogicalResult verifyConvTileAndDecomposeExpertConfig(
-    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig) {
-  if (!isa<linalg::ConvolutionOpInterface>(op)) {
-    return success();
-  }
-
-  auto getTileSizeAtIndex = [](ArrayRef<int64_t> sizes,
-                               ArrayRef<bool> scalableFlags,
-                               unsigned index) -> std::pair<int64_t, bool> {
-    return std::make_pair(sizes[index],
-                          index < scalableFlags.size() && scalableFlags[index]);
-  };
-
-  SmallVector<IREE::CPU::TilingLevel> requiredLevels = {
-      IREE::CPU::DistributionTiles, IREE::CPU::VectorCommonParallelTiles,
-      IREE::CPU::VectorReductionTiles};
-  linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(op);
-  SmallVector<int64_t> shapeAfterTiling = linalgOp.getStaticLoopRanges();
-  for (auto level : requiredLevels) {
-    if (!loweringConfig.hasTilingLevel(level)) {
-      return op->emitOpError("expected ")
-             << IREE::CPU::getTilingLevelName(level) << " is set";
-    }
-    auto tilingLevelAttr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
-        loweringConfig.getTilingLevelAttr(level));
-    for (size_t i = 0, e = tilingLevelAttr.getSizes().size(); i < e; ++i) {
-      auto [size, scalableFlag] = getTileSizeAtIndex(
-          tilingLevelAttr.getSizes(), tilingLevelAttr.getScalableFlags(), i);
-      if (scalableFlag) {
-        shapeAfterTiling[i] = ShapedType::kDynamic;
-        continue;
-      }
-      if (size == 1) {
-        shapeAfterTiling[i] = 1;
-        continue;
-      }
-      if (ShapedType::isDynamicShape(shapeAfterTiling[i]) ||
-          ShapedType::isDynamic(size) || size == 0) {
-        continue;
-      }
-      if (shapeAfterTiling[i] % size != 0) {
-        shapeAfterTiling[i] = ShapedType::kDynamic;
-      } else {
-        shapeAfterTiling[i] = size;
-      }
-    }
-  }
-
-  int64_t khSize, kwSize, ohSize, owSize;
-  auto isSizeExtracted =
-      TypeSwitch<Operation *, LogicalResult>(op)
-          .Case<linalg::Conv2DNhwcHwcfOp, linalg::DepthwiseConv2DNhwcHwcOp,
-                linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
-                linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
-                linalg::PoolingNhwcMinUnsignedOp>([&](auto) {
-            // shape: N, OH, OW, OC, KH, KW, (IC)
-            khSize = shapeAfterTiling[4];
-            kwSize = shapeAfterTiling[5];
-            ohSize = shapeAfterTiling[1];
-            owSize = shapeAfterTiling[2];
-            return success();
-          })
-          .Case<linalg::Conv2DNchwFchwOp>([&](auto) {
-            // shape: N, OC, OH, OW, (IC), KH, KW
-            khSize = shapeAfterTiling[5];
-            kwSize = shapeAfterTiling[6];
-            ohSize = shapeAfterTiling[2];
-            owSize = shapeAfterTiling[3];
-            return success();
-          })
-          .Case<linalg::PoolingNchwSumOp, linalg::PoolingNchwMaxOp>([&](auto) {
-            // shape: N, OC, OH, OW, KH, KW
-            khSize = shapeAfterTiling[4];
-            kwSize = shapeAfterTiling[5];
-            ohSize = shapeAfterTiling[2];
-            owSize = shapeAfterTiling[3];
-            return success();
-          })
-          .Default([&](auto) { return failure(); });
-  if (failed(isSizeExtracted)) {
-    return op->emitOpError("unsupported conv types");
-  }
-
-  bool removeH = (khSize == 1 && ohSize == 1);
-  bool removeW = (kwSize == 1 && owSize == 1);
-  if (!removeH && !removeW) {
-    return op->emitOpError("can't decompose the conv op");
-  }
-
-  return success();
-}
 
 //===---------------------------------------------------------------------===//
 // Codegen pipelines.
@@ -365,7 +191,7 @@ void buildLLVMCPUVectorLoweringPipeline(
 }
 
 void addCPUBufferOpsTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   // Skip tiling reduction loops because this is expected to apply on copy ops
@@ -403,7 +229,7 @@ void addCPUBufferOpsTileAndVectorizePipeline(
 void addMultiTilingExpertPassPipeline(
     OpPassManager &funcPassManager,
     IREE::Codegen::LoweringConfigAttrInterface loweringConfig,
-    LLVMCPUPipelineOptions &pipelineOpt) {
+    const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   for (int i = 0, e = IREE::CPU::TilingLevel::MaxNumTileLevels; i < e; ++i) {
     auto level = static_cast<IREE::CPU::TilingLevel>(i);
@@ -501,7 +327,7 @@ void addMultiTilingExpertPassPipeline(
 }
 
 void addConvTileAndDecomposeExpertPassPipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
@@ -558,8 +384,8 @@ void addConvTileAndDecomposeExpertPassPipeline(
   }
 }
 
-void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      LLVMCPUPipelineOptions &pipelineOpt) {
+void addMmt4dTilingExpertPassPipeline(
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
@@ -608,7 +434,7 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
 }
 
 void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
-                              LLVMCPUPipelineOptions &pipelineOpt) {
+                              const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
 
   // The below two passes are nop if pack/unpack is not specified in ukernels
@@ -650,7 +476,7 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
 }
 
 void addCPULinalgExtTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt) {
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseProducerConsumerPass(
       IREE::CPU::TilingLevel::VectorCommonParallelTiles));
@@ -691,7 +517,7 @@ void addCPULinalgExtTileAndVectorizePipeline(
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               LLVMCPUPipelineOptions &pipelineOpt) {
+                               const LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager, pipelineOpt);
   funcPassManager.addPass(createLLVMCPUTileAndFusePass(
       IREE::CPU::TilingLevel::VectorCommonParallelTiles));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -87,53 +87,33 @@ struct LLVMCPUPipelineOptions {
 /// pipeline is only used for dispatches that just copy data from input
 /// interfaces to output interface.
 void addCPUBufferOpsTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
-                              LLVMCPUPipelineOptions &pipelineOpt);
+                              const LLVMCPUPipelineOptions &pipelineOpt);
 
 void addCPULinalgExtTileAndVectorizePipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes to lower scalars and unknown tensor op (i.e. linalg op
 /// that is not specialized by any pipeline). Adds an additional level of tiling
 /// and converts to memrefs.
 void addCPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               LLVMCPUPipelineOptions &pipelineOpt);
+                               const LLVMCPUPipelineOptions &pipelineOpt);
 
 void addConvTileAndDecomposeExpertPassPipeline(
-    OpPassManager &funcPassManager, LLVMCPUPipelineOptions &pipelineOpt);
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize
 /// lowering of linalg ops on tensors to vectors operations.
-void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
-                                      LLVMCPUPipelineOptions &pipelineOpt);
+void addMmt4dTilingExpertPassPipeline(
+    OpPassManager &funcPassManager, const LLVMCPUPipelineOptions &pipelineOpt);
 
 void addMultiTilingExpertPassPipeline(
     OpPassManager &funcPassManager,
     IREE::Codegen::LoweringConfigAttrInterface loweringConfig,
-    LLVMCPUPipelineOptions &pipelineOpt);
-
-void addTensorToVectorsPassPipeline(OpPassManager &funcPassManager,
-                                    bool lowerToVectors = true);
-
-/// Verifies that the given `loweringConfig` can decompose convolution ops to
-/// lower dim ops. It requires {Distribution, VectorCommonParallel,
-/// VectorReduction} tiling levels.
-LogicalResult verifyConvTileAndDecomposeExpertConfig(
-    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig);
-
-/// Verifies if the tile sizes from `loweringConfig` are valid for each level.
-LogicalResult verifyMultiTilingExpertPassPipelineConfig(
-    Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig);
-
-/// Populates the passes needed to multi level tile and lowering of linalg ops
-/// on tensors to vectors operations.
-LogicalResult verifyTensorToVectorsPassPipelineConfig(
-    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
-    IREE::Codegen::TranslationInfoAttr translationInfo,
-    ArrayRef<int64_t> workgroupSize = {});
+    const LLVMCPUPipelineOptions &pipelineOpt);
 
 //----------------------------------------------------------------------------//
 // LLVMCPU Pass Pipelines for lowering to LLVM dialect.
@@ -144,9 +124,9 @@ LogicalResult verifyTensorToVectorsPassPipelineConfig(
 void buildLLVMCPUCodegenConfigurationPassPipeline(
     OpPassManager &variantPassManager);
 
-/// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
-/// structured ops path. The pass manager `pm` in here should operate on the
-/// module within the IREE::HAL::ExecutableOp.
+/// Populates passes needed to lower high level ops, e.g., linalg, vector, etc,
+/// to LLVM dialect via the structured ops path. The  `variantPassManager`
+/// should operate on the module within the IREE::HAL::ExecutableOp.
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &variantPassManager,
                                      bool enableAArch64SME = false);
 


### PR DESCRIPTION
- Add `const` keyword to pipeline options
- Make lowering config verification be local functions.
- Refresh outdated comment for buildLLVMCPUCodegenPassPipeline.
- Delete two dead function declarations:
  - `addTensorToVectorsPassPipeline`
  - `verifyTensorToVectorsPassPipelineConfig`