### PR TITLE
[Dispatch][GlobalOpt] Improve transpose fusion for conv

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -36,15 +36,6 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
     return true;
   }
 
-  // Don't fuse if all of the consumer maps aren't projected permutations.
-  if (auto linalgConsumerOp = dyn_cast<linalg::LinalgOp>(consumerOp)) {
-    if (!llvm::all_of(
-            linalgConsumerOp.getIndexingMapsArray(),
-            [](AffineMap map) { return map.isProjectedPermutation(); })) {
-      return false;
-    }
-  }
-
   // If the generic op is "just" copy, then fuse always.
   Block &body = producerOp->getRegion(0).front();
   if (std::begin(body)->hasTrait<OpTrait::IsTerminator>())

--- a/compiler/src/iree/compiler/GlobalOptimization/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/generalize_named_ops.mlir
@@ -126,7 +126,7 @@ util.func public @no_generalize_1x1_conv_2d_strides(%input: tensor<1x7x7x2xf32>,
 }
 
 // CHECK-LABEL: @no_generalize_1x1_conv_2d_strides
-//   CHECK-NOT:   linalg.generic
+//       CHECK:   linalg.generic
 //       CHECK:   util.return
 
 // -----
@@ -141,5 +141,5 @@ util.func public @no_generalize_1x1_depthwise_conv(%input: tensor<1x2x3x4xf32>, 
 }
 
 // CHECK-LABEL: @no_generalize_1x1_depthwise_conv
-//   CHECK-NOT:   linalg.generic
+//       CHECK:   linalg.generic
 //       CHECK:   util.return

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
@@ -12,10 +12,10 @@ func.func @single_dispatch_dropunitdims(%lhs : tensor<1x26x18x288xbf16>, %rhs : 
 // CHECK-LABEL: @single_dispatch_dropunitdims
 //  CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<1x26x18x288xbf16>
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:     %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
-//       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
+//       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ARG0]]
 //       CHECK:     %[[CONV:.+]] = linalg.generic {{.*}} ins(%[[COLLAPSE]]
-//       CHECK:     flow.return %[[CONV]]
+//       CHECK:     %[[EXPAND:.+]] = tensor.expand_shape %[[CONV]]
+//       CHECK:     flow.return %[[EXPAND]]
 //       CHECK:   return %[[DISPATCH]]
 
 // -----

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -147,6 +147,7 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   // Generalize transposes and any other remaining named linalg ops that can
   // now be represented as generics.
   passManager.addPass(GlobalOptimization::createGeneralizeLinalgNamedOpsPass());
+  passManager.addPass(DispatchCreation::createFoldUnitExtentDimsForFuncPass());
   passManager.addPass(
       GlobalOptimization::createConvertStridedContractionToContractionPass());
   passManager.addPass(DispatchCreation::createFusionPreprocessingPass());

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan.json
@@ -41,8 +41,6 @@
     "onnx/node/generated/test_argmin_negative_axis_keepdims_random_select_last_index",
     "onnx/node/generated/test_argmin_no_keepdims_example_select_last_index",
     "onnx/node/generated/test_argmin_no_keepdims_random_select_last_index",
-    "onnx/node/generated/test_averagepool_2d_same_lower",
-    "onnx/node/generated/test_averagepool_2d_same_upper",
     "onnx/node/generated/test_basic_deform_conv_with_padding",
     "onnx/node/generated/test_basic_deform_conv_without_padding",
     "onnx/node/generated/test_bernoulli_seed",


### PR DESCRIPTION
Generalizes all Linalg conv operations & allows elementwise fusion with conv ops (non-projected permutation indexing maps). This is important when handling pytorch input e.g. `transpose(NHWC->NCHW)->conv-> transpose back` so that the conv + transposes end up as a single dispatch.