### PR TITLE
[VectorDistribute] Use subgroup_basis instead of subgroup_m/n_count

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -133,9 +133,6 @@ struct ireeGPUSubgroupCountInfo {
   MlirAttribute subgroupNCountAttr;
 };
 
-MLIR_CAPI_EXPORTED ireeGPUSubgroupCountInfo
-ireeGPULoweringConfigAttrGetSubgroupCount(MlirAttribute attr);
-
 MLIR_CAPI_EXPORTED MlirAttribute
 ireeGPULoweringConfigAttrGetMmaKind(MlirAttribute attr);
 

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -466,24 +466,6 @@ NB_MODULE(_ireeCompilerDialects, m) {
             return getIntArrayAttrValues(tilesizes.reductionAttr);
           })
       .def_property_readonly(
-          "subgroup_count_mn",
-          [](MlirAttribute self) -> py::tuple {
-            ireeGPUSubgroupCountInfo info =
-                ireeGPULoweringConfigAttrGetSubgroupCount(self);
-            MlirAttribute mCountAttr = info.subgroupMCountAttr;
-            MlirAttribute nCountAttr = info.subgroupNCountAttr;
-            std::optional<int64_t> mCount;
-            if (!mlirAttributeIsNull(mCountAttr)) {
-              mCount = mlirIntegerAttrGetValueInt(mCountAttr);
-            }
-
-            std::optional<int64_t> nCount;
-            if (!mlirAttributeIsNull(nCountAttr)) {
-              nCount = mlirIntegerAttrGetValueInt(nCountAttr);
-            }
-            return py::make_tuple(mCount, nCount);
-          })
-      .def_property_readonly(
           "mma_kind", [](MlirAttribute self) -> std::optional<MlirAttribute> {
             auto attr = ireeGPULoweringConfigAttrGetMmaKind(self);
             if (!mlirAttributeIsNull(attr))

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -352,7 +352,6 @@ def lowering_config_attr():
     assert lowering_config.attributes == attributes
     assert lowering_config.workgroup_tile_sizes == []
     assert lowering_config.reduction_tile_sizes == []
-    assert lowering_config.subgroup_count_mn == (None, None)
     assert lowering_config.mma_kind == None
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
@@ -361,15 +360,12 @@ def lowering_config_attr():
         {
             "reduction": get_index_array_attr([1]),
             "workgroup": get_index_array_attr([2, 3]),
-            "subgroup_m_count": get_index_attr(1),
-            "subgroup_n_count": get_index_attr(2),
             "mma_kind": mma_attr,
         }
     )
     lowering_config = iree_gpu.LoweringConfigAttr.get(attributes)
     assert lowering_config.workgroup_tile_sizes == [2, 3]
     assert lowering_config.reduction_tile_sizes == [1]
-    assert lowering_config.subgroup_count_mn == (1, 2)
     assert lowering_config.mma_kind == mma_attr
     assert (
         str(lowering_config.mma_kind) == "#iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>"

--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -103,10 +103,10 @@ transform.named_sequence
   %decomposition_config = transform.param.constant {
     qk_attrs = {attention_qk_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
-                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+                                                              subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
     pv_attrs = {attention_pv_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+                                                              subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
   } -> !transform.any_param
 
   transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
@@ -146,7 +146,7 @@ transform.named_sequence
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                 subgroup_m_count = 2, subgroup_n_count = 2,
+                                                 subgroup_basis = [[2, 2, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 64],
                                                  workgroup = [64, 128, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -308,32 +308,6 @@ ireeGPUTileSizes ireeGPULoweringConfigAttrGetTileSizes(MlirAttribute attr) {
   return tilesizes;
 }
 
-ireeGPUSubgroupCountInfo
-ireeGPULoweringConfigAttrGetSubgroupCount(MlirAttribute attr) {
-  auto loweringConfigAttr =
-      llvm::cast<mlir::iree_compiler::IREE::GPU::LoweringConfigAttr>(
-          unwrap(attr));
-  std::optional<int64_t> subgroupMCount =
-      mlir::iree_compiler::IREE::GPU::getSubgroupMCount(loweringConfigAttr);
-  std::optional<int64_t> subgroupNCount =
-      mlir::iree_compiler::IREE::GPU::getSubgroupNCount(loweringConfigAttr);
-
-  ireeGPUSubgroupCountInfo info = {};
-
-  if (subgroupMCount) {
-    info.subgroupMCountAttr = wrap(mlir::IntegerAttr::get(
-        mlir::IndexType::get(loweringConfigAttr.getContext()),
-        *subgroupMCount));
-  }
-
-  if (subgroupNCount) {
-    info.subgroupNCountAttr = wrap(mlir::IntegerAttr::get(
-        mlir::IndexType::get(loweringConfigAttr.getContext()),
-        *subgroupNCount));
-  }
-  return info;
-}
-
 MlirAttribute ireeGPULoweringConfigAttrGetMmaKind(MlirAttribute attr) {
   auto loweringConfigAttr =
       llvm::cast<mlir::iree_compiler::IREE::GPU::LoweringConfigAttr>(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -900,7 +900,7 @@ FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
                               pvSchedule->mSize,
                               pvSchedule->kSize,
                               intrinsicAK,
-                              /*mSubgroupCount=*/schedule.mSubgroupCounts[0],
+                              /*mSubgroupCount=*/pvSchedule->mSubgroupCounts[0],
                               /*nSubgroupCount=*/1,
                               pvSchedule->mTileSizes[0],
                               pvSchedule->kTileSizes[0],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/decompose_horizontally_fused_gemms.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/decompose_horizontally_fused_gemms.mlir
@@ -22,8 +22,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
         attrs = {
             lowering_config = #iree_gpu.lowering_config<{
                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1, 2, 3],
-                reduction = [0, 0, 0, 0, 128], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
-                workgroup = [1, 1, 32, 32, 0]}>} {
+                reduction = [0, 0, 0, 0, 128], workgroup = [1, 1, 32, 32, 0]}>} {
     ^bb0(%in: f16, %in_0: f16, %in_1: f16, %in_2: f16, %out: f32, %out_3: f32, %out_4: f32):
       %7 = arith.extf %in : f16 to f32
       %8 = arith.extf %in_0 : f16 to f32
@@ -56,8 +55,6 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 //  CHECK-SAME:           promote_operands = [0, 1]
 //  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
-//  CHECK-SAME:           subgroup_m_count = 2
-//  CHECK-SAME:           subgroup_n_count = 2
 //  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
 //       CHECK:     ^bb0(%[[B0_0:[a-zA-Z0-9_]+]]: f16, %[[B1_0:[a-zA-Z0-9_]+]]: f16, %[[B2_0:[a-zA-Z0-9_]+]]: f32
 //   CHECK-DAG:       %[[LHS_0:.+]] = arith.extf %[[B0_0]]
@@ -76,8 +73,6 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 //  CHECK-SAME:           promote_operands = [0, 1]
 //  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
-//  CHECK-SAME:           subgroup_m_count = 2
-//  CHECK-SAME:           subgroup_n_count = 2
 //  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
 //       CHECK:     ^bb0(%[[B0_1:[a-zA-Z0-9_]+]]: f16, %[[B1_1:[a-zA-Z0-9_]+]]: f16, %[[B2_1:[a-zA-Z0-9_]+]]: f32
 //   CHECK-DAG:       %[[LHS_1:.+]] = arith.extf %[[B0_1]]
@@ -96,8 +91,6 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 //  CHECK-SAME:           promote_operands = [0, 1]
 //  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
-//  CHECK-SAME:           subgroup_m_count = 2
-//  CHECK-SAME:           subgroup_n_count = 2
 //  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
 //       CHECK:     ^bb0(%[[B0_2:[a-zA-Z0-9_]+]]: f16, %[[B1_2:[a-zA-Z0-9_]+]]: f16, %[[B2_2:[a-zA-Z0-9_]+]]: f32
 //   CHECK-DAG:       %[[LHS_2:.+]] = arith.extf %[[B0_2]]
@@ -130,7 +123,7 @@ func.func @fused_contraction_2(%arg0: tensor<4096x640xf32>,
         attrs = {
             lowering_config = #iree_gpu.lowering_config<{
                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, promote_operands = [0, 1, 2, 3],
-                reduction = [0, 0, 16], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [32, 64, 0]}>} {
+                reduction = [0, 0, 16], workgroup = [32, 64, 0]}>} {
     ^bb0(%in: f32, %in_0: f32, %in_1: f32, %in_2: f32, %out: f32, %out_3: f32, %out_4: f32):
       %4 = arith.mulf %in, %in_0 : f32
       %5 = arith.addf %out, %4 : f32

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -30,45 +30,6 @@ void setMmaKind(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
   attrs.emplace_back(kMmaKindName, kind);
 }
 
-// TODO: Merge subgroup counts functionality into subgroup tiling level
-//       lowering, when we have it implemented.
-constexpr StringLiteral kSubgroupMCountName = "subgroup_m_count";
-constexpr StringLiteral kSubgroupNCountName = "subgroup_n_count";
-
-std::optional<int64_t> getSubgroupMCount(LoweringConfigAttr config) {
-  auto subgroup_m_count_attr =
-      config.getAttributes().getAs<IntegerAttr>(kSubgroupMCountName);
-  if (!subgroup_m_count_attr) {
-    return std::nullopt;
-  }
-  return subgroup_m_count_attr.getInt();
-}
-
-std::optional<int64_t> getSubgroupNCount(LoweringConfigAttr config) {
-  auto subgroup_n_count_attr =
-      config.getAttributes().getAs<IntegerAttr>(kSubgroupNCountName);
-  if (!subgroup_n_count_attr) {
-    return std::nullopt;
-  }
-  return subgroup_n_count_attr.getInt();
-}
-
-void setSubgroupMCount(MLIRContext *context,
-                       SmallVectorImpl<NamedAttribute> &attrs,
-                       int64_t subgroup_m_count) {
-  attrs.emplace_back(
-      kSubgroupMCountName,
-      IntegerAttr::get(IntegerType::get(context, 64), subgroup_m_count));
-}
-
-void setSubgroupNCount(MLIRContext *context,
-                       SmallVectorImpl<NamedAttribute> &attrs,
-                       int64_t subgroup_n_count) {
-  attrs.emplace_back(
-      kSubgroupNCountName,
-      IntegerAttr::get(IntegerType::get(context, 64), subgroup_n_count));
-}
-
 const StringLiteral kSubgroupBasisName = "subgroup_basis";
 const StringLiteral kLaneBasisName = "lane_basis";
 
@@ -86,7 +47,7 @@ static StringLiteral getBasisLevelName(IREE::GPU::TilingLevel level) {
   }
 }
 
-void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
+void setBasis(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
               IREE::GPU::TilingLevel level, const Basis &basis) {
   Builder b(context);
   ArrayAttr basisAttr = b.getArrayAttr(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -16,18 +16,6 @@ IREE::Codegen::InnerTileDescAttrInterface getMmaKind(LoweringConfigAttr config);
 void setMmaKind(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
                 IREE::Codegen::InnerTileDescAttrInterface kind);
 
-// TODO: Merge subgroup counts functionality into subgroup tiling level
-//       lowering, when we have it implemented.
-/// Helper to retrieve/set a target subgroup M/N counts.
-std::optional<int64_t> getSubgroupMCount(LoweringConfigAttr config);
-std::optional<int64_t> getSubgroupNCount(LoweringConfigAttr config);
-void setSubgroupMCount(MLIRContext *context,
-                       SmallVectorImpl<NamedAttribute> &attrs,
-                       int64_t subgroupMCount);
-void setSubgroupNCount(MLIRContext *context,
-                       SmallVectorImpl<NamedAttribute> &attrs,
-                       int64_t subgroupNCount);
-
 // The basis consists of two integer arrays:
 //   - "counts": number of resource to use per dimension in the basis.
 //   - "mapping": a projected permutation to map to basis to the operations
@@ -46,7 +34,7 @@ struct Basis {
 // Helper to retrieve/set distribution basis.
 FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
                           IREE::GPU::TilingLevel level);
-void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
+void setBasis(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
               IREE::GPU::TilingLevel level, const Basis &basis);
 
 /// Helper to retrieve a list of operand indices to promote.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -874,6 +874,21 @@ setReductionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 // Vector Distribution Contraction/Convolution Pipeline Configuration
 //====---------------------------------------------------------------------===//
 
+static IREE::GPU::Basis projectBasis(const IREE::GPU::Basis &basis,
+                                     ArrayRef<int64_t> projectedDims) {
+  // Projection simply involves projecting the mapping and keeping the counts.
+  IREE::GPU::Basis projectedBasis;
+  projectedBasis.counts = basis.counts;
+  SetVector<int64_t> projected(projectedDims.begin(), projectedDims.end());
+  for (auto [dim, map] : llvm::enumerate(basis.mapping)) {
+    if (projected.contains(dim)) {
+      continue;
+    }
+    projectedBasis.mapping.push_back(map);
+  }
+  return projectedBasis;
+}
+
 static LogicalResult
 setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
                                        mlir::FunctionOpInterface entryPoint,
@@ -1002,6 +1017,8 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
     return failure();
   }
 
+  LDBG() << "Schedule: " << schedule;
+
   int64_t flatWorkgroupSize =
       targetSubgroupSize *
       ShapedType::getNumElements(schedule->nSubgroupCounts) *
@@ -1043,8 +1060,15 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   IREE::GPU::setMmaKind(context, attrs, schedule->mmaKind);
-  IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
-  IREE::GPU::setSubgroupNCount(context, attrs, schedule->nSubgroupCounts[0]);
+  IREE::GPU::Basis subgroupBasis = {
+      SmallVector<int64_t>(op.getNumLoops(), 1),
+      // Distribute subgroups from outer to inner. Mostly an arbitrary choice.
+      // We can change this if it matters.
+      llvm::to_vector(llvm::seq<int64_t>(op.getNumLoops()))};
+  subgroupBasis.counts[mDim] = schedule->mSubgroupCounts[0];
+  subgroupBasis.counts[nDim] = schedule->nSubgroupCounts[0];
+  IREE::GPU::setBasis(context, attrs, IREE::GPU::TilingLevel::Subgroup,
+                      subgroupBasis);
 
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
@@ -1296,8 +1320,15 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
       llvm::to_vector(llvm::seq<int64_t>(op.getNumDpsInputs()));
   IREE::GPU::appendPromotedOperandsList(context, attrs, promotedOperands);
   IREE::GPU::setMmaKind(context, attrs, schedule->mmaKind);
-  IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
-  IREE::GPU::setSubgroupNCount(context, attrs, schedule->nSubgroupCounts[0]);
+  IREE::GPU::Basis subgroupBasis = {
+      SmallVector<int64_t>(op.getNumLoops(), 1),
+      // Distribute subgroups from outer to inner. Mostly an arbitrary choice.
+      // We can change this if it matters.
+      llvm::to_vector(llvm::seq<int64_t>(op.getNumLoops()))};
+  subgroupBasis.counts[mDim] = schedule->mSubgroupCounts[0];
+  subgroupBasis.counts[nDim] = schedule->nSubgroupCounts[0];
+  IREE::GPU::setBasis(context, attrs, IREE::GPU::TilingLevel::Subgroup,
+                      subgroupBasis);
 
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
@@ -1476,14 +1507,6 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
 
   auto [qkSchedule, pvSchedule] = attSchedule.value();
 
-  // TODO: Due to a bug in layout configuration, we cannot set warp count on
-  // the N dimension. This is however ok, because we generally do not want to
-  // distribute subgroups on N dimension anyway.
-  if (pvSchedule.nSubgroupCounts[0] != 1) {
-    pvSchedule.nTileSizes[0] *= pvSchedule.nSubgroupCounts[0];
-    pvSchedule.nSubgroupCounts[0] = 1;
-  }
-
   LDBG() << "Target Subgroup size: " << targetSubgroupSize;
   LDBG() << "QK Schedule: " << qkSchedule;
   LDBG() << "PV Schedule: " << pvSchedule;
@@ -1538,21 +1561,29 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   SmallVector<NamedAttribute, 2> qkConfig;
   SmallVector<NamedAttribute, 2> pvConfig;
 
+  IREE::GPU::Basis subgroupBasis = {
+      SmallVector<int64_t>(opInfo.getDomainRank(), 1),
+      // Distribute subgroups from outer to inner. Mostly an arbitrary choice.
+      // We can change this if it matters.
+      llvm::to_vector(llvm::seq<int64_t>(opInfo.getDomainRank()))};
+  if (mDim.has_value()) {
+    subgroupBasis.counts[mDim.value()] = pvSchedule.mSubgroupCounts[0];
+  }
+  if (nDim.has_value()) {
+    subgroupBasis.counts[nDim.value()] = pvSchedule.nSubgroupCounts[0];
+  }
+
   // Configuring for qk matmul.
   IREE::GPU::appendPromotedOperandsList(context, qkConfig, {0, 1});
   IREE::GPU::setMmaKind(context, qkConfig, qkSchedule.mmaKind);
-  IREE::GPU::setSubgroupMCount(context, qkConfig,
-                               qkSchedule.mSubgroupCounts[0]);
-  IREE::GPU::setSubgroupNCount(context, qkConfig,
-                               qkSchedule.nSubgroupCounts[0]);
+  IREE::GPU::setBasis(context, qkConfig, IREE::GPU::TilingLevel::Subgroup,
+                      projectBasis(subgroupBasis, opInfo.getNDims()));
 
   // Configuring for pv matmul.
   IREE::GPU::appendPromotedOperandsList(context, pvConfig, {1});
   IREE::GPU::setMmaKind(context, pvConfig, pvSchedule.mmaKind);
-  IREE::GPU::setSubgroupMCount(context, pvConfig,
-                               pvSchedule.mSubgroupCounts[0]);
-  IREE::GPU::setSubgroupNCount(context, pvConfig,
-                               pvSchedule.nSubgroupCounts[0]);
+  IREE::GPU::setBasis(context, pvConfig, IREE::GPU::TilingLevel::Subgroup,
+                      projectBasis(subgroupBasis, opInfo.getK1Dims()));
 
   SmallVector<NamedAttribute, 2> qkAttrs;
   SmallVector<NamedAttribute, 2> pvAttrs;
@@ -1601,21 +1632,6 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig, CodeGenPipeline::LLVMGPUVectorDistribute,
       workgroupSize, targetSubgroupSize, pipelineConfig);
-}
-
-static IREE::GPU::Basis projectBasis(const IREE::GPU::Basis &basis,
-                                     ArrayRef<int64_t> projectedDims) {
-  // Projection simply involves projecting the mapping and keeping the counts.
-  IREE::GPU::Basis projectedBasis;
-  projectedBasis.counts = basis.counts;
-  SetVector<int64_t> projected(projectedDims.begin(), projectedDims.end());
-  for (auto [dim, map] : llvm::enumerate(basis.mapping)) {
-    if (projected.contains(dim)) {
-      continue;
-    }
-    projectedBasis.mapping.push_back(map);
-  }
-  return projectedBasis;
 }
 
 struct AttentionReductionHeuristicSeeds {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -66,18 +66,84 @@ static IREE::Codegen::InnerTileDescAttrInterface getIntrinsic(Operation *op) {
   return mmaIntrinsic;
 }
 
-static int64_t getSubgroupMCount(Operation *op) {
-  auto config = getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
-  assert(config && "Cannot find intrinsic from unconfigured op.");
+/// Given two arrays bounds and tile, compute bounds /= tile.
+///
+/// If "tile" contains 0, or is smaller than bounds, divide bounds by 1
+/// for those values.
+///
+/// Returns the actual divisor (without zeros or out of bounds) used to compute
+/// bounds /= divisor.
+FailureOr<SmallVector<int64_t>> divideTile(SmallVector<int64_t> &bounds,
+                                           ArrayRef<int64_t> tile) {
+  assert(bounds.size() >= tile.size() &&
+         "cannot divide bounds with a larger tile size");
 
-  return getSubgroupMCount(config).value();
+  SmallVector<int64_t> divisor(bounds.size(), 1);
+  for (auto [div, size] : llvm::zip(divisor, tile)) {
+    if (size == 0) {
+      continue;
+    }
+    div = size;
+  }
+
+  for (auto [bound, div] : llvm::zip_equal(bounds, divisor)) {
+    bound /= div;
+  }
+
+  return divisor;
 }
 
-static int64_t getSubgroupNCount(Operation *op) {
-  auto config = getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
-  assert(config && "Cannot find intrinsic from unconfigured op.");
+SmallVector<int64_t> applyProjectedPermutation(ArrayRef<int64_t> input,
+                                               ArrayRef<int64_t> perm) {
+  SmallVector<int64_t> result;
+  result.reserve(perm.size());
+  for (int64_t dim : perm) {
+    result.push_back(input[dim]);
+  }
+  return result;
+}
 
-  return getSubgroupNCount(config).value();
+SmallVector<int64_t> getStridesFromBasis(ArrayRef<int64_t> basis) {
+  SmallVector<int64_t> strides(basis.size());
+  int64_t currStride = 1;
+  for (auto [stride, size] : llvm::reverse(llvm::zip_equal(strides, basis))) {
+    stride = currStride;
+    currStride *= size;
+  }
+  return strides;
+}
+
+static LogicalResult distributeTilingSizes(Operation *candidate,
+                                           IREE::GPU::LoweringConfigAttr config,
+                                           IREE::GPU::TilingLevel level,
+                                           SmallVector<int64_t> &bounds,
+                                           SmallVector<int64_t> &sizes,
+                                           SmallVector<int64_t> &strides) {
+  if (ShapedType::isDynamicShape(bounds)) {
+    candidate->emitError()
+        << "Cannot set layouts on a dynamically shaped iteration space";
+    return failure();
+  }
+
+  FailureOr<IREE::GPU::Basis> basis = IREE::GPU::getBasis(config, level);
+  if (failed(basis)) {
+    candidate->emitError()
+        << "Could not find a subgroup basis from lowering config";
+    return failure();
+  }
+
+  sizes = applyProjectedPermutation(basis->counts, basis->mapping);
+  strides = applyProjectedPermutation(getStridesFromBasis(basis->counts),
+                                      basis->mapping);
+
+  if (failed(divideTile(bounds, sizes))) {
+    candidate->emitError()
+        << "Could not divide bounds over given basis for level: "
+        << IREE::GPU::stringifyTilingLevel(level);
+    return failure();
+  }
+
+  return success();
 }
 
 struct ContractionLayout {
@@ -92,12 +158,16 @@ struct ContractionLayout {
 // The contraction is expected to have 3 operands: lhs, rhs and acc of the
 // contraction and a single accumulator.
 static FailureOr<ContractionLayout>
-getContractionLayout(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                     int64_t subgroupMCount, int64_t subgroupNCount,
-                     ArrayRef<int64_t> bounds,
+getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
                      ArrayRef<AffineMap> contractIndexingMaps) {
-  auto mmaIntrinsic = dyn_cast<IREE::GPU::MmaInterfaceAttr>(intrinsic);
-  if (!mmaIntrinsic) {
+  auto config = getLoweringConfig<IREE::GPU::LoweringConfigAttr>(candidate);
+  if (!config) {
+    return failure();
+  }
+
+  auto intrinsic =
+      dyn_cast_if_present<IREE::GPU::MmaInterfaceAttr>(getIntrinsic(candidate));
+  if (!intrinsic) {
     return failure();
   }
 
@@ -112,32 +182,27 @@ getContractionLayout(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
   int64_t innerMDim = opInfo.getMDims().back();
   int64_t innerNDim = opInfo.getNDims().back();
   int64_t innerKDim = opInfo.getKDims().back();
-  // Find the number Of subgroups being used from subgroupMCount/subgroupNCount.
-  // Just assign them to the inner-most dimension for now.
-  // TODO: Use subgroup_basis to get this instead and allow distributing
-  // subgroups on multiple dimensions.
-  SmallVector<int64_t> subgroupCounts(rank, 1);
-  SmallVector<int64_t> subgroupStrides(rank, 0);
-  subgroupCounts[innerMDim] = subgroupMCount;
-  subgroupCounts[innerNDim] = subgroupNCount;
-  // Distribute on M and then N.
-  // TODO: Use subgroup_basis to get the strides.
-  subgroupStrides[innerMDim] = 1;
-  subgroupStrides[innerNDim] = subgroupMCount;
+
+  SmallVector<int64_t> batchCounts(bounds);
+
+  // Subgroup distribution layouts.
+  SmallVector<int64_t> subgroupCounts, subgroupStrides;
+  if (failed(distributeTilingSizes(
+          candidate, config, IREE::GPU::TilingLevel::Subgroup, batchCounts,
+          subgroupCounts, subgroupStrides))) {
+    return failure();
+  }
 
   // Since these MMA intrinsics have a given tile size for each subgroup, we can
   // calculate the batch dimensions without looking at the subgroup layout.
   SmallVector<int64_t> subgroupSize(rank, 1);
-  auto [mSize, nSize, kSize] = mmaIntrinsic.getMNKShape();
+  auto [mSize, nSize, kSize] = intrinsic.getMNKShape();
   subgroupSize[innerMDim] = mSize;
   subgroupSize[innerNDim] = nSize;
   subgroupSize[innerKDim] = kSize;
 
-  SmallVector<int64_t> batchCounts(rank);
-  for (auto [batchCount, subgroupCount, subgroupSize, bound] :
-       llvm::zip_equal(batchCounts, subgroupCounts, subgroupSize, bounds)) {
-    int64_t workgroupDimSize = subgroupCount * subgroupSize;
-    batchCount = llvm::divideCeil(bound, workgroupDimSize);
+  for (auto i : llvm::seq<int64_t>(rank)) {
+    batchCounts[i] = llvm::divideCeil(batchCounts[i], subgroupSize[i]);
   }
 
   // MMA intrinsics can be weird and usually don't have a single subgroup
@@ -199,24 +264,17 @@ SmallVector<int64_t> getIterationSpaceBounds(linalg::LinalgOp linalgOp) {
   return bounds;
 }
 
-struct MMASchedule {
-  IREE::Codegen::InnerTileDescAttrInterface intrinsic;
-  int64_t subgroupMCount;
-  int64_t subgroupNCount;
-};
-
-static LogicalResult setContractionAnchor(MMASchedule &schedule,
-                                          SmallVector<bool> promotedOperands,
-                                          RewriterBase &rewriter,
-                                          linalg::LinalgOp contract) {
+static LogicalResult
+setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+                     SmallVector<bool> promotedOperands, RewriterBase &rewriter,
+                     linalg::LinalgOp contract) {
   // This function should have only be called on a contraction op.
   assert(linalg::isaContractionOpInterface(contract) &&
          "cannot set contraction anchor on non contraction op");
 
   SmallVector<int64_t> bounds = getIterationSpaceBounds(contract);
-  auto layouts = getContractionLayout(
-      schedule.intrinsic, schedule.subgroupMCount, schedule.subgroupNCount,
-      bounds, contract.getIndexingMapsArray());
+  auto layouts =
+      getContractionLayout(contract, bounds, contract.getIndexingMapsArray());
   if (failed(layouts)) {
     return contract->emitError("cannot get concrete layout for contraction");
   }
@@ -230,12 +288,9 @@ static LogicalResult setContractionAnchor(MMASchedule &schedule,
 
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(contract);
-  auto layoutedLhs =
-      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.intrinsic);
-  auto layoutedRhs =
-      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.intrinsic);
-  auto layoutedAcc =
-      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.intrinsic);
+  auto layoutedLhs = rewriter.create<ToLayoutOp>(loc, lhs, aLayout, intrinsic);
+  auto layoutedRhs = rewriter.create<ToLayoutOp>(loc, rhs, bLayout, intrinsic);
+  auto layoutedAcc = rewriter.create<ToLayoutOp>(loc, acc, cLayout, intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -258,18 +313,18 @@ static LogicalResult setContractionAnchor(MMASchedule &schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(contract);
-  auto toLayout = ToLayoutOp::create(rewriter, loc, contract->getResult(0),
-                                     cLayout, schedule.intrinsic);
+  auto toLayout = rewriter.create<ToLayoutOp>(loc, contract->getResult(0),
+                                              cLayout, intrinsic);
   rewriter.replaceAllUsesExcept(contract->getResult(0), toLayout.getResult(),
                                 toLayout);
 
   return success();
 }
 
-static LogicalResult setConvolutionAnchor(MMASchedule schedule,
-                                          SmallVector<bool> promotedOperands,
-                                          RewriterBase &rewriter,
-                                          linalg::LinalgOp conv) {
+static LogicalResult
+setConvolutionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+                     SmallVector<bool> promotedOperands, RewriterBase &rewriter,
+                     linalg::LinalgOp conv) {
   // This function should have only be called on a convolution op.
   FailureOr<linalg::ConvolutionDimensions> convDims =
       linalg::inferConvolutionDims(conv);
@@ -295,8 +350,7 @@ static LogicalResult setConvolutionAnchor(MMASchedule schedule,
 
   SmallVector<int64_t> bounds = getIterationSpaceBounds(conv);
   FailureOr<ContractionLayout> layouts =
-      getContractionLayout(schedule.intrinsic, schedule.subgroupMCount,
-                           schedule.subgroupNCount, bounds, maps);
+      getContractionLayout(conv, bounds, maps);
 
   auto [aLayout, bLayout, cLayout] = *layouts;
   Location loc = conv.getLoc();
@@ -307,12 +361,9 @@ static LogicalResult setConvolutionAnchor(MMASchedule schedule,
 
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(conv);
-  auto layoutedLhs =
-      ToLayoutOp::create(rewriter, loc, lhs, aLayout, schedule.intrinsic);
-  auto layoutedRhs =
-      ToLayoutOp::create(rewriter, loc, rhs, bLayout, schedule.intrinsic);
-  auto layoutedAcc =
-      ToLayoutOp::create(rewriter, loc, acc, cLayout, schedule.intrinsic);
+  auto layoutedLhs = rewriter.create<ToLayoutOp>(loc, lhs, aLayout, intrinsic);
+  auto layoutedRhs = rewriter.create<ToLayoutOp>(loc, rhs, bLayout, intrinsic);
+  auto layoutedAcc = rewriter.create<ToLayoutOp>(loc, acc, cLayout, intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -335,8 +386,8 @@ static LogicalResult setConvolutionAnchor(MMASchedule schedule,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(conv);
-  auto toLayout = ToLayoutOp::create(rewriter, loc, conv->getResult(0), cLayout,
-                                     schedule.intrinsic);
+  auto toLayout =
+      rewriter.create<ToLayoutOp>(loc, conv->getResult(0), cLayout, intrinsic);
   rewriter.replaceAllUsesExcept(conv->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -400,12 +451,6 @@ static void swapOperandsToTransposeIntrinsic(RewriterBase &rewriter,
 static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
                                               linalg::LinalgOp qkMatmul,
                                               linalg::LinalgOp pvMatmul) {
-
-  MMASchedule qkSchedule = {getIntrinsic(qkMatmul), getSubgroupMCount(qkMatmul),
-                            getSubgroupNCount(qkMatmul)};
-  MMASchedule pvSchedule = {getIntrinsic(pvMatmul), getSubgroupMCount(pvMatmul),
-                            getSubgroupNCount(pvMatmul)};
-
   // Check if the intrinsic output for qkMatmul can be reused for pvMatmul.
   // We know that pvMatmul takes result of qkMatmul as it's lhs.
   // If the intrinsic output of pvMatmul can be used as rhs of pvMatmul,
@@ -413,10 +458,10 @@ static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
   bool reuseIntrinsicOutput = false;
   bool transposeIntrinsic = false;
 
-  auto qkIntrinsic =
-      cast<IREE::Codegen::InnerTileDescAttrInterface>(qkSchedule.intrinsic);
-  auto pvIntrinsic =
-      cast<IREE::Codegen::InnerTileDescAttrInterface>(pvSchedule.intrinsic);
+  IREE::Codegen::InnerTileDescAttrInterface qkIntrinsic =
+      getIntrinsic(qkMatmul);
+  IREE::Codegen::InnerTileDescAttrInterface pvIntrinsic =
+      getIntrinsic(pvMatmul);
   IREE::GPU::MMASingleSubgroupLayout lhsLayout =
       getSingleSubgroupLayout(pvIntrinsic, IREE::GPU::MMAFragment::Lhs);
   IREE::GPU::MMASingleSubgroupLayout rhsLayout =
@@ -459,20 +504,18 @@ static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
     }
     swapOperandsToTransposeIntrinsic(rewriter, qkGeneric);
     swapOperandsToTransposeIntrinsic(rewriter, pvGeneric);
-    std::swap(qkSchedule.subgroupMCount, qkSchedule.subgroupNCount);
-    std::swap(pvSchedule.subgroupMCount, pvSchedule.subgroupNCount);
 
     // Swap promoted operands.
     std::swap(promotedQKOperands[0], promotedQKOperands[1]);
     std::swap(promotedPVOperands[0], promotedPVOperands[1]);
   }
 
-  if (failed(setContractionAnchor(qkSchedule, promotedQKOperands, rewriter,
+  if (failed(setContractionAnchor(qkIntrinsic, promotedQKOperands, rewriter,
                                   qkMatmul))) {
     return failure();
   }
 
-  return setContractionAnchor(pvSchedule, promotedPVOperands, rewriter,
+  return setContractionAnchor(pvIntrinsic, promotedPVOperands, rewriter,
                               pvMatmul);
 }
 
@@ -565,18 +608,17 @@ static LogicalResult setIntrinsicLoweringConfigLayout(
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
 
   SmallVector<bool> promotedOperands = getPromotedOperands(candidate);
-  MMASchedule schedule = {getIntrinsic(candidate), getSubgroupMCount(candidate),
-                          getSubgroupNCount(candidate)};
+  IREE::Codegen::InnerTileDescAttrInterface intrinsic = getIntrinsic(candidate);
 
   if (linalg::isaContractionOpInterface(candidate)) {
-    if (succeeded(setContractionAnchor(schedule, promotedOperands, rewriter,
+    if (succeeded(setContractionAnchor(intrinsic, promotedOperands, rewriter,
                                        candidate))) {
       return success();
     }
   }
 
   if (succeeded(linalg::inferConvolutionDims(candidate))) {
-    if (succeeded(setConvolutionAnchor(schedule, promotedOperands, rewriter,
+    if (succeeded(setConvolutionAnchor(intrinsic, promotedOperands, rewriter,
                                        candidate))) {
       return success();
     }
@@ -586,86 +628,6 @@ static LogicalResult setIntrinsicLoweringConfigLayout(
                             "based on given lowering config: "
                          << config;
   return failure();
-}
-
-/// Given two arrays bounds and tile, compute bounds /= tile.
-///
-/// If "tile" contains 0, or is smaller than bounds, divide bounds by 1
-/// for those values.
-///
-/// Returns the actual divisor (without zeros or out of bounds) used to compute
-/// bounds /= divisor.
-FailureOr<SmallVector<int64_t>> divideTile(SmallVector<int64_t> &bounds,
-                                           ArrayRef<int64_t> tile) {
-  assert(bounds.size() >= tile.size() &&
-         "cannot divide bounds with a larger tile size");
-
-  SmallVector<int64_t> divisor(bounds.size(), 1);
-  for (auto [div, size] : llvm::zip(divisor, tile)) {
-    if (size == 0) {
-      continue;
-    }
-    div = size;
-  }
-
-  for (auto [bound, div] : llvm::zip_equal(bounds, divisor)) {
-    bound /= div;
-  }
-
-  return divisor;
-}
-
-SmallVector<int64_t> applyProjectedPermutation(ArrayRef<int64_t> input,
-                                               ArrayRef<int64_t> perm) {
-  SmallVector<int64_t> result;
-  result.reserve(perm.size());
-  for (int64_t dim : perm) {
-    result.push_back(input[dim]);
-  }
-  return result;
-}
-
-SmallVector<int64_t> getStridesFromBasis(ArrayRef<int64_t> basis) {
-  SmallVector<int64_t> strides(basis.size());
-  int64_t currStride = 1;
-  for (auto [stride, size] : llvm::reverse(llvm::zip_equal(strides, basis))) {
-    stride = currStride;
-    currStride *= size;
-  }
-  return strides;
-}
-
-static LogicalResult distributeTilingSizes(linalg::LinalgOp candidate,
-                                           IREE::GPU::LoweringConfigAttr config,
-                                           IREE::GPU::TilingLevel level,
-                                           SmallVector<int64_t> &bounds,
-                                           SmallVector<int64_t> &sizes,
-                                           SmallVector<int64_t> &strides) {
-  if (ShapedType::isDynamicShape(bounds)) {
-    candidate->emitError()
-        << "Cannot set layouts on a dynamically shaped iteration space";
-    return failure();
-  }
-
-  FailureOr<IREE::GPU::Basis> basis = IREE::GPU::getBasis(config, level);
-  if (failed(basis)) {
-    candidate->emitError()
-        << "Could not find a subgroup basis from lowering config";
-    return failure();
-  }
-
-  sizes = applyProjectedPermutation(basis->counts, basis->mapping);
-  strides = applyProjectedPermutation(getStridesFromBasis(basis->counts),
-                                      basis->mapping);
-
-  if (failed(divideTile(bounds, sizes))) {
-    candidate->emitError()
-        << "Could not divide bounds over given basis for level: "
-        << IREE::GPU::stringifyTilingLevel(level);
-    return failure();
-  }
-
-  return success();
 }
 
 static LogicalResult setGPULoweringConfigLayout(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -288,9 +288,9 @@ setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
 
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(contract);
-  auto layoutedLhs = rewriter.create<ToLayoutOp>(loc, lhs, aLayout, intrinsic);
-  auto layoutedRhs = rewriter.create<ToLayoutOp>(loc, rhs, bLayout, intrinsic);
-  auto layoutedAcc = rewriter.create<ToLayoutOp>(loc, acc, cLayout, intrinsic);
+  auto layoutedLhs = ToLayoutOp::create(rewriter, loc, lhs, aLayout, intrinsic);
+  auto layoutedRhs = ToLayoutOp::create(rewriter, loc, rhs, bLayout, intrinsic);
+  auto layoutedAcc = ToLayoutOp::create(rewriter, loc, acc, cLayout, intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -313,8 +313,8 @@ setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
 
   // Set layout for result.
   rewriter.setInsertionPointAfter(contract);
-  auto toLayout = rewriter.create<ToLayoutOp>(loc, contract->getResult(0),
-                                              cLayout, intrinsic);
+  auto toLayout = ToLayoutOp::create(rewriter, loc, contract->getResult(0),
+                                     cLayout, intrinsic);
   rewriter.replaceAllUsesExcept(contract->getResult(0), toLayout.getResult(),
                                 toLayout);
 
@@ -361,9 +361,9 @@ setConvolutionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
 
   // Set layouts for lhs, rhs and acc.
   rewriter.setInsertionPoint(conv);
-  auto layoutedLhs = rewriter.create<ToLayoutOp>(loc, lhs, aLayout, intrinsic);
-  auto layoutedRhs = rewriter.create<ToLayoutOp>(loc, rhs, bLayout, intrinsic);
-  auto layoutedAcc = rewriter.create<ToLayoutOp>(loc, acc, cLayout, intrinsic);
+  auto layoutedLhs = ToLayoutOp::create(rewriter, loc, lhs, aLayout, intrinsic);
+  auto layoutedRhs = ToLayoutOp::create(rewriter, loc, rhs, bLayout, intrinsic);
+  auto layoutedAcc = ToLayoutOp::create(rewriter, loc, acc, cLayout, intrinsic);
 
   // Promote matmul lhs and rhs.
   // TODO: This is a hack until layout analysis is improved. The layout analysis
@@ -387,7 +387,7 @@ setConvolutionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
   // Set layout for result.
   rewriter.setInsertionPointAfter(conv);
   auto toLayout =
-      rewriter.create<ToLayoutOp>(loc, conv->getResult(0), cLayout, intrinsic);
+      ToLayoutOp::create(rewriter, loc, conv->getResult(0), cLayout, intrinsic);
   rewriter.replaceAllUsesExcept(conv->getResult(0), toLayout.getResult(),
                                 toLayout);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -16,7 +16,7 @@
 // OPT-IN-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                    subgroup_m_count = 2, subgroup_n_count = 2}>
+                                    subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -88,7 +88,7 @@ hal.executable public @main_0_dispatch_0 {
 // OPT-IN-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                    subgroup_m_count = 2, subgroup_n_count = 2}>
+                                    subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -155,7 +155,7 @@ hal.executable public @main_0_dispatch_0 {
 // OPT-OUT-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <None>>
 #config = #iree_gpu.lowering_config<{workgroup = [128, 128, 0], reduction = [0, 0, 32], promote_operands = [0, 1],
                                     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                    subgroup_m_count = 2, subgroup_n_count = 2}>
+                                    subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx1100.mlir
@@ -33,6 +33,5 @@ func.func @wmma_matmul_1024x1024x1024() {
 // WMMA: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // WMMA-SAME:                           mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>
 // WMMA-SAME:                           reduction =  [0, 0, 64]
-// WMMA-SAME:                           subgroup_m_count = 2
-// WMMA-SAME:                           subgroup_n_count = 2
+// WMMA-LITERAL-SAME:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // WMMA-SAME:                           workgroup =  [64, 128, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -40,8 +40,7 @@ func.func @expanded_matmul_transpose_b() {
 // CHECK: linalg.generic {{.*}}lowering_config =  #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 128]
-// CHECK-SAME:                           subgroup_m_count = 1
-// CHECK-SAME:                           subgroup_n_count = 4
+// CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 64, 0]
 
 // -----
@@ -72,8 +71,7 @@ func.func @conv_nhwc() {
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 32]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 128, 0, 0, 0]
 
 // -----
@@ -137,8 +135,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 64]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
 // -----
@@ -188,8 +185,7 @@ func.func @conv_nchwc() {
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 32]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]
 
 // -----
@@ -263,8 +259,10 @@ func.func @attention_20x4096x64x4096x64() {
 }
 
 // CHECK:                #iree_gpu.lowering_config
-// CHECK-SAME:                           subgroup_m_count = 4
-// CHECK-SAME:                           subgroup_n_count = 1
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 3, 4]]
+// CHECK-SAME:           #iree_gpu.lowering_config
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 2, 3]]
+// CHECK-SAME:           #iree_gpu.lowering_config
 // CHECK-SAME:                           reduction =  [0, 0, 0, 64, 0]
 // CHECK-SAME:                           workgroup =  [1, 64, 0, 0, 64]
 
@@ -305,10 +303,12 @@ func.func @attention_20x4096x64x4096x64_f8() {
   return
 }
 
-// CHECK:      VMFMA_F32_16x16x32_F8E4M3FNUZ
-// CHECK-SAME: MFMA_F32_16x16x32_F8E4M3FNUZ
-// CHECK-SAME: subgroup_m_count = 4
-// CHECK-SAME: subgroup_n_count = 1
+// CHECK:                #iree_gpu.lowering_config
+// CHECK-SAME:            VMFMA_F32_16x16x32_F8E4M3FNUZ
+// CHECK-SAME{LITERAL}:   subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 3, 4]]
+// CHECK-SAME:           #iree_gpu.lowering_config
+// CHECK-SAME:            MFMA_F32_16x16x32_F8E4M3FNUZ
+// CHECK-SAME{LITERAL}:   subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 2, 3]]
 // CHECK-SAME: reduction =  [0, 0, 0, 128, 0]
 // CHECK-SAME: workgroup =  [1, 64, 0, 0, 64]
 
@@ -353,10 +353,12 @@ func.func @attention_large_head_dim_shared_mem() {
 }
 
 // CHECK:                #iree_gpu.lowering_config
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 1
-// CHECK-SAME:                           reduction =  [0, 0, 16, 0]
-// CHECK-SAME:                           workgroup =  [32, 0, 0, 16]
+// CHECK-SAME{LITERAL}:   subgroup_basis = [[2, 1, 1, 1], [0, 2, 3]]
+// CHECK-SAME:           #iree_gpu.lowering_config
+// CHECK-SAME{LITERAL}:   subgroup_basis = [[2, 1, 1, 1], [0, 1, 2]]
+// CHECK:                #iree_gpu.lowering_config
+// CHECK-SAME: reduction =  [0, 0, 16, 0]
+// CHECK-SAME: workgroup =  [32, 0, 0, 16]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -40,8 +40,7 @@ func.func @expanded_matmul_transpose_b() {
 // CHECK: linalg.generic {{.*}}lowering_config =  #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 256]
-// CHECK-SAME:                           subgroup_m_count = 1
-// CHECK-SAME:                           subgroup_n_count = 4
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 64, 0]
 
 // -----
@@ -72,8 +71,7 @@ func.func @conv_nhwc() {
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 64]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 128, 0, 0, 0]
 
 // -----
@@ -104,8 +102,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 128]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
 // -----
@@ -155,8 +152,7 @@ func.func @conv_nchwc() {
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
-// CHECK-SAME:                           subgroup_m_count = 2
-// CHECK-SAME:                           subgroup_n_count = 2
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]
 
 // -----
@@ -230,9 +226,9 @@ func.func @attention_20x4096x64x4096x64() {
 }
 
 // CHECK:      MFMA_F32_16x16x16_F16
+// CHECK-SAME{LITERAL}: subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 3, 4]]
 // CHECK-SAME: MFMA_F32_16x16x32_F16
-// CHECK-SAME: subgroup_m_count = 4
-// CHECK-SAME: subgroup_n_count = 1
+// CHECK-SAME{LITERAL}: subgroup_basis = [[1, 4, 1, 1, 1], [0, 1, 2, 3]]
 // CHECK-SAME: reduction =  [0, 0, 0, 64, 0]
 // CHECK-SAME: workgroup =  [1, 64, 0, 0, 64]
 
@@ -278,9 +274,9 @@ func.func @attention_large_head_dim_shared_mem() {
 }
 
 // CHECK:      MFMA_F32_16x16x16_F16
+// CHECK-SAME{LITERAL}: subgroup_basis = [[4, 1, 1, 1], [0, 2, 3]]
 // CHECK-SAME: MFMA_F32_16x16x32_F16
-// CHECK-SAME: subgroup_m_count = 4
-// CHECK-SAME: subgroup_n_count = 1
+// CHECK-SAME{LITERAL}: subgroup_basis = [[4, 1, 1, 1], [0, 1, 2]]
 // CHECK-SAME: reduction =  [0, 0, 64, 0]
 // CHECK-SAME: workgroup =  [64, 0, 0, 64]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -3,7 +3,7 @@
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
 // RUN:   %s | FileCheck %s
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -49,7 +49,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F16_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], mma_kind = #iree_gpu.mma_layout<WMMAR3_F16_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -8,7 +8,7 @@
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target{for-rocdl=true})))))" \
 // RUN:   %s | FileCheck %s --check-prefix=MEMORY
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -53,7 +53,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -96,7 +96,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 4}>
+#config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -186,7 +186,7 @@ hal.executable @matmul_multiple_k {
         %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [10, 128, 64, 2048], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10x128x64x2048xf16>> -> tensor<10x128x64x2048xf16>
         %5 = tensor.empty() : tensor<2x10x64x64xf16>
         %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2x10x64x64xf16>) -> tensor<2x10x64x64xf16>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf16>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 4}>} {
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<2x128x64x2048xf16>, tensor<10x128x64x2048xf16>) outs(%6 : tensor<2x10x64x64xf16>) attrs =  {lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 0, 0, 1, 128], workgroup = [1, 1, 64, 64, 0, 0], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 4, 1, 1], [0, 1, 2, 3, 4, 5]]}>} {
         ^bb0(%in: f16, %in_0: f16, %out: f16):
           %8 = arith.mulf %in, %in_0 : f16
           %9 = arith.addf %8, %out : f16
@@ -213,7 +213,7 @@ hal.executable @matmul_multiple_k {
 
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 16, n = 16, k = 32)
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -258,7 +258,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // Basic i8, i8 -> i32 matmul.
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -303,7 +303,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // Basic f8, f8 -> f32 matmul. (intrinsic with shape, m = 32, n = 32, k = 16)
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -348,7 +348,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // Basic i8, i8 -> i32 matmul_transpose_b.
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 256], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -398,7 +398,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 128, 0, 0, 0], reduction = [0, 0, 0, 0, 1, 1, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 128, 0, 0, 0], reduction = [0, 0, 0, 0, 1, 1, 32], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -440,7 +440,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [1, 64, 1, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [1, 64, 1, 64, 0], reduction = [0, 0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 2, 1], [0, 1, 2, 3, 4]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
@@ -513,7 +513,7 @@ hal.executable public @main_dispatch_expanded_matmul {
 // NOTE: This test is not exhaustive of all possible ways the above condition is breaking,
 //       but rather is an example of a matmul shape from a model that broke our compilation heuristic.
 
-#config = #iree_gpu.lowering_config<{workgroup = [1, 16, 128, 0], reduction = [0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 4}>
+#config = #iree_gpu.lowering_config<{workgroup = [1, 16, 128, 0], reduction = [0, 0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 4, 1], [0, 1, 2, 3]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
@@ -566,7 +566,7 @@ hal.executable public @contract_schedule_considering_read_layout {
 // This test ensures that we can generate and decompose the right instructions from V(Virtual) MFMAs.
 // (intrinsic with shape, m = 32, n = 32, k = 16)
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -629,7 +629,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // This test ensures we can generate correct instructions from V(Virtual) MFMAs that has only different read layouts.
 // (intrinsic with shape m = 16, n = 16, k = 32)
 
-#config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_m_count = 1, subgroup_n_count = 1}>
+#config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F8E4M3FNUZ>, subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -676,7 +676,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 // This test ensures we can generate correct instructions from V(Virtual) MFMAs that has only different read layouts.
 
-#config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [32, 32, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -753,7 +753,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
                                                     #hal.pipeline.binding<storage_buffer>,
                                                     #hal.pipeline.binding<storage_buffer>]>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
-#config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 128, 0]}>
+#config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 128, 0]}>
 
 hal.executable public @matmul_gather_rhs {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
@@ -847,8 +847,8 @@ hal.executable private @attention_20x4096x64x4096x64 {
                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
                      lowering_config = #config,
                      decomposition_config = {
-                      qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [0, 1]}>},
-                      pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1]}>}
+                      qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 2, 3]], promote_operands = [0, 1]}>},
+                      pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 2, 1, 1, 1], [0, 1, 3, 4]], promote_operands = [1]}>}
                      }}
                      ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) {
                       ^bb0(%score: f32):
@@ -920,8 +920,8 @@ hal.executable private @attention_multiple_m_transpose {
                                                          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
                                                          lowering_config = #config,
                                                          decomposition_config = {
-                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [0, 1]}>},
-                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1]}>}
+                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
                                                          }}
         ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
               ^bb0(%score: f32):
@@ -987,8 +987,8 @@ hal.executable private @attention_mfma_32x32x8 {
                                                          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>],
                                                          lowering_config = #config,
                                                          decomposition_config = {
-                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [0, 1]}>},
-                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1]}>}
+                                                          qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 4]], promote_operands = [0, 1]}>},
+                                                          pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1]}>}
                                                          }}
         ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) {
               ^bb0(%score: f32):
@@ -1067,8 +1067,8 @@ hal.executable private @online_attention_split_k2 {
                                                                     affine_map<(b1, b2, m, n, k1, k2) -> (b1, b2, m)>],
                                                                   lowering_config = #config,
                                                                   decomposition_config = {
-                                                                    qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 1, promote_operands = [0, 1]}>},
-                                                                    pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 1, promote_operands = [1]}>}
+                                                                    qk_attrs = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [0, 1]}>},
+                                                                    pv_attrs = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[1, 1, 1, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1]}>}
                                                                   }}
         ins(%4, %5, %6, %cst : !Q, !K_SK, !V_SK, f16) outs(%empty_o, %empty_rowmax, %empty_rowsum: !O_SK, !ROWRED_SK, !ROWRED_SK) {
               ^bb0(%score: f32):
@@ -1107,8 +1107,8 @@ hal.executable private @online_attention_split_k2 {
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
 
-#qk_config = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], subgroup_m_count = 2 : i64, subgroup_n_count = 1 : i64}>}
-#pv_config = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [1], subgroup_m_count = 2 : i64, subgroup_n_count = 1 : i64}>}
+#qk_config = {attention_qk_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 4]]}>}
+#pv_config = {attention_pv_matmul, lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [1], subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2, 3, 5]]}>}
 #config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2], reduction = [0, 0, 0, 0, 0, 64], workgroup = [1, 1, 64, 64, 0, 0]}>
 
 module {
@@ -1207,7 +1207,7 @@ hal.executable private @matvec_dispatch_0 {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_basis = [[2, 2, 1], [0, 1, 2]]}>
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -1236,7 +1236,7 @@ hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
       %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
       %8 = tensor.empty() : tensor<256x256xf32>
       %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
-      %10 = linalg.matmul {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 64, 0]}>} ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %10 = linalg.matmul {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 64, 0]}>} ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
       %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
       %12 = iree_linalg_ext.map_scatter %10 into %11 {
       ^bb0(%arg0: index, %arg1: index):

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_custom_op.mlir
@@ -40,7 +40,11 @@ func.func @custom_op(%arg0 : tensor<384x512xf32>, %arg1 : tensor<512x128xf32>,
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 //      CHECK:   ^bb
 //      CHECK:     linalg.matmul
-// CHECK-SAME:         lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, promote_operands = [0, 1], reduction = [0, 0, 32], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 64, 0]}>
+// CHECK-SAME:   mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:   promote_operands = [0, 1]
+// CHECK-SAME:   reduction = [0, 0, 32]
+// CHECK-SAME{LITERAL}: subgroup_basis = [[2, 2, 1], [0, 1, 2]]
+// CHECK-SAME:   workgroup = [64, 64, 0]}>
 //      CHECK:   iree_linalg_ext.yield
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
@@ -78,8 +78,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]
-//  CHECK-SAME:       subgroup_m_count = 2
-//  CHECK-SAME:       subgroup_n_count = 2
+//  CHECK-SAME{LITERAL}: subgroup_basis = [[1, 1, 2, 2, 1], [0, 1, 2, 3, 4]]
 //  CHECK-SAME:       workgroup = [1, 1, 32, 32, 0]
 
 // -----
@@ -130,8 +129,7 @@ func.func @fused_contraction_2(%arg0: tensor<4096x640xf32>,
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 16]
-//  CHECK-SAME:       subgroup_m_count = 2
-//  CHECK-SAME:       subgroup_n_count = 2
+//  CHECK-SAME{LITERAL}: subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 //  CHECK-SAME:       workgroup = [32, 64, 0]
 
 // -----
@@ -196,8 +194,7 @@ func.func @fused_contraction_3(%arg0 : tensor<2x4096x640xi8>,
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x64_I8
 //  CHECK-SAME:       promote_operands = [0, 1, 2]
 //  CHECK-SAME:       reduction = [0, 0, 0, 128]
-//  CHECK-SAME:       subgroup_m_count = 2
-//  CHECK-SAME:       subgroup_n_count = 2
+//  CHECK-SAME{LITERAL}: subgroup_basis = [[1, 2, 2, 1], [0, 1, 2, 3]]
 //  CHECK-SAME:       workgroup = [1, 64, 64, 0]
 
 // -----
@@ -283,6 +280,5 @@ func.func @fused_contraction_4(%arg0: tensor<2x4096x640xf16>,
 // GFX950-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]
-//  CHECK-SAME:       subgroup_m_count = 2
-//  CHECK-SAME:       subgroup_n_count = 2
+//  CHECK-SAME{LITERAL}: subgroup_basis = [[1, 1, 2, 2, 1], [0, 1, 2, 3, 4]]
 //  CHECK-SAME:       workgroup = [1, 1, 32, 32, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
@@ -21,7 +21,8 @@ func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   // GENERALIZED:   linalg.generic
   // SPECIALIZED:   linalg.matmul
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 32], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
+  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 32]
+  // CHECK-SAME{LITERAL}: subgroup_basis = [[2, 2, 1], [0, 1, 2]]
   // CHECK-SAME:  workgroup = [32, 32, 0]}>
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !TC -> !DTC
@@ -38,7 +39,8 @@ func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 16], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
+  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 16]
+  // CHECK-SAME{LITERAL}: subgroup_basis = [[2, 2, 1], [0, 1, 2]]
   // CHECK-SAME:  workgroup = [64, 128, 0]}>}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !TC -> !DTC
@@ -55,7 +57,8 @@ func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC
 // CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 func.func @matmul_4096_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 16], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
+  // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 16]
+  // CHECK-SAME{LITERAL}: subgroup_basis = [[2, 2, 1], [0, 1, 2]]
   // CHECK-SAME:  workgroup = [64, 128, 0]}>}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !TC -> !DTC

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -14,7 +14,7 @@
   indexing_maps = #maps,
   iterator_types = ["parallel", "parallel", "reduction"],
   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                              subgroup_m_count = 1, subgroup_n_count = 1}>
+                                              subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>
 }
 
 func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
@@ -64,7 +64,7 @@ func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
   indexing_maps = #maps,
   iterator_types = ["parallel", "parallel", "reduction"],
   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<WMMAR3_F32_16x16x16_F16>,
-                                              subgroup_m_count = 1 : i64, subgroup_n_count = 1 : i64}>
+                                              subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>
 }
 
 func.func @matmul_96x64x16_wmmar3(%lhs: tensor<96x16xf16>,
@@ -114,7 +114,7 @@ func.func @matmul_96x64x16_wmmar3(%lhs: tensor<96x16xf16>,
   indexing_maps = #maps,
   iterator_types = ["parallel", "parallel", "reduction"],
   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<WMMAR4_F32_16x16x16_F16>,
-                                              subgroup_m_count = 1 : i64, subgroup_n_count = 1 : i64}>
+                                              subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>
 }
 
 func.func @matmul_96x64x16_wmmar4(%lhs: tensor<96x16xf16>,
@@ -164,7 +164,7 @@ func.func @matmul_96x64x16_wmmar4(%lhs: tensor<96x16xf16>,
   indexing_maps = #maps,
   iterator_types = ["parallel", "parallel", "reduction"],
   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                              subgroup_m_count = 4, subgroup_n_count = 1}>
+                                              subgroup_basis = [[4, 1, 1], [0, 1, 2]]}>
 }
 
 func.func @matmul_128x64x16_multi_subgroup(%lhs: tensor<128x16xf16>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -142,9 +142,6 @@ hal.executable @ceildiv_expand_dispatch {
 
 // -----
 
-#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 128], promote_operands = [0, 1], mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2}>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>}>
-
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -157,7 +154,7 @@ hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {
-    func.func @matmul_map_scatter() attributes {translation_info = #translation} {
+    func.func @matmul_map_scatter() {
       %true = arith.constant true
       %cst = arith.constant 0.000000e+00 : f32
       %c0 = arith.constant 0 : index
@@ -171,7 +168,7 @@ hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
       %7 = iree_codegen.load_from_buffer %3 : memref<256x256xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<256x256xf16>
       %8 = tensor.empty() : tensor<256x256xf32>
       %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<256x256xf32>) -> tensor<256x256xf32>
-      %10 = linalg.matmul {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 64, 0]}>} ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
+      %10 = linalg.matmul ins(%6, %7 : tensor<256x256xf16>, tensor<256x256xf16>) outs(%9 : tensor<256x256xf32>) -> tensor<256x256xf32>
       %11 = tensor.empty() : tensor<2x16x8x4x4x4x4xf32>
       %12 = iree_linalg_ext.map_scatter %10 into %11 {
       ^bb0(%arg0: index, %arg1: index):

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -122,13 +122,8 @@ class MMASchedule:
     n_tile_count: int
     k_tile_count: int
 
-    def __str__(self):
-        return (
-            "mma_schedule = #iree_gpu.mma_schedule<"
-            + f"intrinsic = #iree_gpu.mma_layout<{self.intrinsic}>, "
-            + f"subgroup_m_count = {self.m_count}, "
-            + f"subgroup_n_count = {self.n_count}>"
-        )
+    def get_subgroup_basis(self) -> str:
+        return f"[[{self.m_count}, {self.n_count}, 1], [0, 1, 2]]"
 
 
 # Describes how to construct compilation info for the testcase.
@@ -168,8 +163,7 @@ class IREEGPUCompilationInfo(CompilationInfo):
             "#iree_codegen.compilation_info<\n"
             f"  lowering_config = #iree_gpu.lowering_config<{{"
             f"  mma_kind = #iree_gpu.mma_layout<{self.mma_schedule.intrinsic}>, "
-            f"  subgroup_m_count = {self.mma_schedule.m_count}, "
-            f"  subgroup_n_count = {self.mma_schedule.n_count}, "
+            f"  subgroup_basis = {self.mma_schedule.get_subgroup_basis()}, "
             f"  workgroup = {self.workgroup_tile}, "
             f"  reduction = {self.reduction_tile} }}>,\n"
             f"  translation_info = #iree_codegen.translation_info<pipeline = {compiler_pipeline} {self.workgroup_size_str()}\n"

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
@@ -29,7 +29,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<4608x21504xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [6, 4, 0], subgroup_m_count = 4 : i64, subgroup_n_count = 2 : i64, workgroup = [384, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [6, 4, 0], subgroup_basis = [[4, 2, 1], [0, 1, 2]], workgroup = [384, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -47,7 +47,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<4608x3072xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 4, 0], subgroup_m_count = 4 : i64, subgroup_n_count = 1 : i64, workgroup = [256, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 4, 0], subgroup_basis = [[4, 1, 1], [0, 1, 2]], workgroup = [256, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -65,7 +65,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<4096x12288xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [2, 4, 0], subgroup_m_count = 4 : i64, subgroup_n_count = 2 : i64, workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [2, 4, 0], subgroup_basis = [[4, 2, 1], [0, 1, 2]], workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -83,7 +83,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<4096x3072xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_m_count = 2 : i64, subgroup_n_count = 4 : i64, workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_basis = [[2, 4, 1], [0, 1, 2]], workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -101,7 +101,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<72x4096x128xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 0, 2], subgroup = [4, 2, 2, 0], subgroup_m_count = 8 : i64, subgroup_n_count = 1 : i64, workgroup = [4, 256, 32, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 0, 2], subgroup = [4, 2, 2, 0], subgroup_basis = [[8, 1, 1], [0, 1, 2]], workgroup = [4, 256, 32, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -119,7 +119,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<4096x3072xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 6, 0], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [128, 192, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 6, 0], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [128, 192, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -137,7 +137,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<512x12288xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 1, 0], subgroup_m_count = 1 : i64, subgroup_n_count = 4 : i64, workgroup = [64, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 1, 0], subgroup_basis = [[1, 4, 1], [0, 1, 2]], workgroup = [64, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
@@ -155,7 +155,7 @@ module attributes {transform.with_named_sequence} {
         linalg.yield %5 : f32
       } -> tensor<512x3072xf32>
     } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_m_count = 1 : i64, subgroup_n_count = 3 : i64, workgroup = [64, 96, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [192, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_basis = [[1, 3, 1], [0, 1, 2]], workgroup = [64, 96, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [192, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -63,10 +63,11 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
     %decomposition_config = transform.param.constant {
       qk_attrs = {attention_qk_matmul,
                   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
-                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
+
       pv_attrs = {attention_pv_matmul,
                   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
     } -> !transform.any_param
 
     transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
@@ -90,10 +91,10 @@ transform.named_sequence @match_attention_f8(%attention: !transform.any_op {tran
     %decomposition_config = transform.param.constant {
       qk_attrs = {attention_qk_matmul,
                   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>,
-                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 4, 5]], promote_operands = [1] }>},
       pv_attrs = {attention_pv_matmul,
                   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F8E4M3FNUZ>,
-                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+                                                               subgroup_basis = [[1, 1, 4, 1, 1, 1], [0, 1, 2, 3, 5]], promote_operands = [1] }>}
     } -> !transform.any_param
 
     transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
@@ -137,7 +138,7 @@ transform.named_sequence @match_mmt_2048x10240x1280(%matmul: !transform.any_op {
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                 subgroup_m_count = 4, subgroup_n_count = 2,
+                                                 subgroup_basis = [[4, 2, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 128],
                                                  workgroup = [128, 320, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -158,7 +159,7 @@ transform.named_sequence @match_mmt_2048x1280x5120(%matmul: !transform.any_op {t
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                 subgroup_m_count = 4, subgroup_n_count = 1,
+                                                 subgroup_basis = [[4, 1, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 256],
                                                  workgroup = [128, 80, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -179,7 +180,7 @@ transform.named_sequence @match_mmt_2048x1280x1280(%matmul: !transform.any_op {t
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                 subgroup_m_count = 2, subgroup_n_count = 2,
+                                                 subgroup_basis = [[2, 2, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 128],
                                                  workgroup = [64, 160, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -201,7 +202,7 @@ transform.named_sequence @match_mmt_8192x640x640(%matmul: !transform.any_op {tra
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                 subgroup_m_count = 8, subgroup_n_count = 1,
+                                                 subgroup_basis = [[8, 1, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 64],
                                                  workgroup = [256, 64, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -222,7 +223,7 @@ transform.named_sequence @match_mmt_8192x5120x640(%matmul: !transform.any_op {tr
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_32x32x16_I8>,
-                                                 subgroup_m_count = 2, subgroup_n_count = 4,
+                                                 subgroup_basis = [[2, 4, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 64],
                                                  workgroup = [256, 128, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -243,7 +244,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                 subgroup_m_count = 8, subgroup_n_count = 1,
+                                                 subgroup_basis = [[8, 1, 1], [0, 1, 2]],
                                                  reduction = [0, 0, 64],
                                                  workgroup = [256, 64, 0]}>,
     translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -276,7 +277,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 4, subgroup_n_count = 2,
+                                                   subgroup_basis = [[1, 4, 2, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 128],
                                                    workgroup = [1, 128, 320, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -297,7 +298,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 2,
+                                                   subgroup_basis = [[1, 2, 2, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 128],
                                                    workgroup = [1, 64, 160, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -319,7 +320,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 2,
+                                                   subgroup_basis = [[1, 2, 2, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 128],
                                                    workgroup = [1, 64, 160, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -342,7 +343,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 8, subgroup_n_count = 1,
+                                                   subgroup_basis = [[1, 8, 1, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 64],
                                                    workgroup = [1, 256, 64, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -363,7 +364,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 1,
+                                                   subgroup_basis = [[1, 2, 1, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 128],
                                                    workgroup = [1, 32, 320, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -384,7 +385,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_32x32x16_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 4,
+                                                   subgroup_basis = [[1, 2, 4, 1], [0, 1, 2, 3]],
                                                    reduction = [0, 0, 0, 64],
                                                    workgroup = [1, 256, 128, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -421,7 +422,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 2,
+                                                   subgroup_basis = [[1, 1, 2, 2, 1], [0, 1, 2, 3, 4]],
                                                    reduction = [0, 0, 0, 0, 128],
                                                    workgroup = [1, 1, 64, 160, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -458,7 +459,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 2,
+                                                   subgroup_basis = [[1, 1, 2, 2, 1], [0, 1, 2, 3, 4]],
                                                    reduction = [0, 0, 0, 0, 128],
                                                    workgroup = [1, 1, 160, 64, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -493,7 +494,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 1,
+                                                   subgroup_basis = [[1, 1, 2, 1, 1], [0, 1, 2, 3, 4]],
                                                    reduction = [0, 0, 0, 0, 128],
                                                    workgroup = [1, 1, 32, 320, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -527,7 +528,7 @@ transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 2, subgroup_n_count = 1,
+                                                   subgroup_basis = [[1, 1, 2, 1, 1], [0, 1, 2, 3, 4]],
                                                    reduction = [0, 0, 0, 0, 128],
                                                    workgroup = [1, 1, 320, 32, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -560,7 +561,7 @@ transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
-                                                   subgroup_m_count = 8, subgroup_n_count = 1,
+                                                   subgroup_basis = [[1, 1, 8, 1, 1], [0, 1, 2, 3, 4]],
                                                    reduction = [0, 0, 0, 0, 64],
                                                    workgroup = [1, 1, 256, 64, 0]}>,
       translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -37,10 +37,10 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   %decomposition_config = transform.param.constant {
     qk_attrs = {attention_qk_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_32x32x16_F16>,
-                                                              subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1] }>},
+                                                              subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2]], promote_operands = [1] }>},
     pv_attrs = {attention_pv_matmul,
                 lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                              subgroup_m_count = 2, subgroup_n_count = 1, promote_operands = [1] }>}
+                                                              subgroup_basis = [[1, 1, 2, 1, 1, 1], [0, 1, 2]], promote_operands = [1] }>}
   } -> !transform.any_param
 
   transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
@@ -84,7 +84,7 @@ transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                subgroup_basis = [[4, 2, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [128, 128, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -106,7 +106,7 @@ transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {t
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                subgroup_basis = [[4, 2, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [128, 128, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -128,7 +128,7 @@ transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {t
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                subgroup_basis = [[4, 2, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [128, 128, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -150,7 +150,7 @@ transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {tr
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                subgroup_m_count = 2, subgroup_n_count = 4,
+                                                subgroup_basis = [[2, 4, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [128, 256, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -172,7 +172,7 @@ transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {tr
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-                                                subgroup_m_count = 2, subgroup_n_count = 1,
+                                                subgroup_basis = [[2, 1, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 128],
                                                 workgroup = [64, 16, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -194,7 +194,7 @@ transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {tra
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                subgroup_m_count = 1, subgroup_n_count = 4,
+                                                subgroup_basis = [[1, 4, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [256, 128, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
@@ -216,7 +216,7 @@ transform.named_sequence @match_mmt_7680x640x2560(%matmul: !transform.any_op {tr
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                subgroup_basis = [[4, 2, 1], [0, 1, 2]],
                                                 reduction = [0, 0, 32],
                                                 workgroup = [256, 128, 0]}>,
   translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute


### PR DESCRIPTION
This patch moves VectorDistribute intrinsic pipeline to use subgroup_m/n_count instead of using the older subgroup_m_count/subgroup_n_count. The advantage over the old way is that it allows us to exactly specify how many subgroups are distributed over the entire iteration space. It also allows us to configure in what order we distribute subgroups and what strides for subgroups each dimension gets.

The new, reduction VectorDistribute pipeline is already using this attribute.

This patch also removes any support for the subgroup_m_count/subgroup_n_count attribute.