### PR TITLE
Use range small vector constructors. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -54,7 +54,7 @@ static SmallVector<Value> getTransferIndicesFromNestedLayout(
   ArrayRef<int64_t> batchOffsets(offsets.begin(), rank);
   ArrayRef<int64_t> outerVectorOffsets(offsets.begin() + rank, rank);
 
-  SmallVector<Value> slicedIndices(indices.begin(), indices.end());
+  SmallVector<Value> slicedIndices(indices);
   for (const auto &[i, dim] : llvm::enumerate(permutationMap.getResults())) {
     // Broadcasted dimension offsets can be used as-is; the read index is
     // invariant of the thread in such cases (and illegal for writes).
@@ -272,7 +272,7 @@ static VectorValue projectVector(RewriterBase &rewriter, Location loc,
     slicedDims.erase(iterSpacePos);
   }
 
-  SmallVector<int64_t> transposePerm(slicedDims.begin(), slicedDims.end());
+  auto transposePerm = llvm::to_vector_of<int64_t>(slicedDims);
   transposePerm.append(remaningDims);
   auto transposed =
       rewriter.create<vector::TransposeOp>(loc, val, transposePerm);

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -466,7 +466,7 @@ static SmallVector<Operation *> getAllFusableProducers(TilingInterface op) {
     }
   }
 
-  SmallVector<Operation *> sortedOps(producers.begin(), producers.end());
+  auto sortedOps = llvm::to_vector_of<Operation *>(producers);
   mlir::computeTopologicalSorting(sortedOps);
   return sortedOps;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -1642,7 +1642,7 @@ struct UnrollInnerTiledPattern
         loc, dstVecType, rewriter.getZeroAttr(dstVecType));
     for (const auto &[offsets, partialResult] : accCache) {
       SmallVector<int64_t> dstStrides(offsets.size() + innerAccShape.size(), 1);
-      SmallVector<int64_t> fullOffsets(offsets.begin(), offsets.end());
+      SmallVector<int64_t> fullOffsets(offsets);
       fullOffsets.append(innerAccShape.size(), 0);
       result = rewriter.create<vector::InsertStridedSliceOp>(
           loc, partialResult, result, fullOffsets, dstStrides);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -29,7 +29,7 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
       cast<IREE::Codegen::PackedLayoutMaterializerAttr>(attr);
   MaterializeEncodingInfo encodingInfo = deviceLayoutAttr.getEncodingInfo(type);
   SmallVector<int64_t> paddedShape(type.getShape());
-  SmallVector<Value> paddedDynamicDims(dynamicDims.begin(), dynamicDims.end());
+  SmallVector<Value> paddedDynamicDims(dynamicDims);
   for (auto [dim, size] : llvm::zip_equal(encodingInfo.innerDimsPos,
                                           encodingInfo.innerTileSizes)) {
     // Only VMVX backend has dynamic inner tile sizes when ukernel is enabled.

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -176,8 +176,8 @@ struct FftOpPartitionableLoops
   getPartitionableLoops(Operation *op,
                         std::optional<unsigned> maxNumPartitionedLoops) const {
     auto fftOp = cast<IREE::LinalgExt::FftOp>(op);
-    auto range = llvm::seq<unsigned>(0, fftOp.getOperandRank());
-    SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
+    auto partitionableLoops =
+        llvm::to_vector(llvm::seq<unsigned>(0, fftOp.getOperandRank()));
     // Indices matter for coeff computation.
     if (!fftOp.hasCoeff()) {
       partitionableLoops.pop_back();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -110,7 +110,7 @@ calculateDistributedTileSize(ArrayRef<int64_t> numElements, OpBuilder &builder,
   // partitionedLoops contains the dimensions we want to distribute.
   // We are distributing them in order onto the different workgroup
   // dimensions.
-  SmallVector<int64_t> distributedDim(numElements.begin(), numElements.end());
+  SmallVector<int64_t> distributedDim(numElements);
   distributedDim.resize(partitionedLoops.size());
   unsigned idIdx = 0;
   std::reverse(distributedDim.begin(), distributedDim.end());

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -120,9 +120,8 @@ static TypedAttr createAttributeFromRawData(Location loc,
   if (elementType.isInteger(1)) {
     // Note: cannot use std::vector because it specializes bool in a way
     // that is not compatible with ArrayRef.
-    llvm::SmallVector<bool> boolVector(rawBuffer.begin(), rawBuffer.end());
-    ArrayRef<bool> boolArray(boolVector.data(), boolVector.size());
-    return DenseElementsAttr::get(tensorType, boolArray);
+    SmallVector<bool> boolVector(rawBuffer);
+    return DenseElementsAttr::get(tensorType, boolVector);
   }
 
   emitError(loc) << "unhandled case when converting raw buffer of "

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -143,7 +143,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   }
 
   // Create empty dispatch region.
-  SmallVector<Value> arguments(argumentsSet.begin(), argumentsSet.end());
+  auto arguments = llvm::to_vector_of<Value>(argumentsSet);
   arguments.append(argumentDims);
   for (unsigned i = 0; i < numResults; ++i) {
     // Tied arguments already have their dynamic result dims in `arguments`. Do

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -302,8 +302,8 @@ findFileInPaths(StringRef filePath, ArrayRef<std::string> searchPaths) {
   // Search each path in turn for a file that exists.
   // It doesn't mean we can open it but we'll get a better error out of the
   // actual open attempt than what we could produce here.
-  for (auto searchPath : searchPaths) {
-    SmallVector<char> tryPath{searchPath.begin(), searchPath.end()};
+  for (const std::string &searchPath : searchPaths) {
+    auto tryPath = llvm::to_vector_of<char>(searchPath);
     llvm::sys::path::append(tryPath, filePath);
     if (llvm::sys::fs::exists(Twine(tryPath))) {
       return Twine(tryPath).str();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2039,8 +2039,8 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsForOperands() {
 }
 
 SmallVector<AffineMap> AttentionOp::getIndexingMapsForResults() {
-  auto maps = getIndexingMapsArray();
-  return SmallVector<AffineMap>(maps.begin() + getNumDpsInputs(), maps.end());
+  return llvm::to_vector_of<AffineMap>(
+      llvm::drop_begin(getIndexingMapsArray(), getNumDpsInputs()));
 }
 
 void AttentionOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
@@ -2400,7 +2400,7 @@ LogicalResult Im2colOp::verify() {
            << ") to match the number of shared dimensions (m_Pos + k_pos = "
            << sharedRank << ")";
   }
-  SmallVector<int64_t> permVec(inputKPerm.begin(), inputKPerm.end());
+  SmallVector<int64_t> permVec(inputKPerm);
   llvm::sort(permVec);
   for (int64_t i = 0; i < static_cast<int64_t>(sharedRank); ++i) {
     if (permVec[i] != i) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -670,7 +670,7 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
       },
       [&](OpBuilder &b, Location loc) {
         // Swap the pairs if false.
-        SmallVector<Value> indices(ivs.begin(), ivs.end());
+        SmallVector<Value> indices(ivs);
         Value ivPlusOne =
             b.create<arith::AddIOp>(loc, scfFor.getInductionVar(), one);
         for (int i = 0, e = getNumDpsInits(); i < e; ++i) {
@@ -840,7 +840,7 @@ LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
 
   auto rank = getOperandRank();
   SmallVector<Value> operands;
-  SmallVector<OpFoldResult> lhsIvs(ivs.begin(), ivs.end());
+  SmallVector<OpFoldResult> lhsIvs(ivs);
   SmallVector<OpFoldResult> ones(rank, b.getIndexAttr(1));
   SmallVector<OpFoldResult> sizes(rank, b.getIndexAttr(1));
   sizes.back() = halfSize;
@@ -849,7 +849,7 @@ LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
   operands.push_back(
       b.create<memref::SubViewOp>(loc, imag, lhsIvs, sizes, ones));
 
-  SmallVector<OpFoldResult> rhsIvs(ivs.begin(), ivs.end());
+  SmallVector<OpFoldResult> rhsIvs(ivs);
   rhsIvs.back() =
       b.create<arith::AddIOp>(loc, ivs.back(), halfSize).getResult();
   operands.push_back(
@@ -969,7 +969,7 @@ LogicalResult ScanOp::generateScalarImplementation(OpBuilder &b, Location loc,
         b.create<scf::YieldOp>(loc);
       },
       [&](OpBuilder &b, Location loc) {
-        SmallVector<Value> indices(ivs.begin(), ivs.end());
+        SmallVector<Value> indices(ivs);
         Value iv = indices[scanDim];
         Value ivMinusOne = b.create<arith::SubIOp>(loc, iv, one);
         indices[scanDim] = ivMinusOne;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -275,7 +275,7 @@ public:
         winogradInput, loc, rewriter, collapsedShape, reassociations);
 
     // Add BatchMatmulOp
-    SmallVector<int64_t> bmmShape(collapsedShape.begin(), collapsedShape.end());
+    SmallVector<int64_t> bmmShape(collapsedShape);
     SmallVector<int64_t> outputShape(outputType.getShape());
     if (isNchwFchw) {
       permute<IREE::LinalgExt::Permutation::NCHW_TO_NHWC>(outputShape);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -48,7 +48,7 @@ SmallVector<int64_t> getExpandedShape(ArrayRef<int64_t> shape,
 SmallVector<int64_t> getCollapsedShape(ArrayRef<int64_t> shape,
                                        int64_t splitReductionRatio, int64_t k,
                                        int64_t targetDim) {
-  SmallVector<int64_t> ans(shape.begin(), shape.end());
+  SmallVector<int64_t> ans(shape);
   ans[targetDim] = k * splitReductionRatio;
   return ans;
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
@@ -65,11 +65,11 @@ void AttentionOpDetail::inferFromIndexingMaps(AffineMap qMap, AffineMap kMap,
   llvm::set_subtract(nSet, bSet);
   llvm::set_subtract(nSet, k2Set);
 
-  batch = SmallVector<int64_t>(bSet.begin(), bSet.end());
-  m = SmallVector<int64_t>(mSet.begin(), mSet.end());
-  k1 = SmallVector<int64_t>(k1Set.begin(), k1Set.end());
-  k2 = SmallVector<int64_t>(k2Set.begin(), k2Set.end());
-  n = SmallVector<int64_t>(nSet.begin(), nSet.end());
+  batch = llvm::to_vector_of<int64_t>(bSet);
+  m = llvm::to_vector_of<int64_t>(mSet);
+  k1 = llvm::to_vector_of<int64_t>(k1Set);
+  k2 = llvm::to_vector_of<int64_t>(k2Set);
+  n = llvm::to_vector_of<int64_t>(nSet);
 
   // Sort to ensure that dims are in outermost to innermost order.
   llvm::sort(batch);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
@@ -238,16 +238,14 @@ inferScaledContractionDimsImpl(ArrayRef<AffineMap> indexingMaps,
 
   // Return each set in sorted order.
   ScaledContractionDimensions dimensions{
-      SmallVector<unsigned, 2>(batches.begin(), batches.end()),
-      SmallVector<unsigned, 2>(ac.begin(), ac.end()),
-      SmallVector<unsigned, 2>(bc.begin(), bc.end()),
-      SmallVector<unsigned, 2>(sa.begin(), sa.end()),
-      SmallVector<unsigned, 2>(ra.begin(), ra.end())};
-  llvm::sort(dimensions.batch.begin(), dimensions.batch.end());
-  llvm::sort(dimensions.m.begin(), dimensions.m.end());
-  llvm::sort(dimensions.n.begin(), dimensions.n.end());
-  llvm::sort(dimensions.k.begin(), dimensions.k.end());
-  llvm::sort(dimensions.kB.begin(), dimensions.kB.end());
+      llvm::to_vector_of<unsigned, 2>(batches),
+      llvm::to_vector_of<unsigned, 2>(ac), llvm::to_vector_of<unsigned, 2>(bc),
+      llvm::to_vector_of<unsigned, 2>(sa), llvm::to_vector_of<unsigned, 2>(ra)};
+  llvm::sort(dimensions.batch);
+  llvm::sort(dimensions.m);
+  llvm::sort(dimensions.n);
+  llvm::sort(dimensions.k);
+  llvm::sort(dimensions.kB);
   return dimensions;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -52,7 +52,7 @@ SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 
   // NOTE: to ensure deterministic output we sort the result so that imports are
   // always added in a consistent order.
-  SmallVector<const T *> results = {resultSet.begin(), resultSet.end()};
+  auto results = llvm::to_vector_of<const T *, 4>(resultSet);
   llvm::sort(
       results, +[](const T *a, const T *b) {
         return a->getDialect()->getNamespace().compare(

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
@@ -293,7 +293,7 @@ struct CallOpConversion : public OpConversionPattern<func::CallOp> {
     // Otherwise this is a direct call to an internal function.
     auto newOp = rewriter.create<IREE::VM::CallOp>(loc, calleeName, resultTypes,
                                                    operands);
-    return SmallVector<Value>(newOp.result_begin(), newOp.result_end());
+    return llvm::to_vector_of<Value>(newOp->getResults());
   }
 
   // Converts a call to an import that may be optional.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
@@ -268,7 +268,7 @@ struct CallOpConversion : public OpConversionPattern<IREE::Util::CallOp> {
     // Otherwise this is a direct call to an internal function.
     auto newOp = rewriter.create<IREE::VM::CallOp>(loc, calleeName, resultTypes,
                                                    operands);
-    return SmallVector<Value>(newOp.result_begin(), newOp.result_end());
+    return llvm::to_vector_of<Value>(newOp.getResults());
   }
 
   // Converts a call to an import that may be optional.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
@@ -67,7 +67,7 @@ gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 
   // NOTE: to ensure deterministic output we sort the result so that imports are
   // always added in a consistent order.
-  SmallVector<const T *> results = {resultSet.begin(), resultSet.end()};
+  auto results = llvm::to_vector_of<const T *, 4>(resultSet);
   llvm::sort(
       results, +[](const T *a, const T *b) {
         return a->getDialect()->getNamespace().compare(

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/GlobalOptimization/Passes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -386,7 +387,7 @@ Value QuantizedMatmulRewriter::getGroupReductionInit(Value input) {
   Value zero = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getFloatAttr(inputType.getElementType(), 0.0));
   SmallVector<int64_t> inputShape(inputType.getShape());
-  SmallVector<int64_t> outputShape(inputShape.begin(), inputShape.end() - 1);
+  SmallVector<int64_t> outputShape(llvm::drop_end(inputShape));
   RankedTensorType outputType =
       RankedTensorType::get(outputShape, inputType.getElementType());
   Value emptyOut = rewriter.create<tensor::EmptyOp>(


### PR DESCRIPTION
The advantage is that these are more concise and less error prone (e.g., passing iterators from two different ranges).