### PR TITLE
[Codegen][LLVMGPU]  Give ops same config irrespective of generalized/specialized

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -58,9 +58,9 @@ struct GPUGeneralizeNamedOpsPass final
     FunctionOpInterface funcOp = getOperation();
     SmallVector<linalg::LinalgOp> namedOpCandidates;
     funcOp.walk([&](linalg::LinalgOp linalgOp) {
-      if (isa<linalg::BatchMatmulOp, linalg::MatmulOp, linalg::MatvecOp,
-              linalg::TransposeOp, linalg::VecmatOp>(linalgOp.getOperation()))
+      if (isInGPUGeneralizeSet(linalgOp.getOperation())) {
         namedOpCandidates.push_back(linalgOp);
+      }
     });
 
     if (failed(generalizeCandidates(&getContext(), namedOpCandidates))) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -58,7 +58,9 @@ struct GPUGeneralizeNamedOpsPass final
     FunctionOpInterface funcOp = getOperation();
     SmallVector<linalg::LinalgOp> namedOpCandidates;
     funcOp.walk([&](linalg::LinalgOp linalgOp) {
-      if (isInGPUGeneralizeSet(linalgOp.getOperation())) {
+      if (isa<linalg::BatchMatmulOp, linalg::DotOp, linalg::MatmulOp,
+              linalg::MatvecOp, linalg::TransposeOp, linalg::VecmatOp>(
+              linalgOp.getOperation())) {
         namedOpCandidates.push_back(linalgOp);
       }
     });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -10,7 +10,6 @@
 
 #include <cstdint>
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -64,13 +63,6 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
 /// **misalign** the rows, but not too much.
 LogicalResult reduceSharedMemoryBankConflicts(mlir::FunctionOpInterface funcOp,
                                               unsigned paddingSizeBits);
-
-/// Return true if `op` will be generalized (converted to a linalg.generic) by
-/// the pass GPUGeneralizeNamedOpsPass.
-inline bool isInGPUGeneralizeSet(Operation *op) {
-  return isa<linalg::BatchMatmulOp, linalg::DotOp, linalg::MatmulOp,
-             linalg::MatvecOp, linalg::TransposeOp, linalg::VecmatOp>(op);
-}
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -63,6 +64,13 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
 /// **misalign** the rows, but not too much.
 LogicalResult reduceSharedMemoryBankConflicts(mlir::FunctionOpInterface funcOp,
                                               unsigned paddingSizeBits);
+
+/// Return true if `op` will be generalized (converted to a linalg.generic) by
+/// the pass GPUGeneralizeNamedOpsPass.
+inline bool isInGPUGeneralizeSet(Operation *op) {
+  return isa<linalg::BatchMatmulOp, linalg::DotOp, linalg::MatmulOp,
+             linalg::MatvecOp, linalg::TransposeOp, linalg::VecmatOp>(op);
+}
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -142,8 +142,10 @@ def GPUGeneralizeNamedOpsPass :
   let summary = "Convert named Linalg ops to linalg.generic ops";
 
   let description = [{
-    Convert a whitelisted set of named Linalg ops to linalg.generics. The whitelist
-    does not contain all named ops.
+    Convert a subset of named Linalg ops to linalg.generics. The subset does not
+    contain all named ops. The rule-of-thumb is that named ops whose operand
+    maps are projections are in the subset. For example convolutions and pooling ops
+    are not generalized by this pass, but matmuls are.
   }];
 }
 


### PR DESCRIPTION
This is part of deprecating the warp reduce pipeline, Before this PR, generalized and specialized ops got different configs (confusingly!). This PR changes some logic that checks if a linalg op is a linalg.generic, to include all named ops (except, for now, convolution ops).