### PR TITLE
[Codegen] Skinny mm/bmm/mv : use to vector distribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -23,11 +23,8 @@ func.func @static_batch_matvec() {
   return
 }
 
-
-// CHECK:     LLVMGPUWarpReduction
+// CHECK:     LLVMGPUVectorDistribute
 // CDNA3:     LLVMGPUTileAndFuse
-
-// We want to deprecate LLVMGPUWarpReduction. Currently LLVMGPUVectorDistribution is not chosen in setReductionVectorDistributionConfig because it fails in 'hasReductionIterator' (which doesn't check specialized ops). This might be an easy whitelisting fix, but I will return to this later (TODO(newling)).
 
 // -----
 
@@ -318,7 +315,7 @@ func.func @i4_dequant_matvec() {
 
 // -----
 
-// Send 2xNxK mmt to the warp reduction pipeline.
+// Send 2xNxK mmt to the vector distribute pipline.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -340,12 +337,7 @@ func.func @skinny_mmt() {
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 512]{{\]}}>
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//       CHECK: func.func @skinny_mmt()
-//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   linalg.matmul_transpose_b
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+// CHECK: LLVMGPUVectorDistribute
 
 // -----
 
@@ -371,12 +363,7 @@ func.func @skinny_mmt() {
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 512]{{\]}}>
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//       CHECK: func.func @skinny_mmt()
-//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   linalg.matmul_transpose_b
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+// CHECK: LLVMGPUVectorDistribute
 
 // -----
 


### PR DESCRIPTION
Before this PR, use of vector distribute was gated on this ad hoc constraint:
```
isa<linalg::ReduceOp, linalg::GenericOp>(op) && llvm::any_of(op.getIteratorTypesArray(), linalg::isReductionIterator);
```

For this PR I wanted to relax that gate to just 

```
llvm::any_of(op.getIteratorTypesArray(), linalg::isReductionIterator)
```
 
 But that failed because there is a test `pooling_dynamic` in nvvm_pipeline.mlir
 that, when it goes down vector distribution, hits an assertion failure in
configure-tensor-layouts about one of the operands not having a projection 
permutation. 

I assume that's because layout inference scheme doesn't work well unless the maps 
are just permutations/projections? 

This PR works around this by gating on not having any non-projecting maps. 
