### PR TITLE
Apply UnsignedWhenEquivalent at the ModuleOp level.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -107,8 +107,9 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
       // Remove if it is added there.
       // https://github.com/llvm/llvm-project/issues/78458
       .addPass(affine::createAffineExpandIndexOpsPass)
-      .addPass(mlir::createLowerAffinePass)
-      .addPass(mlir::arith::createArithUnsignedWhenEquivalentPass);
+      .addPass(mlir::createLowerAffinePass);
+
+  passManager.addPass(mlir::arith::createArithUnsignedWhenEquivalentPass());
 
   // Propagate buffer subranges throughout the program - this should remove any
   // remaining subspans and give us a smaller surface area during conversion.


### PR DESCRIPTION
TSan revealed a race condition when UnsignedWhenEquivalent was being applied. UnsignedWhenEquivalent will call DeadCodeAnalysis which reads data of IREE::Util::FuncOp, however, a different thread will be modifying these operations.