### PR TITLE
[Codegen][AMDGPU] Drop backend reverts, emergency RDNA4 lowering fix

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -69,8 +69,13 @@ struct ReplaceGPUBarrierWithLDSBarrier
   }
 };
 
-static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns) {
-  patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
+static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns,
+                                               const amdgpu::Chipset &chipset) {
+  // TODO(kdrewnia): This if statement is an emergency fix for an incorrect
+  // lowering of amdgpu.lds_barrier.
+  if (chipset.majorVersion != 12) {
+    patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
+  }
 }
 
 /// Hacky pattern to swap `s_setprio` operations with `amdgpu.mfma` ops.
@@ -266,7 +271,7 @@ struct ConvertToROCDLPass final
           /*allowPackedF16Rtz=*/false, /*chipset=*/*maybeChipset);
       arith::populateCeilFloorDivExpandOpsPatterns(patterns);
       populateSwapSetPrioWithMFMAPatterns(patterns);
-      populateConvertGPUToAMDGPUPatterns(patterns);
+      populateConvertGPUToAMDGPUPatterns(patterns, *maybeChipset);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);


### PR DESCRIPTION
The lowering for amdgpu.lds_barrier upstream is incorrect in the face of the backend changes whose reverts this commit drops. The lowering will be fixed in the near future. Meanwhile, stick with gpu.barrier (incurring the full __synchthreads() semantics and thus potentially introduceing unwanted fencing on global memory) for RDNA4 until the issue upstream is resolved.

This may incur performance penalties in some cases.