### PR TITLE
Adding iree_hal_executable_cache_infer_format.

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -697,7 +697,10 @@ public:
     auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
-        builder.getBufferAttr(executableBuilder.getContext()));
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_cuda_ExecutableDef_file_identifier,
+            /*version=*/0));
     binaryOp.setMimeTypeAttr(
         executableBuilder.getStringAttr("application/x-flatbuffers"));
 

--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -732,6 +732,7 @@ public:
     // loader which static library to load for the target binary.
     std::vector<uint8_t> libraryNameVector(libraryName.begin(),
                                            libraryName.end());
+    libraryNameVector.push_back(0); // NUL
     IREE::HAL::ExecutableBinaryOp::create(executableBuilder, variantOp.getLoc(),
                                           variantOp.getSymName(), "static",
                                           libraryNameVector);

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -308,7 +308,10 @@ public:
     auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
-        builder.getBufferAttr(executableBuilder.getContext()));
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_metal_ExecutableDef_file_identifier,
+            /*version=*/0));
     binaryOp.setMimeTypeAttr(
         executableBuilder.getStringAttr("application/x-flatbuffers"));
 

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -960,12 +960,17 @@ protected:
     }
     auto exportsRef = builder.createOffsetVecDestructive(exportRefs);
 
+    auto isaRef = builder.createString(variantOp.getTarget().getFormat());
+    iree_hal_amdgpu_ExecutableDef_isa_add(builder, isaRef);
     iree_hal_amdgpu_ExecutableDef_exports_add(builder, exportsRef);
     iree_hal_amdgpu_ExecutableDef_modules_add(builder, modulesRef);
     iree_hal_amdgpu_ExecutableDef_source_files_add(builder, sourceFilesRef);
     iree_hal_amdgpu_ExecutableDef_end_as_root(builder);
 
-    return builder.getBufferAttr(variantOp.getContext());
+    return builder.getHeaderPrefixedBufferAttr(
+        variantOp.getContext(),
+        /*magic=*/iree_hal_amdgpu_ExecutableDef_file_identifier,
+        /*version=*/0);
   }
 
   FailureOr<DenseIntElementsAttr>
@@ -1049,7 +1054,10 @@ protected:
     iree_hal_hip_ExecutableDef_source_files_add(builder, sourceFilesRef);
     iree_hal_hip_ExecutableDef_end_as_root(builder);
 
-    return builder.getBufferAttr(variantOp.getContext());
+    return builder.getHeaderPrefixedBufferAttr(
+        variantOp.getContext(),
+        /*magic=*/iree_hal_hip_ExecutableDef_file_identifier,
+        /*version=*/0);
   }
 
 private:

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -386,7 +386,10 @@ public:
     auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
-        builder.getBufferAttr(executableBuilder.getContext()));
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_vulkan_ExecutableDef_file_identifier,
+            /*version=*/0));
     binaryOp.setMimeTypeAttr(
         executableBuilder.getStringAttr("application/x-flatbuffers"));
 
@@ -478,7 +481,10 @@ public:
     auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
-        builder.getBufferAttr(executableBuilder.getContext()));
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_vulkan_ExecutableDef_file_identifier,
+            /*version=*/0));
     binaryOp.setMimeTypeAttr(
         executableBuilder.getStringAttr("application/x-flatbuffers"));
 

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -249,7 +249,10 @@ public:
     auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
-        builder.getBufferAttr(executableBuilder.getContext()));
+        builder.getHeaderPrefixedBufferAttr(
+            executableBuilder.getContext(),
+            /*magic=*/iree_hal_webgpu_ExecutableDef_file_identifier,
+            /*version=*/0));
     binaryOp.setMimeTypeAttr(
         executableBuilder.getStringAttr("application/x-flatbuffers"));
 

--- a/compiler/src/iree/compiler/Utils/FlatbufferUtils.h
+++ b/compiler/src/iree/compiler/Utils/FlatbufferUtils.h
@@ -120,6 +120,23 @@ public:
   // as a shaped `vector<SIZExi8>` dense attr. The builder is left unmodified.
   DenseIntElementsAttr getBufferAttr(MLIRContext *context);
 
+  // Captures the current contents of the flatbuffer builder and returns them
+  // as a shaped `vector<SIZExi8>` dense attr. The builder is left unmodified.
+  // A 64-byte prefix structure is prepended to the buffer containing the file
+  // magic number for identification, a coarse version, and an 8 byte size
+  // (excluding the header). See iree_flatbuffer_file_header_t.
+  DenseIntElementsAttr getHeaderPrefixedBufferAttr(MLIRContext *context,
+                                                   uint32_t magic,
+                                                   uint32_t version);
+  DenseIntElementsAttr getHeaderPrefixedBufferAttr(MLIRContext *context,
+                                                   const char *magic,
+                                                   uint32_t version) {
+    assert(strlen(magic) == 4 && "must be a flatbuffers 4 character code");
+    uint32_t magic_value = 0;
+    memcpy(&magic_value, magic, sizeof(magic_value));
+    return getHeaderPrefixedBufferAttr(context, magic_value, version);
+  }
+
   // Copies the current contents of the flatbuffer builder to the target output
   // stream. The builder is left unmodified.
   //

--- a/experimental/webgpu/BUILD.bazel
+++ b/experimental/webgpu/BUILD.bazel
@@ -54,6 +54,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/webgpu/shaders",
         "//runtime/src/iree/hal/utils:buffer_transfer",
         "//runtime/src/iree/hal/utils:executable_debug_info",
+        "//runtime/src/iree/hal/utils:executable_header",
         "//runtime/src/iree/hal/utils:file_transfer",
         "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:queue_emulation",

--- a/experimental/webgpu/CMakeLists.txt
+++ b/experimental/webgpu/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     iree::hal
     iree::experimental::webgpu::platform
     iree::experimental::webgpu::shaders
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation

--- a/experimental/webgpu/executable.h
+++ b/experimental/webgpu/executable.h
@@ -27,6 +27,14 @@ typedef struct iree_hal_webgpu_entry_point_t {
   iree_hal_pipeline_layout_t* layout;
 } iree_hal_webgpu_entry_point_t;
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+iree_status_t iree_hal_webgpu_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 iree_status_t iree_hal_webgpu_executable_create(
     WGPUDevice device, const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);

--- a/experimental/webgpu/nop_executable_cache.c
+++ b/experimental/webgpu/nop_executable_cache.c
@@ -64,6 +64,25 @@ static void iree_hal_webgpu_nop_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_webgpu_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_webgpu_executable_cache_t* executable_cache =
+      iree_hal_webgpu_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                       "WebGPU binary size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_webgpu_nop_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -87,6 +106,7 @@ static iree_status_t iree_hal_webgpu_nop_executable_cache_prepare_executable(
 const iree_hal_executable_cache_vtable_t
     iree_hal_webgpu_nop_executable_cache_vtable = {
         .destroy = iree_hal_webgpu_nop_executable_cache_destroy,
+        .infer_format = iree_hal_webgpu_executable_cache_infer_format,
         .can_prepare_format =
             iree_hal_webgpu_nop_executable_cache_can_prepare_format,
         .prepare_executable =

--- a/experimental/webgpu/nop_executable_cache.c
+++ b/experimental/webgpu/nop_executable_cache.c
@@ -70,15 +70,10 @@ static iree_status_t iree_hal_webgpu_executable_cache_infer_format(
     iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_webgpu_executable_cache_t* executable_cache =
-      iree_hal_webgpu_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                       "WebGPU binary size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_webgpu_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/base/internal/flatcc/parsing.h
+++ b/runtime/src/iree/base/internal/flatcc/parsing.h
@@ -7,6 +7,8 @@
 #ifndef IREE_BASE_INTERNAL_FLATCC_PARSING_H_
 #define IREE_BASE_INTERNAL_FLATCC_PARSING_H_
 
+#include <stdint.h>
+
 //===----------------------------------------------------------------------===//
 // flatcc include order fixes
 //===----------------------------------------------------------------------===//
@@ -28,5 +30,26 @@
 #include "iree/base/internal/flatcc/dummy_verifier.h" // IWYU pragma: export
 
 // clang-format on
+
+//===----------------------------------------------------------------------===//
+// iree_flatbuffer_header_t
+//===----------------------------------------------------------------------===//
+
+// A header preceding flatbuffer data in a file.
+// This is added by IREE tooling to allow for coarse versioning (in case we
+// totally change the file format), flatbuffer sizing, and ensured alignment.
+typedef struct iree_flatbuffer_file_header_t {
+  // 4 byte magic number used for file identification.
+  uint32_t magic;
+  // Version of the content payload.
+  uint32_t version;
+  // Total size, in bytes, of the content following the header.
+  // For flatbuffers this may include the flatbuffer itself plus any trailing
+  // data referenced by it.
+  uint64_t content_size;
+  uint64_t reserved[6];
+} iree_flatbuffer_file_header_t;
+static_assert(sizeof(iree_flatbuffer_file_header_t) == 64,
+              "must be 64-byte padded");
 
 #endif  // IREE_BASE_INTERNAL_FLATCC_PARSING_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -72,6 +72,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
         "//runtime/src/iree/hal/drivers/amdgpu/util:topology",
         "//runtime/src/iree/hal/utils:executable_debug_info",
+        "//runtime/src/iree/hal/utils:executable_header",
         "//runtime/src/iree/hal/utils:file_transfer",
         "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:resource_set",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_cc_library(
     iree::hal::drivers::amdgpu::util::libhsa
     iree::hal::drivers::amdgpu::util::topology
     iree::hal::utils::executable_debug_info
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::resource_set

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.h
@@ -54,6 +54,15 @@ iree_status_t iree_hal_amdgpu_executable_format_supported(
 // This is limited by the field size in iree_hal_amdgpu_device_kernel_args_t.
 #define IREE_HAL_AMDGPU_MAX_DISPATCH_CONSTANT_COUNT UINT16_MAX
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+// The format will be the ISA name like "amdgcn-amd-amdhsa--gfx1100".
+iree_status_t iree_hal_amdgpu_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 // Creates a AMDGPU executable from a binary in memory. Each executable may
 // contain multiple entry points and be composed of several modules presented to
 // the HAL as a single instance. See iree_hal_executable_params_t for more

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
@@ -74,6 +74,25 @@ static void iree_hal_amdgpu_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_amdgpu_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_amdgpu_executable_cache_t* executable_cache =
+      iree_hal_amdgpu_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                       "AMDGPU binary size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_amdgpu_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -101,6 +120,7 @@ static iree_status_t iree_hal_amdgpu_executable_cache_prepare_executable(
 static const iree_hal_executable_cache_vtable_t
     iree_hal_amdgpu_executable_cache_vtable = {
         .destroy = iree_hal_amdgpu_executable_cache_destroy,
+        .infer_format = iree_hal_amdgpu_executable_cache_infer_format,
         .can_prepare_format =
             iree_hal_amdgpu_executable_cache_can_prepare_format,
         .prepare_executable =

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
@@ -80,15 +80,10 @@ static iree_status_t iree_hal_amdgpu_executable_cache_infer_format(
     iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_amdgpu_executable_cache_t* executable_cache =
-      iree_hal_amdgpu_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                       "AMDGPU binary size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_amdgpu_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -62,6 +62,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:deferred_work_queue",
         "//runtime/src/iree/hal/utils:executable_debug_info",
+        "//runtime/src/iree/hal/utils:executable_header",
         "//runtime/src/iree/hal/utils:file_transfer",
         "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:queue_emulation",

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::deferred_work_queue
     iree::hal::utils::executable_debug_info
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -12,6 +12,7 @@
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
 #include "iree/hal/utils/executable_debug_info.h"
+#include "iree/hal/utils/executable_header.h"
 
 // flatcc schemas:
 #include "iree/base/internal/flatcc/parsing.h"
@@ -81,6 +82,38 @@ static iree_status_t iree_hal_cuda_query_limits(
   return iree_ok_status();
 }
 
+iree_status_t iree_hal_cuda_native_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  // Read the header prefix (with unsafe inference if size is unknown).
+  const bool unsafe_infer_size = (executable_data.data_length == 0);
+  iree_const_byte_span_t flatbuffer_data = iree_const_byte_span_empty();
+  IREE_RETURN_IF_ERROR(iree_hal_read_executable_flatbuffer_header(
+      executable_data, unsafe_infer_size,
+      iree_hal_cuda_ExecutableDef_file_identifier, &flatbuffer_data));
+
+  // Verify the flatbuffer structure.
+  if (!iree_hal_cuda_ExecutableDef_verify_as_root(
+          flatbuffer_data.data, flatbuffer_data.data_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "failed to verify executable flatbuffer structure");
+  }
+
+  // Write the format string.
+  iree_string_view_t format = IREE_SV("PTXE");
+  if (format.size >= executable_format_capacity) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "executable format buffer too small");
+  }
+  memcpy(executable_format, format.data, format.size + /*NUL*/ 1);
+
+  // Return the total size (header + flatbuffer).
+  *out_inferred_size =
+      sizeof(iree_flatbuffer_file_header_t) + flatbuffer_data.data_length;
+  return iree_ok_status();
+}
+
 // Verifies the structure of the flatbuffer so that we can avoid doing so during
 // runtime.
 //
@@ -90,10 +123,7 @@ static iree_status_t iree_hal_cuda_query_limits(
 static iree_status_t iree_hal_cuda_native_executable_flatbuffer_verify(
     iree_const_byte_span_t flatbuffer_data,
     const iree_hal_cuda_limits_t* limits) {
-  if (!flatbuffer_data.data) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "flatbuffer data is not present");
-  }
+  IREE_ASSERT(flatbuffer_data.data && flatbuffer_data.data_length >= 16);
 
   // Run flatcc generated verification. This ensures all pointers are in-bounds
   // and that we can safely walk the file, but not that the actual contents of
@@ -222,13 +252,20 @@ iree_status_t iree_hal_cuda_native_executable_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_query_limits(symbols, device, &limits));
 
+  // Read and strip the flatbuffer header prefix.
+  iree_const_byte_span_t executable_flatbuffer = iree_const_byte_span_empty();
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_read_executable_flatbuffer_header(
+          executable_params->executable_data, /*unsafe_infer_size=*/false,
+          iree_hal_cuda_ExecutableDef_file_identifier, &executable_flatbuffer));
+
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_native_executable_flatbuffer_verify(
-              executable_params->executable_data, &limits));
+              executable_flatbuffer, &limits));
 
   iree_hal_cuda_ExecutableDef_table_t executable_def =
-      iree_hal_cuda_ExecutableDef_as_root(
-          executable_params->executable_data.data);
+      iree_hal_cuda_ExecutableDef_as_root(executable_flatbuffer.data);
 
   iree_hal_cuda_ModuleDef_vec_t modules_vec =
       iree_hal_cuda_ExecutableDef_modules_get(executable_def);

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.h
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.h
@@ -45,6 +45,14 @@ typedef struct iree_hal_cuda_kernel_params_t {
   IREE_TRACE(iree_hal_cuda_kernel_debug_info_t debug_info;)
 } iree_hal_cuda_kernel_params_t;
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+iree_status_t iree_hal_cuda_native_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 // Creates an IREE executable from a CUDA PTX module. The module may contain
 // several kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_cuda_native_executable_create(

--- a/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
@@ -79,15 +79,10 @@ static iree_status_t iree_hal_cuda_nop_executable_cache_infer_format(
     iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_cuda_nop_executable_cache_t* executable_cache =
-      iree_hal_cuda_nop_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                       "CUDA binary size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_cuda_native_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
@@ -73,6 +73,25 @@ static void iree_hal_cuda_nop_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_cuda_nop_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_cuda_nop_executable_cache_t* executable_cache =
+      iree_hal_cuda_nop_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                       "CUDA binary size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_cuda_nop_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -95,6 +114,7 @@ static iree_status_t iree_hal_cuda_nop_executable_cache_prepare_executable(
 static const iree_hal_executable_cache_vtable_t
     iree_hal_cuda_nop_executable_cache_vtable = {
         .destroy = iree_hal_cuda_nop_executable_cache_destroy,
+        .infer_format = iree_hal_cuda_nop_executable_cache_infer_format,
         .can_prepare_format =
             iree_hal_cuda_nop_executable_cache_can_prepare_format,
         .prepare_executable =

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -69,6 +69,7 @@ iree_cc_library(
     iree::hal::utils::collective_batch
     iree::hal::utils::executable_debug_info
     iree::hal::utils::deferred_command_buffer
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -10,10 +10,10 @@
 
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
-#include "iree/hal/drivers/hip/context_util.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
 #include "iree/hal/drivers/hip/status_util.h"
 #include "iree/hal/utils/executable_debug_info.h"
+#include "iree/hal/utils/executable_header.h"
 
 // flatcc schemas:
 #include "iree/base/internal/flatcc/parsing.h"
@@ -86,6 +86,38 @@ static iree_status_t iree_hal_hip_query_limits(
   return iree_ok_status();
 }
 
+iree_status_t iree_hal_hip_native_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  // Read the size prefix (with unsafe inference if size is unknown).
+  const bool unsafe_infer_size = (executable_data.data_length == 0);
+  iree_const_byte_span_t flatbuffer_data = iree_const_byte_span_empty();
+  IREE_RETURN_IF_ERROR(iree_hal_read_executable_flatbuffer_header(
+      executable_data, unsafe_infer_size,
+      iree_hal_hip_ExecutableDef_file_identifier, &flatbuffer_data));
+
+  // Verify the flatbuffer structure.
+  if (!iree_hal_hip_ExecutableDef_verify_as_root(flatbuffer_data.data,
+                                                 flatbuffer_data.data_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "failed to verify executable flatbuffer structure");
+  }
+
+  // Write the format string.
+  iree_string_view_t format = IREE_SV("HSACO");
+  if (format.size >= executable_format_capacity) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "executable format buffer too small");
+  }
+  memcpy(executable_format, format.data, format.size + /*NUL*/ 1);
+
+  // Return the total size (header + flatbuffer).
+  *out_inferred_size =
+      sizeof(iree_flatbuffer_file_header_t) + flatbuffer_data.data_length;
+  return iree_ok_status();
+}
+
 // Verifies the structure of the flatbuffer so that we can avoid doing so during
 // runtime.
 //
@@ -95,10 +127,7 @@ static iree_status_t iree_hal_hip_query_limits(
 static iree_status_t iree_hal_hip_native_executable_flatbuffer_verify(
     iree_const_byte_span_t flatbuffer_data,
     const iree_hal_hip_limits_t* limits) {
-  if (!flatbuffer_data.data) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "flatbuffer data is not present");
-  }
+  IREE_ASSERT(flatbuffer_data.data && flatbuffer_data.data_length >= 16);
 
   // Run flatcc generated verification. This ensures all pointers are in-bounds
   // and that we can safely walk the file, but not that the actual contents of
@@ -248,13 +277,20 @@ iree_status_t iree_hal_hip_native_executable_create(
       z0, iree_hal_hip_query_limits(symbols, topology.devices[0].hip_device,
                                     &limits));
 
+  // Read and strip the flatbuffer header prefix.
+  iree_const_byte_span_t executable_flatbuffer = iree_const_byte_span_empty();
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_read_executable_flatbuffer_header(
+          executable_params->executable_data, /*unsafe_infer_size=*/false,
+          iree_hal_hip_ExecutableDef_file_identifier, &executable_flatbuffer));
+
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_hip_native_executable_flatbuffer_verify(
-              executable_params->executable_data, &limits));
+              executable_flatbuffer, &limits));
 
   iree_hal_hip_ExecutableDef_table_t executable_def =
-      iree_hal_hip_ExecutableDef_as_root(
-          executable_params->executable_data.data);
+      iree_hal_hip_ExecutableDef_as_root(executable_flatbuffer.data);
 
   iree_hal_hip_ModuleDef_vec_t modules_vec =
       iree_hal_hip_ExecutableDef_modules_get(executable_def);

--- a/runtime/src/iree/hal/drivers/hip/native_executable.h
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.h
@@ -41,6 +41,14 @@ typedef struct iree_hal_hip_kernel_params_t {
   IREE_TRACE(iree_hal_hip_kernel_debug_info_t debug_info;)
 } iree_hal_hip_kernel_params_t;
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+iree_status_t iree_hal_hip_native_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 // Creates an IREE executable from a HSACO module. The module may contain
 // several kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_hip_native_executable_create(

--- a/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
@@ -80,15 +80,10 @@ static iree_status_t iree_hal_hip_nop_executable_cache_infer_format(
     iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_hip_nop_executable_cache_t* executable_cache =
-      iree_hal_hip_nop_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                       "HIP binary size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_hip_native_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
@@ -74,6 +74,25 @@ static void iree_hal_hip_nop_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_hip_nop_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_hip_nop_executable_cache_t* executable_cache =
+      iree_hal_hip_nop_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                       "HIP binary size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_hip_nop_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -96,6 +115,7 @@ static iree_status_t iree_hal_hip_nop_executable_cache_prepare_executable(
 static const iree_hal_executable_cache_vtable_t
     iree_hal_hip_nop_executable_cache_vtable = {
         .destroy = iree_hal_hip_nop_executable_cache_destroy,
+        .infer_format = iree_hal_hip_nop_executable_cache_infer_format,
         .can_prepare_format =
             iree_hal_hip_nop_executable_cache_can_prepare_format,
         .prepare_executable =

--- a/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     iree::hal::drivers::metal::builtin
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::executable_debug_info
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation

--- a/runtime/src/iree/hal/drivers/metal/executable.h
+++ b/runtime/src/iree/hal/drivers/metal/executable.h
@@ -79,6 +79,14 @@ typedef struct iree_hal_metal_pipeline_t {
   IREE_TRACE(iree_hal_metal_source_location_t source_location;)
 } iree_hal_metal_pipeline_t;
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+iree_status_t iree_hal_metal_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 // Creates a Metal kernel library as an IREE executable. The Metal library may
 // contain several kernel functions that can be extracted along with the
 // associated block size.

--- a/runtime/src/iree/hal/drivers/metal/executable.m
+++ b/runtime/src/iree/hal/drivers/metal/executable.m
@@ -11,6 +11,7 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/utils/executable_debug_info.h"
+#include "iree/hal/utils/executable_header.h"
 
 // flatcc schemas:
 #include "iree/base/internal/flatcc/parsing.h"
@@ -45,6 +46,36 @@ static const iree_hal_metal_executable_t* iree_hal_metal_executable_const_cast(
   return (const iree_hal_metal_executable_t*)base_value;
 }
 
+iree_status_t iree_hal_metal_executable_infer_format(iree_const_byte_span_t executable_data,
+                                                     iree_host_size_t executable_format_capacity,
+                                                     char* executable_format,
+                                                     iree_host_size_t* out_inferred_size) {
+  // Read the header prefix (with unsafe inference if size is unknown).
+  const bool unsafe_infer_size = (executable_data.data_length == 0);
+  iree_const_byte_span_t flatbuffer_data = iree_const_byte_span_empty();
+  IREE_RETURN_IF_ERROR(iree_hal_read_executable_flatbuffer_header(
+      executable_data, unsafe_infer_size, iree_hal_metal_ExecutableDef_file_identifier,
+      &flatbuffer_data));
+
+  // Verify the flatbuffer structure.
+  if (!iree_hal_metal_ExecutableDef_verify_as_root(flatbuffer_data.data,
+                                                   flatbuffer_data.data_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "failed to verify executable flatbuffer structure");
+  }
+
+  // Write the format string.
+  iree_string_view_t format = IREE_SV("PTXE");
+  if (format.size >= executable_format_capacity) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "executable format buffer too small");
+  }
+  memcpy(executable_format, format.data, format.size + /*NUL*/ 1);
+
+  // Return the total size (header + flatbuffer).
+  *out_inferred_size = sizeof(iree_flatbuffer_file_header_t) + flatbuffer_data.data_length;
+  return iree_ok_status();
+}
+
 // Verifies the structure of the flatbuffer so that we can avoid doing so during runtime.
 //
 // There are still some conditions we must be aware of (such as omitted names on functions with
@@ -52,11 +83,7 @@ static const iree_hal_metal_executable_t* iree_hal_metal_executable_const_cast(
 // after this succeeds.
 static iree_status_t iree_hal_metal_executable_flatbuffer_verify(
     iree_const_byte_span_t flatbuffer_data) {
-  if (!flatbuffer_data.data || flatbuffer_data.data_length < 16) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "flatbuffer data is not present or less than 16 bytes (%zu total)",
-                            flatbuffer_data.data_length);
-  }
+  IREE_ASSERT(flatbuffer_data.data && flatbuffer_data.data_length >= 16);
 
   // Run flatcc generated verification. This ensures all pointers are in-bounds and that we can
   // safely walk the file, but not that the actual contents of the flatbuffer meet our expectations.
@@ -380,11 +407,18 @@ iree_status_t iree_hal_metal_executable_create(
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  IREE_RETURN_IF_ERROR(
-      iree_hal_metal_executable_flatbuffer_verify(executable_params->executable_data));
+  // Read and strip the flatbuffer header prefix.
+  iree_const_byte_span_t executable_flatbuffer = iree_const_byte_span_empty();
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_read_executable_flatbuffer_header(executable_params->executable_data,
+                                                     /*unsafe_infer_size=*/false,
+                                                     iree_hal_metal_ExecutableDef_file_identifier,
+                                                     &executable_flatbuffer));
+
+  IREE_RETURN_IF_ERROR(iree_hal_metal_executable_flatbuffer_verify(executable_flatbuffer));
 
   iree_hal_metal_ExecutableDef_table_t executable_def =
-      iree_hal_metal_ExecutableDef_as_root(executable_params->executable_data.data);
+      iree_hal_metal_ExecutableDef_as_root(executable_flatbuffer.data);
 
   iree_hal_metal_PipelineDef_vec_t pipelines_vec =
       iree_hal_metal_ExecutableDef_pipelines_get(executable_def);

--- a/runtime/src/iree/hal/drivers/metal/nop_executable_cache.m
+++ b/runtime/src/iree/hal/drivers/metal/nop_executable_cache.m
@@ -69,14 +69,9 @@ static iree_status_t iree_hal_metal_nop_executable_cache_infer_format(
     iree_hal_executable_caching_mode_t caching_mode, iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_metal_nop_executable_cache_t* executable_cache =
-      iree_hal_metal_nop_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status = iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                                          "Metal binary size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_metal_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format, out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/metal/nop_executable_cache.m
+++ b/runtime/src/iree/hal/drivers/metal/nop_executable_cache.m
@@ -64,6 +64,23 @@ static void iree_hal_metal_nop_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_metal_nop_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode, iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_metal_nop_executable_cache_t* executable_cache =
+      iree_hal_metal_nop_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                                          "Metal binary size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_metal_nop_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode, iree_string_view_t executable_format) {
@@ -81,6 +98,7 @@ static iree_status_t iree_hal_metal_nop_executable_cache_prepare_executable(
 
 static const iree_hal_executable_cache_vtable_t iree_hal_metal_nop_executable_cache_vtable = {
     .destroy = iree_hal_metal_nop_executable_cache_destroy,
+    .infer_format = iree_hal_metal_nop_executable_cache_infer_format,
     .can_prepare_format = iree_hal_metal_nop_executable_cache_can_prepare_format,
     .prepare_executable = iree_hal_metal_nop_executable_cache_prepare_executable,
 };

--- a/runtime/src/iree/hal/drivers/null/executable_cache.c
+++ b/runtime/src/iree/hal/drivers/null/executable_cache.c
@@ -70,6 +70,28 @@ static void iree_hal_null_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_null_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_null_executable_cache_t* executable_cache =
+      iree_hal_null_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // TODO(null): try to guess what the format in executable_data is. Note that
+  // the data_length may be 0 indicating the caller doesn't know how much data
+  // after the base pointer is involved. **THIS IS UNSAFE** but required for
+  // compatibility with CUDA/HIP.
+  iree_status_t status = iree_make_status(
+      IREE_STATUS_UNIMPLEMENTED, "{null} size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_null_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -100,6 +122,7 @@ static iree_status_t iree_hal_null_executable_cache_prepare_executable(
 static const iree_hal_executable_cache_vtable_t
     iree_hal_null_executable_cache_vtable = {
         .destroy = iree_hal_null_executable_cache_destroy,
+        .infer_format = iree_hal_null_executable_cache_infer_format,
         .can_prepare_format = iree_hal_null_executable_cache_can_prepare_format,
         .prepare_executable = iree_hal_null_executable_cache_prepare_executable,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -80,6 +80,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/vulkan/util:ref_ptr",
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:executable_debug_info",
+        "//runtime/src/iree/hal/utils:executable_header",
         "//runtime/src/iree/hal/utils:file_transfer",
         "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:queue_emulation",

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -75,6 +75,7 @@ iree_cc_library(
     iree::hal::drivers::vulkan::util::ref_ptr
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::executable_debug_info
+    iree::hal::utils::executable_header
     iree::hal::utils::file_transfer
     iree::hal::utils::files
     iree::hal::utils::queue_emulation

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.h
@@ -32,6 +32,14 @@ typedef struct iree_hal_vulkan_pipeline_t {
   IREE_TRACE(iree_hal_vulkan_source_location_t source_location;)
 } iree_hal_vulkan_pipeline_t;
 
+// Infers the format of the executable and calculates its total size.
+// If executable_data.data_length is 0 attempts to infer size from the data.
+// Returns the canonical format string and total size of the executable data.
+iree_status_t iree_hal_vulkan_native_executable_infer_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
 // Creates a wrapper for one or more VkPipelines that are sourced from the same
 // IREE executable. Each of the pipelines will share the same shader module
 // and just differs by the entry point into the shader module they reference.

--- a/runtime/src/iree/hal/drivers/vulkan/nop_executable_cache.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/nop_executable_cache.cc
@@ -75,15 +75,10 @@ static iree_status_t iree_hal_vulkan_nop_executable_cache_infer_format(
     iree_const_byte_span_t executable_data,
     iree_host_size_t executable_format_capacity, char* executable_format,
     iree_host_size_t* out_inferred_size) {
-  iree_hal_vulkan_nop_executable_cache_t* executable_cache =
-      iree_hal_vulkan_nop_executable_cache_cast(base_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status =
-      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                       "Vulkan SPIR-V size inference not yet implemented");
-  (void)executable_cache;
-
+  iree_status_t status = iree_hal_vulkan_native_executable_infer_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/drivers/vulkan/nop_executable_cache.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/nop_executable_cache.cc
@@ -69,6 +69,25 @@ static void iree_hal_vulkan_nop_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_vulkan_nop_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_vulkan_nop_executable_cache_t* executable_cache =
+      iree_hal_vulkan_nop_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                       "Vulkan SPIR-V size inference not yet implemented");
+  (void)executable_cache;
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_vulkan_nop_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -112,6 +131,7 @@ namespace {
 const iree_hal_executable_cache_vtable_t
     iree_hal_vulkan_nop_executable_cache_vtable = {
         /*.destroy=*/iree_hal_vulkan_nop_executable_cache_destroy,
+        /*.infer_format=*/iree_hal_vulkan_nop_executable_cache_infer_format,
         /*.can_prepare_format=*/
         iree_hal_vulkan_nop_executable_cache_can_prepare_format,
         /*.prepare_executable=*/

--- a/runtime/src/iree/hal/executable_cache.c
+++ b/runtime/src/iree/hal/executable_cache.c
@@ -42,6 +42,28 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_cache_create(
   return status;
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_executable_cache_infer_format(
+    iree_hal_executable_cache_t* executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(executable_cache);
+  IREE_ASSERT_ARGUMENT(executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+  if (executable_format_capacity == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable_format_capacity must be > 0");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(executable_cache, infer_format)(
+      executable_cache, caching_mode, executable_data,
+      executable_format_capacity, executable_format, out_inferred_size);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT bool iree_hal_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,

--- a/runtime/src/iree/hal/local/BUILD.bazel
+++ b/runtime/src/iree/hal/local/BUILD.bazel
@@ -29,6 +29,15 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "executable_format",
+    srcs = ["executable_format.c"],
+    hdrs = ["executable_format.h"],
+    deps = [
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "executable_library",
     hdrs = ["executable_library.h"],
 )

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -27,6 +27,18 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    executable_format
+  HDRS
+    "executable_format.h"
+  SRCS
+    "executable_format.c"
+  DEPS
+    iree::base
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     executable_library
   HDRS
     "executable_library.h"

--- a/runtime/src/iree/hal/local/executable_format.c
+++ b/runtime/src/iree/hal/local/executable_format.c
@@ -1,0 +1,988 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/local/executable_format.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+// Writes an executable format string with optional prefix as `[prefix]suffix`
+// to |buffer| with |capacity| bytes, including NUL terminator. No-op if no
+// buffer is provided.
+//
+// Example: prefix = "foo", suffix = "bar" => "foobar\0"
+static iree_status_t iree_hal_executable_write_executable_format(
+    const char* prefix, const char* suffix, char* buffer,
+    iree_host_size_t capacity) {
+  if (!capacity || !buffer) return iree_ok_status();  // no-op
+  const iree_host_size_t prefix_length = prefix ? strlen(prefix) : 0;
+  const iree_host_size_t suffix_length = strlen(suffix);
+  const iree_host_size_t format_length =
+      prefix_length + suffix_length + /*NUL*/ 1;
+  if (capacity < format_length) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "insufficient capacity for format string; need %" PRIhsz
+        " but have %" PRIhsz,
+        format_length, capacity);
+  }
+  if (prefix_length > 0) {
+    memcpy(buffer, prefix, prefix_length);
+  }
+  memcpy(buffer + prefix_length, suffix, suffix_length + /*NUL*/ 1);
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// ELF
+//===----------------------------------------------------------------------===//
+
+// ELF magic bytes: 0x7F 'E' 'L' 'F'.
+static const uint8_t kElfMagic[4] = {0x7F, 'E', 'L', 'F'};
+
+typedef enum {
+  IREE_ELF_EM_386 = 0x03,      // Intel 80386
+  IREE_ELF_EM_ARM = 0x28,      // ARM
+  IREE_ELF_EM_X86_64 = 0x3E,   // AMD x86-64 architecture
+  IREE_ELF_EM_AARCH64 = 0xB7,  // ARM AARCH64
+  IREE_ELF_EM_RISCV = 0xF3,    // RISC-V
+} iree_elf_machine_t;
+
+typedef struct {
+  uint8_t e_ident[16];
+  uint16_t e_type;
+  uint16_t e_machine;
+  uint32_t e_version;
+} iree_elf_ehdr_common_t;
+
+typedef struct {
+  iree_elf_ehdr_common_t common;
+  uint32_t e_entry;
+  uint32_t e_phoff;
+  uint32_t e_shoff;
+  uint32_t e_flags;
+  uint16_t e_ehsize;
+  uint16_t e_phentsize;
+  uint16_t e_phnum;
+  uint16_t e_shentsize;
+  uint16_t e_shnum;
+  uint16_t e_shstrndx;
+} iree_elf32_ehdr_t;
+
+typedef struct {
+  iree_elf_ehdr_common_t common;
+  uint64_t e_entry;
+  uint64_t e_phoff;
+  uint64_t e_shoff;
+  uint32_t e_flags;
+  uint16_t e_ehsize;
+  uint16_t e_phentsize;
+  uint16_t e_phnum;
+  uint16_t e_shentsize;
+  uint16_t e_shnum;
+  uint16_t e_shstrndx;
+} iree_elf64_ehdr_t;
+
+typedef struct {
+  uint32_t sh_name;
+  uint32_t sh_type;
+  uint32_t sh_flags;
+  uint32_t sh_addr;
+  uint32_t sh_offset;
+  uint32_t sh_size;
+} iree_elf32_shdr_t;
+
+typedef struct {
+  uint32_t sh_name;
+  uint32_t sh_type;
+  uint64_t sh_flags;
+  uint64_t sh_addr;
+  uint64_t sh_offset;
+  uint64_t sh_size;
+} iree_elf64_shdr_t;
+
+static bool iree_hal_executable_is_elf_file(
+    iree_const_byte_span_t executable_data) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kElfMagic)) {
+    return false;  // too small
+  }
+  return memcmp(executable_data.data, kElfMagic, sizeof(kElfMagic)) == 0;
+}
+
+// Finds the maximum extent by checking section headers (32-bit ELF).
+static iree_status_t iree_hal_executable_calculate_elf_size_32(
+    const iree_elf32_ehdr_t* ehdr, iree_const_byte_span_t executable_data,
+    iree_host_size_t* out_size) {
+  const bool size_unknown = executable_data.data_length == 0;
+  uint32_t max_offset = sizeof(*ehdr);
+
+  // Check program header table.
+  if (ehdr->e_phoff != 0) {
+    const uint32_t ph_end = ehdr->e_phoff + (ehdr->e_phnum * ehdr->e_phentsize);
+    if (ph_end > max_offset) {
+      max_offset = ph_end;  // bump extent
+    }
+  }
+
+  // Check section header table and sections.
+  if (ehdr->e_shoff != 0) {
+    const uint32_t sh_table_end =
+        ehdr->e_shoff + (ehdr->e_shnum * ehdr->e_shentsize);
+    if (sh_table_end > max_offset) {
+      max_offset = sh_table_end;  // bump extent
+    }
+    if (size_unknown || executable_data.data_length >= sh_table_end) {
+      const uint8_t* sh_table = executable_data.data + ehdr->e_shoff;
+      for (uint16_t i = 0; i < ehdr->e_shnum; ++i) {
+        const iree_elf32_shdr_t* shdr =
+            (const iree_elf32_shdr_t*)(sh_table + i * ehdr->e_shentsize);
+        uint32_t section_end = shdr->sh_offset + shdr->sh_size;
+        if (section_end > max_offset) {
+          max_offset = section_end;  // bump extent
+        }
+      }
+    }
+  }
+
+  *out_size = (iree_host_size_t)max_offset;
+  return iree_ok_status();
+}
+
+// Finds the maximum extent by checking section headers (64-bit ELF).
+static iree_status_t iree_hal_executable_calculate_elf_size_64(
+    const iree_elf64_ehdr_t* ehdr, iree_const_byte_span_t executable_data,
+    iree_host_size_t* out_size) {
+  const bool size_unknown = executable_data.data_length == 0;
+  uint64_t max_offset = sizeof(*ehdr);
+
+  // Check program header table.
+  if (ehdr->e_phoff != 0) {
+    const uint64_t ph_end = ehdr->e_phoff + (ehdr->e_phnum * ehdr->e_phentsize);
+    if (ph_end > max_offset) {
+      max_offset = ph_end;  // bump extent
+    }
+  }
+
+  // Check section header table and sections.
+  if (ehdr->e_shoff != 0) {
+    const uint64_t sh_table_end =
+        ehdr->e_shoff + (ehdr->e_shnum * ehdr->e_shentsize);
+    if (sh_table_end > max_offset) {
+      max_offset = sh_table_end;  // bump extent
+    }
+    if (size_unknown || executable_data.data_length >= sh_table_end) {
+      const uint8_t* sh_table = executable_data.data + ehdr->e_shoff;
+      for (uint16_t i = 0; i < ehdr->e_shnum; ++i) {
+        const iree_elf64_shdr_t* shdr =
+            (const iree_elf64_shdr_t*)(sh_table + i * ehdr->e_shentsize);
+        const uint64_t section_end = shdr->sh_offset + shdr->sh_size;
+        if (section_end > max_offset) {
+          max_offset = section_end;  // bump extent
+        }
+      }
+    }
+  }
+
+  *out_size = (iree_host_size_t)max_offset;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_executable_calculate_elf_size(
+    const iree_elf_ehdr_common_t* ehdr, iree_const_byte_span_t executable_data,
+    iree_host_size_t* out_size) {
+  // Check ELF class (32-bit vs 64-bit) as they use different structures and
+  // we need to interpret the contents (beyond common) differently.
+  const bool is_64bit = ehdr->e_ident[4] == 2;  // EI_CLASS = ELFCLASS64
+  if (is_64bit) {
+    return iree_hal_executable_calculate_elf_size_64(
+        (const iree_elf64_ehdr_t*)ehdr, executable_data, out_size);
+  } else {
+    return iree_hal_executable_calculate_elf_size_32(
+        (const iree_elf32_ehdr_t*)ehdr, executable_data, out_size);
+  }
+}
+
+// Returns strings like "x86_64", "arm_64", "riscv_32", "unknown".
+static const char* iree_hal_executable_infer_elf_format_arch(
+    const iree_elf_ehdr_common_t* ehdr) {
+  const uint16_t machine = ehdr->e_machine;
+  switch (machine) {
+    case IREE_ELF_EM_X86_64:
+      return "x86_64";
+    case IREE_ELF_EM_386:
+      return "x86_32";
+    case IREE_ELF_EM_AARCH64:
+      return "arm_64";
+    case IREE_ELF_EM_ARM:
+      return "arm_32";
+    case IREE_ELF_EM_RISCV:
+      if (ehdr->e_ident[4] == 1) {  // ELFCLASS32
+        return "riscv_32";
+      } else {  // ELFCLASS64
+        return "riscv_64";
+      }
+    default:
+      return "unknown";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// FatELF
+//===----------------------------------------------------------------------===//
+
+// FatELF magic bytes: 0xFA 0x70 0x0E 0x1F (little-endian).
+static const uint8_t kFatElfMagic[4] = {0xFA, 0x70, 0x0E, 0x1F};
+
+typedef struct {
+  uint16_t machine;
+  uint8_t osabi;
+  uint8_t osabi_version;
+  uint8_t word_size;
+  uint8_t byte_order;
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint64_t offset;
+  uint64_t size;
+} iree_fatelf_record_t;
+
+typedef struct {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t record_count;
+  uint8_t reserved;
+} iree_fatelf_header_t;
+
+static bool iree_hal_executable_is_fatelf_file(
+    iree_const_byte_span_t executable_data) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kFatElfMagic)) {
+    return false;  // too small
+  }
+  return memcmp(executable_data.data, kFatElfMagic, sizeof(kFatElfMagic)) == 0;
+}
+
+static iree_status_t iree_hal_executable_calculate_fatelf_size(
+    iree_const_byte_span_t executable_data, iree_host_size_t* out_size) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown &&
+      executable_data.data_length < sizeof(iree_fatelf_header_t)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "FatELF data too small for header");
+  }
+  const iree_fatelf_header_t* header =
+      (const iree_fatelf_header_t*)executable_data.data;
+
+  // Calculate the size needed for header and records.
+  uint64_t max_offset =
+      sizeof(*header) + header->record_count * sizeof(iree_fatelf_record_t);
+
+  // Check each record to find the maximum extent.
+  const iree_fatelf_record_t* records =
+      (const iree_fatelf_record_t*)((const uint8_t*)header + sizeof(*header));
+  for (uint8_t i = 0; i < header->record_count; ++i) {
+    const uint64_t record_end = records[i].offset + records[i].size;
+    if (record_end > max_offset) {
+      max_offset = record_end;  // bump extent
+    }
+  }
+
+  *out_size = (iree_host_size_t)max_offset;
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// ELF/FatELF
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_elf_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(!executable_format_capacity || executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+
+  // WARNING: when data_length is 0 we assume we can read at least 4 bytes
+  // for magic number detection. This is UNSAFE and may cause access violations
+  // if the data is not actually at least 4 bytes.
+  const bool size_unknown = executable_data.data_length == 0;
+
+  // If size is known verify we have enough for magic checks.
+  if (!size_unknown && executable_data.data_length < 4) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable data too small to identify format");
+  }
+
+  // When size is unknown we create a temporary span with max size for the
+  // format detection and size calculation functions.
+  iree_const_byte_span_t detection_data = executable_data;
+  if (size_unknown) {
+    detection_data.data_length = IREE_HOST_SIZE_MAX;
+  }
+
+  if ((size_unknown || executable_data.data_length >= sizeof(kFatElfMagic)) &&
+      memcmp(executable_data.data, kFatElfMagic, sizeof(kFatElfMagic)) == 0) {
+    if (size_unknown) {
+      IREE_RETURN_IF_ERROR(iree_hal_executable_calculate_fatelf_size(
+                               detection_data, out_inferred_size),
+                           "calculating FatELF size");
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    return iree_hal_executable_write_executable_format(
+        "embedded-", "fatelf", executable_format, executable_format_capacity);
+  } else if ((size_unknown ||
+              executable_data.data_length >= sizeof(kElfMagic)) &&
+             memcmp(executable_data.data, kElfMagic, sizeof(kElfMagic)) == 0) {
+    const iree_elf_ehdr_common_t* ehdr =
+        (const iree_elf_ehdr_common_t*)executable_data.data;
+    if (size_unknown) {
+      IREE_RETURN_IF_ERROR(iree_hal_executable_calculate_elf_size(
+                               ehdr, detection_data, out_inferred_size),
+                           "calculating ELF size");
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    const char* arch_suffix = iree_hal_executable_infer_elf_format_arch(ehdr);
+    return iree_hal_executable_write_executable_format(
+        "embedded-elf-", arch_suffix, executable_format,
+        executable_format_capacity);
+  }
+
+  return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                          "executable format is not ELF or FatELF");
+}
+
+//===----------------------------------------------------------------------===//
+// DLL
+//===----------------------------------------------------------------------===//
+
+// PE/DLL magic bytes: 'M' 'Z' (DOS header).
+static const uint8_t kPeMagic[2] = {'M', 'Z'};
+
+// PE machine types.
+#define IREE_PE_IMAGE_FILE_MACHINE_I386 0x014C   // x86
+#define IREE_PE_IMAGE_FILE_MACHINE_AMD64 0x8664  // x86_64
+#define IREE_PE_IMAGE_FILE_MACHINE_ARMNT 0x01C4  // ARM
+#define IREE_PE_IMAGE_FILE_MACHINE_ARM64 0xAA64  // ARM64
+
+typedef struct {
+  uint8_t e_magic[2];   // 'M' 'Z'
+  uint8_t padding[58];  // skip to e_lfanew
+  uint32_t e_lfanew;    // offset to PE header
+} iree_dos_header_t;
+
+typedef struct {
+  uint32_t signature;  // "PE\0\0"
+  uint16_t machine;
+  uint16_t numberOfSections;
+  uint32_t timeDateStamp;
+  uint32_t pointerToSymbolTable;
+  uint32_t numberOfSymbols;
+  uint16_t sizeOfOptionalHeader;
+  uint16_t characteristics;
+} iree_pe_file_header_t;
+
+typedef struct {
+  uint8_t name[8];
+  uint32_t virtualSize;
+  uint32_t virtualAddress;
+  uint32_t sizeOfRawData;
+  uint32_t pointerToRawData;
+  uint32_t pointerToRelocations;
+  uint32_t pointerToLinenumbers;
+  uint16_t numberOfRelocations;
+  uint16_t numberOfLinenumbers;
+  uint32_t characteristics;
+} iree_pe_section_header_t;
+
+static bool iree_hal_executable_is_dll_file(
+    iree_const_byte_span_t executable_data) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kPeMagic)) {
+    return false;  // too small
+  }
+  return memcmp(executable_data.data, kPeMagic, sizeof(kPeMagic)) == 0;
+}
+
+static iree_status_t iree_hal_executable_calculate_pe_size(
+    const iree_pe_file_header_t* pe_header, iree_host_size_t* out_size) {
+  // Skip optional header to get to section headers.
+  const uint8_t* section_headers =
+      (const uint8_t*)(pe_header + 1) + pe_header->sizeOfOptionalHeader;
+  uint32_t max_offset = 0;
+  for (uint16_t i = 0; i < pe_header->numberOfSections; ++i) {
+    const iree_pe_section_header_t* section =
+        (const iree_pe_section_header_t*)(section_headers +
+                                          i * sizeof(iree_pe_section_header_t));
+    const uint32_t section_end =
+        section->pointerToRawData + section->sizeOfRawData;
+    if (section_end > max_offset) {
+      max_offset = section_end;  // bump end offset
+    }
+  }
+  *out_size = max_offset;
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_dll_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(!executable_format_capacity || executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+
+  // WARNING: when data_length is 0 we assume we can read at least 2 bytes
+  // for magic number detection. This is UNSAFE but required for compatibility.
+  const bool size_unknown = executable_data.data_length == 0;
+
+  // Check for PE/DLL magic (DOS header 'MZ').
+  if (!size_unknown && executable_data.data_length < sizeof(kPeMagic)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable data too small to identify format");
+  }
+  if (memcmp(executable_data.data, kPeMagic, sizeof(kPeMagic)) != 0) {
+    return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                            "executable format is not PE/DLL");
+  }
+
+  // Need DOS header to find PE header.
+  if (!size_unknown &&
+      executable_data.data_length < sizeof(iree_dos_header_t)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "PE data too small for DOS header");
+  }
+  const iree_dos_header_t* dos_header =
+      (const iree_dos_header_t*)executable_data.data;
+  const uint32_t pe_offset = dos_header->e_lfanew;
+
+  // Check PE signature and get header.
+  if (!size_unknown && pe_offset + sizeof(iree_pe_file_header_t) + 4 >
+                           executable_data.data_length) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "PE header offset out of bounds");
+  }
+  const uint8_t* pe_sig = executable_data.data + pe_offset;
+  if (memcmp(pe_sig, "PE\0\0", 4) != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "Invalid PE signature");
+  }
+  const iree_pe_file_header_t* pe_header =
+      (const iree_pe_file_header_t*)(pe_sig + 4);
+
+  // Calculate the file size using the parsed header if unknown.
+  if (size_unknown) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_executable_calculate_pe_size(pe_header, out_inferred_size),
+        "calculating PE size");
+  } else {
+    *out_inferred_size = executable_data.data_length;
+  }
+
+  // Get architecture from the parsed header.
+  const char* arch_suffix = "unknown";
+  switch (pe_header->machine) {
+    case IREE_PE_IMAGE_FILE_MACHINE_AMD64:
+      arch_suffix = "x86_64";
+      break;
+    case IREE_PE_IMAGE_FILE_MACHINE_I386:
+      arch_suffix = "x86_32";
+      break;
+    case IREE_PE_IMAGE_FILE_MACHINE_ARM64:
+      arch_suffix = "arm_64";
+      break;
+    case IREE_PE_IMAGE_FILE_MACHINE_ARMNT:
+      arch_suffix = "arm_32";
+      break;
+    default:
+      arch_suffix = "unknown";
+      break;
+  }
+  return iree_hal_executable_write_executable_format(
+      "system-dll-", arch_suffix, executable_format,
+      executable_format_capacity);
+}
+
+//===----------------------------------------------------------------------===//
+// MachO
+//===----------------------------------------------------------------------===//
+
+// Mach-O magic bytes (big-endian).
+static const uint8_t kMachO32Magic[4] = {0xFE, 0xED, 0xFA, 0xCE};
+static const uint8_t kMachO64Magic[4] = {0xFE, 0xED, 0xFA, 0xCF};
+static const uint8_t kMachOFatMagic[4] = {0xCA, 0xFE, 0xBA, 0xBE};
+
+#define IREE_MACHO_CPU_TYPE_X86 7
+#define IREE_MACHO_CPU_TYPE_X86_64 (IREE_MACHO_CPU_TYPE_X86 | 0x01000000)
+#define IREE_MACHO_CPU_TYPE_ARM 12
+#define IREE_MACHO_CPU_TYPE_ARM64 (IREE_MACHO_CPU_TYPE_ARM | 0x01000000)
+
+typedef struct {
+  uint32_t magic;
+  uint32_t cputype;
+  uint32_t cpusubtype;
+  uint32_t filetype;
+  uint32_t ncmds;
+  uint32_t sizeofcmds;
+  uint32_t flags;
+} iree_macho_header_32_t;
+
+typedef struct {
+  uint32_t magic;
+  uint32_t cputype;
+  uint32_t cpusubtype;
+  uint32_t filetype;
+  uint32_t ncmds;
+  uint32_t sizeofcmds;
+  uint32_t flags;
+  uint32_t reserved;
+} iree_macho_header_64_t;
+
+typedef struct {
+  uint32_t cmd;
+  uint32_t cmdsize;
+} iree_macho_load_command_t;
+
+typedef struct {
+  uint32_t cmd;
+  uint32_t cmdsize;
+  char segname[16];
+  uint32_t vmaddr;
+  uint32_t vmsize;
+  uint32_t fileoff;
+  uint32_t filesize;
+} iree_macho_segment_command_32_t;
+
+typedef struct {
+  uint32_t cmd;
+  uint32_t cmdsize;
+  char segname[16];
+  uint64_t vmaddr;
+  uint64_t vmsize;
+  uint64_t fileoff;
+  uint64_t filesize;
+} iree_macho_segment_command_64_t;
+
+static iree_host_size_t iree_hal_executable_calculate_macho_size_32(
+    const iree_macho_header_32_t* header) {
+  const uint8_t* cmd_ptr = (const uint8_t*)(header + 1);
+  uint32_t max_offset = sizeof(*header) + header->sizeofcmds;
+  for (uint32_t i = 0; i < header->ncmds; ++i) {
+    const iree_macho_load_command_t* cmd =
+        (const iree_macho_load_command_t*)cmd_ptr;
+    if (cmd->cmd == 0x1) {  // LC_SEGMENT
+      const iree_macho_segment_command_32_t* seg =
+          (const iree_macho_segment_command_32_t*)cmd;
+      const uint32_t segment_end = seg->fileoff + seg->filesize;
+      if (segment_end > max_offset) {
+        max_offset = segment_end;  // bump extent
+      }
+    }
+    cmd_ptr += cmd->cmdsize;
+  }
+  return (iree_host_size_t)max_offset;
+}
+
+static iree_host_size_t iree_hal_executable_calculate_macho_size_64(
+    const iree_macho_header_64_t* header) {
+  const uint8_t* cmd_ptr = (const uint8_t*)(header + 1);
+  uint64_t max_offset = sizeof(*header) + header->sizeofcmds;
+  for (uint32_t i = 0; i < header->ncmds; ++i) {
+    const iree_macho_load_command_t* cmd =
+        (const iree_macho_load_command_t*)cmd_ptr;
+    if (cmd->cmd == 0x19) {  // LC_SEGMENT_64
+      const iree_macho_segment_command_64_t* seg =
+          (const iree_macho_segment_command_64_t*)cmd;
+      const uint64_t segment_end = seg->fileoff + seg->filesize;
+      if (segment_end > max_offset) {
+        max_offset = segment_end;  // bump extent
+      }
+    }
+    cmd_ptr += cmd->cmdsize;
+  }
+  return (iree_host_size_t)max_offset;
+}
+
+static bool iree_hal_executable_is_macho_file(
+    iree_const_byte_span_t executable_data) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kMachO64Magic)) {
+    return false;  // too small
+  }
+  return (memcmp(executable_data.data, kMachO32Magic, sizeof(kMachO32Magic)) ==
+          0) ||
+         (memcmp(executable_data.data, kMachO64Magic, sizeof(kMachO64Magic)) ==
+          0) ||
+         (memcmp(executable_data.data, kMachOFatMagic,
+                 sizeof(kMachOFatMagic)) == 0);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_macho_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(!executable_format_capacity || executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+
+  // WARNING: when data_length is 0 we assume we can read at least 4 bytes
+  // for magic number detection. This is UNSAFE but required for compatibility.
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kMachO64Magic)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable data too small to identify format");
+  }
+  const bool is_32bit =
+      memcmp(executable_data.data, kMachO32Magic, sizeof(kMachO32Magic)) == 0;
+  const bool is_64bit =
+      memcmp(executable_data.data, kMachO64Magic, sizeof(kMachO64Magic)) == 0;
+  const bool is_fat =
+      memcmp(executable_data.data, kMachOFatMagic, sizeof(kMachOFatMagic)) == 0;
+  if (!is_32bit && !is_64bit && !is_fat) {
+    return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                            "executable format is not Mach-O");
+  }
+
+  const char* arch_suffix = "unknown";
+  if (is_64bit) {
+    if (!size_unknown &&
+        executable_data.data_length < sizeof(iree_macho_header_64_t)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Mach-O 64 data too small for header");
+    }
+    const iree_macho_header_64_t* header =
+        (const iree_macho_header_64_t*)executable_data.data;
+    if (size_unknown) {
+      *out_inferred_size = iree_hal_executable_calculate_macho_size_64(header);
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    if (header->cputype == IREE_MACHO_CPU_TYPE_X86_64) {
+      arch_suffix = "x86_64";
+    } else if (header->cputype == IREE_MACHO_CPU_TYPE_ARM64) {
+      arch_suffix = "arm_64";
+    }
+  } else if (is_32bit) {
+    if (!size_unknown &&
+        executable_data.data_length < sizeof(iree_macho_header_32_t)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Mach-O 32 data too small for header");
+    }
+    const iree_macho_header_32_t* header =
+        (const iree_macho_header_32_t*)executable_data.data;
+    if (size_unknown) {
+      *out_inferred_size = iree_hal_executable_calculate_macho_size_32(header);
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    if (header->cputype == IREE_MACHO_CPU_TYPE_X86) {
+      arch_suffix = "x86_32";
+    } else if (header->cputype == IREE_MACHO_CPU_TYPE_ARM) {
+      arch_suffix = "arm_32";
+    }
+  } else if (is_fat) {
+    // Note: For fat binaries we'd need to parse the fat header to determine
+    // architectures, for now we just mark as unknown.
+    return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                            "fat MachO files not yet supported");
+  }
+
+  return iree_hal_executable_write_executable_format(
+      "system-dylib-", arch_suffix, executable_format,
+      executable_format_capacity);
+}
+
+//===----------------------------------------------------------------------===//
+// WASM
+//===----------------------------------------------------------------------===//
+
+// WebAssembly magic bytes: \0 'a' 's' 'm'.
+static const uint8_t kWasmMagic[4] = {0x00, 'a', 's', 'm'};
+
+typedef struct iree_wasm_header_t {
+  uint8_t magic[4];
+  uint32_t version;
+} iree_wasm_header_t;
+
+// WebAssembly section IDs.
+typedef enum {
+  IREE_WASM_SECTION_CUSTOM = 0,
+  IREE_WASM_SECTION_TYPE = 1,
+  IREE_WASM_SECTION_IMPORT = 2,
+  IREE_WASM_SECTION_FUNCTION = 3,
+  IREE_WASM_SECTION_TABLE = 4,
+  IREE_WASM_SECTION_MEMORY = 5,
+  IREE_WASM_SECTION_GLOBAL = 6,
+  IREE_WASM_SECTION_EXPORT = 7,
+  IREE_WASM_SECTION_START = 8,
+  IREE_WASM_SECTION_ELEMENT = 9,
+  IREE_WASM_SECTION_CODE = 10,
+  IREE_WASM_SECTION_DATA = 11,
+  IREE_WASM_SECTION_DATA_COUNT = 12,  // from bulk memory proposal
+} iree_wasm_section_id_t;
+
+static bool iree_hal_executable_is_wasm_file(
+    iree_const_byte_span_t executable_data) {
+  const bool size_unknown = executable_data.data_length == 0;
+  if (!size_unknown && executable_data.data_length < sizeof(kWasmMagic)) {
+    return false;  // too small
+  }
+  return memcmp(executable_data.data, kWasmMagic, sizeof(kWasmMagic)) == 0;
+}
+
+// Decodes an LEB128 unsigned integer from WASM data.
+// Returns the number of bytes consumed or 0 on error.
+static iree_host_size_t iree_hal_wasm_decode_leb128_u32(
+    const uint8_t* data, iree_host_size_t max_bytes, uint32_t* out_value) {
+  if (max_bytes == 0) return 0;
+  uint32_t value = 0;
+  iree_host_size_t bytes_read = 0;
+  uint32_t shift = 0;
+  // Read up to max 5 bytes for u32.
+  while (bytes_read < max_bytes && bytes_read < 5) {
+    uint8_t byte = data[bytes_read++];
+    value |= ((uint32_t)(byte & 0x7F)) << shift;
+    if ((byte & 0x80) == 0) {
+      *out_value = value;
+      return bytes_read;
+    }
+    shift += 7;
+  }
+  return 0;  // error: incomplete or too large
+}
+
+// Decodes an LEB128 unsigned 64-bit integer from WASM data.
+// Returns the number of bytes consumed or 0 on error.
+static iree_host_size_t iree_hal_wasm_decode_leb128_u64(
+    const uint8_t* data, iree_host_size_t max_bytes, uint64_t* out_value) {
+  if (max_bytes == 0) return 0;
+  uint64_t value = 0;
+  iree_host_size_t bytes_read = 0;
+  uint32_t shift = 0;
+  // Read up to max 10 bytes for u64.
+  while (bytes_read < max_bytes && bytes_read < 10) {
+    uint8_t byte = data[bytes_read++];
+    value |= ((uint64_t)(byte & 0x7F)) << shift;
+    if ((byte & 0x80) == 0) {
+      *out_value = value;
+      return bytes_read;
+    }
+    shift += 7;
+  }
+  return 0;  // error: incomplete or too large
+}
+
+// Checks if a WASM memory section contains any 64-bit memories.
+// Returns true if any memory uses 64-bit addressing (flags 0x04-0x07).
+static bool iree_hal_executable_is_memory64_used(
+    const uint8_t* section_data, iree_host_size_t section_size) {
+  iree_host_size_t offset = 0;
+
+  // Read number of memories.
+  uint32_t num_memories = 0;
+  iree_host_size_t consumed = iree_hal_wasm_decode_leb128_u32(
+      section_data + offset, section_size - offset, &num_memories);
+  if (consumed == 0) {
+    return false;  // failed to parse
+  }
+  offset += consumed;
+
+  // Check each memory's limits.
+  for (uint32_t i = 0; i < num_memories && offset < section_size; ++i) {
+    if (offset >= section_size) {
+      return false;  // incomplete section
+    }
+
+    // Flags 0x04-0x07 indicate 64-bit memory.
+    const uint8_t limits_flag = section_data[offset++];
+    if (limits_flag >= 0x04 && limits_flag <= 0x07) {
+      return true;  // found 64-bit memory - early exit
+    }
+
+    // Skip the limit values based on flag.
+    if (limits_flag == 0x00 || limits_flag == 0x02) {
+      // min:u32 only.
+      uint32_t min_val = 0;
+      consumed = iree_hal_wasm_decode_leb128_u32(
+          section_data + offset, section_size - offset, &min_val);
+      if (consumed == 0) break;
+      offset += consumed;
+    } else if (limits_flag == 0x01 || limits_flag == 0x03) {
+      // min:u32 max:u32.
+      uint32_t min_val = 0, max_val = 0;
+      consumed = iree_hal_wasm_decode_leb128_u32(
+          section_data + offset, section_size - offset, &min_val);
+      if (consumed == 0) break;
+      offset += consumed;
+      consumed = iree_hal_wasm_decode_leb128_u32(
+          section_data + offset, section_size - offset, &max_val);
+      if (consumed == 0) break;
+      offset += consumed;
+    } else {
+      return false;  // unknown flag, abort
+    }
+  }
+
+  return false;  // no 64-bit memory found
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_wasm_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(!executable_format_capacity || executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+
+  // WARNING: when data_length is 0 we assume we can read at least 8 bytes
+  // for magic number detection. This is UNSAFE but required for compatibility.
+  const bool size_unknown = executable_data.data_length == 0;
+
+  // If size is known verify we have enough for magic checks.
+  if (!size_unknown &&
+      executable_data.data_length < sizeof(iree_wasm_header_t)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable data too small to identify format");
+  }
+
+  iree_wasm_header_t header;
+  memcpy(&header, executable_data.data, sizeof(header));
+
+  // Check for WebAssembly magic bytes and version.
+  if (memcmp(header.magic, kWasmMagic, sizeof(kWasmMagic)) != 0) {
+    return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                            "executable format is not WebAssembly");
+  }
+
+  // Check version (should be 1).
+  if (header.version != 0x00000001) {
+    return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                            "unsupported WASM version");
+  }
+
+  const uint8_t* data = executable_data.data;
+  const iree_host_size_t max_length =
+      size_unknown ? IREE_HOST_SIZE_MAX : executable_data.data_length;
+
+  // Parse sections to detect memory64 and optionally calculate size.
+  iree_host_size_t offset = sizeof(header);
+  iree_host_size_t max_offset = offset;
+  bool has_memory64 = false;
+  while (offset < max_length) {
+    // Check if we can read section ID.
+    if (!size_unknown && offset >= executable_data.data_length) {
+      break;  // End of known data.
+    }
+
+    // Check if this is a known section ID.
+    const uint8_t section_id = data[offset++];
+    if (section_id > IREE_WASM_SECTION_DATA_COUNT &&
+        section_id != IREE_WASM_SECTION_CUSTOM) {
+      // Unknown section ID, assume end of file.
+      break;
+    }
+
+    // Read section size (LEB128 encoded).
+    const iree_host_size_t bytes_remaining =
+        size_unknown ? 5 : (max_length > offset ? max_length - offset : 0);
+    uint32_t section_size = 0;
+    const iree_host_size_t leb_bytes = iree_hal_wasm_decode_leb128_u32(
+        data + offset, bytes_remaining, &section_size);
+    if (leb_bytes == 0) {
+      // Failed to decode size, assume we've reached the end.
+      break;
+    }
+    offset += leb_bytes;
+
+    // Check for memory section to detect memory64.
+    if (section_id == IREE_WASM_SECTION_MEMORY && !has_memory64) {
+      // Check if this memory section uses 64-bit addressing.
+      has_memory64 =
+          iree_hal_executable_is_memory64_used(data + offset, section_size);
+    }
+
+    offset += section_size;
+    if (size_unknown && offset > max_offset) {
+      max_offset = offset;  // bump extent
+    }
+  }
+  *out_inferred_size = size_unknown ? max_offset : executable_data.data_length;
+
+  // Return format based on whether we found 64-bit memory.
+  const char* format = has_memory64 ? "wasm_64" : "wasm_32";
+  return iree_hal_executable_write_executable_format(
+      NULL, format, executable_format, executable_format_capacity);
+}
+
+//===----------------------------------------------------------------------===//
+// Automatic detection
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_system_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(!executable_format_capacity || executable_format);
+  IREE_ASSERT_ARGUMENT(out_inferred_size);
+  *out_inferred_size = 0;
+
+#if defined(IREE_PLATFORM_WINDOWS)
+  if (iree_hal_executable_is_dll_file(executable_data)) {
+    // Check for PE/DLL on Windows - delegate to the DLL specific function.
+    return iree_hal_executable_infer_dll_format(
+        executable_data, executable_format_capacity, executable_format,
+        out_inferred_size);
+  }
+#elif defined(IREE_PLATFORM_APPLE)
+  if (iree_hal_executable_is_macho_file(executable_data)) {
+    return iree_hal_executable_infer_macho_format(
+        executable_data, executable_format_capacity, executable_format,
+        out_inferred_size);
+  }
+#elif defined(IREE_PLATFORM_EMSCRIPTEN)
+  if (iree_hal_executable_is_wasm_file(executable_data)) {
+    return iree_hal_executable_infer_wasm_format(
+        executable_data, executable_format_capacity, executable_format,
+        out_inferred_size);
+  }
+#else
+  const bool size_unknown = executable_data.data_length == 0;
+  if (iree_hal_executable_is_fatelf_file(executable_data)) {
+    if (size_unknown) {
+      IREE_RETURN_IF_ERROR(iree_hal_executable_calculate_fatelf_size(
+          executable_data, out_inferred_size));
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    return iree_hal_executable_write_executable_format(
+        "system-", "fatelf", executable_format, executable_format_capacity);
+  } else if (iree_hal_executable_is_elf_file(executable_data)) {
+    const iree_elf_ehdr_common_t* ehdr =
+        (const iree_elf_ehdr_common_t*)executable_data.data;
+    if (size_unknown) {
+      IREE_RETURN_IF_ERROR(iree_hal_executable_calculate_elf_size(
+          ehdr, executable_data, out_inferred_size));
+    } else {
+      *out_inferred_size = executable_data.data_length;
+    }
+    const char* arch_suffix = iree_hal_executable_infer_elf_format_arch(ehdr);
+    return iree_hal_executable_write_executable_format(
+        "system-elf-", arch_suffix, executable_format,
+        executable_format_capacity);
+  }
+#endif  // IREE_PLATFORM_*
+
+  return iree_make_status(IREE_STATUS_INCOMPATIBLE,
+                          "unable to detect system executable format");
+}

--- a/runtime/src/iree/hal/local/executable_format.h
+++ b/runtime/src/iree/hal/local/executable_format.h
@@ -1,0 +1,131 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_LOCAL_EXECUTABLE_FORMAT_H_
+#define IREE_HAL_LOCAL_EXECUTABLE_FORMAT_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Infers the format and size of an ELF or FatELF executable.
+// Returns format strings like "embedded-elf-x86_64" or "fatelf".
+//
+// |executable_data| contains the executable binary data. If data_length is 0
+// the function will assume at least 4 bytes are readable for magic detection.
+// This is UNSAFE but required for compatibility with APIs that don't provide
+// size information.
+//
+// |executable_format_capacity| is the buffer size for the format string.
+// |executable_format| receives the NUL-terminated format string.
+//
+// |out_inferred_size| receives the inferred size of the executable in bytes.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if the format string buffer is too small.
+// Returns IREE_STATUS_INCOMPATIBLE if the format is not ELF or FatELF.
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_elf_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
+// Infers the format and size of a PE/DLL executable.
+// Detects Windows PE/DLL binaries and returns format strings like
+// "system-dll-x86_64".
+//
+// |executable_data| contains the executable binary data. If data_length is 0,
+// the function will assume at least 2 bytes are readable for magic detection.
+// This is UNSAFE but required for compatibility with APIs that don't provide
+// size information.
+//
+// |executable_format_capacity| is the buffer size for the format string.
+// |executable_format| receives the NUL-terminated format string.
+//
+// |out_inferred_size| receives the inferred size of the executable in bytes.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if the format string buffer is too small.
+// Returns IREE_STATUS_INCOMPATIBLE if the format is not PE/DLL.
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_dll_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
+// Infers the format and size of a Mach-O executable.
+// Detects Mach-O binaries and returns format strings like
+// "system-dylib-x86_64".
+//
+// |executable_data| contains the executable binary data. If data_length is 0,
+// the function will assume at least 4 bytes are readable for magic detection.
+// This is UNSAFE but required for compatibility with APIs that don't provide
+// size information.
+//
+// |executable_format_capacity| is the buffer size for the format string.
+// |executable_format| receives the NUL-terminated format string.
+//
+// |out_inferred_size| receives the inferred size of the executable in bytes.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if the format string buffer is too small.
+// Returns IREE_STATUS_INCOMPATIBLE if the format is not Mach-O.
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_macho_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
+// Infers the format and size of a WebAssembly module.
+// Detects WebAssembly modules and returns "wasm_32" for standard WASM or
+// "wasm_64" for modules using memory64 (64-bit memory addressing).
+//
+// |executable_data| contains the executable binary data. If data_length is 0,
+// the function will assume at least 4 bytes are readable for magic detection.
+// This is UNSAFE but required for compatibility with APIs that don't provide
+// size information.
+//
+// |executable_format_capacity| is the buffer size for the format string.
+// |executable_format| receives the NUL-terminated format string.
+//
+// |out_inferred_size| receives the inferred size of the executable in bytes.
+// Size inference for WASM may return 0 if not fully implemented.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if the format string buffer is too small.
+// Returns IREE_STATUS_INCOMPATIBLE if the format is not WebAssembly.
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_wasm_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
+// Infers the format and size of a system-native executable.
+//
+// Detects the native format for the current platform:
+// - Windows: PE/DLL format ("system-dll-x86_64")
+// - macOS: Mach-O format ("system-dylib-x86_64")
+// - Emscripten: WebAssembly format ("wasm_32" or "wasm_64")
+// - Linux/Unix: ELF/FatELF format ("system-elf-x86_64")
+//
+// |executable_data| contains the executable binary data. If data_length is 0,
+// the function will assume at least 4 bytes are readable for magic detection.
+// This is UNSAFE but required for compatibility with APIs that don't provide
+// size information.
+//
+// |executable_format_capacity| is the buffer size for the format string.
+// |executable_format| receives the NUL-terminated format string.
+//
+// |out_inferred_size| receives the inferred size of the executable in bytes.
+// A size of 0 may be returned if size calculation is not supported on the
+// current platform for the detected format.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if the format string buffer is too small.
+// Returns IREE_STATUS_INCOMPATIBLE if the format cannot be detected.
+IREE_API_EXPORT iree_status_t iree_hal_executable_infer_system_format(
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_EXECUTABLE_FORMAT_H_

--- a/runtime/src/iree/hal/local/executable_loader.c
+++ b/runtime/src/iree/hal/local/executable_loader.c
@@ -70,6 +70,18 @@ void iree_hal_executable_loader_release(
   }
 }
 
+iree_status_t iree_hal_executable_loader_infer_format(
+    iree_hal_executable_loader_t* executable_loader,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_ASSERT_ARGUMENT(executable_loader);
+  return executable_loader->vtable->infer_format(
+      executable_loader, caching_mode, executable_data,
+      executable_format_capacity, executable_format, out_inferred_size);
+}
+
 bool iree_hal_executable_loader_query_support(
     iree_hal_executable_loader_t* executable_loader,
     iree_hal_executable_caching_mode_t caching_mode,

--- a/runtime/src/iree/hal/local/loaders/BUILD.bazel
+++ b/runtime/src/iree/hal/local/loaders/BUILD.bazel
@@ -29,6 +29,7 @@ iree_runtime_cc_library(
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/local:executable_format",
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local:executable_library_util",
         "//runtime/src/iree/hal/local:executable_loader",
@@ -79,6 +80,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:dynamic_library",
         "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/local:executable_format",
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local:executable_library_util",
         "//runtime/src/iree/hal/local:executable_loader",

--- a/runtime/src/iree/hal/local/loaders/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/loaders/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     iree::base
     iree::hal
     iree::hal::local::elf::elf_module
+    iree::hal::local::executable_format
     iree::hal::local::executable_library
     iree::hal::local::executable_library_util
     iree::hal::local::executable_loader
@@ -66,6 +67,7 @@ iree_cc_library(
     iree::base
     iree::base::internal::dynamic_library
     iree::hal
+    iree::hal::local::executable_format
     iree::hal::local::executable_library
     iree::hal::local::executable_library_util
     iree::hal::local::executable_loader

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -12,6 +12,7 @@
 
 #include "iree/hal/api.h"
 #include "iree/hal/local/elf/elf_module.h"
+#include "iree/hal/local/executable_format.h"
 #include "iree/hal/local/executable_library.h"
 #include "iree/hal/local/executable_library_util.h"
 #include "iree/hal/local/executable_plugin_manager.h"
@@ -315,6 +316,20 @@ static void iree_hal_embedded_elf_loader_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_embedded_elf_loader_infer_format(
+    iree_hal_executable_loader_t* base_executable_loader,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = iree_hal_executable_infer_elf_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_embedded_elf_loader_query_support(
     iree_hal_executable_loader_t* base_executable_loader,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -343,6 +358,7 @@ static iree_status_t iree_hal_embedded_elf_loader_try_load(
 static const iree_hal_executable_loader_vtable_t
     iree_hal_embedded_elf_loader_vtable = {
         .destroy = iree_hal_embedded_elf_loader_destroy,
+        .infer_format = iree_hal_embedded_elf_loader_infer_format,
         .query_support = iree_hal_embedded_elf_loader_query_support,
         .try_load = iree_hal_embedded_elf_loader_try_load,
 };

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -300,6 +300,39 @@ static void iree_hal_static_library_loader_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_static_library_loader_infer_format(
+    iree_hal_executable_loader_t* base_executable_loader,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  // Always return "static" as the format string.
+  const char* format_str = "static";
+  const iree_host_size_t format_length = strlen(format_str) + 1;  // + NUL
+  if (executable_format_capacity < format_length) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "insufficient capacity for format string; need %" PRIhsz
+        " but have %" PRIhsz,
+        format_length, executable_format_capacity);
+  }
+
+  // Copy the format string with NUL terminator.
+  memcpy(executable_format, format_str, format_length);
+
+  // Infer the size of the executable data.
+  if (executable_data.data_length != 0) {
+    // Size is known.
+    *out_inferred_size = executable_data.data_length;
+  } else {
+    // Size is unknown - find the first NUL byte.
+    *out_inferred_size =
+        strlen((const char*)executable_data.data) + 1;  // + NUL
+  }
+
+  return iree_ok_status();
+}
+
 static bool iree_hal_static_library_loader_query_support(
     iree_hal_executable_loader_t* base_executable_loader,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -318,7 +351,7 @@ static iree_status_t iree_hal_static_library_loader_try_load(
   // The executable data is just the name of the library.
   iree_string_view_t library_name = iree_make_string_view(
       (const char*)executable_params->executable_data.data,
-      executable_params->executable_data.data_length);
+      executable_params->executable_data.data_length - /*NUL*/ 1);
 
   // Linear scan of the registered libraries; there's usually only one per
   // module (aka source model) and as such it's a small list and probably not
@@ -344,6 +377,7 @@ static iree_status_t iree_hal_static_library_loader_try_load(
 static const iree_hal_executable_loader_vtable_t
     iree_hal_static_library_loader_vtable = {
         .destroy = iree_hal_static_library_loader_destroy,
+        .infer_format = iree_hal_static_library_loader_infer_format,
         .query_support = iree_hal_static_library_loader_query_support,
         .try_load = iree_hal_static_library_loader_try_load,
 };

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -12,6 +12,7 @@
 
 #include "iree/base/internal/dynamic_library.h"
 #include "iree/hal/api.h"
+#include "iree/hal/local/executable_format.h"
 #include "iree/hal/local/executable_library.h"
 #include "iree/hal/local/executable_library_util.h"
 #include "iree/hal/local/executable_plugin_manager.h"
@@ -446,6 +447,20 @@ static void iree_hal_system_library_loader_destroy(
 #define IREE_PLATFORM_DYLIB_TYPE "elf"
 #endif  // IREE_PLATFORM_*
 
+static iree_status_t iree_hal_system_library_loader_infer_format(
+    iree_hal_executable_loader_t* base_executable_loader,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = iree_hal_executable_infer_system_format(
+      executable_data, executable_format_capacity, executable_format,
+      out_inferred_size);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_system_library_loader_query_support(
     iree_hal_executable_loader_t* base_executable_loader,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -476,6 +491,7 @@ static iree_status_t iree_hal_system_library_loader_try_load(
 static const iree_hal_executable_loader_vtable_t
     iree_hal_system_library_loader_vtable = {
         .destroy = iree_hal_system_library_loader_destroy,
+        .infer_format = iree_hal_system_library_loader_infer_format,
         .query_support = iree_hal_system_library_loader_query_support,
         .try_load = iree_hal_system_library_loader_try_load,
 };

--- a/runtime/src/iree/hal/local/local_executable_cache.c
+++ b/runtime/src/iree/hal/local/local_executable_cache.c
@@ -81,6 +81,40 @@ static void iree_hal_local_executable_cache_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t iree_hal_local_executable_cache_infer_format(
+    iree_hal_executable_cache_t* base_executable_cache,
+    iree_hal_executable_caching_mode_t caching_mode,
+    iree_const_byte_span_t executable_data,
+    iree_host_size_t executable_format_capacity, char* executable_format,
+    iree_host_size_t* out_inferred_size) {
+  iree_hal_local_executable_cache_t* executable_cache =
+      iree_hal_local_executable_cache_cast(base_executable_cache);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < executable_cache->loader_count; ++i) {
+    iree_status_t infer_status = iree_hal_executable_loader_infer_format(
+        executable_cache->loaders[i], caching_mode, executable_data,
+        executable_format_capacity, executable_format, out_inferred_size);
+    if (iree_status_is_ok(status)) {
+      // Successfully inferred.
+      status = iree_ok_status();
+      break;
+    } else if (iree_status_is_incompatible(infer_status)) {
+      // Skip this loader and try another.
+      iree_status_ignore(infer_status);
+      status = iree_status_from_code(IREE_STATUS_INCOMPATIBLE);
+      continue;
+    } else {
+      status = infer_status;
+      break;
+    }
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static bool iree_hal_local_executable_cache_can_prepare_format(
     iree_hal_executable_cache_t* base_executable_cache,
     iree_hal_executable_caching_mode_t caching_mode,
@@ -138,6 +172,7 @@ static iree_status_t iree_hal_local_executable_cache_prepare_executable(
 static const iree_hal_executable_cache_vtable_t
     iree_hal_local_executable_cache_vtable = {
         .destroy = iree_hal_local_executable_cache_destroy,
+        .infer_format = iree_hal_local_executable_cache_infer_format,
         .can_prepare_format =
             iree_hal_local_executable_cache_can_prepare_format,
         .prepare_executable =

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -82,6 +82,16 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "executable_header",
+    srcs = ["executable_header.c"],
+    hdrs = ["executable_header.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal/flatcc:parsing",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "file_cache",
     srcs = ["file_cache.c"],
     hdrs = ["file_cache.h"],

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -98,6 +98,19 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    executable_header
+  HDRS
+    "executable_header.h"
+  SRCS
+    "executable_header.c"
+  DEPS
+    iree::base
+    iree::base::internal::flatcc::parsing
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     file_cache
   HDRS
     "file_cache.h"

--- a/runtime/src/iree/hal/utils/executable_header.c
+++ b/runtime/src/iree/hal/utils/executable_header.c
@@ -1,0 +1,72 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/executable_header.h"
+
+iree_status_t iree_hal_read_executable_flatbuffer_header(
+    iree_const_byte_span_t executable_data, bool unsafe_infer_size,
+    const char file_identifier[4],
+    iree_const_byte_span_t* out_flatbuffer_data) {
+  iree_flatbuffer_file_header_t header = {0};
+
+  // Check minimum size for flatbuffer (size prefix + minimal header).
+  if (!unsafe_infer_size && executable_data.data_length < sizeof(header)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "executable flatbuffer data is not present or less than header size");
+  }
+
+  // Check the magic first; if we supported other file types we'd use this
+  // to switch out to other loaders (maybe). Unless the magic matches we can't
+  // assume there's 64 bytes to read.
+  if (memcmp(executable_data.data, file_identifier, sizeof(header.magic)) !=
+      0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "executable file identifier does not match; expected `%.*s`", 4,
+        file_identifier);
+  }
+
+  // Read the header from the executable data.
+  // This ensures alignment so we can directly access the fields (though the
+  // data itself _should_ be aligned).
+  memcpy(&header, executable_data.data, sizeof(header));
+
+  // Zero-length flatbuffers are invalid.
+  if (header.content_size == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable flatbuffer reported as zero-length");
+  }
+
+  // Verify version. Today we have only a single "latest" version so this is
+  // just a guard for older builds with newer data that may differ in the
+  // future.
+  if (header.version != 0) {
+    return iree_make_status(
+        IREE_STATUS_INCOMPATIBLE,
+        "executable version %u not compatible with this build", header.version);
+  }
+
+  // Verify the size is within bounds.
+  if (!unsafe_infer_size) {
+    const iree_host_size_t remaining_length =
+        executable_data.data_length - sizeof(header);
+    if (header.content_size > remaining_length) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "executable flatbuffer size prefix out of bounds (size is %" PRIu64
+          " but "
+          "only %" PRIhsz " bytes available)",
+          header.content_size, remaining_length);
+    }
+  }
+
+  // Adjust the flatbuffer data to exclude the size prefix.
+  *out_flatbuffer_data = iree_make_const_byte_span(
+      executable_data.data + sizeof(header), header.content_size);
+
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/utils/executable_header.h
+++ b/runtime/src/iree/hal/utils/executable_header.h
@@ -1,0 +1,30 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_EXECUTABLE_HEADER_H_
+#define IREE_HAL_UTILS_EXECUTABLE_HEADER_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/flatcc/parsing.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Reads a iree_flatbuffer_file_header_t from |executable_data| and returns the
+// contained flatbuffer data range in |out_flatbuffer_data|. If the total size
+// of the executable data is unavailable the |unsafe_infer_size| flag allows for
+// parsing without validation of file extents and the returned flatbuffer data
+// will be sized to the range of valid bytes.
+iree_status_t iree_hal_read_executable_flatbuffer_header(
+    iree_const_byte_span_t executable_data, bool unsafe_infer_size,
+    const char file_identifier[4], iree_const_byte_span_t* out_flatbuffer_data);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_EXECUTABLE_HEADER_H_

--- a/runtime/src/iree/schemas/amdgpu_executable_def.fbs
+++ b/runtime/src/iree/schemas/amdgpu_executable_def.fbs
@@ -51,6 +51,10 @@ table ModuleDef {
 }
 
 table ExecutableDef {
+  // Canonical ISA name this executable has been compiled for.
+  // E.g. `amdgcn-amd-amdhsa--gfx1100`
+  isa:string;
+
   // Exported functions in canonical executable entry point order.
   exports:[ExportDef];
 

--- a/runtime/src/iree/vm/bytecode/archive.h
+++ b/runtime/src/iree/vm/bytecode/archive.h
@@ -28,6 +28,13 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_archive_parse_header(
     iree_const_byte_span_t* out_flatbuffer_contents,
     iree_host_size_t* out_rodata_offset);
 
+// Infers the total size of a bytecode archive by parsing its contents.
+// This handles archives with unknown size (data_length == 0) and calculates
+// the total size including any ZIP header, flatbuffer, and rodata segments.
+IREE_API_EXPORT iree_status_t
+iree_vm_bytecode_archive_infer_size(iree_const_byte_span_t archive_contents,
+                                    iree_host_size_t* out_inferred_size);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
This lets us shim bad APIs like CUDA that don't provide the size of the data they are loading while still keeping our code paths that require the size functioning. The new infer-format call can be used to infer the canonical HAL format string for the given executable data and optionally infer its size. Inferring the size is unsafe as we have to trust the data to be correct: something we don't want when using our normal size-provided API. Implementations are provided for all HAL backends (local native binaries and VMVX, AMDGPU, HIP, CUDA, Metal, and Vulkan). All GPU implementations are currently handling only flatbuffers as that's what the compiler produces. When we want to allow non-wrapped binaries then we'll need to implement detection and size inference for those where appropriate (CUDA PTX NUL termination, etc).

**NOTE**: this is a breaking change to GPU executables and requires recompilation. The new header on the files allows coarse versioning in the future.

Fixes #21752. It makes me sad we need the size inference :(