### PR TITLE
[Codegen] Add corner case for SwapExtractWithCollapsePattern

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -485,7 +485,7 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
 
         // Check if offset is from a block argument or an affine.apply op of
         // form (d0 * K) or (K * d0).
-        auto offsetVal = dyn_cast<Value>(collapsedOffset);
+        auto offsetVal = cast<Value>(collapsedOffset);
         auto collapseDefOp = offsetVal.getDefiningOp();
         if (isa<BlockArgument>(offsetVal)) {
           // The loop is already normalized.

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -476,41 +476,53 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
       // IGEMM, while the offset is dynamic and the size is static.
       if (isa<Attribute>(collapsedSize) && isa<Value>(collapsedOffset) &&
           reassocIndices.size() != 1) {
-        // Check if offset is from affine.apply of form (d0 * K) or (K * d0).
-        auto applyOp = collapsedOffset.dyn_cast<Value>()
-                           .getDefiningOp<affine::AffineApplyOp>();
-        if (!applyOp) {
-          return rewriter.notifyMatchFailure(sliceOp,
-                                             "offset is not from affine.apply");
-        }
-
-        AffineMap map = applyOp.getAffineMap();
-        if (map.getNumResults() != 1) {
-          return rewriter.notifyMatchFailure(
-              sliceOp, "affine.apply must have only one result");
-        }
-
         auto maybeStaticSize = getConstantIntValue(collapsedSize);
         if (!maybeStaticSize) {
           return rewriter.notifyMatchFailure(sliceOp,
                                              "collapsed size must be static");
         }
+        auto staticSize = maybeStaticSize.value();
 
-        // Compose all nested affine.apply chains and check if the offset is
-        // multiple of collapsed size.
-        SmallVector<Value> operands(applyOp.getOperands());
-        affine::fullyComposeAffineMapAndOperands(&map, &operands);
-        map = simplifyAffineMap(map);
-        if (!map.getResult(0).isMultipleOf(maybeStaticSize.value())) {
-          return rewriter.notifyMatchFailure(
-              sliceOp, "offset multiplier must be multiple of collapsed size");
-        }
+        // Check if offset is from a block argument or an affine.apply op of
+        // form (d0 * K) or (K * d0).
+        auto offsetVal = dyn_cast<Value>(collapsedOffset);
+        auto collapseDefOp = offsetVal.getDefiningOp();
+        if (isa<BlockArgument>(offsetVal)) {
+          // The loop is already normalized.
+          if (staticSize != 1) {
+            return rewriter.notifyMatchFailure(
+                sliceOp, "collapsed size must be 1 when the collapsed offset "
+                         "is a block argument");
+          }
+        } else if (auto applyOp =
+                       dyn_cast<affine::AffineApplyOp>(collapseDefOp)) {
+          AffineMap map = applyOp.getAffineMap();
+          if (map.getNumResults() != 1) {
+            return rewriter.notifyMatchFailure(
+                sliceOp, "affine.apply must have only one result");
+          }
 
-        unsigned lastReassocSize = srcShape[reassocIndices.back()];
-        if (lastReassocSize % maybeStaticSize.value() != 0) {
+          // Compose all nested affine.apply chains and check if the offset is
+          // multiple of collapsed size.
+          SmallVector<Value> operands(applyOp.getOperands());
+          affine::fullyComposeAffineMapAndOperands(&map, &operands);
+          map = simplifyAffineMap(map);
+          if (!map.getResult(0).isMultipleOf(staticSize)) {
+            return rewriter.notifyMatchFailure(
+                sliceOp,
+                "offset multiplier must be multiple of collapsed size");
+          }
+
+          unsigned lastReassocSize = srcShape[reassocIndices.back()];
+          if (lastReassocSize % staticSize != 0) {
+            return rewriter.notifyMatchFailure(
+                sliceOp,
+                "the last expanded size is not divisible by collapse size");
+          }
+        } else {
           return rewriter.notifyMatchFailure(
               sliceOp,
-              "the last expanded size is not divisible by collapse size");
+              "offset is not from a block argument or affine.apply op");
         }
 
         // Calculate expanded offsets and sizes.


### PR DESCRIPTION
Fix the second case in https://github.com/iree-org/iree/issues/21660.

The performance got regression because the `collapse_shape` wasn't fused into the nested loops properly. The example is a special case that the collapsed offset is not from `affine.apply` op but directly a block argument. After this fix, the performance of the example configuration is improved together with the pre-padding work. To get an idea of perf change for

`convbfp16 -n 16 -c 40 -H 192 -W 128 -k 40 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100`

- Baseline without pre-padding: 452 us.
- Pre-padding without the fix: 920 us.
- Pre-padding with the fix: 220 us.