### PR TITLE
Integrate LLVM at llvm/llvm-project@4b84223aad4f

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -286,7 +286,7 @@ struct DistributeGather final : OpDistributionPattern<vector::GatherOp> {
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
     VectorValue result = gatherOp.getResult();
-    VectorValue indexVec = gatherOp.getIndexVec();
+    VectorValue indexVec = gatherOp.getIndices();
     VectorValue mask = gatherOp.getMask();
     VectorValue passThru = gatherOp.getPassThru();
 
@@ -318,7 +318,7 @@ struct DistributeGather final : OpDistributionPattern<vector::GatherOp> {
     // Simply distribute all operands and results.
     VectorValue distributed = rewriter.create<vector::GatherOp>(
         gatherOp.getLoc(), distributedType, gatherOp.getBase(),
-        gatherOp.getIndices(),
+        gatherOp.getOffsets(),
         getDistributed(rewriter, indexVec, indicesLayout),
         getDistributed(rewriter, mask, maskLayout),
         getDistributed(rewriter, passThru, passThruLayout));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -290,7 +290,7 @@ struct ConvertToROCDLPass final
     {
       RewritePatternSet patterns(&getContext());
       populateGpuRewritePatterns(patterns);
-      populateGpuPromoteShuffleToAMDGPUPatterns(patterns);
+      populateGpuPromoteShuffleToAMDGPUPatterns(patterns, std::nullopt);
       populateGpuSubgroupIdPatterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -115,7 +115,7 @@ void buildGlobalOptimizationPassPipeline(
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(createRemoveZeroExtentTensorsPass)
       .addPass(createDetachElementwiseFromNamedOpsPass)
-      .addPass(mlir::createLinalgNamedOpConversionPass);
+      .addPass(mlir::createSimplifyDepthwiseConvPass);
   mainPassManager.addPass(createEraseUnusedLinalgOperandsPass());
 
   // Expand tensor shapes into SSA values and optimize the whole program.

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -346,7 +346,7 @@ public:
     Operation *op = getOperation();
     MLIRContext *context = op->getContext();
     RewritePatternSet patterns(context);
-    linalg::populateLinalgNamedOpConversionPatterns(patterns);
+    linalg::populateSimplifyDepthwiseConvPatterns(patterns);
     patterns.add<QuantizedConvToConv, QuantizedDepthwiseConvToDepthwiseConv>(
         context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -119,7 +119,7 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
                                       const TransformOptions &options) {
   FunctionLikeNest(passManager)
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
-      .addPass(mlir::createLinalgNamedOpConversionPass)
+      .addPass(mlir::createSimplifyDepthwiseConvPass)
       .addPass(createConvertConvToChannelsLastPass)
       .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
       .addPass(createConvertConvFilterToChannelsLastPass);


### PR DESCRIPTION
Carries the revert of https://github.com/llvm/llvm-project/commit/b4c31dc98dfc929728904cd96f0f4cf812c4d5b5

Fixups:

- https://github.com/llvm/llvm-project/commit/32a5adbd42b044eb5611ff26084d05880ea1b899
  - Rename `createLinalgNamedOpConversionPass` to `createSimplifyDepthwiseConvPass`
- https://github.com/llvm/llvm-project/commit/003cbbd4ca10a79604f55eaa9ba144c614a1e593
  - Add `std::nullopt` arg for `populateGpuPromoteShuffleToAMDGPUPatterns`
- https://github.com/llvm/llvm-project/commit/613ec4c24c145eb20ef1967a714d74c9cf403da5
  - Rename `getIndexVec()` to `getIndices()`
  - Rename `getIndices()` to `getOffsets()`