### PR TITLE
Revert "Move windows builds to experimental to unblock release packages."

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -168,7 +168,7 @@ jobs:
           - runs-on: windows-2022
             build-family: windows
             build-package: py-compiler-pkg
-            experimental: true
+            experimental: false
           - runs-on: windows-2022
             build-family: windows
             build-package: py-runtime-pkg


### PR DESCRIPTION
Reverts iree-org/iree#21712

These release builds are working again thanks to https://github.com/iree-org/iree/pull/21717. Sample successful run: https://github.com/iree-org/iree/actions/runs/17031585155/job/48275510639.