### PR TITLE
Integrate LLVM at llvm/llvm-project@74275a11038c

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
@@ -22,26 +22,24 @@ namespace mlir::iree_compiler {
 static void populateMathFunctionsRewritePatterns(
     RewritePatternSet &patterns,
     const std::function<bool(StringRef)> &predicate) {
-  llvm::SmallVector<StringRef> opMnemonics = {
-    math::TanOp::getOperationName(),
-    math::SinhOp::getOperationName(),
-    math::CoshOp::getOperationName(),
-    math::AsinhOp::getOperationName(),
-    math::AcoshOp::getOperationName(),
-    math::AtanhOp::getOperationName(),
-    math::PowFOp::getOperationName(),
-    math::FPowIOp::getOperationName(),
-    math::Exp2Op::getOperationName(),
-    math::RoundEvenOp::getOperationName()
-  };
-  for (auto it = opMnemonics.begin(); it != opMnemonics.end(); ) {
-    if (!predicate(*it)) {
-      it = opMnemonics.erase(it);
-    } else {
-      ++it;
+  llvm::SmallVector<StringRef> opNames,
+      opFullNames = {math::TanOp::getOperationName(),
+                     math::SinhOp::getOperationName(),
+                     math::CoshOp::getOperationName(),
+                     math::AsinhOp::getOperationName(),
+                     math::AcoshOp::getOperationName(),
+                     math::AtanhOp::getOperationName(),
+                     math::PowFOp::getOperationName(),
+                     math::FPowIOp::getOperationName(),
+                     math::Exp2Op::getOperationName(),
+                     math::RoundEvenOp::getOperationName()};
+  size_t prefix = math::MathDialect::getDialectNamespace().size() + 1;
+  for (auto name : opFullNames) {
+    if (predicate(name)) {
+      opNames.push_back(name.drop_front(prefix));
     }
   }
-  math::populateExpansionPatterns(patterns, opMnemonics);
+  math::populateExpansionPatterns(patterns, opNames);
 }
 
 static bool predicateRewrite(StringRef name,

--- a/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
@@ -22,36 +22,26 @@ namespace mlir::iree_compiler {
 static void populateMathFunctionsRewritePatterns(
     RewritePatternSet &patterns,
     const std::function<bool(StringRef)> &predicate) {
-  if (predicate(math::TanOp::getOperationName())) {
-    populateExpandTanPattern(patterns);
+  llvm::SmallVector<StringRef> opMnemonics = {
+    math::TanOp::getOperationName(),
+    math::SinhOp::getOperationName(),
+    math::CoshOp::getOperationName(),
+    math::AsinhOp::getOperationName(),
+    math::AcoshOp::getOperationName(),
+    math::AtanhOp::getOperationName(),
+    math::PowFOp::getOperationName(),
+    math::FPowIOp::getOperationName(),
+    math::Exp2Op::getOperationName(),
+    math::RoundEvenOp::getOperationName()
+  };
+  for (auto it = opMnemonics.begin(); it != opMnemonics.end(); ) {
+    if (!predicate(*it)) {
+      it = opMnemonics.erase(it);
+    } else {
+      ++it;
+    }
   }
-  if (predicate(math::SinhOp::getOperationName())) {
-    populateExpandSinhPattern(patterns);
-  }
-  if (predicate(math::CoshOp::getOperationName())) {
-    populateExpandCoshPattern(patterns);
-  }
-  if (predicate(math::AsinhOp::getOperationName())) {
-    populateExpandAsinhPattern(patterns);
-  }
-  if (predicate(math::AcoshOp::getOperationName())) {
-    populateExpandAcoshPattern(patterns);
-  }
-  if (predicate(math::AtanhOp::getOperationName())) {
-    populateExpandAtanhPattern(patterns);
-  }
-  if (predicate(math::PowFOp::getOperationName())) {
-    populateExpandPowFPattern(patterns);
-  }
-  if (predicate(math::FPowIOp::getOperationName())) {
-    populateExpandFPowIPattern(patterns);
-  }
-  if (predicate(math::Exp2Op::getOperationName())) {
-    populateExpandExp2FPattern(patterns);
-  }
-  if (predicate(math::RoundEvenOp::getOperationName())) {
-    populateExpandRoundEvenPattern(patterns);
-  }
+  math::populateExpansionPatterns(patterns, opMnemonics);
 }
 
 static bool predicateRewrite(StringRef name,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1054,7 +1054,8 @@ void ConvertToLLVMPass::runOnOperation() {
   populateAffineToStdConversionPatterns(patterns);
   populateSCFToControlFlowConversionPatterns(patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
-  populateExpandTanhPattern(patterns);
+  math::populateExpansionPatterns(patterns,
+                            /*OpMnemonics=*/{math::TanhOp::getOperationName()});
 
   populateComplexToLLVMConversionPatterns(typeConverter, patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1049,13 +1049,17 @@ void ConvertToLLVMPass::runOnOperation() {
   if (use32BitImpl) {
     patterns.add<ExpandMulSIExtended>(patterns.getContext(), /*benefit=*/1024);
   }
-
+  auto populateTanhPatterns = [](RewritePatternSet &p) {
+    StringRef fname = math::TanhOp::getOperationName();
+    size_t prefix = math::MathDialect::getDialectNamespace().size() + 1;
+    StringRef opName = fname.drop_front(prefix);
+    math::populateExpansionPatterns(p, /*OpMnemonics=*/{opName});
+  };
   LLVMConversionTarget target(getContext());
   populateAffineToStdConversionPatterns(patterns);
   populateSCFToControlFlowConversionPatterns(patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
-  math::populateExpansionPatterns(patterns,
-                            /*OpMnemonics=*/{math::TanhOp::getOperationName()});
+  populateTanhPatterns(patterns);
 
   populateComplexToLLVMConversionPatterns(typeConverter, patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
@@ -27,7 +27,7 @@ hal.executable private @apply_scale_no_vector_feature {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xi32>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2xi32>
         %2 = vector.load %0[%c0] : memref<2xi32>, vector<2xi32>
-        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = "SINGLE_ROUND"} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
+        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = SINGLE_ROUND} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
         vector.store %3, %1[%c0] : memref<2xi32>, vector<2xi32>
         return
       }
@@ -72,7 +72,7 @@ hal.executable private @apply_scale_v {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xi32>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2xi32>
         %2 = vector.load %0[%c0] : memref<2xi32>, vector<2xi32>
-        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = "SINGLE_ROUND"} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
+        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = SINGLE_ROUND} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
         vector.store %3, %1[%c0] : memref<2xi32>, vector<2xi32>
         return
       }
@@ -115,7 +115,7 @@ hal.executable private @apply_scale_zve64x {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xi32>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2xi32>
         %2 = vector.load %0[%c0] : memref<2xi32>, vector<2xi32>
-        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = "SINGLE_ROUND"} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
+        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = SINGLE_ROUND} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
         vector.store %3, %1[%c0] : memref<2xi32>, vector<2xi32>
         return
       }
@@ -158,7 +158,7 @@ hal.executable private @apply_scale_zve32x {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xi32>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2xi32>
         %2 = vector.load %0[%c0] : memref<2xi32>, vector<2xi32>
-        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = "SINGLE_ROUND"} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
+        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = SINGLE_ROUND} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
         vector.store %3, %1[%c0] : memref<2xi32>, vector<2xi32>
         return
       }
@@ -208,7 +208,7 @@ hal.executable private @apply_scale_zve32f {
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<2xi32>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<2xi32>
         %2 = vector.load %0[%c0] : memref<2xi32>, vector<2xi32>
-        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = "SINGLE_ROUND"} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
+        %3 = tosa.apply_scale %2, %cst, %cst_0 {rounding_mode = SINGLE_ROUND} : (vector<2xi32>, vector<2xi32>, vector<2xi8>) -> vector<2xi32>
         vector.store %3, %1[%c0] : memref<2xi32>, vector<2xi32>
         return
       }

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
@@ -127,7 +127,7 @@ func.func @fusion_quant_matmul_generic() attributes {hal.executable.target = #ex
     %16 = arith.muli %in_1, %c-128_i32 : i32
     %17 = arith.subi %in_0, %16 : i32
     %18 = arith.addi %in, %17 : i32
-    %19 = tosa.apply_scale %18, %c1101627623_i32, %c36_i8 {rounding_mode = "DOUBLE_ROUND"} : (i32, i32, i8) -> i32
+    %19 = tosa.apply_scale %18, %c1101627623_i32, %c36_i8 {rounding_mode = DOUBLE_ROUND} : (i32, i32, i8) -> i32
     %20 = arith.addi %19, %c-128_i32 : i32
     %21 = arith.cmpi slt, %20, %c-128_i32 : i32
     %22 = arith.select %21, %c-128_i32, %20 : i32

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2282,14 +2282,14 @@ private:
     auto ctx = builder.getContext();
 
     // byteSpan = call.<memberName>;
-    TypedValue<mlir::Type> byteSpan = builder
-                        .create<emitc::MemberOp>(
-                            loc,
-                            emitc::LValueType::get(emitc::OpaqueType::get(
-                                ctx, "iree_byte_span_t")),
-                            memberName, call)
-                        .getResult();
-    // assert(isa<TypedValue<emitc::LValueType>>(byteSpan) )
+    TypedValue<mlir::Type> byteSpan =
+        builder
+            .create<emitc::MemberOp>(
+                loc,
+                emitc::LValueType::get(
+                    emitc::OpaqueType::get(ctx, "iree_byte_span_t")),
+                memberName, call)
+            .getResult();
 
     // alloca_(0) returns NULL in some configurations on Windows. Make sure to
     // allocate at least one byte to get a valid pointer.
@@ -2507,8 +2507,8 @@ private:
         emitc::LValueType::get(emitc::PointerType::get(
             emitc::OpaqueType::get(ctx, "iree_vm_module_t"))),
         /*memberName=*/"module",
-        /*operand=*/import).getResult();
-    auto importModule = dyn_cast<TypedValue<emitc::LValueType>>(im);
+        /*operand=*/import);
+    auto importModule = dyn_cast<TypedValue<emitc::LValueType>>(im.getResult());
     if (!importModule) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2282,13 +2282,14 @@ private:
     auto ctx = builder.getContext();
 
     // byteSpan = call.<memberName>;
-    auto byteSpan = builder
+    TypedValue<mlir::Type> byteSpan = builder
                         .create<emitc::MemberOp>(
                             loc,
                             emitc::LValueType::get(emitc::OpaqueType::get(
                                 ctx, "iree_byte_span_t")),
                             memberName, call)
                         .getResult();
+    // assert(isa<TypedValue<emitc::LValueType>>(byteSpan) )
 
     // alloca_(0) returns NULL in some configurations on Windows. Make sure to
     // allocate at least one byte to get a valid pointer.
@@ -2500,25 +2501,32 @@ private:
     auto ctx = builder.getContext();
 
     // RETURN_IF_ERROR(import->module->begin_call(import->module, stack, call));
-    auto importModule = builder.create<emitc::MemberOfPtrOp>(
+    auto im = builder.create<emitc::MemberOfPtrOp>(
         loc,
         /*type=*/
         emitc::LValueType::get(emitc::PointerType::get(
             emitc::OpaqueType::get(ctx, "iree_vm_module_t"))),
         /*memberName=*/"module",
-        /*operand=*/import);
+        /*operand=*/import).getResult();
+    auto importModule = dyn_cast<TypedValue<emitc::LValueType>>(im);
+    if (!importModule) {
+      return failure();
+    }
 
     // EmitC can't emit function pointers, so we need to fallback to a typedef
     // currently. This and the `EMITC_CALL_INDIRECT` macro can be replaced with
     // a new `emitc.call_indirect` op once it has been added upstream.
     emitc::OpaqueType type = emitc::OpaqueType::get(ctx, "begin_call_t");
 
-    auto beginCall =
+    auto bc =
         builder
             .create<emitc::MemberOfPtrOp>(loc, emitc::LValueType::get(type),
                                           "begin_call", importModule)
             .getResult();
-
+    auto beginCall = dyn_cast<TypedValue<emitc::LValueType>>(bc);
+    if (!beginCall) {
+      return failure();
+    }
     returnIfError(
         /*rewriter=*/builder,
         /*location=*/loc,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -233,10 +233,12 @@ void structDefinition(OpBuilder builder, Location location,
 }
 
 Value structMember(OpBuilder builder, Location location, Type type,
-                   StringRef memberName,
-                   TypedValue<emitc::LValueType> operand) {
-  TypedValue<emitc::LValueType> member = builder.create<emitc::MemberOp>(
-      location, emitc::LValueType::get(type), memberName, operand);
+                   StringRef memberName, TypedValue<mlir::Type> operand) {
+  TypedValue<mlir::Type> member =
+      builder
+          .create<emitc::MemberOp>(location, emitc::LValueType::get(type),
+                                   memberName, operand)
+          .getResult();
   return builder.create<emitc::LoadOp>(location, type, member).getResult();
 }
 
@@ -246,12 +248,14 @@ structMemberAddress(OpBuilder builder, Location location,
                     TypedValue<emitc::LValueType> operand) {
   auto member = builder.create<emitc::MemberOp>(location, type.getPointee(),
                                                 memberName, operand);
-  return addressOf(builder, location, member.getResult());
+  return addressOf(
+      builder, location,
+      llvm::cast<TypedValue<emitc::LValueType>>(member.getResult()));
 }
 
 void structMemberAssign(OpBuilder builder, Location location,
-                        StringRef memberName,
-                        TypedValue<emitc::LValueType> operand, Value data) {
+                        StringRef memberName, TypedValue<mlir::Type> operand,
+                        Value data) {
   Value member = builder.create<emitc::MemberOp>(
       location, emitc::LValueType::get(data.getType()), memberName, operand);
   builder.create<emitc::AssignOp>(location, member, data);
@@ -260,7 +264,7 @@ void structMemberAssign(OpBuilder builder, Location location,
 Value structPtrMember(OpBuilder builder, Location location, Type type,
                       StringRef memberName,
                       TypedValue<emitc::LValueType> operand) {
-  TypedValue<emitc::LValueType> member = builder.create<emitc::MemberOfPtrOp>(
+  TypedValue<mlir::Type> member = builder.create<emitc::MemberOfPtrOp>(
       location, emitc::LValueType::get(type), memberName, operand);
   return builder.create<emitc::LoadOp>(location, type, member).getResult();
 }
@@ -271,7 +275,9 @@ structPtrMemberAddress(OpBuilder builder, Location location,
                        TypedValue<emitc::LValueType> operand) {
   auto member = builder.create<emitc::MemberOfPtrOp>(
       location, emitc::LValueType::get(type.getPointee()), memberName, operand);
-  return addressOf(builder, location, member.getResult());
+  return addressOf(
+      builder, location,
+      llvm::cast<TypedValue<emitc::LValueType>>(member.getResult()));
 }
 
 void structPtrMemberAssign(OpBuilder builder, Location location,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
@@ -103,7 +103,7 @@ void structDefinition(OpBuilder builder, Location location,
                       StringRef structName, ArrayRef<StructField> fields);
 
 Value structMember(OpBuilder builder, Location location, Type type,
-                   StringRef memberName, TypedValue<emitc::LValueType> operand);
+                   StringRef memberName, TypedValue<mlir::Type> operand);
 
 TypedValue<emitc::PointerType>
 structMemberAddress(OpBuilder builder, Location location,
@@ -111,8 +111,8 @@ structMemberAddress(OpBuilder builder, Location location,
                     TypedValue<emitc::LValueType> operand);
 
 void structMemberAssign(OpBuilder builder, Location location,
-                        StringRef memberName,
-                        TypedValue<emitc::LValueType> operand, Value data);
+                        StringRef memberName, TypedValue<mlir::Type> operand,
+                        Value data);
 
 Value structPtrMember(OpBuilder builder, Location location, Type type,
                       StringRef memberName,


### PR DESCRIPTION
Carries the revert of https://github.com/llvm/llvm-project/commit/b4c31dc98dfc929728904cd96f0f4cf812c4d5b5.

Fixups:
https://github.com/llvm/llvm-project/commit/51a1aab6438aa33b15ff7e85bc8609b5ff003764
- Use `populateExpansionPatterns` instead of `populateExpandXXXXPattern`

https://github.com/llvm/llvm-project/commit/685a98c52562130d53f5b8bfdf7a56960ca804e2
- Support array result for emitc.member and emitc.member_of_ptr. Support the new result type when possible, otherwise perform a dynamic cast to the previously supported type. 

https://github.com/llvm/llvm-project/commit/13471e19a3195d8182f2c08af859e3cf0bdebfff
- Avoid requirement to specify enum name for enum attributes i.e 
```mlir
rounding_mode = "SINGLE_ROUND" 
// becomes
rounding_mode = SINGLE_ROUND.
```
