### PR TITLE
[ConstEval] Do not jit parameterized flow.tensor.constants

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/BUILD.bazel
+++ b/compiler/src/iree/compiler/ConstEval/BUILD.bazel
@@ -58,6 +58,7 @@ iree_compiler_cc_library(
         ":PassHeaders",
         ":PassesIncGen",
         ":Runtime",
+        "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Constant",
         "//compiler/src/iree/compiler/Dialect/Util/IR",

--- a/compiler/src/iree/compiler/ConstEval/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ConstEval/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     MLIRFunctionInterfaces
     MLIRIR
     MLIRPass
+    iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::Util::Analysis::Constant
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -335,6 +335,20 @@ module @skip_dependent_initializers {
 
 // -----
 
+// CHECK-LABEL: @skip_parameterized_tensor_constants
+module @skip_parameterized_tensor_constants {
+  util.global private @hoisted : tensor<f32>
+  // CHECK: util.initializer
+  // expected-warning @+1 {{skipping consteval initializer}}
+  util.initializer {
+    %1 = flow.tensor.constant #flow.parameter.named<"runtime"::"global"> : tensor<f32>
+    util.global.store %1, @hoisted : tensor<f32>
+    util.return
+  }
+}
+
+// -----
+
 // TODO(benvanik): rewrite availability to use proper analysis - currently the
 // pass uses ConstExprAnalysis which can't actually indicate what we want when
 // we want it (here that this iota is available for evaluation at compile-time).


### PR DESCRIPTION
Before, we accepted stream.parameter.named attributes as util.global ops from the frontend. After we switched to flow.parameter.named ops, some parameters are now inlined as flow.tensor.constants. Before this patch, const eval did not treat these ops as parameterized and was trying to const eval runtime dependent values, which is not possible.