### PR TITLE
[IO] Generate splat parameters for stream.named.parameters

### DIFF
--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/test/generate_splat_parameter_archive.mlir
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/test/generate_splat_parameter_archive.mlir
@@ -21,6 +21,10 @@ util.global private @tensor_2x2xi4 = #flow.parameter.named<"opt"::"tensor_2x2xi4
 //  DUMP-NEXT: - | - | 2 | `tensor_3xi4`
 util.global private @tensor_3xi4 = #flow.parameter.named<"opt"::"tensor_3xi4"> : tensor<3xi4>
 
+// CHECK-NEXT: util.global private @tensor_5xi4
+//  DUMP-NEXT: - | - | 3 | `tensor_5xi4`
+util.global private @tensor_5xi4 = #stream.parameter.named<"opt"::"tensor_5xi4"> : tensor<5xi4>
+
 util.func private @function() {
   //      CHECK: flow.tensor.constant
   //  DUMP-NEXT: - | - | 4 | `inline`


### PR DESCRIPTION
https://github.com/iree-org/iree/pull/17303 moved support for generating splat archives using stream.parameter.named to flow.parameter.named , however, it looks like the rest of the compiler and the frontends haven't caught up. This patch adds support to generate splat archives from both, flow.parameter.named and stream.parameter.named attributes, until frontends / the rest of the compiler catches up.