### PR TITLE
[CI] Fix mi308 spec for sharktank_models tests

### DIFF
--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -27,7 +27,7 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
 
   %config = transform.param.constant #iree_codegen.compilation_info<
-          lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
+          lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
           translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
                                                             workgroup_size = [64, 4]
                                                             subgroup_size = 64 ,
@@ -37,10 +37,10 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   %decomposition_config = transform.param.constant {
     qk_attrs = {attention_qk_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
-                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+                                                              subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1] }>},
     pv_attrs = {attention_pv_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+                                                              subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1] }>}
   } -> !transform.any_param
 
   transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param


### PR DESCRIPTION
Fixes CI failing from https://github.com/iree-org/iree/commit/dd1688bcc968b265769eb9114023acc2d46789d1 by updating the workgroup tile size to be a divisor of 960, as required by model shapes.