### PR TITLE
Remove iree-preprocessing-pad-to-intrinsics

### DIFF
--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_rocm.json
@@ -45,7 +45,7 @@
         "--iree-hip-waves-per-eu=2",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.15f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
@@ -35,7 +35,7 @@
         "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "run_function": "run_forward",
     "run_test_expecting_to_fail": true

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_rocm.json
@@ -21,7 +21,7 @@
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.7f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_rocm.json
@@ -39,7 +39,7 @@
         "--iree-llvmgpu-enable-prefetch",
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})",
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json"
     ],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
@@ -46,7 +46,7 @@
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
-        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "run_function": "main",
     "compile_chip_expecting_to_fail": ["gfx90a"],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
@@ -46,7 +46,7 @@
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
-        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "run_function": "main",
     "compile_chip_expecting_to_fail": ["gfx90a"],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_rocm.json
@@ -5,7 +5,7 @@
         "--iree-opt-const-eval=false",
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json"
     ],

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
@@ -39,7 +39,7 @@
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.705f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
@@ -39,7 +39,7 @@
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ],
     "pipeline_compiler_flags": [
         "--verify=false",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_rocm.json
@@ -21,7 +21,7 @@
         "--iree-llvmgpu-enable-prefetch=true",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json"
     ],


### PR DESCRIPTION
This should be handled during codegen so it doesn't require a model level transformation.