### PR TITLE
[LinalgExt] Fold subview ops into map_scatter output before decomposing

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -12,11 +12,70 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
 #define GEN_PASS_DEF_DECOMPOSEMAPSCATTERPASS
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h.inc"
+
+/// Fold a subview op into the output of a map_scatter op. The offsets of the
+/// subview op are folded into the body of the map_scatter, and each offset is
+/// added to the corresponding yielded index. The map_scatter op must be
+/// vectorized and bufferized, because this is a cleanup pattern for the vector
+/// decomposition of map_scatter.
+struct FoldSubViewIntoMapScatter final : OpRewritePattern<MapScatterOp> {
+  using OpRewritePattern<MapScatterOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(MapScatterOp mapScatterOp,
+                                PatternRewriter &rewriter) const override {
+    if (!mapScatterOp.isVectorized()) {
+      return rewriter.notifyMatchFailure(mapScatterOp,
+                                         "map_scatter op is not vectorized");
+    }
+    if (!mapScatterOp.hasPureBufferSemantics()) {
+      return rewriter.notifyMatchFailure(
+          mapScatterOp, "map_scatter op has non-buffer semantics");
+    }
+    auto subViewOp =
+        mapScatterOp.getOutput().getDefiningOp<memref::SubViewOp>();
+    if (!subViewOp) {
+      return failure();
+    }
+    if (subViewOp.getSourceType().getRank() != subViewOp.getType().getRank()) {
+      return rewriter.notifyMatchFailure(subViewOp,
+                                         "subview op is rank reducing");
+    }
+    SmallVector<OpFoldResult> strides = subViewOp.getMixedStrides();
+    if (!areAllConstantIntValue(strides, 1)) {
+      return rewriter.notifyMatchFailure(subViewOp,
+                                         "subview op has non-unit strides");
+    }
+    auto mapScatterBodyYield = cast<IREE::LinalgExt::YieldOp>(
+        mapScatterOp.getTransformationRegion().front().getTerminator());
+    SmallVector<Value> yieldedIndices = mapScatterBodyYield.getOperands();
+    Value yieldedMask = yieldedIndices.pop_back_val();
+    rewriter.setInsertionPoint(mapScatterBodyYield);
+    for (auto [yieldedIdx, subViewOffset] :
+         llvm::zip_equal(yieldedIndices, subViewOp.getMixedOffsets())) {
+      Value subViewOffsetVal = getValueOrCreateConstantIndexOp(
+          rewriter, subViewOp.getLoc(), subViewOffset);
+      Value yieldedIdxVal = getValueOrCreateConstantIndexOp(
+          rewriter, mapScatterBodyYield.getLoc(), yieldedIdx);
+      yieldedIdx = rewriter.create<arith::AddIOp>(
+          subViewOp.getLoc(), yieldedIdxVal, subViewOffsetVal);
+    }
+    SmallVector<Value> newYieldedValues(yieldedIndices);
+    newYieldedValues.push_back(yieldedMask);
+    rewriter.modifyOpInPlace(mapScatterBodyYield, [&]() {
+      mapScatterBodyYield.getOperandsMutable().assign(newYieldedValues);
+    });
+    Value subViewSource = subViewOp.getSource();
+    rewriter.modifyOpInPlace(subViewOp, [&]() {
+      mapScatterOp.getOutputMutable().assign(subViewSource);
+    });
+    return success();
+  }
+};
 
 /// Decompose an iree_linalg_ext.map_scatter op with a vector input, and a
 /// memref output. The map_scatter op is lowered into a sequence of vector ops
@@ -154,6 +213,16 @@ struct DecomposeMapScatterPass final
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     auto funcOp = getOperation();
+
+    RewritePatternSet patterns(context);
+    patterns.add<FoldSubViewIntoMapScatter>(context);
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    if (testMapScatterCleanup) {
+      return;
+    }
 
     // Decomposition is only supported for map_scatter ops that are both
     // vectorized and bufferized. Bufferization is a requirement because

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -69,6 +69,11 @@ def DecomposeMapScatterPass :
     "::mlir::vector::VectorDialect",
     "::mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect"
   ];
+  let options = [
+    Option<"testMapScatterCleanup", "test-map-scatter-cleanup", "bool",
+           /*default=*/"false",
+           "Test only map_scatter cleanup patterns.">,
+  ];
 }
 
 def DecomposeWinogradTransformPass :

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -70,9 +70,9 @@ def DecomposeMapScatterPass :
     "::mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect"
   ];
   let options = [
-    Option<"testMapScatterCleanup", "test-map-scatter-cleanup", "bool",
+    Option<"testPreprocessingPatterns", "test-preprocessing-patterns", "bool",
            /*default=*/"false",
-           "Test only map_scatter cleanup patterns.">,
+           "Test only map_scatter decomposition preprocessing patterns.">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter,cse))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=CHECK %s
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter{test-map-scatter-cleanup=true},cse))" \
-// RUN:   --split-input-file %s | FileCheck --check-prefix=CLEANUP %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter{test-preprocessing-patterns=true},cse))" \
+// RUN:   --split-input-file %s | FileCheck --check-prefix=PREPROCESSING %s
 
 func.func @identity_map_scatter(
     %input: vector<4x16xf32>, %output: memref<4x16xf32>
@@ -62,7 +62,7 @@ func.func @map_scatter_with_mask(
 
 // -----
 
-func.func @cleanup_map_scatter_into_subview(
+func.func @map_scatter_into_subview(
     %input: vector<4x16xf32>, %output: memref<8x32xf32>
 ) {
   %subview = memref.subview %output[2, 7][4, 16][1, 1] : memref<8x32xf32> to memref<4x16xf32, strided<[32, 1], offset: 71>>
@@ -73,7 +73,7 @@ func.func @cleanup_map_scatter_into_subview(
   } : vector<4x16xf32> into memref<4x16xf32, strided<[32, 1], offset: 71>>
   return
 }
-// CHECK-LABEL: func.func @cleanup_map_scatter_into_subview(
+// CHECK-LABEL: func.func @map_scatter_into_subview(
 //  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
 //   CHECK-NOT:   memref.subview
@@ -85,15 +85,43 @@ func.func @cleanup_map_scatter_into_subview(
 //       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
 //  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
 
-// CLEANUP-LABEL: func.func @cleanup_map_scatter_into_subview(
-//  CLEANUP-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
-//  CLEANUP-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
-//   CLEANUP-DAG:   %[[C2:.+]] = arith.constant 2 : index
-//   CLEANUP-DAG:   %[[C7:.+]] = arith.constant 7 : index
-//   CLEANUP-NOT:   memref.subview
-//       CLEANUP:   iree_linalg_ext.map_scatter %[[INPUT]] into %[[OUTPUT]] {
-//       CLEANUP:     ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
-//       CLEANUP:       %[[OUT_IDX0:.+]] = arith.addi %[[IDX0]], %[[C2]]
-//       CLEANUP:       %[[OUT_IDX1:.+]] = arith.addi %[[IDX1]], %[[C7]]
-//       CLEANUP:       iree_linalg_ext.yield %[[OUT_IDX0]], %[[OUT_IDX1]]
-//       CLEANUP:   } : vector<4x16xf32> into memref<8x32xf32>
+// PREPROCESSING-LABEL: func.func @map_scatter_into_subview(
+//  PREPROCESSING-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  PREPROCESSING-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   PREPROCESSING-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   PREPROCESSING-DAG:   %[[C7:.+]] = arith.constant 7 : index
+//   PREPROCESSING-NOT:   memref.subview
+//       PREPROCESSING:   iree_linalg_ext.map_scatter %[[INPUT]] into %[[OUTPUT]] {
+//       PREPROCESSING:     ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       PREPROCESSING:       %[[OUT_IDX0:.+]] = arith.addi %[[IDX0]], %[[C2]]
+//       PREPROCESSING:       %[[OUT_IDX1:.+]] = arith.addi %[[IDX1]], %[[C7]]
+//       PREPROCESSING:       iree_linalg_ext.yield %[[OUT_IDX0]], %[[OUT_IDX1]]
+//       PREPROCESSING:   } : vector<4x16xf32> into memref<8x32xf32>
+
+// -----
+
+func.func @map_scatter_into_collapsible_subview(
+    %input: vector<4x16xf32>, %output: memref<8x32xf32>
+) {
+    %subview = memref.subview %output[0, 0][4, 32][1, 1] : memref<8x32xf32> to memref<4x32xf32, strided<[32, 1]>>
+    iree_linalg_ext.map_scatter %input into %subview {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf32> into memref<4x32xf32, strided<[32, 1]>>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_into_collapsible_subview(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[SUBVIEW]] {{.*}} memref<4x32xf32{{.*}} into memref<128xf32
+//   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
+//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
+//   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
+//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
+//  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
+
+// PREPROCESSING-LABEL: func.func @map_scatter_into_collapsible_subview(
+//  PREPROCESSING:        memref.subview


### PR DESCRIPTION
Folds memref.subview ops into iree_linalg_ext.map_scatter ops by adding the offsets to the transformation region of the map_scatter op. This enables decomposition for map_scatter ops that have non-collapsable buffers due to strided subviews.