### PR TITLE
[GPU] Remove reshape by expansion in workgroup scope of combine layout pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -94,6 +94,7 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
 LogicalResult
 combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
                             PadDistributionConfigFn padDistributionConfigFn,
+                            bool doReshapeByExpansion,
                             CombineRelayoutOpsControlFnRef controlFn = nullptr);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -70,9 +70,9 @@ struct GPUCombineLayoutTransformationPass final
     // Workgroup scope.
     CombineRelayoutOpsControlFn controlFn = getCombineRelayoutOpsControlFn(
         IREE::Codegen::RelayoutCombinationScope::Dispatch);
-    if (failed(combineLayoutTransformation(&getContext(), getOperation(),
-                                           gpuPadDistributionConfigFn,
-                                           controlFn))) {
+    if (failed(combineLayoutTransformation(
+            &getContext(), getOperation(), gpuPadDistributionConfigFn,
+            /*doReshapeByExpansion=*/true, controlFn))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -317,6 +317,9 @@ func.func @propagate_relayout_ops(%source : tensor<?x?x128x128xf32>,
 //       DISPATCH-SCOPE:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter %[[COMPUTE_OP]]
 //       DISPATCH-SCOPE:   iree_codegen.store_to_buffer %[[MAP_SCATTER]]
 
+// WORKGROUP-SCOPE-LABEL: @propagate_relayout_ops
+//       WORKGROUP-SCOPE: linalg.generic {{.*}} outs(%{{.*}} : tensor<?xf16>) {
+
 // -----
 
 func.func @insert_in_workgroup_forall(%2 : tensor<32xbf16>, %3 : tensor<32xbf16>, %9 : tensor<10xbf16>) -> (tensor<32xbf16>, tensor<32xbf16>) {


### PR DESCRIPTION
This makes sense in the dispatch scope, but when doing it in the workgroup scope can lead to more reshape ops and lead to problems in in-place bufferizations. 