### PR TITLE
[Codegen] Upgrade Transforms and Utils to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
@@ -44,11 +44,11 @@ static void replaceForWithIf(PatternRewriter &rewriter, scf::ForOp op,
   Block *block = op.getBody();
   ValueRange initArgs = op.getInitArgs();
   Value count =
-      rewriter.create<arith::CmpIOp>(op->getLoc(), arith::CmpIPredicate::sgt,
-                                     op.getUpperBound(), op.getLowerBound());
+      arith::CmpIOp::create(rewriter, op->getLoc(), arith::CmpIPredicate::sgt,
+                            op.getUpperBound(), op.getLowerBound());
   auto ifOp =
-      rewriter.create<scf::IfOp>(op->getLoc(), op.getResultTypes(), count,
-                                 /*withElseRegion=*/initArgs.size() != 0);
+      scf::IfOp::create(rewriter, op->getLoc(), op.getResultTypes(), count,
+                        /*withElseRegion=*/initArgs.size() != 0);
   Operation *terminator = block->getTerminator();
   rewriter.inlineBlockBefore(block, &ifOp.getThenRegion().front(),
                              ifOp.getThenRegion().front().begin(), blockArgs);
@@ -56,7 +56,7 @@ static void replaceForWithIf(PatternRewriter &rewriter, scf::ForOp op,
     rewriter.eraseOp(terminator);
   } else {
     rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(ifOp.getLoc(), initArgs);
+    scf::YieldOp::create(rewriter, ifOp.getLoc(), initArgs);
   }
   rewriter.replaceOp(op, ifOp);
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -63,13 +63,13 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
     // necessary vscale operation and the corresponding static_size * vscale
     // values.
     SmallVector<OpFoldResult> result(staticTileSizes.size());
-    auto vscale = rewriter.create<vector::VectorScaleOp>(loc);
+    auto vscale = vector::VectorScaleOp::create(rewriter, loc);
     for (size_t i = 0; i < result.size(); i++) {
       if (materializeEncodingInfo.scalableTiles.value()[i]) {
         auto staticTileSize =
-            rewriter.create<arith::ConstantIndexOp>(loc, staticTileSizes[i]);
+            arith::ConstantIndexOp::create(rewriter, loc, staticTileSizes[i]);
         auto scalableInnerTileSize =
-            rewriter.create<arith::MulIOp>(loc, staticTileSize, vscale);
+            arith::MulIOp::create(rewriter, loc, staticTileSize, vscale);
         result[i] = scalableInnerTileSize.getResult();
       } else {
         result[i] = rewriter.getI64IntegerAttr(staticTileSizes[i]);
@@ -85,8 +85,8 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
     return failure();
   }
   SmallVector<Type> resultTypes(tensorType.getRank(), rewriter.getIndexType());
-  auto op = rewriter.create<IREE::Codegen::QueryTileSizesOp>(
-      loc, resultTypes, TypeAttr::get(tensorType));
+  auto op = IREE::Codegen::QueryTileSizesOp::create(rewriter, loc, resultTypes,
+                                                    TypeAttr::get(tensorType));
   SmallVector<Value> innerTileSizeValues = op.getResults();
 
   SmallVector<OpFoldResult> result(staticTileSizes.size());
@@ -95,7 +95,7 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
       result[i] = innerTileSizeValues[i];
     } else if (tensorType.isDynamicDim(i)) {
       result[i] =
-          rewriter.create<arith::ConstantIndexOp>(loc, staticTileSizes[i])
+          arith::ConstantIndexOp::create(rewriter, loc, staticTileSizes[i])
               .getResult();
     } else {
       result[i] = rewriter.getI64IntegerAttr(staticTileSizes[i]);


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.

The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.