### PR TITLE
[Codegen][ROCm] Add repro instructions for .rocmasm files

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -728,7 +728,7 @@ public:
         std::string header =
             llvm::formatv(R"TXT(
 ; To reproduce the .optimized.ll from the .linked.ll, run:
-; opt -S -mtriple={0} -mcpu={1} --passes='{2}' <.lined.ll>
+; opt -S -mtriple={0} -mcpu={1} --passes='{2}' <.linked.ll>
 ; The flag '-S' to emit LLVMIR.
 ; The behavior of some passes depends on '-mtriple' and '-mcpu'
 ;

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -751,10 +751,10 @@ public:
         }
         std::string asmHeader = llvm::formatv(
             R"TXT(; To reproduce the .rocmasm from .optimized.ll, run:
-; llc -mtriple={} -mcpu={} <.optimized.ll> -o <out.rocmasm>
+; llc -mtriple={} -mcpu={} -mattr='{}' <.optimized.ll> -o <out.rocmasm>
 
 )TXT",
-            targetTriple, targetCPU);
+            targetTriple, targetCPU, targetMachine->getTargetFeatureString());
 
         std::string targetISA =
             translateModuleToISA(*moduleCopy.get(), *targetMachine);

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -751,7 +751,7 @@ public:
         }
         std::string asmHeader = llvm::formatv(
             R"TXT(; To reproduce the .rocmasm from .optimized.ll, run:
-; llc -mtriple={} -mcpu={} -mattr='{}' <.optimized.ll> -o <out.rocmasm>
+; llc -mtriple={} -mcpu={} -mattr='{}' -O3 <.optimized.ll> -o <out.rocmasm>
 
 )TXT",
             targetTriple, targetCPU, targetMachine->getTargetFeatureString());

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -728,9 +728,12 @@ public:
         std::string header =
             llvm::formatv(R"TXT(
 ; To reproduce the .optimized.ll from the .linked.ll, run:
-; opt -S -mtriple={} -mcpu={} --passes='{}'
+; opt -S -mtriple={0} -mcpu={1} --passes='{2}' <.lined.ll>
 ; The flag '-S' to emit LLVMIR.
 ; The behavior of some passes depends on '-mtriple' and '-mcpu'
+;
+; To reproduce the .rocmasm from .optimized.ll, run:
+; llc -mtriple={0} -mcpu={1} <.optimized.ll> -o <out.rocmasm>
 
 )TXT",
                           targetTriple, targetCPU, passesString);


### PR DESCRIPTION
The instructions will be printed inside the `.ll` files we already dump.

`.rocmasm` files can be generated using the `llc` command, making bisecting llvm easier, since it doesn't require IREE to be in sync with MLIR and LLVM.

Because `llc` is not built by default, you will have to run something like `ninja llc` to use it from within the IREE build.