### PR TITLE
Exclude broken ninja version for Windows package builds.

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "ninja",
+    "ninja<1.13.0",
     # MLIR build depends.
     "numpy",
     "packaging",

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "ninja<1.13.0",
+    "ninja!=1.13.0",
     # MLIR build depends.
     "numpy",
     "packaging",

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "ninja<1.13.0",
+    "ninja!=1.13.0",
     "numpy>=2.0.0b1",
     "packaging",
     "ml_dtypes>=0.5.1",

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "ninja",
+    "ninja<1.13.0",
     "numpy>=2.0.0b1",
     "packaging",
     "ml_dtypes>=0.5.1",


### PR DESCRIPTION
This should fix Windows compiler releases that have been failing with
```
   [1850/2155] Linking CXX shared library tools\IREECompiler.dll
  FAILED: [code=4294967295] tools/IREECompiler.dll lib/IREECompiler.lib
  C:\Windows\system32\cmd.exe /C "cd . && C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-xxafopy2\overlay\Lib\site-packages\cmake\data\bin\cmake.exe -E vs_link_dll --msvc-ver=1944 --intdir=compiler\src\iree\compiler\API\CMakeFiles\iree_compiler_API_SharedImpl.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\iree_compiler_API_SharedImpl.rsp  /out:tools\IREECompiler.dll /implib:lib\IREECompiler.lib /pdb:tools\IREECompiler.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO -natvis:D:/a/iree/iree/c/runtime/iree.natvis -pdbpagesize:32768 && cd ."
  LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\iree_compiler_API_SharedImpl.rsp /out:tools\IREECompiler.dll /implib:lib\IREECompiler.lib /pdb:tools\IREECompiler.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO -natvis:D:/a/iree/iree/c/runtime/iree.natvis -pdbpagesize:32768 /MANIFEST:EMBED,ID=2" failed (exit code 1181) with the following output:
  LINK : fatal error LNK1181: cannot open input file 'nternal\CMakeFiles\iree_compiler_API_Internal_LLDToolEntryPoint.objects.dir\LLDToolEntryPoint.cpp.obj'
```

Working logs: https://github.com/iree-org/iree/actions/runs/16871465902/job/47787005080#step:14:67
Broken logs: https://github.com/iree-org/iree/actions/runs/16899526669/job/47875891202#step:14:67

A bad release was pushed to https://pypi.org/project/ninja/#history (Ninja 1.13.0 is affected by https://github.com/ninja-build/ninja/issues/2616, Ninja 1.13.1 has some fixes). We're still waiting on 1.13.1 to be pushed: https://github.com/scikit-build/ninja-python-distributions/issues/308.

Tested with a local build using
```
powershell -File .\build_tools\python_deploy\build_windows_packages.ps1
```
(failed without this change, succeeds with it)

We can revert https://github.com/iree-org/iree/pull/21712 once we've confirmed that this fixes the build.