### PR TITLE
Revert "Disable failing ARM-SME tests. (#21715)"

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -65,47 +65,46 @@ PREPROCESSING_TRANSPOSE_LHS = "--iree-preprocessing-pass-pipeline=builtin.module
 
 PREPROCESSING_PEEL = "--iree-llvmcpu-vector-pproc-strategy=peel"
 
-# TODO(#21714) These tests are disabled. See issue for details.
-# # LLVMCPU, non-data-tiling, no microkernels, ArmSME
-# [iree_generated_e2e_runner_test(
-#     name = "e2e_matmul_cpu_arm_sme_nondt_%s_%s%s" % (
-#         dtype,
-#         "_transpose_lhs" if transpose_lhs else "",
-#         "_peel" if peel else "",
-#     ),
-#     compiler_flags = [
-#                          "--iree-opt-data-tiling=false",
-#                          "--iree-llvmcpu-enable-scalable-vectorization",
-#                          "--iree-llvmcpu-target-triple=aarch64-unknown-unknown",
-#                      ] + ([PREPROCESSING_TRANSPOSE_LHS] if transpose_lhs else []) +
-#                      ([PREPROCESSING_PEEL] if peel else []),
-#     generator = ":generate_e2e_matmul_tests",
-#     generator_args = [
-#         "--lhs_rhs_type=%s" % dtype,
-#         "--acc_type=%s" % dtype,
-#     ],
-#     tags = [
-#         "requires-arm-sme",
-#     ],
-#     target_backends_and_drivers = [
-#         ("llvm-cpu", "local-task"),
-#     ],
-#     target_cpu_features_variants = ["arm_64:sme:+sve,+sme"],
-#     test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
-#     test_type = "matmul",
-# ) for dtype in [
-#     "f32",
-#     # f64 disabled because it wasn't supported by the test generator at the time
-#     # this was added. When adding it in the future, consider passing
-#     # --iree-input-demote-f64-to-f32=false to the compiler.
-#     # "f64"
-# ] for transpose_lhs in [
-#     True,
-#     False,
-# ] for peel in [
-#     True,
-#     False,
-# ]]
+# LLVMCPU, non-data-tiling, no microkernels, ArmSME
+[iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cpu_arm_sme_nondt_%s_%s%s" % (
+        dtype,
+        "_transpose_lhs" if transpose_lhs else "",
+        "_peel" if peel else "",
+    ),
+    compiler_flags = [
+                         "--iree-opt-data-tiling=false",
+                         "--iree-llvmcpu-enable-scalable-vectorization",
+                         "--iree-llvmcpu-target-triple=aarch64-unknown-unknown",
+                     ] + ([PREPROCESSING_TRANSPOSE_LHS] if transpose_lhs else []) +
+                     ([PREPROCESSING_PEEL] if peel else []),
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % dtype,
+        "--acc_type=%s" % dtype,
+    ],
+    tags = [
+        "requires-arm-sme",
+    ],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = ["arm_64:sme:+sve,+sme"],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+) for dtype in [
+    "f32",
+    # f64 disabled because it wasn't supported by the test generator at the time
+    # this was added. When adding it in the future, consider passing
+    # --iree-input-demote-f64-to-f32=false to the compiler.
+    # "f64"
+] for transpose_lhs in [
+    True,
+    False,
+] for peel in [
+    True,
+    False,
+]]
 
 X86_64_AVX2 = [
     "+avx",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -12,6 +12,114 @@ iree_add_all_subdirs()
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cpu_arm_sme_nondt_f32__transpose_lhs_peel
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
+    "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
+    "--iree-llvmcpu-vector-pproc-strategy=peel"
+  LABELS
+    "requires-arm-sme"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sme:+sve,+sme"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cpu_arm_sme_nondt_f32__transpose_lhs
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
+    "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
+  LABELS
+    "requires-arm-sme"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sme:+sve,+sme"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cpu_arm_sme_nondt_f32__peel
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
+    "--iree-llvmcpu-vector-pproc-strategy=peel"
+  LABELS
+    "requires-arm-sme"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sme:+sve,+sme"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cpu_arm_sme_nondt_f32_
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
+  LABELS
+    "requires-arm-sme"
+  TARGET_CPU_FEATURES_VARIANTS
+    "arm_64:sme:+sve,+sme"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cpu_dt_i8_i32
   TEST_TYPE
     matmul


### PR DESCRIPTION
This reverts commit 992860b44d172f745f7d233036ce74585d598de9.

See https://github.com/iree-org/iree/issues/21714 for a discussion on
the underlying issue.

MLIR fix: https://github.com/llvm/llvm-project/pull/156834

NOTE: This change can only be merged once the MLIR fix has been
integrated.

Signed-off-by: Andrzej Warzynski <andrzej.warzynski@arm.com>
