### PR TITLE
[Codegen][LLVMGPU] Check ops generalized before kernel configuration

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -58,9 +58,9 @@ struct GPUGeneralizeNamedOpsPass final
     FunctionOpInterface funcOp = getOperation();
     SmallVector<linalg::LinalgOp> namedOpCandidates;
     funcOp.walk([&](linalg::LinalgOp linalgOp) {
-      if (isa<linalg::BatchMatmulOp, linalg::MatmulOp, linalg::MatvecOp,
-              linalg::TransposeOp, linalg::VecmatOp>(linalgOp.getOperation()))
+      if (isInGPUGeneralizeSet(linalgOp.getOperation())) {
         namedOpCandidates.push_back(linalgOp);
+      }
     });
 
     if (failed(generalizeCandidates(&getContext(), namedOpCandidates))) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -63,6 +64,13 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
 /// **misalign** the rows, but not too much.
 LogicalResult reduceSharedMemoryBankConflicts(mlir::FunctionOpInterface funcOp,
                                               unsigned paddingSizeBits);
+
+/// Return true if `op` will be generalized (converted to a linalg.generic) by
+/// the pass GPUGeneralizeNamedOpsPass.
+static bool isInGPUGeneralizeSet(Operation *op) {
+  return isa<linalg::BatchMatmulOp, linalg::DotOp, linalg::MatmulOp,
+             linalg::MatvecOp, linalg::TransposeOp, linalg::VecmatOp>(op);
+}
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -67,7 +67,7 @@ LogicalResult reduceSharedMemoryBankConflicts(mlir::FunctionOpInterface funcOp,
 
 /// Return true if `op` will be generalized (converted to a linalg.generic) by
 /// the pass GPUGeneralizeNamedOpsPass.
-static bool isInGPUGeneralizeSet(Operation *op) {
+inline bool isInGPUGeneralizeSet(Operation *op) {
   return isa<linalg::BatchMatmulOp, linalg::DotOp, linalg::MatmulOp,
              linalg::MatvecOp, linalg::TransposeOp, linalg::VecmatOp>(op);
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -142,8 +142,10 @@ def GPUGeneralizeNamedOpsPass :
   let summary = "Convert named Linalg ops to linalg.generic ops";
 
   let description = [{
-    Convert a whitelisted set of named Linalg ops to linalg.generics. The whitelist
-    does not contain all named ops.
+    Convert a subset of named Linalg ops to linalg.generics. The subset does not
+    contain all named ops. The rule-of-thumb is that named ops whose operand
+    maps are projections are in the subset. For example convolutions and pooling ops
+    are not generalized by this pass, but matmuls are.
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -3157,7 +3157,6 @@ static LogicalResult setConvolutionConfig(
 static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPointFn,
                                    Operation *computeOp) {
-
   if (isInGPUGeneralizeSet(computeOp)) {
     return computeOp->emitOpError(
         "is a named op that was expected to be generalized before now.");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --iree-codegen-llvmgpu-use-vector-distribution \
-// RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=WMMA
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=WMMA
 
 // TODO: This test is still using the legacy LLVMGPU kernel config. This needs
 // to be migrated to the rocdl heuristics, but for now is just physically
@@ -30,7 +30,7 @@ func.func @wmma_matmul_1024x1024x1024() {
 }
 
 // WMMA-LABEL: func.func @wmma_matmul_1024x1024x1024()
-// WMMA: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// WMMA: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // WMMA-SAME:                           mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>
 // WMMA-SAME:                           reduction =  [0, 0, 64]
 // WMMA-SAME:                           subgroup_m_count = 2

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-use-vector-distribution \
 // RUN:   --iree-codegen-llvmgpu-use-unaligned-gemm-vector-distribution --iree-codegen-llvmgpu-use-igemm=false \
-// RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // TODO: This test is still using the legacy LLVMGPU kernel config. This needs
 // to be migrated to the rocdl heuristics, but for now is just physically
@@ -134,7 +134,8 @@ func.func @mfma_matmul_1024x1024x1024() {
 }
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
-// CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK: linalg.fill
+// CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 64]
 // CHECK-SAME:                           subgroup_m_count = 2

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-codegen-llvmgpu-use-vector-distribution \
 // RUN:   --iree-codegen-llvmgpu-use-unaligned-gemm-vector-distribution --iree-codegen-llvmgpu-use-igemm=false \
-// RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // TODO: This test is still using the legacy LLVMGPU kernel config. This needs
 // to be migrated to the rocdl heuristics, but for now is just physically
@@ -101,7 +101,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 }
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
-// CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 128]
 // CHECK-SAME:                           subgroup_m_count = 2

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
 
 func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
     %arg2 : tensor<128xf32>) -> tensor<384x128xf32> {
@@ -39,8 +39,9 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
 //      CHECK:   iree_linalg_ext.custom_op
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 //      CHECK:   ^bb
-//      CHECK:     linalg.matmul
+//      CHECK:     linalg.generic
 // CHECK-SAME:         lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, promote_operands = [0, 1], reduction = [0, 0, 32], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 64, 0]}>
+//      CHECK:     linalg.generic
 //      CHECK:   iree_linalg_ext.yield
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
@@ -1,8 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(linalg-specialize-generic-ops,iree-llvmgpu-select-lowering-strategy)' %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,SPECIALIZED
-
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(linalg-generalize-named-ops,iree-llvmgpu-select-lowering-strategy)' %s \
-// RUN:   | FileCheck %s --check-prefixes=CHECK,GENERALIZED
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)' %s \
+// RUN:   | FileCheck %s --check-prefixes=CHECK
 
 
 // ============================================================================
@@ -17,9 +14,7 @@
 //      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
-  // Sanity check that generalize/specialize works.
-  // GENERALIZED:   linalg.generic
-  // SPECIALIZED:   linalg.matmul
+  //      CHECK:  linalg.generic
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
   // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 32], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
   // CHECK-SAME:  workgroup = [32, 32, 0]}>
@@ -100,20 +95,17 @@ func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %ar
 
 // -----
 
-// TODO(newling) specialized form should be the same as generalized form.
 
-//      GENERALIZED:         #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
-// GENERALIZED-SAME:         workgroup_size = [1024, 1, 1] subgroup_size = 64,
-// GENERALIZED-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
-
-//      SPECIALIZED:         #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
+//      CHECK:         #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK-SAME:         workgroup_size = [1024, 1, 1] subgroup_size = 64,
+// CHECK-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
 !TA = tensor<?x4096xf32>
 !TB = tensor<4096x4096xf32>
 !TC = tensor<?x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x4096xf32>>
 func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
-//      GENERALIZED:         #iree_gpu.lowering_config<{lane_basis =  {{\[}}[1, 1, 64], [0, 1, 2]],
-// GENERALIZED-SAME:         partial_reduction = [0, 0, 4096], subgroup_basis =  {{\[}}[1, 1, 16], [0, 1, 2]], thread = [0, 0, 4], workgroup = [1, 1, 0]}
+//      CHECK:         #iree_gpu.lowering_config<{lane_basis =  {{\[}}[1, 1, 64], [0, 1, 2]],
+// CHECK-SAME:         partial_reduction = [0, 0, 4096], subgroup_basis =  {{\[}}[1, 1, 16], [0, 1, 2]], thread = [0, 0, 4], workgroup = [1, 1, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, 4096], strides = [1, 1] : !TC -> !DTC{%arg4}
   return
@@ -157,7 +149,6 @@ func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %a
 !TB = tensor<?x32xf32>
 !TC = tensor<32x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x32xf32>>
-
 //      CHECK:    #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 // CHECK-SAME:    workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false,
 // CHECK-SAME:    no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
@@ -190,23 +181,16 @@ func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC)
 // Dynamic all
 // ============================================================================
 
-
-// TODO(newling) specialized form should follow generalized form.
-
-//     SPECIALIZED:      LLVMGPUWarpReduction
-//     GENERALIZED:      LLVMGPUVectorDistribute
-// GENERALIZED-SAME:     workgroup_size = [1024, 1, 1] subgroup_size = 64,
-
-
+//      CHECK:     LLVMGPUVectorDistribute
+// CHECK-SAME:     workgroup_size = [1024, 1, 1] subgroup_size = 64,
 !TA = tensor<?x?xf32>
 !TB = tensor<?x?xf32>
 !TC = tensor<?x?xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32>>
 func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index, %arg5 : index, %arg6 : index) {
-
-  //      GENERALIZED:     {lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
-  // GENERALIZED-SAME:     partial_reduction = [0, 0, 4096], subgroup_basis = {{\[}}[1, 1, 16], [0, 1, 2]],
-  // GENERALIZED-SAME:     thread = [0, 0, 4], workgroup = [1, 1, 0]}
+  //      CHECK:     {lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+  // CHECK-SAME:     partial_reduction = [0, 0, 4096], subgroup_basis = {{\[}}[1, 1, 16], [0, 1, 2]],
+  // CHECK-SAME:     thread = [0, 0, 4], workgroup = [1, 1, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, %arg5], strides = [1, 1] : !TC -> !DTC{%arg4, %arg5}
   return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s --check-prefix=CDNA3
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s --check-prefix=CDNA3
 
 
 #pipeline_layout = #hal.pipeline.layout<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>
@@ -24,10 +24,8 @@ func.func @static_batch_matvec() {
 }
 
 
-// CHECK:     LLVMGPUWarpReduction
+// CHECK:     LLVMGPUVectorDistribute
 // CDNA3:     LLVMGPUTileAndFuse
-
-// We want to deprecate LLVMGPUWarpReduction. Currently LLVMGPUVectorDistribution is not chosen in setReductionVectorDistributionConfig because it fails in 'hasReductionIterator' (which doesn't check specialized ops). This might be an easy whitelisting fix, but I will return to this later (TODO(newling)).
 
 // -----
 
@@ -325,7 +323,7 @@ func.func @i4_dequant_matvec() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @skinny_mmt() {
+func.func @skinny_mmt_lhs_is_vector() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
@@ -347,16 +345,19 @@ func.func @skinny_mmt() {
   return
 }
 
-// CHECK-DAG: #[[$MA:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG: #[[$MB:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
-// CHECK-DAG: #[[$MC:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 512]{{\]}}>
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//       CHECK: func.func @skinny_mmt()
-//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   linalg.matmul indexing_maps = [#[[$MA]], #[[$MB]], #[[$MC]]]
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//  CHECK-DAG: #[[$MA:.*]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+//  CHECK-DAG: #[[$MB:.*]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+//  CHECK-DAG: #[[$MC:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+//      CHECK: pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: linalg.fill
+//      CHECK: linalg.generic
+// CHECK-SAME: indexing_maps = [#[[$MA]], #[[$MB]], #[[$MC]]]
+// CHECK-SAME: lowering_config = #iree_gpu.lowering_config<{
+// CHECK-SAME:       lane_basis =        {{\[}}[1, 1, 64], [0, 1, 2]],
+// CHECK-SAME:       partial_reduction =       [0, 0, 512],
+// CHECK-SAME:       subgroup_basis =    {{\[}}[1, 1, 1], [0, 1, 2]],
+// CHECK-SAME:       thread =                  [0, 0, 8],
+// CHECK-SAME:       workgroup =               [1, 1, 0]}>}
 
 // -----
 
@@ -367,7 +368,7 @@ func.func @skinny_mmt() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @skinny_mmt() {
+func.func @skinny_mmt_lhs_is_matrix() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4096xf16>>
@@ -389,12 +390,17 @@ func.func @skinny_mmt() {
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 512]{{\]}}>
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
-//       CHECK: func.func @skinny_mmt()
-//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//       CHECK:   linalg.matmul indexing_maps = [#[[$MA]], #[[$MB]], #[[$MC]]]
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//      CHECK: pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK: linalg.fill
+//      CHECK: linalg.generic
+// CHECK-SAME: indexing_maps
+// CHECK-SAME: lowering_config = #iree_gpu.lowering_config<{
+// CHECK-SAME:       lane_basis =        {{\[}}[1, 1, 64], [0, 1, 2]],
+// CHECK-SAME:       partial_reduction =       [0, 0, 512],
+// CHECK-SAME:       subgroup_basis =    {{\[}}[1, 1, 1], [0, 1, 2]],
+// CHECK-SAME:       thread =                  [0, 0, 8],
+// CHECK-SAME:       workgroup =               [8, 1, 0]}>}
+
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_root_op_attribute.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-config-add-tuner-attributes --pass-pipeline='builtin.module(iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-config-add-tuner-attributes --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-llvmgpu-select-lowering-strategy)' %s | FileCheck %s
 
 func.func @matmul(%lhs: tensor<4x4xf32>, %rhs: tensor<4x4xf32>) -> tensor<4x4xf32> {
   %c0 = arith.constant 0.0 : f32
@@ -9,4 +9,9 @@ func.func @matmul(%lhs: tensor<4x4xf32>, %rhs: tensor<4x4xf32>) -> tensor<4x4xf3
   return %result : tensor<4x4xf32>
 }
 
-// CHECK: %2 = linalg.matmul {lowering_config = #{{.*}}, root_op} ins(%arg0, %arg1 : tensor<4x4xf32>, tensor<4x4xf32>) outs(%1 : tensor<4x4xf32>) -> tensor<4x4xf32>
+
+//      CHECK: linalg.fill
+//      CHECK: linalg.generic
+// CHECK-SAME: lowering_config = #{{.*}},
+// CHECK-SAME: root_op
+//      CHECK: return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -235,3 +235,12 @@ func.func @illegal() attributes {translation_info = #translation} {
   linalg.matmul {lowering_config = #config} ins(%0, %1 : memref<1024x512xi8>, memref<512x256xi8>) outs(%2 : memref<1024x256xi8>)
   return
 }
+
+// -----
+
+//expected-error @+1{{'func.func' op failed to set root config}}
+func.func @check_precondition_that_ops_generalized(%arg0: tensor<6x6xf32>, %arg1: tensor<6x6xf32>, %arg2: tensor<6x6xf32>) {
+  // expected-error @+1{{'linalg.matmul' op is a named op that was expected to be generalized before now.}}
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<6x6xf32>, tensor<6x6xf32>) outs(%arg2 : tensor<6x6xf32>) -> tensor<6x6xf32>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s --check-prefix=SM80
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s --check-prefix=SM80
 
 // Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.


### PR DESCRIPTION
Before this change, matmuls that were still specialized (linalg.matmul) were configured for warp reduction, while generalized matmuls (linalg.generics) were configured for down vector distribute. This change adds a check that certain ops are generalized before entering llvmgpu configuration selection. If they are not generalized, the pass fails. 
