### PR TITLE
[DispatchCreation] Fix trailing unit dims case for collapse of expand folding

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -86,7 +86,6 @@ struct DropUnitDimsFromCollapseOfExpand
         if (indices.size() == 1 || interShape[inDim] != 1) {
           continue;
         }
-
         toDrop.insert(inDim);
       }
     }

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -81,38 +81,27 @@ struct DropUnitDimsFromCollapseOfExpand
     // `collapseOp` op.
     llvm::SmallDenseSet<int64_t> toDrop;
     for (const auto &[outDim, indices] : llvm::enumerate(collapseReassoc)) {
-      //int64_t countUnitIdxs = 0;
-      //bool foundFirstUnitDim = false;
-      //int64_t firstUnitDim;
       for (auto [innerIdx, inDim] : llvm::enumerate(indices)) {
         // Can't drop this dim if it isnt statically 1 or if it isn't being
         // combined with any other dimensions.
         if (indices.size() == 1 || interShape[inDim] != 1) {
           continue;
         }
+
         // If we are collapsing multiple unit dims together, at least 1 must be
         // kept (prefer the first).
-        if (outShape[outDim] == 1 && innerIdx != 0) 
+        if (outShape[outDim] == 1 && innerIdx != 0) {
           continue;
-        //if (!foundFirstUnitDim) {
-          //firstUnitDim = inDim;
-          //foundFirstUnitDim = true;
-        //}
-        //countUnitIdxs++;
-
+        }
         toDrop.insert(inDim);
       }
-      // If we found multiple unit dims, we need to keep the first one.
-      //if (countUnitIdxs > 1 && foundFirstUnitDim) {
-      //  toDrop.erase(firstUnitDim);
-      //}
     }
 
     // Remove dimensions from `toDrop` that weren't introduced by the
     // `expandOp` op.
     const auto expandReassoc = expandOp.getReassociationIndices();
     for (const auto &[inDim, indices] : llvm::enumerate(expandReassoc)) {
-      if (indices.size() == 1 || srcShape[inDim] == 1) {
+      if (indices.size() == 1 || srcShape[inDim]==1) {
         toDrop.erase(indices[0]);
       }
     }
@@ -182,6 +171,7 @@ struct DropUnitDimsFromCollapseOfExpand
         expandedDim += newExpandReassoc.back().size();
       }
     }
+
     // Construct the new expand_shape and collapse_shape ops.
     // Note: we must handle the cases where the expand/collapse is no longer
     // needed. Both ops require a non-identity reassociation (i.e. they can't be

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -86,6 +86,13 @@ struct DropUnitDimsFromCollapseOfExpand
         if (indices.size() == 1 || interShape[inDim] != 1) {
           continue;
         }
+
+        // If outShape[outDim] == 1, we must preserve 1 unit dim,
+        // so we drop the first. If the first is the only unit dim,
+        // we can't drop it anyway.
+        if (outShape[outDim] == 1 && innerIdx == 0) {
+          continue;
+        }
         toDrop.insert(inDim);
       }
     }
@@ -93,10 +100,13 @@ struct DropUnitDimsFromCollapseOfExpand
     // Remove dimensions from `toDrop` that weren't introduced by the
     // `expandOp` op.
     const auto expandReassoc = expandOp.getReassociationIndices();
-    for (const auto &[inDim, indices] : llvm::enumerate(expandReassoc)) {
+    for (const auto &indices : expandReassoc) {
+      // If all of indices are in `toDrop`, we must preserve at least one
+      // to avoid an empty reassociation map during expansion.
+      // This can happen when outShape does not have a unit dimension
+      // corresponding to the unit dimensions being dropped here.
       if (llvm::all_of(indices,
                        [&](int64_t idx) { return toDrop.contains(idx); })) {
-
         toDrop.erase(indices[0]);
       }
     }

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -312,3 +312,18 @@ util.func @collapse_of_expand_to_scalar(%arg0: tensor<1x1xf16>, %arg1: index, %a
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<1x1xf16> into tensor<f16>
 //       CHECK:   util.return %[[COLLAPSED]] : tensor<f16>
+
+// -----
+
+util.func @collapse_of_expand_trailing_unit_dims(%arg0: tensor<23040x1xbf16>) -> tensor<4x5760xbf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [4, 5760, 1, 1] : tensor<23040x1xbf16> into tensor<4x5760x1x1xbf16>
+  %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3]] : tensor<4x5760x1x1xbf16> into tensor<4x5760xbf16>
+  util.return %collapsed : tensor<4x5760xbf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_trailing_unit_dims
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<23040x1xbf16>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<23040x1xbf16> into tensor<4x5760x1xbf16>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
+//  CHECK-SAME:     tensor<4x5760x1xbf16> into tensor<4x5760xbf16>
+//       CHECK:   util.return %[[COLLAPSE]] : tensor<4x5760xbf16>

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -327,3 +327,20 @@ util.func @collapse_of_expand_trailing_unit_dims(%arg0: tensor<23040x1xbf16>) ->
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
 //  CHECK-SAME:     tensor<4x5760x1xbf16> into tensor<4x5760xbf16>
 //       CHECK:   util.return %[[COLLAPSE]] : tensor<4x5760xbf16>
+
+// -----
+
+// This test considers the case where we have multiple trailing unit dims but must preserve one for the output,
+// as well as an isolated unit dim that must be preserved for the collapse's reassociation dims.
+util.func @collapse_of_expand_preserved_trailing_unit_dims(%arg0: tensor<1x23040xbf16>) -> tensor<4x5760x1xbf16> {
+  %expanded = tensor.expand_shape %arg0 [[0], [1, 2, 3, 4, 5]] output_shape [1, 4, 5760, 1, 1, 1] : tensor<1x23040xbf16> into tensor<1x4x5760x1x1x1xbf16>
+  %collapsed = tensor.collapse_shape %expanded [[0, 1], [2], [3, 4, 5]] : tensor<1x4x5760x1x1x1xbf16> into tensor<4x5760x1xbf16>
+  util.return %collapsed : tensor<4x5760x1xbf16>
+}
+// CHECK-LABEL: util.func public @collapse_of_expand_preserved_trailing_unit_dims
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x23040xbf16>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1x23040xbf16> into tensor<1x4x5760x1xbf16>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
+//  CHECK-SAME:     tensor<1x4x5760x1xbf16> into tensor<4x5760x1xbf16>
+//       CHECK:   util.return %[[COLLAPSE]] : tensor<4x5760x1xbf16>


### PR DESCRIPTION
Previous logic only prevented collapsing all unit dims in a reassociation element if the first element of the reassociation represented a unit dim in the input.

i.e. it worked for cases like 1x1x44x5 -> 1x44x5
but failed for 5x44x1x1 -> 5x44x1