### PR TITLE
Temporarily disable the circular buffer for parameter uploads.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1956,8 +1956,8 @@ bool iree_hal_hip_transfer_buffer_size_check_condition(void* user_data) {
   iree_hal_hip_transfer_buffer_size_check_data_t* data =
       (iree_hal_hip_transfer_buffer_size_check_data_t*)user_data;
   return iree_hal_hip_transfer_buffer_size_left(
-             data->device, &data->device->devices[data->device_ordinal]) >=
-         data->num_bytes;
+             data->device, &data->device->devices[data->device_ordinal]) ==
+         data->device->params.file_transfer_buffer_size;
 }
 
 // Returns two chunks that are needed to cover the buffer. Pass in an


### PR DESCRIPTION
There is an issue with very large models where parameters are getting corrupted. This disabled the circular buffer and just does single-buffer uploading of parameters. It ends up being fractionally slower (~10%).

Opened #21757 to fix this issue.