### PR TITLE
Replaced --iree-hip-* to --iree-rocm-*

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -159,7 +159,7 @@ function(iree_check_test)
     list(APPEND _BASE_COMPILER_FLAGS "--iree-input-type=${_RULE_INPUT_TYPE}")
   endif()
   if(_NORMALIZED_TARGET_BACKEND STREQUAL "ROCM")
-    list(APPEND _BASE_COMPILER_FLAGS "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}")
+    list(APPEND _BASE_COMPILER_FLAGS "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}")
   endif()
 
   if(_BYTECODE_MODULE_BUILD_ENABLED)

--- a/compiler/bindings/python/iree/build/target_machine.py
+++ b/compiler/bindings/python/iree/build/target_machine.py
@@ -77,14 +77,14 @@ def amdgpu_hal_target_from_flags(
     if not hip_target:
         raise RuntimeError(
             "No HIP targets specified. Pass a chip to target as "
-            "--iree-hip-target=gfx..."
+            "--iree-rocm-target=gfx..."
         )
     return [
         TargetMachine(
             f"hip-{hip_target}",
             extra_flags=[
                 "--iree-hal-target-device=hip",
-                f"--iree-hip-target={hip_target}",
+                f"--iree-rocm-target={hip_target}",
             ],
         )
     ]
@@ -146,7 +146,7 @@ def _(p: argparse.ArgumentParser):
         description="Options controlling explicit targeting of HIP devices",
     )
     hip_g.add_argument(
-        "--iree-hip-target",
+        "--iree-rocm-target",
         help="HIP target selection (i.e. 'gfxYYYY')",
     )
 

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -93,7 +93,7 @@ struct ROCMOptions {
     static cl::OptionCategory category("HIP HAL Target");
 
     binder.opt<std::string>(
-        "iree-hip-target", target, cl::cat(category),
+        "iree-rocm-target", target, cl::cat(category),
         cl::desc(
             // clang-format off
             "HIP target as expected by LLVM AMDGPU backend; e.g., "
@@ -107,7 +107,7 @@ struct ROCMOptions {
             ));
 
     binder.opt<std::string>(
-        "iree-hip-target-features", targetFeatures, cl::cat(category),
+        "iree-rocm-target-features", targetFeatures, cl::cat(category),
         cl::desc("HIP target features as expected by LLVM AMDGPU backend; "
                  "e.g., '+sramecc,+xnack'."));
 
@@ -125,21 +125,21 @@ struct ROCMOptions {
                          clEnumValN(ContainerType::HSACO, "hsaco",
                                     "Raw HSACO image (ELF).")));
 
-    binder.opt<std::string>("iree-hip-bc-dir", bitcodeDirectory,
+    binder.opt<std::string>("iree-rocm-bc-dir", bitcodeDirectory,
                             cl::cat(category),
                             cl::desc("Directory of HIP Bitcode."));
 
-    binder.opt<int>("iree-hip-waves-per-eu", wavesPerEu, cl::cat(category),
+    binder.opt<int>("iree-rocm-waves-per-eu", wavesPerEu, cl::cat(category),
                     cl::desc("Optimization hint specifying minimum "
                              "number of waves per execution unit."));
 
     binder.opt<std::string>(
-        "iree-hip-enable-ukernels", enableROCMUkernels, cl::cat(category),
+        "iree-rocm-enable-ukernels", enableROCMUkernels, cl::cat(category),
         cl::desc("Enables microkernels in the HIP compiler backend. May be "
                  "`default`, `none`, `all`, or a comma-separated list of "
                  "specific unprefixed microkernels to enable, e.g. `mmt4d`."));
     binder.opt<std::string>(
-        "iree-hip-encoding-layout-resolver", encodingLayoutResolver,
+        "iree-rocm-encoding-layout-resolver", encodingLayoutResolver,
         cl::cat(category),
         cl::desc("Selects the way that encodings will be "
                  "resolved. Options are: `none` (resolve to "
@@ -147,18 +147,18 @@ struct ROCMOptions {
                  "on allocations to maximize cache bandwidth), "
                  "and `data-tiling` (enable data tiled layouts)"));
 
-    binder.opt<bool>("iree-hip-llvm-slp-vec", slpVectorization,
+    binder.opt<bool>("iree-rocm-llvm-slp-vec", slpVectorization,
                      cl::cat(category),
                      cl::desc("Enable slp vectorization in llvm opt."));
-    binder.opt<bool>("iree-hip-llvm-global-isel", globalISel, cl::cat(category),
+    binder.opt<bool>("iree-rocm-llvm-global-isel", globalISel, cl::cat(category),
                      cl::desc("Enable global instruction selection in llvm."));
 
     binder.opt<bool>(
-        "iree-hip-specialize-dispatches", specializeDispatches,
+        "iree-rocm-specialize-dispatches", specializeDispatches,
         cl::cat(category),
         cl::desc(
             "Enable runtime specialization of dynamically shaped dispatches."));
-    binder.opt<bool>("iree-hip-enable-tensor-ukernels", enableTensorUKernels,
+    binder.opt<bool>("iree-rocm-enable-tensor-ukernels", enableTensorUKernels,
                      cl::cat(category),
                      cl::desc("Enable MLIR-based ukernels."));
   }
@@ -167,7 +167,7 @@ struct ROCMOptions {
     if (target.empty()) {
       return emitError(builder.getUnknownLoc())
              << "HIP target not set; did you forget to pass "
-                "'--iree-hip-target'?";
+                "'--iree-rocm-target'?";
     }
     if (GPU::normalizeHIPTarget(target).empty()) {
       return emitError(builder.getUnknownLoc(), "Unknown HIP target '")
@@ -687,7 +687,7 @@ public:
         return variantOp.emitError()
                << "cannot find ROCM bitcode files. Check your installation "
                   "consistency and in the worst case, set "
-                  "--iree-hip-bc-dir= to a path on your system.";
+                  "--iree-rocm-bc-dir= to a path on your system.";
       }
       if (failed(linkHIPBitcodeIfNeeded(variantOp.getLoc(), llvmModule.get(),
                                         targetArch,

--- a/compiler/plugins/target/ROCM/builtins/ukernel/test/argmax_linking.mlir
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/test/argmax_linking.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --split-input-file --iree-hal-target-device=hip --iree-hip-enable-ukernels=all --iree-hip-target=gfx1100 --compile-to=executable-targets %s | FileCheck %s
+// RUN: iree-compile --split-input-file --iree-hal-target-device=hip --iree-rocm-enable-ukernels=all --iree-rocm-target=gfx1100 --compile-to=executable-targets %s | FileCheck %s
 
 // We want to check that uKernel is indeed generated from e2e workflow.
 

--- a/compiler/plugins/target/ROCM/test/enable_tensor_ukernels.mlir
+++ b/compiler/plugins/target/ROCM/test/enable_tensor_ukernels.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
-// RUN:   --iree-hip-enable-tensor-ukernels \
+// RUN:   --iree-rocm-enable-tensor-ukernels \
 // RUN:   --verify-diagnostics %s | FileCheck %s
 
 // Make sure we can match and insert a tensor ukernel.

--- a/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
+++ b/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
@@ -1,14 +1,14 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx942 --iree-hip-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
+// RUN:   --iree-rocm-target=gfx942 --iree-rocm-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
+// RUN:   --iree-rocm-target=gfx90a --iree-rocm-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
 
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=data-tiling %s | FileCheck %s --check-prefix=DATA-TILING
+// RUN:   --iree-rocm-target=gfx90a --iree-rocm-encoding-layout-resolver=data-tiling %s | FileCheck %s --check-prefix=DATA-TILING
 
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=none %s | FileCheck %s --check-prefix=NONE
+// RUN:   --iree-rocm-target=gfx90a --iree-rocm-encoding-layout-resolver=none %s | FileCheck %s --check-prefix=NONE
 
 // PAD:      #hal.executable.target<"rocm"
 // PAD-SAME:   iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>

--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -1,48 +1,48 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi300x %s | FileCheck %s --check-prefixes=GFX942,MI300X
+// RUN:   --iree-rocm-target=mi300x %s | FileCheck %s --check-prefixes=GFX942,MI300X
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi300a %s | FileCheck %s --check-prefixes=GFX942,MI300A
+// RUN:   --iree-rocm-target=mi300a %s | FileCheck %s --check-prefixes=GFX942,MI300A
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi308x %s | FileCheck %s --check-prefixes=GFX942,MI308X
+// RUN:   --iree-rocm-target=mi308x %s | FileCheck %s --check-prefixes=GFX942,MI308X
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi325x %s | FileCheck %s --check-prefixes=GFX942,MI325X
+// RUN:   --iree-rocm-target=mi325x %s | FileCheck %s --check-prefixes=GFX942,MI325X
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx950 %s | FileCheck %s --check-prefixes=GFX950
+// RUN:   --iree-rocm-target=gfx950 %s | FileCheck %s --check-prefixes=GFX950
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi350x %s | FileCheck %s --check-prefixes=GFX950,MI350X
+// RUN:   --iree-rocm-target=mi350x %s | FileCheck %s --check-prefixes=GFX950,MI350X
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=mi355x %s | FileCheck %s --check-prefixes=GFX950,MI355X
+// RUN:   --iree-rocm-target=mi355x %s | FileCheck %s --check-prefixes=GFX950,MI355X
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
+// RUN:   --iree-rocm-target=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=w7900 %s | FileCheck %s --check-prefix=GFX1100
+// RUN:   --iree-rocm-target=w7900 %s | FileCheck %s --check-prefix=GFX1100
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=v710 %s | FileCheck %s --check-prefix=GFX1101
+// RUN:   --iree-rocm-target=v710 %s | FileCheck %s --check-prefix=GFX1101
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=w7700 %s | FileCheck %s --check-prefix=GFX1101
+// RUN:   --iree-rocm-target=w7700 %s | FileCheck %s --check-prefix=GFX1101
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx1200 %s | FileCheck %s --check-prefix=GFX1200
+// RUN:   --iree-rocm-target=gfx1200 %s | FileCheck %s --check-prefix=GFX1200
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=rx9060xt %s | FileCheck %s --check-prefixes=GFX1200,RX9060XT
+// RUN:   --iree-rocm-target=rx9060xt %s | FileCheck %s --check-prefixes=GFX1200,RX9060XT
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=gfx1201 %s | FileCheck %s --check-prefix=GFX1201
+// RUN:   --iree-rocm-target=gfx1201 %s | FileCheck %s --check-prefix=GFX1201
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=rx9070xt %s | FileCheck %s --check-prefixes=GFX1201,RX9070XT
+// RUN:   --iree-rocm-target=rx9070xt %s | FileCheck %s --check-prefixes=GFX1201,RX9070XT
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=rx9070 %s | FileCheck %s --check-prefixes=GFX1201,RX9070
+// RUN:   --iree-rocm-target=rx9070 %s | FileCheck %s --check-prefixes=GFX1201,RX9070
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
-// RUN:   --iree-hip-target=r9700 %s | FileCheck %s --check-prefixes=GFX1201,R9700
+// RUN:   --iree-rocm-target=r9700 %s | FileCheck %s --check-prefixes=GFX1201,R9700
 
 // GFX942: target_info = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -46,7 +46,7 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
 
 static llvm::cl::opt<int>
-    clROCMIndexingBits("iree-hip-index-bits",
+    clROCMIndexingBits("iree-rocm-index-bits",
                        llvm::cl::desc("Set the bit width of indices in ROCm."),
                        llvm::cl::init(64));
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-convert-to-rocdl %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-convert-to-rocdl --iree-hip-index-bits=32 %s | FileCheck %s --check-prefix=INDEX32
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx908 --iree-convert-to-rocdl --iree-rocm-index-bits=32 %s | FileCheck %s --check-prefix=INDEX32
 
 // Test that that standard and GPU ops are converted to LLVM and NVVM.
 #pipeline_layout = #hal.pipeline.layout<bindings = [

--- a/docs/website/docs/developers/update-sdxl-golden-outputs.md
+++ b/docs/website/docs/developers/update-sdxl-golden-outputs.md
@@ -66,13 +66,13 @@ iree-build/tools/iree-compile \
   --iree-opt-data-tiling=false \
   --iree-codegen-gpu-native-math-precision=true \
   --iree-codegen-llvmgpu-use-vector-distribution \
-  --iree-hip-waves-per-eu=2 \
+  --iree-rocm-waves-per-eu=2 \
   --iree-execution-model=async-external \
   --iree-scheduling-dump-statistics-format=json \
   --iree-scheduling-dump-statistics-file=compilation_info.json \
   --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics)" \
   --iree-codegen-transform-dialect-library=/path/to/attention_and_matmul_spec_punet_mi300.mlir \
-  --iree-hip-target=gfx942
+  --iree-rocm-target=gfx942
 ```
 
 After compilation, run the module to produce the new outputs that will become

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -163,7 +163,7 @@ IREE_HIP_TARGET=$(rocm_agent_enumerator | sed -n '2 p')  # e.g. gfx1100
 
 iree-compile \
     --iree-hal-target-device=hip \
-    --iree-hip-target=${IREE_HIP_TARGET} \
+    --iree-rocm-target=${IREE_HIP_TARGET} \
     mobilenetv2.mlir -o mobilenet_hip.vmfb
 ```
 
@@ -173,14 +173,14 @@ iree-compile \
 
     That IREE comes with bundled bitcode files, which are used for linking
     certain intrinsics on AMD GPUs. These will be used automatically or if the
-    `--iree-hip-bc-dir` is empty. As additional support may be needed for
+    `--iree-rocm-bc-dir` is empty. As additional support may be needed for
     different chips, users can use this flag to point to an explicit directory.
     For example, in ROCm installations on Linux, this is often found under
     `/opt/rocm/amdgcn/bitcode`.
 
 #### Choosing HIP targets
 
-A HIP target (`iree-hip-target`) matching the LLVM AMDGPU backend is needed
+A HIP target (`iree-rocm-target`) matching the LLVM AMDGPU backend is needed
 to compile towards each GPU chip. Here is a table of commonly used
 architectures:
 
@@ -211,17 +211,17 @@ architectures:
 For a more comprehensive list of prior GPU generations, you can refer to the
 [LLVM AMDGPU backend](https://llvm.org/docs/AMDGPUUsage.html#processors).
 
-The `iree-hip-target` option support three schemes:
+The `iree-rocm-target` option support three schemes:
 
-1. The exact GPU product name (SKU), e.g., `--iree-hip-target=mi300x`. This
+1. The exact GPU product name (SKU), e.g., `--iree-rocm-target=mi300x`. This
     allows the compiler to know about both the target architecture and about
     additional hardware details like the number of compute units. This extra
     information guides some compiler heuristics and allows for SKU-specific
     [tuning specs](../../reference/tuning.md).
 2. The GPU architecture, as defined by LLVM, e.g.,
-    `--iree-hip-target=gfx942`. This scheme allows for architecture-specific
+    `--iree-rocm-target=gfx942`. This scheme allows for architecture-specific
     [tuning specs](../../reference/tuning.md) only.
-3. The architecture code name, e.g., `--iree-hip-target=cdna3`. This scheme
+3. The architecture code name, e.g., `--iree-rocm-target=cdna3`. This scheme
     gets translated to closes matching GPU architecture under the hood.
 
 We support for common code/SKU names without aiming to be exhaustive. If the

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -117,7 +117,7 @@ While compiling this graph with IREE, the flag
 the created dispatches.
 
 ```mlir
-// RUN: iree-compile --iree-hal-target-device=hip --iree-hip-target=gfx942 \
+// RUN: iree-compile --iree-hal-target-device=hip --iree-rocm-target=gfx942 \
             --mlir-print-ir-after=iree-codegen-materialize-user-configs \
             --iree-hal-dump-executable-files-to=<some directory>
 hal.executable public @matmul_reduce_32_1024_2048_dispatch_0 {

--- a/integrations/pjrt/python_packages/iree_rocm_plugin/setup.py
+++ b/integrations/pjrt/python_packages/iree_rocm_plugin/setup.py
@@ -86,7 +86,7 @@ setup(
         # plugins. This augments the path based scanning that Jax does, which
         # is not always robust to all packaging circumstances.
         "jax_plugins": [
-            "iree-hip = jax_plugins.iree_rocm",
+            "iree-rocm = jax_plugins.iree_rocm",
         ],
     },
     install_requires=iree_pjrt_setup.install_requires,

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 unset(IREE_AMDGPU_TEST_COMPILER_FLAGS)
 list(APPEND IREE_AMDGPU_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_hal_cts_test_suite(

--- a/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/cts/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_hal_cts_test_suite(

--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -563,13 +563,13 @@ iree_status_t iree_hal_deferred_work_queue_create(
   // Create the ready-list processing worker itself.
   iree_thread_create_params_t params;
   memset(&params, 0, sizeof(params));
-  params.name = IREE_SV("iree-hip-queue-worker");
+  params.name = IREE_SV("iree-rocm-queue-worker");
   params.create_suspended = false;
   iree_status_t status = iree_thread_create(
       (iree_thread_entry_t)iree_hal_deferred_work_queue_worker_execute, actions,
       params, actions->host_allocator, &actions->worker_thread);
 
-  params.name = IREE_SV("iree-hip-queue-completion");
+  params.name = IREE_SV("iree-rocm-queue-completion");
   params.create_suspended = false;
   if (iree_status_is_ok(status)) {
     status = iree_thread_create(

--- a/tests/e2e/attention/CMakeLists.txt
+++ b/tests/e2e/attention/CMakeLists.txt
@@ -78,7 +78,7 @@ if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx9")
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_generated_e2e_runner_test(

--- a/tests/e2e/collectives/CMakeLists.txt
+++ b/tests/e2e/collectives/CMakeLists.txt
@@ -66,7 +66,7 @@ if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHI
   set(COMMON_ARGS
     "--target_backend=rocm"
     "--driver=hip"
-    "--iree_compiler_args=--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+    "--iree_compiler_args=--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
   )
 
   set(COMMON_LABELS

--- a/tests/e2e/encoding/BUILD.bazel
+++ b/tests/e2e/encoding/BUILD.bazel
@@ -18,7 +18,7 @@ iree_check_single_backend_test_suite(
     srcs = ["encoding.mlir"],
     compiler_flags = [
         "--iree-global-opt-enable-early-materialization=false",
-        "--iree-hip-encoding-layout-resolver=data-tiling",
+        "--iree-rocm-encoding-layout-resolver=data-tiling",
         "--iree-llvmgpu-test-combine-layout-transformation=true",
     ],
     driver = "hip",

--- a/tests/e2e/encoding/CMakeLists.txt
+++ b/tests/e2e/encoding/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_check_single_backend_test_suite(
     "hip"
   COMPILER_FLAGS
     "--iree-global-opt-enable-early-materialization=false"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
 )
 

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1255,7 +1255,7 @@ if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx9")
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_generated_e2e_runner_test(
@@ -1425,7 +1425,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1455,7 +1455,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1485,7 +1485,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1514,9 +1514,9 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-hip-enable-ukernels=multi_mma"
+    "--iree-rocm-enable-ukernels=multi_mma"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1546,7 +1546,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1576,7 +1576,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1606,7 +1606,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1637,7 +1637,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1668,7 +1668,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling=true"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
-    "--iree-hip-encoding-layout-resolver=pad"
+    "--iree-rocm-encoding-layout-resolver=pad"
   LABELS
     "noasan"
     "nomsan"
@@ -1698,7 +1698,7 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling=true"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
-    "--iree-hip-encoding-layout-resolver=pad"
+    "--iree-rocm-encoding-layout-resolver=pad"
   LABELS
     "noasan"
     "nomsan"
@@ -1713,7 +1713,7 @@ elseif(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx11")
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_generated_e2e_runner_test(
@@ -1828,7 +1828,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -1860,7 +1860,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"
     "nomsan"
@@ -1873,7 +1873,7 @@ elseif(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx12")
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
 list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
-  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+  "--iree-rocm-target=${IREE_HIP_TEST_TARGET_CHIP}"
 )
 
 iree_generated_e2e_runner_test(
@@ -2051,7 +2051,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -2083,7 +2083,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -2115,7 +2115,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-experimental-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
+    "--iree-rocm-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/external/iree-test-suites/onnx_models/onnx_models_gpu_hip_rdna3.json
+++ b/tests/external/iree-test-suites/onnx_models/onnx_models_gpu_hip_rdna3.json
@@ -2,7 +2,7 @@
   "config_name": "gpu_hip_rdna3",
   "iree_compile_flags": [
     "--iree-hal-target-device=hip",
-    "--iree-hip-target=gfx1100"
+    "--iree-rocm-target=gfx1100"
   ],
   "iree_run_module_flags": [
     "--device=hip"

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3.json
@@ -2,7 +2,7 @@
   "config_name": "gpu_hip_rdna3",
   "iree_compile_flags": [
     "--iree-hal-target-device=hip",
-    "--iree-hip-target=gfx1100",
+    "--iree-rocm-target=gfx1100",
     "--iree-input-demote-f64-to-f32=false"
   ],
   "iree_run_module_flags": [

--- a/tests/external/iree-test-suites/sharktank_models/benchmarks/sdxl/e2e_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/benchmarks/sdxl/e2e_rocm.json
@@ -10,7 +10,7 @@
     "compilation_required": true,
     "compiled_file_name": "sdxl_full_pipeline_fp16_rocm",
     "compile_flags": [
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-opt-outer-dim-concat=true",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-hal-target-backends=rocm"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_rocm.json
@@ -42,7 +42,7 @@
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
@@ -33,7 +33,7 @@
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-opt-data-tiling=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
     ],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
@@ -19,7 +19,7 @@
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
     ],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
@@ -35,7 +35,7 @@
         "--iree-opt-level=O3",
         "--iree-opt-generalize-matmul=false",
         "--iree-opt-const-eval=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-execution-model=async-external",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
@@ -42,7 +42,7 @@
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-opt-data-tiling=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
@@ -42,7 +42,7 @@
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-opt-data-tiling=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
@@ -35,7 +35,7 @@
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-opt-data-tiling=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
@@ -35,7 +35,7 @@
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-opt-data-tiling=false",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
@@ -19,7 +19,7 @@
         "--iree-opt-level=O3",
         "--iree-opt-const-eval=false",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-hip-waves-per-eu=2",
+        "--iree-rocm-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
         "--iree-scheduling-dump-statistics-format=json",


### PR DESCRIPTION
Fixes #21734
Replaced all compiler flags across the repo
from iree-hip-* to iree-rocm-* and other places which depend on these flags are also modified.

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>