### PR TITLE
[mlir][amdgpu] Replaced `nullopt` with target arch chipset in `populateGpuPromoteShuffleToAMDGPUPatterns` pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -354,8 +354,8 @@ struct ConvertToROCDLPass final
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);
       arith::populateArithToLLVMConversionPatterns(converter, llvmPatterns);
-      amdgpu::Chipset chipset = maybeChipset.value_or(amdgpu::Chipset());
-      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns, chipset);
+      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns,
+                                              *maybeChipset);
       vector::populateVectorRankReducingFMAPattern(llvmPatterns);
       vector::populateVectorInsertExtractStridedSliceTransforms(llvmPatterns);
       vector::populateVectorStepLoweringPatterns(llvmPatterns);
@@ -363,8 +363,8 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
-      populateGpuToROCDLConversionPatterns(converter, llvmPatterns,
-                                           gpu::amd::Runtime::Unknown, chipset);
+      populateGpuToROCDLConversionPatterns(
+          converter, llvmPatterns, gpu::amd::Runtime::Unknown, *maybeChipset);
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -363,8 +363,8 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
-      populateGpuToROCDLConversionPatterns(converter, llvmPatterns,
-                                           gpu::amd::Runtime::Unknown, chipset);
+      populateGpuToROCDLConversionPatterns(
+          converter, llvmPatterns, gpu::amd::Runtime::Unknown, *maybeChipset);
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -354,8 +354,8 @@ struct ConvertToROCDLPass final
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);
       arith::populateArithToLLVMConversionPatterns(converter, llvmPatterns);
-      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns,
-                                              *maybeChipset);
+      amdgpu::Chipset chipset = maybeChipset.value_or(amdgpu::Chipset());
+      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns, chipset);
       vector::populateVectorRankReducingFMAPattern(llvmPatterns);
       vector::populateVectorInsertExtractStridedSliceTransforms(llvmPatterns);
       vector::populateVectorStepLoweringPatterns(llvmPatterns);
@@ -363,8 +363,8 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
-      populateGpuToROCDLConversionPatterns(
-          converter, llvmPatterns, gpu::amd::Runtime::Unknown, *maybeChipset);
+      populateGpuToROCDLConversionPatterns(converter, llvmPatterns,
+                                           gpu::amd::Runtime::Unknown, chipset);
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -354,9 +354,8 @@ struct ConvertToROCDLPass final
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);
       arith::populateArithToLLVMConversionPatterns(converter, llvmPatterns);
-      amdgpu::Chipset chipset =
-          amdgpu::Chipset::parse(targetArch).value_or(amdgpu::Chipset());
-      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns, chipset);
+      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns,
+                                              *maybeChipset);
       vector::populateVectorRankReducingFMAPattern(llvmPatterns);
       vector::populateVectorInsertExtractStridedSliceTransforms(llvmPatterns);
       vector::populateVectorStepLoweringPatterns(llvmPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "conv_pipeline_test_cuda.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
+            "convert_to_rocdl_gfx950.mlir",
             "create_async_groups.mlir",
             "create_tile_sizes.mlir",
             "distribute_to_thread.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "conv_pipeline_test_cuda.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
+    "convert_to_rocdl_gfx950.mlir"
     "create_async_groups.mlir"
     "create_tile_sizes.mlir"
     "distribute_to_thread.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,5 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
-// UNSUPPORTED: gfx942
+// RUN: iree-opt --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
 
 // Test permlane lowering on gfx950.
 #pipeline_layout = #hal.pipeline.layout<bindings = [

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
 // UNSUPPORTED: gfx942
 
-// Test permlane lowering on gfx950
+// Test permlane lowering on gfx950.
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 --iree-convert-to-rocdl %s | FileCheck --check-prefix=CHECK-PERMLANE %s
+// UNSUPPORTED: gfx942
+
+// Test permlane lowering on gfx950
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+module {
+  func.func @test_permlane_16_32_lowering() {
+    %c0  = arith.constant 0 : index
+    %out = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<1xi32>
+
+    %tid = gpu.thread_id x
+    %val = arith.index_castui %tid : index to i32
+
+    // Emits rocdl.permlane*.swap on gfx950
+    %p32 = amdgpu.permlane_swap %val 32 : i32
+    %a32 = arith.addi %val, %p32 : i32
+    %p16 = amdgpu.permlane_swap %a32 16 : i32
+    %sum = arith.addi %a32, %p16 : i32
+
+    %is0 = arith.cmpi eq, %tid, %c0 : index
+    scf.if %is0 {
+      memref.store %sum, %out[%c0] : memref<1xi32>
+    }
+    return
+  }
+}
+
+// CHECK-PERMLANE-LABEL: llvm.func @test_permlane_16_32_lowering
+// CHECK-PERMLANE: rocdl.permlane32.swap
+// CHECK-PERMLANE: rocdl.permlane16.swap

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl_gfx950.mlir
@@ -13,7 +13,7 @@ module {
     %tid = gpu.thread_id x
     %val = arith.index_castui %tid : index to i32
 
-    // Emits rocdl.permlane*.swap on gfx950
+    // Emits rocdl.permlane*.swap on gfx950.
     %p32 = amdgpu.permlane_swap %val 32 : i32
     %a32 = arith.addi %val, %p32 : i32
     %p16 = amdgpu.permlane_swap %a32 16 : i32


### PR DESCRIPTION
* replaced `std::nullopt` with arch `chipset` in `populateGpuPromoteShuffleToAMDGPUPatterns` pass
* added lit test for the same