### PR TITLE
[Codegen] Upgrade Dialect and Interfaces to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
@@ -21,8 +21,8 @@ SmallVector<utils::IteratorType> InnerTiledOp::getLoopIteratorTypes() {
 
 SmallVector<Range> InnerTiledOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
-  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
   SmallVector<Range> ranges;
   SmallVector<AffineMap> indexingMaps = getIndexingMapsArray();
   int64_t numInputs = getNumInputs();
@@ -102,8 +102,8 @@ static tensor::ExtractSliceOp extractSlice(OpBuilder &b, Location loc,
 
   OpFoldResult one = b.getIndexAttr(1);
   SmallVector<OpFoldResult> fullStrides(srcRank, one);
-  return b.create<tensor::ExtractSliceOp>(loc, src, fullOffsets, fullSizes,
-                                          fullStrides);
+  return tensor::ExtractSliceOp::create(b, loc, src, fullOffsets, fullSizes,
+                                        fullStrides);
 }
 
 FailureOr<TilingResult>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -165,11 +165,11 @@ struct FoldBufferCastOfTensorCast final
     if (newSource.getType() != maxStaticType) {
       // Cast to the type with maximum static information if the input and
       // result types contain different static info.
-      newSource = rewriter.create<tensor::CastOp>(castOp.getLoc(),
-                                                  maxStaticType, newSource);
+      newSource = tensor::CastOp::create(rewriter, castOp.getLoc(),
+                                         maxStaticType, newSource);
     }
-    auto newBufferCast = rewriter.create<IREE::GPU::BufferResourceCastOp>(
-        castOp.getLoc(), maxStaticType, newSource,
+    auto newBufferCast = IREE::GPU::BufferResourceCastOp::create(
+        rewriter, castOp.getLoc(), maxStaticType, newSource,
         castOp.getCacheSwizzleStride());
     newBufferCast->setDiscardableAttrs(castOp->getDiscardableAttrDictionary());
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
@@ -27,9 +27,9 @@ Value promoteValue(OpBuilder &builder, Location loc, Value v, Attribute attr) {
   auto tensorType = cast<RankedTensorType>(v.getType());
   SmallVector<OpFoldResult> mixedSizes = tensor::getMixedSizes(builder, loc, v);
 
-  Value empty = builder.create<tensor::EmptyOp>(loc, mixedSizes,
-                                                tensorType.getElementType());
-  auto copy = builder.create<linalg::CopyOp>(loc, v, empty);
+  Value empty = tensor::EmptyOp::create(builder, loc, mixedSizes,
+                                        tensorType.getElementType());
+  auto copy = linalg::CopyOp::create(builder, loc, v, empty);
   setLoweringConfig(copy, attr);
   return copy.getResult(0);
 }
@@ -125,8 +125,8 @@ Value cacheSwizzlePromotionImpl(OpBuilder &builder, OpOperand &operand,
   // Insert the resource cast optimistically. If the input is not castable
   // (e.g. another producer) later patterns will drop it anyway as it is treated
   // like a hint.
-  auto resourceCast = builder.create<IREE::GPU::BufferResourceCastOp>(
-      loc, tensorType, bufferCastValue, cacheSwizzleVal);
+  auto resourceCast = IREE::GPU::BufferResourceCastOp::create(
+      builder, loc, tensorType, bufferCastValue, cacheSwizzleVal);
   bufferCastOperand->assign(resourceCast);
 
   return promotedValue;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -157,9 +157,9 @@ struct BarrierRegionOpBufferizationInterface
     }
 
     rewriter.setInsertionPoint(barrierOp);
-    rewriter.create<gpu::BarrierOp>(barrierOp.getLoc());
+    gpu::BarrierOp::create(rewriter, barrierOp.getLoc());
     rewriter.setInsertionPointAfter(barrierOp);
-    auto afterBarrier = rewriter.create<gpu::BarrierOp>(barrierOp.getLoc());
+    auto afterBarrier = gpu::BarrierOp::create(rewriter, barrierOp.getLoc());
 
     rewriter.inlineBlockBefore(barrierOp.getBody(), afterBarrier,
                                tensorizedOperands);
@@ -220,7 +220,7 @@ struct ValueBarrierOpBufferizationInterface
       return failure();
     }
 
-    rewriter.create<gpu::BarrierOp>(barrierOp.getLoc());
+    gpu::BarrierOp::create(rewriter, barrierOp.getLoc());
 
     SmallVector<Value> buffers;
     buffers.reserve(barrierOp.getNumOperands());
@@ -386,8 +386,8 @@ struct BufferResourceCastOpBufferizationInterface
         // FatRawBufferCast's lowering handles this for us. Just truncate to 14
         // bits.
         Type i14Type = rewriter.getIntegerType(14);
-        cacheSwizzleStride = rewriter.create<arith::IndexCastOp>(
-            loc, i14Type, maybeIndexCacheSwizzle);
+        cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
+                                                        maybeIndexCacheSwizzle);
       }
       buffer = rewriter
                    .create<amdgpu::FatRawBufferCastOp>(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -63,8 +63,8 @@ combineBarrierRegionPair(RewriterBase &rewriter,
   combinedYields.append(bYield.getValues().begin(), bYield.getValues().end());
 
   // Create the new barrier op.
-  auto combinedBarrierOp = rewriter.create<IREE::GPU::BarrierRegionOp>(
-      fusedLoc, combinedTypes, combinedOperands);
+  auto combinedBarrierOp = IREE::GPU::BarrierRegionOp::create(
+      rewriter, fusedLoc, combinedTypes, combinedOperands);
 
   MutableArrayRef<BlockArgument> barrierABbArgReplacements =
       combinedBarrierOp.getBody()->getArguments().take_front(
@@ -85,7 +85,7 @@ combineBarrierRegionPair(RewriterBase &rewriter,
   rewriter.eraseOp(bYield);
 
   rewriter.setInsertionPointToEnd(combinedBarrierOp.getBody());
-  rewriter.create<IREE::GPU::YieldOp>(fusedLoc, combinedYields);
+  IREE::GPU::YieldOp::create(rewriter, fusedLoc, combinedYields);
 
   SmallVector<Value> valuesToReplace = barrierA.getResults();
   ValueRange bResults = barrierB.getResults();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
@@ -147,8 +147,8 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
               permutation, reassociations, expandedType))) {
         continue;
       }
-      auto expandOp = rewriter.create<tensor::ExpandShapeOp>(
-          loc, expandedType, operand, reassociations);
+      auto expandOp = tensor::ExpandShapeOp::create(rewriter, loc, expandedType,
+                                                    operand, reassociations);
       maybeExpands[opIndex] = expandOp;
       newOperands[opIndex] = expandOp.getResult();
 
@@ -187,8 +187,8 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
       newPermutationsAttr = rewriter.getArrayAttr(newPermutations);
     }
     // Create the new inner_tiled op with the expanded type.
-    auto expandedTiledOp = rewriter.create<Codegen::InnerTiledOp>(
-        loc, /*inputs=*/ValueRange{newOperands}.take_front(numInputs),
+    auto expandedTiledOp = Codegen::InnerTiledOp::create(
+        rewriter, loc, /*inputs=*/ValueRange{newOperands}.take_front(numInputs),
         /*inits=*/ValueRange{newOperands}.drop_front(numInputs),
         tiledOp.getIndexingMaps(), tiledOp.getIteratorTypes(),
         tiledOp.getKind(), newPermutationsAttr);
@@ -205,8 +205,8 @@ struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
       if (!tiedInitExpand) {
         continue;
       }
-      result = rewriter.create<tensor::CollapseShapeOp>(
-          loc, tiledOp.getResultTypes()[resIndex], result,
+      result = tensor::CollapseShapeOp::create(
+          rewriter, loc, tiledOp.getResultTypes()[resIndex], result,
           tiedInitExpand.getReassociation());
     }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -444,10 +444,10 @@ NestedLayoutAttr::computeThreadIds(Value threadId, int64_t subgroupSize,
   // Add the subgroup_size to the end of the subgroup delinearization basis.
   subgroupBasis.push_back(subgroupSize);
 
-  auto subgroupSplit = rewriter.create<affine::AffineDelinearizeIndexOp>(
-      loc, threadId, subgroupBasis, /*hasOuterBound=*/false);
-  auto threadSplit = rewriter.create<affine::AffineDelinearizeIndexOp>(
-      loc, threadId, threadBasis, /*hasOuterBound=*/false);
+  auto subgroupSplit = affine::AffineDelinearizeIndexOp::create(
+      rewriter, loc, threadId, subgroupBasis, /*hasOuterBound=*/false);
+  auto threadSplit = affine::AffineDelinearizeIndexOp::create(
+      rewriter, loc, threadId, threadBasis, /*hasOuterBound=*/false);
 
   llvm::transform(subgroupDimToResult, std::back_inserter(virtualTids),
                   [&](size_t idx) { return subgroupSplit.getResult(idx); });

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -606,8 +606,8 @@ struct FoldSingleElementIndexVec final : OpRewritePattern<TransferGatherOp> {
       // Extract the scalar and add it to the
       // corressponding base.
       OpOperand &base = xferOp.getIndicesMutable()[index];
-      Value extracted = rewriter.create<vector::ExtractOp>(
-          xferOp.getLoc(), indexVec,
+      Value extracted = vector::ExtractOp::create(
+          rewriter, xferOp.getLoc(), indexVec,
           SmallVector<int64_t>(vectorTy.getRank(), 0));
       AffineExpr d0, d1;
       bindDims(xferOp.getContext(), d0, d1);

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
@@ -59,13 +59,14 @@ struct DropToLayoutUnitDims final
     VectorLayoutInterface newLayout = toLayoutOp.getLayout().project(unitDims);
 
     Value rankReducedValue = rankReducingExtract.value();
-    auto newToLayoutOp = rewriter.create<IREE::VectorExt::ToLayoutOp>(
-        loc, rankReducedValue.getType(), rankReducedValue, newLayout,
+    auto newToLayoutOp = IREE::VectorExt::ToLayoutOp::create(
+        rewriter, loc, rankReducedValue.getType(), rankReducedValue, newLayout,
         toLayoutOp.getSharedMemoryConversion(), toLayoutOp.getMmaKindAttr());
 
     // Expand to preserve output shape using insert_slice.
-    Value dest = rewriter.create<tensor::EmptyOp>(
-        loc, tensor::getMixedSizes(rewriter, loc, toLayoutOp.getInput()),
+    Value dest = tensor::EmptyOp::create(
+        rewriter, loc,
+        tensor::getMixedSizes(rewriter, loc, toLayoutOp.getInput()),
         inputTy.getElementType());
 
     int64_t rank = inputTy.getRank();

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -302,8 +302,8 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
       linalgOp.getIteratorTypesArray();
 
   Location loc = linalgOp.getLoc();
-  Operation *mmaOp = builder.create<Codegen::InnerTiledOp>(
-      loc, operands.take_front(inputs.size()),
+  Operation *mmaOp = Codegen::InnerTiledOp::create(
+      builder, loc, operands.take_front(inputs.size()),
       operands.take_back(outputs.size()),
       ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes, mma);
   return mmaOp;

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -50,11 +50,11 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
 
     if (type.isDynamicDim(dim)) {
       dim = type.getDynamicDimIndex(dim);
-      auto alignment = builder.create<arith::ConstantIndexOp>(loc, size);
-      paddedDynamicDims[dim] = builder.create<arith::CeilDivSIOp>(
-          loc, paddedDynamicDims[dim], alignment);
-      paddedDynamicDims[dim] =
-          builder.create<arith::MulIOp>(loc, paddedDynamicDims[dim], alignment);
+      auto alignment = arith::ConstantIndexOp::create(builder, loc, size);
+      paddedDynamicDims[dim] = arith::CeilDivSIOp::create(
+          builder, loc, paddedDynamicDims[dim], alignment);
+      paddedDynamicDims[dim] = arith::MulIOp::create(
+          builder, loc, paddedDynamicDims[dim], alignment);
     } else {
       paddedShape[dim] = llvm::alignTo(paddedShape[dim], size);
     }
@@ -75,9 +75,9 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
   }
 
   Value result =
-      builder.create<arith::ConstantIndexOp>(loc, staticCount).getResult();
+      arith::ConstantIndexOp::create(builder, loc, staticCount).getResult();
   for (auto dim : paddedDynamicDims) {
-    result = builder.create<arith::MulIOp>(loc, result, dim);
+    result = arith::MulIOp::create(builder, loc, result, dim);
   }
 
   // Always pack the elements back-to-back for subtypes.
@@ -86,9 +86,9 @@ Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
       assert(false && "unsupported subtype");
       return Value();
     }
-    Value divisor = builder.create<arith::ConstantIndexOp>(
-        loc, kNumBitsInByte / elementBits);
-    result = builder.create<arith::CeilDivUIOp>(loc, result, divisor);
+    Value divisor = arith::ConstantIndexOp::create(
+        builder, loc, kNumBitsInByte / elementBits);
+    result = arith::CeilDivUIOp::create(builder, loc, result, divisor);
   }
 
   return result;

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -144,8 +144,8 @@ struct DispatchTensorStoreOpInterface
               cast<MemRefType>(target.getType()), storeOp.getMixedOffsets(),
               storeOp.getMixedSizes(), storeOp.getMixedStrides()));
 
-      target = rewriter.create<memref::SubViewOp>(
-          storeOp->getLoc(), subviewMemRefType, target,
+      target = memref::SubViewOp::create(
+          rewriter, storeOp->getLoc(), subviewMemRefType, target,
           storeOp.getMixedOffsets(), storeOp.getMixedSizes(),
           storeOp.getMixedStrides());
     } // else: Writing the entire tensor, no subview required.
@@ -390,9 +390,9 @@ static LogicalResult bufferizePackOp(RewriterBase &rewriter, linalg::PackOp op,
 
   // Set insertion point now that potential alloc/dealloc are introduced.
   rewriter.setInsertionPoint(op);
-  rewriter.create<IREE::LinalgExt::PackOp>(
-      op.getLoc(), source, dest, op.getInnerDimsPos(), op.getMixedTiles(),
-      op.getPaddingValue(), op.getOuterDimsPerm());
+  IREE::LinalgExt::PackOp::create(rewriter, op.getLoc(), source, dest,
+                                  op.getInnerDimsPos(), op.getMixedTiles(),
+                                  op.getPaddingValue(), op.getOuterDimsPerm());
 
   // Replace the results of the old op with the new output buffers.
   bufferization::replaceOpWithBufferizedValues(rewriter, op, dest);
@@ -416,9 +416,9 @@ static LogicalResult bufferizeUnPackOp(RewriterBase &rewriter,
 
   // Set insertion point now that potential alloc/dealloc are introduced.
   rewriter.setInsertionPoint(op);
-  rewriter.create<IREE::LinalgExt::UnPackOp>(
-      op.getLoc(), source, dest, op.getInnerDimsPos(), op.getMixedTiles(),
-      op.getOuterDimsPerm());
+  IREE::LinalgExt::UnPackOp::create(rewriter, op.getLoc(), source, dest,
+                                    op.getInnerDimsPos(), op.getMixedTiles(),
+                                    op.getOuterDimsPerm());
 
   // Replace the results of the old op with the new output buffers.
   bufferization::replaceOpWithBufferizedValues(rewriter, op, dest);
@@ -557,8 +557,9 @@ struct DispatchTensorStoreOpSubsetInsertionInterface
   Value buildSubsetExtraction(Operation *op, OpBuilder &builder,
                               Location loc) const {
     auto storeOp = cast<IREE::TensorExt::DispatchTensorStoreOp>(op);
-    auto loadOp = builder.create<IREE::TensorExt::DispatchTensorLoadOp>(
-        loc, llvm::cast<RankedTensorType>(storeOp.getValue().getType()),
+    auto loadOp = IREE::TensorExt::DispatchTensorLoadOp::create(
+        builder, loc,
+        llvm::cast<RankedTensorType>(storeOp.getValue().getType()),
         storeOp.getTarget(), storeOp.getTargetDims(), storeOp.getMixedOffsets(),
         storeOp.getMixedSizes(), storeOp.getMixedStrides());
     return loadOp.getResult();
@@ -650,8 +651,8 @@ struct StoreToBufferOpSubsetInsertionInterface
   Value buildSubsetExtraction(Operation *op, OpBuilder &builder,
                               Location loc) const {
     auto storeOp = cast<IREE::Codegen::StoreToBufferOp>(op);
-    auto loadOp = builder.create<IREE::Codegen::LoadFromBufferOp>(
-        loc, storeOp.getTensor().getType(), storeOp.getBuffer());
+    auto loadOp = IREE::Codegen::LoadFromBufferOp::create(
+        builder, loc, storeOp.getTensor().getType(), storeOp.getBuffer());
     return loadOp.getResult();
   }
 


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.