### PR TITLE
[VectorDistribute] Correctly find new dimensions during reduction config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -537,9 +537,9 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
     if (hasReductionIterator(linalgOp)) {
       return true;
     }
-    // 2. There is no consumer which is a compute op (i.e. it already
+    // 2. There is no consumer which is a compute op (i.e., it already
     // has some way of getting fused).
-    if (!llvm::any_of(linalgOp->getUsers(), [&](Operation *user) {
+    if (llvm::none_of(linalgOp->getUsers(), [&](Operation *user) {
           auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
           return linalgUser && computeOps.contains(linalgUser);
         })) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -524,11 +524,6 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
   // LinalgOp with only parallel dims. This is needed if the op cannot be fused
   // with a reduction or introduces new loop dimensions.
   auto shouldAttachLoweringConfig = [&](linalg::LinalgOp linalgOp) -> bool {
-    // If the operation has a gather, we want to fuse it with the
-    // reduction.
-    if (hasExternalCapture(cast<linalg::GenericOp>(linalgOp))) {
-      return false;
-    }
     // We want to attach a lowering config to this operation if it introduces
     // a new dimension, when going by topological order in the backward slice.
     // The only two ways to introduce a new dimension are:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -492,6 +492,7 @@ getVectorDistributeReductionConfig(
   return loweringConfig;
 }
 
+// TODO: Use IndexingMapInterface here instead of linalg::LinalgOp.
 static LogicalResult
 populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
                    IREE::GPU::TargetAttr target, int64_t workgroupSize,
@@ -528,37 +529,28 @@ populateConfigInfo(const llvm::SetVector<linalg::LinalgOp> &computeOps,
     if (hasExternalCapture(cast<linalg::GenericOp>(linalgOp))) {
       return false;
     }
-    // If some of the users are in computeOps and some are outside of
-    // computeOps; attach lowering config, since the op can't be fused.
-    if (llvm::any_of(linalgOp->getUsers(),
-                     [&](Operation *user) {
-                       auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
-                       return linalgUser && computeOps.contains(linalgUser);
-                     }) &&
-        llvm::any_of(linalgOp->getUsers(), [&](Operation *user) {
-          auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
-          return !linalgUser;
-        })) {
+    // We want to attach a lowering config to this operation if it introduces
+    // a new dimension, when going by topological order in the backward slice.
+    // The only two ways to introduce a new dimension are:
+    //
+    // 1. We have a reduction dimension.
+    if (hasReductionIterator(linalgOp)) {
       return true;
     }
-
-    // If the indexing map introduces new dimensions (more inputs than results),
-    // attach a lowering config.
-    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
-      int64_t operandIdx = linalgOp.getIndexingMapIndex(operand);
-      AffineMap indexingMap = linalgOp.getIndexingMapsArray()[operandIdx];
-      if (indexingMap.getNumResults() > 0 &&
-          indexingMap.getNumInputs() > indexingMap.getNumResults()) {
-        return true;
-      }
+    // 2. There is no consumer which is a compute op (i.e. it already
+    // has some way of getting fused).
+    if (!llvm::any_of(linalgOp->getUsers(), [&](Operation *user) {
+          auto linalgUser = dyn_cast<linalg::LinalgOp>(user);
+          return linalgUser && computeOps.contains(linalgUser);
+        })) {
+      return true;
     }
 
     return false;
   };
 
   for (linalg::LinalgOp linalgOp : computeOps) {
-    if (hasReductionIterator(linalgOp) ||
-        shouldAttachLoweringConfig(linalgOp)) {
+    if (shouldAttachLoweringConfig(linalgOp)) {
       auto loweringConfig = getVectorDistributeReductionConfig(
           linalgOp, target, sharedWgpTiles, workgroupSize, subgroupSize,
           threadLoads);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -755,9 +755,6 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
                                /*convertToDpsOptions=*/std::nullopt,
                                /*reorderStrategy=*/reorderStrategy);
 
-  // Some of the elementwise fusion can benefit from this pass.
-  funcPassManager.addPass(createRematerializeParallelOpsPass());
-
   funcPassManager.addPass(
       IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -245,12 +245,7 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
 //       CHECK: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
-//  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],
-//  CHECK-SAME:               reduction = [0, 4096],
-//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 16], [0, 1]],
-//  CHECK-SAME:               thread = [0, 4],
-//  CHECK-SAME:               workgroup = [1, 0]
+//  CHECK-NOT:      lowering_config
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 64], [0, 1]],


### PR DESCRIPTION
There was an attempted fix in https://github.com/iree-org/iree/pull/21073 which was wrong. The real fix is that we should not be serially tiling parallel dimensions which will anyway get fused into another op which gets tiled.

This removes the rematerialize parallel ops pass and instead fixes the configuration logic.