### PR TITLE
[Codegen] Upgrade iree dialects to free create functions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -85,7 +85,7 @@ Value LayoutAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
       res = requestedSize;
       continue;
     }
-    res = builder.create<arith::MaxUIOp>(loc, res, requestedSize);
+    res = arith::MaxUIOp::create(builder, loc, res, requestedSize);
   }
   return res;
 }
@@ -457,7 +457,7 @@ Value PaddingAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
 
   const int64_t elementSize = getRoundedElementByteWidth(type.getElementType());
   int64_t staticProduct = elementSize;
-  Value dynamicProduct = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value dynamicProduct = arith::ConstantIndexOp::create(builder, loc, 1);
 
   size_t dynamicDimIdx = 0;
   for (auto [dimSize, padValue] : llvm::zip_equal(type.getShape(), padding)) {
@@ -470,9 +470,9 @@ Value PaddingAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
     ++dynamicDimIdx;
 
     if (padValue != 0) {
-      dynamicDimSize = builder.create<arith::AddIOp>(
-          loc, dynamicDimSize,
-          builder.create<arith::ConstantIndexOp>(loc, padValue),
+      dynamicDimSize = arith::AddIOp::create(
+          builder, loc, dynamicDimSize,
+          arith::ConstantIndexOp::create(builder, loc, padValue),
           arith::IntegerOverflowFlags::nsw);
     }
     dynamicProduct = builder.createOrFold<arith::MulIOp>(
@@ -480,7 +480,7 @@ Value PaddingAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
   }
 
   return builder.createOrFold<arith::MulIOp>(
-      loc, builder.create<arith::ConstantIndexOp>(loc, staticProduct),
+      loc, arith::ConstantIndexOp::create(builder, loc, staticProduct),
       dynamicProduct, arith::IntegerOverflowFlags::nsw);
 }
 
@@ -506,7 +506,7 @@ Value IdentityAttr::calculateStorageSizeInBytes(Location loc,
                                                 ValueRange dynamicDims) const {
   const int64_t elementSize = getRoundedElementByteWidth(type.getElementType());
   int64_t staticProduct = elementSize;
-  Value dynamicProduct = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value dynamicProduct = arith::ConstantIndexOp::create(builder, loc, 1);
 
   size_t dynamicDimIdx = 0;
   for (int64_t dimSize : type.getShape()) {
@@ -521,7 +521,7 @@ Value IdentityAttr::calculateStorageSizeInBytes(Location loc,
         loc, dynamicProduct, dynamicDimSize, arith::IntegerOverflowFlags::nsw);
   }
   return builder.createOrFold<arith::MulIOp>(
-      loc, builder.create<arith::ConstantIndexOp>(loc, staticProduct),
+      loc, arith::ConstantIndexOp::create(builder, loc, staticProduct),
       dynamicProduct, arith::IntegerOverflowFlags::nsw);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/ElementPackingUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/ElementPackingUtils.cpp
@@ -114,7 +114,7 @@ Value calculateStorageElementCountInBytes(Location loc,
   }
   // Scale by dynamic dims, if present.
   auto value =
-      builder.create<arith::ConstantIndexOp>(loc, staticCount).getResult();
+      arith::ConstantIndexOp::create(builder, loc, staticCount).getResult();
   for (auto dim : dynamicDims) {
     value = builder.createOrFold<arith::MulIOp>(loc, value, dim);
   }
@@ -124,7 +124,7 @@ Value calculateStorageElementCountInBytes(Location loc,
     unsigned byteElements = 8 / elementBits;
     // TODO(antiagainst): We may want to emit runtime check to make sure this is
     // divisible.
-    auto divisor = builder.create<arith::ConstantIndexOp>(loc, byteElements);
+    auto divisor = arith::ConstantIndexOp::create(builder, loc, byteElements);
     if (!isPackedStorage && dynamicDims.empty() &&
         (staticCount * elementBits) % 8 != 0) {
       return nullptr;
@@ -148,15 +148,15 @@ Value calculateStorageElementOffsetInBytes(Location loc,
   // Sub-byte packing requires putting multiple elements in the same byte.
   if (needToPackSubByteElementBitWidthImpl(elementBits, isPackedStorage)) {
     Value byteElements =
-        builder.create<arith::ConstantIndexOp>(loc, 8 / elementBits);
+        arith::ConstantIndexOp::create(builder, loc, 8 / elementBits);
     // TODO(antiagainst): We may want to emit runtime check to make sure this is
     // divisible.
     return builder.createOrFold<arith::DivUIOp>(loc, linearizedIndex,
                                                 byteElements);
   }
 
-  Value elementBytes = builder.create<arith::ConstantIndexOp>(
-      loc, IREE::Util::getRoundedElementByteWidth(alignedElementType));
+  Value elementBytes = arith::ConstantIndexOp::create(
+      builder, loc, IREE::Util::getRoundedElementByteWidth(alignedElementType));
   return builder.createOrFold<arith::MulIOp>(loc, linearizedIndex,
                                              elementBytes);
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -164,11 +164,11 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
                                 ? inputType.getDimSize(position)
                                 : resultType.getDimSize(position);
           dimSizes[position] =
-              rewriter.create<arith::ConstantIndexOp>(loc, dimSize);
+              arith::ConstantIndexOp::create(rewriter, loc, dimSize);
         } else {
           // Dynamic dim.
           dimSizes[position] =
-              rewriter.create<tensor::DimOp>(loc, input, position);
+              tensor::DimOp::create(rewriter, loc, input, position);
         }
       }
 
@@ -249,14 +249,14 @@ struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
       inputShapes.emplace_back(std::move(inputShape));
     }
 
-    Value replacement = rewriter.create<tensor::EmptyOp>(
-        loc, outputShape, concatOp.getType().getElementType());
+    Value replacement = tensor::EmptyOp::create(
+        rewriter, loc, outputShape, concatOp.getType().getElementType());
 
     SmallVector<int64_t> resultStaticDims;
     SmallVector<Value> resultDynamicDims;
     dispatchIndexOpFoldResults(outputShape, resultDynamicDims,
                                resultStaticDims);
-    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     // Generate the `flow.tensor.update` operations for the concat.
     for (auto [index, input] : llvm::enumerate(concatOp.getInputs())) {
       SmallVector<int64_t> inputStaticShape;
@@ -266,9 +266,9 @@ struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
       SmallVector<Value> offsets(inputStaticShape.size(), zero);
       offsets[0] =
           getValueOrCreateConstantIndexOp(rewriter, loc, concatOffsets[index]);
-      replacement = rewriter.create<IREE::Flow::TensorUpdateOp>(
-          loc, replacement.getType(), replacement, resultDynamicDims, offsets,
-          input, inputDynamicShape);
+      replacement = IREE::Flow::TensorUpdateOp::create(
+          rewriter, loc, replacement.getType(), replacement, resultDynamicDims,
+          offsets, input, inputDynamicShape);
     }
     rewriter.replaceOp(concatOp, replacement);
     return success();
@@ -299,19 +299,20 @@ struct ConvertTensorFromElementsPattern
     }
 
     const int64_t rank = tensorType.getRank();
-    Value result = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), tensorType.getShape(), tensorType.getElementType());
+    Value result =
+        tensor::EmptyOp::create(rewriter, op.getLoc(), tensorType.getShape(),
+                                tensorType.getElementType());
     SmallVector<Value> ivs(rank);
     for (int i = 0, s = op.getNumOperands(); i < s; ++i) {
       int64_t index = i;
       for (int j = rank - 1; j >= 0; --j) {
         int64_t iv = index % tensorType.getDimSize(j);
         index = index / tensorType.getDimSize(j);
-        ivs[j] = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), iv);
+        ivs[j] = arith::ConstantIndexOp::create(rewriter, op.getLoc(), iv);
       }
 
-      result = rewriter.create<Flow::TensorStoreOp>(
-          op.getLoc(), op.getOperand(i), result, ivs);
+      result = Flow::TensorStoreOp::create(rewriter, op.getLoc(),
+                                           op.getOperand(i), result, ivs);
     }
 
     rewriter.replaceOp(op, result);
@@ -327,7 +328,7 @@ static SmallVector<Value> getDynamicTensorSizes(OpBuilder &builder,
   SmallVector<Value> sizes;
   for (const auto [idx, size] : enumerate(type.getShape())) {
     if (type.isDynamicDim(idx)) {
-      Value dim = builder.create<tensor::DimOp>(loc, tensor, idx);
+      Value dim = tensor::DimOp::create(builder, loc, tensor, idx);
       sizes.push_back(dim);
     }
   }
@@ -360,14 +361,14 @@ struct ConvertTensorDialectReshapeOpPattern
     // (ignore static dimensions)
     SmallVector<Value> destSizes;
     for (int i = 0; i < shapeOperandType.getShape()[0]; i++) {
-      Value idx = rewriter.create<arith::ConstantIndexOp>(loc, i);
-      Value element = rewriter.create<tensor::ExtractOp>(loc, op.getShape(),
-                                                         ValueRange({idx}));
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, i);
+      Value element = tensor::ExtractOp::create(rewriter, loc, op.getShape(),
+                                                ValueRange({idx}));
       if (ShapedType::isDynamic(resultType.getShape()[i])) {
         auto elementTy = element.getType();
         if (isa<IntegerType>(elementTy)) {
-          element = rewriter.create<arith::IndexCastOp>(
-              loc, rewriter.getIndexType(), element);
+          element = arith::IndexCastOp::create(
+              rewriter, loc, rewriter.getIndexType(), element);
         }
         destSizes.push_back(element);
       }

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -153,8 +153,9 @@ convertInsertSliceOpToFlowUpdateOp(RewriterBase &rewriter,
     auto unreducedShape = getShapeFromSizes(sizes);
     sourceType =
         RankedTensorType::get(unreducedShape, sourceType.getElementType());
-    source = rewriter.create<IREE::Flow::TensorReshapeOp>(
-        loc, sourceType, source, sourceDynamicDims, sourceDynamicDims);
+    source = IREE::Flow::TensorReshapeOp::create(rewriter, loc, sourceType,
+                                                 source, sourceDynamicDims,
+                                                 sourceDynamicDims);
   }
 
   auto offsetVals = getValueOrCreateConstantIndexOp(rewriter, loc,
@@ -203,12 +204,12 @@ convertExtractSliceOpToFlowSliceOp(RewriterBase &rewriter,
   auto sourceDynamicDims =
       tensor::createDynamicDimValues(rewriter, loc, sliceOp.getSource());
   auto resultDynamicDims = getDynamicValues(sizes);
-  Value replacement = rewriter.create<TensorSliceOp>(
-      loc, resultType, sliceOp.getSource(), sourceDynamicDims, offsetVals,
-      sizeVals, resultDynamicDims);
+  Value replacement = TensorSliceOp::create(
+      rewriter, loc, resultType, sliceOp.getSource(), sourceDynamicDims,
+      offsetVals, sizeVals, resultDynamicDims);
   if (resultType.getRank() > sliceOp.getType().getRank()) {
-    replacement = rewriter.create<IREE::Flow::TensorReshapeOp>(
-        loc, sliceOp.getType(), replacement, resultDynamicDims,
+    replacement = IREE::Flow::TensorReshapeOp::create(
+        rewriter, loc, sliceOp.getType(), replacement, resultDynamicDims,
         resultDynamicDims);
   }
   rewriter.replaceOp(sliceOp, replacement);

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
@@ -75,10 +75,11 @@ FlowDialect::FlowDialect(MLIRContext *context)
 Operation *FlowDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                             Type type, Location loc) {
   if (arith::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
+    return arith::ConstantOp::create(builder, loc, type,
+                                     cast<TypedAttr>(value));
   } else if (IREE::Flow::TensorConstantOp::isBuildableWith(value, type)) {
-    return builder.create<IREE::Flow::TensorConstantOp>(loc, type,
-                                                        cast<TypedAttr>(value));
+    return IREE::Flow::TensorConstantOp::create(builder, loc, type,
+                                                cast<TypedAttr>(value));
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -595,8 +595,9 @@ bool dropUnusedAndRedundantDispatchRegionResults(
     return false;
 
   // Create new region and move over the body.
-  auto newRegionOp = rewriter.create<Flow::DispatchRegionOp>(
-      regionOp.getLoc(), resultTypes, dynamicDims, regionOp.getWorkload());
+  auto newRegionOp =
+      Flow::DispatchRegionOp::create(rewriter, regionOp.getLoc(), resultTypes,
+                                     dynamicDims, regionOp.getWorkload());
   newRegionOp.getBody().takeBody(regionOp.getBody());
 
   // Update terminator.
@@ -1049,9 +1050,10 @@ DispatchWorkgroupsOp::cloneReplacementExcludingOperandsAndResults(
   IREE::Util::excludeTiedOperandAndResultIndices(
       excludedOperandIndices, excludedResultIndices, newTiedOperandIndices);
 
-  auto newOp = rewriter.create<DispatchWorkgroupsOp>(
-      getLoc(), getWorkload(), newResultTypes, newResultDims, newArguments,
-      newArgumentDims, newTiedOperandIndices, getOperation()->getAttrs());
+  auto newOp = DispatchWorkgroupsOp::create(
+      rewriter, getLoc(), getWorkload(), newResultTypes, newResultDims,
+      newArguments, newArgumentDims, newTiedOperandIndices,
+      getOperation()->getAttrs());
   newOp->setDialectAttrs(getOperation()->getDialectAttrs());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -101,7 +101,7 @@ static void rewriteParallelInsertSlices(RewriterBase &rewriter,
            "expected that dest is an output bbArg");
     Value dest = forallOp.getTiedOpOperand(destBbArg)->get();
     // clang-format off
-    IREE::TensorExt::DispatchTensorStoreOp::create(rewriter, 
+    IREE::TensorExt::DispatchTensorStoreOp::create(rewriter,
         loc,
         parallelInsertOp.getSource(),
         tensorToFlowBvm.lookup(dest),
@@ -144,7 +144,7 @@ static void rewriteExtractSlices(RewriterBase &rewriter, scf::ForallOp forallOp,
     auto dynamicDims = IREE::Util::findDynamicDimsInList(index, tensorOperands,
                                                          tensorDynamicDims);
     // clang-format off
-    Value load = IREE::TensorExt::DispatchTensorLoadOp::create(rewriter, 
+    Value load = IREE::TensorExt::DispatchTensorLoadOp::create(rewriter,
         loc,
         sourceFlow,
         dynamicDims,
@@ -330,7 +330,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   SmallVector<Value> allTensorDynamicDims = tensorDynamicDims;
   llvm::append_range(allTensorDynamicDims, resultTensorsDynamicDims);
   // clang-format off
-  auto dispatchOp = IREE::Flow::DispatchWorkgroupsOp::create(rewriter, 
+  auto dispatchOp = IREE::Flow::DispatchWorkgroupsOp::create(rewriter,
       loc,
       /*workload=*/ValueRange{},
       /*resultTypes=*/forallOp.getResultTypes(),

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -69,9 +69,9 @@ static LogicalResult populateWorkgroupCountComputingRegion(
   }
   // Resize to `3` to match IREE's assumptions.
   for (unsigned i = results.size(); i < 3; ++i) {
-    results.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 1));
+    results.push_back(arith::ConstantIndexOp::create(rewriter, loc, 1));
   }
-  rewriter.create<IREE::Flow::ReturnOp>(loc, results);
+  IREE::Flow::ReturnOp::create(rewriter, loc, results);
 
   return success();
 }
@@ -101,7 +101,7 @@ static void rewriteParallelInsertSlices(RewriterBase &rewriter,
            "expected that dest is an output bbArg");
     Value dest = forallOp.getTiedOpOperand(destBbArg)->get();
     // clang-format off
-    rewriter.create<IREE::TensorExt::DispatchTensorStoreOp>(
+    IREE::TensorExt::DispatchTensorStoreOp::create(rewriter, 
         loc,
         parallelInsertOp.getSource(),
         tensorToFlowBvm.lookup(dest),
@@ -144,7 +144,7 @@ static void rewriteExtractSlices(RewriterBase &rewriter, scf::ForallOp forallOp,
     auto dynamicDims = IREE::Util::findDynamicDimsInList(index, tensorOperands,
                                                          tensorDynamicDims);
     // clang-format off
-    Value load = rewriter.create<IREE::TensorExt::DispatchTensorLoadOp>(
+    Value load = IREE::TensorExt::DispatchTensorLoadOp::create(rewriter, 
         loc,
         sourceFlow,
         dynamicDims,
@@ -273,7 +273,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
         getIndicesOfDynamicDims(llvm::cast<ShapedType>(dest.getType()));
     for (int64_t dim : dynamicDims)
       resultTensorsDynamicDims.insert(
-          rewriter.create<tensor::DimOp>(loc, dest, dim));
+          tensor::DimOp::create(rewriter, loc, dest, dim));
   }
   assert(resultTensorOperands.size() == forallOp.getNumResults() &&
          "Expected as many resultTensorOperands as results of forallOp");
@@ -296,7 +296,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
       continue;
     tensorOperands.push_back(v);
     for (int64_t dim : getIndicesOfDynamicDims(tensorType))
-      tensorDynamicDims.push_back(rewriter.create<tensor::DimOp>(loc, v, dim));
+      tensorDynamicDims.push_back(tensor::DimOp::create(rewriter, loc, v, dim));
   }
   // Also add shared outputs. (These are usually already added as result
   // tensor operands.)
@@ -306,7 +306,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
       continue;
     tensorOperands.push_back(v);
     for (int64_t dim : getIndicesOfDynamicDims(tensorType))
-      tensorDynamicDims.push_back(rewriter.create<tensor::DimOp>(loc, v, dim));
+      tensorDynamicDims.push_back(tensor::DimOp::create(rewriter, loc, v, dim));
   }
 
   // Step 3. Create ordered vectors of operands to pass to the builder and
@@ -330,7 +330,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   SmallVector<Value> allTensorDynamicDims = tensorDynamicDims;
   llvm::append_range(allTensorDynamicDims, resultTensorsDynamicDims);
   // clang-format off
-  auto dispatchOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
+  auto dispatchOp = IREE::Flow::DispatchWorkgroupsOp::create(rewriter, 
       loc,
       /*workload=*/ValueRange{},
       /*resultTypes=*/forallOp.getResultTypes(),
@@ -374,7 +374,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   {
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointToEnd(block);
-    rewriter.create<IREE::Flow::ReturnOp>(loc);
+    IREE::Flow::ReturnOp::create(rewriter, loc);
   }
   // Add trailing index bbArgs and perform a basic sanity check.
   block->addArguments(
@@ -411,8 +411,8 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
     // does not work out of the box with IREE::TensorExt::DispatchTensorType.
     auto dynamicDims = IREE::Util::findDynamicDimsInList(
         en.index(), allTensorOperands, allTensorDimsBBArgs);
-    auto loadOp = rewriter.create<IREE::TensorExt::DispatchTensorLoadOp>(
-        loc, llvm::cast<RankedTensorType>(en.value().getType()),
+    auto loadOp = IREE::TensorExt::DispatchTensorLoadOp::create(
+        rewriter, loc, llvm::cast<RankedTensorType>(en.value().getType()),
         tensorToFlowBvm.lookup(en.value()), dynamicDims);
     // Replace the tensor -> iree_tensor_ext.dispatch.tensor entry by a
     // tensor -> iree_tensor_ext.dispatch.tensor.load entry.
@@ -425,9 +425,9 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   for (int64_t rank :
        llvm::seq<int64_t>(0, forallOp.getInductionVars().size())) {
     workgroupIds.push_back(
-        rewriter.create<IREE::Flow::DispatchWorkgroupIDOp>(loc, rank));
+        IREE::Flow::DispatchWorkgroupIDOp::create(rewriter, loc, rank));
     workgroupCounts.push_back(
-        rewriter.create<IREE::Flow::DispatchWorkgroupCountOp>(loc, rank));
+        IREE::Flow::DispatchWorkgroupCountOp::create(rewriter, loc, rank));
   }
   bvm.map(forallOp.getInductionVars(), workgroupIds);
   bvm.map(forallOp.getUpperBound(rewriter), workgroupCounts);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -155,8 +155,8 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   }
 
   // Create the shell dispatch.workgroup ops.
-  auto workgroupsOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
-      loc, regionOp.getWorkload(), regionOp.getResultTypes(),
+  auto workgroupsOp = IREE::Flow::DispatchWorkgroupsOp::create(
+      rewriter, loc, regionOp.getWorkload(), regionOp.getResultTypes(),
       regionOp.getResultDims(), arguments, argumentDims, tiedArguments);
   workgroupsOp->setDialectAttrs(regionOp->getDialectAttrs());
 
@@ -196,8 +196,8 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
            "dynamic dims not found among arguments");
     SmallVector<Value> bbArgDims =
         llvm::map_to_vector(dims, [&](Value v) { return bvm.lookup(v); });
-    Value loadedTensor = rewriter.create<IREE::TensorExt::DispatchTensorLoadOp>(
-        loc, tensorType, inputBbArg, bbArgDims);
+    Value loadedTensor = IREE::TensorExt::DispatchTensorLoadOp::create(
+        rewriter, loc, tensorType, inputBbArg, bbArgDims);
     bvm.map(it.value(), loadedTensor);
     argValues.push_back(loadedTensor);
   }
@@ -240,12 +240,12 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
 #endif // NDEBUG
       SmallVector<Value> bbArgDims =
           llvm::map_to_vector(dims, [&](Value v) { return bvm.lookup(v); });
-      rewriter.create<IREE::TensorExt::DispatchTensorStoreOp>(
-          loc, it.value(), outputBbArg, bbArgDims);
+      IREE::TensorExt::DispatchTensorStoreOp::create(rewriter, loc, it.value(),
+                                                     outputBbArg, bbArgDims);
     }
 
     // Delete the old terminator and create a new one.
-    rewriter.create<IREE::Flow::ReturnOp>(loc);
+    IREE::Flow::ReturnOp::create(rewriter, loc);
     rewriter.eraseOp(terminator);
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
@@ -193,8 +193,7 @@ static void buildChannelInitializer(shard::GridOp grid,
                                     ArrayRef<shard::GridAxis> gridAxes,
                                     bool useNamedDefaultChannels,
                                     ImplicitLocOpBuilder &builder) {
-  IREE::Util::InitializerOp initOp =
-      IREE::Util::InitializerOp::create(builder, );
+  auto initOp = IREE::Util::InitializerOp::create(builder);
   Block *block = builder.createBlock(&initOp.getBody());
   ImplicitLocOpBuilder::InsertionGuard insertionGuard(builder);
   builder.setInsertionPointToStart(block);
@@ -202,7 +201,7 @@ static void buildChannelInitializer(shard::GridOp grid,
       buildChannelCreation(grid, gridAxes, useNamedDefaultChannels, builder);
   IREE::Util::GlobalStoreOp::create(builder, channel,
                                     getGridChannelName(grid, gridAxes));
-  IREE::Util::ReturnOp::create(builder, );
+  IREE::Util::ReturnOp::create(builder);
 }
 
 // Construct a Flow channel inside `module` using

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
@@ -127,9 +127,10 @@ static Value getDefaultChannel(Location loc, shard::GridOp grid,
                                bool useNamedDefaultChannels,
                                OpBuilder &builder) {
   if (useNamedDefaultChannels)
-    return builder.create<IREE::Flow::ChannelDefaultOp>(loc, grid.getSymName());
+    return IREE::Flow::ChannelDefaultOp::create(builder, loc,
+                                                grid.getSymName());
   else
-    return builder.create<IREE::Flow::ChannelDefaultOp>(loc);
+    return IREE::Flow::ChannelDefaultOp::create(builder, loc);
 }
 
 static Value buildCachedChannelLoading(Location loc, shard::GridOp grid,
@@ -141,8 +142,8 @@ static Value buildCachedChannelLoading(Location loc, shard::GridOp grid,
   }
   // TODO: lookup the shard name instead of generating it again - today this
   // will fail if there are any conflicting names during channel creation.
-  return builder.create<IREE::Util::GlobalLoadOp>(
-      loc, builder.getType<IREE::Flow::ChannelType>(),
+  return IREE::Util::GlobalLoadOp::create(
+      builder, loc, builder.getType<IREE::Flow::ChannelType>(),
       getGridChannelName(grid, gridAxes));
 }
 
@@ -166,9 +167,9 @@ static Value buildChannelCreation(shard::GridOp grid,
   Value shardChannel = getDefaultChannel(builder.getLoc(), grid,
                                          useNamedDefaultChannels, builder);
   SmallVector<Value> gridProcessMultiIndex =
-      builder.create<shard::ProcessMultiIndexOp>(grid).getResults();
+      shard::ProcessMultiIndexOp::create(builder, grid).getResults();
   SmallVector<Value> gridShape =
-      builder.create<shard::GridShapeOp>(grid).getResults();
+      shard::GridShapeOp::create(builder, grid).getResults();
   SmallVector<Value> reorderedGridIndex =
       permute(ArrayRef<Value>(gridProcessMultiIndex), gridAxes);
   SmallVector<Value> reorderedGridShape =
@@ -181,8 +182,8 @@ static Value buildChannelCreation(shard::GridOp grid,
                            toOpFoldResults(reorderedGridShape), builder);
   OpFoldResult color = linearIndexFromShape(
       toOpFoldResults(groupIndex), toOpFoldResults(groupsShape), builder);
-  return builder.create<IREE::Flow::ChannelSplitOp>(
-      shardChannel,
+  return IREE::Flow::ChannelSplitOp::create(
+      builder, shardChannel,
       getValueOrCreateConstantIndexOp(builder, builder.getLoc(), color),
       getValueOrCreateConstantIndexOp(builder, builder.getLoc(),
                                       reorderedProcessLinearIndex));
@@ -193,15 +194,15 @@ static void buildChannelInitializer(shard::GridOp grid,
                                     bool useNamedDefaultChannels,
                                     ImplicitLocOpBuilder &builder) {
   IREE::Util::InitializerOp initOp =
-      builder.create<IREE::Util::InitializerOp>();
+      IREE::Util::InitializerOp::create(builder, );
   Block *block = builder.createBlock(&initOp.getBody());
   ImplicitLocOpBuilder::InsertionGuard insertionGuard(builder);
   builder.setInsertionPointToStart(block);
   Value channel =
       buildChannelCreation(grid, gridAxes, useNamedDefaultChannels, builder);
-  builder.create<IREE::Util::GlobalStoreOp>(channel,
-                                            getGridChannelName(grid, gridAxes));
-  builder.create<IREE::Util::ReturnOp>();
+  IREE::Util::GlobalStoreOp::create(builder, channel,
+                                    getGridChannelName(grid, gridAxes));
+  IREE::Util::ReturnOp::create(builder, );
 }
 
 // Construct a Flow channel inside `module` using
@@ -219,8 +220,8 @@ static void buildGlobalChannelCreation(shard::GridOp grid,
   builder.setInsertionPointToStart(&module.getBodyRegion().getBlocks().front());
 
   auto channelName = getGridChannelName(grid, gridAxes);
-  builder.create<IREE::Util::GlobalOp>(
-      builder.getStringAttr("private"), channelName,
+  IREE::Util::GlobalOp::create(
+      builder, builder.getStringAttr("private"), channelName,
       builder.getType<IREE::Flow::ChannelType>(), false, TypedAttr(),
       builder.getAttr<IREE::Util::InlineNeverAttr>());
   buildChannelInitializer(grid, gridAxes, useNamedDefaultChannels, builder);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -58,7 +58,7 @@ struct RewriteTensorEmptyToSplat : public OpRewritePattern<tensor::EmptyOp> {
           emptyTensorOp, "unable to get zero value for element type");
     }
     Value value =
-        rewriter.create<arith::ConstantOp>(loc, elementType, zero.value());
+        arith::ConstantOp::create(rewriter, loc, elementType, zero.value());
     rewriter.replaceOpWithNewOp<TensorSplatOp>(emptyTensorOp, resultType, value,
                                                emptyTensorOp.getDynamicSizes());
     return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -57,8 +57,8 @@ getInRowMajorLayout(OpBuilder &builder, SmallVector<TensorValue> tensorValues,
     }
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointAfterValue(v.value);
-    Value rowMajorTensor = builder.create<IREE::Flow::TensorEncodeOp>(
-        v.value.getLoc(), rankedTensorType.dropEncoding(), v.value,
+    Value rowMajorTensor = IREE::Flow::TensorEncodeOp::create(
+        builder, v.value.getLoc(), rankedTensorType.dropEncoding(), v.value,
         /*operand_dims=*/v.dynamicDims, /*result_dims=*/v.dynamicDims);
     rowMajorTensors.push_back(rowMajorTensor);
     decodedIndices.push_back(idx);
@@ -96,8 +96,8 @@ struct InjectDispatchTracingPass
       std::string inputsLabelStr = appendDecodedValuesToLabel(
           entryPointName + " inputs", decodedInputIndices);
       StringAttr inputsLabel = builder.getStringAttr(inputsLabelStr);
-      builder.create<IREE::Flow::TensorTraceOp>(
-          dispatchOp.getLoc(), inputsLabel, decodedInputValues);
+      IREE::Flow::TensorTraceOp::create(builder, dispatchOp.getLoc(),
+                                        inputsLabel, decodedInputValues);
 
       // Output tensors:
       SmallVector<TensorValue> resultTensorValues = filterTensorValues(
@@ -119,8 +119,8 @@ struct InjectDispatchTracingPass
         }
       }
       builder.setInsertionPointAfter(lastResult);
-      builder.create<IREE::Flow::TensorTraceOp>(
-          dispatchOp.getLoc(), outputsLabel, decodedResultValues);
+      IREE::Flow::TensorTraceOp::create(builder, dispatchOp.getLoc(),
+                                        outputsLabel, decodedResultValues);
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
@@ -53,16 +53,16 @@ static void injectTracingOnOp(Operation *op, StringRef traceKey) {
   OpBuilder builder(op);
   auto inputTensors = getTensorOperands(op);
   if (!inputTensors.empty()) {
-    builder.create<IREE::Flow::TensorTraceOp>(
-        op->getLoc(), builder.getStringAttr(traceKey + " inputs"),
+    IREE::Flow::TensorTraceOp::create(
+        builder, op->getLoc(), builder.getStringAttr(traceKey + " inputs"),
         inputTensors);
   }
 
   builder.setInsertionPointAfter(op);
   auto outputTensors = filterTensorValues(op->getResults());
   if (!outputTensors.empty()) {
-    builder.create<IREE::Flow::TensorTraceOp>(
-        op->getLoc(), builder.getStringAttr(traceKey + " outputs"),
+    IREE::Flow::TensorTraceOp::create(
+        builder, op->getLoc(), builder.getStringAttr(traceKey + " outputs"),
         outputTensors);
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -60,15 +60,15 @@ static void traceOpWithName(IREE::Flow::DispatchOp dispatchOp,
                             std::string name) {
   OpBuilder builder(dispatchOp);
   // Input tensors:
-  builder.create<IREE::Flow::TensorTraceOp>(
-      dispatchOp.getLoc(), builder.getStringAttr(name + " inputs"),
+  IREE::Flow::TensorTraceOp::create(
+      builder, dispatchOp.getLoc(), builder.getStringAttr(name + " inputs"),
       filterNonTensorValues(dispatchOp.getArguments()));
 
   // Output tensors:
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointAfter(dispatchOp);
-  builder.create<IREE::Flow::TensorTraceOp>(
-      dispatchOp.getLoc(), builder.getStringAttr(name + " outputs"),
+  IREE::Flow::TensorTraceOp::create(
+      builder, dispatchOp.getLoc(), builder.getStringAttr(name + " outputs"),
       filterNonTensorValues(dispatchOp.getResults()));
 }
 
@@ -102,8 +102,9 @@ static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
   for (auto retVal : op->getResults()) {
     if (llvm::isa<TensorType>(retVal.getType())) {
       auto type = IREE::HAL::BufferViewType::get(context);
-      auto exportOp = builder.create<IREE::HAL::TensorExportOp>(
-          loc, type, retVal, TypeAttr::get(retVal.getType()), /*name=*/nullptr,
+      auto exportOp = IREE::HAL::TensorExportOp::create(
+          builder, loc, type, retVal, TypeAttr::get(retVal.getType()),
+          /*name=*/nullptr,
           /*affinity=*/nullptr);
       exports.push_back(exportOp.getResult());
       newTypes.push_back(type);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
@@ -132,9 +132,9 @@ struct OutlineConstantsPass
 
       // New immutable global takes the constant attribute in its specified
       // encoding.
-      auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
-          def.op->getLoc(), getConstantName(def), /*isMutable=*/false, def.type,
-          def.value);
+      auto globalOp = IREE::Util::GlobalOp::create(
+          moduleBuilder, def.op->getLoc(), getConstantName(def),
+          /*isMutable=*/false, def.type, def.value);
       globalOp.setPrivate();
       IREE::Util::HoistableAttrInterface::gatherHoistableAttrs(def.op,
                                                                globalOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/Patterns.cpp
@@ -30,9 +30,9 @@ struct ConvertDeviceResolveAnyOp
     Value device;
     auto resolveDevice = [&]() {
       if (!device) {
-        device = rewriter.create<IREE::HAL::DevicesGetOp>(
-            resolveOp.getLoc(), deviceType,
-            rewriter.create<arith::ConstantIndexOp>(resolveOp.getLoc(), 0));
+        device = IREE::HAL::DevicesGetOp::create(
+            rewriter, resolveOp.getLoc(), deviceType,
+            arith::ConstantIndexOp::create(rewriter, resolveOp.getLoc(), 0));
       }
       return device;
     };
@@ -42,11 +42,11 @@ struct ConvertDeviceResolveAnyOp
       if (isa<IREE::HAL::DeviceType>(resultType)) {
         results.push_back(resolveDevice());
       } else if (isa<IREE::HAL::AllocatorType>(resultType)) {
-        results.push_back(rewriter.create<IREE::HAL::DeviceAllocatorOp>(
-            resolveOp.getLoc(), resolveDevice()));
+        results.push_back(IREE::HAL::DeviceAllocatorOp::create(
+            rewriter, resolveOp.getLoc(), resolveDevice()));
       } else if (isa<IntegerType>(resultType)) {
-        results.push_back(rewriter.create<arith::ConstantIntOp>(
-            resolveOp.getLoc(), -1ll, 64));
+        results.push_back(arith::ConstantIntOp::create(
+            rewriter, resolveOp.getLoc(), -1ll, 64));
       }
     }
 
@@ -76,8 +76,8 @@ struct ConvertDeviceResolveAffinityOp
     Value device;
     auto resolveDevice = [&]() {
       if (!device) {
-        device = rewriter.create<IREE::Util::GlobalLoadOp>(
-            resolveOp.getLoc(), deviceType, flatDeviceAttr.getValue(),
+        device = IREE::Util::GlobalLoadOp::create(
+            rewriter, resolveOp.getLoc(), deviceType, flatDeviceAttr.getValue(),
             /*is_immutable=*/true);
       }
       return device;
@@ -88,11 +88,11 @@ struct ConvertDeviceResolveAffinityOp
       if (isa<IREE::HAL::DeviceType>(resultType)) {
         results.push_back(resolveDevice());
       } else if (isa<IREE::HAL::AllocatorType>(resultType)) {
-        results.push_back(rewriter.create<IREE::HAL::DeviceAllocatorOp>(
-            resolveOp.getLoc(), resolveDevice()));
+        results.push_back(IREE::HAL::DeviceAllocatorOp::create(
+            rewriter, resolveOp.getLoc(), resolveDevice()));
       } else if (isa<IntegerType>(resultType)) {
-        results.push_back(rewriter.create<arith::ConstantIntOp>(
-            resolveOp.getLoc(), affinityAttr.getQueueMask(), 64));
+        results.push_back(arith::ConstantIntOp::create(
+            rewriter, resolveOp.getLoc(), affinityAttr.getQueueMask(), 64));
       }
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertAllocatorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertAllocatorOps.cpp
@@ -111,8 +111,8 @@ public:
   LogicalResult
   matchAndRewrite(IREE::HAL::AllocatorImportOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto callOp = rewriter.create<IREE::VM::CallOp>(
-        op.getLoc(), importOp.getName(),
+    auto callOp = IREE::VM::CallOp::create(
+        rewriter, op.getLoc(), importOp.getName(),
         ArrayRef<Type>{
             getTypeConverter()->convertType(op.getResult().getType()),
         },
@@ -133,8 +133,8 @@ public:
         });
     copyImportAttrs(importOp, callOp);
     auto result = callOp.getResults().front();
-    auto didImport = rewriter.create<IREE::VM::CmpNZRefOp>(
-        op.getLoc(), rewriter.getI32Type(), result);
+    auto didImport = IREE::VM::CmpNZRefOp::create(
+        rewriter, op.getLoc(), rewriter.getI32Type(), result);
     rewriter.replaceOp(op, {didImport, result});
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -24,20 +24,20 @@ static std::tuple<Value, Value>
 splitBufferSlot(Location loc, Value bufferOrSlot, OpBuilder &builder) {
   if (!bufferOrSlot) {
     return std::make_tuple(
-        builder.create<IREE::VM::ConstI32ZeroOp>(loc),
-        builder.create<IREE::VM::ConstRefZeroOp>(
-            loc,
+        IREE::VM::ConstI32ZeroOp::create(builder, loc),
+        IREE::VM::ConstRefZeroOp::create(
+            builder, loc,
             IREE::VM::RefType::get(builder.getType<IREE::HAL::BufferType>())));
   } else if (isa<IREE::VM::RefType>(bufferOrSlot.getType())) {
     // Direct buffer binding; pass 0 for table slot.
-    return std::make_tuple(builder.create<IREE::VM::ConstI32ZeroOp>(loc),
+    return std::make_tuple(IREE::VM::ConstI32ZeroOp::create(builder, loc),
                            bufferOrSlot);
   } else {
     // Indirect binding table reference; pass null for the buffer.
     return std::make_tuple(
         castToImportType(bufferOrSlot, builder.getI32Type(), builder),
-        builder.create<IREE::VM::ConstRefZeroOp>(
-            loc,
+        IREE::VM::ConstRefZeroOp::create(
+            builder, loc,
             IREE::VM::RefType::get(builder.getType<IREE::HAL::BufferType>())));
   }
 }
@@ -83,7 +83,7 @@ public:
                                               rewriter.getI32Type(), rewriter));
     } else {
       callOperands.push_back(
-          rewriter.create<IREE::VM::ConstI32ZeroOp>(op.getLoc()));
+          IREE::VM::ConstI32ZeroOp::create(rewriter, op.getLoc()));
     }
 
     auto callOp = rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
@@ -265,7 +265,7 @@ public:
     Value zeroI64;
     auto getZeroI64 = [&]() {
       if (!zeroI64) {
-        zeroI64 = rewriter.create<IREE::VM::ConstI64ZeroOp>(op.getLoc());
+        zeroI64 = IREE::VM::ConstI64ZeroOp::create(rewriter, op.getLoc());
       }
       return zeroI64;
     };
@@ -286,13 +286,13 @@ public:
     SmallVector<Value> callOperands;
     callOperands.push_back(adaptor.getCommandBuffer());
     callOperands.push_back(adaptor.getChannel());
-    callOperands.push_back(rewriter.create<IREE::VM::ConstI32Op>(
-        op.getLoc(), adaptor.getOp().getEncodedValue()));
+    callOperands.push_back(IREE::VM::ConstI32Op::create(
+        rewriter, op.getLoc(), adaptor.getOp().getEncodedValue()));
     if (auto paramValue = adaptor.getParam()) {
       callOperands.push_back(paramValue);
     } else {
       callOperands.push_back(
-          rewriter.create<IREE::VM::ConstI32ZeroOp>(op.getLoc()));
+          IREE::VM::ConstI32ZeroOp::create(rewriter, op.getLoc()));
     }
 
     auto [sendBufferSlot, sendBuffer] =
@@ -346,7 +346,7 @@ public:
 
     auto i32Type = rewriter.getI32Type();
     auto i64Type = rewriter.getI64Type();
-    Value zeroI32 = rewriter.create<IREE::VM::ConstI32ZeroOp>(op.getLoc());
+    Value zeroI32 = IREE::VM::ConstI32ZeroOp::create(rewriter, op.getLoc());
 
     SmallVector<Value, 8> callOperands = {
         adaptor.getCommandBuffer(),
@@ -417,7 +417,7 @@ public:
 
     auto i32Type = rewriter.getI32Type();
     auto i64Type = rewriter.getI64Type();
-    Value zeroI32 = rewriter.create<IREE::VM::ConstI32ZeroOp>(op.getLoc());
+    Value zeroI32 = IREE::VM::ConstI32ZeroOp::create(rewriter, op.getLoc());
 
     auto [workgroupsBufferSlot, workgroupsBuffer] =
         splitBufferSlot(op.getLoc(), adaptor.getWorkgroupsBuffer(), rewriter);

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/Patterns.cpp
@@ -12,9 +12,9 @@ namespace mlir::iree_compiler {
 
 Value getFlagsI64(Location loc, IntegerAttr flagsAttr, OpBuilder &builder) {
   return flagsAttr
-             ? builder.create<IREE::VM::ConstI64Op>(loc, flagsAttr.getInt())
+             ? IREE::VM::ConstI64Op::create(builder, loc, flagsAttr.getInt())
                    .getResult()
-             : builder.create<IREE::VM::ConstI64ZeroOp>(loc).getResult();
+             : IREE::VM::ConstI64ZeroOp::create(builder, loc).getResult();
 }
 
 extern void populateHALAllocatorToVMPatterns(MLIRContext *context,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
@@ -41,10 +41,10 @@ HALTypeConverter::HALTypeConverter(
                               ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
     if (llvm::isa<TensorType>(inputs[0].getType())) {
-      return builder.create<IREE::HAL::TensorExportOp>(loc, type, inputs[0]);
+      return IREE::HAL::TensorExportOp::create(builder, loc, type, inputs[0]);
     } else if (llvm::isa<IREE::HAL::BufferViewType>(inputs[0].getType())) {
-      return builder.create<IREE::HAL::BufferViewBufferOp>(loc, type,
-                                                           inputs[0]);
+      return IREE::HAL::BufferViewBufferOp::create(builder, loc, type,
+                                                   inputs[0]);
     } else {
       emitError(loc) << "unsupported HAL target materialization: "
                      << inputs[0].getType();
@@ -58,7 +58,7 @@ HALTypeConverter::HALTypeConverter(
     auto inputValue = inputs[0];
     auto inputType = inputValue.getType();
     if (llvm::isa<TensorType>(inputType)) {
-      return builder.create<IREE::HAL::TensorExportOp>(loc, type, inputValue);
+      return IREE::HAL::TensorExportOp::create(builder, loc, type, inputValue);
     } else if (llvm::isa<IREE::HAL::BufferType>(inputType)) {
       // Look for the buffer view this buffer came from, if any.
       // If we don't have the origin buffer view then we can't know the shape

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -208,8 +208,8 @@ Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
   if (llvm::isa<IndexType>(type)) {
     // Some folders materialize raw index types, which just become std
     // constants.
-    return builder.create<mlir::arith::ConstantIndexOp>(
-        loc, llvm::cast<IntegerAttr>(value).getValue().getSExtValue());
+    return mlir::arith::ConstantIndexOp::create(
+        builder, loc, llvm::cast<IntegerAttr>(value).getValue().getSExtValue());
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -98,8 +98,8 @@ struct DeduplicateTensorBarrierSources
     if (orderedSources.size() == op.getSources().size()) {
       return failure();
     }
-    auto newOp = rewriter.create<TensorBarrierOp>(op.getLoc(), orderedSources,
-                                                  op.getSignalFence());
+    auto newOp = TensorBarrierOp::create(rewriter, op.getLoc(), orderedSources,
+                                         op.getSignalFence());
     SmallVector<Value> newResults;
     newResults.reserve(newOp.getNumResults());
     for (unsigned newIndex : resultMapping) {
@@ -844,8 +844,8 @@ struct MergeExecutableConstantBlocks
     // about making that work.
     rewriter.setInsertionPoint(blockOps.front());
     auto fusedLoc = rewriter.getFusedLoc(blockLocs);
-    auto newBlockOp = rewriter.create<ExecutableConstantBlockOp>(
-        fusedLoc, rewriter.getFunctionType(inputTypes, resultTypes),
+    auto newBlockOp = ExecutableConstantBlockOp::create(
+        rewriter, fusedLoc, rewriter.getFunctionType(inputTypes, resultTypes),
         rewriter.getArrayAttr(resultKeys), /*arg_attrs=*/ArrayAttr(),
         /*res_attrs=*/ArrayAttr());
 
@@ -1129,8 +1129,8 @@ struct ElideSignaledFence : public OpRewritePattern<FenceSignalOp> {
     }
 
     // Safe to elide.
-    Value nullFence = rewriter.create<IREE::Util::NullOp>(
-        rewriter.getFusedLoc({createOp.getLoc(), signalOp.getLoc()}),
+    Value nullFence = IREE::Util::NullOp::create(
+        rewriter, rewriter.getFusedLoc({createOp.getLoc(), signalOp.getLoc()}),
         fence.getType());
     rewriter.replaceAllUsesWith(fence, nullFence);
     rewriter.eraseOp(signalOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1767,7 +1767,7 @@ Value ExecutableExportOp::calculateCondition(Location loc, Value device,
   // Always evaluate to true if no region is present.
   auto *body = getConditionBody();
   if (!body) {
-    return builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    return arith::ConstantIntOp::create(builder, loc, 1, 1);
   }
 
   // TODO(benvanik): replace with region inlining util.
@@ -1933,7 +1933,8 @@ Value ExecutableVariantOp::createConditionOp(OpBuilder &builder) {
   assert(!getConditionOp() && "condition op already exists");
 
   builder.setInsertionPointToStart(&getRegion().front());
-  auto conditionOp = builder.create<IREE::HAL::ExecutableConditionOp>(getLoc());
+  auto conditionOp =
+      IREE::HAL::ExecutableConditionOp::create(builder, getLoc());
   Block *entryPoint = conditionOp.addEntryBlock();
   Value device = entryPoint->getArgument(0);
 
@@ -1950,8 +1951,8 @@ Value ExecutableVariantOp::buildCondition(Value device, OpBuilder &builder) {
   // Factor in variant condition region, if any.
   auto conditionOp = getConditionOp();
   if (conditionOp) {
-    auto regionOp = builder.create<scf::ExecuteRegionOp>(conditionOp.getLoc(),
-                                                         builder.getI1Type());
+    auto regionOp = scf::ExecuteRegionOp::create(builder, conditionOp.getLoc(),
+                                                 builder.getI1Type());
 
     IRMapping mapper;
     mapper.map(conditionOp.getRegion().getArgument(0), device);
@@ -1964,8 +1965,8 @@ Value ExecutableVariantOp::buildCondition(Value device, OpBuilder &builder) {
       returnOp.erase();
     }
 
-    selected = builder.create<arith::AndIOp>(getLoc(), selected,
-                                             regionOp.getResult(0));
+    selected = arith::AndIOp::create(builder, getLoc(), selected,
+                                     regionOp.getResult(0));
   }
 
   return selected;

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -84,9 +84,9 @@ Value BufferViewType::inferSizeFromValue(Location loc, Value value,
 
 // static
 Value DeviceType::resolveAny(Location loc, OpBuilder &builder) {
-  Value deviceIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
-  return builder.create<IREE::HAL::DevicesGetOp>(
-      loc, builder.getType<IREE::HAL::DeviceType>(), deviceIndex);
+  Value deviceIndex = arith::ConstantIndexOp::create(builder, loc, 0);
+  return IREE::HAL::DevicesGetOp::create(
+      builder, loc, builder.getType<IREE::HAL::DeviceType>(), deviceIndex);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
@@ -86,8 +86,8 @@ struct CaptureExecutableSourcesPass
             &clonedExecutableOp.getBody().emplaceBlock());
         auto clonedVariantOp = cast<IREE::HAL::ExecutableVariantOp>(
             clonedBuilder.clone(*variantOp));
-        clonedBuilder.create<IREE::HAL::ExecutableEndOp>(
-            clonedBuilder.getUnknownLoc());
+        IREE::HAL::ExecutableEndOp::create(clonedBuilder,
+                                           clonedBuilder.getUnknownLoc());
 
         // Capture the source contents and update the locations in the IR to
         // reference it.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineMemoizeRegions.cpp
@@ -74,7 +74,7 @@ struct InlineMemoizeRegionsPass
           memoizeOp.getResultTypes(), fusedResultLocs));
       rewriter.inlineRegionBefore(memoizeOp.getBody(), continueBlock);
       rewriter.setInsertionPointToEnd(initialBlock);
-      rewriter.create<mlir::cf::BranchOp>(memoizeOp.getLoc(), entryBlock);
+      mlir::cf::BranchOp::create(rewriter, memoizeOp.getLoc(), entryBlock);
       for (auto returnOp : returnOps) {
         rewriter.setInsertionPoint(returnOp);
         rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(returnOp, continueBlock,

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
@@ -64,8 +64,8 @@ static Value createChunkHeader(Location loc, iree_idbts_chunk_type_t type,
       VectorType::get({sizeof(header)}, builder.getI8Type()),
       ArrayRef<char>(reinterpret_cast<const char *>(&header), sizeof(header)));
 
-  return builder.create<IREE::Util::BufferConstantOp>(
-      loc, /*name=*/nullptr, dataAttr, builder.getIndexAttr(16),
+  return IREE::Util::BufferConstantOp::create(
+      builder, loc, /*name=*/nullptr, dataAttr, builder.getIndexAttr(16),
       /*mimeType=*/nullptr);
 }
 
@@ -79,22 +79,23 @@ static Value createPadding(Location loc, uint64_t unalignedLength,
   auto zeroAttr = IntegerAttr::get(i8Type, 0);
   auto dataAttr = DenseElementsAttr::get(
       VectorType::get({(int64_t)padding}, i8Type), zeroAttr);
-  return builder.create<IREE::Util::BufferConstantOp>(
-      loc, /*name=*/nullptr, dataAttr, builder.getIndexAttr(16),
+  return IREE::Util::BufferConstantOp::create(
+      builder, loc, /*name=*/nullptr, dataAttr, builder.getIndexAttr(16),
       /*mimeType=*/nullptr);
 }
 
 static void appendListItems(Location loc, Value list, ArrayRef<Value> items,
                             OpBuilder &builder) {
-  Value oldLength = builder.create<IREE::Util::ListSizeOp>(loc, list);
-  Value newLength = builder.create<arith::AddIOp>(
-      loc, oldLength,
-      builder.create<arith::ConstantIndexOp>(loc, items.size()));
-  builder.create<IREE::Util::ListResizeOp>(loc, list, newLength);
+  Value oldLength = IREE::Util::ListSizeOp::create(builder, loc, list);
+  Value newLength = arith::AddIOp::create(
+      builder, loc, oldLength,
+      arith::ConstantIndexOp::create(builder, loc, items.size()));
+  IREE::Util::ListResizeOp::create(builder, loc, list, newLength);
   for (size_t i = 0; i < items.size(); ++i) {
-    Value idx = builder.create<arith::AddIOp>(
-        loc, oldLength, builder.create<arith::ConstantIndexOp>(loc, i));
-    builder.create<IREE::Util::ListSetOp>(loc, list, idx, items[i]);
+    Value idx =
+        arith::AddIOp::create(builder, loc, oldLength,
+                              arith::ConstantIndexOp::create(builder, loc, i));
+    IREE::Util::ListSetOp::create(builder, loc, list, idx, items[i]);
   }
 }
 
@@ -135,22 +136,23 @@ struct MaterializeDispatchInstrumentationPass
     auto bufferType = MemRefType::get({totalBufferSize}, i8Type);
 
     // Create global device-side instrumentation resource.
-    auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
-        loc, "__dispatch_instrumentation",
+    auto globalOp = IREE::Util::GlobalOp::create(
+        moduleBuilder, loc, "__dispatch_instrumentation",
         /*isMutable=*/false,
         moduleBuilder.getType<IREE::Stream::ResourceType>(
             IREE::Stream::Lifetime::External));
     {
-      auto initializerOp = moduleBuilder.create<IREE::Util::InitializerOp>(loc);
+      auto initializerOp =
+          IREE::Util::InitializerOp::create(moduleBuilder, loc);
       auto initializerBuilder =
           OpBuilder::atBlockBegin(initializerOp.addEntryBlock());
       Value bufferSize =
-          initializerBuilder.create<arith::ConstantOp>(loc, bufferSizeAttr);
-      Value buffer = initializerBuilder.create<IREE::Stream::ResourceAllocOp>(
-          loc, globalOp.getType(), bufferSize,
+          arith::ConstantOp::create(initializerBuilder, loc, bufferSizeAttr);
+      Value buffer = IREE::Stream::ResourceAllocOp::create(
+          initializerBuilder, loc, globalOp.getType(), bufferSize,
           /*uninitialized=*/true, /*affinity=*/nullptr);
       globalOp.createStoreOp(loc, buffer, initializerBuilder);
-      initializerBuilder.create<IREE::Util::ReturnOp>(loc);
+      IREE::Util::ReturnOp::create(initializerBuilder, loc);
     }
 
     FlatbufferBuilder metadataBuilder;
@@ -199,11 +201,12 @@ struct MaterializeDispatchInstrumentationPass
         // capturing workgroup ID yet with this instrumentation op and instead
         // leave that until late in the codegen pipeline.
         auto funcBuilder = OpBuilder::atBlockBegin(&funcOp.front());
-        Value zero = funcBuilder.create<arith::ConstantIndexOp>(loc, 0);
-        auto subspanOp = funcBuilder.create<IREE::Stream::BindingSubspanOp>(
-            loc, bufferType, bindingArg, /*byteOffset=*/zero, ValueRange{});
-        funcBuilder.create<IREE::HAL::InstrumentWorkgroupOp>(
-            loc, indexType, subspanOp.getResult(), dispatchIdArg);
+        Value zero = arith::ConstantIndexOp::create(funcBuilder, loc, 0);
+        auto subspanOp = IREE::Stream::BindingSubspanOp::create(
+            funcBuilder, loc, bufferType, bindingArg, /*byteOffset=*/zero,
+            ValueRange{});
+        IREE::HAL::InstrumentWorkgroupOp::create(
+            funcBuilder, loc, indexType, subspanOp.getResult(), dispatchIdArg);
 
         // Build function metadata.
         auto nameRef = metadataBuilder.createString(exportOp.getName());
@@ -232,9 +235,9 @@ struct MaterializeDispatchInstrumentationPass
         // Load the ringbuffer and capture it for use within the execute region.
         auto loadedValue =
             globalOp.createLoadOp(loc, parentBuilder).getLoadedGlobalValue();
-        Value zero = parentBuilder.create<arith::ConstantIndexOp>(loc, 0);
+        Value zero = arith::ConstantIndexOp::create(parentBuilder, loc, 0);
         Value bufferSize =
-            parentBuilder.create<arith::ConstantOp>(loc, bufferSizeAttr);
+            arith::ConstantOp::create(parentBuilder, loc, bufferSizeAttr);
         executeOp.getResourceOperandsMutable().append(loadedValue);
         executeOp.getResourceOperandSizesMutable().append(bufferSize);
         auto bufferArg =
@@ -309,8 +312,8 @@ struct MaterializeDispatchInstrumentationPass
     // Create query function for getting the instrumentation data.
     auto listType = moduleBuilder.getType<IREE::Util::ListType>(
         moduleBuilder.getType<IREE::Util::VariantType>());
-    auto queryOp = moduleBuilder.create<IREE::Util::FuncOp>(
-        loc, "__query_instruments",
+    auto queryOp = IREE::Util::FuncOp::create(
+        moduleBuilder, loc, "__query_instruments",
         moduleBuilder.getFunctionType({listType}, {}));
     {
       queryOp.setPublic();
@@ -325,9 +328,10 @@ struct MaterializeDispatchInstrumentationPass
                             metadataAttr.size(), queryBuilder));
 
       // Grab the read-only dispatch metadata.
-      iovecs.push_back(queryBuilder.create<IREE::Util::BufferConstantOp>(
-          loc, queryBuilder.getStringAttr("dispatch_instrument.fb"),
-          metadataAttr, queryBuilder.getIndexAttr(16),
+      iovecs.push_back(IREE::Util::BufferConstantOp::create(
+          queryBuilder, loc,
+          queryBuilder.getStringAttr("dispatch_instrument.fb"), metadataAttr,
+          queryBuilder.getIndexAttr(16),
           queryBuilder.getStringAttr("application/x-flatbuffers")));
 
       if (Value metadataPadding =
@@ -343,10 +347,10 @@ struct MaterializeDispatchInstrumentationPass
       Value buffer =
           globalOp.createLoadOp(loc, queryBuilder).getLoadedGlobalValue();
       Value bufferSize =
-          queryBuilder.create<arith::ConstantOp>(loc, bufferSizeAttr);
+          arith::ConstantOp::create(queryBuilder, loc, bufferSizeAttr);
       auto bufferViewType = moduleBuilder.getType<IREE::HAL::BufferViewType>();
-      auto exportOp = queryBuilder.create<IREE::Stream::TensorExportOp>(
-          loc, bufferViewType, buffer,
+      auto exportOp = IREE::Stream::TensorExportOp::create(
+          queryBuilder, loc, bufferViewType, buffer,
           RankedTensorType::get({totalBufferSize}, queryBuilder.getI8Type()),
           ValueRange{}, bufferSize,
           /*affinity=*/nullptr);
@@ -358,7 +362,7 @@ struct MaterializeDispatchInstrumentationPass
       }
 
       appendListItems(loc, listArg, iovecs, queryBuilder);
-      queryBuilder.create<IREE::Util::ReturnOp>(loc);
+      IREE::Util::ReturnOp::create(queryBuilder, loc);
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -92,7 +92,8 @@ static void declareDeviceExecutable(IREE::Util::GlobalOpInterface deviceOp,
                     << deviceOp.getGlobalName().getValue()
                     << "` executable global `" << symbolName << "`\n");
   auto executableType = moduleBuilder.getType<IREE::HAL::ExecutableType>();
-  auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
+  auto globalOp = IREE::Util::GlobalOp::create(
+      moduleBuilder,
       moduleBuilder.getFusedLoc(llvm::to_vector(executable.locs)), symbolName,
       /*isMutable=*/false, executableType);
   globalOp.setPrivate();
@@ -123,8 +124,8 @@ static SmallVector<Value> inlineConstantBlockOp(
   LLVM_DEBUG(DBGS() << "- inlining constant block `" << funcName << "`\n");
 
   // Create the function with the region contents of the constant block.
-  auto funcOp = moduleBuilder.create<IREE::Util::FuncOp>(
-      blockOp.getLoc(), funcName, blockOp.getFunctionType());
+  auto funcOp = IREE::Util::FuncOp::create(moduleBuilder, blockOp.getLoc(),
+                                           funcName, blockOp.getFunctionType());
   funcOp.setPrivate();
   IRMapping mapping;
   blockOp.getRegion().cloneInto(&funcOp.getRegion(), mapping);
@@ -142,8 +143,8 @@ static SmallVector<Value> inlineConstantBlockOp(
   if (funcOp.getNumArguments() > 0) {
     callOperands.push_back(callerDevice);
   }
-  auto callOp = callerBuilder.create<IREE::Util::CallOp>(blockOp.getLoc(),
-                                                         funcOp, callOperands);
+  auto callOp = IREE::Util::CallOp::create(callerBuilder, blockOp.getLoc(),
+                                           funcOp, callOperands);
   return llvm::to_vector_of<Value>(callOp.getResults());
 }
 
@@ -175,8 +176,9 @@ initializeExecutable(DeviceResources &deviceResources, Executable &executable,
       initializerBuilder);
 
   // Allow each variant to define how it is loaded and what pipeline it has.
-  auto switchOp = initializerBuilder.create<scf::IndexSwitchOp>(
-      loc, executableType, selectedIndex, caseIndices, caseIndices.size());
+  auto switchOp = scf::IndexSwitchOp::create(initializerBuilder, loc,
+                                             executableType, selectedIndex,
+                                             caseIndices, caseIndices.size());
   for (auto [i, variantOp] : llvm::enumerate(caseVariantOps)) {
     auto &caseBlock = switchOp.getCaseRegions()[i].emplaceBlock();
     auto caseBuilder = OpBuilder::atBlockBegin(&caseBlock);
@@ -202,14 +204,15 @@ initializeExecutable(DeviceResources &deviceResources, Executable &executable,
                 {SymbolRefAttr::get(variantOp.getSymNameAttr())}),
             constantValues);
 
-    caseBuilder.create<scf::YieldOp>(loc, executableValue);
+    scf::YieldOp::create(caseBuilder, loc, executableValue);
   }
 
   // Fallback for no available variant.
   auto &defaultBlock = switchOp.getDefaultRegion().emplaceBlock();
   auto defaultBuilder = OpBuilder::atBlockBegin(&defaultBlock);
-  Value status = defaultBuilder.create<arith::ConstantIntOp>(
-      loc, static_cast<int>(IREE::Util::StatusCode::Unavailable), 32);
+  Value status = arith::ConstantIntOp::create(
+      defaultBuilder, loc,
+      static_cast<int>(IREE::Util::StatusCode::Unavailable), 32);
   {
     std::string errorStr;
     llvm::raw_string_ostream errorStream(errorStr);
@@ -222,11 +225,11 @@ initializeExecutable(DeviceResources &deviceResources, Executable &executable,
       errorStream << variantOp.getTargetAttr().getFormat().getValue();
     });
     errorStream << "]";
-    defaultBuilder.create<IREE::Util::StatusCheckOkOp>(loc, status, errorStr);
+    IREE::Util::StatusCheckOkOp::create(defaultBuilder, loc, status, errorStr);
   }
   auto nullValue =
       defaultBuilder.createOrFold<IREE::Util::NullOp>(loc, executableType);
-  defaultBuilder.create<scf::YieldOp>(loc, nullValue);
+  scf::YieldOp::create(defaultBuilder, loc, nullValue);
 
   return switchOp.getResult(0);
 }
@@ -270,7 +273,7 @@ static void reuseFallbackDeviceResources(DeviceResources &deviceResources,
 static void buildDeviceResourceInitializer(DeviceResources &deviceResources,
                                            OpBuilder &moduleBuilder) {
   auto loc = deviceResources.deviceOp.getLoc();
-  auto initializerOp = moduleBuilder.create<IREE::Util::InitializerOp>(loc);
+  auto initializerOp = IREE::Util::InitializerOp::create(moduleBuilder, loc);
   OpBuilder initializerBuilder =
       OpBuilder::atBlockEnd(initializerOp.addEntryBlock());
   Value initializerDevice =
@@ -281,7 +284,7 @@ static void buildDeviceResourceInitializer(DeviceResources &deviceResources,
   // any queue will have execution scheduled but if we know that it won't (such
   // as when sharding) we can reduce runtime load overhead.
   Value initializerAffinity =
-      initializerBuilder.create<arith::ConstantIntOp>(loc, -1, 64);
+      arith::ConstantIntOp::create(initializerBuilder, loc, -1, 64);
 
   // If there are any fallbacks then we need to handle referencing their
   // resources and otherwise will initialize our own.
@@ -298,12 +301,13 @@ static void buildDeviceResourceInitializer(DeviceResources &deviceResources,
           Value fallbackDevice =
               fallbackResources->deviceOp.createLoadOp(loc, caseBuilder)
                   .getLoadedGlobalValue();
-          return caseBuilder.create<IREE::Util::CmpEQOp>(loc, initializerDevice,
-                                                         fallbackDevice);
+          return IREE::Util::CmpEQOp::create(caseBuilder, loc,
+                                             initializerDevice, fallbackDevice);
         },
         initializerBuilder);
-    auto switchOp = initializerBuilder.create<scf::IndexSwitchOp>(
-        loc, TypeRange{}, selectedIndex, caseIndices, caseIndices.size());
+    auto switchOp = scf::IndexSwitchOp::create(initializerBuilder, loc,
+                                               TypeRange{}, selectedIndex,
+                                               caseIndices, caseIndices.size());
     for (auto [fallbackResources, caseRegion] :
          llvm::zip_equal(deviceResources.fallbackDeviceResources,
                          switchOp.getCaseRegions())) {
@@ -311,16 +315,16 @@ static void buildDeviceResourceInitializer(DeviceResources &deviceResources,
       auto caseBuilder = OpBuilder::atBlockBegin(&caseBlock);
       reuseFallbackDeviceResources(deviceResources, *fallbackResources,
                                    initializerDevice, caseBuilder);
-      caseBuilder.create<scf::YieldOp>(loc);
+      scf::YieldOp::create(caseBuilder, loc);
     }
     auto &defaultBlock = switchOp.getDefaultRegion().emplaceBlock();
     auto defaultBuilder = OpBuilder::atBlockBegin(&defaultBlock);
     initializeDeviceResources(deviceResources, moduleBuilder, initializerDevice,
                               initializerAffinity, defaultBuilder);
-    defaultBuilder.create<scf::YieldOp>(loc);
+    scf::YieldOp::create(defaultBuilder, loc);
   }
 
-  initializerBuilder.create<IREE::Util::ReturnOp>(loc);
+  IREE::Util::ReturnOp::create(initializerBuilder, loc);
 }
 
 // Returns zero or more devices globals that may act as fallbacks for the

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
@@ -64,8 +64,8 @@ static FailureOr<FlatSymbolRefAttr>
 createDeviceGlobal(Location loc, StringAttr name, Attribute targetAttr,
                    OpBuilder &moduleBuilder) {
   auto deviceType = moduleBuilder.getType<IREE::HAL::DeviceType>();
-  auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
-      loc, name, /*isMutable=*/false, deviceType);
+  auto globalOp = IREE::Util::GlobalOp::create(moduleBuilder, loc, name,
+                                               /*isMutable=*/false, deviceType);
   globalOp.setPrivate();
 
   TypedAttr attrValue;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
@@ -152,8 +152,8 @@ static IREE::Util::FuncOp outlineMemoizeRegionBody(
                                 [](Value value) { return value.getType(); }));
   auto funcType =
       moduleBuilder.getFunctionType(argTypes, memoizeOp.getResultTypes());
-  auto funcOp = moduleBuilder.create<IREE::Util::FuncOp>(memoizeOp.getLoc(),
-                                                         name, funcType);
+  auto funcOp = IREE::Util::FuncOp::create(moduleBuilder, memoizeOp.getLoc(),
+                                           name, funcType);
   moduleSymbolTable.insert(funcOp);
   funcOp.setVisibility(SymbolTable::Visibility::Private);
   funcOp.setInliningPolicyAttr(
@@ -210,8 +210,8 @@ static IREE::Util::FuncOp outlineMemoizeRegionBody(
   for (auto returnOp :
        llvm::make_early_inc_range(funcOp.getOps<IREE::HAL::ReturnOp>())) {
     OpBuilder returnBuilder(returnOp);
-    returnBuilder.create<IREE::Util::ReturnOp>(returnOp.getLoc(),
-                                               returnOp.getOperands());
+    IREE::Util::ReturnOp::create(returnBuilder, returnOp.getLoc(),
+                                 returnOp.getOperands());
     returnOp.erase();
   }
 
@@ -236,8 +236,8 @@ static void replaceMemoizeOpWithApply(IREE::HAL::DeviceMemoizeOp memoizeOp,
 
   // Call the function.
   OpBuilder callerBuilder(memoizeOp);
-  auto callOp = callerBuilder.create<IREE::Util::CallOp>(
-      memoizeOp.getLoc(), applyFuncOp, callOperands);
+  auto callOp = IREE::Util::CallOp::create(callerBuilder, memoizeOp.getLoc(),
+                                           applyFuncOp, callOperands);
 
   // Replace memoize op with the results of the function call.
   memoizeOp.replaceAllUsesWith(callOp.getResults());
@@ -261,8 +261,9 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
         (namePrefix + "_result_" + std::to_string(result.getResultNumber()) +
          "_" + deviceName)
             .str();
-    auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
-        resultLoc, globalName, /*isMutable=*/false, result.getType());
+    auto globalOp =
+        IREE::Util::GlobalOp::create(moduleBuilder, resultLoc, globalName,
+                                     /*isMutable=*/false, result.getType());
     moduleSymbolTable.insert(globalOp);
     globalOp.setVisibility(SymbolTable::Visibility::Private);
     resultGlobalOps.push_back(globalOp);
@@ -271,7 +272,7 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
   // Create an initializer to call the apply function and store the results into
   // globals.
   auto initializerOp =
-      moduleBuilder.create<IREE::Util::InitializerOp>(memoizeOp.getLoc());
+      IREE::Util::InitializerOp::create(moduleBuilder, memoizeOp.getLoc());
   auto initializerBuilder =
       OpBuilder::atBlockBegin(initializerOp.addEntryBlock());
 
@@ -283,8 +284,9 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
   Value deviceValue = deviceLoadOp.getLoadedGlobalValue();
   deviceLoadOp.setGlobalImmutable(true);
   mapping.map(memoizeOp.getDevice(), deviceValue);
-  Value queueAffinityValue = initializerBuilder.create<arith::ConstantIntOp>(
-      memoizeOp.getLoc(), memoizeAnalysis.queueAffinity.value_or(-1), 64);
+  Value queueAffinityValue = arith::ConstantIntOp::create(
+      initializerBuilder, memoizeOp.getLoc(),
+      memoizeAnalysis.queueAffinity.value_or(-1), 64);
   mapping.map(memoizeOp.getQueueAffinity(), queueAffinityValue);
 
   // We'll pass the device, affinity, and all dynamic operands to the apply
@@ -307,8 +309,8 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
          "dynamic values not allowed in memoized initialization functions");
 
   // Call the apply function to produce the memoized results.
-  auto callOp = initializerBuilder.create<IREE::Util::CallOp>(
-      memoizeOp.getLoc(), applyFuncOp, callOperands);
+  auto callOp = IREE::Util::CallOp::create(
+      initializerBuilder, memoizeOp.getLoc(), applyFuncOp, callOperands);
 
   // Store the results to the globals.
   for (auto [result, resultGlobalOp] :
@@ -317,7 +319,7 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
                                  initializerBuilder);
   }
 
-  initializerBuilder.create<IREE::Util::ReturnOp>(memoizeOp.getLoc());
+  IREE::Util::ReturnOp::create(initializerBuilder, memoizeOp.getLoc());
 
   return resultGlobalOps;
 }
@@ -355,13 +357,13 @@ static scf::ValueVector recursivelyEmitDeviceTree(
   Value deviceGlobal =
       deviceGlobalOp.createLoadOp(loc, builder).getLoadedGlobalValue();
   Value isDevice =
-      builder.create<IREE::Util::CmpEQOp>(loc, device, deviceGlobal);
-  auto ifOp = builder.create<scf::IfOp>(
-      loc, resultTypes, isDevice, /*addThenBlock=*/true, /*addElseBlock=*/true);
+      IREE::Util::CmpEQOp::create(builder, loc, device, deviceGlobal);
+  auto ifOp = scf::IfOp::create(builder, loc, resultTypes, isDevice,
+                                /*addThenBlock=*/true, /*addElseBlock=*/true);
 
   auto thenBuilder = ifOp.getThenBodyBuilder();
   scf::ValueVector thenResults = perDevice(deviceGlobalOp, thenBuilder);
-  thenBuilder.create<scf::YieldOp>(loc, thenResults);
+  scf::YieldOp::create(thenBuilder, loc, thenResults);
 
   auto elseBuilder = ifOp.getElseBodyBuilder();
   scf::ValueVector elseResults;
@@ -373,7 +375,7 @@ static scf::ValueVector recursivelyEmitDeviceTree(
         remainingDeviceGlobalOps.drop_front(1), perDevice, fallback,
         elseBuilder);
   }
-  elseBuilder.create<scf::YieldOp>(loc, elseResults);
+  scf::YieldOp::create(elseBuilder, loc, elseResults);
 
   return llvm::to_vector_of<Value>(ifOp.getResults());
 }
@@ -412,10 +414,11 @@ createDeviceResultSelectTree(Location loc, TypeRange resultTypes, Value device,
         for (auto resultType : resultTypes) {
           Value fallbackValue;
           if (resultType.isIntOrIndexOrFloat()) {
-            fallbackValue = builder.create<arith::ConstantOp>(
-                loc, resultType, builder.getZeroAttr(resultType));
+            fallbackValue = arith::ConstantOp::create(
+                builder, loc, resultType, builder.getZeroAttr(resultType));
           } else {
-            fallbackValue = builder.create<IREE::Util::NullOp>(loc, resultType);
+            fallbackValue =
+                IREE::Util::NullOp::create(builder, loc, resultType);
           }
           fallbackValues.push_back(fallbackValue);
         }
@@ -444,8 +447,8 @@ static IREE::Util::FuncOp createLookupFunc(IREE::HAL::DeviceMemoizeOp memoizeOp,
                                 [](Value value) { return value.getType(); }));
   auto funcType =
       moduleBuilder.getFunctionType(argTypes, memoizeOp.getResultTypes());
-  auto funcOp = moduleBuilder.create<IREE::Util::FuncOp>(memoizeOp.getLoc(),
-                                                         name, funcType);
+  auto funcOp = IREE::Util::FuncOp::create(moduleBuilder, memoizeOp.getLoc(),
+                                           name, funcType);
   moduleSymbolTable.insert(funcOp);
   funcOp.setVisibility(SymbolTable::Visibility::Private);
   auto funcBuilder = OpBuilder::atBlockBegin(funcOp.addEntryBlock());
@@ -483,7 +486,8 @@ static IREE::Util::FuncOp createLookupFunc(IREE::HAL::DeviceMemoizeOp memoizeOp,
       memoizeOp.getLoc(), funcType.getResults(),
       mapping.lookup(memoizeOp.getDevice()), deviceResultMap, funcBuilder);
 
-  funcBuilder.create<IREE::Util::ReturnOp>(memoizeOp.getLoc(), selectedResults);
+  IREE::Util::ReturnOp::create(funcBuilder, memoizeOp.getLoc(),
+                               selectedResults);
 
   return funcOp;
 }
@@ -500,8 +504,8 @@ static void replaceMemoizeOpWithLookup(IREE::HAL::DeviceMemoizeOp memoizeOp,
 
   // Call the function.
   OpBuilder callerBuilder(memoizeOp);
-  auto callOp = callerBuilder.create<IREE::Util::CallOp>(
-      memoizeOp.getLoc(), lookupFuncOp, callOperands);
+  auto callOp = IREE::Util::CallOp::create(callerBuilder, memoizeOp.getLoc(),
+                                           lookupFuncOp, callOperands);
 
   // Replace memoize op with the results of the function call.
   memoizeOp.replaceAllUsesWith(callOp.getResults());

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/RepeatDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/RepeatDispatches.cpp
@@ -41,8 +41,8 @@ struct RepeatDispatchesPass
         // will have an over optimistic result. Inserting barriers avoids that,
         // but it assumes that the command buffer has a linear dispatch
         // structure.
-        builder.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
-            op.getLoc(), op.getCommandBuffer(),
+        IREE::HAL::CommandBufferExecutionBarrierOp::create(
+            builder, op.getLoc(), op.getCommandBuffer(),
             IREE::HAL::ExecutionStageBitfield::CommandRetire |
                 IREE::HAL::ExecutionStageBitfield::Dispatch,
             IREE::HAL::ExecutionStageBitfield::CommandIssue |

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveTopologyQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveTopologyQueries.cpp
@@ -160,9 +160,9 @@ resolveMemoryPropertiesOp(AllocatorResolveMemoryPropertiesOp op,
     // If we don't have an optimal attribute, we just set the default
     // memory types and buffer usage.
     auto memoryTypeOp =
-        builder.create<IREE::HAL::MemoryTypeOp>(loc, memoryTypes);
+        IREE::HAL::MemoryTypeOp::create(builder, loc, memoryTypes);
     auto bufferUsageOp =
-        builder.create<IREE::HAL::BufferUsageOp>(loc, bufferUsage);
+        IREE::HAL::BufferUsageOp::create(builder, loc, bufferUsage);
     op.replaceAllUsesWith(ValueRange{memoryTypeOp, bufferUsageOp});
     op.erase();
     LLVM_DEBUG(llvm::dbgs()
@@ -192,9 +192,10 @@ resolveMemoryPropertiesOp(AllocatorResolveMemoryPropertiesOp op,
                              "with shared usage bits\n");
 
   // Create the resolved memory type and buffer usage ops.
-  auto memoryTypeOp = builder.create<IREE::HAL::MemoryTypeOp>(loc, memoryTypes);
+  auto memoryTypeOp =
+      IREE::HAL::MemoryTypeOp::create(builder, loc, memoryTypes);
   auto bufferUsageOp =
-      builder.create<IREE::HAL::BufferUsageOp>(loc, bufferUsage);
+      IREE::HAL::BufferUsageOp::create(builder, loc, bufferUsage);
   op.replaceAllUsesWith(ValueRange{memoryTypeOp, bufferUsageOp});
   op.erase();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -224,7 +224,7 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
                                                       Location loc,
                                                       ValueRange ivs) {
   auto indexDepth = getIndexDepth();
-  Value update = b.create<memref::LoadOp>(loc, getUpdates(), ivs);
+  Value update = memref::LoadOp::create(b, loc, getUpdates(), ivs);
   SmallVector<Value> starts;
   SmallVector<Value> loadIndices;
   append_range(loadIndices, ivs.take_front(getBatchRank()));
@@ -246,19 +246,19 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
   }
   for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
     if (getIndicesType().getRank() > getBatchRank()) {
-      loadIndices.back() = b.create<arith::ConstantIndexOp>(loc, i);
+      loadIndices.back() = arith::ConstantIndexOp::create(b, loc, i);
     }
-    Value idx = b.create<memref::LoadOp>(loc, getIndices(), loadIndices);
-    Value ret = b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx);
+    Value idx = memref::LoadOp::create(b, loc, getIndices(), loadIndices);
+    Value ret = arith::IndexCastOp::create(b, loc, b.getIndexType(), idx);
 
     auto dim = dimMap[i];
 
     if (starts[dim])
-      ret = b.create<arith::AddIOp>(loc, ret, starts[dim]);
+      ret = arith::AddIOp::create(b, loc, ret, starts[dim]);
     starts[dim] = ret;
   }
 
-  Value init = b.create<memref::LoadOp>(loc, getOriginal(), starts);
+  Value init = memref::LoadOp::create(b, loc, getOriginal(), starts);
 
   IRMapping bvm;
   Block &block = getRegion().front();
@@ -269,8 +269,8 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
   }
   // The last op is linalg_ext.yield op. Store the operand to
   // destination.
-  b.create<memref::StoreOp>(
-      loc, bvm.lookupOrDefault(block.getTerminator()->getOperand(0)),
+  memref::StoreOp::create(
+      b, loc, bvm.lookupOrDefault(block.getTerminator()->getOperand(0)),
       getOriginal(), starts);
   return success();
 }
@@ -398,21 +398,21 @@ LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,
   ArrayRef<int64_t> dimMap = getDimensionMap();
   for (int64_t i = 0; i < indexDepth; ++i) {
     if (hasIndexDim) {
-      loadIndices.back() = b.create<arith::ConstantIndexOp>(loc, i);
+      loadIndices.back() = arith::ConstantIndexOp::create(b, loc, i);
     }
-    Value idx = b.create<memref::LoadOp>(loc, getIndices(), loadIndices);
-    Value ret = b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx);
+    Value idx = memref::LoadOp::create(b, loc, getIndices(), loadIndices);
+    Value ret = arith::IndexCastOp::create(b, loc, b.getIndexType(), idx);
     auto dim = dimMap[i];
     if (starts[dim])
-      ret = b.create<arith::AddIOp>(loc, ret, starts[dim]);
+      ret = arith::AddIOp::create(b, loc, ret, starts[dim]);
     starts[dim] = ret;
   }
 
-  Value init = b.create<memref::LoadOp>(loc, getSource(), starts);
+  Value init = memref::LoadOp::create(b, loc, getSource(), starts);
 
   // The last op is linalg_ext.yield op. Store the operand to
   // destination.
-  b.create<memref::StoreOp>(loc, init, getOutput(), ivs);
+  memref::StoreOp::create(b, loc, init, getOutput(), ivs);
   return success();
 }
 
@@ -540,12 +540,12 @@ LogicalResult MapScatterOp::generateScalarImplementation(OpBuilder &b,
     ArrayRef<Value> storeIndices = yieldedValues.drop_back();
     auto thenBuilder = [&](OpBuilder &ifBuilder, Location ifLoc) {
       SmallVector<OpFoldResult> ivsOfr(ivs);
-      Value input = ifBuilder.create<memref::LoadOp>(ifLoc, getInput(), ivs);
-      ifBuilder.create<memref::StoreOp>(ifLoc, input, getOutput(),
-                                        storeIndices);
-      ifBuilder.create<scf::YieldOp>(ifLoc);
+      Value input = memref::LoadOp::create(ifBuilder, ifLoc, getInput(), ivs);
+      memref::StoreOp::create(ifBuilder, ifLoc, input, getOutput(),
+                              storeIndices);
+      scf::YieldOp::create(ifBuilder, ifLoc);
     };
-    nestedBuilder.create<scf::IfOp>(nestedLoc, ifCond, thenBuilder);
+    scf::IfOp::create(nestedBuilder, nestedLoc, ifCond, thenBuilder);
   };
   inlineMapScatterBody(b, loc, ivs, bodyBuilder);
   return success();
@@ -621,26 +621,28 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
   SmallVector<Value> indices, sortBlkArgs;
   indices.append(ivs.begin(), ivs.end());
   // Bubble sort innermost loop.
-  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(b, loc, 0);
+  Value one = arith::ConstantIndexOp::create(b, loc, 1);
   Value ub;
   if (getOperandType(0).isDynamicDim(sortDim)) {
-    ub = b.create<memref::DimOp>(loc, getOperand(0), sortDim);
+    ub = memref::DimOp::create(b, loc, getOperand(0), sortDim);
   } else {
-    ub = b.create<arith::ConstantIndexOp>(
-        loc, getOperandType(0).getDimSize(sortDim));
+    ub = arith::ConstantIndexOp::create(b, loc,
+                                        getOperandType(0).getDimSize(sortDim));
   }
-  ub = b.create<arith::SubIOp>(loc, ub, one);
-  auto scfFor = b.create<scf::ForOp>(
-      loc, zero, ub, one, ValueRange{},
+  ub = arith::SubIOp::create(b, loc, ub, one);
+  auto scfFor = scf::ForOp::create(
+      b, loc, zero, ub, one, ValueRange{},
       [&](OpBuilder &b, Location loc, Value iv, ValueRange iters) {
         SmallVector<Value> indices(ivs);
-        Value ivPlusOne = b.create<arith::AddIOp>(loc, iv, one);
+        Value ivPlusOne = arith::AddIOp::create(b, loc, iv, one);
         for (auto output : getDpsInits()) {
           indices[sortDim] = iv;
-          sortBlkArgs.push_back(b.create<memref::LoadOp>(loc, output, indices));
+          sortBlkArgs.push_back(
+              memref::LoadOp::create(b, loc, output, indices));
           indices[sortDim] = ivPlusOne;
-          sortBlkArgs.push_back(b.create<memref::LoadOp>(loc, output, indices));
+          sortBlkArgs.push_back(
+              memref::LoadOp::create(b, loc, output, indices));
         }
       });
 
@@ -662,28 +664,28 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
 
   OpBuilder::InsertionGuard g(b);
   b.setInsertionPointToEnd(&region.front());
-  b.create<scf::IfOp>(
-      loc, cond,
+  scf::IfOp::create(
+      b, loc, cond,
       [&](OpBuilder &b, Location loc) {
         // Do not swap the pairs if true.
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       },
       [&](OpBuilder &b, Location loc) {
         // Swap the pairs if false.
         SmallVector<Value> indices(ivs);
         Value ivPlusOne =
-            b.create<arith::AddIOp>(loc, scfFor.getInductionVar(), one);
+            arith::AddIOp::create(b, loc, scfFor.getInductionVar(), one);
         for (int i = 0, e = getNumDpsInits(); i < e; ++i) {
           Value v1 = sortBlkArgs[i * 2];
           Value v2 = sortBlkArgs[i * 2 + 1];
           indices[sortDim] = scfFor.getInductionVar();
-          b.create<memref::StoreOp>(loc, v2, getDpsInits()[i], indices);
+          memref::StoreOp::create(b, loc, v2, getDpsInits()[i], indices);
           indices[sortDim] = ivPlusOne;
-          b.create<memref::StoreOp>(loc, v1, getDpsInits()[i], indices);
+          memref::StoreOp::create(b, loc, v1, getDpsInits()[i], indices);
         }
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       });
-  b.create<scf::YieldOp>(loc);
+  scf::YieldOp::create(b, loc);
   return success();
 }
 
@@ -703,8 +705,8 @@ SmallVector<utils::IteratorType> FftOp::getLoopIteratorTypes() {
 SmallVector<Range> FftOp::getIterationDomain(OpBuilder &builder) {
   SmallVector<Range> res;
   Location loc = getLoc();
-  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
   for (auto [idx, val] : llvm::enumerate(getOperandShape().drop_back())) {
     OpFoldResult size;
     if (ShapedType::isDynamic(val)) {
@@ -716,7 +718,7 @@ SmallVector<Range> FftOp::getIterationDomain(OpBuilder &builder) {
   }
 
   OpFoldResult size = getDim(builder, loc, getReal(), getOperandRank() - 1);
-  Value stride = builder.create<arith::ShLIOp>(loc, one, getStage());
+  Value stride = arith::ShLIOp::create(builder, loc, one, getStage());
   res.emplace_back(Range{/*offset=*/zero, size, /*stride=*/stride});
   return res;
 }
@@ -729,18 +731,18 @@ void FftOp::generateScalarImplWithoutCoeffBuf(OpBuilder &b, Location loc,
 
   auto f32Type = b.getF32Type();
   auto indexToF32 = [](OpBuilder &builder, Location loc, Value v) -> Value {
-    v = builder.create<arith::IndexCastOp>(loc, builder.getI32Type(), v);
-    return builder.create<arith::SIToFPOp>(loc, builder.getF32Type(), v);
+    v = arith::IndexCastOp::create(builder, loc, builder.getI32Type(), v);
+    return arith::SIToFPOp::create(builder, loc, builder.getF32Type(), v);
   };
 
   // We will need exp(-2 * PI * j / m * I), compute "-2 * PI / m" for imag part
   // first.
-  Value coeff = b.create<arith::ConstantFloatOp>(
-      loc, f32Type, llvm::APFloat(static_cast<float>(-2 * acos(-1))));
-  coeff = b.create<arith::DivFOp>(loc, coeff, indexToF32(b, loc, wholeSize));
+  Value coeff = arith::ConstantFloatOp::create(
+      b, loc, f32Type, llvm::APFloat(static_cast<float>(-2 * acos(-1))));
+  coeff = arith::DivFOp::create(b, loc, coeff, indexToF32(b, loc, wholeSize));
 
-  b.create<linalg::GenericOp>(
-      loc, TypeRange{}, ValueRange{}, operands, maps, getLoopIteratorTypes(),
+  linalg::GenericOp::create(
+      b, loc, TypeRange{}, ValueRange{}, operands, maps, getLoopIteratorTypes(),
       [&](OpBuilder &b, Location loc, ValueRange args) {
         Value lhsReal = args[0];
         Value lhsImag = args[1];
@@ -748,29 +750,29 @@ void FftOp::generateScalarImplWithoutCoeffBuf(OpBuilder &b, Location loc,
         Value rhsImag = args[3];
 
         // Compute "-2 * PI / m * j"
-        Value w = b.create<arith::MulFOp>(
-            loc, coeff,
-            indexToF32(b, loc, b.create<linalg::IndexOp>(loc, rank - 1)));
-        Value wReal = b.create<math::CosOp>(loc, w);
-        Value wImag = b.create<math::SinOp>(loc, w);
+        Value w = arith::MulFOp::create(
+            b, loc, coeff,
+            indexToF32(b, loc, linalg::IndexOp::create(b, loc, rank - 1)));
+        Value wReal = math::CosOp::create(b, loc, w);
+        Value wImag = math::SinOp::create(b, loc, w);
 
         // t = w * a[k + j + mh];
         // ->  (x + yi)(u + vi) = (xu - yv) + (xv + yu)i
-        Value xu = b.create<arith::MulFOp>(loc, wReal, rhsReal);
-        Value yv = b.create<arith::MulFOp>(loc, wImag, rhsImag);
-        Value xv = b.create<arith::MulFOp>(loc, wReal, rhsImag);
-        Value yu = b.create<arith::MulFOp>(loc, wImag, rhsReal);
-        Value tReal = b.create<arith::SubFOp>(loc, xu, yv);
-        Value tImag = b.create<arith::AddFOp>(loc, xv, yu);
+        Value xu = arith::MulFOp::create(b, loc, wReal, rhsReal);
+        Value yv = arith::MulFOp::create(b, loc, wImag, rhsImag);
+        Value xv = arith::MulFOp::create(b, loc, wReal, rhsImag);
+        Value yu = arith::MulFOp::create(b, loc, wImag, rhsReal);
+        Value tReal = arith::SubFOp::create(b, loc, xu, yv);
+        Value tImag = arith::AddFOp::create(b, loc, xv, yu);
 
         // cplx u = a[k + j];
         // a[k + j] = u + t;
         // a[k + j + mh] = u - t;
-        Value r1 = b.create<arith::AddFOp>(loc, lhsReal, tReal);
-        Value r2 = b.create<arith::AddFOp>(loc, lhsImag, tImag);
-        Value r3 = b.create<arith::SubFOp>(loc, lhsReal, tReal);
-        Value r4 = b.create<arith::SubFOp>(loc, lhsImag, tImag);
-        b.create<linalg::YieldOp>(loc, ValueRange{r1, r2, r3, r4});
+        Value r1 = arith::AddFOp::create(b, loc, lhsReal, tReal);
+        Value r2 = arith::AddFOp::create(b, loc, lhsImag, tImag);
+        Value r3 = arith::SubFOp::create(b, loc, lhsReal, tReal);
+        Value r4 = arith::SubFOp::create(b, loc, lhsImag, tImag);
+        linalg::YieldOp::create(b, loc, ValueRange{r1, r2, r3, r4});
       });
 }
 
@@ -784,8 +786,8 @@ void FftOp::generateScalarImplWithCoeffBuf(OpBuilder &b, Location loc,
       2, AffineMap::get(rank, 0, b.getAffineDimExpr(rank - 1), b.getContext()));
   maps.append(operands.size(), b.getMultiDimIdentityMap(rank));
 
-  b.create<linalg::GenericOp>(
-      loc, TypeRange{}, ValueRange{getRealCoeff(), getImagCoeff()}, operands,
+  linalg::GenericOp::create(
+      b, loc, TypeRange{}, ValueRange{getRealCoeff(), getImagCoeff()}, operands,
       maps, getLoopIteratorTypes(),
       [&](OpBuilder &b, Location loc, ValueRange args) {
         Value wReal = args[0];
@@ -797,21 +799,21 @@ void FftOp::generateScalarImplWithCoeffBuf(OpBuilder &b, Location loc,
 
         // t = w * a[k + j + mh];
         // ->  (x + yi)(u + vi) = (xu - yv) + (xv + yu)i
-        Value xu = b.create<arith::MulFOp>(loc, wReal, rhsReal);
-        Value yv = b.create<arith::MulFOp>(loc, wImag, rhsImag);
-        Value xv = b.create<arith::MulFOp>(loc, wReal, rhsImag);
-        Value yu = b.create<arith::MulFOp>(loc, wImag, rhsReal);
-        Value tReal = b.create<arith::SubFOp>(loc, xu, yv);
-        Value tImag = b.create<arith::AddFOp>(loc, xv, yu);
+        Value xu = arith::MulFOp::create(b, loc, wReal, rhsReal);
+        Value yv = arith::MulFOp::create(b, loc, wImag, rhsImag);
+        Value xv = arith::MulFOp::create(b, loc, wReal, rhsImag);
+        Value yu = arith::MulFOp::create(b, loc, wImag, rhsReal);
+        Value tReal = arith::SubFOp::create(b, loc, xu, yv);
+        Value tImag = arith::AddFOp::create(b, loc, xv, yu);
 
         // cplx u = a[k + j];
         // a[k + j] = u + t;
         // a[k + j + mh] = u - t;
-        Value r1 = b.create<arith::AddFOp>(loc, lhsReal, tReal);
-        Value r2 = b.create<arith::AddFOp>(loc, lhsImag, tImag);
-        Value r3 = b.create<arith::SubFOp>(loc, lhsReal, tReal);
-        Value r4 = b.create<arith::SubFOp>(loc, lhsImag, tImag);
-        b.create<linalg::YieldOp>(loc, ValueRange{r1, r2, r3, r4});
+        Value r1 = arith::AddFOp::create(b, loc, lhsReal, tReal);
+        Value r2 = arith::AddFOp::create(b, loc, lhsImag, tImag);
+        Value r3 = arith::SubFOp::create(b, loc, lhsReal, tReal);
+        Value r4 = arith::SubFOp::create(b, loc, lhsImag, tImag);
+        linalg::YieldOp::create(b, loc, ValueRange{r1, r2, r3, r4});
       });
 }
 
@@ -834,9 +836,9 @@ LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
   Value real = getReal();
   Value imag = getImag();
   Value stage = getStage();
-  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
-  Value wholeSize = b.create<arith::ShLIOp>(loc, one, stage);
-  Value halfSize = b.create<arith::ShRSIOp>(loc, wholeSize, one);
+  Value one = arith::ConstantIndexOp::create(b, loc, 1);
+  Value wholeSize = arith::ShLIOp::create(b, loc, one, stage);
+  Value halfSize = arith::ShRSIOp::create(b, loc, wholeSize, one);
 
   auto rank = getOperandRank();
   SmallVector<Value> operands;
@@ -845,17 +847,17 @@ LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
   SmallVector<OpFoldResult> sizes(rank, b.getIndexAttr(1));
   sizes.back() = halfSize;
   operands.push_back(
-      b.create<memref::SubViewOp>(loc, real, lhsIvs, sizes, ones));
+      memref::SubViewOp::create(b, loc, real, lhsIvs, sizes, ones));
   operands.push_back(
-      b.create<memref::SubViewOp>(loc, imag, lhsIvs, sizes, ones));
+      memref::SubViewOp::create(b, loc, imag, lhsIvs, sizes, ones));
 
   SmallVector<OpFoldResult> rhsIvs(ivs);
   rhsIvs.back() =
-      b.create<arith::AddIOp>(loc, ivs.back(), halfSize).getResult();
+      arith::AddIOp::create(b, loc, ivs.back(), halfSize).getResult();
   operands.push_back(
-      b.create<memref::SubViewOp>(loc, real, rhsIvs, sizes, ones));
+      memref::SubViewOp::create(b, loc, real, rhsIvs, sizes, ones));
   operands.push_back(
-      b.create<memref::SubViewOp>(loc, imag, rhsIvs, sizes, ones));
+      memref::SubViewOp::create(b, loc, imag, rhsIvs, sizes, ones));
 
   if (hasCoeff()) {
     generateScalarImplWithCoeffBuf(b, loc, operands);
@@ -942,11 +944,11 @@ LogicalResult ScanOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
   SmallVector<Value> indices, scanBlkArgs;
   indices.append(ivs.begin(), ivs.end());
-  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(b, loc, 0);
+  Value one = arith::ConstantIndexOp::create(b, loc, 1);
   auto scanDim = getDimension();
-  auto cond = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                      indices[scanDim], zero);
+  auto cond = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq,
+                                    indices[scanDim], zero);
   bool isInclusive = getInclusive();
   SmallVector<Value> accIndices;
   for (int i = 0; i < indices.size(); i++) {
@@ -955,32 +957,32 @@ LogicalResult ScanOp::generateScalarImplementation(OpBuilder &b, Location loc,
     }
   }
 
-  auto scfIf = b.create<scf::IfOp>(
-      loc, cond,
+  auto scfIf = scf::IfOp::create(
+      b, loc, cond,
       [&](OpBuilder &b, Location loc) {
         if (isInclusive) {
-          auto value = b.create<memref::LoadOp>(loc, getInput(), indices);
-          b.create<memref::StoreOp>(loc, value, getOutput(), indices);
+          auto value = memref::LoadOp::create(b, loc, getInput(), indices);
+          memref::StoreOp::create(b, loc, value, getOutput(), indices);
         } else {
           auto value =
-              b.create<memref::LoadOp>(loc, getAccumulator(), accIndices);
-          b.create<memref::StoreOp>(loc, value, getOutput(), indices);
+              memref::LoadOp::create(b, loc, getAccumulator(), accIndices);
+          memref::StoreOp::create(b, loc, value, getOutput(), indices);
         }
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       },
       [&](OpBuilder &b, Location loc) {
         SmallVector<Value> indices(ivs);
         Value iv = indices[scanDim];
-        Value ivMinusOne = b.create<arith::SubIOp>(loc, iv, one);
+        Value ivMinusOne = arith::SubIOp::create(b, loc, iv, one);
         indices[scanDim] = ivMinusOne;
         scanBlkArgs.push_back(
-            b.create<memref::LoadOp>(loc, getOutput(), indices));
+            memref::LoadOp::create(b, loc, getOutput(), indices));
         Value i0;
         if (!isInclusive)
-          i0 = b.create<memref::LoadOp>(loc, getInput(), indices);
+          i0 = memref::LoadOp::create(b, loc, getInput(), indices);
         indices[scanDim] = iv;
         if (isInclusive)
-          i0 = b.create<memref::LoadOp>(loc, getInput(), indices);
+          i0 = memref::LoadOp::create(b, loc, getInput(), indices);
         scanBlkArgs.push_back(i0);
       });
 
@@ -997,13 +999,13 @@ LogicalResult ScanOp::generateScalarImplementation(OpBuilder &b, Location loc,
     for (auto &blockOp : srcBlock.without_terminator()) {
       b.clone(blockOp, bvm);
     }
-    b.create<memref::StoreOp>(
-        loc, bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0)),
+    memref::StoreOp::create(
+        b, loc, bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0)),
         getOutput(), indices);
-    b.create<memref::StoreOp>(
-        loc, bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0)),
+    memref::StoreOp::create(
+        b, loc, bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0)),
         getAccumulator(), accIndices);
-    b.create<scf::YieldOp>(loc);
+    scf::YieldOp::create(b, loc);
   }
   return success();
 }
@@ -1116,23 +1118,23 @@ SmallVector<utils::IteratorType> TopkOp::getLoopIteratorTypes() {
 LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
   uint64_t kDim = getDimension();
-  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
-  Value initialValue = b.create<memref::LoadOp>(loc, getValues(), ivs);
+  Value zero = arith::ConstantIndexOp::create(b, loc, 0);
+  Value one = arith::ConstantIndexOp::create(b, loc, 1);
+  Value initialValue = memref::LoadOp::create(b, loc, getValues(), ivs);
 
   // If the indices tensor is not provided, the value index is derived from the
   // loop induction variables.
   Value initialIndex;
   if (getIndices()) {
-    initialIndex = b.create<memref::LoadOp>(loc, *getIndices(), ivs);
+    initialIndex = memref::LoadOp::create(b, loc, *getIndices(), ivs);
   } else {
     Value rawInitialIndex = ivs[kDim];
     initialIndex =
-        b.create<arith::IndexCastOp>(loc, b.getI32Type(), rawInitialIndex);
+        arith::IndexCastOp::create(b, loc, b.getI32Type(), rawInitialIndex);
   }
 
   // Compute K (ub) from the selected dim of the output
-  Value ub = b.create<memref::DimOp>(loc, outputValues(), getDimension());
+  Value ub = memref::DimOp::create(b, loc, outputValues(), getDimension());
 
   // Inner K loop functions:
   //   Load current K value and index
@@ -1143,13 +1145,13 @@ LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
   //   Store new k value and index
   //   Yield loop carry values after K selection
   Value kValue, kIndex;
-  auto scfFor = b.create<scf::ForOp>(
-      loc, zero, ub, one, ValueRange{initialValue, initialIndex},
+  auto scfFor = scf::ForOp::create(
+      b, loc, zero, ub, one, ValueRange{initialValue, initialIndex},
       [&](OpBuilder &b, Location loc, Value iv, ValueRange loopCarryValues) {
         SmallVector<Value> indices(ivs);
         indices[kDim] = iv;
-        kValue = b.create<memref::LoadOp>(loc, outputValues(), indices);
-        kIndex = b.create<memref::LoadOp>(loc, outputIndices(), indices);
+        kValue = memref::LoadOp::create(b, loc, outputValues(), indices);
+        kIndex = memref::LoadOp::create(b, loc, outputIndices(), indices);
       });
 
   SmallVector<Value> indices(ivs);
@@ -1183,28 +1185,29 @@ LogicalResult TopkOp::generateScalarImplementation(OpBuilder &b, Location loc,
     //   f(x,y) --> forwardCmpRes
     //   f(y,x) --> reverseCmpRes
     //   if forwardCmpRes == reverseCmpRes then select which came first
-    Value cmpValuesEqual = b.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::eq, forwardCmpRes, reverseCmpRes);
-    Value cmpFirstIndex = b.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::slt, loopCarryValues[1], kIndex);
+    Value cmpValuesEqual = arith::CmpIOp::create(
+        b, loc, arith::CmpIPredicate::eq, forwardCmpRes, reverseCmpRes);
+    Value cmpFirstIndex = arith::CmpIOp::create(
+        b, loc, arith::CmpIPredicate::slt, loopCarryValues[1], kIndex);
     Value combinedCmpEqRes =
-        b.create<arith::AndIOp>(loc, cmpValuesEqual, cmpFirstIndex);
+        arith::AndIOp::create(b, loc, cmpValuesEqual, cmpFirstIndex);
     // True if N > K or N came before K
     Value indexCmpRes =
-        b.create<arith::OrIOp>(loc, forwardCmpRes, combinedCmpEqRes);
+        arith::OrIOp::create(b, loc, forwardCmpRes, combinedCmpEqRes);
     // Select results for K based on comparisons
-    Value resultKValue = b.create<arith::SelectOp>(loc, forwardCmpRes,
-                                                   loopCarryValues[0], kValue);
-    Value resultKIndex =
-        b.create<arith::SelectOp>(loc, indexCmpRes, loopCarryValues[1], kIndex);
-    b.create<memref::StoreOp>(loc, resultKValue, outputValues(), indices);
-    b.create<memref::StoreOp>(loc, resultKIndex, outputIndices(), indices);
+    Value resultKValue = arith::SelectOp::create(b, loc, forwardCmpRes,
+                                                 loopCarryValues[0], kValue);
+    Value resultKIndex = arith::SelectOp::create(b, loc, indexCmpRes,
+                                                 loopCarryValues[1], kIndex);
+    memref::StoreOp::create(b, loc, resultKValue, outputValues(), indices);
+    memref::StoreOp::create(b, loc, resultKIndex, outputIndices(), indices);
     // Select loop carry, opposite of K results
-    Value resultCarryValue = b.create<arith::SelectOp>(
-        loc, forwardCmpRes, kValue, loopCarryValues[0]);
-    Value resultCarryIndex =
-        b.create<arith::SelectOp>(loc, indexCmpRes, kIndex, loopCarryValues[1]);
-    b.create<scf::YieldOp>(loc, ValueRange{resultCarryValue, resultCarryIndex});
+    Value resultCarryValue = arith::SelectOp::create(
+        b, loc, forwardCmpRes, kValue, loopCarryValues[0]);
+    Value resultCarryIndex = arith::SelectOp::create(
+        b, loc, indexCmpRes, kIndex, loopCarryValues[1]);
+    scf::YieldOp::create(b, loc,
+                         ValueRange{resultCarryValue, resultCarryIndex});
   }
   return success();
 }
@@ -1406,11 +1409,11 @@ LogicalResult ArgCompareOp::generateScalarImplementation(OpBuilder &b,
   }
 
   Value bestValueSoFar =
-      b.create<memref::LoadOp>(loc, outputValue(), parallelIndices);
+      memref::LoadOp::create(b, loc, outputValue(), parallelIndices);
   Value bestIndexSoFar =
-      b.create<memref::LoadOp>(loc, outputIndex(), parallelIndices);
+      memref::LoadOp::create(b, loc, outputIndex(), parallelIndices);
 
-  Value candidateValue = b.create<memref::LoadOp>(loc, getInputValue(), ivs);
+  Value candidateValue = memref::LoadOp::create(b, loc, getInputValue(), ivs);
 
   auto &srcBlock = getRegion().front();
   IRMapping regionMap;
@@ -1421,22 +1424,24 @@ LogicalResult ArgCompareOp::generateScalarImplementation(OpBuilder &b,
   }
 
   Value cmpResult = regionMap.lookup(srcBlock.getTerminator()->getOperand(0));
-  Value selectedValue =
-      b.create<arith::SelectOp>(loc, cmpResult, candidateValue, bestValueSoFar);
+  Value selectedValue = arith::SelectOp::create(b, loc, cmpResult,
+                                                candidateValue, bestValueSoFar);
   Value indexOffset = ivs[reductionDim];
   if (getIndexBase()) {
-    indexOffset = b.create<arith::AddIOp>(loc, getIndexBase(), indexOffset);
+    indexOffset = arith::AddIOp::create(b, loc, getIndexBase(), indexOffset);
   }
   Value castedIndex = indexOffset;
   if (castedIndex.getType() != bestIndexSoFar.getType()) {
-    castedIndex = b.create<arith::IndexCastOp>(loc, bestIndexSoFar.getType(),
-                                               castedIndex);
+    castedIndex = arith::IndexCastOp::create(b, loc, bestIndexSoFar.getType(),
+                                             castedIndex);
   }
 
   Value selectedIndex =
-      b.create<arith::SelectOp>(loc, cmpResult, castedIndex, bestIndexSoFar);
-  b.create<memref::StoreOp>(loc, selectedValue, outputValue(), parallelIndices);
-  b.create<memref::StoreOp>(loc, selectedIndex, outputIndex(), parallelIndices);
+      arith::SelectOp::create(b, loc, cmpResult, castedIndex, bestIndexSoFar);
+  memref::StoreOp::create(b, loc, selectedValue, outputValue(),
+                          parallelIndices);
+  memref::StoreOp::create(b, loc, selectedIndex, outputIndex(),
+                          parallelIndices);
   return success();
 }
 
@@ -1454,8 +1459,8 @@ static SmallVector<Range> getIterationDomain(OpTy op, OpBuilder &builder) {
   int64_t rank = (std::is_same<OpTy, PackOp>::value) ? op.getInputRank()
                                                      : op.getOutputRank();
   SmallVector<Range> loopBounds(rank);
-  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
   ReifiedRankedShapedTypeDims resultShape;
   (void)op.reifyResultShapes(builder, resultShape);
   for (auto dim : llvm::seq<int64_t>(0, rank)) {
@@ -1526,8 +1531,8 @@ static void generatePackOpScalarImplementationBody(PackOp packOp,
   }
 
   auto createLoad = [&]() -> Value {
-    return builder.create<memref::LoadOp>(
-        loc, packOp.getInput(),
+    return memref::LoadOp::create(
+        builder, loc, packOp.getInput(),
         getValueOrCreateConstantIndexOp(builder, loc, sourceIndices));
   };
   Value scalar;
@@ -1545,18 +1550,18 @@ static void generatePackOpScalarImplementationBody(PackOp packOp,
                  .create<scf::IfOp>(
                      loc, isInBounds, /*thenBuilder=*/
                      [&](OpBuilder &b, Location l) {
-                       b.create<scf::YieldOp>(l, createLoad());
+                       scf::YieldOp::create(b, l, createLoad());
                      },
                      /*elseBuilder=*/
                      [&](OpBuilder &b, Location l) {
-                       b.create<scf::YieldOp>(l, paddingValue);
+                       scf::YieldOp::create(b, l, paddingValue);
                      })
                  .getResult(0);
   } else {
     scalar = createLoad();
   }
 
-  builder.create<memref::StoreOp>(loc, scalar, packOp.getOutput(), ivs);
+  memref::StoreOp::create(builder, loc, scalar, packOp.getOutput(), ivs);
 }
 
 LogicalResult PackOp::generateScalarImplementation(OpBuilder &builder,
@@ -1577,8 +1582,8 @@ LogicalResult PackOp::generateScalarImplementation(OpBuilder &builder,
   }
 
   // Generate the loops that iterate over the data tile.
-  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
 
   // All loops except the innermost are simple loops that just iterate
   // over the tile dimensions.
@@ -1586,13 +1591,13 @@ LogicalResult PackOp::generateScalarImplementation(OpBuilder &builder,
        llvm::seq<unsigned>(getInputRank(), getOutputRank() - 1)) {
     Value ub = getValueOrCreateConstantIndexOp(builder, loc,
                                                outputShape[0][dataTileDim]);
-    scf::ForOp loop = builder.create<scf::ForOp>(loc, zero, ub, one);
+    scf::ForOp loop = scf::ForOp::create(builder, loc, zero, ub, one);
     builder.setInsertionPointToStart(loop.getBody());
     ivVec.push_back(loop.getInductionVar());
   }
   // The body of the innermost loops does the actual data movement.
-  builder.create<scf::ForOp>(
-      loc, zero,
+  scf::ForOp::create(
+      builder, loc, zero,
       getValueOrCreateConstantIndexOp(builder, loc, outputShape[0].back()), one,
       ValueRange{},
       [&](OpBuilder &bodyBuilder, Location bodyLoc, Value iv,
@@ -1600,7 +1605,7 @@ LogicalResult PackOp::generateScalarImplementation(OpBuilder &builder,
         ivVec.push_back(iv);
         generatePackOpScalarImplementationBody(*this, bodyBuilder, bodyLoc,
                                                ivVec);
-        bodyBuilder.create<scf::YieldOp>(bodyLoc);
+        scf::YieldOp::create(bodyBuilder, bodyLoc);
       });
   return success();
 }
@@ -1663,8 +1668,8 @@ LogicalResult UnPackOp::generateScalarImplementation(OpBuilder &builder,
   }
 
   llvm::append_range(inputIvs, interchangedInputIvsPointLoops);
-  Value scalar = builder.create<memref::LoadOp>(loc, getInput(), inputIvs);
-  builder.create<memref::StoreOp>(loc, scalar, getOutput(), ivs);
+  Value scalar = memref::LoadOp::create(builder, loc, getInput(), inputIvs);
+  memref::StoreOp::create(builder, loc, scalar, getOutput(), ivs);
   return success();
 }
 
@@ -2582,9 +2587,9 @@ OnlineAttentionOp::generateInitialTensorForPartialReduction(
   Type maxElTy = getElementTypeOrSelf(getMax().getType());
   Type sumElTy = getElementTypeOrSelf(getSum().getType());
 
-  Value partialAcc = b.create<tensor::EmptyOp>(loc, accSize, accElTy);
-  Value partialMax = b.create<tensor::EmptyOp>(loc, maxSize, maxElTy);
-  Value partialSum = b.create<tensor::EmptyOp>(loc, sumSize, sumElTy);
+  Value partialAcc = tensor::EmptyOp::create(b, loc, accSize, accElTy);
+  Value partialMax = tensor::EmptyOp::create(b, loc, maxSize, maxElTy);
+  Value partialSum = tensor::EmptyOp::create(b, loc, sumSize, sumElTy);
 
   Value accInit = arith::getIdentityValue(arith::AtomicRMWKind::addf, accElTy,
                                           b, loc, /*useOnlyFiniteValue=*/true);
@@ -2594,12 +2599,15 @@ OnlineAttentionOp::generateInitialTensorForPartialReduction(
   Value sumInit =
       arith::getIdentityValue(arith::AtomicRMWKind::addf, sumElTy, b, loc);
 
-  Value accFill = b.create<linalg::FillOp>(loc, ValueRange{accInit}, partialAcc)
-                      .getResult(0);
-  Value maxFill = b.create<linalg::FillOp>(loc, ValueRange{maxInit}, partialMax)
-                      .getResult(0);
-  Value sumFill = b.create<linalg::FillOp>(loc, ValueRange{sumInit}, partialSum)
-                      .getResult(0);
+  Value accFill =
+      linalg::FillOp::create(b, loc, ValueRange{accInit}, partialAcc)
+          .getResult(0);
+  Value maxFill =
+      linalg::FillOp::create(b, loc, ValueRange{maxInit}, partialMax)
+          .getResult(0);
+  Value sumFill =
+      linalg::FillOp::create(b, loc, ValueRange{sumInit}, partialSum)
+          .getResult(0);
 
   return SmallVector<Value>{accFill, maxFill, sumFill};
 }
@@ -2702,11 +2710,11 @@ static linalg::ReduceOp reduceOnK2(OnlineAttentionOp attn, AffineMap partialMap,
     }
   }
 
-  return b.create<linalg::ReduceOp>(
-      loc, partialResult, init, partialReductionDims,
+  return linalg::ReduceOp::create(
+      b, loc, partialResult, init, partialReductionDims,
       [&](OpBuilder &b, Location loc, ValueRange inputs) {
-        Value reduced = b.create<CombinerOp>(loc, inputs[0], inputs[1]);
-        b.create<linalg::YieldOp>(loc, reduced);
+        Value reduced = CombinerOp::create(b, loc, inputs[0], inputs[1]);
+        linalg::YieldOp::create(b, loc, reduced);
       });
 };
 
@@ -2722,15 +2730,15 @@ static Value elementwiseValueInPlace(OpBuilder &builder, Location loc,
   SmallVector<utils::IteratorType> iteratorTypes(inputMap.getNumDims(),
                                                  utils::IteratorType::parallel);
 
-  auto genericOp = builder.create<linalg::GenericOp>(
-      loc, value.getType(), scale, value,
+  auto genericOp = linalg::GenericOp::create(
+      builder, loc, value.getType(), scale, value,
       SmallVector<AffineMap>{scaleMap, inputMap}, iteratorTypes,
       [&](OpBuilder &b, Location loc, ValueRange args) {
         // Convert scale to the same datatype as input.
         Value scale = convertScalarToDtype(b, loc, args[0], args[1].getType(),
                                            /*isUnsignedCast=*/false);
-        Value result = b.create<T>(loc, scale, args[1]);
-        b.create<linalg::YieldOp>(loc, result);
+        Value result = T::create(b, loc, scale, args[1]);
+        linalg::YieldOp::create(b, loc, result);
       });
   return genericOp.getResult(0);
 }
@@ -2746,16 +2754,16 @@ static Value computeSubAndExp2(OpBuilder &builder, Location loc,
 
   SmallVector<utils::IteratorType> iteratorTypes(inputMap.getNumDims(),
                                                  utils::IteratorType::parallel);
-  auto genericOp = builder.create<linalg::GenericOp>(
-      loc, output.getType(), input, output,
+  auto genericOp = linalg::GenericOp::create(
+      builder, loc, output.getType(), input, output,
       SmallVector<AffineMap>{inputMap, outputMap}, iteratorTypes,
       [&](OpBuilder &b, Location loc, ValueRange args) {
         // Convert input to the same datatype as output.
         Value in = convertScalarToDtype(b, loc, args[0], args[1].getType(),
                                         /*isUnsignedCast=*/false);
-        Value diff = b.create<arith::SubFOp>(loc, args[1], in);
-        Value weight = b.create<math::Exp2Op>(loc, diff);
-        b.create<linalg::YieldOp>(loc, weight);
+        Value diff = arith::SubFOp::create(b, loc, args[1], in);
+        Value weight = math::Exp2Op::create(b, loc, diff);
+        linalg::YieldOp::create(b, loc, weight);
       });
   return genericOp.getResult(0);
 }
@@ -3032,8 +3040,8 @@ materializeTiledShape(OpBuilder &builder, Location loc, Value valueToTile,
   auto shapedType = dyn_cast<ShapedType>(valueToTile.getType());
   auto *sliceOp = TypeSwitch<ShapedType, Operation *>(shapedType)
                       .Case([&](RankedTensorType) {
-                        return builder.create<tensor::ExtractSliceOp>(
-                            loc, valueToTile, sliceParams.offsets,
+                        return tensor::ExtractSliceOp::create(
+                            builder, loc, valueToTile, sliceParams.offsets,
                             sliceParams.sizes, sliceParams.strides);
                       })
                       .Default([](ShapedType) -> Operation * {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -39,8 +39,8 @@ static LogicalResult lowerToLoopsImpl(OpBuilder &builder,
     return tilableOp.generateScalarImplementation(builder, loc, ivs);
   }
   LogicalResult status = success();
-  builder.create<scf::ForOp>(
-      loc,
+  scf::ForOp::create(
+      builder, loc,
       getValueOrCreateConstantIndexOp(builder, loc,
                                       loopRanges[loopDepth].offset),
       getValueOrCreateConstantIndexOp(builder, loc, loopRanges[loopDepth].size),
@@ -49,7 +49,7 @@ static LogicalResult lowerToLoopsImpl(OpBuilder &builder,
       ValueRange{}, [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
         ivs.push_back(iv);
         status = lowerToLoopsImpl(b, tilableOp, loopRanges, loopDepth + 1, ivs);
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       });
   return status;
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TransposeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TransposeFusion.cpp
@@ -171,10 +171,10 @@ struct BubbleTransposeVFromAttentionOp
         tensor::getMixedSizes(rewriter, loc, value);
     applyPermutationToVector(transVShape, perm);
     Value initTransV =
-        rewriter.create<tensor::EmptyOp>(loc, transVShape, valueElType)
+        tensor::EmptyOp::create(rewriter, loc, transVShape, valueElType)
             .getResult();
     Value transposeV =
-        rewriter.create<linalg::TransposeOp>(loc, value, initTransV, perm)
+        linalg::TransposeOp::create(rewriter, loc, value, initTransV, perm)
             ->getResult(0);
 
     // Generate transpose V map.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
@@ -34,12 +34,13 @@ struct VectorizeStaticMapScatterOpPattern final
     }
     Location loc = mapScatterOp.getLoc();
     rewriter.setInsertionPoint(mapScatterOp);
-    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> zeros(inputType.getRank(), zero);
     auto inputVectorType =
         VectorType::get(inputType.getShape(), inputType.getElementType());
-    Value inputVector = rewriter.create<vector::TransferReadOp>(
-        loc, inputVectorType, mapScatterOp.getInput(), /*indices=*/zeros,
+    Value inputVector = vector::TransferReadOp::create(
+        rewriter, loc, inputVectorType, mapScatterOp.getInput(),
+        /*indices=*/zeros,
         /*padding=*/std::nullopt);
     auto vectorizedMapScatterOp =
         clone(rewriter, mapScatterOp, mapScatterOp.getResultTypes(),

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -60,7 +60,7 @@ OpFoldResult mulAddOfrs(OpBuilder &builder, Location loc, OpFoldResult a,
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
   if (!type.isDynamicDim(dim)) {
-    return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
+    return arith::ConstantIndexOp::create(builder, loc, type.getDimSize(dim));
   }
   return TypeSwitch<Type, Value>(v.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {
@@ -101,11 +101,11 @@ Operation *getSlice(OpBuilder &b, Location loc, Value src,
                     ArrayRef<OpFoldResult> strides) {
   return TypeSwitch<Type, Operation *>(src.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Operation * {
-        return b.create<tensor::ExtractSliceOp>(loc, src, offsets, sizes,
-                                                strides);
+        return tensor::ExtractSliceOp::create(b, loc, src, offsets, sizes,
+                                              strides);
       })
       .Case<MemRefType>([&](MemRefType type) -> Operation * {
-        return b.create<memref::SubViewOp>(loc, src, offsets, sizes, strides);
+        return memref::SubViewOp::create(b, loc, src, offsets, sizes, strides);
       })
       .Default([&](Type t) -> Operation * {
         assert(false && "invalid type");
@@ -117,11 +117,11 @@ Value castValue(OpBuilder &b, Location loc, Value src, ShapedType type) {
   return TypeSwitch<Type, Value>(src.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {
         assert(isa<RankedTensorType>(type) && "expected compatible type");
-        return b.create<tensor::CastOp>(loc, type, src)->getResult(0);
+        return tensor::CastOp::create(b, loc, type, src)->getResult(0);
       })
       .Case<MemRefType>([&](MemRefType type) -> Value {
         assert(isa<MemRefType>(type) && "expected compatible type");
-        return b.create<memref::CastOp>(loc, type, src)->getResult(0);
+        return memref::CastOp::create(b, loc, type, src)->getResult(0);
       })
       .Default([&](Type t) {
         assert(false && "invalid type");
@@ -159,9 +159,10 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                                 Location loc, RewriterBase &rewriter) {
   ArrayRef<float> vector(val, rows * cols);
   SmallVector<int64_t> shape{rows, cols};
-  return rewriter.create<arith::ConstantOp>(
-      loc, DenseFPElementsAttr::get(
-               RankedTensorType::get(shape, rewriter.getF32Type()), vector));
+  return arith::ConstantOp::create(
+      rewriter, loc,
+      DenseFPElementsAttr::get(
+          RankedTensorType::get(shape, rewriter.getF32Type()), vector));
 }
 
 SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -39,9 +39,9 @@ static Value buildResultSizeOf(Location loc, Value tensorValue,
                                ConversionPatternRewriter &rewriter) {
   // TODO(benvanik): see if we can stash this on the side to avoid expensive
   // materialization of a bunch of redundant IR.
-  return rewriter.create<IREE::Stream::TensorSizeOfOp>(
-      loc, rewriter.getIndexType(), TypeAttr::get(tensorValue.getType()),
-      dynamicDims, affinityAttr);
+  return IREE::Stream::TensorSizeOfOp::create(
+      rewriter, loc, rewriter.getIndexType(),
+      TypeAttr::get(tensorValue.getType()), dynamicDims, affinityAttr);
 }
 
 struct ConvertTensorConstantOp
@@ -55,8 +55,8 @@ public:
     // Capture the tensor constant strongly typed with constant lifetime.
     auto constantType = rewriter.getType<IREE::Stream::ResourceType>(
         IREE::Stream::Lifetime::Constant);
-    auto newOp = rewriter.create<IREE::Stream::TensorConstantOp>(
-        constantOp.getLoc(), constantType,
+    auto newOp = IREE::Stream::TensorConstantOp::create(
+        rewriter, constantOp.getLoc(), constantType,
         convertAttributeToStream(constantOp.getValue()),
         TypeAttr::get(constantOp.getType()), ValueRange{},
         executionAffinityAttr);
@@ -65,9 +65,9 @@ public:
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
     auto constantSize = rewriter.createOrFold<IREE::Stream::ResourceSizeOp>(
         constantOp.getLoc(), rewriter.getIndexType(), newOp.getResult());
-    auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-        constantOp.getLoc(), unknownType, newOp.getResult(), constantSize,
-        constantSize,
+    auto transferOp = IREE::Stream::AsyncTransferOp::create(
+        rewriter, constantOp.getLoc(), unknownType, newOp.getResult(),
+        constantSize, constantSize,
         /*source_affinity=*/executionAffinityAttr,
         /*result_affinity=*/executionAffinityAttr);
     rewriter.replaceOpWithMultiple(constantOp,
@@ -94,8 +94,8 @@ public:
     SmallVector<Value> dynamicDims;
     for (unsigned i = 0; i < resultType.getRank(); ++i) {
       if (resultType.isDynamicDim(i)) {
-        Value staticDim = rewriter.create<arith::ConstantIndexOp>(
-            constantOp.getLoc(), attrType.getDimSize(i));
+        Value staticDim = arith::ConstantIndexOp::create(
+            rewriter, constantOp.getLoc(), attrType.getDimSize(i));
         Value dynamicDim = rewriter
                                .create<IREE::Util::OptimizationBarrierOp>(
                                    constantOp.getLoc(), staticDim)
@@ -107,8 +107,8 @@ public:
     // Capture the tensor constant strongly typed with constant lifetime.
     auto constantType = rewriter.getType<IREE::Stream::ResourceType>(
         IREE::Stream::Lifetime::Constant);
-    auto newOp = rewriter.create<IREE::Stream::TensorConstantOp>(
-        constantOp.getLoc(), constantType,
+    auto newOp = IREE::Stream::TensorConstantOp::create(
+        rewriter, constantOp.getLoc(), constantType,
         convertAttributeToStream(constantOp.getValue()),
         TypeAttr::get(resultType), dynamicDims, executionAffinityAttr);
 
@@ -116,9 +116,9 @@ public:
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
     auto constantSize = rewriter.createOrFold<IREE::Stream::ResourceSizeOp>(
         constantOp.getLoc(), rewriter.getIndexType(), newOp.getResult());
-    auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-        constantOp.getLoc(), unknownType, newOp.getResult(), constantSize,
-        constantSize,
+    auto transferOp = IREE::Stream::AsyncTransferOp::create(
+        rewriter, constantOp.getLoc(), unknownType, newOp.getResult(),
+        constantSize, constantSize,
         /*source_affinity=*/executionAffinityAttr,
         /*result_affinity=*/executionAffinityAttr);
     rewriter.replaceOpWithMultiple(constantOp, {{transferOp, constantSize}});
@@ -150,10 +150,11 @@ struct ConvertTensorCastLikeOp
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getResultDims(),
                           resultAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    Value cloneOp = rewriter.create<IREE::Stream::TensorCloneOp>(
-        op.getLoc(), unknownType, source.resource, op.getSource().getType(),
-        op.getSourceDims(), source.resourceSize, op.getResult().getType(),
-        flattenValues(adaptor.getResultDims()), resultSize, resultAffinityAttr);
+    Value cloneOp = IREE::Stream::TensorCloneOp::create(
+        rewriter, op.getLoc(), unknownType, source.resource,
+        op.getSource().getType(), op.getSourceDims(), source.resourceSize,
+        op.getResult().getType(), flattenValues(adaptor.getResultDims()),
+        resultSize, resultAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{cloneOp, resultSize}});
     return success();
   }
@@ -170,8 +171,8 @@ struct ConvertTensorAllocaOp
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getResultDims(),
                           executionAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto allocaOp = rewriter.create<IREE::Stream::AsyncAllocaOp>(
-        op.getLoc(), unknownType, resultSize, executionAffinityAttr);
+    auto allocaOp = IREE::Stream::AsyncAllocaOp::create(
+        rewriter, op.getLoc(), unknownType, resultSize, executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{allocaOp.getResult(), resultSize}});
     return success();
   }
@@ -188,8 +189,8 @@ struct ConvertTensorEmptyOp
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getResultDims(),
                           executionAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto emptyOp = rewriter.create<IREE::Stream::TensorEmptyOp>(
-        op.getLoc(), unknownType, op.getResult().getType(),
+    auto emptyOp = IREE::Stream::TensorEmptyOp::create(
+        rewriter, op.getLoc(), unknownType, op.getResult().getType(),
         flattenValues(adaptor.getResultDims()), resultSize,
         executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{emptyOp.getResult(), resultSize}});
@@ -208,8 +209,8 @@ struct ConvertTensorSplatOp
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getResultDims(),
                           executionAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto splatOp = rewriter.create<IREE::Stream::TensorSplatOp>(
-        op.getLoc(), unknownType, adaptor.getValue().front(),
+    auto splatOp = IREE::Stream::TensorSplatOp::create(
+        rewriter, op.getLoc(), unknownType, adaptor.getValue().front(),
         op.getResult().getType(), flattenValues(adaptor.getResultDims()),
         resultSize, executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{splatOp, resultSize}});
@@ -228,11 +229,11 @@ struct ConvertTensorCloneOp
                                           adaptor.getOperand(),
                                           executionAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto cloneOp = rewriter.create<IREE::Stream::TensorCloneOp>(
-        op.getLoc(), unknownType, operand.resource, op.getOperand().getType(),
-        op.getOperandDims(), operand.resourceSize, op.getResult().getType(),
-        flattenValues(adaptor.getOperandDims()), operand.resourceSize,
-        executionAffinityAttr);
+    auto cloneOp = IREE::Stream::TensorCloneOp::create(
+        rewriter, op.getLoc(), unknownType, operand.resource,
+        op.getOperand().getType(), op.getOperandDims(), operand.resourceSize,
+        op.getResult().getType(), flattenValues(adaptor.getOperandDims()),
+        operand.resourceSize, executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{cloneOp, operand.resourceSize}});
     return success();
   }
@@ -252,11 +253,11 @@ struct ConvertTensorEncodeOp
     auto resultSize =
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getOperandDims(),
                           executionAffinityAttr, rewriter);
-    auto encodeOp = rewriter.create<IREE::Stream::TensorEncodeOp>(
-        op.getLoc(), unknownType, operand.resource, op.getOperand().getType(),
-        op.getOperandDims(), operand.resourceSize, op.getResult().getType(),
-        flattenValues(adaptor.getResultDims()), resultSize,
-        executionAffinityAttr);
+    auto encodeOp = IREE::Stream::TensorEncodeOp::create(
+        rewriter, op.getLoc(), unknownType, operand.resource,
+        op.getOperand().getType(), op.getOperandDims(), operand.resourceSize,
+        op.getResult().getType(), flattenValues(adaptor.getResultDims()),
+        resultSize, executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{encodeOp, resultSize}});
     return success();
   }
@@ -271,8 +272,8 @@ struct ConvertTensorBarrierOp
       ConversionPatternRewriter &rewriter) const override {
     auto operand = resolveTensorOperands(op.getLoc(), op.getOperand(),
                                          adaptor.getOperand(), rewriter);
-    auto barrierOp = rewriter.create<IREE::Stream::AsyncBarrierOp>(
-        op.getLoc(), operand.resource.getType(), operand.resource,
+    auto barrierOp = IREE::Stream::AsyncBarrierOp::create(
+        rewriter, op.getLoc(), operand.resource.getType(), operand.resource,
         operand.resourceSize,
         /*affinity=*/executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{barrierOp, operand.resourceSize}});
@@ -293,9 +294,9 @@ struct ConvertTensorTransferOp
     auto operand = resolveTensorOperands(op.getLoc(), op.getOperand(),
                                          adaptor.getOperand(), rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-        op.getLoc(), unknownType, operand.resource, operand.resourceSize,
-        operand.resourceSize,
+    auto transferOp = IREE::Stream::AsyncTransferOp::create(
+        rewriter, op.getLoc(), unknownType, operand.resource,
+        operand.resourceSize, operand.resourceSize,
         /*source_affinity=*/operand.affinity,
         /*result_affinity=*/executionAffinityAttr);
     rewriter.replaceOpWithMultiple(op, {{transferOp, operand.resourceSize}});
@@ -317,9 +318,9 @@ struct ConvertTensorSliceOp
         buildResultSizeOf(op.getLoc(), op.getResult(), op.getResultDims(),
                           executionAffinityAttr, rewriter);
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    auto sliceOp = rewriter.create<IREE::Stream::TensorSliceOp>(
-        op.getLoc(), unknownType, source.resource, op.getSource().getType(),
-        op.getSourceDims(), source.resourceSize,
+    auto sliceOp = IREE::Stream::TensorSliceOp::create(
+        rewriter, op.getLoc(), unknownType, source.resource,
+        op.getSource().getType(), op.getSourceDims(), source.resourceSize,
         flattenValues(adaptor.getStartIndices()),
         flattenValues(adaptor.getLengths()), op.getResult().getType(),
         flattenValues(adaptor.getResultDims()), resultSize,
@@ -342,8 +343,8 @@ struct ConvertTensorUpdateOp
     auto update =
         transferTensorOperands(op.getLoc(), op.getUpdate(), adaptor.getUpdate(),
                                executionAffinityAttr, rewriter);
-    auto updateOp = rewriter.create<IREE::Stream::TensorUpdateOp>(
-        op.getLoc(), target.resource.getType(), target.resource,
+    auto updateOp = IREE::Stream::TensorUpdateOp::create(
+        rewriter, op.getLoc(), target.resource.getType(), target.resource,
         op.getTarget().getType(), flattenValues(adaptor.getTargetDims()),
         target.resourceSize, flattenValues(adaptor.getStartIndices()),
         update.resource, op.getUpdate().getType(), op.getUpdateDims(),
@@ -397,9 +398,9 @@ struct ConvertTensorLoadOp
     // Scalar tensors get transferred without slicing.
     auto sourceEncoding = op.getSource().getType();
     if (isScalarTensor(sourceEncoding)) {
-      auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-          op.getLoc(), stagingType, source.resource, source.resourceSize,
-          source.resourceSize,
+      auto transferOp = IREE::Stream::AsyncTransferOp::create(
+          rewriter, op.getLoc(), stagingType, source.resource,
+          source.resourceSize, source.resourceSize,
           /*source_affinity=*/source.affinity,
           /*result_affinity=*/source.affinity);
       rewriter.replaceOpWithNewOp<IREE::Stream::TensorLoadOp>(
@@ -425,15 +426,16 @@ struct ConvertTensorLoadOp
     auto resultEncoding =
         RankedTensorType::get(resultDims, sourceEncoding.getElementType(),
                               sourceEncoding.getEncoding());
-    Value resultSize = rewriter.create<IREE::Stream::TensorSizeOfOp>(
-        op.getLoc(), resultEncoding, ValueRange{}, source.affinity);
-    auto sliceOp = rewriter.create<IREE::Stream::TensorSliceOp>(
-        op.getLoc(), source.resource.getType(), source.resource, sourceEncoding,
-        convertedSourceDims, source.resourceSize, sliceIndices, sliceLengths,
-        resultEncoding, ValueRange{}, resultSize, source.affinity);
-    auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-        op.getLoc(), stagingType, sliceOp.getResult(), sliceOp.getResultSize(),
-        sliceOp.getResultSize(),
+    Value resultSize = IREE::Stream::TensorSizeOfOp::create(
+        rewriter, op.getLoc(), resultEncoding, ValueRange{}, source.affinity);
+    auto sliceOp = IREE::Stream::TensorSliceOp::create(
+        rewriter, op.getLoc(), source.resource.getType(), source.resource,
+        sourceEncoding, convertedSourceDims, source.resourceSize, sliceIndices,
+        sliceLengths, resultEncoding, ValueRange{}, resultSize,
+        source.affinity);
+    auto transferOp = IREE::Stream::AsyncTransferOp::create(
+        rewriter, op.getLoc(), stagingType, sliceOp.getResult(),
+        sliceOp.getResultSize(), sliceOp.getResultSize(),
         /*source_affinity=*/source.affinity,
         /*result_affinity=*/source.affinity);
     rewriter.replaceOpWithNewOp<IREE::Stream::TensorLoadOp>(
@@ -458,8 +460,8 @@ struct ConvertTensorStoreOp
     auto stagingType = rewriter.getType<IREE::Stream::ResourceType>(
         IREE::Stream::Lifetime::Staging);
     if (target.resource.getType() == stagingType) {
-      auto storeOp = rewriter.create<IREE::Stream::TensorStoreOp>(
-          op.getLoc(), target.resource.getType(), target.resource,
+      auto storeOp = IREE::Stream::TensorStoreOp::create(
+          rewriter, op.getLoc(), target.resource.getType(), target.resource,
           op.getTarget().getType(), flattenValues(adaptor.getTargetDims()),
           target.resourceSize, flattenValues(adaptor.getIndices()),
           adaptor.getValue().front());
@@ -474,8 +476,8 @@ struct ConvertTensorStoreOp
     indexSet.populate(convertedIndices);
     SmallVector<Value> lengths(convertedIndices.size(), indexSet.get(1));
     auto targetEncoding = op.getTarget().getType();
-    auto fillOp = rewriter.create<IREE::Stream::TensorFillOp>(
-        op.getLoc(), target.resource, targetEncoding,
+    auto fillOp = IREE::Stream::TensorFillOp::create(
+        rewriter, op.getLoc(), target.resource, targetEncoding,
         flattenValues(adaptor.getTargetDims()), target.resourceSize,
         convertedIndices, lengths, adaptor.getValue().front(), target.affinity);
     rewriter.replaceOpWithMultiple(op, {{fillOp, target.resourceSize}});
@@ -500,9 +502,9 @@ struct ConvertTensorTraceOp
           IREE::Stream::Lifetime::Staging);
       auto traceSource = source.resource;
       if (source.resource.getType() != stagingType) {
-        traceSource = rewriter.create<IREE::Stream::AsyncTransferOp>(
-            op.getLoc(), stagingType, source.resource, source.resourceSize,
-            source.resourceSize,
+        traceSource = IREE::Stream::AsyncTransferOp::create(
+            rewriter, op.getLoc(), stagingType, source.resource,
+            source.resourceSize, source.resourceSize,
             /*source_affinity=*/source.affinity,
             /*result_affinity=*/source.affinity);
       }
@@ -583,9 +585,9 @@ struct ConvertAllGatherOp
         /*reduction=*/std::nullopt,
         static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
 
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
-        op.getLoc(), op.getType().getNumElements());
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+    auto elementCount = arith::ConstantIndexOp::create(
+        rewriter, op.getLoc(), op.getType().getNumElements());
     auto newTargetCast =
         transferTensorOperands(op.getLoc(), op.getTarget(), adaptor.getTarget(),
                                executionAffinityAttr, rewriter);
@@ -593,8 +595,8 @@ struct ConvertAllGatherOp
         transferTensorOperands(op.getLoc(), op.getSource(), adaptor.getSource(),
                                executionAffinityAttr, rewriter);
 
-    auto collectiveOp = rewriter.create<IREE::Stream::AsyncCollectiveOp>(
-        op.getLoc(), collectiveAttr,
+    auto collectiveOp = IREE::Stream::AsyncCollectiveOp::create(
+        rewriter, op.getLoc(), collectiveAttr,
         /*target=*/newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
@@ -626,9 +628,9 @@ struct ConvertAllReduceOp
         static_cast<IREE::Stream::CollectiveReductionOp>(op.getReductionOp()),
         static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
 
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
-        op.getLoc(), op.getType().getNumElements());
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+    auto elementCount = arith::ConstantIndexOp::create(
+        rewriter, op.getLoc(), op.getType().getNumElements());
     auto newTargetCast =
         transferTensorOperands(op.getLoc(), op.getTarget(), adaptor.getTarget(),
                                executionAffinityAttr, rewriter);
@@ -636,8 +638,8 @@ struct ConvertAllReduceOp
         transferTensorOperands(op.getLoc(), op.getSource(), adaptor.getSource(),
                                executionAffinityAttr, rewriter);
 
-    auto collectiveOp = rewriter.create<IREE::Stream::AsyncCollectiveOp>(
-        op.getLoc(), collectiveAttr,
+    auto collectiveOp = IREE::Stream::AsyncCollectiveOp::create(
+        rewriter, op.getLoc(), collectiveAttr,
         /*target=*/newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
@@ -669,9 +671,9 @@ struct ConvertAllToAllOp
         /*reduction=*/std::nullopt,
         static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
 
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
-        op.getLoc(), op.getType().getNumElements());
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+    auto elementCount = arith::ConstantIndexOp::create(
+        rewriter, op.getLoc(), op.getType().getNumElements());
     auto newTargetCast =
         transferTensorOperands(op.getLoc(), op.getTarget(), adaptor.getTarget(),
                                executionAffinityAttr, rewriter);
@@ -679,8 +681,8 @@ struct ConvertAllToAllOp
         transferTensorOperands(op.getLoc(), op.getSource(), adaptor.getSource(),
                                executionAffinityAttr, rewriter);
 
-    auto collectiveOp = rewriter.create<IREE::Stream::AsyncCollectiveOp>(
-        op.getLoc(), collectiveAttr,
+    auto collectiveOp = IREE::Stream::AsyncCollectiveOp::create(
+        rewriter, op.getLoc(), collectiveAttr,
         /*target=*/newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
@@ -712,9 +714,9 @@ struct ConvertReduceScatterOp : public AffinityOpConversionPattern<
         static_cast<IREE::Stream::CollectiveReductionOp>(op.getReductionOp()),
         static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
 
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
-        op.getLoc(), op.getType().getNumElements());
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+    auto elementCount = arith::ConstantIndexOp::create(
+        rewriter, op.getLoc(), op.getType().getNumElements());
     auto newTargetCast =
         transferTensorOperands(op.getLoc(), op.getTarget(), adaptor.getTarget(),
                                executionAffinityAttr, rewriter);
@@ -722,8 +724,8 @@ struct ConvertReduceScatterOp : public AffinityOpConversionPattern<
         transferTensorOperands(op.getLoc(), op.getSource(), adaptor.getSource(),
                                executionAffinityAttr, rewriter);
 
-    auto collectiveOp = rewriter.create<IREE::Stream::AsyncCollectiveOp>(
-        op.getLoc(), collectiveAttr,
+    auto collectiveOp = IREE::Stream::AsyncCollectiveOp::create(
+        rewriter, op.getLoc(), collectiveAttr,
         /*target=*/newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
@@ -755,9 +757,9 @@ struct ConvertCollectiveSendRecvOp
         /*reduction=*/std::nullopt,
         static_cast<IREE::Stream::CollectiveElementType>(op.getElementType()));
 
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-    auto elementCount = rewriter.create<arith::ConstantIndexOp>(
-        op.getLoc(), op.getType().getNumElements());
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+    auto elementCount = arith::ConstantIndexOp::create(
+        rewriter, op.getLoc(), op.getType().getNumElements());
     auto newTargetCast =
         transferTensorOperands(op.getLoc(), op.getTarget(), adaptor.getTarget(),
                                executionAffinityAttr, rewriter);
@@ -767,20 +769,20 @@ struct ConvertCollectiveSendRecvOp
 
     // Pack send, recv into param. The values are checked to be within the
     // 16-bit range during lowering to Flow dialect.
-    auto send = rewriter.create<arith::IndexCastOp>(
-        op.getLoc(), rewriter.getI32Type(), adaptor.getSend());
-    auto lo = rewriter.create<arith::AndIOp>(
-        op.getLoc(), send,
-        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0xFFFF, 32));
-    auto recv = rewriter.create<arith::IndexCastOp>(
-        op.getLoc(), rewriter.getI32Type(), adaptor.getRecv());
-    auto hi = rewriter.create<arith::ShLIOp>(
-        op.getLoc(), recv,
-        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 16, 32));
-    auto param = rewriter.create<arith::OrIOp>(op.getLoc(), hi, lo);
+    auto send = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getI32Type(), adaptor.getSend());
+    auto lo = arith::AndIOp::create(
+        rewriter, op.getLoc(), send,
+        arith::ConstantIntOp::create(rewriter, op.getLoc(), 0xFFFF, 32));
+    auto recv = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getI32Type(), adaptor.getRecv());
+    auto hi = arith::ShLIOp::create(
+        rewriter, op.getLoc(), recv,
+        arith::ConstantIntOp::create(rewriter, op.getLoc(), 16, 32));
+    auto param = arith::OrIOp::create(rewriter, op.getLoc(), hi, lo);
 
-    auto collectiveOp = rewriter.create<IREE::Stream::AsyncCollectiveOp>(
-        op.getLoc(), collectiveAttr,
+    auto collectiveOp = IREE::Stream::AsyncCollectiveOp::create(
+        rewriter, op.getLoc(), collectiveAttr,
         /*target=*/newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
@@ -861,13 +863,13 @@ struct ConvertDispatchOp
       }
     }
 
-    auto newOp = rewriter.create<IREE::Stream::TensorDispatchOp>(
-        op.getLoc(), resultTypes, flattenValues(adaptor.getWorkload()),
-        adaptor.getEntryPointsAttr(), operands, operandSizes,
-        rewriter.getTypeArrayAttr(operandEncodings), op.getArgumentDims(),
-        resultSizes, rewriter.getTypeArrayAttr(resultEncodings),
-        op.getResultDims(), adaptor.getTiedOperandsAttr(),
-        executionAffinityAttr);
+    auto newOp = IREE::Stream::TensorDispatchOp::create(
+        rewriter, op.getLoc(), resultTypes,
+        flattenValues(adaptor.getWorkload()), adaptor.getEntryPointsAttr(),
+        operands, operandSizes, rewriter.getTypeArrayAttr(operandEncodings),
+        op.getArgumentDims(), resultSizes,
+        rewriter.getTypeArrayAttr(resultEncodings), op.getResultDims(),
+        adaptor.getTiedOperandsAttr(), executionAffinityAttr);
     newOp->setDialectAttrs(
         llvm::make_filter_range(op->getDialectAttrs(), [](NamedAttribute attr) {
           return attr.getName() != "stream.affinity";
@@ -925,7 +927,7 @@ struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
       IREE::Stream::AffinityAttr executionAffinityAttr,
       ConversionPatternRewriter &rewriter) const override {
     // Zero is going to be used for each operand to start.
-    auto zeroOffset = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+    auto zeroOffset = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
 
     // Query and resolve all operands and their sizes.
     SmallVector<Value> callOperands;
@@ -981,9 +983,9 @@ struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
       }
     }
 
-    auto newOp = rewriter.create<IREE::Stream::AsyncCallOp>(
-        op.getLoc(), resultTypes, adaptor.getCalleeAttr(), callOperands,
-        callOperandSizes, callOperandOffsets, callOperandEnds,
+    auto newOp = IREE::Stream::AsyncCallOp::create(
+        rewriter, op.getLoc(), resultTypes, adaptor.getCalleeAttr(),
+        callOperands, callOperandSizes, callOperandOffsets, callOperandEnds,
         callOperandLengths, resultSizes, adaptor.getTiedOperandsAttr(),
         op.getArgAttrsAttr(), op.getResAttrsAttr(), executionAffinityAttr);
     newOp->setDialectAttrs(op->getDialectAttrs());
@@ -1041,8 +1043,8 @@ static bool insertBindingOp(BlockArgument arg,
     }
   }
 
-  auto subspanOp = builder.create<IREE::Stream::BindingSubspanOp>(
-      arg.getLoc(), tensorType, arg, zero, dynamicDims);
+  auto subspanOp = IREE::Stream::BindingSubspanOp::create(
+      builder, arg.getLoc(), tensorType, arg, zero, dynamicDims);
   arg.replaceAllUsesExcept(subspanOp.getResult(), subspanOp);
 
   // If we needed to insert at a special point restore back to the original
@@ -1093,16 +1095,16 @@ struct ConvertExecutableOp
   matchAndRewrite(IREE::Flow::ExecutableOp flowOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // flow.executable -> stream.executable
-    auto streamOp = rewriter.create<IREE::Stream::ExecutableOp>(
-        flowOp.getLoc(), flowOp.getSymName());
+    auto streamOp = IREE::Stream::ExecutableOp::create(
+        rewriter, flowOp.getLoc(), flowOp.getSymName());
     streamOp.setVisibility(flowOp.getVisibility());
     streamOp->setDialectAttrs(flowOp->getDialectAttrs());
     rewriter.setInsertionPointToStart(&streamOp.getBody().front());
 
     // flow.executable.export -> stream.executable.export
     for (auto exportOp : flowOp.getOps<IREE::Flow::ExecutableExportOp>()) {
-      auto newOp = rewriter.create<IREE::Stream::ExecutableExportOp>(
-          exportOp.getLoc(), exportOp.getSymName(),
+      auto newOp = IREE::Stream::ExecutableExportOp::create(
+          rewriter, exportOp.getLoc(), exportOp.getSymName(),
           exportOp.getFunctionRefAttr());
       newOp->setDialectAttrs(exportOp->getDialectAttrs());
       if (!exportOp.getWorkgroupCount().empty()) {
@@ -1132,7 +1134,8 @@ struct ConvertExecutableOp
                "flow dispatches have no results");
 
         rewriter.setInsertionPointToStart(&funcOp.front());
-        auto zero = rewriter.create<arith::ConstantIndexOp>(funcOp.getLoc(), 0);
+        auto zero =
+            arith::ConstantIndexOp::create(rewriter, funcOp.getLoc(), 0);
         for (auto arg : funcOp.front().getArguments()) {
           auto oldType = arg.getType();
           if (auto tensorType =

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -67,8 +67,8 @@ ConvertedTensor transferTensorOperands(
   bool isBarrier = resource.getDefiningOp() &&
                    isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
   if (affinityAttr != requiredAffinityAttr && !isBarrier) {
-    resource = builder.create<IREE::Stream::AsyncTransferOp>(
-        loc, resource.getType(), resource, resourceSize, resourceSize,
+    resource = IREE::Stream::AsyncTransferOp::create(
+        builder, loc, resource.getType(), resource, resourceSize, resourceSize,
         affinityAttr, requiredAffinityAttr);
   }
   return {requiredAffinityAttr, resource, resourceSize};

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -117,12 +117,13 @@ Operation *StreamDialect::materializeConstant(OpBuilder &builder,
                                               Attribute value, Type type,
                                               Location loc) {
   if (mlir::func::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<mlir::func::ConstantOp>(
-        loc, type, llvm::cast<FlatSymbolRefAttr>(value));
+    return mlir::func::ConstantOp::create(builder, loc, type,
+                                          llvm::cast<FlatSymbolRefAttr>(value));
   } else if (arith::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
+    return arith::ConstantOp::create(builder, loc, type,
+                                     cast<TypedAttr>(value));
   } else if (llvm::isa<IREE::Stream::TimepointAttr>(value)) {
-    return builder.create<IREE::Stream::TimepointImmediateOp>(loc);
+    return IREE::Stream::TimepointImmediateOp::create(builder, loc);
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1408,9 +1408,9 @@ ResourceAllocOp::createSuballocations(
   if (locs.empty())
     return {};
   if (locs.size() == 1) {
-    auto allocOp = builder.create<IREE::Stream::ResourceAllocOp>(
-        locs.front(), resourceType, storageSizes.front(), uninitialized,
-        affinityAttr);
+    auto allocOp = IREE::Stream::ResourceAllocOp::create(
+        builder, locs.front(), resourceType, storageSizes.front(),
+        uninitialized, affinityAttr);
     return {allocOp, {allocOp.getResult()}};
   }
   auto fusedLoc = builder.getFusedLoc(locs);
@@ -1430,13 +1430,13 @@ ResourceAllocOp::createSuballocations(
   // pack op.
   auto indexType = builder.getIndexType();
   SmallVector<Type> packedOffsetTypes(sliceCount, indexType);
-  auto packOp = builder.create<IREE::Stream::ResourcePackOp>(
-      fusedLoc, indexType, packedOffsetTypes, /*offset=*/nullptr,
+  auto packOp = IREE::Stream::ResourcePackOp::create(
+      builder, fusedLoc, indexType, packedOffsetTypes, /*offset=*/nullptr,
       builder.getIndexArrayAttr(lifetimeIntervals), storageSizes, affinityAttr);
 
   // Create the new alloca based on the total required size.
-  auto allocOp = builder.create<IREE::Stream::ResourceAllocOp>(
-      fusedLoc, resourceType, packOp.getTotalLength(), uninitialized,
+  auto allocOp = IREE::Stream::ResourceAllocOp::create(
+      builder, fusedLoc, resourceType, packOp.getTotalLength(), uninitialized,
       affinityAttr);
   auto slab = allocOp.getResult();
   auto slabSize = packOp.getTotalLength();
@@ -1470,8 +1470,9 @@ ResourceAllocaOp::createSuballocations(Type timepointType, Type resourceType,
   if (locs.empty())
     return {};
   if (locs.size() == 1) {
-    auto allocaOp = builder.create<IREE::Stream::ResourceAllocaOp>(
-        locs.front(), resourceType, timepointType, storageSizes.front(),
+    auto allocaOp = IREE::Stream::ResourceAllocaOp::create(
+        builder, locs.front(), resourceType, timepointType,
+        storageSizes.front(),
         /*indeterminate_lifetime=*/UnitAttr{}, awaitTimepoint, affinityAttr);
     return {allocaOp, {allocaOp.getResult()}};
   }
@@ -1495,13 +1496,13 @@ ResourceAllocaOp::createSuballocations(Type timepointType, Type resourceType,
   // pack op.
   auto indexType = builder.getIndexType();
   SmallVector<Type> packedOffsetTypes(sliceCount, indexType);
-  auto packOp = builder.create<IREE::Stream::ResourcePackOp>(
-      fusedLoc, indexType, packedOffsetTypes, /*offset=*/nullptr,
+  auto packOp = IREE::Stream::ResourcePackOp::create(
+      builder, fusedLoc, indexType, packedOffsetTypes, /*offset=*/nullptr,
       builder.getIndexArrayAttr(lifetimeIntervals), storageSizes, affinityAttr);
 
   // Create the new alloca based on the total required size.
-  auto allocaOp = builder.create<IREE::Stream::ResourceAllocaOp>(
-      fusedLoc, resourceType, timepointType, packOp.getTotalLength(),
+  auto allocaOp = IREE::Stream::ResourceAllocaOp::create(
+      builder, fusedLoc, resourceType, timepointType, packOp.getTotalLength(),
       /*indeterminate_lifetime=*/UnitAttr{}, awaitTimepoint, affinityAttr);
   auto slab = allocaOp.getResult();
   auto slabSize = packOp.getTotalLength();
@@ -3176,8 +3177,8 @@ AsyncExecuteOp::cloneReplacementExcludingOperandsAndResults(
   assert(getTiedOperandsIndexAndLength().first == 0 &&
          "operands must be the first ODS group");
 
-  auto newOp = rewriter.create<AsyncExecuteOp>(
-      getLoc(), newResultTypes, newResultSizes, getAwaitTimepoint(),
+  auto newOp = AsyncExecuteOp::create(
+      rewriter, getLoc(), newResultTypes, newResultSizes, getAwaitTimepoint(),
       newOperandsValues, newOperandSizes, newTiedOperandIndices,
       getOperation()->getAttrs());
   auto &newBody = newOp.getClosureBodyRegion();
@@ -3297,8 +3298,8 @@ AsyncConcurrentOp::cloneReplacementExcludingOperandsAndResults(
   assert(getTiedOperandsIndexAndLength().first == 0 &&
          "operands must be the first ODS group");
 
-  auto newOp = rewriter.create<AsyncConcurrentOp>(
-      getLoc(), newResultTypes, newResultSizes, newOperandsValues,
+  auto newOp = AsyncConcurrentOp::create(
+      rewriter, getLoc(), newResultTypes, newResultSizes, newOperandsValues,
       newOperandSizes, newTiedOperandIndices, getOperation()->getAttrs());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
@@ -4092,9 +4093,9 @@ CmdExecuteOp::cloneReplacementExcludingOperandsAndResults(
       newOperandsValues, newOperandSizes, excludedOperandIndices,
       newResultTypes, newResultSizes, excludedResultIndices);
 
-  auto newOp = rewriter.create<CmdExecuteOp>(getLoc(), getAwaitTimepoint(),
-                                             newOperandsValues, newOperandSizes,
-                                             getOperation()->getAttrs());
+  auto newOp = CmdExecuteOp::create(rewriter, getLoc(), getAwaitTimepoint(),
+                                    newOperandsValues, newOperandSizes,
+                                    getOperation()->getAttrs());
   newOp.setOnce(getOnce());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
@@ -4173,8 +4174,8 @@ Value TimepointJoinOp::join(Location loc, ValueRange timepoints,
   assert(!timepoints.empty() && "must have at least one timepoint");
   if (timepoints.size() == 1)
     return timepoints.front();
-  return builder.create<IREE::Stream::TimepointJoinOp>(
-      loc, builder.getType<IREE::Stream::TimepointType>(), timepoints);
+  return IREE::Stream::TimepointJoinOp::create(
+      builder, loc, builder.getType<IREE::Stream::TimepointType>(), timepoints);
 }
 
 // static

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -526,8 +526,8 @@ Value ResourceType::createSubrangeOp(Location loc, Value resource,
                                      Value resourceSize, Value subrangeOffset,
                                      Value subrangeLength,
                                      OpBuilder &builder) const {
-  return builder.create<IREE::Stream::ResourceSubviewOp>(
-      loc, resource, resourceSize, subrangeOffset, subrangeLength);
+  return IREE::Stream::ResourceSubviewOp::create(
+      builder, loc, resource, resourceSize, subrangeOffset, subrangeLength);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchAssumptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchAssumptions.cpp
@@ -173,8 +173,8 @@ static void annotateExport(IREE::Stream::ExecutableOp executableOp,
 
   // Do the rewrite.
   OpBuilder builder = OpBuilder::atBlockBegin(&funcOp.front());
-  auto assumeOp = builder.create<IREE::Util::AssumeIntOp>(
-      funcOp.getLoc(), arguments, argumentAssumptions);
+  auto assumeOp = IREE::Util::AssumeIntOp::create(
+      builder, funcOp.getLoc(), arguments, argumentAssumptions);
   for (unsigned argIndex = 0; argIndex < arguments.size(); ++argIndex) {
     arguments[argIndex].replaceAllUsesExcept(assumeOp.getResult(argIndex),
                                              assumeOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
@@ -662,10 +662,10 @@ static void processFuncOp(FunctionOpInterface funcOp) {
           lastTimepoint.printAsOperand(llvm::dbgs(), *asmState);
           llvm::dbgs() << " directly\n";
         });
-        auto deallocaOp = builder.create<IREE::Stream::ResourceDeallocaOp>(
-            timepointsLoc, builder.getType<IREE::Stream::TimepointType>(),
-            resource, resourceSize, preferOrigin, lastTimepoint,
-            resourceAffinity);
+        auto deallocaOp = IREE::Stream::ResourceDeallocaOp::create(
+            builder, timepointsLoc,
+            builder.getType<IREE::Stream::TimepointType>(), resource,
+            resourceSize, preferOrigin, lastTimepoint, resourceAffinity);
         lastTimepoint.replaceAllUsesExcept(deallocaOp.getResultTimepoint(),
                                            deallocaOp);
       } else if (timepoints.size() > 1) {
@@ -685,13 +685,15 @@ static void processFuncOp(FunctionOpInterface funcOp) {
           lastTimepoint.printAsOperand(llvm::dbgs(), *asmState);
           llvm::dbgs() << " as a join\n";
         });
-        auto joinOp = builder.create<IREE::Stream::TimepointJoinOp>(
-            timepointsLoc, builder.getType<IREE::Stream::TimepointType>(),
+        auto joinOp = IREE::Stream::TimepointJoinOp::create(
+            builder, timepointsLoc,
+            builder.getType<IREE::Stream::TimepointType>(),
             llvm::map_to_vector(timepoints,
                                 [](Value timepoint) { return timepoint; }));
-        auto deallocaOp = builder.create<IREE::Stream::ResourceDeallocaOp>(
-            timepointsLoc, builder.getType<IREE::Stream::TimepointType>(),
-            resource, resourceSize, preferOrigin, joinOp.getResultTimepoint(),
+        auto deallocaOp = IREE::Stream::ResourceDeallocaOp::create(
+            builder, timepointsLoc,
+            builder.getType<IREE::Stream::TimepointType>(), resource,
+            resourceSize, preferOrigin, joinOp.getResultTimepoint(),
             resourceAffinity);
         lastTimepoint.replaceAllUsesExcept(deallocaOp.getResultTimepoint(),
                                            joinOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
@@ -703,8 +703,8 @@ static bool tryElideTimepointsInRegion(Region &region,
     if (existingReplacement != pendingReplacements.end()) {
       return existingReplacement->second;
     }
-    return builder.create<IREE::Stream::TimepointImmediateOp>(
-        elidedTimepoint.getLoc());
+    return IREE::Stream::TimepointImmediateOp::create(builder,
+                                                      elidedTimepoint.getLoc());
   };
 
   // Elides |elidedTimepoint| by replacing all its uses by |op| with an
@@ -746,9 +746,8 @@ static bool tryElideTimepointsInRegion(Region &region,
       return; // already immediate
     OpBuilder afterBuilder(op);
     afterBuilder.setInsertionPointAfterValue(elidedTimepoint);
-    Value immediateTimepoint =
-        afterBuilder.create<IREE::Stream::TimepointImmediateOp>(
-            elidedTimepoint.getLoc());
+    Value immediateTimepoint = IREE::Stream::TimepointImmediateOp::create(
+        afterBuilder, elidedTimepoint.getLoc());
     // Defer actually swapping until later.
     pendingReplacements.insert(
         std::make_pair(elidedTimepoint, immediateTimepoint));

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -58,8 +58,8 @@ replaceUsesAndTransfer(Value oldValue, Value newValue,
       newValue.getLoc(), newValue, builder);
   IREE::Stream::AffinityAttr sourceAffinity = usageAffinityAttr;
   IREE::Stream::AffinityAttr resultAffinity = usageAffinityAttr;
-  Value transferValue = builder.create<IREE::Stream::AsyncTransferOp>(
-      newValue.getLoc(), oldValue.getType(), newValue, newValueSize,
+  Value transferValue = IREE::Stream::AsyncTransferOp::create(
+      builder, newValue.getLoc(), oldValue.getType(), newValue, newValueSize,
       newValueSize, sourceAffinity, resultAffinity);
   oldValue.replaceAllUsesWith(transferValue);
 }
@@ -153,8 +153,8 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp,
 
     // TODO(multi-device): possibly perform analysis to pick an affinity based
     // on usage. Today we assume the resource affinity matches the execution op.
-    auto allocaOp = builder.create<IREE::Stream::AsyncAllocaOp>(
-        dispatchOp.getLoc(), result.getType(), resultSize,
+    auto allocaOp = IREE::Stream::AsyncAllocaOp::create(
+        builder, dispatchOp.getLoc(), result.getType(), resultSize,
         dispatchOp.getAffinityAttr());
 
     auto operandIndex = dispatchOp.getResourceOperands().size();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
@@ -229,8 +229,8 @@ inlineUniformConstants(mlir::FunctionOpInterface funcOp,
     unsigned argIdx = operandToArgMap[operandIdx];
     auto arg = entryBlock.getArgument(argIdx);
     deadArgMap.set(argIdx);
-    auto constantOp = builder.create<arith::ConstantOp>(
-        builder.getFusedLoc(operandLocs[operandIdx]),
+    auto constantOp = arith::ConstantOp::create(
+        builder, builder.getFusedLoc(operandLocs[operandIdx]),
         builder.getIntegerAttr(arg.getType(),
                                operandValues[operandIdx].value()));
     arg.replaceAllUsesWith(constantOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -298,8 +298,8 @@ static void updateDispatchSite(IREE::Stream::CmdDispatchOp dispatchOp,
 
   // Replace the old dispatch op with a new one.
   OpBuilder builder(dispatchOp);
-  auto newOp = builder.create<IREE::Stream::CmdDispatchOp>(
-      dispatchOp.getLoc(), dispatchOp.getWorkload(),
+  auto newOp = IREE::Stream::CmdDispatchOp::create(
+      builder, dispatchOp.getLoc(), dispatchOp.getWorkload(),
       dispatchOp.getEntryPointsAttr(), newOperands, newResources,
       newResourceSizes, newOffsets, newLengths,
       builder.getArrayAttr(newAccesses));

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
@@ -213,8 +213,8 @@ static LogicalResult replaceBuiltinSplatOp(IREE::Stream::AsyncSplatOp splatOp,
       splatOp.getResult().getType(),
   };
   OpBuilder builder(splatOp);
-  auto dispatchOp = builder.create<IREE::Stream::AsyncDispatchOp>(
-      loc, resultTypes, workload,
+  auto dispatchOp = IREE::Stream::AsyncDispatchOp::create(
+      builder, loc, resultTypes, workload,
       builder.getArrayAttr({SymbolRefAttr::get(
           builder.getStringAttr(builtinName),
           FlatSymbolRefAttr::get(builder.getContext(), builtinName))}),
@@ -308,8 +308,8 @@ static LogicalResult replaceBuiltinFillOp(IREE::Stream::AsyncFillOp fillOp,
       fillOp.getResult().getType(),
   };
   OpBuilder builder(fillOp);
-  auto dispatchOp = builder.create<IREE::Stream::AsyncDispatchOp>(
-      loc, resultTypes, workload,
+  auto dispatchOp = IREE::Stream::AsyncDispatchOp::create(
+      builder, loc, resultTypes, workload,
       builder.getArrayAttr({SymbolRefAttr::get(
           builder.getStringAttr(builtinName),
           FlatSymbolRefAttr::get(builder.getContext(), builtinName))}),

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -89,8 +89,8 @@ static Value materializeOperandCOW(Location loc, OpOperand &operand,
   auto sizeAwareType =
       llvm::cast<IREE::Util::SizeAwareTypeInterface>(resourceType);
   auto size = sizeAwareType.queryValueSize(loc, operand.get(), builder);
-  return builder.create<IREE::Stream::AsyncCloneOp>(
-      loc, resourceType, operand.get(), size, size, affinity);
+  return IREE::Stream::AsyncCloneOp::create(
+      builder, loc, resourceType, operand.get(), size, size, affinity);
 }
 
 // Materializes a copy for each mutated operand on |tiedOp| as required.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -107,31 +107,32 @@ static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
   for (auto argument : block.getArguments().drop_front(1).take_front(
            encodeOp.getSourceEncodingDims().size())) {
     sourceDynamicDims.push_back(
-        builder.create<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
-            loc, argument, builder.getIndexAttr(ordinalCount++)));
+        IREE::TensorExt::DispatchWorkloadOrdinalOp::create(
+            builder, loc, argument, builder.getIndexAttr(ordinalCount++)));
   }
   for (auto argument : block.getArguments().drop_back(1).take_back(
            encodeOp.getResultEncodingDims().size())) {
     destinationDynamicDims.push_back(
-        builder.create<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
-            loc, argument, builder.getIndexAttr(ordinalCount++)));
+        IREE::TensorExt::DispatchWorkloadOrdinalOp::create(
+            builder, loc, argument, builder.getIndexAttr(ordinalCount++)));
   }
 
-  auto zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+  auto zero = arith::ConstantIndexOp::create(builder, loc, 0);
   auto sourceDispatchType = IREE::TensorExt::DispatchTensorType::get(
       IREE::TensorExt::TensorAccess::ReadOnly, encodeOp.getSourceEncoding());
-  Value source = builder.create<IREE::Stream::BindingSubspanOp>(
-      loc, sourceDispatchType, block.getArgument(0), zero, sourceDynamicDims);
+  Value source = IREE::Stream::BindingSubspanOp::create(
+      builder, loc, sourceDispatchType, block.getArgument(0), zero,
+      sourceDynamicDims);
   auto destinationDispatchType = IREE::TensorExt::DispatchTensorType::get(
       IREE::TensorExt::TensorAccess::WriteOnly, encodeOp.getResultEncoding());
-  Value destination = builder.create<IREE::Stream::BindingSubspanOp>(
-      loc, destinationDispatchType, block.getArguments().back(), zero,
+  Value destination = IREE::Stream::BindingSubspanOp::create(
+      builder, loc, destinationDispatchType, block.getArguments().back(), zero,
       destinationDynamicDims);
 
   // Load the value from the source binding.
   RankedTensorType sourceType = sourceDispatchType.asRankedTensorType();
-  Value value = builder.create<IREE::TensorExt::DispatchTensorLoadOp>(
-      loc, sourceType, source, sourceDynamicDims);
+  Value value = IREE::TensorExt::DispatchTensorLoadOp::create(
+      builder, loc, sourceType, source, sourceDynamicDims);
 
   // We can only add/remove encodings using set_encoding/unset_encoding ops
   // today. Thus, we firstly need to bring the tensor encodings to pure tensor
@@ -140,19 +141,19 @@ static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
       destinationDispatchType.asRankedTensorType();
   if (sourceType != destinationType) {
     if (sourceType.getEncoding()) {
-      value = builder.create<IREE::Encoding::UnsetEncodingOp>(
-          loc, sourceType.dropEncoding(), value, sourceDynamicDims);
+      value = IREE::Encoding::UnsetEncodingOp::create(
+          builder, loc, sourceType.dropEncoding(), value, sourceDynamicDims);
     }
     if (destinationType.getEncoding()) {
-      value = builder.create<IREE::Encoding::SetEncodingOp>(
-          loc, destinationType, value);
+      value = IREE::Encoding::SetEncodingOp::create(builder, loc,
+                                                    destinationType, value);
     }
   }
 
   // Store the value to the destination binding.
-  builder.create<IREE::TensorExt::DispatchTensorStoreOp>(
-      loc, value, destination, destinationDynamicDims);
-  builder.create<func::ReturnOp>(loc);
+  IREE::TensorExt::DispatchTensorStoreOp::create(
+      builder, loc, value, destination, destinationDynamicDims);
+  func::ReturnOp::create(builder, loc);
 
   return funcOp;
 }
@@ -183,16 +184,16 @@ createExportOp(RewriterBase &rewriter, Location loc,
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(&executableOp.getBody().front());
-  auto exportOp = rewriter.create<IREE::Stream::ExecutableExportOp>(
-      loc, funcOp.getName(), SymbolRefAttr::get(funcOp));
+  auto exportOp = IREE::Stream::ExecutableExportOp::create(
+      rewriter, loc, funcOp.getName(), SymbolRefAttr::get(funcOp));
   Block *block = rewriter.createBlock(&exportOp.getWorkgroupCount(),
                                       exportOp.getWorkgroupCount().end(),
                                       workloadTypes, workloadLocs);
   rewriter.setInsertionPointToStart(block);
   auto defaultCountOp =
-      rewriter.create<IREE::TensorExt::DispatchWorkgroupCountFromSliceOp>(
-          loc, block->getArguments());
-  rewriter.create<IREE::Stream::ReturnOp>(loc, defaultCountOp.getResults());
+      IREE::TensorExt::DispatchWorkgroupCountFromSliceOp::create(
+          rewriter, loc, block->getArguments());
+  IREE::Stream::ReturnOp::create(rewriter, loc, defaultCountOp.getResults());
   return exportOp;
 }
 
@@ -210,7 +211,7 @@ createExecutableAndExport(RewriterBase &rewriter,
   Location loc = encodeOp.getLoc();
   std::string executableName = "_encoding_" + std::to_string(executableId);
   auto executableOp =
-      rewriter.create<IREE::Stream::ExecutableOp>(loc, executableName);
+      IREE::Stream::ExecutableOp::create(rewriter, loc, executableName);
   executableOp.getOperation()->moveBefore(parentFuncOp);
   executableOp.setPrivate();
 
@@ -219,7 +220,7 @@ createExecutableAndExport(RewriterBase &rewriter,
   std::string funcName = executableName + "_" + getDispatchFuncName(encodeOp);
   auto funcOp = createWorkgroupFunc(encodeOp, funcName);
   rewriter.setInsertionPointToStart(&executableOp.getBody().front());
-  auto innerModule = rewriter.create<mlir::ModuleOp>(loc);
+  auto innerModule = mlir::ModuleOp::create(rewriter, loc);
   innerModule.push_back(funcOp);
   IREE::Stream::ExecutableExportOp exportOp =
       createExportOp(rewriter, loc, encodeOp, executableOp, funcOp);
@@ -243,7 +244,7 @@ replaceEncodeOpWithDispatchOp(RewriterBase &rewriter,
                               IREE::Stream::ExecutableExportOp exportOp) {
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(encodeOp);
-  Value zero = rewriter.create<arith::ConstantIndexOp>(encodeOp.getLoc(), 0);
+  Value zero = arith::ConstantIndexOp::create(rewriter, encodeOp.getLoc(), 0);
   SmallVector<Value> operandOffsets = {zero};
   SmallVector<Value> operandEnds = {encodeOp.getSourceSize()};
   SmallVector<Value> operandLengths = {encodeOp.getSourceSize()};

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -132,8 +132,8 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
       auto resultSize = rewriter.createOrFold<IREE::Stream::ResourceSizeOp>(
           op->getLoc(), result);
       auto affinityAttr = getOpAffinity(op);
-      auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-          op->getLoc(), newType, result, resultSize, resultSize,
+      auto transferOp = IREE::Stream::AsyncTransferOp::create(
+          rewriter, op->getLoc(), newType, result, resultSize, resultSize,
           /*source_affinity=*/affinityAttr,
           /*target_affinity=*/affinityAttr);
       result.replaceUsesWithIf(transferOp.getResult(), [&](OpOperand &operand) {
@@ -180,8 +180,8 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
           }
         }
       }
-      auto transferOp = rewriter.create<IREE::Stream::AsyncTransferOp>(
-          result.getLoc(), newType, result, resultSize, resultSize,
+      auto transferOp = IREE::Stream::AsyncTransferOp::create(
+          rewriter, result.getLoc(), newType, result, resultSize, resultSize,
           /*source_affinity=*/affinityAttr,
           /*target_affinity=*/affinityAttr);
       result.replaceAllUsesExcept(transferOp.getResult(), transferOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReuseAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReuseAllocations.cpp
@@ -95,8 +95,8 @@ tryReuseExistingAllocation(IREE::Stream::ResourceAllocaOp allocaOp) {
   Value availableTimepoint = chosenDeallocaOp.getAwaitTimepoint();
   if (!availableTimepoint) {
     OpBuilder builder(chosenDeallocaOp);
-    availableTimepoint = builder.create<IREE::Stream::TimepointImmediateOp>(
-        chosenDeallocaOp.getLoc());
+    availableTimepoint = IREE::Stream::TimepointImmediateOp::create(
+        builder, chosenDeallocaOp.getLoc());
   }
   allocaOp.replaceAllUsesWith(
       ValueRange{chosenDeallocaOp.getOperand(), availableTimepoint});

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
@@ -105,9 +105,9 @@ struct WavePartitionBuilder {
 
     // TODO(benvanik): tie operands, or leave to canonicalization.
     SmallVector<int64_t> tiedOperands;
-    concurrentOp = parentBuilder.create<IREE::Stream::AsyncConcurrentOp>(
-        fusedLoc, resultTypes, resultSizes, operands, operandSizes,
-        tiedOperands);
+    concurrentOp = IREE::Stream::AsyncConcurrentOp::create(
+        parentBuilder, fusedLoc, resultTypes, resultSizes, operands,
+        operandSizes, tiedOperands);
 
     // Add entry block and arguments.
     auto &entryBlock = concurrentOp.getBody().emplaceBlock();
@@ -162,8 +162,8 @@ struct WavePartitionBuilder {
       if (resultSize)
         resultSizes.push_back(resultSize);
     }
-    builder.create<IREE::Stream::YieldOp>(concurrentOp.getLoc(), results,
-                                          resultSizes);
+    IREE::Stream::YieldOp::create(builder, concurrentOp.getLoc(), results,
+                                  resultSizes);
   }
 
   size_t ordinal = -1;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -105,9 +105,9 @@ struct ExecutePartitionBuilder {
 
     // TODO(benvanik): tie operands, or leave to canonicalization.
     SmallVector<int64_t> tiedOperands;
-    executeOp = parentBuilder.create<IREE::Stream::AsyncExecuteOp>(
-        fusedLoc, resultTypes, resultSizes, /*awaitTimepoint=*/Value{},
-        operands, operandSizes, tiedOperands);
+    executeOp = IREE::Stream::AsyncExecuteOp::create(
+        parentBuilder, fusedLoc, resultTypes, resultSizes,
+        /*awaitTimepoint=*/Value{}, operands, operandSizes, tiedOperands);
     if (partition->affinity) {
       executeOp.setAffinityAttr(partition->affinity);
     }
@@ -181,8 +181,8 @@ struct ExecutePartitionBuilder {
       if (resultSize)
         resultSizes.push_back(resultSize);
     }
-    builder.create<IREE::Stream::YieldOp>(executeOp.getLoc(), results,
-                                          resultSizes);
+    IREE::Stream::YieldOp::create(builder, executeOp.getLoc(), results,
+                                  resultSizes);
     return executeOp;
   }
 
@@ -279,8 +279,8 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
         // prematurely tie their lifetimes together. By having unique awaits
         // we allow propagation to move the waits further to where the values
         // are used (including right into other execution regions).
-        auto awaitOp = builder.create<IREE::Stream::TimepointAwaitOp>(
-            executeOp.getLoc(), newResult, newResultSize,
+        auto awaitOp = IREE::Stream::TimepointAwaitOp::create(
+            builder, executeOp.getLoc(), newResult, newResultSize,
             executeOp.getResultTimepoint());
 
         // Explicitly copy the Value since it is marked as const.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -181,8 +181,8 @@ static void insertConstantTableLookup(mlir::FunctionOpInterface funcOp,
   SmallVector<Value> tableTensors;
   for (auto &set : constantTable.sets) {
     auto tableAttr = buildConstantSetAttr(set, builder);
-    auto tableTensor = builder.create<arith::ConstantOp>(
-        builder.getFusedLoc(set.locs.takeVector()), tableAttr);
+    auto tableTensor = arith::ConstantOp::create(
+        builder, builder.getFusedLoc(set.locs.takeVector()), tableAttr);
     tableTensors.push_back(tableTensor);
   }
 
@@ -204,8 +204,8 @@ static void insertConstantTableLookup(mlir::FunctionOpInterface funcOp,
                                     })
                                 .getResult();
       if (extractedValue.getType() != arg.getType()) {
-        extractedValue = builder.create<arith::IndexCastOp>(
-            arg.getLoc(), arg.getType(), extractedValue);
+        extractedValue = arith::IndexCastOp::create(
+            builder, arg.getLoc(), arg.getType(), extractedValue);
       }
       arg.replaceAllUsesWith(extractedValue);
     }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -55,7 +55,8 @@ Operation *IREETensorExtDialect::materializeConstant(OpBuilder &builder,
                                                      Attribute value, Type type,
                                                      Location loc) {
   if (arith::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
+    return arith::ConstantOp::create(builder, loc, type,
+                                     cast<TypedAttr>(value));
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
@@ -298,9 +298,9 @@ struct ConvertIfOp : public OpConversionPattern<scf::IfOp> {
         llvm::map_to_vector(ifOp.getResultTypes(), [&](Type type) {
           return getTypeConverter()->convertType(type);
         });
-    auto newOp = rewriter.create<scf::IfOp>(ifOp.getLoc(), resultTypes,
-                                            adaptor.getCondition(),
-                                            ifOp.elseBlock() != nullptr);
+    auto newOp =
+        scf::IfOp::create(rewriter, ifOp.getLoc(), resultTypes,
+                          adaptor.getCondition(), ifOp.elseBlock() != nullptr);
     rewriter.inlineRegionBefore(ifOp.getThenRegion(), newOp.getThenRegion(),
                                 newOp.getThenRegion().end());
     rewriter.eraseBlock(&newOp.getThenRegion().front());

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/FuncToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/FuncToUtil/Patterns.cpp
@@ -65,8 +65,9 @@ struct FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
     auto newFuncType = mlir::FunctionType::get(
         srcOp.getContext(), signatureConversion.getConvertedTypes(),
         convertedResultTypes);
-    auto newFuncOp = rewriter.create<IREE::Util::FuncOp>(
-        srcOp.getLoc(), srcOp.getName(), newFuncType, tiedOperandsAttr);
+    auto newFuncOp =
+        IREE::Util::FuncOp::create(rewriter, srcOp.getLoc(), srcOp.getName(),
+                                   newFuncType, tiedOperandsAttr);
     newFuncOp.setSymVisibilityAttr(srcOp.getSymVisibilityAttr());
     rewriter.inlineRegionBefore(srcOp.getBody(), newFuncOp.getFunctionBody(),
                                 newFuncOp.end());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -88,8 +88,8 @@ struct UtilInlinerInterface : public DialectInlinerInterface {
     if (!returnOp)
       return;
     OpBuilder builder(op);
-    builder.create<mlir::cf::BranchOp>(op->getLoc(), newDest,
-                                       returnOp.getOperands());
+    mlir::cf::BranchOp::create(builder, op->getLoc(), newDest,
+                               returnOp.getOperands());
     op->erase();
   }
 
@@ -128,9 +128,10 @@ UtilDialect::UtilDialect(MLIRContext *context)
 Operation *UtilDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                             Type type, Location loc) {
   if (isa<IREE::Util::NullAttr>(value)) {
-    return builder.create<IREE::Util::NullOp>(loc, type);
+    return IREE::Util::NullOp::create(builder, loc, type);
   } else if (arith::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
+    return arith::ConstantOp::create(builder, loc, type,
+                                     cast<TypedAttr>(value));
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -49,11 +49,11 @@ Value buildIfElseTree(
   for (size_t i = 0; i < count; ++i) {
     caseValues.push_back(caseBuilder(loc, i, builder));
   }
-  Value result = builder.create<arith::ConstantIndexOp>(loc, -1);
+  Value result = arith::ConstantIndexOp::create(builder, loc, -1);
   for (int i = count - 1; i >= 0; --i) {
-    result = builder.create<arith::SelectOp>(
-        loc, caseValues[i], builder.create<arith::ConstantIndexOp>(loc, i),
-        result);
+    result = arith::SelectOp::create(
+        builder, loc, caseValues[i],
+        arith::ConstantIndexOp::create(builder, loc, i), result);
   }
   return result;
 }
@@ -1911,10 +1911,10 @@ IREE::Util::CallOp IREE::Util::CallOp::cloneAndExpand(
                            IREE::Util::TiedOpInterface::kUntiedIndex);
   }
 
-  return builder.create<IREE::Util::CallOp>(
-      getLoc(), newResultTypes, getCallee(), newOperands,
-      builder.getIndexArrayAttr(newTiedOperands), getArgAttrsAttr(),
-      getResAttrsAttr());
+  return IREE::Util::CallOp::create(builder, getLoc(), newResultTypes,
+                                    getCallee(), newOperands,
+                                    builder.getIndexArrayAttr(newTiedOperands),
+                                    getArgAttrsAttr(), getResAttrsAttr());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2013,12 +2013,13 @@ IREE::Util::GlobalLoadOpInterface GlobalOp::createLoadOp(Location loc,
   // TODO(benvanik): create with the immutable flag if the global is immutable.
   // Today we avoid this and let analysis add the immutable flag when safe
   // (not in initializers/etc).
-  return builder.create<IREE::Util::GlobalLoadOp>(loc, getType(), getSymName());
+  return IREE::Util::GlobalLoadOp::create(builder, loc, getType(),
+                                          getSymName());
 }
 
 IREE::Util::GlobalStoreOpInterface
 GlobalOp::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::Util::GlobalStoreOp>(loc, value, getSymName());
+  return IREE::Util::GlobalStoreOp::create(builder, loc, value, getSymName());
 }
 
 void GlobalAddressOp::getAsmResultNames(

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -48,8 +48,8 @@ Value BufferType::createSubrangeOp(Location loc, Value resource,
                                    Value resourceSize, Value subrangeOffset,
                                    Value subrangeLength,
                                    OpBuilder &builder) const {
-  return builder.create<IREE::Util::BufferSubspanOp>(
-      loc, resource, resourceSize, subrangeOffset, subrangeLength);
+  return IREE::Util::BufferSubspanOp::create(
+      builder, loc, resource, resourceSize, subrangeOffset, subrangeLength);
 }
 
 //===----------------------------------------------------------------------===//
@@ -839,7 +839,7 @@ static SmallVector<Value> buildShape(Location loc, ShapedType type,
     if (ShapedType::isDynamic(dim)) {
       dims.push_back(dynamicDims[dynamicIdx++]);
     } else {
-      dims.push_back(builder.create<arith::ConstantIndexOp>(loc, dim));
+      dims.push_back(arith::ConstantIndexOp::create(builder, loc, dim));
     }
   }
   return dims;

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
@@ -440,8 +440,8 @@ DiagnosedSilenceableFailure IREE::Util::transform_dialect::CastAndCallOp::apply(
     replacements = terminator->getOperands();
     rewriter.eraseOp(terminator);
   } else {
-    auto callOp = rewriter.create<IREE::Util::CallOp>(
-        insertionPoint->getLoc(), targetFunction.getResultTypes(),
+    auto callOp = IREE::Util::CallOp::create(
+        rewriter, insertionPoint->getLoc(), targetFunction.getResultTypes(),
         targetFunction.getName(), inputs, /*tied_operands=*/ArrayAttr{},
         /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
     exceptedUser = callOp;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -56,7 +56,7 @@ public:
     // we are combining - this ensures that module initialization order is
     // preserved.
     OpBuilder builder(initializerOps.front());
-    auto newOp = builder.create<IREE::Util::InitializerOp>(fusedLoc);
+    auto newOp = IREE::Util::InitializerOp::create(builder, fusedLoc);
     builder.setInsertionPointToStart(newOp.addEntryBlock());
     InlinerInterface inlinerInterface(&getContext());
     for (auto initializerOp : initializerOps) {
@@ -74,7 +74,7 @@ public:
       builder.setInsertionPointToEnd(&newOp.back());
       initializerOp.erase();
     }
-    builder.create<IREE::Util::ReturnOp>(fusedLoc);
+    IREE::Util::ReturnOp::create(builder, fusedLoc);
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -186,10 +186,10 @@ static Value tryMaterializeConstant(Location loc, Type type, Attribute attr,
                                     OpBuilder &builder) {
   if (arith::ConstantOp::isBuildableWith(attr, type)) {
     // Common case fast-path.
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(attr));
+    return arith::ConstantOp::create(builder, loc, type, cast<TypedAttr>(attr));
   } else if (mlir::func::ConstantOp::isBuildableWith(attr, type)) {
-    return builder.create<mlir::func::ConstantOp>(
-        loc, type, llvm::cast<FlatSymbolRefAttr>(attr));
+    return mlir::func::ConstantOp::create(builder, loc, type,
+                                          llvm::cast<FlatSymbolRefAttr>(attr));
   }
   // Fallback that asks a dialect to materialize things. This may fail!
   auto *op = attr.getDialect().materializeConstant(builder, attr, type, loc);

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -187,8 +187,8 @@ public:
 
     // No existing mapping - create a new global.
     OpBuilder moduleBuilder(topLevelOp);
-    auto initializerOp =
-        moduleBuilder.create<IREE::Util::InitializerOp>(originalValue.getLoc());
+    auto initializerOp = IREE::Util::InitializerOp::create(
+        moduleBuilder, originalValue.getLoc());
     initializerOp->setDialectAttrs(dialectAttrs);
     auto initializerBuilder =
         OpBuilder::atBlockEnd(initializerOp.addEntryBlock());
@@ -288,8 +288,8 @@ public:
         // Allow the storage type of the global to differ from the local type.
         globalType = hoistableType.getPreferredStorageType();
       }
-      auto globalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
-          loc, getHoistedName(globalType), false, globalType);
+      auto globalOp = IREE::Util::GlobalOp::create(
+          moduleBuilder, loc, getHoistedName(globalType), false, globalType);
       moduleSymbols.insert(globalOp);
       SymbolTable::setSymbolVisibility(globalOp,
                                        SymbolTable::Visibility::Private);
@@ -319,7 +319,7 @@ public:
       globalOp.createStoreOp(loc, clonedResult, initializerBuilder);
     }
 
-    initializerBuilder.create<IREE::Util::ReturnOp>(loc);
+    IREE::Util::ReturnOp::create(initializerBuilder, loc);
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -413,8 +413,8 @@ static void replaceValueWithConstant(Value value, LocAttr constantValue,
 
   // Immutable global loads are represented as constant symbol refs.
   if (auto globalRef = dyn_cast<SymbolRefAttr>(constantValue.attr)) {
-    op = builder.create<IREE::Util::GlobalLoadOp>(
-        constantValue.loc.value(), constantValue.type,
+    op = IREE::Util::GlobalLoadOp::create(
+        builder, constantValue.loc.value(), constantValue.type,
         globalRef.getLeafReference().getValue(),
         /*is_immutable=*/true);
   }
@@ -423,9 +423,9 @@ static void replaceValueWithConstant(Value value, LocAttr constantValue,
   // themselves.
   if (arith::ConstantOp::isBuildableWith(constantValue.attr,
                                          constantValue.type)) {
-    op = builder.create<arith::ConstantOp>(constantValue.loc.value(),
-                                           constantValue.type,
-                                           cast<TypedAttr>(constantValue.attr));
+    op = arith::ConstantOp::create(builder, constantValue.loc.value(),
+                                   constantValue.type,
+                                   cast<TypedAttr>(constantValue.attr));
   }
 
   // Try the attr and type dialects to see if they can materialize.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/TestConversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/TestConversion.cpp
@@ -26,7 +26,7 @@ namespace {
 
 static Value buildUnrealizedConversionCastOp(OpBuilder &builder, Type toType,
                                              ValueRange inputs, Location loc) {
-  return builder.create<UnrealizedConversionCastOp>(loc, toType, inputs)
+  return UnrealizedConversionCastOp::create(builder, loc, toType, inputs)
       .getResult(0);
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
@@ -537,14 +537,14 @@ struct SignExtendIOpConversion : public OpConversionPattern<arith::ExtSIOp> {
       if (dstType.isInteger(32)) {
         rewriter.replaceOpWithNewOp<IREE::VM::SelectI32Op>(
             srcOp, dstType, adaptor.getIn(),
-            rewriter.create<IREE::VM::ConstI32Op>(srcOp.getLoc(), 0xFFFFFFFFu),
-            rewriter.create<IREE::VM::ConstI32ZeroOp>(srcOp.getLoc()));
+            IREE::VM::ConstI32Op::create(rewriter, srcOp.getLoc(), 0xFFFFFFFFu),
+            IREE::VM::ConstI32ZeroOp::create(rewriter, srcOp.getLoc()));
       } else if (dstType.isInteger(64)) {
         rewriter.replaceOpWithNewOp<IREE::VM::SelectI64Op>(
             srcOp, dstType, adaptor.getIn(),
-            rewriter.create<IREE::VM::ConstI64Op>(srcOp.getLoc(),
-                                                  0xFFFFFFFFFFFFFFFFull),
-            rewriter.create<IREE::VM::ConstI64ZeroOp>(srcOp.getLoc()));
+            IREE::VM::ConstI64Op::create(rewriter, srcOp.getLoc(),
+                                         0xFFFFFFFFFFFFFFFFull),
+            IREE::VM::ConstI64ZeroOp::create(rewriter, srcOp.getLoc()));
       } else {
         return rewriter.notifyMatchFailure(srcOp,
                                            "unsupported i1 sign extension");
@@ -672,8 +672,9 @@ struct SIToFPOpConversion : public OpConversionPattern<arith::SIToFPOp> {
     }
 
     if (srcType.getIntOrFloatBitWidth() < 32) {
-      input = rewriter.create<arith::ExtSIOp>(
-          srcOp.getLoc(), IntegerType::get(this->getContext(), 32), input);
+      input = arith::ExtSIOp::create(rewriter, srcOp.getLoc(),
+                                     IntegerType::get(this->getContext(), 32),
+                                     input);
     }
 
     rewriter.replaceOpWithNewOp<IREE::VM::CastSI32F32Op>(srcOp, resultType,
@@ -719,8 +720,9 @@ struct UIToFPOpConversion : public OpConversionPattern<arith::UIToFPOp> {
     }
 
     if (srcType.getIntOrFloatBitWidth() < 32) {
-      input = rewriter.create<arith::ExtUIOp>(
-          srcOp.getLoc(), IntegerType::get(this->getContext(), 32), input);
+      input = arith::ExtUIOp::create(rewriter, srcOp.getLoc(),
+                                     IntegerType::get(this->getContext(), 32),
+                                     input);
     }
 
     rewriter.replaceOpWithNewOp<IREE::VM::CastUI32F32Op>(srcOp, resultType,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
@@ -109,7 +109,7 @@ TypeConverter::TypeConverter(TargetOptions targetOptions)
         !llvm::isa<IntegerType>(inputs.front().getType())) {
       return nullptr;
     }
-    return builder.create<arith::IndexCastOp>(loc, type, inputs.front());
+    return arith::IndexCastOp::create(builder, loc, type, inputs.front());
   });
 
   addTargetMaterialization(

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -20,7 +20,7 @@ struct InitializerOpConversion
   LogicalResult
   matchAndRewrite(IREE::Util::InitializerOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto newOp = rewriter.create<IREE::VM::InitializerOp>(op.getLoc());
+    auto newOp = IREE::VM::InitializerOp::create(rewriter, op.getLoc());
     rewriter.cloneRegionBefore(op.getBody(), newOp.getBody(),
                                newOp.getBody().begin());
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
@@ -43,8 +43,8 @@ class ListCreateOpConversion
     if (initialCapacity) {
       initialCapacity = castToI32(initialCapacity, rewriter);
     } else {
-      initialCapacity = rewriter.create<IREE::VM::ConstI32Op>(
-          srcOp.getLoc(), rewriter.getI32IntegerAttr(0));
+      initialCapacity = IREE::VM::ConstI32Op::create(
+          rewriter, srcOp.getLoc(), rewriter.getI32IntegerAttr(0));
     }
     rewriter.replaceOpWithNewOp<IREE::VM::ListAllocOp>(
         srcOp, typeConverter->convertType(srcOp.getResult().getType()),
@@ -59,8 +59,8 @@ class ListSizeOpConversion
   LogicalResult
   matchAndRewrite(IREE::Util::ListSizeOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value size = rewriter.create<IREE::VM::ListSizeOp>(
-        srcOp.getLoc(), rewriter.getI32Type(), adaptor.getList());
+    Value size = IREE::VM::ListSizeOp::create(
+        rewriter, srcOp.getLoc(), rewriter.getI32Type(), adaptor.getList());
     rewriter.replaceOp(srcOp, castToIndex(size, rewriter));
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -101,7 +101,8 @@ struct VMInlinerInterface : public DialectInlinerInterface {
 
     // Replace the return with a branch to the dest.
     OpBuilder builder(op);
-    builder.create<VM::BranchOp>(op->getLoc(), newDest, returnOp.getOperands());
+    VM::BranchOp::create(builder, op->getLoc(), newDest,
+                         returnOp.getOperands());
     op->erase();
   }
 
@@ -264,32 +265,32 @@ Operation *VMDialect::materializeConstant(OpBuilder &builder, Attribute value,
   if (ConstI32Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstI32Op::convertConstValue(typedValue);
     if (llvm::cast<IntegerAttr>(convertedValue).getValue() == 0) {
-      return builder.create<VM::ConstI32ZeroOp>(loc);
+      return VM::ConstI32ZeroOp::create(builder, loc);
     }
-    return builder.create<VM::ConstI32Op>(loc, convertedValue);
+    return VM::ConstI32Op::create(builder, loc, convertedValue);
   } else if (ConstI64Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstI64Op::convertConstValue(typedValue);
     if (llvm::cast<IntegerAttr>(convertedValue).getValue() == 0) {
-      return builder.create<VM::ConstI64ZeroOp>(loc);
+      return VM::ConstI64ZeroOp::create(builder, loc);
     }
-    return builder.create<VM::ConstI64Op>(loc, convertedValue);
+    return VM::ConstI64Op::create(builder, loc, convertedValue);
   } else if (ConstF32Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstF32Op::convertConstValue(typedValue);
     if (llvm::cast<FloatAttr>(convertedValue).getValue().isZero()) {
-      return builder.create<VM::ConstF32ZeroOp>(loc);
+      return VM::ConstF32ZeroOp::create(builder, loc);
     }
-    return builder.create<VM::ConstF32Op>(loc, convertedValue);
+    return VM::ConstF32Op::create(builder, loc, convertedValue);
   } else if (ConstF64Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstF64Op::convertConstValue(typedValue);
     if (llvm::cast<FloatAttr>(convertedValue).getValue().isZero()) {
-      return builder.create<VM::ConstF64ZeroOp>(loc);
+      return VM::ConstF64ZeroOp::create(builder, loc);
     }
-    return builder.create<VM::ConstF64Op>(loc, convertedValue);
+    return VM::ConstF64Op::create(builder, loc, convertedValue);
   } else if (llvm::isa<IREE::VM::RefType>(type)) {
     // The only constant type we support for refs is null so we can just
     // emit that here.
     // TODO(benvanik): relace unit attr with a proper null ref attr.
-    return builder.create<VM::ConstRefZeroOp>(loc, type);
+    return VM::ConstRefZeroOp::create(builder, loc, type);
   }
   // TODO(benvanik): handle other constant value types.
   return nullptr;

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -2800,7 +2800,7 @@ struct RewritePseudoCmpNZToNE : public OpRewritePattern<T> {
   LogicalResult matchAndRewrite(T op,
                                 PatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<U>(op, op.getType(), op.getOperand(),
-                                   rewriter.create<CZ>(op.getLoc()));
+                                   CZ::create(rewriter, op.getLoc()));
     return success();
   }
 };
@@ -2903,7 +2903,7 @@ struct NullCheckCmpEQRefToCmpNZRef : public OpRewritePattern<CmpEQRefOp> {
     Attribute rhs;
     if (matchPattern(op.getRhs(), m_Constant(&rhs))) {
       auto cmpNz =
-          rewriter.create<CmpNZRefOp>(op.getLoc(), op.getType(), op.getLhs());
+          CmpNZRefOp::create(rewriter, op.getLoc(), op.getType(), op.getLhs());
       rewriter.replaceOpWithNewOp<XorI32Op>(
           op, op.getType(), cmpNz,
           rewriter.createOrFold<IREE::VM::ConstI32Op>(op.getLoc(), 1));
@@ -3204,8 +3204,8 @@ struct RewriteCondFailToBranchFail : public OpRewritePattern<CondFailOp> {
         rewriter.createBlock(block, {op.getStatus().getType()}, {op.getLoc()});
     block->moveBefore(failBlock);
     rewriter.setInsertionPointToStart(failBlock);
-    rewriter.create<FailOp>(op.getLoc(), failBlock->getArgument(0),
-                            op.getMessage().value_or(""));
+    FailOp::create(rewriter, op.getLoc(), failBlock->getArgument(0),
+                   op.getMessage().value_or(""));
 
     // Replace the original cond_fail with our cond_branch, splitting the block
     // and continuing if the condition is not taken.

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -423,56 +423,56 @@ Block *InitializerOp::addBlock() {
 
 IREE::Util::GlobalLoadOpInterface
 GlobalI32Op::createLoadOp(Location loc, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalLoadI32Op>(loc, builder.getI32Type(),
-                                                   getGlobalName());
+  return IREE::VM::GlobalLoadI32Op::create(builder, loc, builder.getI32Type(),
+                                           getGlobalName());
 }
 IREE::Util::GlobalStoreOpInterface
 GlobalI32Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalStoreI32Op>(loc, value,
-                                                    getGlobalName());
+  return IREE::VM::GlobalStoreI32Op::create(builder, loc, value,
+                                            getGlobalName());
 }
 
 IREE::Util::GlobalLoadOpInterface
 GlobalI64Op::createLoadOp(Location loc, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalLoadI64Op>(loc, builder.getI64Type(),
-                                                   getGlobalName());
+  return IREE::VM::GlobalLoadI64Op::create(builder, loc, builder.getI64Type(),
+                                           getGlobalName());
 }
 IREE::Util::GlobalStoreOpInterface
 GlobalI64Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalStoreI64Op>(loc, value,
-                                                    getGlobalName());
+  return IREE::VM::GlobalStoreI64Op::create(builder, loc, value,
+                                            getGlobalName());
 }
 
 IREE::Util::GlobalLoadOpInterface
 GlobalF32Op::createLoadOp(Location loc, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalLoadF32Op>(loc, builder.getF32Type(),
-                                                   getGlobalName());
+  return IREE::VM::GlobalLoadF32Op::create(builder, loc, builder.getF32Type(),
+                                           getGlobalName());
 }
 IREE::Util::GlobalStoreOpInterface
 GlobalF32Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalStoreF32Op>(loc, value,
-                                                    getGlobalName());
+  return IREE::VM::GlobalStoreF32Op::create(builder, loc, value,
+                                            getGlobalName());
 }
 
 IREE::Util::GlobalLoadOpInterface
 GlobalF64Op::createLoadOp(Location loc, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalLoadF64Op>(loc, builder.getF64Type(),
-                                                   getGlobalName());
+  return IREE::VM::GlobalLoadF64Op::create(builder, loc, builder.getF64Type(),
+                                           getGlobalName());
 }
 IREE::Util::GlobalStoreOpInterface
 GlobalF64Op::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalStoreF64Op>(loc, value,
-                                                    getGlobalName());
+  return IREE::VM::GlobalStoreF64Op::create(builder, loc, value,
+                                            getGlobalName());
 }
 
 IREE::Util::GlobalLoadOpInterface
 GlobalRefOp::createLoadOp(Location loc, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalLoadRefOp>(loc, getType(),
-                                                   getSymName());
+  return IREE::VM::GlobalLoadRefOp::create(builder, loc, getType(),
+                                           getSymName());
 }
 IREE::Util::GlobalStoreOpInterface
 GlobalRefOp::createStoreOp(Location loc, Value value, OpBuilder &builder) {
-  return builder.create<IREE::VM::GlobalStoreRefOp>(loc, value, getSymName());
+  return IREE::VM::GlobalStoreRefOp::create(builder, loc, value, getSymName());
 }
 
 template <typename T>

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -36,9 +36,9 @@ appendOrCreateInitFuncOp(IREE::VM::ModuleOp moduleOp, StringRef name,
   OpBuilder funcBuilder(moduleOp.getContext());
   if (!funcOp) {
     // Create a new empty function.
-    funcOp = moduleBuilder.create<IREE::VM::FuncOp>(
-        moduleBuilder.getUnknownLoc(), name,
-        moduleBuilder.getFunctionType({}, {}));
+    funcOp =
+        IREE::VM::FuncOp::create(moduleBuilder, moduleBuilder.getUnknownLoc(),
+                                 name, moduleBuilder.getFunctionType({}, {}));
     funcBuilder = OpBuilder::atBlockEnd(funcOp.addEntryBlock());
     return std::make_tuple(funcOp, funcBuilder);
   }
@@ -80,7 +80,7 @@ static void exportFuncIfNeeded(IREE::VM::ModuleOp moduleOp,
 
   // Add vm.export if needed.
   OpBuilder moduleBuilder(funcOp);
-  moduleBuilder.create<IREE::VM::ExportOp>(funcOp.getLoc(), funcOp);
+  IREE::VM::ExportOp::create(moduleBuilder, funcOp.getLoc(), funcOp);
 }
 
 // Updates the mutability of globals based on whether they are stored anywhere
@@ -185,8 +185,8 @@ class GlobalInitializationPass
     }
 
     // Add returns to the initializers.
-    initBuilder.create<IREE::VM::ReturnOp>(initBuilder.getUnknownLoc());
-    deinitBuilder.create<IREE::VM::ReturnOp>(deinitBuilder.getUnknownLoc());
+    IREE::VM::ReturnOp::create(initBuilder, initBuilder.getUnknownLoc());
+    IREE::VM::ReturnOp::create(deinitBuilder, deinitBuilder.getUnknownLoc());
 
     // Correct mutability of all globals.
     fixupGlobalMutability(moduleOp, symbolTable);
@@ -265,10 +265,10 @@ class GlobalInitializationPass
     if (auto integerType = llvm::dyn_cast<IntegerType>(value.getType())) {
       switch (integerType.getIntOrFloatBitWidth()) {
       case 32:
-        builder.create<IREE::VM::GlobalStoreI32Op>(loc, value, symName);
+        IREE::VM::GlobalStoreI32Op::create(builder, loc, value, symName);
         return success();
       case 64:
-        builder.create<IREE::VM::GlobalStoreI64Op>(loc, value, symName);
+        IREE::VM::GlobalStoreI64Op::create(builder, loc, value, symName);
         return success();
       default:
         return failure();
@@ -276,10 +276,10 @@ class GlobalInitializationPass
     } else if (auto floatType = llvm::dyn_cast<FloatType>(value.getType())) {
       switch (floatType.getIntOrFloatBitWidth()) {
       case 32:
-        builder.create<IREE::VM::GlobalStoreF32Op>(loc, value, symName);
+        IREE::VM::GlobalStoreF32Op::create(builder, loc, value, symName);
         return success();
       case 64:
-        builder.create<IREE::VM::GlobalStoreF64Op>(loc, value, symName);
+        IREE::VM::GlobalStoreF64Op::create(builder, loc, value, symName);
         return success();
       default:
         return failure();

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
@@ -42,9 +42,9 @@ class HoistInlinedRodataPass
       } else {
         moduleBuilder.setInsertionPointToStart(&moduleOp.getBlock());
       }
-      auto rodataOp = moduleBuilder.create<IREE::VM::RodataOp>(
-          inlineOp.getLoc(), inferConstantName(parentOp, inlineOp),
-          inlineOp.getValue());
+      auto rodataOp = IREE::VM::RodataOp::create(
+          moduleBuilder, inlineOp.getLoc(),
+          inferConstantName(parentOp, inlineOp), inlineOp.getValue());
       if (auto alignmentAttr = inlineOp.getAlignmentAttr()) {
         rodataOp.setAlignmentAttr(alignmentAttr);
       }
@@ -83,8 +83,8 @@ private:
   void replaceInlineOpWithRodataRef(IREE::VM::RodataInlineOp inlineOp,
                                     IREE::VM::RodataOp rodataOp) {
     OpBuilder builder(inlineOp);
-    auto refOp =
-        builder.create<IREE::VM::ConstRefRodataOp>(inlineOp.getLoc(), rodataOp);
+    auto refOp = IREE::VM::ConstRefRodataOp::create(builder, inlineOp.getLoc(),
+                                                    rodataOp);
     inlineOp.replaceAllUsesWith(refOp.getValue());
     inlineOp.erase();
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -115,7 +115,7 @@ class OrdinalAllocationPass
 
       OpBuilder builder(op);
       auto ordinalOp =
-          builder.create<IREE::VM::ConstI32Op>(op.getLoc(), ordinal);
+          IREE::VM::ConstI32Op::create(builder, op.getLoc(), ordinal);
       op.getReturnedGlobalRef().replaceAllUsesWith(ordinalOp);
 
       deadOps.push_back(op);

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -60,18 +60,18 @@ static void reifyRodataTable(RewriterBase &rewriter,
       IREE::VM::RefType::get(rewriter.getType<IREE::VM::BufferType>());
   IREE::VM::RodataInlineOp tableRodata;
   if constexpr (std::is_same<IntTy, int32_t>()) {
-    tableRodata = rewriter.create<IREE::VM::RodataInlineOp>(
-        tableOp.getLoc(), refType, rewriter.getI32VectorAttr(table));
+    tableRodata = IREE::VM::RodataInlineOp::create(
+        rewriter, tableOp.getLoc(), refType, rewriter.getI32VectorAttr(table));
   } else {
-    tableRodata = rewriter.create<IREE::VM::RodataInlineOp>(
-        tableOp.getLoc(), refType, rewriter.getI64VectorAttr(table));
+    tableRodata = IREE::VM::RodataInlineOp::create(
+        rewriter, tableOp.getLoc(), refType, rewriter.getI64VectorAttr(table));
   }
   if (auto tableNameAttr = tableOp.getTableNameAttr()) {
     tableRodata.setNameAttr(tableNameAttr);
   }
 
-  auto dataRodata = rewriter.create<IREE::VM::RodataInlineOp>(
-      tableOp.getLoc(), refType,
+  auto dataRodata = IREE::VM::RodataInlineOp::create(
+      rewriter, tableOp.getLoc(), refType,
       IREE::Util::CompositeAttr::get(rewriter.getContext(), dataAttrs));
   if (auto dataNameAttr = tableOp.getDataNameAttr()) {
     dataRodata.setNameAttr(dataNameAttr);

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
@@ -78,8 +78,8 @@ static void processBufferGlobal(Explorer &explorer,
     for (auto loadOp : globalInfo->getLoads()) {
       OpBuilder builder(loadOp);
       auto loadedValue = loadOp.getLoadedGlobalValue();
-      auto zeroRefOp = builder.create<IREE::VM::ConstRefZeroOp>(
-          loadOp.getLoc(), loadedValue.getType());
+      auto zeroRefOp = IREE::VM::ConstRefZeroOp::create(
+          builder, loadOp.getLoc(), loadedValue.getType());
       loadedValue.replaceAllUsesWith(zeroRefOp.getResult());
       deadOps.insert(loadOp);
     }
@@ -99,7 +99,7 @@ static void processBufferGlobal(Explorer &explorer,
   for (auto loadOp : globalInfo->getLoads()) {
     OpBuilder builder(loadOp);
     auto rodataRefOp =
-        builder.create<IREE::VM::ConstRefRodataOp>(loadOp.getLoc(), rodataOp);
+        IREE::VM::ConstRefRodataOp::create(builder, loadOp.getLoc(), rodataOp);
     auto loadedValue = loadOp.getLoadedGlobalValue();
     loadedValue.replaceAllUsesWith(rodataRefOp.getResult());
     deadOps.insert(loadOp);

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -117,8 +117,8 @@ struct ConvertHALInterfaceWorkgroupIDOp
     Value workgroupDimI32 =
         op->getParentOfType<mlir::FunctionOpInterface>().getArgument(
             kEntryArgWorkgroupX + dim);
-    Value workgroupDim = rewriter.create<arith::IndexCastOp>(
-        op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
+    Value workgroupDim = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
     rewriter.replaceOp(op, workgroupDim);
     return success();
   }
@@ -141,8 +141,8 @@ struct ConvertHALInterfaceWorkgroupSizeOp
     Value workgroupDimI32 =
         op->getParentOfType<mlir::FunctionOpInterface>().getArgument(
             kEntryArgWorkgroupSizeX + dim);
-    Value workgroupDim = rewriter.create<arith::IndexCastOp>(
-        op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
+    Value workgroupDim = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
     rewriter.replaceOp(op, workgroupDim);
     return success();
   }
@@ -165,8 +165,8 @@ struct ConvertHALInterfaceWorkgroupCountOp
     Value workgroupDimI32 =
         op->getParentOfType<mlir::FunctionOpInterface>().getArgument(
             kEntryArgWorkgroupCountX + dim);
-    Value workgroupDim = rewriter.create<arith::IndexCastOp>(
-        op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
+    Value workgroupDim = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), workgroupDimI32);
     rewriter.replaceOp(op, workgroupDim);
     return success();
   }
@@ -187,7 +187,7 @@ struct ConvertHALInterfaceConstantLoadOp
     // HACK: we could find the total push constant count and avoid this size op
     // but it'd require walking all the way up to the hal.executable export.
     auto constantsSize =
-        rewriter.create<IREE::Util::BufferSizeOp>(op.getLoc(), constantsArg);
+        IREE::Util::BufferSizeOp::create(rewriter, op.getLoc(), constantsArg);
     auto resultType = getTypeConverter()->convertType(op.getResult().getType());
 
     // Index -> byte offset.

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -249,8 +249,8 @@ struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
     for (int i = 0; i < sourceRank; i++) {
       sizeStrideTypes.push_back(indexType);
     }
-    auto sourceDesc = rewriter.create<GetBufferDescriptorOp>(
-        loc, op.getBaseBuffer().getType(), indexType, sizeStrideTypes,
+    auto sourceDesc = GetBufferDescriptorOp::create(
+        rewriter, loc, op.getBaseBuffer().getType(), indexType, sizeStrideTypes,
         sizeStrideTypes, source);
 
     FailureOr<DescriptorInfo> resultDescriptor =


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339. The main benefit of free functions is better tab completion with LSP/IDE.

I'm splitting the upgrade in chunks going by project directories.