### PR TITLE
[Codegen] Upgrade LLVMCPU and LLVMGPU to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -146,8 +146,8 @@ struct ConvertHALEntryPointFuncOp
     // Clone the function as an LLVMFuncOp and convert all interior types.
     auto int32Type = IntegerType::get(rewriter.getContext(), 32);
     auto llvmFuncType = LLVM::LLVMFunctionType::get(int32Type, abiInputTypes);
-    auto llvmFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
-        stdFuncOp.getLoc(), stdFuncOp.getName(), llvmFuncType,
+    auto llvmFuncOp = LLVM::LLVMFuncOp::create(
+        rewriter, stdFuncOp.getLoc(), stdFuncOp.getName(), llvmFuncType,
         LLVM::Linkage::External, /*dsoLocal=*/false, /*cconv=*/LLVM::CConv::C,
         /*comdat=*/nullptr, funcAttrs);
     rewriter.inlineRegionBefore(stdFuncOp.getFunctionBody(),
@@ -347,20 +347,21 @@ acquireInstrumentationEntry(Location loc, Value buffer, Value bufferPtr,
   Value basePtr = MemRefDescriptor(bufferPtr).alignedPtr(builder, loc);
 
   Value offsetIndex =
-      builder.create<LLVM::ConstantOp>(loc, i64Type, headOffset);
+      LLVM::ConstantOp::create(builder, loc, i64Type, headOffset);
   auto i8Type = builder.getI8Type();
-  Value offsetPtr = builder.create<LLVM::GEPOp>(
-      loc, basePtr.getType(), i8Type, basePtr, offsetIndex,
+  Value offsetPtr = LLVM::GEPOp::create(
+      builder, loc, basePtr.getType(), i8Type, basePtr, offsetIndex,
       /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
-  Value rawOffset = builder.create<LLVM::AtomicRMWOp>(
-      loc, LLVM::AtomicBinOp::add, offsetPtr, entrySize,
-      LLVM::AtomicOrdering::monotonic);
+  Value rawOffset =
+      LLVM::AtomicRMWOp::create(builder, loc, LLVM::AtomicBinOp::add, offsetPtr,
+                                entrySize, LLVM::AtomicOrdering::monotonic);
   Value offsetMask =
-      builder.create<LLVM::ConstantOp>(loc, i64Type, ringSize - 1);
-  Value wrappedOffset = builder.create<LLVM::AndOp>(loc, rawOffset, offsetMask);
+      LLVM::ConstantOp::create(builder, loc, i64Type, ringSize - 1);
+  Value wrappedOffset =
+      LLVM::AndOp::create(builder, loc, rawOffset, offsetMask);
 
-  Value entryPtr = builder.create<LLVM::GEPOp>(loc, basePtr.getType(), i8Type,
-                                               basePtr, wrappedOffset);
+  Value entryPtr = LLVM::GEPOp::create(builder, loc, basePtr.getType(), i8Type,
+                                       basePtr, wrappedOffset);
 
   return {basePtr, entryPtr, wrappedOffset};
 }
@@ -370,22 +371,22 @@ static InstrumentationEntry appendInstrumentationEntry(
     ArrayRef<Value> entryValues, DataLayout &dataLayout, OpBuilder &builder) {
   auto i64Type = builder.getI64Type();
 
-  Value entrySize = builder.create<LLVM::ConstantOp>(
-      loc, i64Type, dataLayout.getTypeSize(entryType));
+  Value entrySize = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                             dataLayout.getTypeSize(entryType));
   auto entry =
       acquireInstrumentationEntry(loc, buffer, bufferPtr, entrySize, builder);
 
-  Value entryStruct = builder.create<LLVM::UndefOp>(loc, entryType);
+  Value entryStruct = LLVM::UndefOp::create(builder, loc, entryType);
   for (auto entryValue : llvm::enumerate(entryValues)) {
-    entryStruct = builder.create<LLVM::InsertValueOp>(
-        loc, entryStruct, entryValue.value(), entryValue.index());
+    entryStruct = LLVM::InsertValueOp::create(
+        builder, loc, entryStruct, entryValue.value(), entryValue.index());
   }
 
-  builder.create<LLVM::StoreOp>(
-      loc, entryStruct,
-      builder.create<LLVM::BitcastOp>(
-          loc, LLVM::LLVMPointerType::get(builder.getContext()),
-          entry.entryPtr),
+  LLVM::StoreOp::create(
+      builder, loc, entryStruct,
+      LLVM::BitcastOp::create(builder, loc,
+                              LLVM::LLVMPointerType::get(builder.getContext()),
+                              entry.entryPtr),
       /*alignment=*/16);
 
   return entry;
@@ -429,9 +430,9 @@ struct ConvertHALInstrumentWorkgroupOp
     // NOTE: we could pre-shift this to avoid needing to do it in each group.
     // We just need to do the shift - the bottom two bits will be the 00 tag.
     Value rawDispatchId = instrumentOp.getDispatchId();
-    Value header = rewriter.create<LLVM::ShlOp>(
-        loc, i32Type, rawDispatchId,
-        rewriter.create<LLVM::ConstantOp>(loc, i32Type, 8)); // | 8bit tag
+    Value header = LLVM::ShlOp::create(
+        rewriter, loc, i32Type, rawDispatchId,
+        LLVM::ConstantOp::create(rewriter, loc, i32Type, 8)); // | 8bit tag
 
     auto entry = appendInstrumentationEntry(
         loc, instrumentOp.getBuffer(), operands.getBuffer(), entryType,
@@ -450,12 +451,12 @@ struct ConvertHALInstrumentWorkgroupOp
     // Prepare the 40-bit key used by all accesses - we do this once so that we
     // can ensure it's hoisted.
     // Consumers expect 40 bits of offset << 24 bits.
-    Value workgroupKey = rewriter.create<LLVM::ShlOp>(
-        loc,
-        rewriter.create<LLVM::AndOp>(
-            loc, entry.offset,
-            rewriter.create<LLVM::ConstantOp>(loc, i64Type, 0xFFFFFFFFFFll)),
-        rewriter.create<LLVM::ConstantOp>(loc, i64Type, 24));
+    Value workgroupKey = LLVM::ShlOp::create(
+        rewriter, loc,
+        LLVM::AndOp::create(
+            rewriter, loc, entry.offset,
+            LLVM::ConstantOp::create(rewriter, loc, i64Type, 0xFFFFFFFFFFll)),
+        LLVM::ConstantOp::create(rewriter, loc, i64Type, 24));
 
     rewriter.replaceOp(instrumentOp, workgroupKey);
     return success();
@@ -551,19 +552,19 @@ struct ConvertHALInstrumentValueOp
     // 8 bit type
     // 8 bit ordinal
     // 40 bit workgroup offset
-    Value header = rewriter.create<LLVM::OrOp>(
-        loc, operands.getWorkgroupKey(),
-        rewriter.create<LLVM::ConstantOp>(
-            loc, i64Type,
+    Value header = LLVM::OrOp::create(
+        rewriter, loc, operands.getWorkgroupKey(),
+        LLVM::ConstantOp::create(
+            rewriter, loc, i64Type,
             (instrumentOp.getOrdinal().getZExtValue() << 16) |
                 (valueType.value() << 8) |
                 IREE_INSTRUMENT_DISPATCH_TYPE_VALUE));
 
     // Bitcast to an integer and widen to 64 bits.
-    Value bits = rewriter.create<LLVM::ZExtOp>(
-        loc, i64Type,
-        rewriter.create<LLVM::BitcastOp>(
-            loc,
+    Value bits = LLVM::ZExtOp::create(
+        rewriter, loc, i64Type,
+        LLVM::BitcastOp::create(
+            rewriter, loc,
             rewriter.getIntegerType(
                 instrumentOp.getType().getIntOrFloatBitWidth()),
             operands.getOperand()));
@@ -604,16 +605,17 @@ struct ConvertHALInstrumentMemoryLoadOp
     // 40 bit workgroup offset
     int64_t loadSize = getMemoryAccessByteSize(instrumentOp.getType());
     assert(loadSize <= UINT16_MAX && "16-bit length maximum");
-    Value header = rewriter.create<LLVM::OrOp>(
-        loc, operands.getWorkgroupKey(),
-        rewriter.create<LLVM::ConstantOp>(
-            loc, i64Type,
+    Value header = LLVM::OrOp::create(
+        rewriter, loc, operands.getWorkgroupKey(),
+        LLVM::ConstantOp::create(
+            rewriter, loc, i64Type,
             (loadSize << 8) | IREE_INSTRUMENT_DISPATCH_TYPE_MEMORY_LOAD));
 
     Value loadPtr = getStridedElementPtr(
         rewriter, loc, llvm::cast<MemRefType>(instrumentOp.getBase().getType()),
         operands.getBase(), operands.getIndices());
-    Value addressI64 = rewriter.create<LLVM::PtrToIntOp>(loc, i64Type, loadPtr);
+    Value addressI64 =
+        LLVM::PtrToIntOp::create(rewriter, loc, i64Type, loadPtr);
 
     appendInstrumentationEntry(loc, instrumentOp.getBuffer(),
                                operands.getBuffer(), entryType,
@@ -651,17 +653,17 @@ struct ConvertHALInstrumentMemoryStoreOp
     // 40 bit workgroup offset
     int64_t storeSize = getMemoryAccessByteSize(instrumentOp.getType());
     assert(storeSize <= UINT16_MAX && "16-bit length maximum");
-    Value header = rewriter.create<LLVM::OrOp>(
-        loc, operands.getWorkgroupKey(),
-        rewriter.create<LLVM::ConstantOp>(
-            loc, i64Type,
+    Value header = LLVM::OrOp::create(
+        rewriter, loc, operands.getWorkgroupKey(),
+        LLVM::ConstantOp::create(
+            rewriter, loc, i64Type,
             (storeSize << 8) | IREE_INSTRUMENT_DISPATCH_TYPE_MEMORY_STORE));
 
     Value storePtr = getStridedElementPtr(
         rewriter, loc, llvm::cast<MemRefType>(instrumentOp.getBase().getType()),
         operands.getBase(), operands.getIndices());
     Value addressI64 =
-        rewriter.create<LLVM::PtrToIntOp>(loc, i64Type, storePtr);
+        LLVM::PtrToIntOp::create(rewriter, loc, i64Type, storePtr);
 
     appendInstrumentationEntry(loc, instrumentOp.getBuffer(),
                                operands.getBuffer(), entryType,
@@ -744,8 +746,8 @@ struct RewriteFuncOpABI : public OpRewritePattern<LLVM::LLVMFuncOp> {
         return llvm::cast<DictionaryAttr>(attr);
       });
     }
-    rewriter.create<LLVM::LLVMFuncOp>(
-        funcOp.getLoc(), funcOp.getName(), expectedType.value(),
+    LLVM::LLVMFuncOp::create(
+        rewriter, funcOp.getLoc(), funcOp.getName(), expectedType.value(),
         funcOp.getLinkage(), funcOp.getDsoLocal(), funcOp.getCConv(),
         /*comdat=*/nullptr, attrs, argAttrs, funcOp.getFunctionEntryCount());
     rewriter.eraseOp(funcOp);
@@ -904,18 +906,18 @@ public:
       shiftValAttr =
           SplatElementsAttr::get(cast<ShapedType>(wideType), shiftValAttr);
     }
-    Value shiftVal = rewriter.create<arith::ConstantOp>(loc, shiftValAttr);
+    Value shiftVal = arith::ConstantOp::create(rewriter, loc, shiftValAttr);
 
-    Value lhsExt = rewriter.create<arith::ExtSIOp>(loc, wideType, op.getLhs());
-    Value rhsExt = rewriter.create<arith::ExtSIOp>(loc, wideType, op.getRhs());
+    Value lhsExt = arith::ExtSIOp::create(rewriter, loc, wideType, op.getLhs());
+    Value rhsExt = arith::ExtSIOp::create(rewriter, loc, wideType, op.getRhs());
     Value mulExt =
-        rewriter.create<arith::MulIOp>(loc, wideType, lhsExt, rhsExt);
-    Value low = rewriter.create<arith::MulIOp>(loc, resultType, op.getLhs(),
-                                               op.getRhs());
+        arith::MulIOp::create(rewriter, loc, wideType, lhsExt, rhsExt);
+    Value low = arith::MulIOp::create(rewriter, loc, resultType, op.getLhs(),
+                                      op.getRhs());
 
     // Produce two 32-bit results.
-    Value highExt = rewriter.create<arith::ShRUIOp>(loc, mulExt, shiftVal);
-    Value high = rewriter.create<arith::TruncIOp>(loc, resultType, highExt);
+    Value highExt = arith::ShRUIOp::create(rewriter, loc, mulExt, shiftVal);
+    Value high = arith::TruncIOp::create(rewriter, loc, resultType, highExt);
 
     rewriter.replaceOp(op, {low, high});
     return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ExpandF16OpToF32Pass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ExpandF16OpToF32Pass.cpp
@@ -43,10 +43,10 @@ public:
         operands.push_back(operand);
         continue;
       }
-      Value ext = rewriter.create<arith::ExtFOp>(loc, f32Type, operand);
+      Value ext = arith::ExtFOp::create(rewriter, loc, f32Type, operand);
       operands.push_back(ext);
     }
-    Value newOp = rewriter.create<Op>(loc, f32Type, operands);
+    Value newOp = Op::create(rewriter, loc, f32Type, operands);
 
     rewriter.replaceOpWithNewOp<arith::TruncFOp>(op, resultType, newOp);
     return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
@@ -35,8 +35,8 @@ struct LLVMCPULinkExecutablesPass
     // Create our new "linked" hal.executable.
     SymbolTable moduleTable(moduleOp);
     std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
-    auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
-        moduleOp.getLoc(), linkedExecutableName);
+    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
         sourceExecutableOps.front().getVisibility());
     moduleTable.insert(linkedExecutableOp);
@@ -57,11 +57,10 @@ struct LLVMCPULinkExecutablesPass
               ? targetAttr.getSymbolNameFragment()
               : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
-      auto linkedTargetOp =
-          executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
-              moduleOp.getLoc(), linkedVariantName, targetAttr);
+      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
       auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      targetBuilder.create<mlir::ModuleOp>(moduleOp.getLoc());
+      mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
 
       auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
                               mlir::ModuleOp linkedInnerModule,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -26,10 +26,11 @@ public:
   LogicalResult matchAndRewrite(LLVM::FMAOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto mulPart = rewriter.create<LLVM::FMulOp>(loc, op.getResult().getType(),
-                                                 op.getA(), op.getB());
-    auto fmaResult = rewriter.create<LLVM::FAddOp>(
-        loc, mulPart.getResult().getType(), mulPart.getResult(), op.getC());
+    auto mulPart = LLVM::FMulOp::create(rewriter, loc, op.getResult().getType(),
+                                        op.getA(), op.getB());
+    auto fmaResult =
+        LLVM::FAddOp::create(rewriter, loc, mulPart.getResult().getType(),
+                             mulPart.getResult(), op.getC());
     rewriter.replaceOp(op, fmaResult.getResult());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -174,8 +174,8 @@ static Value extract1DSlice(PatternRewriter &rewriter, Location loc,
   assert(dstVecType.getRank() == 1);
   std::array<int64_t, 1> offsets{position};
   std::array<int64_t, 1> strides{1};
-  return rewriter.create<vector::ExtractStridedSliceOp>(
-      loc, input, offsets, dstVecType.getShape(), strides);
+  return vector::ExtractStridedSliceOp::create(rewriter, loc, input, offsets,
+                                               dstVecType.getShape(), strides);
 }
 
 // Helper to extract an element of a 1D vector.
@@ -185,7 +185,7 @@ static Value extract(PatternRewriter &rewriter, Location loc, Value input,
   assert(vectorType.getRank() == 1);
   (void)vectorType;
   std::array<int64_t, 1> offsets{position};
-  return rewriter.create<vector::ExtractOp>(loc, input, offsets);
+  return vector::ExtractOp::create(rewriter, loc, input, offsets);
 }
 
 // Helper to flatten a N-dimensional vector to a 1D vector.
@@ -193,7 +193,7 @@ static Value flatten(PatternRewriter &rewriter, Location loc, Value vector) {
   VectorType inputVecType = llvm::cast<VectorType>(vector.getType());
   VectorType dstType = VectorType::get(inputVecType.getNumElements(),
                                        inputVecType.getElementType());
-  return rewriter.create<vector::ShapeCastOp>(loc, dstType, vector);
+  return vector::ShapeCastOp::create(rewriter, loc, dstType, vector);
 }
 
 // Describes a kernel. This struct is kept small to separate the kernels
@@ -870,8 +870,8 @@ private:
     std::string code;
     std::string constraints;
     generateAsmCodeAndConstraints(code, constraints);
-    LLVM::InlineAsmOp asmOp = rewriter.create<LLVM::InlineAsmOp>(
-        loc, returnType, inputs, code, constraints,
+    LLVM::InlineAsmOp asmOp = LLVM::InlineAsmOp::create(
+        rewriter, loc, returnType, inputs, code, constraints,
         /*has_side_effects=*/false, /*is_align_stack=*/false,
         LLVM::TailCallKind::None, dialectAttr,
         /*operand_attrs=*/ArrayAttr());
@@ -879,8 +879,8 @@ private:
     SmallVector<Value> resVec;
     for (int i = 0; i < kernel.accRegs; ++i) {
       SmallVector<int64_t, 1> position = {i};
-      resVec.push_back(
-          rewriter.create<LLVM::ExtractValueOp>(loc, asmOp.getRes(), position));
+      resVec.push_back(LLVM::ExtractValueOp::create(rewriter, loc,
+                                                    asmOp.getRes(), position));
     }
     return resVec;
   }
@@ -985,12 +985,12 @@ public:
         rewriter, loc, lhsRegVectors, rhsRegVectors, accRegVectors);
     // Insert the result vectors of size 4 into the overall result vector of
     // size 64, still 1D.
-    Value result = rewriter.create<arith::ConstantOp>(loc, flatAccVectorType,
-                                                      resultInitializer);
+    Value result = arith::ConstantOp::create(rewriter, loc, flatAccVectorType,
+                                             resultInitializer);
     int accRegNumElements = accRegVectorType.getNumElements();
     for (int i = 0; i < kernel.accRegs; ++i) {
-      result = rewriter.create<vector::InsertStridedSliceOp>(
-          loc, resRegVectors[i], result,
+      result = vector::InsertStridedSliceOp::create(
+          rewriter, loc, resRegVectors[i], result,
           std::array<int64_t, 1>{accRegNumElements * i},
           std::array<int64_t, 1>{1});
     }
@@ -1052,12 +1052,12 @@ public:
     {
       int idx = 0;
       for (int row = 0; row < 8; ++row) {
-        auto accRow = rewriter.create<vector::ExtractOp>(
-            loc, acc, ArrayRef<int64_t>{row});
+        auto accRow = vector::ExtractOp::create(rewriter, loc, acc,
+                                                ArrayRef<int64_t>{row});
         for (int col = 0; col < 8; col += 4) {
-          auto accChunk = rewriter.create<vector::ExtractStridedSliceOp>(
-              loc, accRow, ArrayRef<int64_t>{col}, ArrayRef<int64_t>{4},
-              ArrayRef<int64_t>{1});
+          auto accChunk = vector::ExtractStridedSliceOp::create(
+              rewriter, loc, accRow, ArrayRef<int64_t>{col},
+              ArrayRef<int64_t>{4}, ArrayRef<int64_t>{1});
           assert(accChunk.getType() == int32x4VType);
           accChunks[idx++] = accChunk;
         }
@@ -1066,8 +1066,8 @@ public:
 
     auto int8x4x4VType = VectorType::get({4, 4}, rewriter.getIntegerType(8));
     auto extract4x4 = [&](Value in, int rowOffset, int colOffset) {
-      auto chunk = rewriter.create<vector::ExtractStridedSliceOp>(
-          loc, in, ArrayRef<int64_t>{rowOffset, colOffset},
+      auto chunk = vector::ExtractStridedSliceOp::create(
+          rewriter, loc, in, ArrayRef<int64_t>{rowOffset, colOffset},
           ArrayRef<int64_t>{4, 4}, ArrayRef<int64_t>{1, 1});
       assert(chunk.getType() == int8x4x4VType);
       return chunk;
@@ -1078,14 +1078,15 @@ public:
     std::array<Value, 2> rhsHalves = {extract4x4(inRhs, 0, 0),
                                       extract4x4(inRhs, 4, 0)};
 
-    auto int8Zero4x4 = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(int8x4x4VType));
+    auto int8Zero4x4 = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(int8x4x4VType));
     auto sdot = [&](Value acc, Value a, Value b, int64_t lane) -> Value {
-      auto bReplicatedLane = rewriter.create<vector::ShuffleOp>(
-          loc, b, int8Zero4x4, ArrayRef<int64_t>{lane, lane, lane, lane});
+      auto bReplicatedLane =
+          vector::ShuffleOp::create(rewriter, loc, b, int8Zero4x4,
+                                    ArrayRef<int64_t>{lane, lane, lane, lane});
 
-      return rewriter.create<arm_neon::Sdot2dOp>(loc, int32x4VType, acc, a,
-                                                 bReplicatedLane);
+      return arm_neon::Sdot2dOp::create(rewriter, loc, int32x4VType, acc, a,
+                                        bReplicatedLane);
     };
 
     std::array<Value, 16> dstChunks;
@@ -1106,8 +1107,8 @@ public:
       int idx = 0;
       for (int row = 0; row < 8; ++row) {
         for (int col = 0; col < 8; col += 4) {
-          acc = rewriter.create<vector::InsertStridedSliceOp>(
-              loc, dstChunks[idx++], acc, ArrayRef<int64_t>{row, col},
+          acc = vector::InsertStridedSliceOp::create(
+              rewriter, loc, dstChunks[idx++], acc, ArrayRef<int64_t>{row, col},
               ArrayRef<int64_t>{1});
         }
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -184,8 +184,8 @@ struct LowerToElementsPattern : public OpRewritePattern<vector::ToElementsOp> {
     }
     auto vec1DType =
         VectorType::get({vecType.getNumElements()}, vecType.getElementType());
-    Value shapeCast = rewriter.create<vector::ShapeCastOp>(
-        op.getLoc(), vec1DType, op.getSource());
+    Value shapeCast = vector::ShapeCastOp::create(rewriter, op.getLoc(),
+                                                  vec1DType, op.getSource());
     rewriter.replaceOpWithNewOp<vector::ToElementsOp>(op, op.getResultTypes(),
                                                       shapeCast);
     return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ExtractAddressComputationGPUPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ExtractAddressComputationGPUPass.cpp
@@ -39,8 +39,8 @@ static nvgpu::LdMatrixOp rebuildLdMatrixOp(RewriterBase &rewriter,
                                            Value srcMemRef,
                                            ArrayRef<Value> indices) {
   Location loc = ldMatrixOp.getLoc();
-  return rewriter.create<nvgpu::LdMatrixOp>(
-      loc, ldMatrixOp.getResult().getType(), srcMemRef, indices,
+  return nvgpu::LdMatrixOp::create(
+      rewriter, loc, ldMatrixOp.getResult().getType(), srcMemRef, indices,
       ldMatrixOp.getTranspose(), ldMatrixOp.getNumTiles());
 }
 
@@ -48,9 +48,8 @@ SmallVector<OpFoldResult>
 getLdMatrixOpViewSizeForEachDim(RewriterBase &rewriter,
                                 nvgpu::LdMatrixOp ldMatrixOp) {
   Location loc = ldMatrixOp.getLoc();
-  auto extractStridedMetadataOp =
-      rewriter.create<memref::ExtractStridedMetadataOp>(
-          loc, ldMatrixOp.getSrcMemref());
+  auto extractStridedMetadataOp = memref::ExtractStridedMetadataOp::create(
+      rewriter, loc, ldMatrixOp.getSrcMemref());
   SmallVector<OpFoldResult> srcSizes =
       extractStridedMetadataOp.getConstifiedMixedSizes();
   SmallVector<OpFoldResult> indices =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
@@ -45,8 +45,8 @@ struct LLVMGPUCastAddressSpaceFunctionPass final
             mlir::MemRefType new_memrefType = mlir::MemRefType::get(
                 memrefType.getShape(), memrefType.getElementType(),
                 memrefType.getLayout());
-            operand = rewriter.create<memref::MemorySpaceCastOp>(
-                operand.getLoc(), new_memrefType, operand);
+            operand = memref::MemorySpaceCastOp::create(
+                rewriter, operand.getLoc(), new_memrefType, operand);
             anyCasted = true;
           }
         }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -71,9 +71,9 @@ struct UpcastContractOutput final : OpRewritePattern<vector::ContractionOp> {
     Location loc = contractOp.getLoc();
     auto dstCType = srcCType.clone(dstCElemFType);
     auto extOp =
-        rewriter.create<arith::ExtFOp>(loc, dstCType, contractOp.getAcc());
-    auto newContractOp = rewriter.create<vector::ContractionOp>(
-        loc, contractOp.getLhs(), contractOp.getRhs(), extOp,
+        arith::ExtFOp::create(rewriter, loc, dstCType, contractOp.getAcc());
+    auto newContractOp = vector::ContractionOp::create(
+        rewriter, loc, contractOp.getLhs(), contractOp.getRhs(), extOp,
         contractOp.getIndexingMaps(), contractOp.getIteratorTypes());
     newContractOp->setDiscardableAttrs(
         contractOp->getDiscardableAttrDictionary());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -189,11 +189,11 @@ static LogicalResult setContractionAnchor(IREE::GPU::MMAScheduleAttr schedule,
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(contract);
   auto layoutedLhs =
-      rewriter.create<ToLayoutOp>(loc, lhs, aLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.getIntrinsic());
   auto layoutedRhs =
-      rewriter.create<ToLayoutOp>(loc, rhs, bLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.getIntrinsic());
   auto layoutedAcc =
-      rewriter.create<ToLayoutOp>(loc, acc, cLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.getIntrinsic());
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -216,8 +216,8 @@ static LogicalResult setContractionAnchor(IREE::GPU::MMAScheduleAttr schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(contract);
-  auto toLayout = rewriter.create<ToLayoutOp>(loc, contract->getResult(0),
-                                              cLayout, schedule.getIntrinsic());
+  auto toLayout = ToLayoutOp::create(rewriter, loc, contract->getResult(0),
+                                     cLayout, schedule.getIntrinsic());
   rewriter.replaceAllUsesExcept(contract->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -276,11 +276,11 @@ static LogicalResult setConvolutionAnchor(IREE::GPU::MMAScheduleAttr schedule,
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(conv);
   auto layoutedLhs =
-      rewriter.create<ToLayoutOp>(loc, lhs, aLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.getIntrinsic());
   auto layoutedRhs =
-      rewriter.create<ToLayoutOp>(loc, rhs, bLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.getIntrinsic());
   auto layoutedAcc =
-      rewriter.create<ToLayoutOp>(loc, acc, cLayout, schedule.getIntrinsic());
+      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.getIntrinsic());
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -303,8 +303,8 @@ static LogicalResult setConvolutionAnchor(IREE::GPU::MMAScheduleAttr schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(conv);
-  auto toLayout = rewriter.create<ToLayoutOp>(loc, conv->getResult(0), cLayout,
-                                              schedule.getIntrinsic());
+  auto toLayout = ToLayoutOp::create(rewriter, loc, conv->getResult(0), cLayout,
+                                     schedule.getIntrinsic());
   rewriter.replaceAllUsesExcept(conv->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -553,7 +553,7 @@ static LogicalResult setDerivedThreadConfigLayout(
   for (OpResult result : linalgOp->getResults()) {
     VectorLayoutInterface resultLayout =
         getLayoutForMap(layout, linalgOp.getIndexingMapMatchingResult(result));
-    auto toLayout = rewriter.create<ToLayoutOp>(loc, result, resultLayout);
+    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 
@@ -725,7 +725,7 @@ static LogicalResult setGPULoweringConfigLayout(
     VectorLayoutInterface operandLayout =
         getLayoutForMap(layout, candidate.getMatchingIndexingMap(&operand));
     auto toLayout =
-        rewriter.create<ToLayoutOp>(loc, operand.get(), operandLayout);
+        ToLayoutOp::create(rewriter, loc, operand.get(), operandLayout);
     // Set shared memory promotion if requested.
     toLayout.setSharedMemoryConversion(
         promotedOperands[operand.getOperandNumber()]);
@@ -736,7 +736,7 @@ static LogicalResult setGPULoweringConfigLayout(
   for (OpResult result : candidate->getResults()) {
     VectorLayoutInterface resultLayout =
         getLayoutForMap(layout, candidate.getIndexingMapMatchingResult(result));
-    auto toLayout = rewriter.create<ToLayoutOp>(loc, result, resultLayout);
+    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
@@ -74,8 +74,8 @@ struct LLVMGPULinkExecutablesPass
     // Create our new "linked" hal.executable.
     SymbolTable moduleTable(moduleOp);
     std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
-    auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
-        moduleOp.getLoc(), linkedExecutableName);
+    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
         sourceExecutableOps.front().getVisibility());
     moduleTable.insert(linkedExecutableOp);
@@ -96,11 +96,10 @@ struct LLVMGPULinkExecutablesPass
               ? targetAttr.getSymbolNameFragment()
               : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
-      auto linkedTargetOp =
-          executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
-              moduleOp.getLoc(), linkedVariantName, targetAttr);
+      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
       auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      targetBuilder.create<mlir::ModuleOp>(moduleOp.getLoc());
+      mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
 
       auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
                               mlir::ModuleOp linkedInnerModule,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -103,7 +103,7 @@ calculateDistributedTileSize(ArrayRef<int64_t> numElements, OpBuilder &builder,
   if (partitionedLoops.empty()) {
     return tileSizesVal;
   }
-  auto zero = builder.create<arith::ConstantIndexOp>(operation->getLoc(), 0);
+  auto zero = arith::ConstantIndexOp::create(builder, operation->getLoc(), 0);
   tileSizesVal.resize(
       cast<TilingInterface>(operation).getLoopIteratorTypes().size(), zero);
 
@@ -117,8 +117,8 @@ calculateDistributedTileSize(ArrayRef<int64_t> numElements, OpBuilder &builder,
   for (unsigned depth : partitionedLoops) {
     if (depth >= blockTileSize.size())
       continue;
-    tileSizesVal[depth] = builder.create<arith::ConstantIndexOp>(
-        operation->getLoc(),
+    tileSizesVal[depth] = arith::ConstantIndexOp::create(
+        builder, operation->getLoc(),
         llvm::divideCeil(blockTileSize[depth], distributedDim[idIdx++]));
     if (idIdx == kNumMaxParallelDims)
       break;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -96,8 +96,8 @@ struct LLVMGPUVectorDistributePass final
                                          func.getLoc(), gpu::Dimension::x)};
     std::reverse(workgroupSize.begin(), workgroupSize.end());
 
-    Value linearThreadIdVal = rewriter.create<affine::AffineLinearizeIndexOp>(
-        func.getLoc(), threadGrid, workgroupSize, /*disjoint=*/true);
+    Value linearThreadIdVal = affine::AffineLinearizeIndexOp::create(
+        rewriter, func.getLoc(), threadGrid, workgroupSize, /*disjoint=*/true);
 
     std::optional<int64_t> subgroupSize = getSubgroupSize(func);
     if (!subgroupSize) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -49,9 +49,9 @@ struct PromoteContractOperands final
     Value rhs =
         promoteToElementType(loc, rewriter, contractOp.getRhs(), resultElType);
 
-    auto replacement = rewriter.create<vector::ContractionOp>(
-        loc, lhs, rhs, contractOp.getAcc(), contractOp.getIndexingMaps(),
-        contractOp.getIteratorTypes());
+    auto replacement = vector::ContractionOp::create(
+        rewriter, loc, lhs, rhs, contractOp.getAcc(),
+        contractOp.getIndexingMaps(), contractOp.getIteratorTypes());
 
     if (!maskOp) {
       return replacement.getResult();
@@ -77,10 +77,10 @@ struct PromoteContractOperands final
       promotedType = vecType.clone(promotedType);
 
     if (isa<FloatType>(dstElementType))
-      return rewriter.create<arith::ExtFOp>(loc, promotedType, v);
+      return arith::ExtFOp::create(rewriter, loc, promotedType, v);
     // For integer types, vector.contract only supports signless integer types
     // and promotion happens via sign extension.
-    return rewriter.create<arith::ExtSIOp>(loc, promotedType, v);
+    return arith::ExtSIOp::create(rewriter, loc, promotedType, v);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -19,12 +19,12 @@ namespace mlir::iree_compiler {
 namespace {
 
 Value createI1And(Location loc, ArrayRef<Value> values, OpBuilder &builder) {
-  Value base =
-      builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), values[0]);
+  Value base = arith::IndexCastUIOp::create(builder, loc, builder.getI1Type(),
+                                            values[0]);
   for (Value value : values.drop_front()) {
     Value rhs =
-        builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), value);
-    base = builder.create<arith::AndIOp>(loc, base, rhs);
+        arith::IndexCastUIOp::create(builder, loc, builder.getI1Type(), value);
+    base = arith::AndIOp::create(builder, loc, base, rhs);
   }
   return base;
 }
@@ -99,14 +99,14 @@ void simplifyMaskOps(RewriterBase &rewriter, vector::CreateMaskOp maskOp) {
 
     rewriter.setInsertionPoint(readOp);
     Value selectValue = createI1And(loc, ValuesToAnd, rewriter);
-    auto constantValue = rewriter.create<vector::BroadcastOp>(
-        loc, readOp.getVectorType(), readOp.getPadding());
+    auto constantValue = vector::BroadcastOp::create(
+        rewriter, loc, readOp.getVectorType(), readOp.getPadding());
 
-    auto newReadOp = rewriter.create<vector::TransferReadOp>(
-        loc, readOp.getVectorType(), readOp.getBase(), readOp.getIndices(),
-        readOp.getPadding(), ArrayRef<bool>{inBounds});
-    auto selectOp = rewriter.create<arith::SelectOp>(loc, selectValue,
-                                                     newReadOp, constantValue);
+    auto newReadOp = vector::TransferReadOp::create(
+        rewriter, loc, readOp.getVectorType(), readOp.getBase(),
+        readOp.getIndices(), readOp.getPadding(), ArrayRef<bool>{inBounds});
+    auto selectOp = arith::SelectOp::create(rewriter, loc, selectValue,
+                                            newReadOp, constantValue);
     rewriter.replaceAllUsesWith(readOp, selectOp);
   }
 }


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.