### PR TITLE
[DT][SVE] adjust tile sizes for mmt4d & disable transposition of narrow-N matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -23,6 +23,9 @@
 //   3. Heuristics for cache-friendly dispatch tiling can get complex on CPU,
 //      so it is nice that they have fewer narrow cases to consider.
 //
+// The only current exception to this is Arm SVE. It currently adheres to the
+// canonical form of scalable vectorisation and keeps the N dimension to be
+// scalable.
 // This transposition is made easier by (and was all along part of the idea in)
 // the RHS-transposition in mmt4d (the t in mmt4d), as generally with matrix
 // multiplication
@@ -468,6 +471,7 @@ static SmallVector<TileMxNxK> enumerateMatmulTileArm64(TypeRange elementTypes,
                                                        DictionaryAttr config) {
   // For SVE and scalable vectors, this methods selects base sizes that match
   // the NEON fixed-width sizes.
+  // TODO: Add SME inner tile sizes and corresponding tests.
   assert(elementTypes.size() == 3);
   Type lhs = elementTypes[0];
   Type rhs = elementTypes[1];

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -106,6 +106,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Utils",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -165,6 +165,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils
+    iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms
     iree::compiler::Utils

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -105,27 +105,25 @@ func.func @matmul_with_fill(%15: tensor<1024x256xi8>, %16: tensor<256x256xi8>, %
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map = affine_map<()[s0] -> (s0 ceildiv 8)>
 #map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-module {
-  func.func @mmt4d_tensors() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
-    %c8 = arith.constant 8 : index
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-    %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-    %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
-    %3 = affine.apply #map()[%0]
-    %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
-    %vscale = vector.vscale
-    %c8_vscale = arith.muli %vscale, %c8 : index
-    %5 = affine.apply #map1()[%1, %c8_vscale]
-    %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
-    %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-    %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
-    %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
-    %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale} -> tensor<?x?x8x?xf32>
-    %11 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-    iree_tensor_ext.dispatch.tensor.store %11, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-    return
-  }
+func.func @mmt4d_tensors() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+  %c8 = arith.constant 8 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+  %3 = affine.apply #map()[%0]
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %5 = affine.apply #map1()[%1, %c8_vscale]
+  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
+  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
+  %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
+  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
+  %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale} -> tensor<?x?x8x?xf32>
+  %11 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
+  iree_tensor_ext.dispatch.tensor.store %11, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
+  return
 }
 // CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [2, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
@@ -144,29 +142,27 @@ module {
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map = affine_map<()[s0] -> (s0 ceildiv 8)>
 #map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-module {
-  func.func @mmtd4_with_fill() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c8 = arith.constant 8 : index
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-    %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-    %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
-    %3 = affine.apply #map()[%0]
-    %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
-    %vscale = vector.vscale
-    %c8_vscale = arith.muli %vscale, %c8 : index
-    %5 = affine.apply #map1()[%1, %c8_vscale]
-    %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
-    %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-    %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
-    %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
-    %10 = tensor.empty(%3, %5, %c8_vscale) : tensor<?x?x8x?xf32>
-    %11 = linalg.fill ins(%cst : f32) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-    %12 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%11 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-    iree_tensor_ext.dispatch.tensor.store %12, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-    return
-  }
+func.func @mmtd4_with_fill() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c8 = arith.constant 8 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+  %3 = affine.apply #map()[%0]
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %5 = affine.apply #map1()[%1, %c8_vscale]
+  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
+  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
+  %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
+  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
+  %10 = tensor.empty(%3, %5, %c8_vscale) : tensor<?x?x8x?xf32>
+  %11 = linalg.fill ins(%cst : f32) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
+  %12 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%11 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
+  iree_tensor_ext.dispatch.tensor.store %12, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
+  return
 }
 // CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 0, 8]>
 // CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [2, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -97,6 +97,8 @@ func.func @matmul_with_fill(%15: tensor<1024x256xi8>, %16: tensor<256x256xi8>, %
 
 // -----
 
+// This case tests if the inner tile size of the mmt4d is inferred properly from the shape-aware HAL binding and set accordingly.
+
 #pipeline_layout = #hal.pipeline.layout<constants = 0, bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -97,77 +97,48 @@ func.func @matmul_with_fill(%15: tensor<1024x256xi8>, %16: tensor<256x256xi8>, %
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
+#pipeline_layout = #hal.pipeline.layout<constants = 0, bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
-#map = affine_map<()[s0] -> (s0 ceildiv 8)>
-#map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-func.func @mmt4d_tensors() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+#map = affine_map<()[s0] -> (256 ceildiv s0)>
+func.func @mmt4d_tensors(%arg0: tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x?x1xf32>) -> tensor<32x?x8x?xf32> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
   %c8 = arith.constant 8 : index
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
-  %3 = affine.apply #map()[%0]
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
   %vscale = vector.vscale
   %c8_vscale = arith.muli %vscale, %c8 : index
-  %5 = affine.apply #map1()[%1, %c8_vscale]
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
-  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-  %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
-  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
-  %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale} -> tensor<?x?x8x?xf32>
-  %11 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-  iree_tensor_ext.dispatch.tensor.store %11, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-  return
+  %n0 = affine.apply #map()[%c8_vscale]
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x?x8x?xf32>>{%n0, %c8_vscale}
+  %init = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [32, %n0, 8, %c8_vscale], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x?x8x?xf32>>{%n0, %c8_vscale} -> tensor<32x?x8x?xf32>
+  %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%init : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
+  return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [2, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
-// CHECK:      func.func @mmt4d_tensors()
+// CHECK:      func.func @mmt4d_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.mmt4d
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
-#map = affine_map<()[s0] -> (s0 ceildiv 8)>
-#map1 = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-func.func @mmtd4_with_fill() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+#map = affine_map<()[s0] -> (256 ceildiv s0)>
+func.func @mmtd4_with_fill(%arg0 : tensor<32x128x8x1xf32>, %arg1 : tensor<?x128x?x1xf32>) -> tensor<32x?x8x?xf32> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
   %cst = arith.constant 0.000000e+00 : f32
   %c8 = arith.constant 8 : index
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
-  %3 = affine.apply #map()[%0]
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2}
   %vscale = vector.vscale
   %c8_vscale = arith.muli %vscale, %c8 : index
-  %5 = affine.apply #map1()[%1, %c8_vscale]
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale}
-  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-  %8 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%3, %2, 8, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x1xf32>>{%3, %2} -> tensor<?x?x8x1xf32>
-  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0, 0, 0], sizes = [%5, %2, %c8_vscale, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?x1xf32>>{%5, %2, %c8_vscale} -> tensor<?x?x?x1xf32>
-  %10 = tensor.empty(%3, %5, %c8_vscale) : tensor<?x?x8x?xf32>
-  %11 = linalg.fill ins(%cst : f32) outs(%10 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-  %12 = linalg.mmt4d ins(%8, %9 : tensor<?x?x8x1xf32>, tensor<?x?x?x1xf32>) outs(%11 : tensor<?x?x8x?xf32>) -> tensor<?x?x8x?xf32>
-  iree_tensor_ext.dispatch.tensor.store %12, %7, offsets = [0, 0, 0, 0], sizes = [%3, %5, 8, %c8_vscale], strides = [1, 1, 1, 1] : tensor<?x?x8x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x8x?xf32>>{%3, %5, %c8_vscale}
-  return
+  %0 = affine.apply #map()[%c8_vscale]
+  %init = tensor.empty(%0, %c8_vscale) : tensor<32x?x8x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
+  %mmt4d = linalg.mmt4d ins(%arg0, %arg1 : tensor<32x128x8x1xf32>, tensor<?x128x?x1xf32>) outs(%fill : tensor<32x?x8x?xf32>) -> tensor<32x?x8x?xf32>
+  return %mmt4d : tensor<32x?x8x?xf32>
 }
-// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 0, 8]>
-// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [2, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+// CHECK-DAG:  #[[CONFIG1:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 8, [8]]>
+// CHECK-DAG:  #[[CONFIG2:.+]] = #iree_cpu.lowering_config<distribution = [4, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK:      #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = Mmt4dTilingExpert>
-// CHECK:      func.func @mmtd4_with_fill()
+// CHECK:      func.func @mmtd4_with_fill
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.fill
 // CHECK-SAME:     lowering_config = #[[CONFIG1]]

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1638,6 +1638,8 @@ getScalableTileSizesAndFlags(SmallVector<OpFoldResult> mixedInnerTiles) {
   SmallVector<int64_t> tileSizes(mixedInnerTiles.size(), 0);
   IREE::Codegen::ScalableTileFlags scalableFlags(mixedInnerTiles.size(), false);
   for (unsigned pos = 0; pos < mixedInnerTiles.size(); ++pos) {
+    // Check if we have SSA values that represent the inner tile sizes.
+    // This is the case for scalable tile sizes.
     if (auto innerTileVal = dyn_cast<Value>(mixedInnerTiles[pos])) {
       FailureOr<int64_t> innerTile =
           getStaticPartOfScalableTileSize(innerTileVal.getDefiningOp());
@@ -1649,6 +1651,8 @@ getScalableTileSizesAndFlags(SmallVector<OpFoldResult> mixedInnerTiles) {
       scalableFlags[pos] = true;
       continue;
     }
+    // Check if we have integer attributes that represent the inner tile sizes.
+    // This is the case for static tile sizes.
     std::optional<int64_t> innerTile =
         getConstantIntValue(mixedInnerTiles[pos]);
     if (!innerTile.has_value()) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1623,7 +1623,7 @@ getScalableTileSizesAndFlags(ArrayRef<OpFoldResult> mixedInnerTiles) {
     // This is the case for scalable tile sizes.
     if (auto innerTileVal = dyn_cast<Value>(mixedInnerTiles[pos])) {
       std::optional<int64_t> innerTile =
-          getConstantVscaleMultiplier(innerTileVal);
+          vector::getConstantVscaleMultiplier(innerTileVal);
       if (!innerTile) {
         LDBG() << "Found non-scalable dynamic inner tile!";
         return std::nullopt;

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -310,18 +310,12 @@ getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr);
 using SizesAndScalableFlags =
     std::pair<SmallVector<int64_t>, SmallVector<bool>>;
 
-// This utility function returns the static part of scalable inner tile sizes.
-// These are - as of now always and probably should always be - arith.muli ops
-// with `vector.vscale` on one side and an `arith.constant` on the other. It
-// returns the constant if found.
-FailureOr<int64_t> getStaticPartOfScalableTileSize(Operation *op);
-
 // This function takes a vector of mixed sizes and returns the static tile sizes
 // and scalable tile flags. For scalable inner tiles, it returns the static
 // counterpart and the corresponding flag. E.g. for [8, [8]] it returns [8, 8]
 // and [false, true].
-FailureOr<SizesAndScalableFlags>
-getScalableTileSizesAndFlags(SmallVector<OpFoldResult> mixedSizes);
+std::optional<SizesAndScalableFlags>
+getScalableTileSizesAndFlags(ArrayRef<OpFoldResult> mixedSizes);
 
 using DimBound = vector::ConstantOrScalableBound;
 using DimBoundSize = DimBound::BoundSize;

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -279,8 +279,49 @@ void sinkOpsInCFG(const SmallVector<Operation *> &allocs,
 // the inputs.
 bool hasFusedLeadingOp(linalg::LinalgOp rootOp);
 
+/// Retrieves the DenormalFpMathAttr for F32 values from the given target
+/// configuration. This attribute specifies how denormal floating-point values
+/// are handled in F32 operations.
+IREE::Codegen::DenormalFpMathAttr
+getConfigDenormalFpMathF32Attr(DictionaryAttr targetConfig);
+std::optional<IREE::Codegen::DenormalFpMath>
+getConfigDenormalFpMathF32(DictionaryAttr targetConfig);
+
+/// Adds a denormal floating-point math configuration for F32 values to the
+/// configuration list. This configures how denormal floating-point values are
+/// handled in F32 operations.
+void addConfigDenormalFpMathF32(MLIRContext *context,
+                                IREE::Codegen::DenormalFpMath mode,
+                                SmallVectorImpl<NamedAttribute> &config);
+
+// Utility to make sure we are storing the full incoming subspan. Otherwise we
+// cannot simply adjust the subspan's resultant type later.
+bool isFullSlice(OffsetSizeAndStrideOpInterface sliceLoadStoreOp,
+                 IREE::TensorExt::DispatchTensorType tensorType,
+                 ValueRange dynamicDims);
+
+//===---------------------------------------------------------------------===//
+// Scalable size utility functions
+//===---------------------------------------------------------------------===//
+
 std::optional<vector::VscaleRange>
 getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr);
+
+using SizesAndScalableFlags =
+    std::pair<SmallVector<int64_t>, SmallVector<bool>>;
+
+// This utility function returns the static part of scalable inner tile sizes.
+// These are - as of now always and probably should always be - arith.muli ops
+// with `vector.vscale` on one side and an `arith.constant` on the other. It
+// returns the constant if found.
+FailureOr<int64_t> getStaticPartOfScalableTileSize(Operation *op);
+
+// This function takes a vector of mixed sizes and returns the static tile sizes
+// and scalable tile flags. For scalable inner tiles, it returns the static
+// counterpart and the corresponding flag. E.g. for [8, [8]] it returns [8, 8]
+// and [false, true].
+FailureOr<SizesAndScalableFlags>
+getScalableTileSizesAndFlags(SmallVector<OpFoldResult> mixedSizes);
 
 using DimBound = vector::ConstantOrScalableBound;
 using DimBoundSize = DimBound::BoundSize;
@@ -297,33 +338,9 @@ computeDimUpperBound(Value shapedValue, unsigned dimNum,
                      std::optional<vector::VscaleRange> vscaleRange,
                      RoundUpVscaleMultiple = RoundUpVscaleMultiple::No);
 
-// Utility to make sure we are storing the full incoming subspan. Otherwise we
-// cannot simply adjust the subspan's resultant type later.
-bool isFullSlice(OffsetSizeAndStrideOpInterface sliceLoadStoreOp,
-                 IREE::TensorExt::DispatchTensorType tensorType,
-                 ValueRange dynamicDims);
-
-/// Retrieves the DenormalFpMathAttr for F32 values from the given target
-/// configuration. This attribute specifies how denormal floating-point values
-/// are handled in F32 operations.
-IREE::Codegen::DenormalFpMathAttr
-getConfigDenormalFpMathF32Attr(DictionaryAttr targetConfig);
-std::optional<IREE::Codegen::DenormalFpMath>
-getConfigDenormalFpMathF32(DictionaryAttr targetConfig);
-
-/// Adds a denormal floating-point math configuration for F32 values to the
-/// configuration list. This configures how denormal floating-point values are
-/// handled in F32 operations.
-void addConfigDenormalFpMathF32(MLIRContext *context,
-                                IREE::Codegen::DenormalFpMath mode,
-                                SmallVectorImpl<NamedAttribute> &config);
-
 //===----------------------------------------------------------------------===//
 // Utility functions for vector size inference for dynamic shapes
 //===----------------------------------------------------------------------===//
-
-using SizesAndScalableFlags =
-    std::pair<SmallVector<int64_t>, SmallVector<bool>>;
 
 struct VectorizationTileSizes {
   SmallVector<int64_t> destShape;


### PR DESCRIPTION
This PR builds upon #21304 and takes a step forward to adjust tile sizes in the existence of scalable inner tiles with `mmt4d`. This is step 2/N to enable data-tiling with SVE. There will be others to adjust tile sizes for packs/unpacks as well.

Also, since SVE requires the `N` dimension to be scalable - AFAIK because of vectorization unrolling on the inner `M` dimension and this currently not being supported for scalable `M` dims - disables transposition of narrow-N matmuls.

On another note, we currently walk the IR to retrieve the inner tile sizes of the `mmt4d`. This mechanism currently assumes that only `M` and `N` dimensions could be scalable, which holds for SME and SVE.
Although for future references, we could either find another mechanism to communicate the inner tile sizes chosen during materialization to the tile size selection OR extend this method to handle the inputs - and therefore infer the scalable K as well.

Note: materialization of SME is currently not supported.