### PR TITLE
[DispatchCreation] Sink bit-extend producers into split-reduction `forall` loop

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -223,3 +223,46 @@ util.func public @split_reduction_arg_compare(%arg0: tensor<4x1x128256xf16>) -> 
 //  CHECK-SAME:        outs(%[[FILL_F16]], %[[FILL_I32]] :
 //  CHECK-SAME:        dimensions = [2]
 //       CHECK:    util.return %[[REDUCE]]#0, %[[REDUCE]]#1
+
+// -----
+
+util.func public @split_reduction_bitext_producer(%arg0: tensor<?x?xf32>) -> tensor<?xf64> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %dim1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+
+  %empty0 = tensor.empty(%dim0, %dim1) : tensor<?x?xf64>
+  %extf = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0 : tensor<?x?xf32>) outs(%empty0 : tensor<?x?xf64>) {
+  ^bb0(%in: f32, %out: f64):
+    %e = arith.extf %in : f32 to f64
+    linalg.yield %e : f64
+  } -> tensor<?x?xf64>
+
+  %cst = arith.constant 0.000000e+00 : f64
+  %empty1 = tensor.empty(%dim0) : tensor<?xf64>
+  %init = linalg.fill ins(%cst : f64) outs(%empty1 : tensor<?xf64>) -> tensor<?xf64>
+  %reduce = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"],
+      iree_linalg_ext.split_reduction = [128]}
+      ins(%extf : tensor<?x?xf64>) outs(%init : tensor<?xf64>) {
+  ^bb0(%in: f64, %out: f64):
+    %add = arith.addf %in, %out : f64
+    linalg.yield %add : f64
+  } -> tensor<?xf64>
+  util.return %reduce : tensor<?xf64>
+}
+// Bit extends should be fused into the 'forall' loop.
+// CHECK-LABEL:  @split_reduction_bitext_producer
+// CHECK: scf.forall {{.+}} {
+// CHECK:   linalg.generic {
+// CHECK:     arith.extf
+// CHECK:   }
+// CHECK:   linalg.generic {
+// CHECK:     arith.addf
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
Previously these would end up outside the `forall` loop.

The motivation for this change is getting batchnorm reductions to go down vector-distribute (#21824). Part of the computation looks like:
```
%promoted = linalg.generic ins(%input) ... { arith.extf .. } : tensor<NxHxWxCxbf16> -> tensor<NxHxWxCxf32>
%reduced  = linalg.generic ins(%promoted) ... { arith.addf ... } : tensor<NxHxWxCxf32> -> tensor<Cxf32>
```
The bit-extend and the reduction end up in the same dispatch. However the reduction vector-distribute recognizer bails out if there are any linalg ops outside the split-reduction `forall` op, so we need to ensure the bit-extension is included:
https://github.com/iree-org/iree/blob/33548616294b02b60467d9c7b68e494a85c7b17f/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp#L621-L633
