### PR TITLE
[ROCM] Update Ukernel infra to allow ROCM-specific bitcode ukernel lowering

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/BUILD.bazel
@@ -28,6 +28,7 @@ iree_td_library(
         include = ["*.td"],
     ),
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:td_files",
         "//compiler/src/iree/compiler/Dialect/Util/IR:td_files",
         "@llvm-project//mlir:DialectUtilsTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -64,6 +65,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
     ],
@@ -102,5 +104,6 @@ iree_gentbl_cc_library(
     td_file = "ROCMAttrs.td",
     deps = [
         ":td_files",
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:td_files",
     ],
 )

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     ::ROCMDialectGen
     LLVMSupport
     MLIRIR
+    MLIRLinalgDialect
     MLIRParser
     MLIRSupport
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -79,7 +79,7 @@ static LogicalResult handleArgmaxUkernel(
   return success();
 }
 
-LogicalResult UKernelProviderAttr::createAndReplaceWithUkernelOp(
+std::optional<LogicalResult> UKernelProviderAttr::createAndReplaceWithUkernelOp(
     RewriterBase &rewriter, StringRef name, DictionaryAttr targetConfiguration,
     Operation *contextualOp, SmallVectorImpl<Value> &inputs,
     SmallVectorImpl<Value> &outputs,
@@ -89,7 +89,7 @@ LogicalResult UKernelProviderAttr::createAndReplaceWithUkernelOp(
                                contextualOp, inputs, outputs, otherOperands);
   }
   // TODO(avarma): Add multi_mfma ukernel support via descriptors.
-  return failure();
+  return std::nullopt;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -6,7 +6,9 @@
 
 #include "compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h"
 #include "compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
@@ -25,6 +27,72 @@ FailureOr<mlir::ModuleOp>
 BuiltinTuningModuleAttr::getModule(Operation * /*annotationSite*/) const {
   auto &rocmDialect = cast<ROCMDialect>(getDialect());
   return rocmDialect.getOrLoadBuiltinModule(getBuiltinFilename());
+}
+
+//===----------------------------------------------------------------------===//
+// UKernelProviderAttr
+//===----------------------------------------------------------------------===//
+
+/// Utility function to help create and replace argmax linalg with a ukernel.
+static LogicalResult handleArgmaxUkernel(RewriterBase &rewriter, StringRef name,
+                                         DictionaryAttr targetConfiguration,
+                                         Operation *contextualOp,
+                                         SmallVector<Value> &inputs,
+                                         SmallVector<Value> &outputs,
+                                         SmallVector<Value> &otherOperands) {
+  auto genericOp = dyn_cast<linalg::GenericOp>(contextualOp);
+  if (!genericOp) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "expected a linalg.generic op for argmax");
+  }
+  // Currently only support 1D reduction, where reduc is on fastest dim.
+  // Tiling argmax ukernel is also set to enforce this structure.
+  const int kReductionDim = genericOp.getNumLoops() - 1;
+  Location loc = genericOp.getLoc();
+  Value reductionDimSize = rewriter.create<tensor::DimOp>(
+      loc, genericOp.getDpsInputOperand(0)->get(), kReductionDim);
+  bool isPureArgmax = genericOp.getResults()[0].use_empty();
+  Value writeMaxValueFlag = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getI1Type(), rewriter.getBoolAttr(!isPureArgmax));
+  otherOperands.push_back(reductionDimSize);
+  otherOperands.push_back(writeMaxValueFlag);
+  MLIRContext *context = rewriter.getContext();
+  auto fnDefAttrs = DictionaryAttr::get(
+      context, {{StringAttr::get(context, "vm.import.module"),
+                 StringAttr::get(context, "rocm")}});
+  auto ukernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
+      loc, contextualOp->getResults().getTypes(), name, inputs, outputs,
+      otherOperands, fnDefAttrs,
+      /*num_strided_outer_dims=*/0);
+  if (isPureArgmax) {
+    rewriter.replaceAllUsesWith(genericOp.getResults()[1],
+                                ukernelOp.getResults()[1]);
+  } else {
+    auto origResults = genericOp.getResults();
+    auto newResults = ukernelOp.getResults();
+    if (origResults.size() != newResults.size()) {
+      return rewriter.notifyMatchFailure(genericOp, "result count mismatch");
+    }
+    rewriter.replaceAllUsesWith(genericOp.getResults()[0],
+                                ukernelOp.getResults()[0]);
+    rewriter.replaceAllUsesWith(genericOp.getResults()[1],
+                                ukernelOp.getResults()[1]);
+  }
+  return success();
+}
+
+LogicalResult UKernelProviderAttr::createAndReplaceWithUkernelOp(
+    RewriterBase &rewriter, StringRef name, DictionaryAttr targetConfiguration,
+    Operation *contextualOp, SmallVector<Value> &inputs,
+    SmallVector<Value> &outputs, SmallVector<Value> &otherOperands) const {
+  if (name.contains("argmax")) {
+    return handleArgmaxUkernel(rewriter, name, targetConfiguration,
+                               contextualOp, inputs, outputs, otherOperands);
+  } else {
+    // TODO(avarma): Add multi_mfma ukernel support via descriptors.
+    return failure();
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.td
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.td
@@ -8,6 +8,7 @@
 #define IREE_PLUGINS_TARGET_ROCM_DIALECT_ROCMATTRS
 
 include "ROCMDialect.td"
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
@@ -36,6 +37,20 @@ def ROCM_BuiltinTuningModuleAttr :
     StringRefParameter<>:$builtin_filename
   );
   let assemblyFormat = "`<` $builtin_filename `>`";
+}
+
+def ROCM_UKernelProviderAttr  :
+    AttrDef<ROCM_Dialect, "UKernelProvider", [
+    DeclareAttrInterfaceMethods<IREECodegen_UKernelProviderInterface, [
+        "createAndReplaceWithUkernelOp"
+      ]>
+    ]> {
+  let mnemonic = "ukernel_provider";
+  let summary = [{
+    An attribute that provides context specific ukernel implementations for ROCM.
+  }];
+  let parameters = (ins);
+  let assemblyFormat = [{}];
 }
 
 #endif // IREE_PLUGINS_TARGET_ROCM_DIALECT_ROCMATTRS

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/test/roundtrip.mlir
@@ -1,8 +1,10 @@
 // RUN: iree-opt %s | iree-opt | FileCheck %s
 
 module @tuning_module attributes {
+  iree_codegen.ukernel_provider = #rocm.ukernel_provider,
   rocm.spec = #rocm.builtin.tuning_module<"iree_default_tuning_spec_gfx942.mlir"> } {
 }
 
 // CHECK-LABEL: module @tuning_module
+//  CHECK-SAME:   iree_codegen.ukernel_provider = #rocm.ukernel_provider
 //  CHECK-SAME:   #rocm.builtin.tuning_module<"iree_default_tuning_spec_gfx942.mlir">

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -330,6 +330,10 @@ public:
     }
 
     addConfig("ukernels", b.getStringAttr(options.enableROCMUkernels));
+    if (options.enableROCMUkernels != "none") {
+      addConfig("iree_codegen.ukernel_provider",
+                IREE::ROCM::UKernelProviderAttr::get(context));
+    }
     if (options.wavesPerEu > 0) {
       addConfigWavesPerEu(b.getContext(), options.wavesPerEu, configItems);
     }

--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
@@ -113,8 +113,9 @@ convertToUKernelGeneric(RewriterBase &rewriter, Operation *op, StringRef name,
   if (provider) {
     if (failed(provider.createAndReplaceWithUkernelOp(
             rewriter, name, targetConfiguration, op, tensorInputs,
-            tensorOutputs, otherOperands)))
+            tensorOutputs, otherOperands))) {
       return failure();
+    }
   } else {
     rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
         op, op->getResults().getTypes(), name, tensorInputs, tensorOutputs,

--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
@@ -116,12 +116,11 @@ convertToUKernelGeneric(RewriterBase &rewriter, Operation *op, StringRef name,
         op, op->getResults().getTypes(), name, tensorInputs, tensorOutputs,
         otherOperands, DictionaryAttr(),
         /*strided_outer_dims=*/0);
-  } else if (failed(provider.createAndReplaceWithUkernelOp(
-                 rewriter, name, targetConfiguration, op, tensorInputs,
-                 tensorOutputs, otherOperands))) {
-    return failure();
+    return success();
   }
-  return success();
+  return provider.createAndReplaceWithUkernelOp(
+      rewriter, name, targetConfiguration, op, tensorInputs, tensorOutputs,
+      otherOperands);
 }
 
 /// Replaces the operation `op` with the inlined body of the target function.

--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
@@ -110,17 +110,16 @@ convertToUKernelGeneric(RewriterBase &rewriter, Operation *op, StringRef name,
   }
 
   rewriter.setInsertionPoint(op);
-  if (provider) {
-    if (failed(provider.createAndReplaceWithUkernelOp(
-            rewriter, name, targetConfiguration, op, tensorInputs,
-            tensorOutputs, otherOperands))) {
-      return failure();
-    }
-  } else {
+  if (!provider) {
+    // Default ukernel generic op is created when a provider doesn't exist.
     rewriter.replaceOpWithNewOp<IREE::Codegen::UKernelGenericOp>(
         op, op->getResults().getTypes(), name, tensorInputs, tensorOutputs,
         otherOperands, DictionaryAttr(),
         /*strided_outer_dims=*/0);
+  } else if (failed(provider.createAndReplaceWithUkernelOp(
+                 rewriter, name, targetConfiguration, op, tensorInputs,
+                 tensorOutputs, otherOperands))) {
+    return failure();
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_bitcode_descriptor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_bitcode_descriptor.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt --iree-codegen-lower-bitcode-ukernels %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-lower-bitcode-ukernels --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: @ukernel_test
+// CHECK-LABEL: @ukernel_test_without_provider
 // CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]: tensor<16x32xf32>
 // CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]: tensor<16x32xf32>
 // CHECK-NOT:     linalg.generic
@@ -14,7 +14,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
-  func.func @ukernel_test(%arg0: tensor<16x32xf32>, %arg1: tensor<16x32xf32>) -> tensor<16x16xf32> {
+  func.func @ukernel_test_without_provider(%arg0: tensor<16x32xf32>, %arg1: tensor<16x32xf32>) -> tensor<16x16xf32> {
     %cst = arith.constant 0.000000e+00 : f32
     %0 = tensor.empty() : tensor<16x16xf32>
     %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<16x16xf32>) -> tensor<16x16xf32>
@@ -25,5 +25,75 @@ module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
       linalg.yield %4 : f32
     } -> tensor<16x16xf32>
     return %2 : tensor<16x16xf32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL:       @pure_argmax_ukernel_test_with_provider
+// CHECK-SAME:          %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:          %[[ARG1:[a-zA-Z0-9]+]]: tensor<f32>
+// CHECK-SAME:          %[[ARG2:[a-zA-Z0-9]+]]: tensor<i64>
+// CHECK:               %[[C0:.*]] = arith.constant 0 : index
+// CHECK:               %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xf32>
+// CHECK:               %[[FALSE:.*]] = arith.constant false
+// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f32i64"
+// CHECK-SAME:            ins(%[[ARG0]] : tensor<?xf32>)
+// CHECK-SAME:            outs(%[[ARG1]], %[[ARG2]] : tensor<f32>, tensor<i64>)
+// CHECK-SAME:            (%[[DIM]], %[[FALSE]] : index, i1)
+// CHECK-SAME:            fn_def_attrs {vm.import.module = "rocm"}
+// CHECK-SAME{LITERAL}:   strided_dims([[], [], []])
+// CHECK:               return %[[MICRO_KERNEL]]#1
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.ukernel_provider = #rocm.ukernel_provider}>
+#map = affine_map<(d0) -> (d0)>
+#map1 = affine_map<(d0) -> ()>
+module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  func.func @pure_argmax_ukernel_test_with_provider(%arg0: tensor<?xf32>, %arg1: tensor<f32>, %arg2: tensor<i64>) -> tensor<i64> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0:2 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["reduction"]} ins(%arg0 : tensor<?xf32>) outs(%arg1, %arg2 : tensor<f32>, tensor<i64>) attrs =  {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_argmax_f32i64", bitcode>} {
+    ^bb0(%in: f32, %out: f32, %out_0: i64):
+      %1 = linalg.index 0 : index
+      %2 = arith.index_cast %1 : index to i64
+      %3 = arith.maximumf %in, %out : f32
+      %4 = arith.cmpf ogt, %in, %out : f32
+      %5 = arith.select %4, %2, %out_0 : i64
+      linalg.yield %3, %5 : f32, i64
+    } -> (tensor<f32>, tensor<i64>)
+    return %0#1 : tensor<i64>
+  }
+}
+
+// -----
+
+// CHECK-LABEL:       @argmax_ukernel_test_with_provider
+// CHECK-SAME:          %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:          %[[ARG1:[a-zA-Z0-9]+]]: tensor<f32>
+// CHECK-SAME:          %[[ARG2:[a-zA-Z0-9]+]]: tensor<i64>
+// CHECK:               %[[C0:.*]] = arith.constant 0 : index
+// CHECK:               %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xf32>
+// CHECK:               %[[TRUE:.*]] = arith.constant true
+// CHECK:               %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic "iree_uk_amdgpu_argmax_f32i64"
+// CHECK-SAME:            ins(%[[ARG0]] : tensor<?xf32>)
+// CHECK-SAME:            outs(%[[ARG1]], %[[ARG2]] : tensor<f32>, tensor<i64>)
+// CHECK-SAME:            (%[[DIM]], %[[TRUE]] : index, i1)
+// CHECK-SAME:            fn_def_attrs {vm.import.module = "rocm"}
+// CHECK-SAME{LITERAL}:   strided_dims([[], [], []])
+// CHECK:               return %[[MICRO_KERNEL]]#0, %[[MICRO_KERNEL]]#1
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.ukernel_provider = #rocm.ukernel_provider}>
+#map = affine_map<(d0) -> (d0)>
+#map1 = affine_map<(d0) -> ()>
+module attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  func.func @argmax_ukernel_test_with_provider(%arg0: tensor<?xf32>, %arg1: tensor<f32>, %arg2: tensor<i64>) -> (tensor<f32>, tensor<i64>) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0:2 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["reduction"]} ins(%arg0 : tensor<?xf32>) outs(%arg1, %arg2 : tensor<f32>, tensor<i64>) attrs =  {iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"iree_uk_amdgpu_argmax_f32i64", bitcode>} {
+    ^bb0(%in: f32, %out: f32, %out_0: i64):
+      %1 = linalg.index 0 : index
+      %2 = arith.index_cast %1 : index to i64
+      %3 = arith.maximumf %in, %out : f32
+      %4 = arith.cmpf ogt, %in, %out : f32
+      %5 = arith.select %4, %2, %out_0 : i64
+      linalg.yield %3, %5 : f32, i64
+    } -> (tensor<f32>, tensor<i64>)
+    return %0#0, %0#1 : tensor<f32>, tensor<i64>
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -558,7 +558,7 @@ def IREECodegen_UKernelProviderInterface :
         |other_operands| and adds to it a few context-specific as well as
         backend specific implementations to create the ukernel op.
       }],
-      /*retTy=*/"::mlir::LogicalResult",
+      /*retTy=*/"std::optional<::mlir::LogicalResult>",
       /*methodName=*/"createAndReplaceWithUkernelOp",
       /*args=*/(ins "::mlir::RewriterBase&":$b,
                     "::mlir::StringRef":$name,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -564,9 +564,9 @@ def IREECodegen_UKernelProviderInterface :
                     "::mlir::StringRef":$name,
                     "::mlir::DictionaryAttr":$target_configuration,
                     "::mlir::Operation *":$contextual_op,
-                    "::llvm::SmallVector<Value>&":$inputs,
-                    "::llvm::SmallVector<Value>&":$outputs,
-                    "::llvm::SmallVector<Value>&":$other_operands),
+                    "::llvm::SmallVectorImpl<::mlir::Value>&":$inputs,
+                    "::llvm::SmallVectorImpl<::mlir::Value>&":$outputs,
+                    "::llvm::SmallVectorImpl<::mlir::Value>&":$other_operands),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return failure();

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -557,6 +557,9 @@ def IREECodegen_UKernelProviderInterface :
         which implementation to provide. It takes in |inputs|, |outputs| and
         |other_operands| and adds to it a few context-specific as well as
         backend specific implementations to create the ukernel op.
+        Returning std::nullopt indicates falling back to default implementation.
+        Otherwise success/failure indicates the status of the custom replacement
+        implementation.
       }],
       /*retTy=*/"std::optional<::mlir::LogicalResult>",
       /*methodName=*/"createAndReplaceWithUkernelOp",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -549,6 +549,29 @@ def IREECodegen_UKernelProviderInterface :
         return failure();
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Creates and replaces the |contextual_op| with a ukernel referenced by
+        |name| backed by this attribute. Takes |target_configuration| in
+        case the provider wants to make any feature specific decisions for
+        which implementation to provide. It takes in |inputs|, |outputs| and
+        |other_operands| and adds to it a few context-specific as well as
+        backend specific implementations to create the ukernel op.
+      }],
+      /*retTy=*/"::mlir::LogicalResult",
+      /*methodName=*/"createAndReplaceWithUkernelOp",
+      /*args=*/(ins "::mlir::RewriterBase&":$b,
+                    "::mlir::StringRef":$name,
+                    "::mlir::DictionaryAttr":$target_configuration,
+                    "::mlir::Operation *":$contextual_op,
+                    "::llvm::SmallVector<Value>&":$inputs,
+                    "::llvm::SmallVector<Value>&":$outputs,
+                    "::llvm::SmallVector<Value>&":$other_operands),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
   ];
 }
 


### PR DESCRIPTION
-- This commit introduces the following changes :-
a. Adds `createAndReplaceWithUkernel` to UkernelProviderInterface.
b. Creates a ROCMUkernelProviderAttr implementing `createAndReplaceWithUkernel`.
c. Updates LowerUkernelDescriptors to make use of `createAndReplaceWithUkernel` while lowering to ukernel.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>