### PR TITLE
Drop needless template parameters from patterns. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -171,7 +171,7 @@ dropBatchTileSize(IREE::CPU::LoweringConfigAttr config) {
 /// Pattern to convert linalg.batch_mmt4d with batch dim = 1 into mmt4d.
 struct ConvertBatchMmt4DtoMmt4DPattern
     : public OpRewritePattern<linalg::BatchMmt4DOp> {
-  using OpRewritePattern<linalg::BatchMmt4DOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::BatchMmt4DOp op,
                                 PatternRewriter &rewriter) const override {
@@ -251,7 +251,7 @@ struct ConvertBatchMmt4DtoMmt4DPattern
 };
 
 struct Convert3DPackto2DPackPattern : public OpRewritePattern<linalg::PackOp> {
-  using OpRewritePattern<linalg::PackOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::PackOp packOp,
                                 PatternRewriter &rewriter) const override {
@@ -321,7 +321,7 @@ struct Convert3DPackto2DPackPattern : public OpRewritePattern<linalg::PackOp> {
 
 struct Convert5DUnPackto4DUnPackPattern
     : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern<linalg::UnPackOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::UnPackOp unpackOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
@@ -34,7 +34,7 @@ namespace {
 /// not common in practice, so it is not supported now.
 struct SinkDownCollapsingUnitDimsAcrossUnpack final
     : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern<linalg::UnPackOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::UnPackOp op,
                                 PatternRewriter &rewriter) const override {
     if (!isIdentityPermutation(op.getOuterDimsPerm())) {

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -46,7 +46,7 @@ namespace {
 /// A wrapper pattern that calls linalg::lowerPack on linalg::PackOp. It lowers
 /// a linalg.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
 struct LowerPackPattern : public OpRewritePattern<linalg::PackOp> {
-  using OpRewritePattern<linalg::PackOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   explicit LowerPackPattern(MLIRContext *context,
                             std::optional<PackUnPackControlFn> controlFn)
@@ -79,7 +79,7 @@ private:
 /// lowers a linalg.unpack op to tensor.empty + linalg.transpose +
 /// tensor.collapse_shape + tensor.extract_slice ops.
 struct LowerUnPackPattern : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern<linalg::UnPackOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   explicit LowerUnPackPattern(MLIRContext *context,
                               std::optional<PackUnPackControlFn> controlFn)

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
@@ -28,7 +28,7 @@ static bool isScalarOrTensorOfSizeOne(Type t) {
 }
 
 struct FuseElementWiseGenericOps : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
@@ -17,7 +17,7 @@ namespace {
 // (from
 // https://github.com/ROCm/llvm-project/blob/amd-staging/amd/device-libs/ocml/src/erfF.cl#L11)
 struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
-  using OpRewritePattern<math::ErfOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(math::ErfOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -23,7 +23,7 @@ namespace {
 
 struct CanonicalizeForOpInductionVarShape final
     : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   // Return true if it might be possible to yield the operand of `op` instead of
   // its result.
@@ -200,7 +200,7 @@ struct CanonicalizeForOpInductionVarShape final
 /// pattern allows packing i4/i8/f16 values into i32 variables tightly so that
 /// we can generate shader conformant SPIR-V.
 struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -151,7 +151,7 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
 // MMA types but MMA load can transpose the matrix when loading.
 struct CombineTransferReadOpBroadcast final
     : public OpRewritePattern<vector::BroadcastOp> {
-  using OpRewritePattern<vector::BroadcastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::BroadcastOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -165,7 +165,7 @@ struct InsertToBroadcast final : OpRewritePattern<vector::InsertOp> {
 
 /// Pattern to sink `gpu.barrier` ops out of a `warp_execute_on_lane_0` op.
 struct WarpOpBarrier final : OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
-  using OpRewritePattern<gpu::WarpExecuteOnLane0Op>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(gpu::WarpExecuteOnLane0Op warpOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
@@ -77,7 +77,7 @@ static bool isTrivialSubViewOp(memref::SubViewOp subviewOp) {
 class DynamicTrivialSubViewOpFolder final
     : public OpRewritePattern<memref::SubViewOp> {
 public:
-  using OpRewritePattern<memref::SubViewOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(memref::SubViewOp subViewOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -131,7 +131,7 @@ namespace {
 
 struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     : public OpRewritePattern<memref::ExtractStridedMetadataOp> {
-  using OpRewritePattern<memref::ExtractStridedMetadataOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(memref::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
     auto binding =

--- a/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
@@ -18,7 +18,7 @@ namespace mlir::iree_compiler {
 
 namespace {
 struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
-  using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(memref::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -282,7 +282,7 @@ struct CastLikeInsertSliceOpFolder final
 /// write to memory.
 // TODO: Consider upstreaming
 struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::TransferReadOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -37,7 +37,7 @@ namespace {
 class TransposeUnitDimToShapeCast
     : public OpRewritePattern<vector::TransposeOp> {
 public:
-  using OpRewritePattern<vector::TransposeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::TransposeOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -29,7 +29,7 @@ static bool isScalarOrTensorOfSizeOne(Type t) {
 /// `flow.dispatch.region`.
 struct RematerializeParallelOpsPattern
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -90,7 +90,7 @@ inferCollapsedShape(RewriterBase &rewriter, Location loc,
 ///       tensor<864xf32>
 struct FoldCollapseShapeIntoInterfaceTensorLoad
     : OpRewritePattern<tensor::CollapseShapeOp> {
-  using OpRewritePattern<tensor::CollapseShapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::CollapseShapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
@@ -166,7 +166,7 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
 ///       tensor<864xf32>
 struct FoldExpandShapeIntoInterfaceTensorLoad
     : OpRewritePattern<tensor::ExpandShapeOp> {
-  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
@@ -820,7 +820,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
 /// the source hal.interface.binding.subspan
 struct FoldInnerBitcastIntoInterfaceTensorLoad
     : OpRewritePattern<IREE::TensorExt::BitCastOp> {
-  using OpRewritePattern<IREE::TensorExt::BitCastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const override {
@@ -1031,7 +1031,7 @@ expandMemrefOperand(RewriterBase &rewriter, OpTy tensorToMemrefOp,
 /// tensor operand with the source of the expand_shape.
 struct FoldExpandShapeIntoStoreToBuffer
     : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
-  using OpRewritePattern<IREE::Codegen::StoreToBufferOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1055,7 +1055,7 @@ struct FoldExpandShapeIntoStoreToBuffer
 /// tensor operand with the source of the collapse_shape.
 struct FoldCollapseShapeIntoStoreToBuffer
     : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
-  using OpRewritePattern<IREE::Codegen::StoreToBufferOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1083,7 +1083,7 @@ struct FoldCollapseShapeIntoStoreToBuffer
 /// the collapse_shape with the collapsed load_from_buffer op.
 struct FoldCollapseShapeIntoLoadFromBuffer
     : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
-  using OpRewritePattern<IREE::Codegen::LoadFromBufferOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
@@ -1112,7 +1112,7 @@ struct FoldCollapseShapeIntoLoadFromBuffer
 /// expand_shape with the expanded load_from_buffer op.
 struct FoldExpandShapeIntoLoadFromBuffer
     : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
-  using OpRewritePattern<IREE::Codegen::LoadFromBufferOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -566,7 +566,7 @@ namespace {
 /// slice.
 struct SwapExtractSliceWithDispatchTensorLoad
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -597,7 +597,7 @@ struct SwapExtractSliceWithDispatchTensorLoad
 /// `empty` of the slice.
 struct SwapExtractSliceWithTensorEmpty
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -136,7 +136,7 @@ namespace {
 // TODO: atm hardcoded on linalg.fill but we could take any result of any
 // generic that yields a constant in that result.
 struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const final {
     Operation *currentOp = padOp.getSource().getDefiningOp();
@@ -904,7 +904,7 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
 namespace {
 /// Pattern to rewrite tensor.empty to tensor.alloc.
 struct EmptyTensorLoweringPattern : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern<tensor::EmptyOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::EmptyOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -124,7 +124,7 @@ namespace {
 
 struct FoldRelayoutOpIntoMapScatterPattern
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern<IREE::LinalgExt::MapScatterOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
@@ -145,7 +145,7 @@ struct FoldRelayoutOpIntoMapScatterPattern
 
 struct FoldPadOpIntoMapScatterPattern
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern<IREE::LinalgExt::MapScatterOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   FoldPadOpIntoMapScatterPattern(MLIRContext *context,
                                  PadDistributionConfigFn configFn,
                                  PatternBenefit benefit = 1)
@@ -337,7 +337,7 @@ namespace {
 
 struct SwapExpandShapeWithSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -655,7 +655,7 @@ namespace {
 
 struct SwapCollapseShapeWithSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -955,7 +955,7 @@ fuseExtractSliceIntoProducerForall(RewriterBase &rewriter,
 namespace {
 struct LowerInnerTiledPattern
     : public OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern<IREE::Codegen::InnerTiledOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     if (tiledOp.hasTensorSemantics()) {
@@ -1429,7 +1429,7 @@ distributeInnerTiledOp(RewriterBase &rewriter,
 namespace {
 struct DropInnerTiledUnitDimsPattern
     : public OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern<IREE::Codegen::InnerTiledOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     if (tiledOp.hasTensorSemantics()) {
@@ -1786,7 +1786,7 @@ void mapLaneForalls(RewriterBase &rewriter, Operation *funcOp,
 namespace {
 struct LowerBarrierRegion
     : public OpRewritePattern<IREE::GPU::BarrierRegionOp> {
-  using OpRewritePattern<IREE::GPU::BarrierRegionOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::GPU::BarrierRegionOp barrierRegionOp,
                                 PatternRewriter &rewriter) const final {
     Location loc = barrierRegionOp.getLoc();
@@ -1877,7 +1877,7 @@ vectorizeStaticInnerTiledOp(RewriterBase &rewriter,
 namespace {
 struct VectorizeStaticInnerTiledOpPattern final
     : OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern<IREE::Codegen::InnerTiledOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     return vectorizeStaticInnerTiledOp(rewriter, tiledOp);
@@ -1896,7 +1896,7 @@ void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns) {
 namespace {
 struct LowerValueBarrierPattern
     : public OpRewritePattern<IREE::GPU::ValueBarrierOp> {
-  using OpRewritePattern<IREE::GPU::ValueBarrierOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::GPU::ValueBarrierOp barrier,
                                 PatternRewriter &rewriter) const override {
     if (barrier.hasTensorSemantics()) {
@@ -1913,7 +1913,7 @@ struct LowerValueBarrierPattern
 
 struct LowerGlobalLoadDMAPattern
     : public OpRewritePattern<IREE::GPU::GlobalLoadDMAOp> {
-  using OpRewritePattern<IREE::GPU::GlobalLoadDMAOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::GPU::GlobalLoadDMAOp dmaOp,
                                 PatternRewriter &rewriter) const override {
     Type transferType = rewriter.getI32Type();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -885,7 +885,7 @@ struct RewriteExternCallOpToDynamicImportCallOp
 /// vectorized.
 class ExpandMulSIExtended : public OpRewritePattern<arith::MulSIExtendedOp> {
 public:
-  using OpRewritePattern<arith::MulSIExtendedOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(arith::MulSIExtendedOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -21,7 +21,7 @@ namespace {
 // TODO(ataei): Upstream this pattern if needed ?
 class UnfusedFMAOpsPassConversion : public OpRewritePattern<LLVM::FMAOp> {
 public:
-  using OpRewritePattern<LLVM::FMAOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(LLVM::FMAOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -1020,7 +1020,7 @@ public:
 struct MMT_8x4x8_i8i8i32_Aarch64Dotprod_Intrinsics
     : public OpRewritePattern<vector::ContractionOp> {
 public:
-  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::ContractionOp contractionOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -147,7 +147,7 @@ struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
 };
 
 struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(memref::AllocOp allocOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -59,7 +59,7 @@ namespace {
 // operations as well.
 struct ReplaceGPUBarrierWithLDSBarrier
     : public OpRewritePattern<gpu::BarrierOp> {
-  using OpRewritePattern<gpu::BarrierOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(gpu::BarrierOp op,
                                 PatternRewriter &rewriter) const override {
@@ -96,7 +96,7 @@ static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns) {
 /// effort.
 constexpr StringLiteral kSwapName = "iree_gpu.swap_mfma";
 struct SwapSetPrioWithMFMA : public OpRewritePattern<ROCDL::SetPrioOp> {
-  using OpRewritePattern<ROCDL::SetPrioOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ROCDL::SetPrioOp setPrio,
                                 PatternRewriter &rewriter) const override {
     if (!setPrio->hasAttr(kSwapName)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -410,7 +410,7 @@ namespace {
 /// gpu.synchronize
 /// %0 = memref.load %src[%c0] : memref<1024xf32>
 struct WarpOpLoad : public OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
-  using OpRewritePattern<gpu::WarpExecuteOnLane0Op>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(gpu::WarpExecuteOnLane0Op warpOp,
                                 PatternRewriter &rewriter) const override {
     OpOperand *operand = getWarpResult(warpOp, llvm::IsaPred<memref::LoadOp>);
@@ -454,7 +454,7 @@ struct WarpOpLoad : public OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
 /// really have the semantic of global variables. Therefore hoisting them is
 /// always correct for static allocations.
 struct HoistSharedMemoryAlloc : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(memref::AllocOp alloc,
                                 PatternRewriter &rewriter) const override {
     if (!iree_compiler::hasSharedMemoryAddressSpace(alloc.getType()))
@@ -1347,7 +1347,7 @@ namespace {
 /// Polygeist.
 class BarrierElimination final : public OpRewritePattern<gpu::BarrierOp> {
 public:
-  using OpRewritePattern<gpu::BarrierOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(gpu::BarrierOp barrier,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -279,7 +279,7 @@ void populateVectorUnrollPatterns(ArrayRef<int64_t> cooperativeOpSize,
 class CombineContractTranspose final
     : public OpRewritePattern<vector::ContractionOp> {
 public:
-  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::ContractionOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -162,7 +162,7 @@ static std::optional<int64_t> foldAffineMin(affine::AffineMinOp minOp) {
 namespace {
 struct AffineMinDistributedSCFCanonicalizationPattern
     : public mlir::OpRewritePattern<mlir::affine::AffineMinOp> {
-  using OpRewritePattern<mlir::affine::AffineMinOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   mlir::LogicalResult
   matchAndRewrite(mlir::affine::AffineMinOp minOp,

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -574,7 +574,7 @@ static SmallVector<Attribute> appendSplitReductionMappingToWorkgroupMapping(
 // loop also has workgroup mapping.
 struct FoldSplitReductionForallWithWorkgroupForall
     : public OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern<scf::ForallOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(scf::ForallOp forallOp,
                                 PatternRewriter &rewriter) const override {
@@ -940,7 +940,7 @@ distributeLinalgOpsWithFilter(mlir::FunctionOpInterface funcOp,
 
 namespace {
 struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(scf::ForOp loop,
                                 PatternRewriter &rewriter) const final {
     if (loop.getBody()->getOperations().size() == 1) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -50,7 +50,7 @@ struct ConvertLinalgFillPattern final
 /// Convert tensor.insert_slice ops into flow.tensor.update ops where possible.
 struct ConvertTensorInsertSlicePattern
     : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
                                 PatternRewriter &rewriter) const override {
     return convertInsertSliceOpToFlowUpdateOp(rewriter, insertOp);
@@ -59,7 +59,7 @@ struct ConvertTensorInsertSlicePattern
 
 /// Convert tensor.insert ops into flow.tensor.store ops where possible.
 struct ConvertTensorInsertPattern : public OpRewritePattern<tensor::InsertOp> {
-  using OpRewritePattern<tensor::InsertOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::InsertOp insertOp,
                                 PatternRewriter &rewriter) const override {
     if (insertOp->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -75,7 +75,7 @@ struct ConvertTensorInsertPattern : public OpRewritePattern<tensor::InsertOp> {
 /// Convert tensor.extract_slice ops into flow.tensor.slice ops where possible.
 struct ConvertTensorExtractSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     return convertExtractSliceOpToFlowSliceOp(rewriter, sliceOp);
@@ -84,7 +84,7 @@ struct ConvertTensorExtractSlicePattern
 
 struct ConvertTensorExtractPattern
     : public OpRewritePattern<tensor::ExtractOp> {
-  using OpRewritePattern<tensor::ExtractOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractOp op,
                                 PatternRewriter &rewriter) const override {
@@ -99,7 +99,7 @@ struct ConvertTensorExtractPattern
 
 struct ConvertTensorExtBitcastPattern
     : public OpRewritePattern<TensorExt::BitCastOp> {
-  using OpRewritePattern<TensorExt::BitCastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorExt::BitCastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -114,7 +114,7 @@ struct ConvertTensorExtBitcastPattern
 
 struct ConvertTensorBitcastPattern
     : public OpRewritePattern<tensor::BitcastOp> {
-  using OpRewritePattern<tensor::BitcastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::BitcastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -130,7 +130,7 @@ struct ConvertTensorBitcastPattern
 };
 
 struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
-  using OpRewritePattern<tensor::CastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::CastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -194,7 +194,7 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
 };
 
 struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
-  using OpRewritePattern<tensor::ConcatOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {
@@ -277,7 +277,7 @@ struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
 
 struct ConvertTensorFromElementsPattern
     : public OpRewritePattern<tensor::FromElementsOp> {
-  using OpRewritePattern<tensor::FromElementsOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::FromElementsOp op,
                                 PatternRewriter &rewriter) const override {
     // TODO: This pattern was mainly added to iron out some kinks specific to
@@ -337,7 +337,7 @@ static SmallVector<Value> getDynamicTensorSizes(OpBuilder &builder,
 /// Convert tensor.reshape ops into flow.tensor.reshape ops where possible.
 struct ConvertTensorDialectReshapeOpPattern
     : public OpRewritePattern<tensor::ReshapeOp> {
-  using OpRewritePattern<tensor::ReshapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -449,7 +449,7 @@ namespace {
 
 struct ExpandDynamicShapeConstant
     : public OpRewritePattern<TensorDynamicConstantOp> {
-  using OpRewritePattern<TensorDynamicConstantOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorDynamicConstantOp op,
                                 PatternRewriter &rewriter) const override {
     auto constantOp = rewriter.create<IREE::Flow::TensorConstantOp>(
@@ -566,7 +566,7 @@ struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
 };
 
 struct ResolveShapedRank : public OpRewritePattern<tensor::RankOp> {
-  using OpRewritePattern<tensor::RankOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::RankOp op,
                                 PatternRewriter &rewriter) const override {
     auto shapedType = llvm::cast<ShapedType>(op.getTensor().getType());
@@ -577,7 +577,7 @@ struct ResolveShapedRank : public OpRewritePattern<tensor::RankOp> {
 };
 
 struct ResolveShapedDim : public OpRewritePattern<tensor::DimOp> {
-  using OpRewritePattern<tensor::DimOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::DimOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getConstantIndex().has_value()) {
@@ -677,7 +677,7 @@ namespace {
 // Replace `flow.tensor.splat`-`flow.tensor.load` op-pairs by the input
 // primitive value for the splat op.
 struct FoldSplatLoadIntoPrimitive : public OpRewritePattern<TensorLoadOp> {
-  using OpRewritePattern<TensorLoadOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceOp =
@@ -750,7 +750,7 @@ void TensorEmptyOp::getCanonicalizationPatterns(RewritePatternSet &results,
 namespace {
 
 struct FoldSplatReshapeIntoSplat : public OpRewritePattern<TensorReshapeOp> {
-  using OpRewritePattern<TensorReshapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorReshapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
     auto splatOp = dyn_cast_if_present<TensorSplatOp>(
@@ -1069,7 +1069,7 @@ namespace {
 // When the target tensor is a result of a tensor.cast operation, the op needs
 // to be updated to use the source of the cast as the target tensor.
 struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
-  using OpRewritePattern<TensorUpdateOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     auto targetCastOp = updateOp.getTarget().getDefiningOp<tensor::CastOp>();
@@ -1097,7 +1097,7 @@ struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
 
 struct ReplaceOpIfTensorUpdateOperandZeroElements
     : public OpRewritePattern<TensorUpdateOp> {
-  using OpRewritePattern<TensorUpdateOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TensorUpdateOp op,
                                 PatternRewriter &rewriter) const override {
     auto operand = op.getUpdate();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -628,7 +628,7 @@ bool dropUnusedAndRedundantDispatchRegionResults(
 
 struct DispatchRegionDropUnusedResults
     : public OpRewritePattern<DispatchRegionOp> {
-  using OpRewritePattern<DispatchRegionOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(DispatchRegionOp regionOp,
                                 PatternRewriter &rewriter) const final {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalize.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalize.cpp
@@ -35,7 +35,7 @@ static std::optional<SmallVector<OpFoldResult>> getDefiningMixedSizes(Value v) {
 }
 
 struct FoldFullInsertSlice : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertSliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -87,7 +87,7 @@ struct FoldFullInsertSlice : public OpRewritePattern<tensor::InsertSliceOp> {
 /// Convert an "affine.apply" operation into a sequence of arith ops.
 class AffineApplyLowering : public OpRewritePattern<affine::AffineApplyOp> {
 public:
-  using OpRewritePattern<affine::AffineApplyOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(affine::AffineApplyOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -43,7 +43,7 @@ namespace {
 
 /// Converts an tensor.empty() op to `flow.tensor.splat` op.
 struct RewriteTensorEmptyToSplat : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern<tensor::EmptyOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::EmptyOp emptyTensorOp,
                                 PatternRewriter &rewriter) const override {
     if (!shouldBeConvertedToFlowTensorOp(emptyTensorOp)) {
@@ -67,7 +67,7 @@ struct RewriteTensorEmptyToSplat : public OpRewritePattern<tensor::EmptyOp> {
 
 /// Converts an tensor.empty() op to `flow.tensor.empty` op.
 struct RewriteTensorEmptyToEmpty : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern<tensor::EmptyOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::EmptyOp emptyTensorOp,
                                 PatternRewriter &rewriter) const override {
     if (!shouldBeConvertedToFlowTensorOp(emptyTensorOp)) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -499,7 +499,7 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
 namespace {
 
 struct ConvertReturnPattern : public OpRewritePattern<IREE::Stream::ReturnOp> {
-  using OpRewritePattern<IREE::Stream::ReturnOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Stream::ReturnOp op,
                                 PatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<IREE::HAL::ReturnOp>(op, op.getOperands());
@@ -522,7 +522,7 @@ struct ConvertDispatchWorkgroupInfoPattern final
 
 struct InlineConstantWorkgroupSizePattern
     : public OpRewritePattern<IREE::HAL::InterfaceWorkgroupSizeOp> {
-  using OpRewritePattern<IREE::HAL::InterfaceWorkgroupSizeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::HAL::InterfaceWorkgroupSizeOp sizeOp,
                                 PatternRewriter &rewriter) const override {
     // Lookup the entry point matching the parent.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -112,7 +112,7 @@ struct FoldWinogradOpUnitDims : public OpRewritePattern<TransformOp> {
 /// ````
 struct DecomposeWinogradFilterTransform
     : public OpRewritePattern<WinogradFilterTransformOp> {
-  using OpRewritePattern<WinogradFilterTransformOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(WinogradFilterTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {
@@ -194,7 +194,7 @@ struct DecomposeWinogradFilterTransform
 /// ````
 struct DecomposeWinogradInputTransform
     : public OpRewritePattern<WinogradInputTransformOp> {
-  using OpRewritePattern<WinogradInputTransformOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(WinogradInputTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {
@@ -277,7 +277,7 @@ struct DecomposeWinogradInputTransform
 /// ````
 struct DecomposeWinogradOutputTransform
     : public OpRewritePattern<WinogradOutputTransformOp> {
-  using OpRewritePattern<WinogradOutputTransformOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(WinogradOutputTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -463,7 +463,7 @@ fuseWithReshapeByExpansion(OpTy op, Operation *reshapeOp,
 namespace {
 
 struct DropScatterUnitIndexDepth final : public OpRewritePattern<ScatterOp> {
-  using OpRewritePattern<ScatterOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ScatterOp scatterOp,
                                 PatternRewriter &rewriter) const override {
     llvm::ArrayRef<int64_t> indicesShape =
@@ -576,7 +576,7 @@ Value rankExpandValue(RewriterBase &rewriter, Location loc, Value destVal,
 }
 
 struct DropMapScatterUnitDims final : public OpRewritePattern<MapScatterOp> {
-  using OpRewritePattern<MapScatterOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   DropMapScatterUnitDims(MLIRContext *context,
                          linalg::ControlDropUnitDims options,
                          PatternBenefit benefit = 1)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
@@ -20,7 +20,7 @@ namespace {
 
 struct VectorizeStaticMapScatterOpPattern final
     : OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern<IREE::LinalgExt::MapScatterOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
     if (mapScatterOp.isVectorized()) {

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -17,7 +17,7 @@ namespace mlir::iree_compiler::IREE::TensorExt {
 
 namespace {
 struct ReplaceBitCastIfTensorOperandEmpty final : OpRewritePattern<BitCastOp> {
-  using OpRewritePattern<BitCastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BitCastOp op,
                                 PatternRewriter &rewriter) const override {
     auto emptyOp =
@@ -31,7 +31,7 @@ struct ReplaceBitCastIfTensorOperandEmpty final : OpRewritePattern<BitCastOp> {
 };
 
 struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
-  using OpRewritePattern<BitCastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const final {

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::IREE::TensorExt {
 /// `tensor.extract_slice`.
 struct FoldTensorLoadWithExtractSlice
     : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -207,7 +207,7 @@ namespace {
 
 /// Deduplicates operands, merging assume ranges along the way.
 struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
-  using OpRewritePattern<AssumeIntOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(AssumeIntOp op,
                                 PatternRewriter &rewriter) const override {
     ArrayAttr assumptions = op.getAssumptions();
@@ -269,7 +269,7 @@ struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
 ///
 /// Where X | Y.
 struct FoldDivMulOfAssume : public OpRewritePattern<arith::MulIOp> {
-  using OpRewritePattern<arith::MulIOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(arith::MulIOp mulOp,
                                 PatternRewriter &rewriter) const override {
     APInt mulConstantInt;
@@ -343,7 +343,7 @@ namespace {
 /// Folds cast ops into the result of other ops.
 /// Only safe to apply to ops that don't care about their types.
 struct FoldCastIntoNullOp : public OpRewritePattern<CastOp> {
-  using OpRewritePattern<CastOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CastOp castOp,
                                 PatternRewriter &rewriter) const override {
     auto nullOp = dyn_cast_or_null<NullOp>(castOp.getOperand().getDefiningOp());
@@ -824,7 +824,7 @@ namespace {
 
 struct ExpandUnfoldableConstantOp
     : public OpRewritePattern<UnfoldableConstantOp> {
-  using OpRewritePattern<IREE::Util::UnfoldableConstantOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(UnfoldableConstantOp op,
                                 PatternRewriter &rewriter) const override {
     auto stdConst = rewriter.create<arith::ConstantOp>(
@@ -909,7 +909,7 @@ namespace {
 /// store back to the same global: we want to be able to elide the entire load
 /// and store.
 struct EraseUnusedGlobalStoreOp : public OpRewritePattern<GlobalStoreOp> {
-  using OpRewritePattern<GlobalStoreOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(GlobalStoreOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -2897,7 +2897,7 @@ namespace {
 
 /// Changes a cmp.eq.ref check against null to a cmp.nz.ref and inverted cond.
 struct NullCheckCmpEQRefToCmpNZRef : public OpRewritePattern<CmpEQRefOp> {
-  using OpRewritePattern<CmpEQRefOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CmpEQRefOp op,
                                 PatternRewriter &rewriter) const override {
     Attribute rhs;
@@ -2932,7 +2932,7 @@ namespace {
 
 /// Changes a cmp.ne.ref check against null to a cmp.nz.ref.
 struct NullCheckCmpNERefToCmpNZRef : public OpRewritePattern<CmpNERefOp> {
-  using OpRewritePattern<CmpNERefOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CmpNERefOp op,
                                 PatternRewriter &rewriter) const override {
     Attribute rhs;
@@ -3027,7 +3027,7 @@ namespace {
 ///
 /// (same logic as for std.br)
 struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
-  using OpRewritePattern<BranchOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     // Check that the successor block has a single predecessor.
@@ -3053,7 +3053,7 @@ struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
 ///
 /// (same logic as for std.br)
 struct SimplifyPassThroughBr : public OpRewritePattern<BranchOp> {
-  using OpRewritePattern<BranchOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     Block *dest = op.getDest();
@@ -3085,7 +3085,7 @@ namespace {
 
 /// Simplifies a cond_br with a constant condition to an unconditional branch.
 struct SimplifyConstCondBranchPred : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern<CondBranchOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     if (matchPattern(op.getCondition(), m_NonZero())) {
@@ -3106,7 +3106,7 @@ struct SimplifyConstCondBranchPred : public OpRewritePattern<CondBranchOp> {
 /// Simplifies a cond_br with both targets (including operands) being equal to
 /// an unconditional branch.
 struct SimplifySameTargetCondBranchOp : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern<CondBranchOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     if (op.getTrueDest() != op.getFalseDest()) {
@@ -3129,7 +3129,7 @@ struct SimplifySameTargetCondBranchOp : public OpRewritePattern<CondBranchOp> {
 
 /// Swaps the cond_br true and false targets if the condition is inverted.
 struct SwapInvertedCondBranchOpTargets : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern<CondBranchOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     // TODO(benvanik): figure out something more reliable when the xor may be
@@ -3166,7 +3166,7 @@ namespace {
 
 /// Converts a vm.call.variadic to a non-variadic function to a normal vm.call.
 struct ConvertNonVariadicToCallOp : public OpRewritePattern<CallVariadicOp> {
-  using OpRewritePattern<CallVariadicOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CallVariadicOp op,
                                 PatternRewriter &rewriter) const override {
     // If any segment size is != -1 (which indicates variadic) we bail.
@@ -3193,7 +3193,7 @@ namespace {
 
 /// Rewrites a cond_fail op to a cond_branch to a fail op.
 struct RewriteCondFailToBranchFail : public OpRewritePattern<CondFailOp> {
-  using OpRewritePattern<CondFailOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CondFailOp op,
                                 PatternRewriter &rewriter) const override {
     auto *block = rewriter.getInsertionBlock();
@@ -3358,7 +3358,7 @@ struct RemoveDisabledDebugAsyncOp : public OpRewritePattern<T> {
 };
 
 struct SimplifyConstCondBreakPred : public OpRewritePattern<CondBreakOp> {
-  using OpRewritePattern<CondBreakOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CondBreakOp op,
                                 PatternRewriter &rewriter) const override {
     IntegerAttr condValue;

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -226,7 +226,7 @@ replaceOffsetSizesAndStridesWith(RewriterBase &rewriter,
 namespace {
 
 struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern<GetBufferDescriptorOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto subview = op.getSource().template getDefiningOp<memref::SubViewOp>();
@@ -291,7 +291,7 @@ struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
 
 struct FromHalInterfaceBindingSubspan
     : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern<GetBufferDescriptorOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto binding =
@@ -338,7 +338,7 @@ getBaseBufferReplacementForDescriptor(GetBufferDescriptorOp descriptorOp,
 
 struct FromMemRefAssumeAlignment
     : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern<GetBufferDescriptorOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto assumeOp = op.getSource().getDefiningOp<memref::AssumeAlignmentOp>();
@@ -380,7 +380,7 @@ struct FromMemRefAssumeAlignment
 // Allocations always return a non-offset memref and are matched by this
 // pattern.
 struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern<GetBufferDescriptorOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto alloca = op.getSource().template getDefiningOp<memref::AllocaOp>();
@@ -414,7 +414,7 @@ struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
 // MemRef globals are always static shaped and reference a non-offset
 // buffer.
 struct FromGlobal : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern<GetBufferDescriptorOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto global = op.getSource().template getDefiningOp<memref::GetGlobalOp>();

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -53,7 +53,7 @@ struct BubbleUpExpandShapesPass final
 // Because `extract_slice` ops and dequantize-like ops get cloned into regions
 // later, it's okay to bubble up through multi-use dequant ops.
 struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const final {
@@ -167,7 +167,7 @@ struct SwapExtractSliceOfFill final
 struct BubbleExpandThroughExtract final
     : public OpRewritePattern<tensor::ExpandShapeOp> {
 
-  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {
@@ -270,7 +270,7 @@ struct BubbleExpandThroughExtract final
 
 struct BubbleExpandThroughConcat final
     : public OpRewritePattern<tensor::ExpandShapeOp> {
-  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -176,7 +176,7 @@ struct HoistEncodingOpsPass
 /// of a dispatch.
 struct BubbleUpSetEncodingOp
     : public OpRewritePattern<IREE::Encoding::SetEncodingOp> {
-  using OpRewritePattern<IREE::Encoding::SetEncodingOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {
@@ -202,7 +202,7 @@ struct BubbleUpSetEncodingOp
 /// Pattern to sink UnsetEncoding ops down through consumers.
 struct SinkUnsetEncodingOp
     : public OpRewritePattern<IREE::Encoding::UnsetEncodingOp> {
-  using OpRewritePattern<IREE::Encoding::UnsetEncodingOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IREE::Encoding::UnsetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
@@ -35,7 +35,7 @@ namespace {
 /// tensor.insert_slice. This is needed till tensor.pad op can be fused with its
 /// consumers.
 struct TensorPadOpConversion : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   TensorPadOpConversion(MLIRContext *context, bool skipSingleLinalgOpUses)
       : OpRewritePattern<tensor::PadOp>(context, skipSingleLinalgOpUses),
         skipSingleLinalgOpUses(skipSingleLinalgOpUses) {}

--- a/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
@@ -31,7 +31,7 @@ namespace {
 /// dimension.
 struct MakeReductionInnermostPattern final
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     SmallVector<unsigned> interchange;
@@ -64,7 +64,7 @@ struct MakeReductionInnermostPattern final
 /// fixes up elementwise operations for which that is not the case.
 struct TransposeGenericOpPattern final
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     if (!genericOp.hasPureTensorSemantics()) {

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
@@ -22,7 +22,7 @@ namespace {
 class ConvertStridedContractionToContraction
     : public OpRewritePattern<linalg::GenericOp> {
 public:
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     // Check if the generic op satisfies all other conditions for being a

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -190,7 +190,7 @@ namespace {
 class FuseTransposeWithProducerLinalgOp
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   FuseTransposeWithProducerLinalgOp(MLIRContext *ctx, bool aggressiveProp,
                                     bool convProp, PatternBenefit b = 1)
       : OpRewritePattern<linalg::TransposeOp>(ctx, b),
@@ -306,7 +306,7 @@ private:
 class BubbleTransposeThroughCollapseShape
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {
@@ -375,7 +375,7 @@ namespace {
 // new propagation opportunities and eases the analysis in fusion/later passes.
 class ComposeTransposes : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp consumer,
                                 PatternRewriter &rewriter) const override {
@@ -408,7 +408,7 @@ public:
 class SinkTransposeThroughExtractSlice
     : public OpRewritePattern<tensor::ExtractSliceOp> {
 public:
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractOp,
                                 PatternRewriter &rewriter) const override {
@@ -503,7 +503,7 @@ public:
 class SinkTransposeThroughExpandShape
     : public OpRewritePattern<tensor::ExpandShapeOp> {
 public:
-  using OpRewritePattern<tensor::ExpandShapeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {
@@ -723,7 +723,7 @@ getTransposedIndexingMaps(linalg::GenericOp genericOp,
 class SinkTransposeThroughUnaryElementwiseInput
     : public OpRewritePattern<linalg::GenericOp> {
 public:
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
@@ -815,7 +815,7 @@ public:
 class BubbleTransposeThroughUnaryElementwiseDpsInit
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -127,7 +127,7 @@ Value multiplyDims(ImplicitLocOpBuilder &builder, Value value,
 // https://arxiv.org/abs/1712.05877.
 struct QuantizedConvToConv
     : public OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
-  using OpRewritePattern<linalg::Conv2DNhwcHwcfQOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfQOp op,
                                 PatternRewriter &rewriter) const override {
@@ -247,7 +247,7 @@ struct QuantizedConvToConv
 // https://arxiv.org/abs/1712.05877.
 struct QuantizedDepthwiseConvToDepthwiseConv
     : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp> {
-  using OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcQOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -64,7 +64,7 @@ struct ReplaceZeroExtentOperands : public RewritePattern {
 /// Forward the destination of a `tensor.insert_slice` to its uses
 /// if the source is zero-extent.
 struct FoldZeroExtentInserts : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::IREE::Check {
 namespace {
 // Rewrites expect_eq_const -> expect_eq
 struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
-  using OpRewritePattern<ExpectEqConstOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ExpectEqConstOp op,
                                 PatternRewriter &rewriter) const override {
     auto rhs = rewriter.create<arith::ConstantOp>(op.getLoc(), op.getValue());
@@ -29,7 +29,7 @@ struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
 // Rewrites expect_almost_eq_const -> expect_almost_eq
 struct ExpectAlmostEqConstOpToExpectAlmostEqOp
     : public OpRewritePattern<ExpectAlmostEqConstOp> {
-  using OpRewritePattern<ExpectAlmostEqConstOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ExpectAlmostEqConstOp op,
                                 PatternRewriter &rewriter) const override {
     auto rhs = rewriter.create<arith::ConstantOp>(op.getLoc(), op.getValue());

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -199,7 +199,7 @@ namespace {
 /// Skips a hal.buffer_view.buffer accessor when the buffer view was created in
 /// the same scope and we know the origin buffer.
 struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
-  using OpRewritePattern<BufferViewBufferOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(BufferViewBufferOp op,
                                 PatternRewriter &rewriter) const override {
     if (auto createOp = dyn_cast_or_null<BufferViewCreateOp>(

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -239,7 +239,7 @@ public:
 class ConvertDepthwiseConv2DNhwcHwc final
     : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcOp> {
 public:
-  using OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcOp convOp,
                                 PatternRewriter &rewriter) const override {


### PR DESCRIPTION
These using declarations for ['inheriting constructors'](https://en.cppreference.com/w/cpp/language/using_declaration.html#:~:text=h%0AD%3A%3Ah-,Inheriting%20constructors,-If%20the%20using) are only required in templated classes.

Cleaning this up mostly to stop proliferation via copy+paste of old code.