### PR TITLE
[ROCM] Readd SpecializeExports pass

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -391,6 +391,7 @@ public:
         });
       }
     }
+    passManager.addPass(createSpecializeExportsPass());
     buildLLVMGPUCodegenCommonConfigurationPassPipeline(passManager);
     OpPassManager &modulePassManager = passManager.nest<ModuleOp>();
     if (options.enableTensorUKernels) {


### PR DESCRIPTION
This pass was accidentally dropped recently and is needed for specializations to actually apply. Readd it to the ROCM pipeline.