### PR TITLE
Guard more optimization flags under `--iree-opt-level`.

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -454,6 +454,14 @@ Session::Session(GlobalInit &globalInit)
   vmTargetOptions.bindOptions(binder);
   bytecodeTargetOptions.bindOptions(binder);
   // TODO: Fix binder support for cTargetOptions.
+
+  if (pipelineOptions.optLevel == llvm::OptimizationLevel::O0) {
+    std::string msg = R"MSG(
+Defaulting to O0 will result in poor performance, which enables only minimal optimizations while higher levels enable progressively more aggressive optimizations.
+
+See https://iree.dev/reference/optimization-options/#optimization-level for more details.)MSG";
+    llvm::dbgs() << msg << "\n";
+  }
 }
 
 struct Source {

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -159,15 +159,21 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
                                   "along the outer most dimension."),
                    llvm::cl::cat(category));
   binder.opt<bool>("iree-opt-data-tiling", dataTiling,
+                   {init_at_opt(llvm::OptimizationLevel::O0, false),
+                    init_at_opt(llvm::OptimizationLevel::O2, true)},
                    llvm::cl::desc("Enables data tiling path."),
                    llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-opt-const-eval", constEval,
+      {init_at_opt(llvm::OptimizationLevel::O0, false),
+       init_at_opt(llvm::OptimizationLevel::O1, true)},
       llvm::cl::desc("Enables eager evaluation of constants using the full "
                      "compiler and runtime (on by default)."),
       llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-opt-const-expr-hoisting", constExprHoisting,
+      {init_at_opt(llvm::OptimizationLevel::O0, false),
+       init_at_opt(llvm::OptimizationLevel::O1, true)},
       llvm::cl::desc(
           "Hoists the results of latent constant expressions into immutable "
           "global initializers for evaluation at program load."),

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -124,14 +124,14 @@ struct GlobalOptimizationOptions {
   // Enables data tiling in global optimization phase. There are two data-tiling
   // flags during the transition state. The other has to be off if this one is
   // enabled. Any feature built on top of this path will be deprecated.
-  bool dataTiling = true;
+  bool dataTiling = false;
 
   // Enables const-expr hoisting into globals.
-  bool constExprHoisting = true;
+  bool constExprHoisting = false;
 
   // Enables recursive evaluation of immutable globals using the compiler
   // and runtime.
-  bool constEval = true;
+  bool constEval = false;
 
   // Optimizations to reduce numeric precision where it is safe to do so.
   bool numericPrecisionReduction = false;

--- a/tests/external/iree-test-suites/onnx_models/onnx_models_cpu_llvm_task.json
+++ b/tests/external/iree-test-suites/onnx_models/onnx_models_cpu_llvm_task.json
@@ -3,7 +3,8 @@
   "iree_compile_flags": [
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",
-    "--iree-llvmcpu-target-cpu=host"
+    "--iree-llvmcpu-target-cpu=host",
+    "--iree-opt-level=O2"
   ],
   "iree_run_module_flags": [
     "--device=local-task"

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync.json
@@ -3,6 +3,7 @@
   "iree_compile_flags": [
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",
+    "--iree-opt-level=O2",
     "--iree-input-demote-f64-to-f32=false"
   ],
   "iree_run_module_flags": [

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_cpu.json
@@ -42,7 +42,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O1"
+        "--iree-opt-level=O2"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.15f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_cpu.json
@@ -30,7 +30,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "run_function": "run_forward",
     "run_test_expecting_to_fail": true

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
@@ -18,7 +18,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.01f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_cpu.json
@@ -34,7 +34,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O1",
+        "--iree-opt-level=O2",
         "--iree-llvmcpu-distribution-size=32",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_cpu.json
@@ -4,7 +4,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "compile_only": true
 }

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
@@ -31,7 +31,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.8f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
@@ -31,7 +31,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "pipeline_compiler_flags": [
         "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
@@ -18,7 +18,7 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O2"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.02f"


### PR DESCRIPTION
- Enables `iree-opt-const-expr-hoisting` and `iree-opt-const-eval` only when the optimization level is O1 or higher.
- Enables `iree-opt-data-tiling` only when the optimization is O2 or higher, because it is not supported by all the backends.

The above optimizations are all disabled at O0. The revision also emits a warning when O0 is set.
