### PR TITLE
[GPU][DT] Fix LHS operand offset calculation for DataTiledMMAAttr

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -551,9 +551,9 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(%lhs: tensor<
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
 //  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]
 //       CHECK:   scf.forall (%[[THREAD_ID:.+]]) in (256) shared_outs(%[[ACC_ARG:.+]] = %[[ACC]]) -> (tensor<1x1x2x2x4x16x4xf32>)
-//   CHECK-DAG:     %[[LHS_IN_IDS:.+]]:5 = affine.delinearize_index %[[THREAD_ID]] into (2, 4, 4, 4)
+//   CHECK-DAG:     %[[LHS_IN_IDS:.+]]:6 = affine.delinearize_index %[[THREAD_ID]] into (2, 2, 4, 4, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
-//  CHECK-SAME:       [0, 0, %[[LHS_IN_IDS]]#1, %[[LHS_IN_IDS]]#2, %[[LHS_IN_IDS]]#3, %[[LHS_IN_IDS]]#4, 0] [1, 1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       [0, 0, %[[LHS_IN_IDS]]#1, %[[LHS_IN_IDS]]#3, %[[LHS_IN_IDS]]#4, %[[LHS_IN_IDS]]#5, 0] [1, 1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
 //   CHECK-DAG:     %[[IN_IDS:.+]]:4 = affine.delinearize_index %[[THREAD_ID]] into (2, 4, 16)
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
 //  CHECK-SAME:       [0, 0, %[[IN_IDS]]#1, %[[IN_IDS]]#2, %[[IN_IDS]]#3, 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1]


### PR DESCRIPTION
`DistributeInnerTiledToLanesPass` creates `AffineDelinearizeIndexOp` to delinearize the thread index within a workgroup and generate offsets for slicing the operands of InnerTiled operations.

Currently, the delinearization for `DataTiledMMAAttr` relies solely on the operand swizzle. However, for the LHS, this swizzle does not include the subGroupsN dimension, which could result in incorrect offset calculations.

This PR fixes the issue by inserting a dummy subGroupsN dimension when delinearizing for LHS, ensuring that offsets are generated correctly according to the full subGroupsM × subGroupsN thread space.

Note that, no special handling is required for the RHS operand, since subGroupsM is treated as an implicit leading dimension and therefore omitted anyway.

Closes #21789