### PR TITLE
[Codegen] Upgrade Common, SPIRV, VMVX to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -167,14 +167,14 @@ blockDynamicDimensionsOfValue(RewriterBase &rewriter,
   auto outputType = RankedTensorType::get(
       staticOutputShape, tensorType.getElementType(), tensorType.getEncoding());
 
-  auto expandShapeOp = rewriter.create<tensor::ExpandShapeOp>(
-      loc, outputType, v, reassociation, outputShape);
+  auto expandShapeOp = tensor::ExpandShapeOp::create(
+      rewriter, loc, outputType, v, reassociation, outputShape);
   Value barrier = rewriter
                       .create<IREE::Util::OptimizationBarrierOp>(
                           loc, expandShapeOp.getResult())
                       .getResult(0);
-  auto collapseShapeOp = rewriter.create<tensor::CollapseShapeOp>(
-      loc, tensorType, barrier, reassociation);
+  auto collapseShapeOp = tensor::CollapseShapeOp::create(
+      rewriter, loc, tensorType, barrier, reassociation);
   return ReshapeOps{expandShapeOp, collapseShapeOp};
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
@@ -56,11 +56,10 @@ struct BubbleUpAcrossCastOp
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(sourceCastOp);
     Location loc = ordinalOp.getLoc();
-    Value reverseCastOp = rewriter.create<CastOpTy>(
-        loc, rewriter.getIndexType(), sourceCastOp.getIn());
-    Value newOrdinalOp =
-        rewriter.create<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
-            loc, reverseCastOp, ordinalOp.getOrdinal());
+    Value reverseCastOp = CastOpTy::create(
+        rewriter, loc, rewriter.getIndexType(), sourceCastOp.getIn());
+    Value newOrdinalOp = IREE::TensorExt::DispatchWorkloadOrdinalOp::create(
+        rewriter, loc, reverseCastOp, ordinalOp.getOrdinal());
     rewriter.replaceOp(sourceCastOp, newOrdinalOp);
     rewriter.replaceOp(ordinalOp, newOrdinalOp);
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
@@ -38,8 +38,8 @@ static Value getBufferizedSubspanOrSubview(
   MemRefType subviewMemRefType = memref::SubViewOp::inferRankReducedResultType(
       tensorType.getShape(), cast<MemRefType>(subspanMemref.getType()), offsets,
       sizes, strides);
-  return rewriter.create<memref::SubViewOp>(
-      loc, subviewMemRefType, subspanMemref, offsets, sizes, strides);
+  return memref::SubViewOp::create(rewriter, loc, subviewMemRefType,
+                                   subspanMemref, offsets, sizes, strides);
 }
 
 static void

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -238,26 +238,26 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op,
   flags |= IREE_UK_FLAG_MMT4D_ALLOW_GENERIC_FALLBACK_TILE_FUNCTION;
 
   Location loc = op.getLoc();
-  Value m = rewriter.create<tensor::DimOp>(loc, lhs, 0);
-  Value n = rewriter.create<tensor::DimOp>(loc, rhs, 0);
-  Value k = rewriter.create<tensor::DimOp>(loc, rhs, 1);
+  Value m = tensor::DimOp::create(rewriter, loc, lhs, 0);
+  Value n = tensor::DimOp::create(rewriter, loc, rhs, 0);
+  Value k = tensor::DimOp::create(rewriter, loc, rhs, 1);
 
   auto getDimAsI32 = [](RewriterBase &rewriter, Location loc, Value value,
                         int dim) -> Value {
-    return rewriter.create<arith::IndexCastOp>(
-        loc, rewriter.getI32Type(),
-        rewriter.create<tensor::DimOp>(loc, value, dim));
+    return arith::IndexCastOp::create(
+        rewriter, loc, rewriter.getI32Type(),
+        tensor::DimOp::create(rewriter, loc, value, dim));
   };
   Value m0 = getDimAsI32(rewriter, loc, lhs, 2);
   Value n0 = getDimAsI32(rewriter, loc, rhs, 2);
   Value k0 = getDimAsI32(rewriter, loc, rhs, 3);
-  Value flagsVal = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI32IntegerAttr(flags));
+  Value flagsVal = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI32IntegerAttr(flags));
   auto fn = getFnNameAndDefAttrs(ukernelName, rewriter, targetAttr);
   SmallVector<Type> returnTypes =
       getUKernelGenericReturnTypes(targetAttr, outType);
-  auto genericMicroKernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
-      loc, returnTypes, fn.name, ValueRange{lhs, rhs}, out,
+  auto genericMicroKernelOp = IREE::Codegen::UKernelGenericOp::create(
+      rewriter, loc, returnTypes, fn.name, ValueRange{lhs, rhs}, out,
       ValueRange{m, n, k, m0, n0, k0, flagsVal},
       /*fn_def_attrs=*/rewriter.getDictionaryAttr(fn.defAttrs),
       /*num_strided_outer_dims=*/1);
@@ -343,8 +343,8 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::PackOp op,
   Value paddingVal = op.getPaddingValue();
   // If the pack op didn't have a padding_value attribute, default to 0.
   if (!paddingVal) {
-    paddingVal =
-        rewriter.create<arith::ConstantOp>(loc, i64, rewriter.getZeroAttr(i64));
+    paddingVal = arith::ConstantOp::create(rewriter, loc, i64,
+                                           rewriter.getZeroAttr(i64));
   }
   int paddingValBitWidth = paddingVal.getType().getIntOrFloatBitWidth();
   // Non-integer element types get bitcast to integer of same bit width.
@@ -354,7 +354,7 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::PackOp op,
       return rewriter.notifyMatchFailure(op, "no integer type with this width");
     }
     paddingVal =
-        rewriter.create<arith::BitcastOp>(loc, sameWidthIntType, paddingVal);
+        arith::BitcastOp::create(rewriter, loc, sameWidthIntType, paddingVal);
   }
   // Element types > 64bits could be supported, when the padding value is a
   // repeating 64-bit pattern. For now, we leave this as not-yet-implemented.
@@ -365,21 +365,21 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::PackOp op,
   // Integers narrower than 64 bit get extended to 64 bits, it doesn't matter
   // how, as the high bits are unused.
   if (paddingValBitWidth < 64) {
-    paddingVal = rewriter.create<arith::ExtUIOp>(loc, i64, paddingVal);
+    paddingVal = arith::ExtUIOp::create(rewriter, loc, i64, paddingVal);
   }
-  Value in_size0 = rewriter.create<tensor::DimOp>(loc, in, 0);
-  Value in_size1 = rewriter.create<tensor::DimOp>(loc, in, 1);
-  Value out_size0 = rewriter.create<tensor::DimOp>(loc, out, 0);
-  Value out_size1 = rewriter.create<tensor::DimOp>(loc, out, 1);
-  Value out_size2 = rewriter.create<tensor::DimOp>(loc, out, 2);
-  Value out_size3 = rewriter.create<tensor::DimOp>(loc, out, 3);
-  Value flagsVal = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI32IntegerAttr(flags));
+  Value in_size0 = tensor::DimOp::create(rewriter, loc, in, 0);
+  Value in_size1 = tensor::DimOp::create(rewriter, loc, in, 1);
+  Value out_size0 = tensor::DimOp::create(rewriter, loc, out, 0);
+  Value out_size1 = tensor::DimOp::create(rewriter, loc, out, 1);
+  Value out_size2 = tensor::DimOp::create(rewriter, loc, out, 2);
+  Value out_size3 = tensor::DimOp::create(rewriter, loc, out, 3);
+  Value flagsVal = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI32IntegerAttr(flags));
   auto fn = getFnNameAndDefAttrs(ukernelName, rewriter, targetAttr);
   SmallVector<Type> returnTypes =
       getUKernelGenericReturnTypes(targetAttr, outType);
-  auto genericMicroKernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
-      loc, returnTypes, fn.name, in, out,
+  auto genericMicroKernelOp = IREE::Codegen::UKernelGenericOp::create(
+      rewriter, loc, returnTypes, fn.name, in, out,
       ValueRange{in_size0, in_size1, out_size0, out_size1, out_size2, out_size3,
                  paddingVal, flagsVal},
       /*fn_def_attrs=*/rewriter.getDictionaryAttr(fn.defAttrs),
@@ -455,19 +455,19 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::UnPackOp op,
   }
 
   Location loc = op.getLoc();
-  Value in_size0 = rewriter.create<tensor::DimOp>(loc, in, 0);
-  Value in_size1 = rewriter.create<tensor::DimOp>(loc, in, 1);
-  Value in_size2 = rewriter.create<tensor::DimOp>(loc, in, 2);
-  Value in_size3 = rewriter.create<tensor::DimOp>(loc, in, 3);
-  Value out_size0 = rewriter.create<tensor::DimOp>(loc, out, 0);
-  Value out_size1 = rewriter.create<tensor::DimOp>(loc, out, 1);
-  Value flagsVal = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI32IntegerAttr(flags));
+  Value in_size0 = tensor::DimOp::create(rewriter, loc, in, 0);
+  Value in_size1 = tensor::DimOp::create(rewriter, loc, in, 1);
+  Value in_size2 = tensor::DimOp::create(rewriter, loc, in, 2);
+  Value in_size3 = tensor::DimOp::create(rewriter, loc, in, 3);
+  Value out_size0 = tensor::DimOp::create(rewriter, loc, out, 0);
+  Value out_size1 = tensor::DimOp::create(rewriter, loc, out, 1);
+  Value flagsVal = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI32IntegerAttr(flags));
   auto fn = getFnNameAndDefAttrs(ukernelName, rewriter, targetAttr);
   SmallVector<Type> returnTypes =
       getUKernelGenericReturnTypes(targetAttr, outType);
-  auto genericMicroKernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
-      loc, returnTypes, fn.name, in, out,
+  auto genericMicroKernelOp = IREE::Codegen::UKernelGenericOp::create(
+      rewriter, loc, returnTypes, fn.name, in, out,
       ValueRange{in_size0, in_size1, in_size2, in_size3, out_size0, out_size1,
                  flagsVal},
       /*fn_def_attrs=*/rewriter.getDictionaryAttr(fn.defAttrs),
@@ -576,7 +576,7 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
   SmallVector<Value> inputValues;
   Location loc = op.getLoc();
   for (int64_t i : tensorType.getShape()) {
-    inputValues.push_back(rewriter.create<arith::ConstantIndexOp>(loc, i));
+    inputValues.push_back(arith::ConstantIndexOp::create(rewriter, loc, i));
   }
   uint32_t flagForUserAndOperandTypes =
       getFlagForUserAndOperandTypes(encoding, encoding.getElementTypesArray());
@@ -585,11 +585,11 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
   if (!flagForUserAndOperandTypes || !flagForIndex) {
     return rewriter.notifyMatchFailure(op, "unhandled encoding");
   }
-  inputValues.push_back(rewriter.create<arith::ConstantIntOp>(
-      loc, flagForUserAndOperandTypes | flagForIndex, 32));
+  inputValues.push_back(arith::ConstantIntOp::create(
+      rewriter, loc, flagForUserAndOperandTypes | flagForIndex, 32));
   auto fn = getFnNameAndDefAttrs(ukernelName, rewriter, targetAttr);
-  auto genericMicroKernelOp = rewriter.create<IREE::Codegen::UKernelGenericOp>(
-      loc, resultTypes, fn.name, inputValues, /*outs=*/ValueRange{},
+  auto genericMicroKernelOp = IREE::Codegen::UKernelGenericOp::create(
+      rewriter, loc, resultTypes, fn.name, inputValues, /*outs=*/ValueRange{},
       /*other_operands=*/ValueRange{},
       /*fn_def_attrs=*/rewriter.getDictionaryAttr(fn.defAttrs),
       /*strided_dims=*/nullptr);

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -233,9 +233,9 @@ struct ConvertBatchMmt4DtoMmt4DPattern
           rhs.getLoc(), "rhs producer should be reduced, but reduction failed");
     }
 
-    auto mmt4DOp = rewriter.create<linalg::Mmt4DOp>(
-        loc, reducedOut.getType(), ValueRange{reducedLhs, reducedRhs},
-        ValueRange{reducedOut});
+    auto mmt4DOp = linalg::Mmt4DOp::create(rewriter, loc, reducedOut.getType(),
+                                           ValueRange{reducedLhs, reducedRhs},
+                                           ValueRange{reducedOut});
 
     auto loweringConfig = getLoweringConfig<IREE::CPU::LoweringConfigAttr>(op);
     if (loweringConfig) {
@@ -308,9 +308,9 @@ struct Convert3DPackto2DPackPattern : public OpRewritePattern<linalg::PackOp> {
     auto reducedDest = tensor::createCanonicalRankReducingExtractSliceOp(
         rewriter, loc, packOp.getDest(), reducedDestType);
 
-    auto newPackOp = rewriter.create<linalg::PackOp>(
-        loc, reducedSrc, reducedDest, newInnerDimsPos, packOp.getMixedTiles(),
-        packOp.getPaddingValue(), newOuterDimsPerm);
+    auto newPackOp = linalg::PackOp::create(
+        rewriter, loc, reducedSrc, reducedDest, newInnerDimsPos,
+        packOp.getMixedTiles(), packOp.getPaddingValue(), newOuterDimsPerm);
 
     auto insertSliceOp = tensor::createCanonicalRankReducingInsertSliceOp(
         rewriter, loc, newPackOp.getResult(), packOp.getDest());
@@ -386,9 +386,9 @@ struct Convert5DUnPackto4DUnPackPattern
     auto reducedDest = tensor::createCanonicalRankReducingExtractSliceOp(
         rewriter, loc, unpackOp.getDest(), reducedDestType);
 
-    auto newUnpackOp = rewriter.create<linalg::UnPackOp>(
-        loc, reducedSrc, reducedDest, newInnerDimsPos, unpackOp.getMixedTiles(),
-        newOuterDimsPerm);
+    auto newUnpackOp = linalg::UnPackOp::create(
+        rewriter, loc, reducedSrc, reducedDest, newInnerDimsPos,
+        unpackOp.getMixedTiles(), newOuterDimsPerm);
 
     auto insertSliceOp = tensor::createCanonicalRankReducingInsertSliceOp(
         rewriter, loc, newUnpackOp.getResult(), unpackOp.getDest());

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
@@ -126,10 +126,10 @@ struct SinkDownCollapsingUnitDimsAcrossUnpack final
     }
 
     Location loc = op.getLoc();
-    auto newDestOp = rewriter.create<tensor::EmptyOp>(
-        loc, destShape, emptyOp.getType().getElementType());
-    auto newUnpackOp = rewriter.create<linalg::UnPackOp>(
-        loc, collapseOp.getSrc(), newDestOp, innerDimPos, innerTiles);
+    auto newDestOp = tensor::EmptyOp::create(
+        rewriter, loc, destShape, emptyOp.getType().getElementType());
+    auto newUnpackOp = linalg::UnPackOp::create(
+        rewriter, loc, collapseOp.getSrc(), newDestOp, innerDimPos, innerTiles);
     SmallVector<ReassociationIndices> newRi;
     for (int64_t i = 0, e = op.getDestRank(); i < e; ++i) {
       if (i == outerRi[0]) {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -51,11 +51,11 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
     return nullptr;
 
   if (inputETy.getIntOrFloatBitWidth() > eTy.getIntOrFloatBitWidth()) {
-    return builder.create<arith::TruncFOp>(loc, type, inputs[0]);
+    return arith::TruncFOp::create(builder, loc, type, inputs[0]);
   }
 
   if (inputETy.getIntOrFloatBitWidth() < eTy.getIntOrFloatBitWidth()) {
-    return builder.create<arith::ExtFOp>(loc, type, inputs[0]);
+    return arith::ExtFOp::create(builder, loc, type, inputs[0]);
   }
 
   return nullptr;

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -256,7 +256,7 @@ struct ConvertAmdgpuFatRawBufferCast final
 
 Value materializeArithBitcast(OpBuilder &builder, Type resultTy,
                               mlir::ValueRange inputs, mlir::Location loc) {
-  return builder.create<arith::BitcastOp>(loc, resultTy, inputs);
+  return arith::BitcastOp::create(builder, loc, resultTy, inputs);
 }
 
 static void populateIreeBf16EmulationPatterns(RewritePatternSet &patterns,

--- a/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.cpp
@@ -37,8 +37,8 @@ static memref::LoadOp rebuildLoadOp(RewriterBase &rewriter,
                                     memref::LoadOp loadOp, Value srcMemRef,
                                     ArrayRef<Value> indices) {
   Location loc = loadOp.getLoc();
-  return rewriter.create<memref::LoadOp>(loc, srcMemRef, indices,
-                                         loadOp.getNontemporal());
+  return memref::LoadOp::create(rewriter, loc, srcMemRef, indices,
+                                loadOp.getNontemporal());
 }
 
 SmallVector<OpFoldResult> getLoadOpViewSizeForEachDim(RewriterBase &rewriter,
@@ -65,9 +65,8 @@ static memref::StoreOp rebuildStoreOp(RewriterBase &rewriter,
                                       memref::StoreOp storeOp, Value srcMemRef,
                                       ArrayRef<Value> indices) {
   Location loc = storeOp.getLoc();
-  return rewriter.create<memref::StoreOp>(loc, storeOp.getValueToStore(),
-                                          srcMemRef, indices,
-                                          storeOp.getNontemporal());
+  return memref::StoreOp::create(rewriter, loc, storeOp.getValueToStore(),
+                                 srcMemRef, indices, storeOp.getNontemporal());
 }
 
 SmallVector<OpFoldResult>

--- a/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
@@ -32,45 +32,45 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
 
     // Create constants.
     Type f32Type = rewriter.getF32Type();
-    auto oneF = rewriter.create<arith::ConstantOp>(
-        loc, f32Type, rewriter.getF32FloatAttr(1.0f));
+    auto oneF = arith::ConstantOp::create(rewriter, loc, f32Type,
+                                          rewriter.getF32FloatAttr(1.0f));
 
     // Get abs value.
-    Value ax = rewriter.create<math::AbsFOp>(loc, input);
+    Value ax = math::AbsFOp::create(rewriter, loc, input);
 
     // Create comparison for |x| < 1.0.
-    Value cmp = rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLT,
-                                               ax, oneF);
+    Value cmp = arith::CmpFOp::create(rewriter, loc, arith::CmpFPredicate::OLT,
+                                      ax, oneF);
 
     // Create if statement.
-    auto ifOp = rewriter.create<scf::IfOp>(loc, resultType, cmp, true);
+    auto ifOp = scf::IfOp::create(rewriter, loc, resultType, cmp, true);
 
     // --- Then region (|x| < 1.0) ---
     {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
       // Define polynomial coefficients for |x| < 1.0.
-      auto c1_0 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(-0x1.268bc2p-11f));
-      auto c1_1 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.420828p-8f));
-      auto c1_2 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(-0x1.b5937p-6f));
-      auto c1_3 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.ce077cp-4f));
-      auto c1_4 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(-0x1.81266p-2f));
-      auto c1_5 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.06eba0p-3f));
+      auto c1_0 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(-0x1.268bc2p-11f));
+      auto c1_1 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.420828p-8f));
+      auto c1_2 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(-0x1.b5937p-6f));
+      auto c1_3 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.ce077cp-4f));
+      auto c1_4 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(-0x1.81266p-2f));
+      auto c1_5 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.06eba0p-3f));
 
-      Value t = rewriter.create<arith::MulFOp>(loc, ax, ax);
-      Value mad1 = rewriter.create<math::FmaOp>(loc, t, c1_0, c1_1);
-      Value mad2 = rewriter.create<math::FmaOp>(loc, t, mad1, c1_2);
-      Value mad3 = rewriter.create<math::FmaOp>(loc, t, mad2, c1_3);
-      Value mad4 = rewriter.create<math::FmaOp>(loc, t, mad3, c1_4);
-      Value p = rewriter.create<math::FmaOp>(loc, t, mad4, c1_5);
-      Value result = rewriter.create<math::FmaOp>(loc, ax, p, ax);
-      rewriter.create<scf::YieldOp>(loc, result);
+      Value t = arith::MulFOp::create(rewriter, loc, ax, ax);
+      Value mad1 = math::FmaOp::create(rewriter, loc, t, c1_0, c1_1);
+      Value mad2 = math::FmaOp::create(rewriter, loc, t, mad1, c1_2);
+      Value mad3 = math::FmaOp::create(rewriter, loc, t, mad2, c1_3);
+      Value mad4 = math::FmaOp::create(rewriter, loc, t, mad3, c1_4);
+      Value p = math::FmaOp::create(rewriter, loc, t, mad4, c1_5);
+      Value result = math::FmaOp::create(rewriter, loc, ax, p, ax);
+      scf::YieldOp::create(rewriter, loc, result);
     } // End then region.
 
     // --- Else region (|x| >= 1.0) ---
@@ -79,38 +79,38 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
       rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
 
       // Define polynomial coefficients for |x| >= 1.0
-      auto c2_0 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.1d3156p-16f));
-      auto c2_1 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(-0x1.8d129p-12f));
-      auto c2_2 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.f9a6d2p-9f));
-      auto c2_3 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(-0x1.8c3164p-6f));
-      auto c2_4 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.b4e9c8p-4f));
-      auto c2_5 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.4515fap-1f));
-      auto c2_6 = rewriter.create<arith::ConstantOp>(
-          loc, f32Type, rewriter.getF32FloatAttr(0x1.078e50p-3f));
+      auto c2_0 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.1d3156p-16f));
+      auto c2_1 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(-0x1.8d129p-12f));
+      auto c2_2 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.f9a6d2p-9f));
+      auto c2_3 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(-0x1.8c3164p-6f));
+      auto c2_4 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.b4e9c8p-4f));
+      auto c2_5 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.4515fap-1f));
+      auto c2_6 = arith::ConstantOp::create(
+          rewriter, loc, f32Type, rewriter.getF32FloatAttr(0x1.078e50p-3f));
 
-      Value mad5 = rewriter.create<math::FmaOp>(loc, ax, c2_0, c2_1);
-      Value mad6 = rewriter.create<math::FmaOp>(loc, ax, mad5, c2_2);
-      Value mad7 = rewriter.create<math::FmaOp>(loc, ax, mad6, c2_3);
-      Value mad8 = rewriter.create<math::FmaOp>(loc, ax, mad7, c2_4);
-      Value mad9 = rewriter.create<math::FmaOp>(loc, ax, mad8, c2_5);
-      Value mad10 = rewriter.create<math::FmaOp>(loc, ax, mad9, c2_6);
+      Value mad5 = math::FmaOp::create(rewriter, loc, ax, c2_0, c2_1);
+      Value mad6 = math::FmaOp::create(rewriter, loc, ax, mad5, c2_2);
+      Value mad7 = math::FmaOp::create(rewriter, loc, ax, mad6, c2_3);
+      Value mad8 = math::FmaOp::create(rewriter, loc, ax, mad7, c2_4);
+      Value mad9 = math::FmaOp::create(rewriter, loc, ax, mad8, c2_5);
+      Value mad10 = math::FmaOp::create(rewriter, loc, ax, mad9, c2_6);
       // In the C code, there's an extra fma(ax, p, ax) here, which seems
       // incorrect based on the standard erf approximation formula and leads to
       // values > 1. The typical approximation leads directly to the exponent
-      // term. Value p2 = rewriter.create<math::FmaOp>(loc, ax, mad10, ax); //
+      // term. Value p2 = math::FmaOp::create(rewriter, loc, ax, mad10, ax); //
       // Original line based on C code.
       Value p2 = mad10; // Corrected based on typical erf formula structure for
                         // |x| >= 1
-      Value negP2 = rewriter.create<arith::NegFOp>(loc, p2);
-      Value expNegP2 = rewriter.create<math::ExpOp>(loc, negP2);
-      Value result2 = rewriter.create<arith::SubFOp>(loc, oneF, expNegP2);
-      rewriter.create<scf::YieldOp>(loc, result2);
+      Value negP2 = arith::NegFOp::create(rewriter, loc, p2);
+      Value expNegP2 = math::ExpOp::create(rewriter, loc, negP2);
+      Value result2 = arith::SubFOp::create(rewriter, loc, oneF, expNegP2);
+      scf::YieldOp::create(rewriter, loc, result2);
     } // End else region
 
     // Set insertion point after the if.
@@ -118,7 +118,7 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
 
     // Restore the sign: BUILTIN_COPYSIGN_F32(ret, x)
     Value finalResult =
-        rewriter.create<math::CopySignOp>(loc, ifOp.getResult(0), input);
+        math::CopySignOp::create(rewriter, loc, ifOp.getResult(0), input);
     // Replace the original op with our implementation.
     rewriter.replaceOp(op, finalResult);
 

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
@@ -105,10 +105,10 @@ public:
     for (const auto &it : llvm::enumerate(xferOp.getIndices())) {
       OpFoldResult offset =
           extractOp.getMixedOffsets()[it.index() + rankReduced];
-      newIndices.push_back(rewriter.create<arith::AddIOp>(
-          xferOp->getLoc(), it.value(),
-          getValueOrCreateConstantIndexOp(rewriter, extractOp.getLoc(),
-                                          offset)));
+      newIndices.push_back(
+          arith::AddIOp::create(rewriter, xferOp->getLoc(), it.value(),
+                                getValueOrCreateConstantIndexOp(
+                                    rewriter, extractOp.getLoc(), offset)));
     }
     SmallVector<bool> inBounds(xferOp.getTransferRank(), true);
     rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
@@ -316,8 +316,8 @@ public:
 
     Location loc = extractSliceOp.getLoc();
     SmallVector<OpFoldResult> mixedSizes = extractSliceOp.getMixedSizes();
-    auto init = rewriter.create<tensor::EmptyOp>(
-        loc, mixedSizes, extractSliceOp.getType().getElementType());
+    auto init = tensor::EmptyOp::create(
+        rewriter, loc, mixedSizes, extractSliceOp.getType().getElementType());
 
     auto indices = xferOp.getIndices();
 

--- a/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
@@ -70,10 +70,10 @@ static LogicalResult forallToForLoop(RewriterBase &rewriter,
       auto strides =
           llvm::map_to_vector(parallelInsert.getStrides(),
                               [&](Value v) { return map.lookupOrDefault(v); });
-      auto insertSlice = builder.create<tensor::InsertSliceOp>(
-          parallelInsert.getLoc(), source, dest, offsets, sizes, strides,
-          parallelInsert.getStaticOffsets(), parallelInsert.getStaticSizes(),
-          parallelInsert.getStaticStrides());
+      auto insertSlice = tensor::InsertSliceOp::create(
+          builder, parallelInsert.getLoc(), source, dest, offsets, sizes,
+          strides, parallelInsert.getStaticOffsets(),
+          parallelInsert.getStaticSizes(), parallelInsert.getStaticStrides());
       yieldedValues.push_back(insertSlice.getResult());
     }
     return yieldedValues;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
@@ -147,9 +147,9 @@ decomposeHorizontallyFusedGemmOperations(RewriterBase &rewriter,
         inputs, [](OpOperand *operand) { return operand->get(); });
     SmallVector<Value> initVals = llvm::map_to_vector(
         inits, [](OpOperand *operand) { return operand->get(); });
-    auto newOp = rewriter.create<linalg::GenericOp>(
-        linalgOp.getLoc(), TypeRange{inits[0]->get().getType()}, inputVals,
-        initVals, indexingMaps, iteratorTypes,
+    auto newOp = linalg::GenericOp::create(
+        rewriter, linalgOp.getLoc(), TypeRange{inits[0]->get().getType()},
+        inputVals, initVals, indexingMaps, iteratorTypes,
         [&](OpBuilder &b, Location loc, ValueRange blockArgs) {
           Block *oldBody = linalgOp.getBlock();
           usedInputs.insert(resultNumber + linalgOp.getNumDpsInputs());
@@ -166,7 +166,7 @@ decomposeHorizontallyFusedGemmOperations(RewriterBase &rewriter,
             b.clone(*usedOperation, regionMapping);
           }
 
-          b.create<linalg::YieldOp>(loc, regionMapping.lookup(result));
+          linalg::YieldOp::create(b, loc, regionMapping.lookup(result));
         });
 
     // If on decomposition any dims are unused propagating lowering config isnt

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -78,8 +78,9 @@ struct BubbleResourceCastPattern
               }
 
               rewriter.setInsertionPoint(extract);
-              auto newCast = rewriter.create<IREE::GPU::BufferResourceCastOp>(
-                  loc, extract.getSource().getType(), extract.getSource());
+              auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                  rewriter, loc, extract.getSource().getType(),
+                  extract.getSource());
               extract.getSourceMutable().assign(newCast);
               return true;
             })
@@ -89,8 +90,8 @@ struct BubbleResourceCastPattern
               }
 
               rewriter.setInsertionPoint(expand);
-              auto newCast = rewriter.create<IREE::GPU::BufferResourceCastOp>(
-                  loc, expand.getSrcType(), expand.getSrc());
+              auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                  rewriter, loc, expand.getSrcType(), expand.getSrc());
               expand.getSrcMutable().assign(newCast);
               return true;
             })
@@ -101,9 +102,8 @@ struct BubbleResourceCastPattern
                   }
 
                   rewriter.setInsertionPoint(collapse);
-                  auto newCast =
-                      rewriter.create<IREE::GPU::BufferResourceCastOp>(
-                          loc, collapse.getSrcType(), collapse.getSrc());
+                  auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                      rewriter, loc, collapse.getSrcType(), collapse.getSrc());
                   collapse.getSrcMutable().assign(newCast);
                   return true;
                 })
@@ -113,8 +113,8 @@ struct BubbleResourceCastPattern
               }
 
               rewriter.setInsertionPoint(pad);
-              auto newCast = rewriter.create<IREE::GPU::BufferResourceCastOp>(
-                  loc, pad.getSourceType(), pad.getSource());
+              auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                  rewriter, loc, pad.getSourceType(), pad.getSource());
               pad.getSourceMutable().assign(newCast);
               return true;
             })
@@ -126,8 +126,9 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(linalgOp);
               // Only propagate to input operands.
               for (auto inputOperand : linalgOp.getDpsInputOperands()) {
-                auto newCast = rewriter.create<IREE::GPU::BufferResourceCastOp>(
-                    loc, inputOperand->get().getType(), inputOperand->get());
+                auto newCast = IREE::GPU::BufferResourceCastOp::create(
+                    rewriter, loc, inputOperand->get().getType(),
+                    inputOperand->get());
                 inputOperand->assign(newCast);
               }
               return true;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineValueBarriers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineValueBarriers.cpp
@@ -81,7 +81,7 @@ combineValueBarrierOps(RewriterBase &rewriter, Location loc,
                            barrierOp.getInputs().end());
   }
   auto combinedBarrierOp =
-      rewriter.create<IREE::GPU::ValueBarrierOp>(loc, barrierOperands);
+      IREE::GPU::ValueBarrierOp::create(rewriter, loc, barrierOperands);
 
   // Replace all uses of the previous barrier with new barrier.
   int resultNumber = 0;
@@ -194,8 +194,8 @@ combineValueBarrierPair(RewriterBase &rewriter,
   barrierOperands.append(barrierB.getOperands().begin(),
                          barrierB.getOperands().end());
 
-  auto combinedBarrierOp = rewriter.create<IREE::GPU::ValueBarrierOp>(
-      barrierB.getLoc(), barrierOperands);
+  auto combinedBarrierOp = IREE::GPU::ValueBarrierOp::create(
+      rewriter, barrierB.getLoc(), barrierOperands);
 
   int numOperandsA = barrierA.getNumOperands();
   int numOperandsB = barrierB.getNumOperands();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
@@ -45,7 +45,7 @@ DiagnosedSilenceableFailure static mapNestedForallToThreadsImpl(
 
   // Create an early zero index value for replacements.
   Location loc = target->getLoc();
-  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
   DiagnosedSilenceableFailure diag = DiagnosedSilenceableFailure::success();
   WalkResult walkResult = target->walk([&](scf::ForallOp forallOp) {
     diag = mlir::transform::gpu::mapOneForallToThreadsImpl(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -45,8 +45,8 @@ struct DistributeConstants final : OpDistributionPattern<arith::ConstantOp> {
     Type elementType = constant.getType().getElementType();
     auto vectorType =
         VectorType::get(layout.getDistributedShape(), elementType);
-    auto distributedOp = rewriter.create<arith::ConstantOp>(
-        constantOp.getLoc(), vectorType,
+    auto distributedOp = arith::ConstantOp::create(
+        rewriter, constantOp.getLoc(), vectorType,
         SplatElementsAttr::get(vectorType, attr.getSplatValue<Attribute>()));
     replaceOpWithDistributedValues(rewriter, constantOp,
                                    distributedOp->getResult(0));
@@ -176,9 +176,9 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
       newInitArgs.push_back(initArg);
     }
 
-    auto newForOp = rewriter.create<scf::ForOp>(
-        forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
-        forOp.getStep(), newInitArgs);
+    auto newForOp =
+        scf::ForOp::create(rewriter, forOp.getLoc(), forOp.getLowerBound(),
+                           forOp.getUpperBound(), forOp.getStep(), newInitArgs);
     newForOp->setAttrs(forOp->getAttrs());
     Block *loopBody = newForOp.getBody();
 
@@ -225,7 +225,7 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
     // Since this operation has no results, we can directly replace it using
     // the standard API.
     auto distributedYieldOp =
-        rewriter.create<scf::YieldOp>(yieldOp.getLoc(), operands);
+        scf::YieldOp::create(rewriter, yieldOp.getLoc(), operands);
     rewriter.replaceOp(yieldOp, distributedYieldOp);
     return success();
   }
@@ -240,8 +240,8 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
     for (auto [bbArg, oldInit] : llvm::zip_equal(bbArgs, oldInits)) {
       Value val = bbArg;
       if (auto oldVectorInit = dyn_cast<VectorValue>(oldInit)) {
-        val = rewriter.create<IREE::VectorExt::ToSIMDOp>(
-            oldVectorInit.getLoc(), oldVectorInit.getType(), val);
+        val = IREE::VectorExt::ToSIMDOp::create(
+            rewriter, oldVectorInit.getLoc(), oldVectorInit.getType(), val);
       }
       replacements.push_back(val);
     }
@@ -316,8 +316,8 @@ struct DistributeGather final : OpDistributionPattern<vector::GatherOp> {
     VectorType distributedType = VectorType::get(distributedShape, elementType);
 
     // Simply distribute all operands and results.
-    VectorValue distributed = rewriter.create<vector::GatherOp>(
-        gatherOp.getLoc(), distributedType, gatherOp.getBase(),
+    VectorValue distributed = vector::GatherOp::create(
+        rewriter, gatherOp.getLoc(), distributedType, gatherOp.getBase(),
         gatherOp.getOffsets(),
         getDistributed(rewriter, indexVec, indicesLayout),
         getDistributed(rewriter, mask, maskLayout),
@@ -344,9 +344,9 @@ struct DistributeTrivialExtract final
     VectorValue source = extractOp.getVector();
     VectorLayoutInterface sourceLayout = signature[source];
 
-    Value distributed = rewriter.create<vector::ExtractOp>(
-        extractOp.getLoc(), getDistributed(rewriter, source, sourceLayout),
-        ArrayRef<int64_t>{});
+    Value distributed = vector::ExtractOp::create(
+        rewriter, extractOp.getLoc(),
+        getDistributed(rewriter, source, sourceLayout), ArrayRef<int64_t>{});
 
     replaceOpWithDistributedValues(rewriter, extractOp, distributed);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -191,26 +191,26 @@ struct PackDestinationForOp final : OpRewritePattern<scf::YieldOp> {
         packOp.getMixedTiles(), packOp.getInnerDimsPos(),
         packOp.getOuterDimsPerm());
 
-    auto packedDest = rewriter.create<linalg::PackOp>(
-        loc, forOp.getInitArgs()[tiedResultIdx], input,
+    auto packedDest = linalg::PackOp::create(
+        rewriter, loc, forOp.getInitArgs()[tiedResultIdx], input,
         packOp.getInnerDimsPos(), packOp.getMixedTiles(),
         packOp.getPaddingValue(), packOp.getOuterDimsPerm());
 
     auto packOpValues = llvm::to_vector_of<Value>(forOp.getInitArgs());
     packOpValues[tiedResultIdx] = packedDest.getResult();
-    scf::ForOp newForOp = rewriter.create<scf::ForOp>(
-        loc, forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
-        packOpValues);
+    scf::ForOp newForOp = scf::ForOp::create(
+        rewriter, loc, forOp.getLowerBound(), forOp.getUpperBound(),
+        forOp.getStep(), packOpValues);
 
     // Destination tensor for the new unpackOp, based on the shape of the
     // original tensor that got packed, to help unpack into unaligned shapes and
     // drop padding added by the packOp.
-    Value empty = rewriter.create<tensor::EmptyOp>(
-        loc, packOp.getSourceType().getShape(),
+    Value empty = tensor::EmptyOp::create(
+        rewriter, loc, packOp.getSourceType().getShape(),
         packOp.getSourceType().getElementType());
 
-    auto unpackedOutput = rewriter.create<linalg::UnPackOp>(
-        loc, newForOp.getResults()[tiedResultIdx], empty,
+    auto unpackedOutput = linalg::UnPackOp::create(
+        rewriter, loc, newForOp.getResults()[tiedResultIdx], empty,
         unpackOp.getInnerDimsPos(), unpackOp.getMixedTiles(),
         unpackOp.getOuterDimsPerm());
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -123,15 +123,17 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
         llvm::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
             vectorShapeCollapse, sourceType, subViewOffsets, subViewSizes,
             subViewStrides));
-    Value subView = rewriter.create<memref::SubViewOp>(
-        loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value readCollapse = rewriter.create<vector::TransferReadOp>(
-        loc, vectorTypeCollapse, subView, ValueRange{c0, c0}, newidentityMap,
-        transferReadOp.getPadding(), transferReadOp.getMask(), newInBoundsAttr);
+    Value subView =
+        memref::SubViewOp::create(rewriter, loc, resultType, source,
+                                  subViewOffsets, subViewSizes, subViewStrides);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value readCollapse = vector::TransferReadOp::create(
+        rewriter, loc, vectorTypeCollapse, subView, ValueRange{c0, c0},
+        newidentityMap, transferReadOp.getPadding(), transferReadOp.getMask(),
+        newInBoundsAttr);
 
-    Value readBroadcast = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTypeBroadcast, readCollapse);
+    Value readBroadcast = vector::BroadcastOp::create(
+        rewriter, loc, vectorTypeBroadcast, readCollapse);
     SmallVector<int64_t> transposePermutation;
     for (int i = 0; i < vectorType.getRank(); i++) {
       if (i == vectorType.getRank() - 2)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -80,20 +80,20 @@ static Operation *replaceOpWithPredicatedOp(RewriterBase &rewriter,
   // Create srcElement Value based on the pred.
   // The next few lins generate the below code:
   // srcElement = (pred) ?  prevSrcElements : 0;
-  Value dstElements =
-      rewriter.create<arith::ConstantOp>(loc, asyncCopyOp.getDstElementsAttr());
+  Value dstElements = arith::ConstantOp::create(
+      rewriter, loc, asyncCopyOp.getDstElementsAttr());
   Value originalSrcElement =
       asyncCopyOp.getSrcElements() ? asyncCopyOp.getSrcElements() : dstElements;
-  Value c0Index = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0Index = arith::ConstantIndexOp::create(rewriter, loc, 0);
   auto srcElements =
-      rewriter.create<arith::SelectOp>(loc, pred, originalSrcElement, c0Index);
+      arith::SelectOp::create(rewriter, loc, pred, originalSrcElement, c0Index);
   int64_t sizeInBytes =
       (asyncCopyOp.getDst().getType().getElementTypeBitWidth() *
        asyncCopyOp.getDstElements().getZExtValue()) /
       8;
   UnitAttr bypassL1 = sizeInBytes == 16 ? rewriter.getUnitAttr() : UnitAttr();
-  auto asyncCopyZfillOp = rewriter.create<nvgpu::DeviceAsyncCopyOp>(
-      loc, nvgpu::DeviceAsyncTokenType::get(asyncCopyOp.getContext()),
+  auto asyncCopyZfillOp = nvgpu::DeviceAsyncCopyOp::create(
+      rewriter, loc, nvgpu::DeviceAsyncTokenType::get(asyncCopyOp.getContext()),
       asyncCopyOp.getDst(), asyncCopyOp.getDstIndices(), asyncCopyOp.getSrc(),
       asyncCopyOp.getSrcIndices(), asyncCopyOp.getDstElements(), srcElements,
       bypassL1);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -65,11 +65,12 @@ static void padAlloc(MLIRContext *context, memref::AllocOp allocOp,
   IRRewriter rewriter(context);
   rewriter.setInsertionPoint(allocOp);
   Location loc = allocOp.getLoc();
-  Value paddedAlloc = rewriter.create<memref::AllocOp>(loc, allocType);
+  Value paddedAlloc = memref::AllocOp::create(rewriter, loc, allocType);
   SmallVector<int64_t> offsets(shape.size(), 0);
   SmallVector<int64_t> strides(shape.size(), 1);
-  Value subview = rewriter.create<memref::SubViewOp>(
-      loc, paddedAlloc, offsets, allocOp.getType().getShape(), strides);
+  Value subview =
+      memref::SubViewOp::create(rewriter, loc, paddedAlloc, offsets,
+                                allocOp.getType().getShape(), strides);
   replaceMemrefUsesAndPropagateType(rewriter, loc, allocOp, subview);
   rewriter.eraseOp(allocOp);
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReuseSharedMemoryAllocs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReuseSharedMemoryAllocs.cpp
@@ -254,7 +254,7 @@ struct GPUReuseSharedMemoryAllocsPass final
         // Add a barrier if the `otherLiveness` comes before `liveness`.
         if (dominanceInfo.dominates(otherLiveness.first, liveness.first)) {
           builder.setInsertionPoint(liveness.first);
-          builder.create<gpu::BarrierOp>(liveness.first->getLoc());
+          gpu::BarrierOp::create(builder, liveness.first->getLoc());
           break;
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -116,8 +116,9 @@ struct SwapAllocTensorPattern final
 
     rewriter.setInsertionPoint(linalgOp);
     std::optional<Attribute> memorySpace = allocOp.getMemorySpace();
-    auto newAllocOp = rewriter.create<bufferization::AllocTensorOp>(
-        allocOp.getLoc(), allocOp.getType(), allocOp.getDynamicSizes(),
+    auto newAllocOp = bufferization::AllocTensorOp::create(
+        rewriter, allocOp.getLoc(), allocOp.getType(),
+        allocOp.getDynamicSizes(),
         /*copy=*/Value(),
         memorySpace ? cast<IntegerAttr>(*memorySpace) : IntegerAttr());
     rewriter.modifyOpInPlace(linalgOp, [&]() {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
@@ -82,8 +82,8 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
   newIndexingMaps.push_back(filterMap);
   newIndexingMaps.push_back(indexingMaps[2]);
   // Create the new contraction op and replace the old convolution op.
-  auto newOp = rewriter.create<linalg::GenericOp>(
-      linalgOp.getLoc(), linalgOp.getDpsInits().getType(),
+  auto newOp = linalg::GenericOp::create(
+      rewriter, linalgOp.getLoc(), linalgOp.getDpsInits().getType(),
       linalgOp.getDpsInputs(), linalgOp.getDpsInits(), newIndexingMaps,
       linalgOp.getIteratorTypesArray(), /*bodyBuild=*/nullptr,
       getPrunedAttributeList(linalgOp));

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -139,8 +139,8 @@ DistributionPattern::getDistributed(RewriterBase &rewriter, VectorValue value,
   SmallVector<int64_t> distributedShape = layout.getDistributedShape();
   VectorType distributedType =
       VectorType::get(distributedShape, value.getType().getElementType());
-  auto toSIMT = rewriter.create<IREE::VectorExt::ToSIMTOp>(
-      value.getLoc(), distributedType, value);
+  auto toSIMT = IREE::VectorExt::ToSIMTOp::create(rewriter, value.getLoc(),
+                                                  distributedType, value);
   return toSIMT.getResult();
 }
 
@@ -154,8 +154,8 @@ SmallVector<Value> DistributionPattern::getOpDistributedReplacements(
       auto oldResult = cast<VectorValue>(opResult);
       // Create a toSIMD op to convert the value back to the simd.
       rewriter.setInsertionPointAfterValue(oldResult);
-      Value toSIMD = rewriter.create<IREE::VectorExt::ToSIMDOp>(
-          oldResult.getLoc(), oldResult.getType(), replacement);
+      Value toSIMD = IREE::VectorExt::ToSIMDOp::create(
+          rewriter, oldResult.getLoc(), oldResult.getType(), replacement);
       // Add to replacements.
       replacement = toSIMD;
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -53,7 +53,7 @@ static Value allocateGlobalSharedMemory(Location loc, OpBuilder &builder,
     memrefType = MemRefType::get({1}, type, MemRefLayoutAttrInterface{},
                                  addressSpaceAttr);
   }
-  return builder.create<memref::AllocOp>(loc, memrefType);
+  return memref::AllocOp::create(builder, loc, memrefType);
 }
 
 /// Returns true if the given op is a memref.load from a uniform buffer or
@@ -177,7 +177,7 @@ struct WarpOpBarrier final : OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
       return failure();
 
     rewriter.setInsertionPointAfter(warpOp);
-    (void)rewriter.create<gpu::BarrierOp>(barrierOp.getLoc());
+    (void)gpu::BarrierOp::create(rewriter, barrierOp.getLoc());
     rewriter.eraseOp(barrierOp);
     return success();
   }
@@ -189,9 +189,9 @@ static Value simpleWarpShuffleFunction(Location loc, OpBuilder &builder,
   assert((val.getType().isF32() || val.getType().isInteger(32)) &&
          "unsupported shuffle type");
   Type i32Type = builder.getIntegerType(32);
-  Value srcIdxI32 = builder.create<arith::IndexCastOp>(loc, i32Type, srcIdx);
-  Value warpSzI32 = builder.create<arith::ConstantOp>(
-      loc, builder.getIntegerAttr(i32Type, warpSz));
+  Value srcIdxI32 = arith::IndexCastOp::create(builder, loc, i32Type, srcIdx);
+  Value warpSzI32 = arith::ConstantOp::create(
+      builder, loc, builder.getIntegerAttr(i32Type, warpSz));
   Value result = builder
                      .create<gpu::ShuffleOp>(loc, val, srcIdxI32, warpSzI32,
                                              gpu::ShuffleMode::IDX)
@@ -237,11 +237,11 @@ struct VectorReductionToGPUPass final
     const int groupSize = workgroupSize[0];
     Location loc = funcOp.getLoc();
     OpBuilder builder(funcOp);
-    auto threadX = builder.create<gpu::ThreadIdOp>(loc, builder.getIndexType(),
-                                                   gpu::Dimension::x);
-    auto cstGroupSize = builder.create<arith::ConstantIndexOp>(loc, groupSize);
-    auto warpOp = builder.create<gpu::WarpExecuteOnLane0Op>(
-        loc, TypeRange(), threadX.getResult(), groupSize);
+    auto threadX = gpu::ThreadIdOp::create(builder, loc, builder.getIndexType(),
+                                           gpu::Dimension::x);
+    auto cstGroupSize = arith::ConstantIndexOp::create(builder, loc, groupSize);
+    auto warpOp = gpu::WarpExecuteOnLane0Op::create(
+        builder, loc, TypeRange(), threadX.getResult(), groupSize);
     warpOp.getWarpRegion().takeBody(funcOp.getFunctionBody());
     Block &newBlock = funcOp.getFunctionBody().emplaceBlock();
     threadX->moveBefore(&newBlock, newBlock.end());
@@ -250,7 +250,7 @@ struct VectorReductionToGPUPass final
     warpOp.getWarpRegion().getBlocks().back().back().moveBefore(&newBlock,
                                                                 newBlock.end());
     builder.setInsertionPointToEnd(&warpOp.getWarpRegion().getBlocks().back());
-    builder.create<gpu::YieldOp>(loc);
+    gpu::YieldOp::create(builder, loc);
 
     debugPrint(funcOp, "after step #2: wrapping code with the warp execute op");
 
@@ -308,7 +308,7 @@ struct VectorReductionToGPUPass final
       options.warpAllocationFn = allocateGlobalSharedMemory;
       options.warpSyncronizationFn = [](Location loc, OpBuilder &builder,
                                         gpu::WarpExecuteOnLane0Op warpOp) {
-        builder.create<gpu::BarrierOp>(loc);
+        gpu::BarrierOp::create(builder, loc);
       };
       vector::populateWarpExecuteOnLane0OpToScfForPattern(patterns, options);
       (void)applyPatternsGreedily(getOperation(), std::move(patterns));

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -34,10 +34,10 @@ static std::pair<Value, Value> makeTransposedIds(Location loc, OpBuilder b,
                                                  Value workgroupCountX,
                                                  Value workgroupCountY) {
   Value linearized =
-      b.create<arith::MulIOp>(loc, workgroupIdY, workgroupCountX);
-  linearized = b.create<arith::AddIOp>(loc, linearized, workgroupIdX);
-  Value newX = b.create<arith::DivUIOp>(loc, linearized, workgroupCountY);
-  Value newY = b.create<arith::RemUIOp>(loc, linearized, workgroupCountY);
+      arith::MulIOp::create(b, loc, workgroupIdY, workgroupCountX);
+  linearized = arith::AddIOp::create(b, loc, linearized, workgroupIdX);
+  Value newX = arith::DivUIOp::create(b, loc, linearized, workgroupCountY);
+  Value newY = arith::RemUIOp::create(b, loc, linearized, workgroupCountY);
   return {newX, newY};
 }
 
@@ -55,17 +55,17 @@ getWorkgroupCountsXY(OpBuilder &builder, FunctionOpInterface funcOp,
                << "Using static workgroup counts: X = " << workgroupCounts[0]
                << ", Y = " << workgroupCounts[1] << "\n");
     Value workgroupCountX =
-        builder.create<arith::ConstantIndexOp>(loc, workgroupCounts[0]);
+        arith::ConstantIndexOp::create(builder, loc, workgroupCounts[0]);
     Value workgroupCountY =
-        builder.create<arith::ConstantIndexOp>(loc, workgroupCounts[1]);
+        arith::ConstantIndexOp::create(builder, loc, workgroupCounts[1]);
     return {workgroupCountX, workgroupCountY};
   }
 
   LLVM_DEBUG(llvm::dbgs() << "Using dynamic workgroup counts\n");
   Value dynamicCountX =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(loc, 0, xBound);
+      IREE::HAL::InterfaceWorkgroupCountOp::create(builder, loc, 0, xBound);
   Value dynamicCountY =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(loc, 1, yBound);
+      IREE::HAL::InterfaceWorkgroupCountOp::create(builder, loc, 1, yBound);
   return {dynamicCountX, dynamicCountY};
 }
 
@@ -101,10 +101,10 @@ reorderWorkgroupsInFunc(FunctionOpInterface funcOp,
   // that to RAUW the old ones. This way we don't have to worry about the
   // picking the exact insertion points that do not violate dominance between
   // their defs and users.
-  Value workgroupIdX = builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(
-      funcOp.getLoc(), 0, oldXId.getUpperBound());
-  Value workgroupIdY = builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(
-      funcOp.getLoc(), 1, oldYId.getUpperBound());
+  Value workgroupIdX = IREE::HAL::InterfaceWorkgroupIDOp::create(
+      builder, funcOp.getLoc(), 0, oldXId.getUpperBound());
+  Value workgroupIdY = IREE::HAL::InterfaceWorkgroupIDOp::create(
+      builder, funcOp.getLoc(), 1, oldYId.getUpperBound());
   auto [workgroupCntX, workgroupCntY] = getWorkgroupCountsXY(
       builder, funcOp, oldXId.getUpperBound(), oldYId.getUpperBound());
   Value newWorkgroupIdX;

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -65,7 +65,7 @@ static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
       type = MemRefType::get(type.getShape(), type.getElementType(),
                              type.getLayout());
   }
-  return builder.create<memref::AllocOp>(loc, type, dynamicSizes).getResult();
+  return memref::AllocOp::create(builder, loc, type, dynamicSizes).getResult();
 }
 static LogicalResult defaultMemCpyFn(OpBuilder &builder, Location loc,
                                      Value from, Value to) {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -202,11 +202,11 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
       newBufferType = MemRefType::get(
           staticLinearShape, memRefType.getElementType(),
           MemRefLayoutAttrInterface(), memRefType.getMemorySpace());
-      Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-      newBinding = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-          loc, newBufferType, binding.getLayoutAttr(), binding.getBindingAttr(),
-          zero, dynamicLinearShape, binding.getAlignmentAttr(),
-          binding.getDescriptorFlagsAttr());
+      Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      newBinding = IREE::HAL::InterfaceBindingSubspanOp::create(
+          rewriter, loc, newBufferType, binding.getLayoutAttr(),
+          binding.getBindingAttr(), zero, dynamicLinearShape,
+          binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);
@@ -215,8 +215,8 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
       if (newBufferType == baseBufferType) {
         results.push_back(newBinding);
       } else {
-        Value reinterpretCast = rewriter.create<memref::ReinterpretCastOp>(
-            loc, baseBufferType, newBinding, /*offset=*/0,
+        Value reinterpretCast = memref::ReinterpretCastOp::create(
+            rewriter, loc, baseBufferType, newBinding, /*offset=*/0,
             /*sizes=*/ArrayRef<int64_t>(),
             /*strides=*/ArrayRef<int64_t>());
         results.push_back(reinterpretCast);

--- a/compiler/src/iree/compiler/Codegen/Common/IREEInjectAssumeAlignment.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEInjectAssumeAlignment.cpp
@@ -41,8 +41,8 @@ LogicalResult InjectAssumeAlignmentForSubspanOp::matchAndRewrite(
   }
   Location loc = op.getLoc();
   rewriter.setInsertionPointAfter(op);
-  auto alignOp = rewriter.create<memref::AssumeAlignmentOp>(
-      loc, op.getResult(), op.calculateAlignment().value());
+  auto alignOp = memref::AssumeAlignmentOp::create(
+      rewriter, loc, op.getResult(), op.calculateAlignment().value());
   rewriter.replaceAllUsesExcept(op.getResult(), alignOp.getResult(), alignOp);
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
@@ -42,41 +42,37 @@ struct InstrumentMemoryAccessesPass
           .Case<memref::LoadOp>([&](auto loadOp) {
             OpBuilder builder(loadOp);
             builder.setInsertionPointAfter(loadOp);
-            auto instrumentOp =
-                builder.create<IREE::HAL::InstrumentMemoryLoadOp>(
-                    loadOp.getLoc(), loadOp.getResult().getType(), buffer,
-                    workgroupKey, loadOp.getResult(), loadOp.getMemRef(),
-                    loadOp.getIndices());
+            auto instrumentOp = IREE::HAL::InstrumentMemoryLoadOp::create(
+                builder, loadOp.getLoc(), loadOp.getResult().getType(), buffer,
+                workgroupKey, loadOp.getResult(), loadOp.getMemRef(),
+                loadOp.getIndices());
             loadOp.getResult().replaceAllUsesExcept(instrumentOp.getResult(),
                                                     instrumentOp);
           })
           .Case<memref::StoreOp>([&](auto storeOp) {
             OpBuilder builder(storeOp);
-            auto instrumentOp =
-                builder.create<IREE::HAL::InstrumentMemoryStoreOp>(
-                    storeOp.getLoc(), storeOp.getValueToStore().getType(),
-                    buffer, workgroupKey, storeOp.getValueToStore(),
-                    storeOp.getMemRef(), storeOp.getIndices());
+            auto instrumentOp = IREE::HAL::InstrumentMemoryStoreOp::create(
+                builder, storeOp.getLoc(), storeOp.getValueToStore().getType(),
+                buffer, workgroupKey, storeOp.getValueToStore(),
+                storeOp.getMemRef(), storeOp.getIndices());
             storeOp.getValueMutable().assign(instrumentOp.getResult());
           })
           .Case<vector::LoadOp>([&](auto loadOp) {
             OpBuilder builder(loadOp);
             builder.setInsertionPointAfter(loadOp);
-            auto instrumentOp =
-                builder.create<IREE::HAL::InstrumentMemoryLoadOp>(
-                    loadOp.getLoc(), loadOp.getVectorType(), buffer,
-                    workgroupKey, loadOp.getResult(), loadOp.getBase(),
-                    loadOp.getIndices());
+            auto instrumentOp = IREE::HAL::InstrumentMemoryLoadOp::create(
+                builder, loadOp.getLoc(), loadOp.getVectorType(), buffer,
+                workgroupKey, loadOp.getResult(), loadOp.getBase(),
+                loadOp.getIndices());
             loadOp.getResult().replaceAllUsesExcept(instrumentOp.getResult(),
                                                     instrumentOp);
           })
           .Case<vector::StoreOp>([&](auto storeOp) {
             OpBuilder builder(storeOp);
-            auto instrumentOp =
-                builder.create<IREE::HAL::InstrumentMemoryStoreOp>(
-                    storeOp.getLoc(), storeOp.getVectorType(), buffer,
-                    workgroupKey, storeOp.getValueToStore(), storeOp.getBase(),
-                    storeOp.getIndices());
+            auto instrumentOp = IREE::HAL::InstrumentMemoryStoreOp::create(
+                builder, storeOp.getLoc(), storeOp.getVectorType(), buffer,
+                workgroupKey, storeOp.getValueToStore(), storeOp.getBase(),
+                storeOp.getIndices());
             storeOp.getValueToStoreMutable().assign(instrumentOp.getResult());
           })
           .Default([&](Operation *) {});

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -282,10 +282,10 @@ static NamedSequenceOp createKernelConfigOp(OpBuilder &builder, Location loc,
   //   transform.yield %arg0 : !transform.any_op
   // }
 
-  return builder.create<NamedSequenceOp>(loc, name, TypeAttr::get(specType),
-                                         /*sym_visibility=*/StringAttr{},
-                                         /*arg_attrs=*/ArrayAttr{},
-                                         /*res_attrs=*/ArrayAttr{});
+  return NamedSequenceOp::create(builder, loc, name, TypeAttr::get(specType),
+                                 /*sym_visibility=*/StringAttr{},
+                                 /*arg_attrs=*/ArrayAttr{},
+                                 /*res_attrs=*/ArrayAttr{});
 }
 
 static FailureOr<NamedSequenceOp>
@@ -363,7 +363,7 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
                   .front();
   }
 
-  builder.create<transform::YieldOp>(loc, operand);
+  transform::YieldOp::create(builder, loc, operand);
 
   if (failed(mlir::verify(module))) {
     return module.emitError("Linked tuning spec failed to verify");
@@ -442,13 +442,13 @@ static FailureOr<NamedSequenceOp> emitLinkedDefaultTuningSpec(ModuleOp module) {
   Block *body = builder.createBlock(&region, region.begin(),
                                     newEntryPoint.getArgumentTypes(), loc);
   builder.setInsertionPointToStart(body);
-  auto mergedForeachMatch = builder.create<ForeachMatchOp>(
-      loc, resultTypes, newEntryPoint.getArgument(0),
+  auto mergedForeachMatch = ForeachMatchOp::create(
+      builder, loc, resultTypes, newEntryPoint.getArgument(0),
       /* forwarded_inputs = */ ValueRange(),
       /* restrictRoot = */ nullptr, /* flattenResults = */ nullptr,
       builder.getArrayAttr(mergedMatchers),
       builder.getArrayAttr(mergedActions));
-  builder.create<transform::YieldOp>(loc, mergedForeachMatch->getResult(0));
+  transform::YieldOp::create(builder, loc, mergedForeachMatch->getResult(0));
 
   // Step 3: Remove the original inner modules after merging.
   for (auto innerModule :

--- a/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerUKernelDescriptors.cpp
@@ -56,7 +56,7 @@ static void populateCastConversions(TypeConverter &converter) {
     if (!inputTy || !CastOpTy::areCastCompatible(inputTy, resultType)) {
       return Value();
     }
-    return builder.create<CastOpTy>(loc, resultType, input).getResult();
+    return CastOpTy::create(builder, loc, resultType, input).getResult();
   });
   converter.addTargetMaterialization([](OpBuilder &builder, TargetTy resultType,
                                         ValueRange inputs,
@@ -69,7 +69,7 @@ static void populateCastConversions(TypeConverter &converter) {
     if (!inputTy || !CastOpTy::areCastCompatible(inputTy, resultType)) {
       return Value();
     }
-    return builder.create<CastOpTy>(loc, resultType, input).getResult();
+    return CastOpTy::create(builder, loc, resultType, input).getResult();
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
@@ -154,8 +154,8 @@ LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
   }
 
   rewriter.setInsertionPointAfter(forallOp);
-  auto newLoop = rewriter.create<scf::ForallOp>(
-      rewriter.getUnknownLoc(), newLoopParams->lowerBounds,
+  auto newLoop = scf::ForallOp::create(
+      rewriter, rewriter.getUnknownLoc(), newLoopParams->lowerBounds,
       newLoopParams->upperBounds, newLoopParams->steps, forallOp.getOutputs(),
       forallOp.getMapping());
   rewriter.eraseOp(newLoop.getTerminator());

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -337,8 +337,8 @@ struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
            "GenericVectorization.cpp::FoldMaskedTransferRAW for information");
 
     // Materialize the padding with a constant.
-    auto padVal = rewriter.create<vector::BroadcastOp>(
-        rPad.getLoc(), valToStore.getType(), rPad);
+    auto padVal = vector::BroadcastOp::create(rewriter, rPad.getLoc(),
+                                              valToStore.getType(), rPad);
     rewriter.replaceOpWithNewOp<arith::SelectOp>(op, wMask, valToStore, padVal);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
@@ -95,11 +95,11 @@ static LogicalResult padAlloc(MLIRContext *context, AllocLikeOp allocOp,
   MemRefType allocType = MemRefType::get(shape, elType, AffineMap(),
                                          allocOp.getType().getMemorySpace());
   Location loc = allocOp.getLoc();
-  Value paddedAlloc = rewriter.create<AllocLikeOp>(loc, allocType);
+  Value paddedAlloc = AllocLikeOp::create(rewriter, loc, allocType);
   SmallVector<OpFoldResult> offsets(shape.size(), rewriter.getIndexAttr(0));
   SmallVector<OpFoldResult> strides(shape.size(), rewriter.getIndexAttr(1));
-  Value subview = rewriter.create<memref::SubViewOp>(loc, paddedAlloc, offsets,
-                                                     sizes, strides);
+  Value subview = memref::SubViewOp::create(rewriter, loc, paddedAlloc, offsets,
+                                            sizes, strides);
   replaceMemrefUsesAndPropagateType(rewriter, loc, allocOp, subview);
   rewriter.eraseOp(allocOp);
   return success();

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
@@ -81,10 +81,10 @@ struct ExtractConstantApplyOffset final
 
     AffineMap newMap =
         AffineMap::get(map.getNumDims(), map.getNumSymbols(), addExpr.getLHS());
-    Value newApply = rewriter.create<affine::AffineApplyOp>(
-        apply.getLoc(), newMap, apply.getOperands());
-    Value offset =
-        rewriter.create<arith::ConstantIndexOp>(apply.getLoc(), constantOffset);
+    Value newApply = affine::AffineApplyOp::create(rewriter, apply.getLoc(),
+                                                   newMap, apply.getOperands());
+    Value offset = arith::ConstantIndexOp::create(rewriter, apply.getLoc(),
+                                                  constantOffset);
     rewriter.replaceOpWithNewOp<arith::AddIOp>(
         apply, newApply, offset, arith::IntegerOverflowFlags::nsw);
     return success();
@@ -159,7 +159,7 @@ struct PropagateConstantAddsThroughLinearize final
     auto getZero = [&]() {
       if (zero)
         return zero;
-      zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      zero = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
       return zero;
     };
     bool didReplace = false;
@@ -220,9 +220,10 @@ struct PropagateConstantAddsThroughLinearize final
 
     rewriter.setInsertionPointAfter(op);
     Value offset =
-        rewriter.create<arith::ConstantIndexOp>(op.getLoc(), runningOffset);
-    auto addOp = rewriter.create<arith::AddIOp>(
-        op.getLoc(), op.getResult(), offset, arith::IntegerOverflowFlags::nsw);
+        arith::ConstantIndexOp::create(rewriter, op.getLoc(), runningOffset);
+    auto addOp =
+        arith::AddIOp::create(rewriter, op.getLoc(), op.getResult(), offset,
+                              arith::IntegerOverflowFlags::nsw);
     rewriter.replaceAllUsesExcept(op, addOp, addOp);
     return success();
   }
@@ -253,7 +254,7 @@ struct FoldDivisibleConstantMulsIntoLinearize final
     auto getZero = [&]() {
       if (zero)
         return zero;
-      zero = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      zero = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
       return zero;
     };
 

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -605,17 +605,17 @@ resolveSplitReduceForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
     return forallOp->emitOpError("failed to lower split reduction modifier op");
   }
 
-  auto procIdOp = rewriter.create<IREE::HAL::InterfaceWorkgroupIDOp>(
-      loc, static_cast<unsigned>(delinearizeFrom));
-  auto nTotalProcsOp = rewriter.create<IREE::HAL::InterfaceWorkgroupCountOp>(
-      loc, static_cast<unsigned>(delinearizeFrom));
+  auto procIdOp = IREE::HAL::InterfaceWorkgroupIDOp::create(
+      rewriter, loc, static_cast<unsigned>(delinearizeFrom));
+  auto nTotalProcsOp = IREE::HAL::InterfaceWorkgroupCountOp::create(
+      rewriter, loc, static_cast<unsigned>(delinearizeFrom));
   OpFoldResult nTotalProcs = nTotalProcsOp.getResult();
   OpFoldResult origNProcs = affine::makeComposedFoldedAffineApply(
       rewriter, loc, s0.floorDiv(s1), {nTotalProcs, nSplitProcs});
   SmallVector<OpFoldResult> basis = numIters;
   basis.push_back(origNProcs);
-  auto delinearizeOp = rewriter.create<affine::AffineDelinearizeIndexOp>(
-      loc, procIdOp.getResult(), basis);
+  auto delinearizeOp = affine::AffineDelinearizeIndexOp::create(
+      rewriter, loc, procIdOp.getResult(), basis);
 
   Value workgroupIdReplacement = delinearizeOp.getResults().back();
 

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -289,7 +289,7 @@ static void specializeExportedFunction(
       builder.setInsertionPointToStart(newCondition);
 
       Value exportCondition =
-          builder.create<arith::ConstantIntOp>(loc, builder.getI1Type(), 1);
+          arith::ConstantIntOp::create(builder, loc, builder.getI1Type(), 1);
 
       for (auto [range, assumedSize] :
            llvm::zip(specializationRange, workloadMapping)) {
@@ -300,32 +300,32 @@ static void specializeExportedFunction(
         // +1 for the device.
         Value workload =
             newCondition->getArgument(assumedSize.workloadOrdinal + 1);
-        Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+        Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
 
         if (range.getUmin().has_value()) {
-          Value uminVal = builder.create<arith::ConstantIndexOp>(
-              loc, range.getUmin().value());
-          Value cmp = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::ule, uminVal, workload);
+          Value uminVal = arith::ConstantIndexOp::create(
+              builder, loc, range.getUmin().value());
+          Value cmp = arith::CmpIOp::create(
+              builder, loc, arith::CmpIPredicate::ule, uminVal, workload);
           exportCondition =
-              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+              arith::AndIOp::create(builder, loc, cmp, exportCondition);
         }
         if (range.getUmax().has_value()) {
-          Value umaxVal = builder.create<arith::ConstantIndexOp>(
-              loc, range.getUmax().value());
-          Value cmp = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::uge, umaxVal, workload);
+          Value umaxVal = arith::ConstantIndexOp::create(
+              builder, loc, range.getUmax().value());
+          Value cmp = arith::CmpIOp::create(
+              builder, loc, arith::CmpIPredicate::uge, umaxVal, workload);
           exportCondition =
-              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+              arith::AndIOp::create(builder, loc, cmp, exportCondition);
         }
         if (range.getUdiv().has_value()) {
-          Value udivVal = builder.create<arith::ConstantIndexOp>(
-              loc, range.getUdiv().value());
-          Value rem = builder.create<arith::RemUIOp>(loc, workload, udivVal);
-          Value cmp = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::eq, rem, zero);
+          Value udivVal = arith::ConstantIndexOp::create(
+              builder, loc, range.getUdiv().value());
+          Value rem = arith::RemUIOp::create(builder, loc, workload, udivVal);
+          Value cmp = arith::CmpIOp::create(
+              builder, loc, arith::CmpIPredicate::eq, rem, zero);
           exportCondition =
-              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+              arith::AndIOp::create(builder, loc, cmp, exportCondition);
         }
 
         if (auto originalAssumeOp = llvm::dyn_cast<IREE::Util::AssumeIntOp>(
@@ -364,7 +364,7 @@ static void specializeExportedFunction(
         }
       }
 
-      builder.create<IREE::HAL::ReturnOp>(loc, exportCondition);
+      IREE::HAL::ReturnOp::create(builder, loc, exportCondition);
     }
     // Current function is still the original function, just with a new symbol
     // name.

--- a/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
@@ -39,8 +39,8 @@ struct TestPartitionableLoopsInterfacePattern
     auto type =
         RankedTensorType::get(partitionableLoops.size(), rewriter.getI32Type());
     auto constantAttr = DenseIntElementsAttr::get(type, partitionableLoops);
-    rewriter.create<IREE::Util::UnfoldableConstantOp>(interfaceOp.getLoc(),
-                                                      constantAttr);
+    IREE::Util::UnfoldableConstantOp::create(rewriter, interfaceOp.getLoc(),
+                                             constantAttr);
     rewriter.modifyOpInPlace(interfaceOp,
                              [&] { interfaceOp->removeAttr(kAttributeName); });
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -199,7 +199,7 @@ static LogicalResult lowerDispatchWorkgroupCountForDagRootOp(
     }
     numWorkgroups.push_back(numTileAlongDim);
   }
-  Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
   numWorkgroups.resize(workgroupCountOp.getNumResults(), one);
   rewriter.replaceOp(workgroupCountOp, numWorkgroups);
   return success();
@@ -366,7 +366,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     // Check if tile sizes are deduced from the configuration. If so use
     // those.
     return llvm::map_to_vector(tileSizes, [&](int64_t ts) -> Value {
-      return builder.create<arith::ConstantIndexOp>(op->getLoc(), ts);
+      return arith::ConstantIndexOp::create(builder, op->getLoc(), ts);
     });
   };
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -169,12 +169,12 @@ static SmallVector<scf::ForOp> generateTileLoopNest(
     Value lbVal = getValueOrCreateConstantIndexOp(builder, loc, lb);
     Value ubVal = getValueOrCreateConstantIndexOp(builder, loc, ub);
     Value stepVal = getValueOrCreateConstantIndexOp(builder, loc, step);
-    auto loop = builder.create<scf::ForOp>(
-        loc, lbVal, ubVal, stepVal, ValueRange{},
+    auto loop = scf::ForOp::create(
+        builder, loc, lbVal, ubVal, stepVal, ValueRange{},
         [&](OpBuilder &bodyBuilder, Location bodyLoc, Value iv,
             ValueRange /*iterArgs*/) {
           sizes[index] = createBoundedTileSize(iv, tileSizeVals[index], ub);
-          builder.create<scf::YieldOp>(loc);
+          scf::YieldOp::create(builder, loc);
         });
     offsets[index] = loop.getInductionVar();
     loops.push_back(loop);
@@ -232,8 +232,8 @@ static LogicalResult replaceStoresWithTiledVersion(
         "failed to create tiled iree_tensor_ext.dispatch.tensor.store op");
   }
 
-  rewriter.create<IREE::TensorExt::DispatchTensorStoreOp>(
-      storeOp.getLoc(), tiledValue, storeOp.getTarget(),
+  IREE::TensorExt::DispatchTensorStoreOp::create(
+      rewriter, storeOp.getLoc(), tiledValue, storeOp.getTarget(),
       clonedSliceAndVals.dynamicDims, combinedOffsets, combinedSizes,
       combinedStrides);
   rewriter.eraseOp(storeOp);

--- a/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -53,9 +53,9 @@ static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
     unsigned sourceBitWidth = sourceType.getIntOrFloatBitWidth();
     unsigned destBitWidth = targetType.getIntOrFloatBitWidth();
     if (sourceBitWidth > destBitWidth) {
-      return b.create<arith::TruncIOp>(loc, targetType, source);
+      return arith::TruncIOp::create(b, loc, targetType, source);
     } else {
-      return b.create<arith::ExtUIOp>(loc, targetType, source);
+      return arith::ExtUIOp::create(b, loc, targetType, source);
     }
   }
   return nullptr;
@@ -310,8 +310,8 @@ struct TensorExtractTypePropagation
   matchAndRewrite(tensor::ExtractOp extractOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = extractOp.getLoc();
-    Value newExtract = rewriter.create<tensor::ExtractOp>(
-        loc, adaptor.getTensor(), adaptor.getIndices());
+    Value newExtract = tensor::ExtractOp::create(
+        rewriter, loc, adaptor.getTensor(), adaptor.getIndices());
     Value replacement = convertElementType(
         rewriter, loc, extractOp.getResult().getType(), newExtract);
     rewriter.replaceOp(extractOp, replacement);

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -242,7 +242,7 @@ ChangeResult DistributionLayout::resolveWithPossibleConflict(
   // Create a resolution operation. This conflict should be handeled later by
   // someone else, not this analysis.
   Operation *resolveOp =
-      builder.create<IREE::VectorExt::ToLayoutOp>(input.getLoc(), input, rhs);
+      IREE::VectorExt::ToLayoutOp::create(builder, input.getLoc(), input, rhs);
   Value resolvedValue = resolveOp->getResult(0);
   opOperand.set(resolvedValue);
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
@@ -24,9 +24,9 @@ struct ConvertLinalgCopyToMemrefCopy final : OpRewritePattern<linalg::CopyOp> {
     if (copyOp.hasPureTensorSemantics()) {
       return failure();
     }
-    rewriter.create<memref::CopyOp>(copyOp.getLoc(),
-                                    copyOp.getDpsInputOperand(0)->get(),
-                                    copyOp.getDpsInitOperand(0)->get());
+    memref::CopyOp::create(rewriter, copyOp.getLoc(),
+                           copyOp.getDpsInputOperand(0)->get(),
+                           copyOp.getDpsInitOperand(0)->get());
     rewriter.eraseOp(copyOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -104,8 +104,8 @@ struct ConvertUtilAssumeIntOp final
     }
 
     if (!newArgs.empty()) {
-      auto newOp = rewriter.create<IREE::Util::AssumeIntOp>(
-          op.getLoc(), newArgs, newAssumptions);
+      auto newOp = IREE::Util::AssumeIntOp::create(rewriter, op.getLoc(),
+                                                   newArgs, newAssumptions);
       LLVM_DEBUG(llvm::dbgs()
                  << "WideIntegerEmulation: new op: " << newOp << "\n");
 
@@ -117,10 +117,10 @@ struct ConvertUtilAssumeIntOp final
         Type newType = getTypeConverter()->convertType(
             op.getResult(replacementLoc).getType());
         if (auto vecType = dyn_cast_if_present<VectorType>(newType)) {
-          Value zeros = rewriter.create<arith::ConstantOp>(
-              op.getLoc(), newType, rewriter.getZeroAttr(newType));
-          replacement = rewriter.create<vector::InsertOp>(
-              op.getLoc(), result, zeros, ArrayRef<int64_t>{0});
+          Value zeros = arith::ConstantOp::create(
+              rewriter, op.getLoc(), newType, rewriter.getZeroAttr(newType));
+          replacement = vector::InsertOp::create(rewriter, op.getLoc(), result,
+                                                 zeros, ArrayRef<int64_t>{0});
         }
         replacements[replacementLoc] = replacement;
       }
@@ -195,8 +195,8 @@ struct FlattenElementwisePattern final : RewritePattern {
     // Shape cast results.
     for (auto [oldResult, newResult] :
          llvm::zip_equal(op->getResults(), newOp->getResults())) {
-      Value cast = rewriter.create<vector::ShapeCastOp>(
-          loc, oldResult.getType(), newResult);
+      Value cast = vector::ShapeCastOp::create(rewriter, loc,
+                                               oldResult.getType(), newResult);
       rewriter.replaceAllUsesWith(oldResult, cast);
     }
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -82,11 +82,11 @@ rewriteStorageBufferSubspanOp(RewriterBase &rewriter,
 
   SmallVector<Value, 1> dynamicDims;
   assert(subspanOp.getDynamicDims().empty());
-  dynamicDims.push_back(rewriter.create<arith::ConstantIndexOp>(
-      subspanOp.getLoc(), oldType.getNumElements()));
+  dynamicDims.push_back(arith::ConstantIndexOp::create(
+      rewriter, subspanOp.getLoc(), oldType.getNumElements()));
 
-  auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-      subspanOp.getLoc(), newType, subspanOp.getLayoutAttr(),
+  auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
+      rewriter, subspanOp.getLoc(), newType, subspanOp.getLayoutAttr(),
       subspanOp.getBindingAttr(), subspanOp.getByteOffset(), dynamicDims,
       subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -167,8 +167,8 @@ struct SPIRVLinkExecutablesPass final
     OpBuilder moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
 
     // Create our new "linked" hal.executable.
-    auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
-        moduleOp.getLoc(), linkedExecutableName);
+    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
         sourceExecutableOps.front().getVisibility());
     OpBuilder executableBuilder =
@@ -180,11 +180,10 @@ struct SPIRVLinkExecutablesPass final
           executableTargetAttrs.size() == 1
               ? attr.getSymbolNameFragment()
               : llvm::formatv("{}_{}", attr.getSymbolNameFragment(), index);
-      auto linkedTargetOp =
-          executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
-              moduleOp.getLoc(), linkedVariantName, attr);
+      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+          executableBuilder, moduleOp.getLoc(), linkedVariantName, attr);
       auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      targetBuilder.create<mlir::ModuleOp>(moduleOp.getLoc());
+      mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
 
       auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
                               mlir::ModuleOp linkedInnerModule,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -150,7 +150,7 @@ static LogicalResult tileToSubgroup(mlir::FunctionOpInterface funcOp,
     tileSizes.resize(
         std::min(cast<linalg::LinalgOp>(op).getNumParallelLoops(), 3u));
     return llvm::map_to_vector(tileSizes, [&](int64_t v) -> Value {
-      return builder.create<arith::ConstantIndexOp>(op->getLoc(), v);
+      return arith::ConstantIndexOp::create(builder, op->getLoc(), v);
     });
   };
   auto tilingOptions = linalg::LinalgTilingOptions()
@@ -312,8 +312,8 @@ public:
     if (!foundTranspose)
       return failure();
 
-    Value res = rewriter.create<vector::ContractionOp>(
-        loc, newSources[0], newSources[1], newSources[2],
+    Value res = vector::ContractionOp::create(
+        rewriter, loc, newSources[0], newSources[1], newSources[2],
         rewriter.getAffineMapArrayAttr(newMaps), op.getIteratorTypes());
     rewriter.replaceOp(op, res);
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -384,8 +384,8 @@ public:
     // If the transfer_read can be replaced by a load after vectorization use
     // LoadOp and cast back to the original type.
     if (*vectorMemrefElemSize == *readVecSize) {
-      Value newLoad = rewriter.create<memref::LoadOp>(
-          loc, memrefVectorType, adaptor.getBase(), indices.value());
+      Value newLoad = memref::LoadOp::create(
+          rewriter, loc, memrefVectorType, adaptor.getBase(), indices.value());
       rewriter.replaceOpWithNewOp<vector::BitCastOp>(read, readVectorType,
                                                      newLoad);
       return success();
@@ -413,11 +413,11 @@ public:
                         memrefVectorType.getElementType());
 
     for (int i = 0; i < vectorCount; ++i) {
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      indices->back() = rewriter.create<affine::AffineApplyOp>(
-          loc, addMap, ValueRange{oldIndex, iVal});
+      Value iVal = arith::ConstantIndexOp::create(rewriter, loc, i);
+      indices->back() = affine::AffineApplyOp::create(
+          rewriter, loc, addMap, ValueRange{oldIndex, iVal});
       vectors.push_back(
-          rewriter.create<memref::LoadOp>(loc, adaptor.getBase(), *indices));
+          memref::LoadOp::create(rewriter, loc, adaptor.getBase(), *indices));
     }
 
     // If there is only two component vectors, we can use ShuffleOp, which is a
@@ -425,8 +425,8 @@ public:
     if (vectorCount == 2) {
       SmallVector<int64_t> seqIndices =
           llvm::to_vector(llvm::seq<int64_t>(readVectorType.getNumElements()));
-      auto ShuffleOp = rewriter.create<vector::ShuffleOp>(
-          loc, vectors[0], vectors[1], seqIndices);
+      auto ShuffleOp = vector::ShuffleOp::create(rewriter, loc, vectors[0],
+                                                 vectors[1], seqIndices);
       rewriter.replaceOpWithNewOp<vector::BitCastOp>(read, readVectorType,
                                                      ShuffleOp);
       return success();
@@ -435,12 +435,12 @@ public:
     SmallVector<int64_t> offsets(combinedType.getRank(), 0);
     SmallVector<int64_t> strides(combinedType.getRank(), 1);
 
-    Value newVector = rewriter.create<arith::ConstantOp>(
-        loc, combinedType, rewriter.getZeroAttr(combinedType));
+    Value newVector = arith::ConstantOp::create(
+        rewriter, loc, combinedType, rewriter.getZeroAttr(combinedType));
     for (int i = 0; i < vectorCount; ++i) {
       offsets.back() = i * memrefVectorType.getNumElements();
-      newVector = rewriter.create<vector::InsertStridedSliceOp>(
-          loc, vectors[i], newVector, offsets, strides);
+      newVector = vector::InsertStridedSliceOp::create(
+          rewriter, loc, vectors[i], newVector, offsets, strides);
     }
 
     rewriter.replaceOp(read, newVector);
@@ -487,8 +487,8 @@ public:
     // If the transfer_write can be replaced by a store after vectorization cast
     // the original value and use StoreOp.
     if (*vectorMemrefElemSize == *writeVecSize) {
-      Value data = rewriter.create<vector::BitCastOp>(
-          loc, memrefVectorType, adaptor.getValueToStore());
+      Value data = vector::BitCastOp::create(rewriter, loc, memrefVectorType,
+                                             adaptor.getValueToStore());
       rewriter.replaceOpWithNewOp<memref::StoreOp>(
           write, data, adaptor.getBase(), indices.value());
       return success();
@@ -517,15 +517,15 @@ public:
 
     for (int i = 0; i < vectorCount; ++i) {
       offsets.back() = i * memrefVectorType.getNumElements();
-      auto slice = rewriter.create<vector::ExtractStridedSliceOp>(
-          loc, adaptor.getValueToStore(), offsets, sizes, strides);
+      auto slice = vector::ExtractStridedSliceOp::create(
+          rewriter, loc, adaptor.getValueToStore(), offsets, sizes, strides);
       auto component =
-          rewriter.create<vector::BitCastOp>(loc, memrefVectorType, slice);
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      indices->back() = rewriter.create<affine::AffineApplyOp>(
-          loc, addMap, ValueRange{oldIndex, iVal});
-      rewriter.create<memref::StoreOp>(loc, component, adaptor.getBase(),
-                                       *indices);
+          vector::BitCastOp::create(rewriter, loc, memrefVectorType, slice);
+      Value iVal = arith::ConstantIndexOp::create(rewriter, loc, i);
+      indices->back() = affine::AffineApplyOp::create(
+          rewriter, loc, addMap, ValueRange{oldIndex, iVal});
+      memref::StoreOp::create(rewriter, loc, component, adaptor.getBase(),
+                              *indices);
     }
 
     rewriter.eraseOp(write);
@@ -615,10 +615,10 @@ FailureOr<SmallVector<Value>> MemRefConversionPattern<OpTy>::adjustIndices(
   auto divMap = AffineMap::get(0, 2, {sym0.floorDiv(sym1)}, context);
 
   unsigned ratio = *vectorMemrefElemSize / *scalarMemrefElemSize;
-  Value valueRatio = rewriter.create<arith::ConstantIndexOp>(loc, ratio);
+  Value valueRatio = arith::ConstantIndexOp::create(rewriter, loc, ratio);
   auto newIndices = llvm::to_vector(indices);
-  newIndices.back() = rewriter.create<affine::AffineApplyOp>(
-      loc, divMap, ValueRange{indices.back(), valueRatio});
+  newIndices.back() = affine::AffineApplyOp::create(
+      rewriter, loc, divMap, ValueRange{indices.back(), valueRatio});
   return newIndices;
 }
 
@@ -778,14 +778,14 @@ static Value predicateMaybeMaskedScalarTransfer(
     auto thenBuilder = [&](OpBuilder &b, Location loc) {
       Value thenRes = thenConditionBuilder(b, loc);
       if (thenRes) {
-        b.create<scf::YieldOp>(loc, thenRes);
+        scf::YieldOp::create(b, loc, thenRes);
       } else {
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       }
     };
-    auto ifOp = b.create<scf::IfOp>(loc, maybeMaskBit,
-                                    /*thenBuilder=*/thenBuilder,
-                                    /*elseBuilder=*/elseConditionBuilder);
+    auto ifOp = scf::IfOp::create(b, loc, maybeMaskBit,
+                                  /*thenBuilder=*/thenBuilder,
+                                  /*elseBuilder=*/elseConditionBuilder);
 
     return !ifOp.getNumResults() ? Value() : ifOp->getResult(0);
   }
@@ -813,8 +813,8 @@ struct ScalarizeVectorTransferRead final
     if (vectorType.getRank() == 0) {
       Value maybeMaskBit;
       if (maybeMask) {
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
-                                                          ArrayRef<int64_t>{0});
+        maybeMaskBit = vector::ExtractOp::create(rewriter, loc, maybeMask,
+                                                 ArrayRef<int64_t>{0});
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
@@ -823,7 +823,7 @@ struct ScalarizeVectorTransferRead final
             .getResult();
       };
       auto elseCond = [&](OpBuilder &b, Location loc) {
-        b.create<scf::YieldOp>(loc, readOp.getPadding());
+        scf::YieldOp::create(b, loc, readOp.getPadding());
       };
 
       Value scalar = predicateMaybeMaskedScalarTransfer(
@@ -844,8 +844,8 @@ struct ScalarizeVectorTransferRead final
     auto indices = llvm::to_vector(readOp.getIndices());
     Value oldIndex = indices[dimPos];
 
-    Value newVector = rewriter.create<arith::ConstantOp>(
-        loc, vectorType, rewriter.getZeroAttr(vectorType));
+    Value newVector = arith::ConstantOp::create(
+        rewriter, loc, vectorType, rewriter.getZeroAttr(vectorType));
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
       // Extract the mask bit for this value if present.
       Value maybeMaskBit;
@@ -853,24 +853,25 @@ struct ScalarizeVectorTransferRead final
         // The result vector is 1-D and we have a projected permutation, meaning
         // we can just extract the mask bit using the same index as the loaded
         // vector.
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
-                                                          ArrayRef<int64_t>{i});
+        maybeMaskBit = vector::ExtractOp::create(rewriter, loc, maybeMask,
+                                                 ArrayRef<int64_t>{i});
       }
 
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      Value iVal = arith::ConstantIndexOp::create(rewriter, loc, i);
       auto thenCond = [&](OpBuilder &b, Location loc) {
-        indices[dimPos] = b.create<affine::AffineApplyOp>(
-            loc, addMap, ValueRange{oldIndex, iVal});
-        Value scalar = b.create<memref::LoadOp>(loc, readOp.getBase(), indices);
+        indices[dimPos] = affine::AffineApplyOp::create(
+            b, loc, addMap, ValueRange{oldIndex, iVal});
+        Value scalar =
+            memref::LoadOp::create(b, loc, readOp.getBase(), indices);
         return scalar;
       };
       auto elseCond = [&](OpBuilder &b, Location loc) {
-        b.create<scf::YieldOp>(loc, readOp.getPadding());
+        scf::YieldOp::create(b, loc, readOp.getPadding());
       };
 
       Value scalar = predicateMaybeMaskedScalarTransfer(
           rewriter, loc, maybeMaskBit, thenCond, elseCond);
-      newVector = rewriter.create<vector::InsertOp>(loc, scalar, newVector, i);
+      newVector = vector::InsertOp::create(rewriter, loc, scalar, newVector, i);
     }
     rewriter.replaceOp(readOp, newVector);
     return success();
@@ -888,8 +889,8 @@ struct ScalarizeVectorLoad final : public OpRewritePattern<vector::LoadOp> {
 
     Location loc = loadOp.getLoc();
     if (vectorType.getRank() == 0) {
-      Value scalar = rewriter.create<memref::LoadOp>(loc, loadOp.getBase(),
-                                                     loadOp.getIndices());
+      Value scalar = memref::LoadOp::create(rewriter, loc, loadOp.getBase(),
+                                            loadOp.getIndices());
       rewriter.replaceOpWithNewOp<vector::BroadcastOp>(loadOp, vectorType,
                                                        scalar);
       return success();
@@ -906,15 +907,15 @@ struct ScalarizeVectorLoad final : public OpRewritePattern<vector::LoadOp> {
     auto indices = llvm::to_vector(loadOp.getIndices());
     Value oldIndex = indices[dimPos];
 
-    Value newVector = rewriter.create<arith::ConstantOp>(
-        loc, vectorType, rewriter.getZeroAttr(vectorType));
+    Value newVector = arith::ConstantOp::create(
+        rewriter, loc, vectorType, rewriter.getZeroAttr(vectorType));
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      indices[dimPos] = rewriter.create<affine::AffineApplyOp>(
-          loc, addMap, ValueRange{oldIndex, iVal});
+      Value iVal = arith::ConstantIndexOp::create(rewriter, loc, i);
+      indices[dimPos] = affine::AffineApplyOp::create(
+          rewriter, loc, addMap, ValueRange{oldIndex, iVal});
       Value scalar =
-          rewriter.create<memref::LoadOp>(loc, loadOp.getBase(), indices);
-      newVector = rewriter.create<vector::InsertOp>(loc, scalar, newVector, i);
+          memref::LoadOp::create(rewriter, loc, loadOp.getBase(), indices);
+      newVector = vector::InsertOp::create(rewriter, loc, scalar, newVector, i);
     }
     rewriter.replaceOp(loadOp, newVector);
     return success();
@@ -938,14 +939,14 @@ struct ScalarizeVectorTransferWrite final
 
       Value maybeMaskBit;
       if (maybeMask) {
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
-                                                          ArrayRef<int64_t>{0});
+        maybeMaskBit = vector::ExtractOp::create(rewriter, loc, maybeMask,
+                                                 ArrayRef<int64_t>{0});
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
-        Value scalar = b.create<vector::ExtractOp>(loc, writeOp.getVector());
-        b.create<memref::StoreOp>(loc, scalar, writeOp.getBase(),
-                                  writeOp.getIndices());
+        Value scalar = vector::ExtractOp::create(b, loc, writeOp.getVector());
+        memref::StoreOp::create(b, loc, scalar, writeOp.getBase(),
+                                writeOp.getIndices());
         return Value();
       };
 
@@ -971,16 +972,17 @@ struct ScalarizeVectorTransferWrite final
         // The result vector is 1-D and we have a projected permutation, meaning
         // we can just extract the mask bit using the same index as the written
         // vector.
-        maybeMaskBit = rewriter.create<vector::ExtractOp>(loc, maybeMask,
-                                                          ArrayRef<int64_t>{i});
+        maybeMaskBit = vector::ExtractOp::create(rewriter, loc, maybeMask,
+                                                 ArrayRef<int64_t>{i});
       }
 
-      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      Value iVal = arith::ConstantIndexOp::create(rewriter, loc, i);
       auto thenCond = [&](OpBuilder &b, Location loc) {
-        indices[dimPos] = b.create<affine::AffineApplyOp>(
-            loc, addMap, ValueRange{oldIndex, iVal});
-        Value scalar = b.create<vector::ExtractOp>(loc, writeOp.getVector(), i);
-        b.create<memref::StoreOp>(loc, scalar, writeOp.getBase(), indices);
+        indices[dimPos] = affine::AffineApplyOp::create(
+            b, loc, addMap, ValueRange{oldIndex, iVal});
+        Value scalar =
+            vector::ExtractOp::create(b, loc, writeOp.getVector(), i);
+        memref::StoreOp::create(b, loc, scalar, writeOp.getBase(), indices);
         return Value();
       };
       (void)predicateMaybeMaskedScalarTransfer(rewriter, loc, maybeMaskBit,
@@ -1021,19 +1023,19 @@ struct ReifyExtractOfCreateMask final
 
     Location loc = maskOp.getLoc();
     Value maskBit =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(true));
     for (auto [idx, size] :
          llvm::zip_equal(extractOp.getMixedPosition(), maskOp.getOperands())) {
       Value idxVal;
       if (auto attr = dyn_cast<Attribute>(idx)) {
-        idxVal = rewriter.create<arith::ConstantIndexOp>(
-            loc, dyn_cast<IntegerAttr>(attr).getInt());
+        idxVal = arith::ConstantIndexOp::create(
+            rewriter, loc, dyn_cast<IntegerAttr>(attr).getInt());
       } else {
         idxVal = dyn_cast<Value>(idx);
       }
-      Value cmpIdx = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::slt, idxVal, size);
-      maskBit = rewriter.create<arith::AndIOp>(loc, cmpIdx, maskBit);
+      Value cmpIdx = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::slt, idxVal, size);
+      maskBit = arith::AndIOp::create(rewriter, loc, cmpIdx, maskBit);
     }
     rewriter.replaceOp(extractOp, maskBit);
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -67,7 +67,7 @@ getSPIRVTileSizeComputeFn(mlir::FunctionOpInterface funcOp, int tilingLevel) {
   linalg::TileSizeComputationFunction computeFn =
       [tileSizes](OpBuilder &builder, Operation *op) {
         auto range = llvm::map_range(*tileSizes, [&](int64_t size) -> Value {
-          return builder.create<arith::ConstantIndexOp>(op->getLoc(), size);
+          return arith::ConstantIndexOp::create(builder, op->getLoc(), size);
         });
         return llvm::to_vector(range);
       };
@@ -101,8 +101,8 @@ getGPUProcessorIdAndCountImpl(OpBuilder &builder, Location loc, unsigned dim) {
   std::array<gpu::Dimension, kNumGPUDims> dimAttr{
       gpu::Dimension::x, gpu::Dimension::y, gpu::Dimension::z};
   Type indexType = builder.getIndexType();
-  return {builder.create<GPUIdOp>(loc, indexType, dimAttr[dim]),
-          builder.create<GPUCountOp>(loc, indexType, dimAttr[dim]),
+  return {GPUIdOp::create(builder, loc, indexType, dimAttr[dim]),
+          GPUCountOp::create(builder, loc, indexType, dimAttr[dim]),
           linalg::DistributionMethod::Cyclic};
 }
 

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
@@ -34,8 +34,8 @@ struct VMVXLinkExecutablesPass
     // Create our new "linked" hal.executable.
     std::string linkedExecutableName =
         llvm::formatv("{}_linked_{}", moduleName, "vmvx");
-    auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
-        moduleOp.getLoc(), linkedExecutableName);
+    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
         sourceExecutableOps.front().getVisibility());
     auto executableBuilder =
@@ -50,16 +50,15 @@ struct VMVXLinkExecutablesPass
               ? targetAttr.getSymbolNameFragment()
               : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
-      auto linkedTargetOp =
-          executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
-              moduleOp.getLoc(), linkedVariantName, targetAttr);
+      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
       auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      auto linkedModuleOp = targetBuilder.create<ModuleOp>(moduleOp.getLoc());
+      auto linkedModuleOp = ModuleOp::create(targetBuilder, moduleOp.getLoc());
 
       // Add an empty vm.module to that module as our vm.funcs must live in it.
       auto nestedBuilder = OpBuilder::atBlockBegin(linkedModuleOp.getBody());
-      nestedBuilder.create<IREE::VM::ModuleOp>(moduleOp.getLoc(),
-                                               "linked_module");
+      IREE::VM::ModuleOp::create(nestedBuilder, moduleOp.getLoc(),
+                                 "linked_module");
 
       auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
                               mlir::ModuleOp linkedInnerModule,

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
@@ -50,7 +50,7 @@ SmallVector<Value> permuteStrides(Location loc, AffineMap indexingMap,
   for (Value &stride : strides) {
     if (!stride) {
       if (!zero) {
-        zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+        zero = arith::ConstantIndexOp::create(builder, loc, 0);
       }
       stride = zero;
     }
@@ -65,7 +65,7 @@ void leftPadToRank(Location loc, SmallVectorImpl<Value> &indices,
   Value padValue;
   while (indices.size() < minRank) {
     if (!padValue) {
-      padValue = builder.create<arith::ConstantIndexOp>(loc, padIndex);
+      padValue = arith::ConstantIndexOp::create(builder, loc, padIndex);
     }
     indices.insert(indices.begin(), padValue);
   }
@@ -195,9 +195,9 @@ public:
       sizeStrideTypes.push_back(indexType);
     }
 
-    auto op = builder.create<IREE::VMVX::GetBufferDescriptorOp>(
-        loc, builder.getType<IREE::Util::BufferType>(), builder.getIndexType(),
-        sizeStrideTypes, sizeStrideTypes, buffer);
+    auto op = IREE::VMVX::GetBufferDescriptorOp::create(
+        builder, loc, builder.getType<IREE::Util::BufferType>(),
+        builder.getIndexType(), sizeStrideTypes, sizeStrideTypes, buffer);
 
     desc->baseBuffer = op.getBaseBuffer();
     desc->offset = op.getOffset();
@@ -308,8 +308,8 @@ struct BinaryEmitter {
 
     switch (selection.opType) {
     case OpType::GenericBinary: {
-      rewriter.create<IREE::VMVX::BinaryOp>(
-          loc, rewriter.getStringAttr(selection.opcode),
+      IREE::VMVX::BinaryOp::create(
+          rewriter, loc, rewriter.getStringAttr(selection.opcode),
           // LHS
           params.in0Buffer, operands.first.bufferDesc->offset,
           params.in0Strides,
@@ -411,8 +411,8 @@ struct UnaryEmitter {
 
     switch (selection.opType) {
     case OpType::GenericUnary: {
-      rewriter.create<IREE::VMVX::UnaryOp>(
-          loc, rewriter.getStringAttr(selection.opcode),
+      IREE::VMVX::UnaryOp::create(
+          rewriter, loc, rewriter.getStringAttr(selection.opcode),
           // IN
           params.inBuffer, operand.bufferDesc->offset, params.inStrides,
           // OUT
@@ -508,16 +508,15 @@ struct CopyEmitter {
     leftPadToRank(loc, outStrides, 2, 0, rewriter);
     leftPadToRank(loc, sizes, 2, 1, rewriter);
 
-    rewriter.create<IREE::VMVX::CopyOp>(
-        loc,
-        // IN
-        inBuffer, in.bufferDesc->offset, inStrides,
-        // OUT
-        outBuffer, out.bufferDesc->offset, outStrides,
-        // Sizes
-        sizes,
-        // Element type.
-        in.bufferDesc->getElementTypeAttr());
+    IREE::VMVX::CopyOp::create(rewriter, loc,
+                               // IN
+                               inBuffer, in.bufferDesc->offset, inStrides,
+                               // OUT
+                               outBuffer, out.bufferDesc->offset, outStrides,
+                               // Sizes
+                               sizes,
+                               // Element type.
+                               in.bufferDesc->getElementTypeAttr());
   }
 };
 


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.