### PR TITLE
[Codegen] Only decompose ops when folding into map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -277,10 +277,10 @@ foldPackIntoMapScatter(RewriterBase &rewriter, linalg::PackOp packOp,
 static FailureOr<MapScatterOp>
 foldUnpackIntoMapScatter(RewriterBase &rewriter, linalg::UnPackOp unpackOp,
                          MapScatterOp mapScatterOp) {
-  assert(mapScatterOp.getInput() == packOp->getResult(0) &&
-         "expected packOp to be the producer of mapScatterOp");
+  assert(mapScatterOp.getInput() == unpackOp->getResult(0) &&
+         "expected unpackOp to be the producer of mapScatterOp");
 
-  // Decompose the pack op, and fold each decomposed op one by one.
+  // Decompose the unpack op, and fold each decomposed op one by one.
   rewriter.setInsertionPoint(unpackOp);
   FailureOr<linalg::LowerUnPackOpResult> result = linalg::lowerUnPack(
       rewriter, unpackOp, /*lowerUnpadLikeWithExtractSlice=*/false);

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -27,51 +28,6 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 using IREE::LinalgExt::MapScatterOp;
-
-//===----------------------------------------------------------------------===//
-// Preprocessing Utilities
-//===----------------------------------------------------------------------===//
-
-/// Convert complex ops into simpler ops by decomposing or raising to a named
-/// op.
-///  - `PackOp`s and `UnPackOp`s are decomposed.
-///  - Transpose `linalg::GenericOp`s are raised to `linalg::TransposeOp`s.
-static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
-                                       FunctionOpInterface funcOp) {
-  OpBuilder::InsertionGuard g(rewriter);
-  SmallVector<linalg::PackOp> packOps(
-      funcOp.getFunctionBody().getOps<linalg::PackOp>());
-  for (auto packOp : packOps) {
-    rewriter.setInsertionPoint(packOp);
-    FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
-        rewriter, packOp, /*lowerPadLikeWithInsertSlice=*/false);
-    // For aligned pack ops, the pad will be a no-op, and can be folded away.
-    // Fold it here so it does not complicate the index transformation folding
-    // later on.
-    if (failed(result) || !result->padOp) {
-      continue;
-    }
-    if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
-        areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
-      rewriter.replaceOp(result->padOp, result->padOp.getSource());
-    }
-  }
-  SmallVector<linalg::UnPackOp> unPackOps(
-      funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
-  for (auto unPackOp : unPackOps) {
-    rewriter.setInsertionPoint(unPackOp);
-    (void)linalg::lowerUnPack(rewriter, unPackOp,
-                              /*lowerUnpadLikeWithExtractSlice=*/false);
-  }
-  SmallVector<linalg::GenericOp> genericOps(
-      funcOp.getFunctionBody().getOps<linalg::GenericOp>());
-  for (auto genericOp : genericOps) {
-    if (linalg::isaTransposeOpInterface(genericOp)) {
-      rewriter.setInsertionPoint(genericOp);
-      (void)linalg::specializeGenericOp(rewriter, genericOp);
-    }
-  }
-}
 
 //===----------------------------------------------------------------------===//
 // Combining Layout Transformation Ops
@@ -90,15 +46,28 @@ foldIdentityLikeOpIntoMapScatter(RewriterBase &rewriter, Operation *op,
   return mapScatterOp;
 }
 
-/// Fold a `transposeOp` into a consumer `mapScatterOp`, by transposing the
-/// uses of the `mapScatterOp`s transformation_region block arguments.
-static MapScatterOp foldTransposeIntoMapScatter(RewriterBase &rewriter,
-                                                linalg::TransposeOp transposeOp,
-                                                MapScatterOp mapScatterOp) {
-  assert(mapScatterOp.getInput() == transposeOp->getResult(0) &&
+/// Fold a transpose op into a consumer `mapScatterOp`, by transposing the
+/// uses of the `mapScatterOp`s transformation_region block arguments. If
+/// the `linalgOp` is not a transpose, then return failure.
+static FailureOr<MapScatterOp>
+foldTransposeIntoMapScatter(RewriterBase &rewriter, linalg::LinalgOp linalgOp,
+                            MapScatterOp mapScatterOp) {
+  ArrayRef<int64_t> perm;
+  if (auto transposeOp =
+          dyn_cast<linalg::TransposeOp>(linalgOp.getOperation())) {
+    perm = transposeOp.getPermutation();
+  } else if (auto genericOp =
+                 dyn_cast<linalg::GenericOp>(linalgOp.getOperation())) {
+    std::optional<SmallVector<int64_t>> maybePerm =
+        linalg::isaTransposeOpInterface(genericOp);
+    if (!maybePerm.has_value()) {
+      return rewriter.notifyMatchFailure(linalgOp, "not a transpose op");
+    }
+    perm = maybePerm.value();
+  }
+  assert(mapScatterOp.getInput() == linalgOp->getResult(0) &&
          "expected transposeOp to be the producer of mapScatterOp");
 
-  ArrayRef<int64_t> perm = transposeOp.getPermutation();
   auto indexTransformBuilder =
       [&](ArrayRef<BlockArgument> srcIndices) -> SmallVector<Value> {
     SmallVector<Value> indexValues(srcIndices);
@@ -107,7 +76,8 @@ static MapScatterOp foldTransposeIntoMapScatter(RewriterBase &rewriter,
   rewriter.modifyOpInPlace(mapScatterOp, [&]() {
     mapScatterOp.insertTransformationAtStart(rewriter, indexTransformBuilder,
                                              perm.size());
-    mapScatterOp.getInputMutable().assign(transposeOp.getInput());
+    mapScatterOp.getInputMutable().assign(
+        linalgOp.getDpsInputOperand(0)->get());
   });
   return mapScatterOp;
 }
@@ -232,6 +202,122 @@ foldExtractSliceIntoMapScatter(RewriterBase &rewriter,
   return mapScatterOp;
 }
 
+///
+static std::optional<OpOperand *>
+getMapScatterOutputBuffer(MapScatterOp mapScatterOp) {
+  // Find the output buffer that the mapScatterOp is stored into.
+  if (!mapScatterOp->hasOneUse()) {
+    return std::nullopt;
+  }
+  auto storeOp = dyn_cast<IREE::Codegen::StoreToBufferOp>(
+      *mapScatterOp->getUsers().begin());
+  if (!storeOp) {
+    return std::nullopt;
+  }
+  return &storeOp.getBufferMutable();
+}
+
+FailureOr<MapScatterOp>
+foldPackIntoMapScatter(RewriterBase &rewriter, linalg::PackOp packOp,
+                       MapScatterOp mapScatterOp,
+                       PadDistributionConfigFn padDistributionConfigFn) {
+  assert(mapScatterOp.getInput() == packOp->getResult(0) &&
+         "expected packOp to be the producer of mapScatterOp");
+  // If the pack has padding semantics, then we need to be able to
+  // distribute the pad.
+  if (packOp.getPaddingValue() && !padDistributionConfigFn) {
+    return rewriter.notifyMatchFailure(
+        packOp, "packOp has padding semantics, but pad folding is not allowed");
+  }
+  if (packOp.getPaddingValue() && !getMapScatterOutputBuffer(mapScatterOp)) {
+    return rewriter.notifyMatchFailure(
+        mapScatterOp, "packOp has padding semantics, and map_scatter user "
+                      "is not an iree_codegen.store_to_buffer op");
+  }
+
+  // Decompose the pack op, and fold each decomposed op one by one.
+  rewriter.setInsertionPoint(packOp);
+  FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
+      rewriter, packOp, /*lowerPadLikeWithInsertSlice=*/false);
+  if (failed(result)) {
+    return rewriter.notifyMatchFailure(packOp,
+                                       "could not decompose linalg.pack");
+  }
+
+  // Fold TransposeOp.
+  if (linalg::TransposeOp transposeOp = result->transposeOp) {
+    mapScatterOp =
+        foldTransposeIntoMapScatter(rewriter, transposeOp, mapScatterOp)
+            .value();
+  }
+  // Fold ExpandShapeOp.
+  if (tensor::ExpandShapeOp expandShapeOp = result->expandShapeOp) {
+    mapScatterOp =
+        foldExpandShapeIntoMapScatter(rewriter, expandShapeOp, mapScatterOp);
+  }
+  // Fold PadOp.
+  if (tensor::PadOp padOp = result->padOp) {
+    // For aligned pack ops, the pad will be a no-op, and can be folded away.
+    // Fold it here so it does not complicate the index transformation.
+    if (areAllConstantIntValue(padOp.getMixedLowPad(), 0) &&
+        areAllConstantIntValue(padOp.getMixedHighPad(), 0)) {
+      rewriter.replaceOp(padOp, padOp.getSource());
+    } else {
+      // `foldPadIntoMapScatter` is guaranteed to succeed because we checked
+      // for the outputBuffer above.
+      mapScatterOp = foldPadIntoMapScatter(rewriter, padOp, mapScatterOp,
+                                           padDistributionConfigFn)
+                         .value();
+    }
+  }
+  return mapScatterOp;
+}
+
+/// Fold a `unpackOp` into a consumer `mapScatterOp`.
+static FailureOr<MapScatterOp>
+foldUnpackIntoMapScatter(RewriterBase &rewriter, linalg::UnPackOp unpackOp,
+                         MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == packOp->getResult(0) &&
+         "expected packOp to be the producer of mapScatterOp");
+
+  // Decompose the pack op, and fold each decomposed op one by one.
+  rewriter.setInsertionPoint(unpackOp);
+  FailureOr<linalg::LowerUnPackOpResult> result = linalg::lowerUnPack(
+      rewriter, unpackOp, /*lowerUnpadLikeWithExtractSlice=*/false);
+  if (failed(result)) {
+    return rewriter.notifyMatchFailure(unpackOp,
+                                       "could not decompose linalg.unpack");
+  }
+
+  // The unpack decomposition will generate a linalg.copy, but it is
+  // not included in the `LowerUnPackOpResult`.
+  if (auto copyOp = mapScatterOp.getInput().getDefiningOp<linalg::CopyOp>()) {
+    mapScatterOp =
+        foldIdentityLikeOpIntoMapScatter(rewriter, copyOp, mapScatterOp);
+  }
+  // Fold ExtractSliceOp.
+  if (tensor::ExtractSliceOp extractSliceOp = result->extractSliceOp) {
+    // `foldExtractSliceIntoMapScatter` is guaranteed to succeed because the
+    // unpack decomposition creates a non-strided, zero offset slice with no
+    // rank reduction.
+    mapScatterOp =
+        foldExtractSliceIntoMapScatter(rewriter, extractSliceOp, mapScatterOp)
+            .value();
+  }
+  // Fold CollapseShapeOp.
+  if (tensor::CollapseShapeOp collapseShapeOp = result->collapseShapeOp) {
+    mapScatterOp = foldCollapseShapeIntoMapScatter(rewriter, collapseShapeOp,
+                                                   mapScatterOp);
+  }
+  // Fold TransposeOp.
+  if (linalg::TransposeOp transposeOp = result->transposeOp) {
+    mapScatterOp =
+        foldTransposeIntoMapScatter(rewriter, transposeOp, mapScatterOp)
+            .value();
+  }
+  return mapScatterOp;
+}
+
 static void buildNestedDistributionLoops(
     RewriterBase &rewriter, Location loc, int64_t distributionLevel,
     SmallVector<OpFoldResult> lbs, SmallVector<OpFoldResult> ubs,
@@ -280,20 +366,15 @@ FailureOr<MapScatterOp>
 foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
                       MapScatterOp mapScatterOp,
                       PadDistributionConfigFn padDistributionConfigFn) {
-  // Find the output buffer that the mapScatterOp is stored into.
-  if (!mapScatterOp->hasOneUse()) {
-    return rewriter.notifyMatchFailure(
-        mapScatterOp, "map_scatter does not have a single user");
-  }
-  auto storeOp = dyn_cast<IREE::Codegen::StoreToBufferOp>(
-      *mapScatterOp->getUsers().begin());
-  if (!storeOp) {
+  std::optional<OpOperand *> maybeOutputBuffer =
+      getMapScatterOutputBuffer(mapScatterOp);
+  if (!maybeOutputBuffer.has_value()) {
     return rewriter.notifyMatchFailure(
         mapScatterOp,
         "map_scatter user is not an iree_codegen.store_to_buffer op");
   }
 
-  rewriter.setInsertionPointAfter(storeOp);
+  rewriter.setInsertionPointAfter(maybeOutputBuffer.value()->getOwner());
   Location loc = padOp->getLoc();
   SmallVector<OpFoldResult> padSrcSizes =
       tensor::getMixedSizes(rewriter, loc, padOp.getSource());
@@ -301,7 +382,7 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
       tensor::getMixedSizes(rewriter, loc, padOp.getResult());
 
   // Write the padding values directly into the outputBuffer.
-  Value outputBuffer = storeOp.getBuffer();
+  Value outputBuffer = maybeOutputBuffer.value()->get();
   auto innerLoopBuilder = [&](OpBuilder &b, Location loopLoc, ValueRange ivs) {
     // We need to scatter the padding values according to the existing
     // mapScatterOp transformation, so clone the transformation into the
@@ -412,6 +493,9 @@ FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
       .Case<linalg::TransposeOp>([&](linalg::TransposeOp transposeOp) {
         return foldTransposeIntoMapScatter(rewriter, transposeOp, mapScatterOp);
       })
+      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
+        return foldTransposeIntoMapScatter(rewriter, genericOp, mapScatterOp);
+      })
       .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
         return foldExpandShapeIntoMapScatter(rewriter, expandOp, mapScatterOp);
       })
@@ -422,6 +506,12 @@ FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
       .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp extractSliceOp) {
         return foldExtractSliceIntoMapScatter(rewriter, extractSliceOp,
                                               mapScatterOp);
+      })
+      .Case<linalg::PackOp>([&](linalg::PackOp packOp) {
+        return foldPackIntoMapScatter(rewriter, packOp, mapScatterOp);
+      })
+      .Case<linalg::UnPackOp>([&](linalg::UnPackOp unpackOp) {
+        return foldUnpackIntoMapScatter(rewriter, unpackOp, mapScatterOp);
       })
       .Default([](Operation *) { return failure(); });
 }
@@ -450,9 +540,12 @@ static MapScatterOp insertIdentityMapScatter(RewriterBase &rewriter,
 }
 
 bool isSupportedRelayoutOp(Operation *op) {
+  if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+    return linalg::isaTransposeOpInterface(genericOp).has_value();
+  }
   return isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp,
              tensor::ExtractSliceOp, tensor::PadOp, linalg::CopyOp,
-             linalg::TransposeOp>(op);
+             linalg::TransposeOp, linalg::UnPackOp, linalg::PackOp>(op);
 }
 
 /// Insert identity map_scatter ops after the given operation if it is a valid
@@ -551,12 +644,8 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
     return failure();
   }
 
-  // Apply some preprocessing to convert complex layout transformation
-  // ops like pack and unpack into simpler supported ops.
-  IRRewriter rewriter(ctx);
-  simplifyComplexRelayoutOps(rewriter, funcOp);
-
   // Combine relayout operations into new the map_scatter ops.
+  IRRewriter rewriter(ctx);
   RewritePatternSet relayoutCombinationPatterns(ctx);
   relayoutCombinationPatterns.add<InsertMapScatterOpPattern>(ctx, controlFn);
   populateCombineRelayoutOpPatterns(relayoutCombinationPatterns,

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -79,6 +79,16 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
                       IREE::LinalgExt::MapScatterOp mapScatterOp,
                       PadDistributionConfigFn padDistributionConfigFn);
 
+/// Fold a `packOp` into a consumer `mapScatterOp` by decomposing the
+/// pack op, and then folding the decomposed ops into the map_scatter. If
+/// the `padDistributionConfigFn` is `nullptr`, then padding semantics are
+/// not allowed on the pack. Otherwise, the `padDistributionConfigFn` will
+/// be used to distribute the pad in the decomposed op sequence.
+FailureOr<IREE::LinalgExt::MapScatterOp> foldPackIntoMapScatter(
+    RewriterBase &rewriter, linalg::PackOp packOp,
+    IREE::LinalgExt::MapScatterOp mapScatterOp,
+    PadDistributionConfigFn padDistributionConfigFn = nullptr);
+
 /// Combines any layout/indexing transformation ops at the ends of a dispatch.
 /// Finds `iree_codegen.store_to_buffer` ops in the `funcOp`, and combines any
 /// layout transformation ops (like expand_shape, transpose, pack, etc.) that

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -169,6 +169,32 @@ private:
   PadDistributionConfigFn padDistributionConfigFn;
 };
 
+struct FoldPackOpIntoMapScatterPattern
+    : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+  FoldPackOpIntoMapScatterPattern(MLIRContext *context,
+                                  PadDistributionConfigFn configFn,
+                                  PatternBenefit benefit = 1)
+      : OpRewritePattern<IREE::LinalgExt::MapScatterOp>(context, benefit),
+        padDistributionConfigFn(std::move(configFn)) {}
+
+  LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
+                                PatternRewriter &rewriter) const override {
+    auto packOp = mapScatterOp.getInput().getDefiningOp<linalg::PackOp>();
+    if (!packOp) {
+      return failure();
+    }
+    if (failed(foldPackIntoMapScatter(rewriter, packOp, mapScatterOp,
+                                      padDistributionConfigFn))) {
+      return failure();
+    }
+    return success();
+  }
+
+private:
+  PadDistributionConfigFn padDistributionConfigFn;
+};
+
 } // namespace
 
 void populateCombineRelayoutOpPatterns(
@@ -176,8 +202,9 @@ void populateCombineRelayoutOpPatterns(
     PadDistributionConfigFn padDistributionConfigFn) {
   patterns.add<FoldRelayoutOpIntoMapScatterPattern>(patterns.getContext());
   if (padDistributionConfigFn) {
-    patterns.add<FoldPadOpIntoMapScatterPattern>(patterns.getContext(),
-                                                 padDistributionConfigFn);
+    patterns
+        .add<FoldPadOpIntoMapScatterPattern, FoldPackOpIntoMapScatterPattern>(
+            patterns.getContext(), padDistributionConfigFn);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -64,6 +64,34 @@ func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16
 
 // -----
 
+func.func @fold_generic_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0, d1)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%source : tensor<2x4x16xf32>)
+      outs(%init : tensor<4x16x2xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+  } -> tensor<4x16x2xf32>
+  iree_codegen.store_to_buffer %transposed, %result : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @fold_generic_transpose_op
+//  DISPATCH-SCOPE-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  DISPATCH-SCOPE-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   DISPATCH-SCOPE-DAG:   %[[TRUE:.+]] = arith.constant true
+//       DISPATCH-SCOPE:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
+//       DISPATCH-SCOPE:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  DISPATCH-SCOPE-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  DISPATCH-SCOPE-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       DISPATCH-SCOPE:     iree_linalg_ext.yield %[[IDX1]], %[[IDX2]], %[[IDX0]], %[[TRUE]]
+//       DISPATCH-SCOPE:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
+//       DISPATCH-SCOPE:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<4x16x2xf32> into memref<4x16x2xf32>
+
+// -----
+
 func.func @fold_extract_slice_op(%source : tensor<64xf32>, %result : memref<63xf32>) {
   %slice = tensor.extract_slice %source[0] [63] [1] : tensor<64xf32> to tensor<63xf32>
   iree_codegen.store_to_buffer %slice, %result : tensor<63xf32> into memref<63xf32>
@@ -429,3 +457,28 @@ func.func @consumer_unfusable_due_to_init(%arg0: tensor<?xi32>, %arg1: tensor<?x
 //       DISPATCH-SCOPE:     scf.forall.in_parallel
 //       DISPATCH-SCOPE:       tensor.parallel_insert_slice
 //       DISPATCH-SCOPE:   linalg.generic
+
+// -----
+
+func.func @dont_decompose_unfolded_ops(%source : tensor<250x250xf32>, %result : memref<2x2x128x128xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %dest = tensor.empty() : tensor<2x2x128x128xf32>
+  %pack = linalg.pack %source padding_value(%cst : f32)
+      outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [128, 128]
+      into %dest : tensor<250x250xf32> -> tensor<2x2x128x128xf32>
+  %barrier = util.optimization_barrier %pack : tensor<2x2x128x128xf32>
+  %transpose = linalg.transpose
+      ins(%barrier : tensor<2x2x128x128xf32>)
+      outs(%dest : tensor<2x2x128x128xf32>)
+      permutation = [1, 0, 2, 3]
+  iree_codegen.store_to_buffer %transpose, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
+  return
+}
+
+// Ensure that composite ops are not decomposed if they are
+// not able to be folded into a map_scatter op.
+
+// DISPATCH-SCOPE-LABEL: func @dont_decompose_unfolded_ops
+//       DISPATCH-SCOPE:   linalg.pack
+//       DISPATCH-SCOPE:   util.optimization_barrier
+//       DISPATCH-SCOPE:   iree_linalg_ext.map_scatter

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1290,11 +1290,6 @@ static void buildLLVMGPUCodegenCommonConfigurationPassPipelineImpl(
     if (clCombineLayoutTransformation) {
       funcPassManager.addPass(createBufferizeDispatchTensorLoadStorePass);
       funcPassManager.addPass(createGPUCombineLayoutTransformationPass);
-      // GPUCombineLayoutTransformationPass specializes transpose ops, so they
-      // need to be generalized again.
-      // TODO(Max191): Re-generalize in the GPUCombineLayoutTransformationPass,
-      // and remove the extra GPUGeneralizeNamedOpsPass invocation.
-      funcPassManager.addPass(createGPUGeneralizeNamedOpsPass);
     }
     // This materializes into 'nop' in the absence of pad encoding layout
     // attributes.


### PR DESCRIPTION
Removes the `simplifyComplexRelayoutOps` phase of `CombineLayoutTransformation`, which previously would decompose all pack and unpack ops (and specialize transpose generic ops) before beginning relayout op folding. Instead, the pass now performs the decomposition just before the pack and unpack ops are to be folded, which prevents ops from being decomposed without being folded into a map_scatter.

An extra invocation of `GPUGeneralizeNamedOps`, which was there to re-generalize transpose ops after `CombineLayoutTransformation`. Since the generalized transpose ops can be handled directly now, we can remove the pass invocation.