### PR TITLE
[Codegen][LLVMGPU] Later scf-to-cf to support math.erf 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1040,8 +1040,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
         auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
         return createGPUCheckResourceUsagePass(getIndexBitwidth);
       })
-      // SCF -> CF
-      .addPass(createSCFToControlFlowPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
       // Hoist allocations back into the entry block, as lowering to CF may have
@@ -1051,6 +1049,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createConvertComplexToStandardPass)
       // Math dialect ops rewrites, approximations, casts.
       .addPass(createMathTransformPass)
+      // SCF -> CF
+      .addPass(createSCFToControlFlowPass)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass([]() {
         IREEExpandStridedMetadataPassOptions options;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1040,8 +1040,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
         auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
         return createGPUCheckResourceUsagePass(getIndexBitwidth);
       })
-      .addPass(createCanonicalizerPass)
-      .addPass(createCSEPass)
       // Hoist allocations back into the entry block, as lowering to CF may have
       // split the block at a point before the allocation.
       .addPass(createHoistStaticallyBoundAllocationsPass)


### PR DESCRIPTION
Before this PR, `math-transform` ran after `cf-to-scf`. But `math-transform` introduces `scf.if` when there is a `math.erf`. 

This PR moves `scf-to-cf` later, so that the scf.if can be converted. Fixes https://github.com/iree-org/iree/issues/21813

