### PR TITLE
Upgrade GlobalOpt, InputConversion, ExternalInterfacess to free create function. NFC.

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/EncodingExternalModels.cpp
@@ -92,13 +92,13 @@ struct ContractionOpPropagationInterface final
           RankedTensorType operandEncodingType =
               collapseOp.getSrcType().cloneWithEncoding(
                   operandEncodings.front());
-          Value newEncodingOp = builder.create<IREE::Encoding::SetEncodingOp>(
-              loc, operandEncodingType, collapseOp.getSrc());
+          Value newEncodingOp = IREE::Encoding::SetEncodingOp::create(
+              builder, loc, operandEncodingType, collapseOp.getSrc());
           auto resultEncodingType =
               dyn_cast<RankedTensorType>(opResult.getType())
                   .cloneWithEncoding(resultEncodings.front());
-          Value newCollapseOp = builder.create<tensor::CollapseShapeOp>(
-              loc, resultEncodingType, newEncodingOp,
+          Value newCollapseOp = tensor::CollapseShapeOp::create(
+              builder, loc, resultEncodingType, newEncodingOp,
               collapseOp.getReassociationIndices());
           IREE::Encoding::PropagationResult result;
           result.replacements = {newCollapseOp};
@@ -228,9 +228,8 @@ struct GenericOpPropagationInterface final
                 auto resType = RankedTensorType::get(
                     operandType.getShape(), operandType.getElementType(),
                     encoding);
-                Value encodedInput =
-                    rewriter.create<IREE::Encoding::SetEncodingOp>(
-                        loc, resType, operand->get());
+                Value encodedInput = IREE::Encoding::SetEncodingOp::create(
+                    rewriter, loc, resType, operand->get());
                 result.generatedEncodingOps.push_back(
                     encodedInput.getDefiningOp());
                 encodedOperands.push_back(encodedInput);
@@ -253,8 +252,8 @@ struct GenericOpPropagationInterface final
 
                 // Create encoded generic op.
                 rewriter.setInsertionPointAfter(emptyOp);
-                Value encodedInit = rewriter.create<tensor::EmptyOp>(
-                    loc, emptyOp.getType().getShape(),
+                Value encodedInit = tensor::EmptyOp::create(
+                    rewriter, loc, emptyOp.getType().getShape(),
                     resultEncodingType.getElementType(),
                     emptyOp.getDynamicSizes(), encoding);
                 resultEncodingTypes.push_back(resultEncodingType);
@@ -271,10 +270,9 @@ struct GenericOpPropagationInterface final
                 auto resultType =
                     cast<RankedTensorType>(genericResult.getType())
                         .dropEncoding();
-                auto newUnsetEncoding =
-                    rewriter.create<IREE::Encoding::UnsetEncodingOp>(
-                        encodingOp.getLoc(), resultType, genericResult,
-                        encodingOp.getResultDims());
+                auto newUnsetEncoding = IREE::Encoding::UnsetEncodingOp::create(
+                    rewriter, encodingOp.getLoc(), resultType, genericResult,
+                    encodingOp.getResultDims());
                 result.replacements.push_back(newUnsetEncoding.getResult());
                 result.generatedEncodingOps.push_back(newUnsetEncoding);
               }

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
@@ -117,8 +117,8 @@ public:
       }
       vSizes.push_back(rewriter.createOrFold<tensor::DimOp>(loc, input, i));
     }
-    Value extractedSlice = rewriter.create<tensor::ExtractSliceOp>(
-        loc, sliceTy, input, vOffset, vSizes, vStride);
+    Value extractedSlice = tensor::ExtractSliceOp::create(
+        rewriter, loc, sliceTy, input, vOffset, vSizes, vStride);
     rewriter.startOpModification(op);
     op.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr(mapRange));
     op.setOperand(0, extractedSlice);

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -28,7 +28,7 @@ static Value createTranspose(OpBuilder &builder, Value source,
   applyPermutationToVector(mixedSizes, perm);
   Type elemType = cast<RankedTensorType>(source.getType()).getElementType();
   Value empty =
-      builder.create<tensor::EmptyOp>(source.getLoc(), mixedSizes, elemType)
+      tensor::EmptyOp::create(builder, source.getLoc(), mixedSizes, elemType)
           .getResult();
   return builder
       .create<linalg::TransposeOp>(source.getLoc(), source, empty, perm)
@@ -75,9 +75,9 @@ struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
     SmallVector<int64_t> newShape = applyPermutation(concatShape, permutation);
     auto newConcatType = RankedTensorType::get(
         newShape, concatOp.getResultType().getElementType());
-    Value newConcat = rewriter.create<tensor::ConcatOp>(
-        concatOp.getLoc(), newConcatType, /*dim=*/outerMostNonUnitDim,
-        transposedInputs);
+    Value newConcat =
+        tensor::ConcatOp::create(rewriter, concatOp.getLoc(), newConcatType,
+                                 /*dim=*/outerMostNonUnitDim, transposedInputs);
     auto invPerm = invertPermutationVector(permutation);
     Value transposedConcat = createTranspose(rewriter, newConcat, invPerm);
     rewriter.replaceOp(concatOp, transposedConcat);

--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
@@ -65,17 +65,17 @@ struct DemoteContractionInputsToBF16Pattern
             inputType.getRank(), utils::IteratorType::parallel);
         SmallVector<OpFoldResult> mixedSizes =
             tensor::getMixedSizes(rewriter, loc, input);
-        Value empty = rewriter.create<tensor::EmptyOp>(loc, mixedSizes,
-                                                       rewriter.getBF16Type());
+        Value empty = tensor::EmptyOp::create(rewriter, loc, mixedSizes,
+                                              rewriter.getBF16Type());
         demotedInputs.push_back(
             rewriter
                 .create<linalg::GenericOp>(
                     loc, TypeRange{demotedInputType}, ValueRange{input},
                     ValueRange{empty}, maps, iteratorTypes,
                     [&](OpBuilder &b, Location loc, ValueRange args) {
-                      Value result = b.create<arith::TruncFOp>(
-                          loc, rewriter.getBF16Type(), args[0]);
-                      b.create<linalg::YieldOp>(loc, result);
+                      Value result = arith::TruncFOp::create(
+                          b, loc, rewriter.getBF16Type(), args[0]);
+                      linalg::YieldOp::create(b, loc, result);
                     })
                 ->getResults()[0]);
       }

--- a/compiler/src/iree/compiler/GlobalOptimization/InferNumericNarrowing.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/InferNumericNarrowing.cpp
@@ -123,8 +123,8 @@ class InferNumericNarrowingPass
     if (type.getWidth() != 0) {
       range = std::make_pair(minValue, maxValue);
     }
-    auto annotationOp = builder.create<IREE::Util::NumericOptionalNarrowOp>(
-        probePoint.getLoc(), probePoint, type, range);
+    auto annotationOp = IREE::Util::NumericOptionalNarrowOp::create(
+        builder, probePoint.getLoc(), probePoint, type, range);
     probePoint.replaceAllUsesExcept(annotationOp, annotationOp);
   }
 };

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -24,8 +24,8 @@ static Value bitcastToStaticTypeImpl(OpBuilder &b, Location loc,
     return global;
   }
   // No dynamic dims because we are always bitcasting constants.
-  return b.create<IREE::TensorExt::BitCastOp>(loc, targetType, global,
-                                              ValueRange(), ValueRange());
+  return IREE::TensorExt::BitCastOp::create(b, loc, targetType, global,
+                                            ValueRange(), ValueRange());
 }
 
 struct HoistableTensorTypeInterface
@@ -103,7 +103,7 @@ struct HoistableIndexTypeInterface
         !isa<IndexType>(init.getType())) {
       return init;
     }
-    return builder.create<arith::IndexCastOp>(loc, storageType, init);
+    return arith::IndexCastOp::create(builder, loc, storageType, init);
   }
   static Value decodeStorageType(OpBuilder &builder, Location loc,
                                  Type originalType, Value loadedGlobal) {
@@ -112,7 +112,7 @@ struct HoistableIndexTypeInterface
         !isa<IntegerType>(loadedGlobal.getType())) {
       return loadedGlobal;
     }
-    return builder.create<arith::IndexCastOp>(loc, originalType, loadedGlobal);
+    return arith::IndexCastOp::create(builder, loc, originalType, loadedGlobal);
   }
 };
 

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -50,16 +50,16 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
   if (llvm::isa<FloatType>(origElementType) &&
       llvm::isa<IntegerType>(toElementType)) {
     if (isSigned) {
-      return builder.create<arith::FPToSIOp>(loc, toType, origValue);
+      return arith::FPToSIOp::create(builder, loc, toType, origValue);
     } else {
-      return builder.create<arith::FPToUIOp>(loc, toType, origValue);
+      return arith::FPToUIOp::create(builder, loc, toType, origValue);
     }
   } else if (llvm::isa<IntegerType>(origElementType) &&
              llvm::isa<FloatType>(toElementType)) {
     if (isSigned) {
-      return builder.create<arith::SIToFPOp>(loc, toType, origValue);
+      return arith::SIToFPOp::create(builder, loc, toType, origValue);
     } else {
-      return builder.create<arith::UIToFPOp>(loc, toType, origValue);
+      return arith::UIToFPOp::create(builder, loc, toType, origValue);
     }
   } else {
     // If we need int<->int and float<->float, implement those cases. Since
@@ -153,7 +153,7 @@ struct LinalgFillCast
                 fillInit)
             .getCasted();
     Value fillResult =
-        rewriter.create<linalg::FillOp>(loc, fillInput, fillInit).result();
+        linalg::FillOp::create(rewriter, loc, fillInput, fillInit).result();
     rewriter.replaceOp(castOp, fillResult);
     return success();
   }
@@ -242,8 +242,8 @@ struct LinalgFpMatmulToLowP : public OpRewritePattern<linalg::MatmulOp> {
     Value newAccum =
         castNumeric(accumParams->producer, accumLowPType, isSigned, rewriter);
 
-    auto newMatmulOp = rewriter.create<linalg::MatmulOp>(
-        loc, ValueRange{newLhs, newRhs}, ValueRange{newAccum});
+    auto newMatmulOp = linalg::MatmulOp::create(
+        rewriter, loc, ValueRange{newLhs, newRhs}, ValueRange{newAccum});
     if (!isSigned) {
       newMatmulOp.setCast(linalg::TypeFn::cast_unsigned);
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -141,8 +141,8 @@ raiseTensorExtractToInput(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
     }
   };
 
-  linalg::GenericOp newLinalgOp = rewriter.create<linalg::GenericOp>(
-      linalgOp.getLoc(), linalgOp.getResultTypes(), newInputs,
+  linalg::GenericOp newLinalgOp = linalg::GenericOp::create(
+      rewriter, linalgOp.getLoc(), linalgOp.getResultTypes(), newInputs,
       linalgOp.getOutputs(),
       ArrayAttr::get(linalgOp->getContext(), newIndexingMaps),
       linalgOp.getIteratorTypesAttr(), linalgOp.getDocAttr(),
@@ -198,8 +198,8 @@ tryRaiseToExtractSlice(AffineMap inputIndexingMap, AffineMap outputIndexingMap,
       offsets.push_back(zero);
       // Get the dim size from the output tensor.
       if (ShapedType::isDynamic(outShape[currOutDim])) {
-        auto dim = rewriter.create<tensor::DimOp>(linalgOp.getLoc(), output,
-                                                  currOutDim);
+        auto dim = tensor::DimOp::create(rewriter, linalgOp.getLoc(), output,
+                                         currOutDim);
         sizes.push_back(dim.getResult());
       } else {
         sizes.push_back(rewriter.getI64IntegerAttr(outShape[currOutDim]));
@@ -220,8 +220,8 @@ tryRaiseToExtractSlice(AffineMap inputIndexingMap, AffineMap outputIndexingMap,
   // will always be 1.
   SmallVector<OpFoldResult> strides(inputIndexingMap.getNumResults(), one);
 
-  return rewriter.create<tensor::ExtractSliceOp>(
-      linalgOp.getLoc(), outType, input, offsets, sizes, strides);
+  return tensor::ExtractSliceOp::create(rewriter, linalgOp.getLoc(), outType,
+                                        input, offsets, sizes, strides);
 }
 
 /// Matches a linalg.generic operation with a single input and init output
@@ -630,8 +630,8 @@ public:
           {rewriter.getIndexAttr(dim), size, offset}));
     }
 
-    Value paddingValue = rewriter.create<arith::ConstantOp>(
-        constantDest.getLoc(), denseAttr.getElementType(),
+    Value paddingValue = arith::ConstantOp::create(
+        rewriter, constantDest.getLoc(), denseAttr.getElementType(),
         denseAttr.getSplatValue<TypedAttr>());
     rewriter.replaceOpWithNewOp<tensor::PadOp>(sliceOp, sliceOp.getResultType(),
                                                sliceOp.getSource(), lowPadding,
@@ -891,11 +891,11 @@ static Value createCatNegateAndSlice(RewriterBase &rewriter, Value outTensor,
                                                          : sliceSize / 2);
   Type expandedType =
       RankedTensorType::get(targetShape, sourceType.getElementType());
-  Value expanded = rewriter.create<tensor::ExpandShapeOp>(loc, expandedType,
-                                                          source, reassoc);
+  Value expanded = tensor::ExpandShapeOp::create(rewriter, loc, expandedType,
+                                                 source, reassoc);
 
-  Value expandedOutTensor = rewriter.create<tensor::ExpandShapeOp>(
-      loc, expandedType, outTensor, reassoc);
+  Value expandedOutTensor = tensor::ExpandShapeOp::create(
+      rewriter, loc, expandedType, outTensor, reassoc);
 
   SmallVector<AffineMap> indexingMaps = {
       rewriter.getMultiDimIdentityMap(targetShape.size())};
@@ -905,29 +905,29 @@ static Value createCatNegateAndSlice(RewriterBase &rewriter, Value outTensor,
   auto bodyBuilder = [&](OpBuilder &b, Location loc, ValueRange args) {
     SmallVector<Value> extractionIndices;
     for (size_t i = 0, e = targetShape.size(); i < e; ++i) {
-      extractionIndices.push_back(b.create<linalg::IndexOp>(loc, i));
+      extractionIndices.push_back(linalg::IndexOp::create(b, loc, i));
     }
 
     Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
 
     // Take the reverse of the second to last iterator. Because we statically
     // guaranteed it to be 2 it just becomes `1 - iters[-2]`.
-    Value reverseSplitIdx = rewriter.create<arith::SubIOp>(
-        loc, c1, extractionIndices[targetShape.size() - 2]);
+    Value reverseSplitIdx = arith::SubIOp::create(
+        rewriter, loc, c1, extractionIndices[targetShape.size() - 2]);
     extractionIndices[targetShape.size() - 2] = reverseSplitIdx;
 
     // Extract the value from input tensor and negate the top half of the result
     // slice (lower half of the input slice).
     Value inputVal =
-        b.create<tensor::ExtractOp>(loc, expanded, extractionIndices);
-    Value maybeNegate = b.create<arith::NegFOp>(loc, inputVal);
+        tensor::ExtractOp::create(b, loc, expanded, extractionIndices);
+    Value maybeNegate = arith::NegFOp::create(b, loc, inputVal);
 
-    Value isEqual = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                            reverseSplitIdx, c1);
+    Value isEqual = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq,
+                                          reverseSplitIdx, c1);
     Value select =
-        rewriter.create<arith::SelectOp>(loc, isEqual, maybeNegate, inputVal);
-    b.create<linalg::YieldOp>(loc, select);
+        arith::SelectOp::create(rewriter, loc, isEqual, maybeNegate, inputVal);
+    linalg::YieldOp::create(b, loc, select);
   };
 
   Value result =
@@ -937,8 +937,8 @@ static Value createCatNegateAndSlice(RewriterBase &rewriter, Value outTensor,
                                      indexingMaps, iteratorTypes, bodyBuilder)
           .getResult(0);
 
-  return rewriter.create<tensor::CollapseShapeOp>(loc, outTensor.getType(),
-                                                  result, reassoc);
+  return tensor::CollapseShapeOp::create(rewriter, loc, outTensor.getType(),
+                                         result, reassoc);
 }
 
 static Value rewriteCatNegateAndSlice(RewriterBase &rewriter,
@@ -954,9 +954,9 @@ static Value rewriteCatNegateAndSlice(RewriterBase &rewriter,
                                       tensor::ConcatOp concatOp, Value source) {
   rewriter.setInsertionPoint(concatOp);
   Type elemType = cast<RankedTensorType>(source.getType()).getElementType();
-  Value outTensor = rewriter.create<tensor::EmptyOp>(
-      source.getLoc(), tensor::getMixedSizes(rewriter, source.getLoc(), source),
-      elemType);
+  Value outTensor = tensor::EmptyOp::create(
+      rewriter, source.getLoc(),
+      tensor::getMixedSizes(rewriter, source.getLoc(), source), elemType);
   return createCatNegateAndSlice(rewriter, outTensor, source);
 }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -51,8 +51,8 @@ struct ReplaceZeroExtentOperands : public RewritePattern {
       Operation *owner = operand.getOwner();
       int operandNum = operand.getOperandNumber();
       auto shape = tensor::getMixedSizes(rewriter, loc, operand.get());
-      auto emptyTensorOp = rewriter.create<tensor::EmptyOp>(
-          loc, shape, operandType->getElementType());
+      auto emptyTensorOp = tensor::EmptyOp::create(
+          rewriter, loc, shape, operandType->getElementType());
       rewriter.modifyOpInPlace(
           owner, [&]() { owner->setOperand(operandNum, emptyTensorOp); });
       didUpdate = true;

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -86,11 +86,10 @@ Value createGenericElementwiseCastOp(
   auto castedType = inputType.clone(elementType);
   SmallVector<OpFoldResult> inputMixedSizes =
       tensor::getMixedSizes(builder, loc, input);
-  Value init =
-      encoding
-          ? builder.create<tensor::EmptyOp>(loc, inputMixedSizes, elementType,
-                                            *encoding)
-          : builder.create<tensor::EmptyOp>(loc, inputMixedSizes, elementType);
+  Value init = encoding ? tensor::EmptyOp::create(builder, loc, inputMixedSizes,
+                                                  elementType, *encoding)
+                        : tensor::EmptyOp::create(builder, loc, inputMixedSizes,
+                                                  elementType);
   return builder
       .create<linalg::GenericOp>(
           loc, castedType, input, init, maps, iteratorTypes,
@@ -99,7 +98,7 @@ Value createGenericElementwiseCastOp(
                 b.create(nestedLoc, castOp->getName().getIdentifier(), args[0],
                          elementType)
                     ->getResult(0);
-            b.create<linalg::YieldOp>(nestedLoc, castRes);
+            linalg::YieldOp::create(b, nestedLoc, castRes);
           },
           attrs)
       .getResult(0);
@@ -118,16 +117,16 @@ Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
 
     staticSizes.push_back(ty.getDimSize(i));
     if (ty.isDynamicDim(i)) {
-      dynSizes.push_back(rewriter.create<tensor::DimOp>(val, i));
+      dynSizes.push_back(tensor::DimOp::create(rewriter, val, i));
     }
   }
 
   // Create a zero-filled accumulator.
   Value initAcc =
-      rewriter.create<tensor::EmptyOp>(staticSizes, accETy, dynSizes);
-  Value zeroInt = rewriter.create<arith::ConstantIntOp>(accETy, 0).getResult();
+      tensor::EmptyOp::create(rewriter, staticSizes, accETy, dynSizes);
+  Value zeroInt = arith::ConstantIntOp::create(rewriter, accETy, 0).getResult();
   Value zeroAcc =
-      rewriter.create<linalg::FillOp>(zeroInt, initAcc).getResult(0);
+      linalg::FillOp::create(rewriter, zeroInt, initAcc).getResult(0);
 
   SmallVector<AffineExpr> filterExprs(ty.getRank());
   SmallVector<AffineExpr> outputExprs;
@@ -160,9 +159,9 @@ Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
           zeroAcc.getType(), ValueRange{val}, ValueRange{zeroAcc}, affineMaps,
           iterators,
           [=](OpBuilder &b, Location loc, ValueRange args) {
-            Value ext = b.create<arith::ExtSIOp>(loc, accETy, args[0]);
-            Value sum = b.create<arith::AddIOp>(loc, ext, args[1]);
-            b.create<linalg::YieldOp>(loc, sum);
+            Value ext = arith::ExtSIOp::create(b, loc, accETy, args[0]);
+            Value sum = arith::AddIOp::create(b, loc, ext, args[1]);
+            linalg::YieldOp::create(b, loc, sum);
           })
       .getResult(0);
 }

--- a/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
@@ -46,11 +46,11 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
     return nullptr;
 
   if (inputETy.getIntOrFloatBitWidth() > eTy.getIntOrFloatBitWidth()) {
-    return builder.create<arith::TruncFOp>(loc, type, inputs[0]);
+    return arith::TruncFOp::create(builder, loc, type, inputs[0]);
   }
 
   if (inputETy.getIntOrFloatBitWidth() < eTy.getIntOrFloatBitWidth()) {
-    return builder.create<arith::ExtFOp>(loc, type, inputs[0]);
+    return arith::ExtFOp::create(builder, loc, type, inputs[0]);
   }
 
   return nullptr;
@@ -68,15 +68,15 @@ Value convertRankedInteger(OpBuilder &builder, Type type, ValueRange inputs,
   int64_t outBitwidth = eTy.getIntOrFloatBitWidth();
 
   if (inBitwidth > outBitwidth) {
-    return builder.create<arith::TruncIOp>(loc, type, inputs[0]);
+    return arith::TruncIOp::create(builder, loc, type, inputs[0]);
   }
 
   if (inBitwidth < outBitwidth && isUnsigned) {
-    return builder.create<arith::ExtUIOp>(loc, type, inputs[0]);
+    return arith::ExtUIOp::create(builder, loc, type, inputs[0]);
   }
 
   if (inBitwidth < outBitwidth && !isUnsigned) {
-    return builder.create<arith::ExtSIOp>(loc, type, inputs[0]);
+    return arith::ExtSIOp::create(builder, loc, type, inputs[0]);
   }
 
   return nullptr;


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.