### PR TITLE
[iree][codegen] Add the `#iree_gpu.optimize_occupancy` attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -749,4 +749,28 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GPU Occupancy Optimization Attribute
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_OptimizeOccupancyAttr : AttrDef<IREEGPU_Dialect, "OptimizeOccupancy"> {
+  let mnemonic = "optimize_occupancy";
+  let summary = [{An attribute indicating GPU occupancy needs to be optimized.}];
+  let description = [{
+    This attribute can be attached to operations to indicate that GPU occupancy
+    should be optimized during code generation.
+  }];
+
+  let assemblyFormat = "";
+  let parameters = (ins);
+
+  let extraClassDeclaration = [{
+    // Returns the key name for OptimizeOccupancyAttr in the translation info
+    // config dictionary.
+    static StringRef getDictKeyName() {
+      return "gpu_optimize_occupancy";
+    }
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -114,3 +114,80 @@ builtin.module {
 
 // CHECK-LABEL: llvm.func @test_no_kern_arg
 // CHECK-SAME:    (%{{.+}}: i32)
+
+// -----
+
+// Check that we set the `waves-per-eu` attribute
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none,
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
+      builtin.module {
+        llvm.func @test_kern_arg(%arg0: i32) attributes {llvm_func_attrs = {gpu_optimize_occupancy = #iree_gpu.optimize_occupancy}} {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_kern_arg
+// CHECK-NOT:   gpu_optimize_occupancy = #iree_gpu.optimize_occupancy
+// CHECK:       rocdl.waves_per_eu = 2 : i64
+
+// -----
+
+// Check that we set the `waves-per-eu` attribute and we preserve other attributes
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none,
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
+      builtin.module {
+        llvm.func @test_kern_arg(%arg0: i32) attributes {llvm_func_attrs = {check_attr, gpu_optimize_occupancy = #iree_gpu.optimize_occupancy}} {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_kern_arg
+// CHECK:       llvm_func_attrs = {check_attr
+// CHECK-NOT:   gpu_optimize_occupancy = #iree_gpu.optimize_occupancy}
+// CHECK:       rocdl.waves_per_eu = 2 : i64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -240,6 +240,7 @@ func.func @attention_20x4096x64x4096x64() {
 
 // CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-NOT:   prefetch_shared_memory = true
+// CHECK:       gpu_optimize_occupancy = #iree_gpu.optimize_occupancy
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 
@@ -291,7 +292,8 @@ func.func @attention_large_head_dim_shared_mem() {
 // and the QK matmul used MFMA_F32_32x32x64_F8E4M3FN. Vector distribution failed
 // to distribute these layouts to threads.
 
-//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:  gpu_optimize_occupancy = #iree_gpu.optimize_occupancy
 // CHECK-LABEL: func.func @attention_check_mma_accs_compatable
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>


### PR DESCRIPTION
This patch makes the following changes:
- Introduces `#iree_gpu.optimize_occupancy` attribute to signal GPU occupancy optimization.
- Sets `waves-per-eu` to 2 for kernels with this attribute on AMD targets.
- Updates pipeline and kernel annotation logic to support occupancy optimization.
- Adds and updates tests for attribute propagation and behavior.