### PR TITLE
[DT] Graduate data-tiling fusion from experimental flag to binding option.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
@@ -1,5 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline)" \
-// RUN:          --iree-dispatch-creation-experimental-data-tiling %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{data-tiling})" %s | FileCheck %s
 
 // Tests to make sure that the set encoding pass work as in the dispatch
 // creation pipeline. For example, we expect dimension collapsing to happen

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -312,6 +312,9 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
                      "since all backends dont support it yet"));
   binder.opt<bool>("iree-dispatch-creation-fuse-multi-use", enableFuseMultiUse,
                    llvm::cl::desc("Fuse operations with multiple uses."));
+  binder.opt<bool>("iree-dispatch-creation-data-tiling", dataTiling,
+                   llvm::cl::desc("Enables data tiling path."),
+                   llvm::cl::cat(category));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -121,8 +121,8 @@ struct GlobalOptimizationOptions {
   // Enables transposing all concatenations to the outer most dimension.
   bool outerDimConcat = false;
 
-  // Enables data tiling in global optimization phase.There are two data-tiling
-  // flags during the transition state. The other has to be off if it is
+  // Enables data tiling in global optimization phase. There are two data-tiling
+  // flags during the transition state. The other has to be off if this one is
   // enabled. Any feature built on top of this path will be deprecated.
   bool dataTiling = true;
 
@@ -223,7 +223,7 @@ struct DispatchCreationOptions {
   bool enableFuseMultiUse = true;
 
   // Enables data tiling in dispatch creation phase. There are two data-tiling
-  // flags during the transition state. The other has to be off if it is
+  // flags during the transition state. The other has to be off if this one is
   // enabled. The main difference is that this path enables the fusion for
   // data-tiled ops.
   bool dataTiling = false;

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -121,7 +121,9 @@ struct GlobalOptimizationOptions {
   // Enables transposing all concatenations to the outer most dimension.
   bool outerDimConcat = false;
 
-  // Enables data tiling.
+  // Enables data tiling in global optimization phase.There are two data-tiling
+  // flags during the transition state. The other has to be off if it is
+  // enabled. Any feature built on top of this path will be deprecated.
   bool dataTiling = true;
 
   // Enables const-expr hoisting into globals.
@@ -219,6 +221,12 @@ struct DispatchCreationOptions {
 
   bool enableAggressiveFusion = false;
   bool enableFuseMultiUse = true;
+
+  // Enables data tiling in dispatch creation phase. There are two data-tiling
+  // flags during the transition state. The other has to be off if it is
+  // enabled. The main difference is that this path enables the fusion for
+  // data-tiled ops.
+  bool dataTiling = false;
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<DispatchCreationOptions>;

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -57,7 +57,7 @@ iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_dt_fusion_local-task",
     srcs = ["narrow_n_matmuls.mlir"],
     compiler_flags = [
-        "--iree-dispatch-creation-experimental-data-tiling",
+        "--iree-dispatch-creation-data-tiling",
         "--iree-llvmcpu-target-cpu=generic",
         "--iree-opt-data-tiling=false",
     ],

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -44,7 +44,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-llvmcpu-target-cpu=generic"
     "--iree-opt-data-tiling=false"
   LABELS

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1424,7 +1424,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1454,7 +1454,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1484,7 +1484,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1515,7 +1515,7 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-hip-enable-ukernels=multi_mma"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1545,7 +1545,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1575,7 +1575,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1605,7 +1605,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
@@ -1635,7 +1635,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
     "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
@@ -1666,7 +1666,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling=true"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
     "--iree-hip-encoding-layout-resolver=pad"
   LABELS
@@ -1696,7 +1696,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling=true"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
     "--iree-hip-encoding-layout-resolver=pad"
   LABELS
@@ -1827,7 +1827,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -1859,7 +1859,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"
@@ -2050,7 +2050,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -2082,7 +2082,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -2114,7 +2114,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
-    "--iree-dispatch-creation-experimental-data-tiling"
+    "--iree-dispatch-creation-data-tiling"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"


### PR DESCRIPTION
The data-tiling path starting from DispatchCreation phase is very close to be useful. Thus, we can start guarding the path under the binding option. It is shown in two CI jobs:

- IREE tests: https://github.com/iree-org/iree/actions/runs/17116883103/job/48549667004?pr=21441
- Integration tests: https://github.com/iree-org/iree/actions/runs/17116883094/job/48549979850?pr=21441

The only failure is a lowering strategy selection in x86 config, which will be gone with proper fix for the workaround.

The revision also introduces `dataTiling` option to `iree-dispatch-creation-pipeline` that exposes the control to `iree-opt`, because the binding options are not available in `iree-opt` scope.

Note: the PR is not linked directly, because it can be force-push. Thus, only the links to CI jobs are provided in the commit description.