### PR TITLE
Display a warning when we spill SGPRs or VGPRs

### DIFF
--- a/compiler/plugins/target/ROCM/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Analysis",
         "@llvm-project//llvm:BitWriter",
         "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:FrontendOffloading",
         "@llvm-project//llvm:IPO",
         "@llvm-project//llvm:IRReader",
         "@llvm-project//llvm:Linker",

--- a/compiler/plugins/target/ROCM/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     LLVMAnalysis
     LLVMBitWriter
     LLVMCore
+    LLVMFrontendOffloading
     LLVMIRReader
     LLVMLinker
     LLVMMC

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -272,9 +272,9 @@ static void checkRegisterSpilling(IREE::HAL::ExecutableVariantOp &variantOp,
     for (const auto &[_, metaData] : infoMap) {
       if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount > 0) {
         emitWarning(variantOp.getLoc())
-            << "Register spill : " << "VGPRSpillCount : "
+            << "Register spill: " << "VGPRSpillCount: "
             << metaData.VGPRSpillCount
-            << " / SGPRSpillCount : " << metaData.SGPRSpillCount;
+            << " / SGPRSpillCount: " << metaData.SGPRSpillCount;
       }
     }
   }

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -262,17 +262,18 @@ static std::string translateModuleToISA(llvm::Module &module,
   return targetISA;
 }
 
-void checkRegisterSpilling(OpBuilder &builder, const std::string obj) {
+static void checkRegisterSpilling(OpBuilder &builder, StringRef obj) {
   uint16_t abi_version;
-  llvm::StringMap<llvm::offloading::amdgpu::AMDGPUKernelMetaData> info_map;
+  llvm::StringMap<llvm::offloading::amdgpu::AMDGPUKernelMetaData> infoMap;
 
   if (!llvm::offloading::amdgpu::getAMDGPUMetaDataFromImage(
-          llvm::MemoryBufferRef(obj, ""), info_map, abi_version)) {
-    for (auto &entry : info_map) {
-      llvm::StringRef kernelName = entry.getKey();
+          llvm::MemoryBufferRef(obj, ""), infoMap, abi_version)) {
+    for (llvm::StringMapEntry<llvm::offloading::amdgpu::AMDGPUKernelMetaData>
+             &entry : infoMap) {
+      StringRef kernelName = entry.getKey();
       llvm::offloading::amdgpu::AMDGPUKernelMetaData &metaData =
           entry.getValue();
-      if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount) {
+      if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount > 0) {
         emitWarning(builder.getUnknownLoc())
             << "Register spill on kernel " << kernelName << ": "
             << "VGPRSpillCount : " << metaData.VGPRSpillCount

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -89,7 +89,7 @@ struct ROCMOptions {
   bool enableTensorUKernels = false;
   IREE::Codegen::DenormalFpMath denormalFpMathF32 =
       IREE::Codegen::DenormalFpMath::None;
-  bool disableRegSpillWarning = false;
+  bool enableRegSpillWarning = false;
 
   void bindOptions(OptionsBinder &binder) {
     using namespace llvm;
@@ -174,9 +174,9 @@ struct ROCMOptions {
             clEnumValN(IREE::Codegen::DenormalFpMath::PositiveZero,
                        "positive-zero", "Convert denormals to positive zero")));
 
-    binder.opt<bool>("iree-hip-disable-register-spill-warning",
-                     disableRegSpillWarning, cl::cat(category),
-                     cl::desc("Do not report register spilling for AMD GPUs"));
+    binder.opt<bool>("iree-hip-enable-register-spill-warning",
+                     enableRegSpillWarning, cl::cat(category),
+                     cl::desc("Report register spilling for AMD GPUs"));
   }
 
   LogicalResult verify(mlir::Builder &builder) const {
@@ -808,7 +808,7 @@ public:
       if (targetHSACO.empty())
         return failure();
 
-      if (!options.disableRegSpillWarning) {
+      if (options.enableRegSpillWarning) {
         checkRegisterSpilling(variantOp, targetObj);
       }
     }

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -262,22 +262,24 @@ static std::string translateModuleToISA(llvm::Module &module,
   return targetISA;
 }
 
-void checkRegisterSpilling(OpBuilder &builder, const std::string obj){
-    uint16_t abi_version;
-    llvm::StringMap<llvm::offloading::amdgpu::AMDGPUKernelMetaData> info_map;
+void checkRegisterSpilling(OpBuilder &builder, const std::string obj) {
+  uint16_t abi_version;
+  llvm::StringMap<llvm::offloading::amdgpu::AMDGPUKernelMetaData> info_map;
 
-    if (!llvm::offloading::amdgpu::getAMDGPUMetaDataFromImage(
-            llvm::MemoryBufferRef(obj, ""), info_map, abi_version)) {
-          for (auto &entry : info_map) {
-              llvm::StringRef kernelName = entry.getKey();
-              llvm::offloading::amdgpu::AMDGPUKernelMetaData &metaData = entry.getValue();
-              if (metaData.SGPRSpillCount>0 || metaData.VGPRSpillCount){
-                emitWarning(builder.getUnknownLoc()) <<
-                "Register spill on kernel "  << kernelName << ": " <<
-                "VGPRSpillCount : " << metaData.VGPRSpillCount << " / SGPRSpillCount : " << metaData.SGPRSpillCount;
-              }
-          }
+  if (!llvm::offloading::amdgpu::getAMDGPUMetaDataFromImage(
+          llvm::MemoryBufferRef(obj, ""), info_map, abi_version)) {
+    for (auto &entry : info_map) {
+      llvm::StringRef kernelName = entry.getKey();
+      llvm::offloading::amdgpu::AMDGPUKernelMetaData &metaData =
+          entry.getValue();
+      if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount) {
+        emitWarning(builder.getUnknownLoc())
+            << "Register spill on kernel " << kernelName << ": "
+            << "VGPRSpillCount : " << metaData.VGPRSpillCount
+            << " / SGPRSpillCount : " << metaData.SGPRSpillCount;
+      }
     }
+  }
 }
 
 } // namespace
@@ -802,7 +804,7 @@ public:
       targetHSACO = createHsaco(variantOp.getLoc(), targetObj, libraryName);
       if (targetHSACO.empty())
         return failure();
-      
+
       checkRegisterSpilling(executableBuilder, targetObj);
     }
 


### PR DESCRIPTION
Displays a warning when the generated ISA for AMD GPUs causes register spilling.
This is disabled by default but it can be enabled using the command line option : `--iree-hip-enable-register-spill-warning`