### PR TITLE
[Codegen] Improve early bufferized padding codegen

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
@@ -9,16 +9,14 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
   iree_codegen.store_to_buffer %padded, %result : tensor<256xf32> into memref<256xf32>
   return
 }
-//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 64)>
-//       CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (256, d1 + 64, d0 + 1)>
+//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (2, d0 + 1)>
+//       CHECK: #[[$MAP1:.+]] = affine_map<(d0) -> (256, d0 + 1)>
 // CHECK-LABEL: @fold_pad_op
 //  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[PAD_VAL:.+]] = arith.constant 0.000000e+00 : f32
 //   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-//   CHECK-DAG:   %[[C252:.+]] = arith.constant 252 : index
 //       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<256xf32>
 //       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
 //  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
@@ -27,17 +25,24 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
 //       CHECK:   } : tensor<250xf32> into tensor<256xf32> -> tensor<256xf32>
 //       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
 
-//       CHECK:   scf.forall (%[[WG_IV:.+]]) = (0) to (256) step (64) {
-//       CHECK:     %[[WG_TILE_UB:.+]] = affine.min #[[$MAP]](%[[WG_IV]])
-//       CHECK:     scf.forall (%[[THREAD_IV:.+]]) = (%[[WG_IV]]) to (%[[WG_TILE_UB]]) step (1) {
-//       CHECK:       %[[THREAD_TILE_UB:.+]] = affine.min #[[$MAP1]](%[[THREAD_IV]], %[[WG_IV]])
-//       CHECK:       scf.for %[[IDX:.+]] = %[[THREAD_IV]] to %[[THREAD_TILE_UB]] step %[[C1]] {
-//   CHECK-DAG:         %[[IS_LOW_PAD:.+]] = arith.cmpi ult, %[[IDX]], %[[C2]] : index
-//   CHECK-DAG:         %[[IS_HIGH_PAD:.+]] = arith.cmpi uge, %[[IDX]], %[[C252]] : index
-//   CHECK-DAG:         %[[IS_PAD:.+]] = arith.ori %[[IS_LOW_PAD]], %[[IS_HIGH_PAD]] : i1
-//       CHECK:         scf.if %[[IS_PAD]] {
-//  CHECK-NEXT:           memref.store %[[PAD_VAL]], %[[RESULT]][%[[IDX]]] : memref<256xf32>
-//  CHECK-NEXT:         }
-//  CHECK:            }
-//  CHECK:          } {mapping = [#gpu.thread<linear_dim_0>]}
-//  CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+// Low padding
+
+//       CHECK:   scf.forall (%[[WG_LOOP0_IV:.+]]) = (0) to (2) step (64) {
+//       CHECK:     scf.forall (%[[THREAD_LOOP0_IV:.+]]) in (2) {
+//       CHECK:       %[[THREAD_TILE0_UB:.+]] = affine.min #[[$MAP]](%[[THREAD_LOOP0_IV]])
+//       CHECK:       scf.for %[[LOW_IDX:.+]] = %[[THREAD_LOOP0_IV]] to %[[THREAD_TILE0_UB]] step %[[C1]] {
+//  CHECK-NEXT:         memref.store %[[PAD_VAL]], %[[RESULT]][%[[LOW_IDX]]] : memref<256xf32>
+//      CHECK:        }
+//      CHECK:      } {mapping = [#gpu.thread<linear_dim_0>]}
+//      CHECK:    } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+
+// High padding
+
+//       CHECK:   scf.forall (%[[WG_LOOP1_IV:.+]]) = (252) to (256) step (64) {
+//       CHECK:     scf.forall (%[[THREAD_LOOP1_IV:.+]]) = (252) to (256) step (1) {
+//       CHECK:       %[[THREAD_TILE1_UB:.+]] = affine.min #[[$MAP1]](%[[THREAD_LOOP1_IV]])
+//       CHECK:       scf.for %[[HIGH_IDX:.+]] = %[[THREAD_LOOP1_IV]] to %[[THREAD_TILE1_UB]] step %[[C1]] {
+//  CHECK-NEXT:         memref.store %[[PAD_VAL]], %[[RESULT]][%[[HIGH_IDX]]] : memref<256xf32>
+//      CHECK:        }
+//      CHECK:      } {mapping = [#gpu.thread<linear_dim_0>]}
+//      CHECK:    } {mapping = [#iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_relayout_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_relayout_ops.mlir
@@ -55,7 +55,11 @@ func.func @relayout_ops_with_compute_between() {
 // CHECK:        iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[DEST_BUFFER]]
 // CHECK:        scf.forall
 // CHECK:          scf.forall
-// CHECK:            scf.if
-// CHECK-NEXT:         memref.store %[[PAD_VAL]], %[[DEST_BUFFER]]
+// CHECK:            memref.store %[[PAD_VAL]], %[[DEST_BUFFER]]
+// CHECK:          } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+// CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
+// CHECK:        scf.forall
+// CHECK:          scf.forall
+// CHECK:            memref.store %[[PAD_VAL]], %[[DEST_BUFFER]]
 // CHECK:          } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 // CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}


### PR DESCRIPTION
The current way we handle padding in CombineLayoutTransformation (the early bufferization path) turns out to be very inefficient in some cases, because we spend a lot of time spinning on indexing computation while iterating over the output buffer. This PR updates the way we generate the IR for writing padding values to avoid iterating over the non-padded parts of the output buffer. The old and new methods are described below:

### Old method ###

For a given tensor with padding, we would simply iterate over the entire tensor, and write padding values when the indices fell within the padded part of the output buffer. Visually this looks like the following:
```
          1st (only) loop (`x` == masked off)
         |———————————————————————————————————| 
                            |
                            v
         +———————————————————————————————————+
         | . . . . . . . . . . . . . . . . . |
         | . +———————————————————————+ . . . |
         | . | x x x x x x x x x x x | . . . |
         | . | x x x x x x x x x x x | . . . |
         | . | x x x x x x x x x x x | . . . |
         | . | x x x x x x x x x x x | . . . |
         | . +———————————————————————+ . . . |
         | . . . . . . . . . . . . . . . . . |
         +———————————————————————————————————+
```
### New method ###

There are multiple distributed loops, each loop performing the padding for a hyperplane spanning the low or high pad of a corresponding dimension, and fully spanning all other dimensions of the tensor. This means that there is some overlap on the intersection of high and low padding for each dimension.

```
 1st loop (low pad d0)        2nd loop (high pad d0)
        |———|                       |———————|
          |                             |
          v                             v
        +———+———————————————————————+———————+     ———
        | . | . . . . . . . . . . . | . . . | <--  |  3rd loop (low pad d1)
        +———+———————————————————————+———————+     ———
        | . | . . . . . . . . . . . | . . . |
        | . | . . . . . . . . . . . | . . . |
        | . | . . . . . . . . . . . | . . . |
        | . | . . . . . . . . . . . | . . . |
        +———+———————————————————————+———————+     ———
        | . | . . . . . . . . . . . | . . . | <--  |  4th loop (high pad d1)
        +———+———————————————————————+———————+     ———
```

With the new method, there is some overlap between loops, but the overall padding computation is much cheaper because padding is expected to be small relative to the output buffer size.