### PR TITLE
[iree][codegen] Add denormal and occupancy optimization attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -701,12 +701,13 @@ static FailureOr<int64_t> reconcileSubgroupSize(
 /// Helper function to retrieve the target-func-attrs value from translation
 /// info.
 static DictionaryAttr
-getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo) {
+getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo,
+                   StringRef key) {
   auto translationConfig = translationInfo.getConfiguration();
   if (!translationConfig) {
     return nullptr;
   }
-  auto attr = translationConfig.getAs<DictionaryAttr>("llvm_func_attrs");
+  auto attr = translationConfig.getAs<DictionaryAttr>(key);
   if (!attr) {
     return nullptr;
   }
@@ -801,9 +802,14 @@ void ReconcileTranslationInfoPass::runOnOperation() {
       // translation info into the func-like op. This is not the best
       // place to do this, but the intent is after this pass all the
       // lowering configs and translation infos will be deleted.
-      DictionaryAttr targetFuncAttrs = getTargetFuncAttrs(translationInfo);
+      DictionaryAttr targetFuncAttrs =
+          getTargetFuncAttrs(translationInfo, "llvm_func_attrs");
       if (targetFuncAttrs) {
         funcOp->setAttr("llvm_func_attrs", targetFuncAttrs);
+      }
+      if (DictionaryAttr targetFuncAttrs =
+              getTargetFuncAttrs(translationInfo, kFuncAttrsName)) {
+        funcOp->setAttr(kFuncAttrsName, targetFuncAttrs);
       }
     }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -52,6 +52,7 @@ constexpr StringLiteral kSerializedTuningSpecAttrName =
     "iree_codegen.tuning_spec_mlirbc";
 constexpr StringLiteral kKernelConfigSpecName = "__kernel_config";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
+constexpr StringLiteral kFuncAttrsName = "func_attrs";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -610,4 +610,38 @@ def IREECodegen_XORShuffleAttr  :
   let genVerifyDecl = 1;
 }
 
+//===---------------------------------------------------------------------===//
+// iree_codegen.denormal_mode
+//===---------------------------------------------------------------------===//
+
+// Do not add any denormal mode.
+def DenormalMode_None : I32EnumCase<"None", 0, "none">;
+// Convert denormals to zero while preserving sign.
+def DenormalMode_PreserveSign : I32EnumCase<"PreserveSign", 1, "preserve-sign">;
+// Convert denormals to positive zero.
+def DenormalMode_PositiveZero : I32EnumCase<"PositiveZero", 2, "positive-zero">;
+
+// Denormal fp mode.
+def DenormalFpMathEnum : I32Enum<
+  "DenormalFpMath",
+  "Denormal mode for fp math", [
+    DenormalMode_None,
+    DenormalMode_PreserveSign,
+    DenormalMode_PositiveZero
+  ]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+}
+
+def DenormalFpMathAttr :
+  EnumAttr<IREECodegen_Dialect, DenormalFpMathEnum, "denormal_fp_math"> {
+  let assemblyFormat = "`<` $value `>`";
+
+  let extraClassDeclaration = [{
+    /// Returns the key name for fp32 DenormalFpMathAttr in a DictionaryAttr.
+    static StringRef getFP32DictKeyName() {
+      return "denormal_fp_math_f32";
+    }
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -727,4 +727,28 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GPU Occupancy Optimization Attribute
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_OptimizeOccupancyAttr : AttrDef<IREEGPU_Dialect, "OptimizeOccupancy"> {
+  let mnemonic = "optimize_occupancy";
+  let summary = [{An attribute indicating GPU occupancy needs to be optimized.}];
+  let description = [{
+    This attribute can be attached to operations to indicate that GPU occupancy
+    should be optimized during code generation.
+  }];
+
+  let assemblyFormat = "";
+  let parameters = (ins);
+
+  let extraClassDeclaration = [{
+    // Returns the key name for OptimizeOccupancyAttr in the translation info
+    // config dictionary.
+    static StringRef getDictKeyName() {
+      return "gpu_optimize_occupancy";
+    }
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1326,6 +1326,25 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
       targetSubgroupSize, pipelineConfig);
 }
 
+/// Sets attention specific pipeline attributes. Currently, this only affects
+/// AMD targets.
+static void
+setAttentionPipelineAttributes(IREE::GPU::TargetAttr target,
+                               SmallVectorImpl<NamedAttribute> &pipelineAttrs) {
+  if (!target.isAMD()) {
+    return;
+  }
+  Builder b(target.getContext());
+  NamedAttrList funcAttrs;
+  funcAttrs.append(IREE::GPU::OptimizeOccupancyAttr::getDictKeyName(),
+                   b.getAttr<IREE::GPU::OptimizeOccupancyAttr>());
+  funcAttrs.append(IREE::Codegen::DenormalFpMathAttr::getFP32DictKeyName(),
+                   b.getAttr<IREE::Codegen::DenormalFpMathAttr>(
+                       IREE::Codegen::DenormalFpMath::PreserveSign));
+  pipelineAttrs.emplace_back(kFuncAttrsName,
+                             funcAttrs.getDictionary(b.getContext()));
+}
+
 static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
     IREE::GPU::TargetAttr target, mlir::FunctionOpInterface entryPoint,
     IREE::LinalgExt::AttentionOp op) {
@@ -1576,6 +1595,8 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
+
+  setAttentionPipelineAttributes(target, pipelineAttrs);
 
   // TODO: We do not turn prefetching on even when requested by the prefetching
   // flag because there is a shared memory allocation the two matmuls, which

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -240,11 +240,11 @@ func.func @attention_20x4096x64x4096x64() {
 
 // CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-NOT:   prefetch_shared_memory = true
+// CHECK:       func_attrs = {
+// CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
+// CHECK:       gpu_optimize_occupancy = #iree_gpu.optimize_occupancy
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
-
-// Test to check if having a large head dim, which would lead to high shared
-// memory usage, can select tile sizes that fit shared memory.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -291,7 +291,10 @@ func.func @attention_large_head_dim_shared_mem() {
 // and the QK matmul used MFMA_F32_32x32x64_F8E4M3FN. Vector distribution failed
 // to distribute these layouts to threads.
 
-//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK:       func_attrs = {
+// CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
+// CHECK:       gpu_optimize_occupancy = #iree_gpu.optimize_occupancy
 // CHECK-LABEL: func.func @attention_check_mma_accs_compatable
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>


### PR DESCRIPTION
This commit adds support for two new attributes `#iree_codegen.denormal_fp_math`, and `#iree_gpu.optimize_occupancy`. These attributes are set at the function level, and handled through a dictionary attribute with key `func_attrs` in the `translation_info` attribute. Which will be propagated until it reaches the `*AnnotateKernelForTranslation` passes.

A `#iree_codegen.denormal_fp_math` attribute specifies how denormal floating-point values are handled.
A`#iree_gpu.optimize_occupancy` attribute specifies that a better resource utilization should be employed.

Currently these attributes are only set for `attention` dispatches on AMD targets.