### PR TITLE
Upgrade all remaining code to free create functions. NFC.

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -128,10 +128,10 @@ static Value createSharedMemory(RewriterBase &rewriter, Location loc,
   if (!sharedMemoryBytes) {
     IREE::Codegen::NullPointerType nullPointerType =
         IREE::Codegen::NullPointerType::get(rewriter.getContext());
-    return rewriter.create<IREE::Codegen::NullPointerOp>(loc, nullPointerType);
+    return IREE::Codegen::NullPointerOp::create(rewriter, loc, nullPointerType);
   }
   auto allocOp =
-      rewriter.create<bufferization::AllocTensorOp>(loc, tensorType, dynSizes);
+      bufferization::AllocTensorOp::create(rewriter, loc, tensorType, dynSizes);
   Attribute sharedAddrSpace = gpu::AddressSpaceAttr::get(
       rewriter.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
   allocOp.setMemorySpaceAttr(sharedAddrSpace);
@@ -403,10 +403,10 @@ static LogicalResult handleInnerTiledMmaUkernel(
   Location loc = op->getLoc();
   Type I32Type = rewriter.getI32Type();
   auto castIndexToI32 = [&](Value val) {
-    return rewriter.create<arith::IndexCastOp>(loc, I32Type, val);
+    return arith::IndexCastOp::create(rewriter, loc, I32Type, val);
   };
   auto constI32 = [&](int val) {
-    return rewriter.create<arith::ConstantIntOp>(loc, I32Type, val);
+    return arith::ConstantIntOp::create(rewriter, loc, I32Type, val);
   };
   MLIRContext *context = rewriter.getContext();
   std::optional<int64_t> maybeSharedMemoryBytes =
@@ -415,7 +415,7 @@ static LogicalResult handleInnerTiledMmaUkernel(
       (!maybeSharedMemoryBytes) ? 0 : maybeSharedMemoryBytes.value();
   Value sharedMemory = createSharedMemory(rewriter, loc, sharedMemoryBytes);
   Value k = castIndexToI32(
-      rewriter.create<tensor::DimOp>(op.getLoc(), op.getInputs()[0], 1));
+      tensor::DimOp::create(rewriter, op.getLoc(), op.getInputs()[0], 1));
   Value intrinsicsM = constI32(mma.getIntrinsicsM());
   Value subgroupsM = constI32(mma.getSubgroupsM());
   Value intrinsicsN = constI32(mma.getIntrinsicsN());

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
@@ -235,9 +235,9 @@ convertStreamableFunc(mlir::ModuleOp moduleOp, IREE::Util::FuncOp funcOp,
       anyTiedOperands
           ? moduleBuilder.getIndexArrayAttr(streamableFunc.tiedOperands)
           : ArrayAttr{};
-  streamableFunc.funcOp = moduleBuilder.create<IREE::Flow::FuncOp>(
-      funcOp.getLoc(), funcOp.getName(), functionType, tiedOperandsAttr,
-      funcAttrs, funcArgAttrs, funcResAttrs);
+  streamableFunc.funcOp = IREE::Flow::FuncOp::create(
+      moduleBuilder, funcOp.getLoc(), funcOp.getName(), functionType,
+      tiedOperandsAttr, funcAttrs, funcArgAttrs, funcResAttrs);
 
   // Swap out the symbol in the symbol table.
   symbolTable.erase(funcOp);
@@ -266,8 +266,8 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
     // It should return the required number of dynamic dimensions.
     SmallVector<Type> resultDimTypes(streamableFunc.requiredResultDims,
                                      builder.getIndexType());
-    auto calculateCallOp = builder.create<IREE::Util::CallOp>(
-        callOp.getLoc(), resultDimTypes,
+    auto calculateCallOp = IREE::Util::CallOp::create(
+        builder, callOp.getLoc(), resultDimTypes,
         streamableFunc.resultDimsFunc.getLeafReference().getValue(),
         callOp.getOperands(), /*tied_operands=*/ArrayAttr{},
         callOp.getArgAttrsAttr(), callOp.getResAttrsAttr());
@@ -302,8 +302,8 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
   }
 
   // Replace the original func.call with the new flow.call.
-  auto streamableCallOp = builder.create<IREE::Flow::CallOp>(
-      callOp.getLoc(), callOp.getCalleeAttr(), callOp.getResultTypes(),
+  auto streamableCallOp = IREE::Flow::CallOp::create(
+      builder, callOp.getLoc(), callOp.getCalleeAttr(), callOp.getResultTypes(),
       resultDims, callOp.getOperands(), argDims,
       streamableFunc.funcOp.getTiedOperandsAttr());
   streamableCallOp->setDialectAttrs(callOp->getDialectAttrs());

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -185,14 +185,16 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     // program and the tensors consumed by the import.
     if (tensorArgs.empty()) {
       // No tensors passed to the import - pass in an immediate signal.
-      waitFence = entryBuilder.create<IREE::Util::NullOp>(
-          importOp.getLoc(), entryBuilder.getType<IREE::HAL::FenceType>());
+      waitFence = IREE::Util::NullOp::create(
+          entryBuilder, importOp.getLoc(),
+          entryBuilder.getType<IREE::HAL::FenceType>());
     } else {
-      waitFence = entryBuilder.create<IREE::HAL::FenceCreateOp>(
-          importOp.getLoc(), entryBuilder.getType<IREE::HAL::FenceType>(),
-          device, IREE::HAL::FenceFlagBitfield::None);
-      auto barrierOp = entryBuilder.create<IREE::HAL::TensorBarrierOp>(
-          importOp.getLoc(), tensorArgs, waitFence);
+      waitFence = IREE::HAL::FenceCreateOp::create(
+          entryBuilder, importOp.getLoc(),
+          entryBuilder.getType<IREE::HAL::FenceType>(), device,
+          IREE::HAL::FenceFlagBitfield::None);
+      auto barrierOp = IREE::HAL::TensorBarrierOp::create(
+          entryBuilder, importOp.getLoc(), tensorArgs, waitFence);
       for (auto [argIndex, readyArg] :
            llvm::zip_equal(tensorArgIndices, barrierOp.getResults())) {
         entryArgs[argIndex] = readyArg;
@@ -207,12 +209,14 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
         llvm::any_of(oldImportType.getResults(), llvm::IsaPred<TensorType>);
     if (!haveTensorResults && !hasSideEffects) {
       // No tensors returned from import - pass in an immediate signal.
-      signalFence = entryBuilder.create<IREE::Util::NullOp>(
-          importOp.getLoc(), entryBuilder.getType<IREE::HAL::FenceType>());
+      signalFence = IREE::Util::NullOp::create(
+          entryBuilder, importOp.getLoc(),
+          entryBuilder.getType<IREE::HAL::FenceType>());
     } else {
-      signalFence = entryBuilder.create<IREE::HAL::FenceCreateOp>(
-          importOp.getLoc(), entryBuilder.getType<IREE::HAL::FenceType>(),
-          device, IREE::HAL::FenceFlagBitfield::None);
+      signalFence = IREE::HAL::FenceCreateOp::create(
+          entryBuilder, importOp.getLoc(),
+          entryBuilder.getType<IREE::HAL::FenceType>(), device,
+          IREE::HAL::FenceFlagBitfield::None);
     }
     break;
   }
@@ -231,8 +235,8 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
       // import.
       auto encodingAttr =
           importOp.getArgAttrOfType<TypeAttr>(argIndex, "iree.abi.encoding");
-      auto tensorExportOp = entryBuilder.create<IREE::HAL::TensorExportOp>(
-          arg.getLoc(), newType, arg,
+      auto tensorExportOp = IREE::HAL::TensorExportOp::create(
+          entryBuilder, arg.getLoc(), newType, arg,
           fallback(encodingAttr, TypeAttr::get(oldType)),
           /*name=*/nullptr,
           fallback(importOp.getArgAttr(argIndex, "iree.abi.affinity"),
@@ -250,18 +254,18 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   }
 
   // Make the call with the updated types.
-  auto callOp = entryBuilder.create<IREE::Util::CallOp>(importOp.getLoc(),
-                                                        importOp, arguments);
+  auto callOp = IREE::Util::CallOp::create(entryBuilder, importOp.getLoc(),
+                                           importOp, arguments);
 
   // If the call has side-effects then we need to wait on its signal fence on
   // the host. This is because they may have launched a thread of their own to
   // perform work that we can't track.
   if (hasSideEffects && signalFence) {
     auto timeoutMillis =
-        entryBuilder.create<arith::ConstantIntOp>(importOp.getLoc(), -1, 32);
-    entryBuilder.create<IREE::HAL::FenceAwaitOp>(
-        importOp.getLoc(), entryBuilder.getI32Type(), timeoutMillis,
-        IREE::HAL::WaitFlagBitfield::None, signalFence);
+        arith::ConstantIntOp::create(entryBuilder, importOp.getLoc(), -1, 32);
+    IREE::HAL::FenceAwaitOp::create(
+        entryBuilder, importOp.getLoc(), entryBuilder.getI32Type(),
+        timeoutMillis, IREE::HAL::WaitFlagBitfield::None, signalFence);
   }
 
   // Marshal results.
@@ -278,8 +282,8 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
           resultIndex, "iree.abi.consume");
       auto affinityAttr =
           importOp.getResultAttr(resultIndex, "iree.abi.affinity");
-      auto tensorImportOp = entryBuilder.create<IREE::HAL::TensorImportOp>(
-          importOp.getLoc(), oldType, result,
+      auto tensorImportOp = IREE::HAL::TensorImportOp::create(
+          entryBuilder, importOp.getLoc(), oldType, result,
           fallback(encodingAttr, TypeAttr::get(oldType)),
           consumeAttr ? true : false, signalFence,
           /*name=*/nullptr, fallback(affinityAttr, defaultAffinityAttr));
@@ -289,7 +293,7 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     }
   }
 
-  entryBuilder.create<IREE::Util::ReturnOp>(importOp.getLoc(), results);
+  IREE::Util::ReturnOp::create(entryBuilder, importOp.getLoc(), results);
 
   stripABIAttrs(importOp);
 
@@ -616,8 +620,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
       auto affinityAttr = exportOp.getArgAttr(argIndex, "iree.abi.affinity");
       auto argName = inferArgumentName(entryBuilder.getContext(), argIndex,
                                        exportOp.getArgAttrDict(argIndex));
-      auto tensorImportOp = entryBuilder.create<IREE::HAL::TensorImportOp>(
-          arg.getLoc(), oldType, arg,
+      auto tensorImportOp = IREE::HAL::TensorImportOp::create(
+          entryBuilder, arg.getLoc(), oldType, arg,
           fallback(encodingAttr, TypeAttr::get(oldType)),
           /*consume=*/consumeAttr ? true : false, waitFence, argName,
           fallback(affinityAttr, defaultAffinityAttr));
@@ -628,8 +632,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   }
 
   // Make the call with the original types.
-  auto callOp = entryBuilder.create<IREE::Util::CallOp>(exportOp.getLoc(),
-                                                        exportOp, arguments);
+  auto callOp = IREE::Util::CallOp::create(entryBuilder, exportOp.getLoc(),
+                                           exportOp, arguments);
   auto asyncResults = llvm::to_vector(callOp.getResults());
 
   // Alias results to storage buffers if provided.
@@ -641,8 +645,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     auto source = asyncResults[resultIndex];
     auto sourceDims = IREE::Util::buildDynamicDimsForValue(
         exportOp.getLoc(), source, entryBuilder);
-    auto aliasOp = entryBuilder.create<IREE::HAL::TensorAliasOp>(
-        exportOp.getLoc(), source.getType(), source, sourceDims,
+    auto aliasOp = IREE::HAL::TensorAliasOp::create(
+        entryBuilder, exportOp.getLoc(), source.getType(), source, sourceDims,
         resultStorages[resultIndex], waitFence,
         fallback(exportOp.getResultAttr(resultIndex, "iree.abi.affinity"),
                  defaultAffinityAttr));
@@ -662,11 +666,11 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     if (asyncTensors.empty()) {
       // TODO(benvanik): maybe use a global timeline? global stores may not
       // have completed by now in cases where the user wants to loop back.
-      entryBuilder.create<IREE::HAL::FenceSignalOp>(exportOp.getLoc(),
-                                                    signalFence);
+      IREE::HAL::FenceSignalOp::create(entryBuilder, exportOp.getLoc(),
+                                       signalFence);
     } else {
-      auto barrierOp = entryBuilder.create<IREE::HAL::TensorBarrierOp>(
-          exportOp.getLoc(), asyncTensors, signalFence);
+      auto barrierOp = IREE::HAL::TensorBarrierOp::create(
+          entryBuilder, exportOp.getLoc(), asyncTensors, signalFence);
       asyncResults = llvm::to_vector(barrierOp.getResults());
     }
   }
@@ -686,8 +690,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
                           exportOp.getResultAttrDict(resultIndex));
       auto dynamicDims = IREE::Util::buildDynamicDimsForValue(
           result.getLoc(), result, entryBuilder);
-      auto tensorExportOp = entryBuilder.create<IREE::HAL::TensorExportOp>(
-          result.getLoc(), newType, result,
+      auto tensorExportOp = IREE::HAL::TensorExportOp::create(
+          entryBuilder, result.getLoc(), newType, result,
           fallback(encodingAttr, TypeAttr::get(result.getType())), dynamicDims,
           resultName, fallback(affinityAttr, defaultAffinityAttr));
       results.push_back(tensorExportOp);
@@ -698,7 +702,7 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
 
   stripABIAttrs(exportOp);
 
-  entryBuilder.create<IREE::Util::ReturnOp>(exportOp.getLoc(), results);
+  IREE::Util::ReturnOp::create(entryBuilder, exportOp.getLoc(), results);
   return wrapperOp;
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -231,11 +231,11 @@ static LogicalResult setContractionAnchor(MMASchedule &schedule,
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(contract);
   auto layoutedLhs =
-      rewriter.create<ToLayoutOp>(loc, lhs, aLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.intrinsic);
   auto layoutedRhs =
-      rewriter.create<ToLayoutOp>(loc, rhs, bLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.intrinsic);
   auto layoutedAcc =
-      rewriter.create<ToLayoutOp>(loc, acc, cLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -258,8 +258,8 @@ static LogicalResult setContractionAnchor(MMASchedule &schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(contract);
-  auto toLayout = rewriter.create<ToLayoutOp>(loc, contract->getResult(0),
-                                              cLayout, schedule.intrinsic);
+  auto toLayout = ToLayoutOp::create(rewriter, loc, contract->getResult(0),
+                                     cLayout, schedule.intrinsic);
   rewriter.replaceAllUsesExcept(contract->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -308,11 +308,11 @@ static LogicalResult setConvolutionAnchor(MMASchedule schedule,
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(conv);
   auto layoutedLhs =
-      rewriter.create<ToLayoutOp>(loc, lhs, aLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.intrinsic);
   auto layoutedRhs =
-      rewriter.create<ToLayoutOp>(loc, rhs, bLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.intrinsic);
   auto layoutedAcc =
-      rewriter.create<ToLayoutOp>(loc, acc, cLayout, schedule.intrinsic);
+      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -335,8 +335,8 @@ static LogicalResult setConvolutionAnchor(MMASchedule schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(conv);
-  auto toLayout = rewriter.create<ToLayoutOp>(loc, conv->getResult(0), cLayout,
-                                              schedule.intrinsic);
+  auto toLayout = ToLayoutOp::create(rewriter, loc, conv->getResult(0), cLayout,
+                                     schedule.intrinsic);
   rewriter.replaceAllUsesExcept(conv->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -553,7 +553,7 @@ static LogicalResult setDerivedThreadConfigLayout(
   for (OpResult result : linalgOp->getResults()) {
     VectorLayoutInterface resultLayout =
         layout.apply(linalgOp.getIndexingMapMatchingResult(result));
-    auto toLayout = rewriter.create<ToLayoutOp>(loc, result, resultLayout);
+    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 
@@ -728,7 +728,7 @@ static LogicalResult setGPULoweringConfigLayout(
   for (OpResult result : candidate->getResults()) {
     VectorLayoutInterface resultLayout =
         layout.apply(candidate.getIndexingMapMatchingResult(result));
-    auto toLayout = rewriter.create<ToLayoutOp>(loc, result, resultLayout);
+    auto toLayout = ToLayoutOp::create(rewriter, loc, result, resultLayout);
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -473,8 +473,8 @@ public:
                                 targetSymbolTable, moduleBuilder)))
       return failure();
 
-    auto funcOp = moduleBuilder.create<IREE::Util::FuncOp>(
-        initializerOp.getLoc(), "jit_eval",
+    auto funcOp = IREE::Util::FuncOp::create(
+        moduleBuilder, initializerOp.getLoc(), "jit_eval",
         moduleBuilder.getFunctionType({}, {}));
     targetSymbolTable.insert(funcOp);
     IRMapping unusedMapping;
@@ -489,7 +489,7 @@ public:
 private:
   static ModuleOp createInnerModule(ModuleOp sourceModuleOp) {
     OpBuilder builder = OpBuilder::atBlockEnd(sourceModuleOp.getBody());
-    auto m = builder.create<ModuleOp>(sourceModuleOp.getLoc());
+    auto m = ModuleOp::create(builder, sourceModuleOp.getLoc());
     m->setAttr("iree.consteval", builder.getUnitAttr());
     return m;
   }
@@ -583,7 +583,7 @@ private:
     // Rewrite the terminator and the function type.
     entryBlock->getTerminator()->erase();
     OpBuilder termBuilder = OpBuilder::atBlockEnd(entryBlock);
-    termBuilder.create<IREE::Util::ReturnOp>(funcOp.getLoc(), returns);
+    IREE::Util::ReturnOp::create(termBuilder, funcOp.getLoc(), returns);
     funcOp.setType(termBuilder.getFunctionType(argumentTypes, returnTypes));
 
     jitFunctions.push_back(std::move(desc));

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -92,8 +92,8 @@ collapseExtractSlice(tensor::ExtractSliceOp sliceOp,
   }
 
   RankedTensorType resultType = sliceOp.getResultType();
-  Value collapseOp = rewriter.create<tensor::CollapseShapeOp>(
-      loc, sliceOp.getSource(), reassociation);
+  Value collapseOp = tensor::CollapseShapeOp::create(
+      rewriter, loc, sliceOp.getSource(), reassociation);
   Value newSliceOp = tensor::ExtractSliceOp::create(
       rewriter, loc, collapseOp, collapsedOffsets, collapsedSizes,
       collapsedStrides);
@@ -867,8 +867,8 @@ hoistTensorReshapesOutOfDispatchRegion(
   }
 
   // 5. Create the new dispatch op.
-  auto newDispatchOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
-      loc, newReturnTypes, newDynamicDims, dispatchOp.getWorkload());
+  auto newDispatchOp = IREE::Flow::DispatchRegionOp::create(
+      rewriter, loc, newReturnTypes, newDynamicDims, dispatchOp.getWorkload());
 
   // 5a. Move the body over, but replace the `flow.return` to use the new yield
   // values.
@@ -908,8 +908,8 @@ hoistTensorReshapesOutOfDispatchRegion(
     SmallVector<OpFoldResult> outputShape =
         mlir::getMixedValues(shapedType.getShape(), dynamicDims, rewriter);
 
-    auto newExpandShapeOp = rewriter.create<tensor::ExpandShapeOp>(
-        loc, origResult.getType(), returnValue,
+    auto newExpandShapeOp = tensor::ExpandShapeOp::create(
+        rewriter, loc, origResult.getType(), returnValue,
         allReassociationIndicesRef.front(), outputShape);
     allReassociationIndicesRef = allReassociationIndicesRef.drop_front();
     rewriter.replaceAllUsesWith(origResult, newExpandShapeOp.getResult());

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -96,8 +96,8 @@ struct GatherFusionPattern final : public OpRewritePattern<tensor::ExtractOp> {
           });
       SmallVector<Value, 4> indices = extractOp.getIndices();
       indices = applyProjectedPermutation(indices, perm);
-      auto newExtract = rewriter.create<tensor::ExtractOp>(
-          extractOp.getLoc(), operand.get(), indices);
+      auto newExtract = tensor::ExtractOp::create(rewriter, extractOp.getLoc(),
+                                                  operand.get(), indices);
       extractOps.push_back(newExtract);
     }
     rewriter.cloneRegionBefore(producerOp.getRegion(), consumerOp.getRegion(),

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -185,8 +185,8 @@ struct DropUnitDimsFromCollapseOfExpand
     Value newExpanded = expandOp.getSrc();
     if (!llvm::all_of(newExpandReassoc,
                       llvm::hasSingleElement<ReassociationIndicesRef>)) {
-      newExpanded = rewriter.create<tensor::ExpandShapeOp>(
-          expandOp.getLoc(),
+      newExpanded = tensor::ExpandShapeOp::create(
+          rewriter, expandOp.getLoc(),
           RankedTensorType::get(newInterShape,
                                 expandOp.getType().getElementType()),
           expandOp.getSrc(), newExpandReassoc, newInterSizes);
@@ -195,9 +195,9 @@ struct DropUnitDimsFromCollapseOfExpand
     Value result = newExpanded;
     if (!llvm::all_of(newCollapseReassoc,
                       llvm::hasSingleElement<ReassociationIndicesRef>)) {
-      result = rewriter.create<tensor::CollapseShapeOp>(
-          collapseOp.getLoc(), collapseOp.getType(), newExpanded,
-          newCollapseReassoc);
+      result = tensor::CollapseShapeOp::create(rewriter, collapseOp.getLoc(),
+                                               collapseOp.getType(),
+                                               newExpanded, newCollapseReassoc);
     }
     rewriter.replaceOp(collapseOp, result);
     return success();
@@ -299,8 +299,8 @@ foldUnitDimsOnGlobal(IRRewriter &rewriter, IREE::Util::GlobalOpInterface global,
   }
   for (auto store : storeOps) {
     rewriter.setInsertionPoint(store);
-    Value collapse = rewriter.create<tensor::CollapseShapeOp>(
-        store.getLoc(), newGlobalType, store->getOperand(0),
+    Value collapse = tensor::CollapseShapeOp::create(
+        rewriter, store.getLoc(), newGlobalType, store->getOperand(0),
         expandShapeReInds.value());
     auto newStore =
         clone(rewriter, store, store->getResultTypes(), store->getOperands());

--- a/compiler/src/iree/compiler/DispatchCreation/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormScalarDispatches.cpp
@@ -285,10 +285,10 @@ void FormScalarDispatchesPass::runOnOperation() {
     Block *countBody = rewriter.createBlock(&countRegion, countRegion.begin());
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointToStart(countBody);
-    auto one = rewriter.create<arith::ConstantIndexOp>(
-        dispatchRegionOp.value()->getLoc(), 1);
-    rewriter.create<IREE::Flow::ReturnOp>(dispatchRegionOp.value()->getLoc(),
-                                          ValueRange{one, one, one});
+    auto one = arith::ConstantIndexOp::create(
+        rewriter, dispatchRegionOp.value()->getLoc(), 1);
+    IREE::Flow::ReturnOp::create(rewriter, dispatchRegionOp.value()->getLoc(),
+                                 ValueRange{one, one, one});
   }
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -424,8 +424,8 @@ fuseContractionsHorizontally(RewriterBase &rewriter, Location loc,
 
   SmallVector<AffineMap> fusedIndexingMaps = std::move(fusedInsIndexingMaps);
   fusedIndexingMaps.append(fusedOutsIndexingMaps);
-  auto fusedOp = rewriter.create<linalg::GenericOp>(
-      loc, fusedResultTypes, fusedIns, fusedOuts, fusedIndexingMaps,
+  auto fusedOp = linalg::GenericOp::create(
+      rewriter, loc, fusedResultTypes, fusedIns, fusedOuts, fusedIndexingMaps,
       fusedIteratorTypes, [](OpBuilder &, Location, ValueRange) {});
 
   Block *fusedBody = fusedOp.getBlock();
@@ -461,7 +461,7 @@ fuseContractionsHorizontally(RewriterBase &rewriter, Location loc,
   }
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointToEnd(fusedBody);
-  rewriter.create<linalg::YieldOp>(loc, yieldVals);
+  linalg::YieldOp::create(rewriter, loc, yieldVals);
 
   unsigned resultsIndex = 0;
   for (auto linalgOp : linalgOps) {

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -110,16 +110,16 @@ bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
     auto operandType = cast<RankedTensorType>(operand->get().getType());
     auto resType = RankedTensorType::get(
         operandType.getShape(), operandType.getElementType(), newEncoding);
-    Value encodedInput = rewriter.create<IREE::Encoding::SetEncodingOp>(
-        loc, resType, operand->get());
+    Value encodedInput = IREE::Encoding::SetEncodingOp::create(
+        rewriter, loc, resType, operand->get());
     encodedOperands.push_back(encodedInput);
   }
 
   // Create encoded generic op.
   SmallVector<OpFoldResult> mixedSizes =
       tensor::getMixedSizes(rewriter, loc, encodingOp.getSource());
-  Value encodedInit = rewriter.create<tensor::EmptyOp>(
-      loc, mixedSizes, encodedType.getElementType(), encoding);
+  Value encodedInit = tensor::EmptyOp::create(
+      rewriter, loc, mixedSizes, encodedType.getElementType(), encoding);
   encodedOperands.push_back(encodedInit);
   auto encodedGenericOp =
       clone(rewriter, genericOp, encodingOp.getResultType(), encodedOperands);

--- a/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
@@ -72,8 +72,8 @@ static LogicalResult createDefaultWorkgroupCountRegion(
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointToStart(block);
   Operation *defaultCountOp =
-      rewriter.create<IREE::TensorExt::DispatchWorkgroupCountFromSliceOp>(
-          loc, block->getArguments());
+      IREE::TensorExt::DispatchWorkgroupCountFromSliceOp::create(
+          rewriter, loc, block->getArguments());
 
   // Check for presence of `scf.forall` operations created by partial reduction
   // tiling.
@@ -98,7 +98,7 @@ static LogicalResult createDefaultWorkgroupCountRegion(
         IREE::TensorExt::DispatchWorkgroupCountSplitReductionModifierOp>(
         loc, defaultCountOp->getResults(), block->getArguments());
   }
-  rewriter.create<IREE::Flow::ReturnOp>(loc, defaultCountOp->getResults());
+  IREE::Flow::ReturnOp::create(rewriter, loc, defaultCountOp->getResults());
 
   // Update the `workgroupsOp` region.
   rewriter.modifyOpInPlace(workgroupsOp, [&]() {
@@ -117,9 +117,8 @@ static LogicalResult createDefaultWorkgroupCountRegion(
       if (!llvm::isa<IndexType>(operand.getType()))
         continue;
       BlockArgument arg = workgroupsOp.getInputBlockArgument(index);
-      auto ordinalOp =
-          rewriter.create<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
-              loc, arg, rewriter.getIndexAttr(ordinalNumber++));
+      auto ordinalOp = IREE::TensorExt::DispatchWorkloadOrdinalOp::create(
+          rewriter, loc, arg, rewriter.getIndexAttr(ordinalNumber++));
       rewriter.replaceAllUsesExcept(arg, ordinalOp, ordinalOp);
     }
   });

--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceFlowDispatchResultBySplat.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceFlowDispatchResultBySplat.cpp
@@ -53,8 +53,8 @@ void mlir::iree_compiler::Reducer::reduceFlowDispatchResultBySplatDelta(
   for (auto dispatchOp : keepOps) {
     builder.setInsertionPointAfter(dispatchOp);
     for (Value result : dispatchOp.getResults()) {
-      builder.create<IREE::Util::OptimizationBarrierOp>(dispatchOp.getLoc(),
-                                                        result);
+      IREE::Util::OptimizationBarrierOp::create(builder, dispatchOp.getLoc(),
+                                                result);
     }
   }
 
@@ -69,10 +69,10 @@ void mlir::iree_compiler::Reducer::reduceFlowDispatchResultBySplatDelta(
       auto tensorType = cast<RankedTensorType>(result.getType());
       auto elType = tensorType.getElementType();
       auto zeroAttr = builder.getZeroAttr(elType);
-      auto zero = builder.create<arith::ConstantOp>(result.getLoc(), zeroAttr);
+      auto zero = arith::ConstantOp::create(builder, result.getLoc(), zeroAttr);
 
-      auto splat = builder.create<IREE::Flow::TensorSplatOp>(
-          result.getLoc(), tensorType, zero, dynamicDims);
+      auto splat = IREE::Flow::TensorSplatOp::create(
+          builder, result.getLoc(), tensorType, zero, dynamicDims);
       result.replaceAllUsesWith(splat);
     }
 

--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceLinalgOnTensorsDelta.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceLinalgOnTensorsDelta.cpp
@@ -67,8 +67,8 @@ void mlir::iree_compiler::Reducer::reduceLinalgOnTensorsDelta(
   for (auto linalgOp : keepOps) {
     builder.setInsertionPointAfter(linalgOp);
     for (Value result : linalgOp->getResults()) {
-      builder.create<IREE::Util::OptimizationBarrierOp>(linalgOp.getLoc(),
-                                                        result);
+      IREE::Util::OptimizationBarrierOp::create(builder, linalgOp.getLoc(),
+                                                result);
     }
   }
 
@@ -112,7 +112,7 @@ void mlir::iree_compiler::Reducer::reduceLinalgOnTensorsDelta(
                     .getResult();
 
     // Build linalg.fill for this out.
-    newOut = builder.create<linalg::FillOp>(linalgOp.getLoc(), zero, init)
+    newOut = linalg::FillOp::create(builder, linalgOp.getLoc(), zero, init)
                  .getResult(0);
 
     out.replaceAllUsesWith(newOut);


### PR DESCRIPTION
The builder create methods are deprecated: https://mlir.llvm.org/deprecation/. See https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339. The main benefit of free functions is better tab completion with LSP/IDE.

This should take care of all the remaining uses of create methods.