### PR TITLE
[Codegen][LLVMGPU] Replace LLVMGPUSimpleDistribute pipeline with TileAndFuse

### DIFF
--- a/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
+++ b/compiler/plugins/target/ROCM/test/ukernel_pipeline_transform.mlir
@@ -139,7 +139,7 @@ func.func @no_ukernel_argmax_1d_f16i64() attributes {
   return
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [1, 1, 1]>
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1]
 //      CHECK: func.func @no_ukernel_argmax_1d_f16i64()
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //  CHECK-NOT:   iree_codegen.ukernel.generic
@@ -244,7 +244,7 @@ func.func @not_neg_inf_init_argmax_1d() attributes {
   return
 }
 
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [1, 1, 1]>
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1]
 //      CHECK: func.func @not_neg_inf_init_argmax_1d()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
 //  CHECK-NOT:   iree_codegen.ukernel.generic

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -122,6 +123,7 @@ struct GPUDistributeCopyUsingForallPass final
     mlir::FunctionOpInterface funcOp = getOperation();
 
     SmallVector<memref::CopyOp> copies;
+    SmallVector<linalg::CopyOp> linalgCopies;
 
     // Walk in PreOrder so that parent operations are visited before children,
     // thus allowing all operations contained within thread/warp/lane foralls
@@ -137,12 +139,28 @@ struct GPUDistributeCopyUsingForallPass final
       }
       if (auto copy = dyn_cast<memref::CopyOp>(op)) {
         copies.push_back(copy);
+      } else if (auto linalgCopy = dyn_cast<linalg::CopyOp>(op)) {
+        if (!linalgCopy.hasPureTensorSemantics()) {
+          linalgCopies.push_back(linalgCopy);
+        }
       }
       return WalkResult::advance();
     });
 
     IRRewriter rewriter(context);
-    for (auto copy : copies) {
+
+    // Convert memref-based linalg.copy ops to memref.copy so they can be
+    // distributed with the same logic.
+    for (linalg::CopyOp linalgCopy : linalgCopies) {
+      rewriter.setInsertionPoint(linalgCopy);
+      auto newCopy = memref::CopyOp::create(rewriter, linalgCopy.getLoc(),
+                                            linalgCopy.getInputs()[0],
+                                            linalgCopy.getDpsInits()[0]);
+      copies.push_back(newCopy);
+      rewriter.eraseOp(linalgCopy);
+    }
+
+    for (memref::CopyOp copy : copies) {
       rewriter.setInsertionPoint(copy);
       SmallVector<OpFoldResult> tileSizes = getCopyTileSizes(rewriter, copy);
       distributeCopyToThreads(rewriter, copy, tileSizes);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGreedilyDistributeToThreads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGreedilyDistributeToThreads.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Interfaces/TilingInterface.h"
 
 namespace mlir::iree_compiler {
@@ -33,6 +34,40 @@ struct GPUGreedilyDistributeToThreadsPass final
 };
 } // namespace
 
+/// Wraps an op in a single iteration `scf.forall`. This approximates
+/// `if %thread_id == 0`. The expected usage is for scalar operations
+/// that can't be distributed anyway but need to only happen once.
+static void scalarizeOp(RewriterBase &rewriter, Operation *op) {
+  OpBuilder::InsertionGuard g(rewriter);
+
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
+  if (!dpsOp || dpsOp->getNumResults() != dpsOp.getNumDpsInits()) {
+    return;
+  }
+
+  rewriter.setInsertionPoint(op);
+
+  SmallVector<Attribute> mapping = {gpu::GPUThreadMappingAttr::get(
+      rewriter.getContext(), gpu::MappingId::LinearDim0)};
+  scf::ForallOp forallOp = scf::ForallOp::create(
+      rewriter, op->getLoc(), ArrayRef<OpFoldResult>{rewriter.getIndexAttr(0)},
+      ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)},
+      ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)},
+      /*outputs=*/dpsOp.getDpsInits(),
+      /*mapping=*/rewriter.getArrayAttr(mapping));
+  rewriter.moveOpBefore(op, forallOp.getBody(), forallOp.getBody()->begin());
+  rewriter.replaceAllOpUsesWith(dpsOp, forallOp);
+
+  scf::InParallelOp terminator = forallOp.getTerminator();
+  rewriter.setInsertionPointToStart(terminator.getBody());
+  for (auto [result, blockInit] :
+       llvm::zip_equal(dpsOp->getResults(), forallOp.getRegionIterArgs())) {
+    tensor::ParallelInsertSliceOp::create(
+        rewriter, op->getLoc(), result, blockInit, ArrayRef<OpFoldResult>{},
+        ArrayRef<OpFoldResult>{}, ArrayRef<OpFoldResult>{});
+  }
+}
+
 /// Helper to tile and greedily fuse the given operation to threads. This uses
 /// the iree_gpu.derived_thread_config logic internally to determine tile sizes
 /// to use. This does not yield any fused operation and only replaces the tiling
@@ -42,16 +77,22 @@ struct GPUGreedilyDistributeToThreadsPass final
 /// verification steps will throw an error if distribution does not occur.
 static void tileToThreads(RewriterBase &rewriter,
                           TilingInterface tilingInterfaceOp) {
-  rewriter.setInsertionPoint(tilingInterfaceOp);
+  OpBuilder::InsertionGuard guard(rewriter);
+  int64_t numLoops = tilingInterfaceOp.getLoopIteratorTypes().size();
+
+  // Special case scalar ops to make the mapping non-empty.
+  if (numLoops == 0) {
+    return scalarizeOp(rewriter, tilingInterfaceOp);
+  }
+
   auto configAttr =
       IREE::GPU::DerivedThreadConfigAttr::get(rewriter.getContext());
   SmallVector<OpFoldResult> tileSizes = configAttr.getTilingLevelSizes(
       rewriter, llvm::to_underlying(IREE::GPU::TilingLevel::Thread),
       tilingInterfaceOp);
 
-  // Pad the tile sizes with zero.
+  rewriter.setInsertionPoint(tilingInterfaceOp);
   auto zero = rewriter.getIndexAttr(0);
-  int64_t numLoops = tilingInterfaceOp.getLoopIteratorTypes().size();
   if (tileSizes.size() > numLoops) {
     return;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -64,7 +64,7 @@ def GPUCreateFastSlowPathPass :
 
 def GPUDistributeCopyUsingForallPass :
     InterfacePass<"iree-codegen-gpu-distribute-copy-using-forall", "mlir::FunctionOpInterface"> {
-  let summary = "Pass to distribute copies to threads.";
+  let summary = "Pass to distribute memref copies to threads.";
   let dependentDialects = [
     "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect", "::mlir::scf::SCFDialect"
   ];

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
@@ -253,3 +253,92 @@ func.func @map_store(%arg0: tensor<2x32xf32>, %arg1: tensor<64x256xf32>) -> tens
 //       CHECK:   iree_linalg_ext.map_store
 //       CHECK:     tensor<1x4xf32> into tensor<64x256xf32>
 //       CHECK:   scf.forall.in_parallel
+
+// -----
+
+// Generic fallback tests for ops using PartitionableLoopsInterface.
+
+#config = #iree_gpu.derived_thread_config
+func.func @gather(%source: tensor<100x8xf32>, %indices: tensor<4x1xi32>, %init: tensor<4x8xf32>) -> tensor<4x8xf32>
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+    } {
+  %0 = iree_linalg_ext.gather {lowering_config = #config} dimension_map = [0]
+    ins(%source, %indices : tensor<100x8xf32>, tensor<4x1xi32>)
+    outs(%init : tensor<4x8xf32>) -> tensor<4x8xf32>
+  return %0 : tensor<4x8xf32>
+}
+
+// CHECK-LABEL: func.func @gather
+//       CHECK:   scf.forall ({{.*}}) in (4, 8)
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:   mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]
+
+// -----
+
+#config = #iree_gpu.derived_thread_config
+func.func @scan(%arg0: tensor<32x16xi32>, %arg1: tensor<32x16xi32>, %arg2: tensor<32xi32>) -> (tensor<32x16xi32>, tensor<32xi32>)
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+    } {
+  %0:2 = iree_linalg_ext.scan {lowering_config = #config}
+    dimension(1) inclusive(true)
+    ins(%arg0 : tensor<32x16xi32>)
+    outs(%arg1, %arg2 : tensor<32x16xi32>, tensor<32xi32>) {
+    ^bb0(%in: i32, %out: i32):
+      %sum = arith.addi %in, %out : i32
+      iree_linalg_ext.yield %sum : i32
+  } -> tensor<32x16xi32>, tensor<32xi32>
+  return %0#0, %0#1 : tensor<32x16xi32>, tensor<32xi32>
+}
+
+// Scan dimension(1) is reduction, only dimension(0) is partitionable.
+// CHECK-LABEL: func.func @scan
+//       CHECK:   scf.forall ({{.*}}) in (32)
+//       CHECK:     iree_linalg_ext.scan
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
+#config = #iree_gpu.derived_thread_config
+func.func @fft(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>) -> (tensor<32x64xf32>, tensor<32x64xf32>)
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+    } {
+  %cst1 = arith.constant 1 : index
+  %0:2 = iree_linalg_ext.fft {lowering_config = #config}
+    ins(%cst1 : index)
+    outs(%arg0, %arg1 : tensor<32x64xf32>, tensor<32x64xf32>)
+    : tensor<32x64xf32>, tensor<32x64xf32>
+  return %0#0, %0#1 : tensor<32x64xf32>, tensor<32x64xf32>
+}
+
+// FFT without coefficients: last dim is not partitionable.
+// CHECK-LABEL: func.func @fft
+//       CHECK:   scf.forall ({{.*}}) in (32)
+//       CHECK:     iree_linalg_ext.fft
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
+#config = #iree_gpu.derived_thread_config
+func.func @map_load(%source: tensor<4x64xf32>, %output: tensor<4x64xf32>) -> tensor<4x64xf32>
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+    } {
+  %0 = iree_linalg_ext.map_load {lowering_config = #config} %source into %output {
+  ^bb0(%idx0: index, %idx1: index):
+    %pad = arith.constant 0.0 : f32
+    iree_linalg_ext.yield %idx0, %idx1, %pad : index, index, f32
+  } : tensor<4x64xf32> into tensor<4x64xf32> -> tensor<4x64xf32>
+  return %0 : tensor<4x64xf32>
+}
+
+// All loops are parallel and partitionable.
+// CHECK-LABEL: func.func @map_load
+//       CHECK:   scf.forall ({{.*}}) in (4, 64)
+//       CHECK:     iree_linalg_ext.map_load
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:   mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -2295,7 +2295,7 @@ hal.executable private @scatter {
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @scatter() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [1, 1, 1]>} {
+      func.func @scatter() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [1, 1, 1]>} {
         %c228075520 = arith.constant 228075520 : index
         %c251668480 = arith.constant 251668480 : index
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -36,16 +36,14 @@ def LLVMGPU_Default
     : I32EnumAttrCase<"LLVMGPUDefault", 100>;
 def LLVMGPU_BaseLowering
     : I32EnumAttrCase<"LLVMGPUBaseLowering", 101>;
-def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute", 102>;
 def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 103>;
+    : I32EnumAttrCase<"LLVMGPUVectorize", 102>;
 def LLVMGPU_VectorDistribute
-    : I32EnumAttrCase<"LLVMGPUVectorDistribute", 104>;
+    : I32EnumAttrCase<"LLVMGPUVectorDistribute", 103>;
 def LLVMGPU_WinogradVectorize
-    : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 105>;
+    : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 104>;
 def LLVMGPU_TileAndFuse
-    : I32EnumAttrCase<"LLVMGPUTileAndFuse", 106>;
+    : I32EnumAttrCase<"LLVMGPUTileAndFuse", 105>;
 
 def SPIRV_BaseLowering
     : I32EnumAttrCase<"SPIRVBaseLowering", 200>;
@@ -83,7 +81,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     CPU_DataTiling, CPU_LinalgExtTileAndVectorize,
 
     // LLVMGPU CodeGen pipelines
-    LLVMGPU_Default, LLVMGPU_BaseLowering, LLVMGPU_SimpleDistribute,
+    LLVMGPU_Default, LLVMGPU_BaseLowering,
     LLVMGPU_Vectorize, LLVMGPU_VectorDistribute,
     LLVMGPU_WinogradVectorize, LLVMGPU_TileAndFuse,
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -92,6 +92,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:HoistableRegionOpInterface",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -74,6 +74,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Interfaces::HoistableRegionOpInterface
+    iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::Encoding::Utils
     iree::compiler::Dialect::LinalgExt::IR

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -8,12 +8,14 @@
 #include <numeric>
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/TilingInterface.h"
 
 namespace mlir::iree_compiler::IREE::GPU {
 
@@ -185,7 +187,26 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
         return getVectorTileSizesFromLoopRanges(loopBounds, numThreads,
                                                 vectorSize);
       })
-      .Default([&](Operation *op) -> SmallVector<int64_t> { return {}; });
+      .Default([&](Operation *op) -> SmallVector<int64_t> {
+        // Generic fallback for ops implementing TilingInterface and
+        // PartitionableLoopsInterface. Tiles partitionable loops to 1.
+        auto tilingOp = dyn_cast<TilingInterface>(op);
+        if (!tilingOp) {
+          return {};
+        }
+        auto partitionableOp = dyn_cast<PartitionableLoopsInterface>(op);
+        if (!partitionableOp) {
+          return {};
+        }
+        int64_t numLoops = tilingOp.getLoopIteratorTypes().size();
+        SmallVector<unsigned> partitionableLoops =
+            partitionableOp.getPartitionableLoops(std::nullopt);
+        SmallVector<int64_t> tileSizes(numLoops, 0);
+        for (unsigned idx : partitionableLoops) {
+          tileSizes[idx] = 1;
+        }
+        return tileSizes;
+      });
 }
 
 // TODO: make it a query.

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -237,6 +237,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:UBDialect",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
     MLIRAnalysis
     MLIRArithDialect
     MLIRIR
+    MLIRSupport
     MLIRTensorDialect
     MLIRUBDialect
     MLIRVectorDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -180,6 +180,32 @@ static bool needsLoweringConfigPropagation(
   return !llvm::is_contained(supportedPipelines, pipeline);
 }
 
+static LogicalResult setDefaultWorkgroupOnlyTilingConfig(
+    FunctionOpInterface entryPoint, Operation *op, IREE::GPU::TargetAttr target,
+    ArrayRef<int64_t> workgroupTileSizes, ArrayRef<int64_t> workgroupSize) {
+  MLIRContext *context = op->getContext();
+  Builder b(context);
+  auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+      context, /*prefetch_num_stages=*/0,
+      /*no_reduce_shared_memory_bank_conflicts=*/true,
+      /*use_igemm_convolution=*/false,
+      /*reorder_workgroups_strategy=*/std::nullopt);
+  const int preferredSubgroupSize = target.getPreferredSubgroupSize();
+  SmallVector<NamedAttribute, 3> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes))};
+
+  auto configDict = b.getDictionaryAttr(attrs);
+  auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
+  SmallVector<NamedAttribute, 1> pipelineAttrs;
+  pipelineAttrs.emplace_back(
+      b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+      pipelineOptions);
+  auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUTileAndFuse,
+      workgroupSize, preferredSubgroupSize, pipelineConfig);
+}
+
 //====---------------------------------------------------------------------===//
 // Matmul Configuration Helpers
 //====---------------------------------------------------------------------===//
@@ -1338,8 +1364,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // This configuration is not really smart right now. It just makes sure that
   // attention always compiles and tries to distribute workload on threads,
   // subgroups and workgroups as much as it can.
-  // TODO: Update this configuration with target information, like the
-  // WarpReduction pipeline does.
+  // TODO: Update this configuration with target information.
 
   // For memory bound attention, per workgroup, we have input shapes:
   //
@@ -1500,7 +1525,6 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
                                             ArrayRef<int32_t> subgroupSizes,
                                             unsigned softwarePipelineDepth,
                                             CodeGenPipeline pipeline) {
-    TileSizesListType tileSizes;
     unsigned numParallelLoops = op.getNumParallelLoops();
     unsigned numReductionLoops = op.getNumReductionLoops();
     SmallVector<int64_t> workgroupTileSizes(
@@ -1525,62 +1549,48 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
       subgroupSize = subgroupSizes.front();
     }
 
-    // For the LLVMGPUTileAndFuse pipeline, we need to split tile sizes
-    // for workgroup, thread, and reduction.
-    if (pipeline == CodeGenPipeline::LLVMGPUTileAndFuse) {
+    // Split tile sizes for workgroup, thread, and reduction.
+    MLIRContext *context = op.getContext();
+    Builder b(context);
 
-      MLIRContext *context = op.getContext();
-      Builder b(context);
+    SmallVector<int64_t> threadTileSizes(numParallelLoops + numReductionLoops,
+                                         0);
+    std::fill(threadTileSizes.begin(),
+              threadTileSizes.begin() + numParallelLoops, 1);
 
-      SmallVector<int64_t> threadTileSizes(numParallelLoops + numReductionLoops,
-                                           0);
-      std::fill(threadTileSizes.begin(),
-                threadTileSizes.begin() + numParallelLoops, 1);
+    threadTileSizes[numParallelLoops - 2] =
+        (tileX / workgroupSize[0]) < 1 ? 1 : (tileX / workgroupSize[0]);
+    threadTileSizes[numParallelLoops - 1] =
+        (tileY / workgroupSize[1]) < 1 ? 1 : (tileY / workgroupSize[1]);
 
-      threadTileSizes[numParallelLoops - 2] =
-          (tileX / workgroupSize[0]) < 1 ? 1 : (tileX / workgroupSize[0]);
-      threadTileSizes[numParallelLoops - 1] =
-          (tileY / workgroupSize[1]) < 1 ? 1 : (tileY / workgroupSize[1]);
+    SmallVector<int64_t> reductionTileSizes(
+        numParallelLoops + numReductionLoops, 0);
+    reductionTileSizes[numParallelLoops + numReductionLoops - 1] = tileK;
 
-      SmallVector<int64_t> reductionTileSizes(
-          numParallelLoops + numReductionLoops, 0);
-      reductionTileSizes[numParallelLoops + numReductionLoops - 1] = tileK;
+    SmallVector<NamedAttribute, 3> attrs = {
+        NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+        NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
+        NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
 
-      SmallVector<NamedAttribute, 3> attrs = {
-          NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
-          NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
-          NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
+    auto configDict = b.getDictionaryAttr(attrs);
+    auto loweringConfig =
+        IREE::GPU::LoweringConfigAttr::get(context, configDict);
+    SmallVector<NamedAttribute, 1> pipelineAttrs;
+    // Default to no prefetching if not specified.
+    int64_t prefetchStages = clPrefetchNumStages.getValue().value_or(0);
+    auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+        context, /*prefetch_num_stages=*/prefetchStages,
+        /*no_reduce_shared_memory_bank_conflicts=*/true,
+        /*use_igemm_convolution=*/false,
+        /*reorder_workgroups_strategy=*/std::nullopt);
+    pipelineAttrs.emplace_back(
+        b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+        pipelineOptions);
+    auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
 
-      auto configDict = b.getDictionaryAttr(attrs);
-      auto loweringConfig =
-          IREE::GPU::LoweringConfigAttr::get(context, configDict);
-      SmallVector<NamedAttribute, 1> pipelineAttrs;
-      // Default to no prefetching if not specified.
-      int64_t prefetchStages = clPrefetchNumStages.getValue().value_or(0);
-      auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
-          context, /*prefetch_num_stages=*/prefetchStages,
-          /*no_reduce_shared_memory_bank_conflicts=*/true,
-          /*use_igemm_convolution=*/false,
-          /*reorder_workgroups_strategy=*/std::nullopt);
-      pipelineAttrs.emplace_back(
-          b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
-          pipelineOptions);
-      auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
-
-      return setOpConfigAndEntryPointFnTranslation(
-          entryPoint, op, loweringConfig, pipeline, workgroupSize, subgroupSize,
-          pipelineConfig);
-    }
-
-    // Other pipeline (MatmulTensorCore) expect the reduction tile size to be in
-    // the same list.
-    workgroupTileSizes[numParallelLoops + numReductionLoops - 1] = tileK;
-    tileSizes.emplace_back(std::move(workgroupTileSizes));
-
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, pipeline, workgroupSize, subgroupSize,
-        getSoftwarePipeliningAttrDict(op->getContext(), softwarePipelineDepth,
-                                      /*softwarePipelineStoreStage=*/1));
+    return setOpConfigAndEntryPointFnTranslation(entryPoint, op, loweringConfig,
+                                                 pipeline, workgroupSize,
+                                                 subgroupSize, pipelineConfig);
   };
   // Infer the MxN size of the matmul based on operands and indexing maps.
   auto lhsShape =
@@ -1697,10 +1707,8 @@ static LogicalResult setFftConfig(IREE::GPU::TargetAttr target,
       return failure();
     }
   }
-  TileSizesListType tileSizes = {workgroupTileSize};
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-      workgroupSize);
+  return setDefaultWorkgroupOnlyTilingConfig(entryPoint, op, target,
+                                             workgroupTileSize, workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1745,15 +1753,12 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPoint,
                                    Operation *op) {
-  TileSizesListType tileSizes;
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
   auto partitionedLoops =
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
   if (partitionedLoops.empty()) {
-    tileSizes.push_back({});
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-        {1, 1, 1});
+    return setDefaultWorkgroupOnlyTilingConfig(entryPoint, op, target, {},
+                                               {1, 1, 1});
   }
   size_t numLoops = partitionedLoops.back() + 1;
   // To get peak occupancy we need a workgroup size of at least two warps
@@ -1776,10 +1781,8 @@ static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
       break;
     }
   }
-  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, CodeGenPipeline::LLVMGPUDistribute,
-      workgroupSize);
+  return setDefaultWorkgroupOnlyTilingConfig(entryPoint, op, target,
+                                             workgroupTileSizes, workgroupSize);
 }
 
 //====---------------------------------------------------------------------===//
@@ -1790,17 +1793,33 @@ static LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
                                           mlir::FunctionOpInterface entryPoint,
                                           Operation *op) {
-  CodeGenPipeline passPipeline = CodeGenPipeline::LLVMGPUDistribute;
-  TileSizesListType tileSizes;
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
   auto partitionedLoops = interfaceOp.getPartitionableLoops(std::nullopt);
+
+  MLIRContext *context = op->getContext();
+  Builder b(context);
+  auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+      context, /*prefetch_num_stages=*/0,
+      /*no_reduce_shared_memory_bank_conflicts=*/true,
+      /*use_igemm_convolution=*/false,
+      /*reorder_workgroups_strategy=*/std::nullopt);
+  const int preferredSubgroupSize = target.getPreferredSubgroupSize();
+
   if (partitionedLoops.empty()) {
-    tileSizes.push_back({});
-    return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
-                                                 passPipeline, {1, 1, 1});
+    auto configDict = b.getDictionaryAttr({});
+    auto loweringConfig =
+        IREE::GPU::LoweringConfigAttr::get(context, configDict);
+    SmallVector<NamedAttribute, 1> pipelineAttrs;
+    pipelineAttrs.emplace_back(
+        b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+        pipelineOptions);
+    auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
+
+    return setOpConfigAndEntryPointFnTranslation(
+        entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUTileAndFuse,
+        {1, 1, 1}, preferredSubgroupSize, pipelineConfig);
   }
 
-  const int preferredSubgroupSize = target.getPreferredSubgroupSize();
   size_t numLoops = partitionedLoops.back() + 1;
   // To get peak occupancy we need a workgroup size of at least two warps.
   std::array<int64_t, 3> workgroupSize = {2 * preferredSubgroupSize, 1, 1};
@@ -1876,14 +1895,10 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
   // Pick a vectorSize of 1 for op that we know won't get vectorized.
   // Also skip vectorization for linalg on memref (no result) as the pipeline
   // relies on tensor level tiling.
-  // TODO(thomasraoux): This could be improved by checking if the linalg op
-  // would fail vectorization.
   if (!linalgOp || op->getNumResults() != 1 ||
       llvm::any_of(linalgOp.getIndexingMapsArray(),
                    [](AffineMap m) { return !m.isProjectedPermutation(); })) {
     vectorSize = 1;
-  } else {
-    passPipeline = CodeGenPipeline::LLVMGPUVectorize;
   }
 
   int64_t id = 0;
@@ -1906,15 +1921,36 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
     }
   }
 
+  SmallVector<NamedAttribute, 3> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes))};
+
   if (linalgOp) {
-    // Tile reduction dimension to 4 to allow doing load4 if the reduction size
-    // is the most inner dimension.
-    workgroupTileSizes.append(linalgOp.getNumReductionLoops(), 4);
+    int64_t numReduction = linalgOp.getNumReductionLoops();
+    if (numReduction > 0) {
+      // Tile reduction dimension to 4 to allow doing load4 if the reduction
+      // size is the most inner dimension.
+      SmallVector<int64_t> reductionTileSizes(linalgOp.getNumLoops(), 0);
+      for (auto [dim, iterType] :
+           llvm::enumerate(linalgOp.getIteratorTypesArray())) {
+        if (linalg::isReductionIterator(iterType)) {
+          reductionTileSizes[dim] = 4;
+        }
+      }
+      attrs.push_back(
+          NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes)));
+    }
   }
-  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
-  return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
-                                               passPipeline, workgroupSize,
-                                               preferredSubgroupSize);
+
+  auto configDict = b.getDictionaryAttr(attrs);
+  auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
+  SmallVector<NamedAttribute, 1> pipelineAttrs;
+  pipelineAttrs.emplace_back(
+      b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+      pipelineOptions);
+  auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUTileAndFuse,
+      workgroupSize, preferredSubgroupSize, pipelineConfig);
 }
 
 /// Returns true if it's MatVec like i.e., either the bound of M or N dim = 1,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -103,9 +103,6 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
     case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUBaseLowering:
       addGPUBaseLoweringPassPipeline(pipeline);
       break;
-    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute:
-      addGPUSimpleDistributePassPipeline(pipeline);
-      break;
     case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize:
       addGPUVectorizationPassPipeline(pipeline);
       break;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -78,11 +78,6 @@ static llvm::cl::opt<bool> clLLVMGPUEnableSharedMemoryReuse(
         "Enable shared memory reuse in the vector distribute pipeline"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clDistributeToWorkgroupsUsingForall(
-    "iree-llvmgpu-test-distribute-to-workgroups-using-forall",
-    llvm::cl::desc("Use scf.forall for distribution to workgroups"),
-    llvm::cl::init(false), llvm::cl::Hidden);
-
 static llvm::cl::opt<bool> clCombineLayoutTransformation(
     "iree-llvmgpu-test-combine-layout-transformation",
     llvm::cl::desc("Combine relayout ops during dispatch configuration"),
@@ -876,19 +871,6 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-}
-
-void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager) {
-  tileAndBufferize(funcPassManager);
-
-  // Distribute linalg onto threads within the workgroup.
-  funcPassManager.addPass(createLLVMGPUTileAndDistributePass(
-      /*distributeToWarp=*/clDistributeToWorkgroupsUsingForall));
-  funcPassManager.addPass(createCanonicalizerPass());
-  funcPassManager.addPass(createCSEPass());
-
-  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
-  funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 }
 
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -29,11 +29,6 @@ using IREE::GPU::GPUPipelineOptions;
 // LLVMGPU Backend Pass Pipelines
 //----------------------------------------------------------------------------//
 
-/// Simple lowering only distributute linalg ops on blocks and threads. This
-/// will result in scalar operations. Expects pass manager to be a
-/// module-level pass manager.
-void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager);
-
 /// Lowering config driven pipeline that uses greedy tile + fuse to distribute
 /// to threads.
 void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -529,10 +529,10 @@ func.func @only_scattered_dim(%arg0: tensor<48xf32>,
 }
 
 // CHECK-LABEL: func.func @only_scattered_dim(
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [128, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
 
-//       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_codegen.lowering_config
-//  CHECK-SAME:     tile_sizes = {{\[}}[128]]
+//       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     workgroup = [128]
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1091,10 +1091,12 @@ FftOp::getTiledImplementation(OpBuilder &builder,
   int64_t rank = getOperandRank();
   SmallVector<OpFoldResult> strides(rank, builder.getI64IntegerAttr(1));
   SmallVector<Operation *> slices;
-  SmallVector<Value> tiledOperands(3);
-  tiledOperands[0] = getStage();
-  tiledOperands[1] = getRealCoeff();
-  tiledOperands[2] = getImagCoeff();
+  SmallVector<Value> tiledOperands;
+  tiledOperands.push_back(getStage());
+  if (hasCoeff()) {
+    tiledOperands.push_back(getRealCoeff());
+    tiledOperands.push_back(getImagCoeff());
+  }
   SmallVector<Type, 4> resultTypes;
 
   for (Value out : getDpsInits()) {

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -193,7 +193,7 @@ static bool checkContractionOpEquivalence(MLIRContext *context, Operation *aOp,
   }
 
   // TODO(#20116): hack to prevent codegen failure for small horizontally fused
-  // matmuls that go down LLVMGPUDistribute.
+  // matmuls.
   unsigned mDimsSize = 1;
   for (unsigned dim : aContractionDims.value().m) {
     mDimsSize *= aStaticDims[dim];


### PR DESCRIPTION
1/n on removing old pipelines. This also lets us drop the flag for
forall based workgroup distribution since all pipelines use it now.

Additionally cleans up some stale KernelConfig logic that has become
dead over time.