### PR TITLE
Fix SmallVector conversion error with gcc

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -52,7 +52,7 @@ SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 
   // NOTE: to ensure deterministic output we sort the result so that imports are
   // always added in a consistent order.
-  auto results = llvm::to_vector_of<const T *, 4>(resultSet);
+  auto results = llvm::to_vector_of<const T *>(resultSet);
   llvm::sort(
       results, +[](const T *a, const T *b) {
         return a->getDialect()->getNamespace().compare(

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
@@ -67,7 +67,7 @@ gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 
   // NOTE: to ensure deterministic output we sort the result so that imports are
   // always added in a consistent order.
-  auto results = llvm::to_vector_of<const T *, 4>(resultSet);
+  auto results = llvm::to_vector_of<const T *>(resultSet);
   llvm::sort(
       results, +[](const T *a, const T *b) {
         return a->getDialect()->getNamespace().compare(


### PR DESCRIPTION
Fixes the following error I get when compiling with gcc after https://github.com/iree-org/iree/pull/21719:
```
iree/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp: In instantiation of ‘llvm::SmallVector<const T*> mlir::iree_compiler::IREE::Stream::{anonymous}::gatherUsedDialectInterfaces(mlir::ModuleOp) [with T = mlir::iree_compiler::IREE::Stream::AffinityAnalysisDialectInterface]’:
iree/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp:524:54:   required from here
iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp:61:10: error: could not convert ‘results’ from ‘SmallVector<[...],4>’ to ‘SmallVector<[...],6>’
   61 |   return results;
      |          ^~~~~~~
      |          |
      |          SmallVector<[...],4>
ninja: build stopped: subcommand failed.
```