### PR TITLE
Upgrade Preprocessing and Modules to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
@@ -26,21 +26,21 @@ struct OptionalCheckImportConversion : public VMImportOpConversion<T, Adaptor> {
   LogicalResult
   matchAndRewrite(T op, typename T::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto hasImport = rewriter.create<IREE::VM::ImportResolvedOp>(
-        op.getLoc(), rewriter.getI32Type(), this->importOp.getName());
+    auto hasImport = IREE::VM::ImportResolvedOp::create(
+        rewriter, op.getLoc(), rewriter.getI32Type(), this->importOp.getName());
     auto *followingBlock = rewriter.splitBlock(rewriter.getInsertionBlock(),
                                                rewriter.getInsertionPoint());
     auto *callBlock = rewriter.createBlock(followingBlock);
     rewriter.setInsertionPointAfter(hasImport);
-    rewriter.create<IREE::VM::CondBranchOp>(op.getLoc(), hasImport, callBlock,
-                                            followingBlock);
+    IREE::VM::CondBranchOp::create(rewriter, op.getLoc(), hasImport, callBlock,
+                                   followingBlock);
     rewriter.setInsertionPointToStart(callBlock);
     auto results = rewriteToCall(op, adaptor, this->importOp,
                                  *this->getTypeConverter(), rewriter);
     if (!results.has_value())
       return failure();
     rewriter.replaceOp(op, results.value());
-    rewriter.create<IREE::VM::BranchOp>(op.getLoc(), followingBlock);
+    IREE::VM::BranchOp::create(rewriter, op.getLoc(), followingBlock);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
@@ -19,7 +19,7 @@ struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ExpectEqConstOp op,
                                 PatternRewriter &rewriter) const override {
-    auto rhs = rewriter.create<arith::ConstantOp>(op.getLoc(), op.getValue());
+    auto rhs = arith::ConstantOp::create(rewriter, op.getLoc(), op.getValue());
     rewriter.replaceOpWithNewOp<ExpectEqOp>(op, op.getDevice(), op.getLhs(),
                                             rhs);
     return success();
@@ -32,7 +32,7 @@ struct ExpectAlmostEqConstOpToExpectAlmostEqOp
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ExpectAlmostEqConstOp op,
                                 PatternRewriter &rewriter) const override {
-    auto rhs = rewriter.create<arith::ConstantOp>(op.getLoc(), op.getValue());
+    auto rhs = arith::ConstantOp::create(rewriter, op.getLoc(), op.getValue());
     rewriter.replaceOpWithNewOp<ExpectAlmostEqOp>(
         op, op.getDevice(), op.getLhs(), rhs, op.getAtolAttr(),
         op.getRtolAttr());

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
@@ -110,8 +110,8 @@ struct BufferLoadOpPattern
     Value storageBuffer =
         rewriter.createOrFold<IREE::HAL::Inline::BufferStorageOp>(
             op.getLoc(), adaptor.getSourceBuffer());
-    Value storageSize = rewriter.create<IREE::HAL::Inline::BufferLengthOp>(
-        op.getLoc(), adaptor.getSourceBuffer());
+    Value storageSize = IREE::HAL::Inline::BufferLengthOp::create(
+        rewriter, op.getLoc(), adaptor.getSourceBuffer());
     auto loadType = getTypeConverter()->convertType(op.getResult().getType());
     auto elementSize =
         rewriter.createOrFold<IREE::Util::SizeOfOp>(op.getLoc(), loadType);
@@ -131,8 +131,8 @@ struct BufferStoreOpPattern
     Value storageBuffer =
         rewriter.createOrFold<IREE::HAL::Inline::BufferStorageOp>(
             op.getLoc(), adaptor.getTargetBuffer());
-    Value storageSize = rewriter.create<IREE::HAL::Inline::BufferLengthOp>(
-        op.getLoc(), adaptor.getTargetBuffer());
+    Value storageSize = IREE::HAL::Inline::BufferLengthOp::create(
+        rewriter, op.getLoc(), adaptor.getTargetBuffer());
     auto elementSize = rewriter.createOrFold<IREE::Util::SizeOfOp>(
         op.getLoc(), adaptor.getValue().getType());
     rewriter.replaceOpWithNewOp<IREE::Util::BufferStoreOp>(

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
@@ -44,8 +44,8 @@ struct ExecutableLoadOpConversion
   matchAndRewrite(IREE::HAL::Loader::ExecutableLoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Get format string as a rodata blob.
-    auto executableFormatStr = rewriter.create<IREE::VM::RodataInlineOp>(
-        loadOp.getLoc(), loadOp.getFormatAttr());
+    auto executableFormatStr = IREE::VM::RodataInlineOp::create(
+        rewriter, loadOp.getLoc(), loadOp.getFormatAttr());
 
     // Pack constants, if any.
     auto constantBuffer = createPackedConstantBuffer(

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
@@ -71,8 +71,8 @@ struct CmdDispatchOpPattern
     }
 
     // Lookup executable reference.
-    auto lookupOp = rewriter.create<IREE::HAL::Loader::ExecutableLookupOp>(
-        loc, rewriter.getType<IREE::HAL::ExecutableType>(),
+    auto lookupOp = IREE::HAL::Loader::ExecutableLookupOp::create(
+        rewriter, loc, rewriter.getType<IREE::HAL::ExecutableType>(),
         executableOp.getName());
 
     // TODO(benvanik): use scf.index_switch as with the full HAL.
@@ -128,15 +128,14 @@ struct CmdDispatchOpPattern
         SymbolRefAttr::get(builder.getContext(), executableOp.getName(),
                            {SymbolRefAttr::get(exportOp->getParentOp()),
                             SymbolRefAttr::get(exportOp)});
-    Value ordinal =
-        builder.create<IREE::HAL::Loader::ExecutableExportOrdinalOp>(
-            loc, builder.getIndexType(), entryPointAttr);
+    Value ordinal = IREE::HAL::Loader::ExecutableExportOrdinalOp::create(
+        builder, loc, builder.getIndexType(), entryPointAttr);
 
     // Dispatch with a target-specific workgroup count.
     auto workgroupCount = exportOp.calculateWorkgroupCount(
         loc, /*device=*/nullptr, adaptor.getWorkload(), builder);
-    builder.create<IREE::HAL::Loader::ExecutableDispatchOp>(
-        loc, executable, ordinal, workgroupCount[0], workgroupCount[1],
+    IREE::HAL::Loader::ExecutableDispatchOp::create(
+        builder, loc, executable, ordinal, workgroupCount[0], workgroupCount[1],
         workgroupCount[2], pushConstants, bindingBuffers, bindingOffsets,
         bindingLengths);
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -45,9 +45,9 @@ static Value createTransposeOp(RewriterBase &rewriter, Location loc,
   applyPermutationToVector(dimSizes, perm);
 
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto emptyTensor = rewriter.create<tensor::EmptyOp>(
-      loc, dimSizes, tensorType.getElementType());
-  return rewriter.create<linalg::TransposeOp>(loc, tensor, emptyTensor, perm)
+  auto emptyTensor = tensor::EmptyOp::create(rewriter, loc, dimSizes,
+                                             tensorType.getElementType());
+  return linalg::TransposeOp::create(rewriter, loc, tensor, emptyTensor, perm)
       .getResult()[0];
 }
 
@@ -70,9 +70,10 @@ convertConvFilterToTargetLayout(linalg::Conv2DNhwcHwcfOp convOp,
 
   SmallVector<utils::IteratorType> iterators = convOp.getIteratorTypesArray();
 
-  auto genericOp = rewriter.create<linalg::GenericOp>(
-      loc, output.getType(), ValueRange{input, transposedFilter}, output,
-      ArrayRef<AffineMap>{inputMap, transposedFilterMap, outputMap}, iterators);
+  auto genericOp = linalg::GenericOp::create(
+      rewriter, loc, output.getType(), ValueRange{input, transposedFilter},
+      output, ArrayRef<AffineMap>{inputMap, transposedFilterMap, outputMap},
+      iterators);
 
   // Reuse the same payload as the original convolution op.
   rewriter.inlineRegionBefore(convOp->getRegion(0), genericOp.getRegion(),

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -172,8 +172,8 @@ struct FoldAttentionAndTranspose
         getIndexingMap(6, {d0, d2, d1, d5})};
     ArrayAttr newIndexingMapsAttr =
         rewriter.getAffineMapArrayAttr(newIndexingMaps);
-    auto newAttentionOp = rewriter.create<IREE::LinalgExt::AttentionOp>(
-        attentionOp.getLoc(), expandedInit.getType(), expandedQuery,
+    auto newAttentionOp = IREE::LinalgExt::AttentionOp::create(
+        rewriter, attentionOp.getLoc(), expandedInit.getType(), expandedQuery,
         expandedKey, expandedValue, attentionOp.getScale(), expandedInit,
         newIndexingMapsAttr);
     rewriter.replaceOp(transposeLikeOp, newAttentionOp);

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -138,8 +138,8 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
 
   auto resultTypes =
       llvm::map_to_vector(results, [](Value v) -> Type { return v.getType(); });
-  auto dispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
-      funcOp.getLoc(), resultTypes,
+  auto dispatchRegionOp = IREE::Flow::DispatchRegionOp::create(
+      rewriter, funcOp.getLoc(), resultTypes,
       /*result_dims=*/ValueRange{}, /*workload=*/ValueRange{});
   Region &regionOpBody = dispatchRegionOp.getBody();
   Block *newBlock = rewriter.createBlock(&regionOpBody, regionOpBody.begin());
@@ -147,8 +147,8 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
     rewriter.moveOpBefore(op, newBlock, newBlock->end());
   }
   rewriter.setInsertionPointToEnd(newBlock);
-  rewriter.create<IREE::Flow::ReturnOp>(dispatchRegionOp.getLoc(),
-                                        results.getArrayRef());
+  IREE::Flow::ReturnOp::create(rewriter, dispatchRegionOp.getLoc(),
+                               results.getArrayRef());
   rewriter.replaceUsesWithIf(
       results.getArrayRef(), dispatchRegionOp->getResults(),
       [&](OpOperand &use) {

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
@@ -80,11 +80,11 @@ public:
     auto rhsPaddedType = RankedTensorType::get(
         getFullShape({newKSize, newNSize}), rhsType.getElementType());
 
-    Value lhsPaddingValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(lhsType.getElementType()));
+    Value lhsPaddingValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(lhsType.getElementType()));
 
-    Value rhsPaddingValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(rhsType.getElementType()));
+    Value rhsPaddingValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(rhsType.getElementType()));
 
     auto createPadding = [&](ArrayRef<int64_t> padding) {
       SmallVector<OpFoldResult> result;
@@ -99,15 +99,15 @@ public:
 
     Value paddedLhs = lhs;
     if (paddingForM > 0 || paddingForK > 0) {
-      paddedLhs = rewriter.create<tensor::PadOp>(
-          loc, lhsPaddedType, lhs, createPadding({0, 0}),
+      paddedLhs = tensor::PadOp::create(
+          rewriter, loc, lhsPaddedType, lhs, createPadding({0, 0}),
           createPadding({paddingForM, paddingForK}), lhsPaddingValue);
     }
 
     Value paddedRhs = rhs;
     if (paddingForK > 0 || paddingForN > 0) {
-      paddedRhs = rewriter.create<tensor::PadOp>(
-          loc, rhsPaddedType, rhs, createPadding({0, 0}),
+      paddedRhs = tensor::PadOp::create(
+          rewriter, loc, rhsPaddedType, rhs, createPadding({0, 0}),
           createPadding({paddingForK, paddingForN}), rhsPaddingValue);
     }
 
@@ -120,10 +120,10 @@ public:
     } else {
       auto newResultType = RankedTensorType::get(
           getFullShape({newMSize, newNSize}), resultType.getElementType());
-      Value resultPaddingValue = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getZeroAttr(resultType.getElementType()));
-      Value paddedResult = rewriter.create<tensor::PadOp>(
-          loc, newResultType, result, createPadding({0, 0}),
+      Value resultPaddingValue = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getZeroAttr(resultType.getElementType()));
+      Value paddedResult = tensor::PadOp::create(
+          rewriter, loc, newResultType, result, createPadding({0, 0}),
           createPadding({paddingForM, paddingForN}), resultPaddingValue);
       auto paddedMatmulOp =
           mlir::clone(rewriter, linalgOp, {newResultType},


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.