### PR TITLE
[GPU][DT] Add pingpong ukernels for data tiling (f8 and f16)

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -92,6 +92,22 @@ static LogicalResult matchContraction(PatternRewriter &rewriter,
   return success();
 }
 
+/// Helper to check whether the given value is cast-compatible with the given
+/// type.
+static LogicalResult matchCastCompatibleType(PatternRewriter &rewriter,
+                                             Value value, Type type) {
+  if (auto targetTensorType = dyn_cast<RankedTensorType>(type)) {
+    if (!isCastableToTensorType(value.getType(), targetTensorType)) {
+      return failure();
+    }
+    return success();
+  }
+  if (value.getType() != type) {
+    return failure();
+  }
+  return success();
+}
+
 /// PDL utility that checks whether the size of the dimension of the provided
 /// value is a multiple of the divisor.
 static LogicalResult dimIsMultipleOf(PatternRewriter &rewriter, Value value,
@@ -196,6 +212,8 @@ populatePDLModuleFromBuiltin(MLIRContext *context, RewritePatternSet &patterns,
   pdlModule.registerConstraintFunction("hasAttr", hasAttr);
   pdlModule.registerConstraintFunction("dimIsBound", dimIsBound);
   pdlModule.registerConstraintFunction("dimIsMultipleOf", dimIsMultipleOf);
+  pdlModule.registerConstraintFunction("matchCastCompatibleType",
+                                       matchCastCompatibleType);
   pdlModule.registerConstraintFunction("matchContraction", matchContraction);
   pdlModule.registerRewriteFunction("annotateOperation", annotateOperation);
   patterns.insert(std::move(pdlModule));

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/BUILD.bazel
@@ -47,6 +47,8 @@ iree_lit_test_suite(
 iree_c_embed_data(
     name = "iree_mlir_ukernels_amdgpu",
     srcs = [
+        "iree_uk_amdgpu_dt_matmul_f16.mlir",
+        "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir",
         "iree_uk_amdgpu_matmul_bf16.mlir",
         "iree_uk_amdgpu_matmul_f16.mlir",
         "iree_uk_amdgpu_matmul_f8E4M3FN.mlir",
@@ -62,6 +64,8 @@ iree_c_embed_data(
 iree_lit_test_suite(
     name = "verify_mlir_ukernels_amdgpu",
     srcs = [
+        "iree_uk_amdgpu_dt_matmul_f16.mlir",
+        "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir",
         "iree_uk_amdgpu_matmul_bf16.mlir",
         "iree_uk_amdgpu_matmul_f16.mlir",
         "iree_uk_amdgpu_matmul_f8E4M3FN.mlir",

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/CMakeLists.txt
@@ -41,6 +41,8 @@ iree_c_embed_data(
   NAME
     iree_mlir_ukernels_amdgpu
   SRCS
+    "iree_uk_amdgpu_dt_matmul_f16.mlir"
+    "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
     "iree_uk_amdgpu_matmul_bf16.mlir"
     "iree_uk_amdgpu_matmul_f16.mlir"
     "iree_uk_amdgpu_matmul_f8E4M3FN.mlir"
@@ -57,6 +59,8 @@ iree_lit_test_suite(
   NAME
     verify_mlir_ukernels_amdgpu
   SRCS
+    "iree_uk_amdgpu_dt_matmul_f16.mlir"
+    "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
     "iree_uk_amdgpu_matmul_bf16.mlir"
     "iree_uk_amdgpu_matmul_f16.mlir"
     "iree_uk_amdgpu_matmul_f8E4M3FN.mlir"

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
@@ -1,0 +1,259 @@
+//  RUN: iree-opt %s
+
+!acc_base_ty = tensor<1x1x2x4x8x4x4x16x4xf32>
+!lhs_base_ty = tensor<1x?x2x8x4x4x4x4xf16>
+!lhs_expand_ty = tensor<1x?x4x2x8x4x4x2x2x4xf16>
+!rhs_base_ty = tensor<1x?x4x4x4x16x4xf16>
+!rhs_expand_ty = tensor<1x?x4x4x4x4x8x2x4xf16>
+!in_ty = tensor<?x4x16x32x8xf16>
+!shared_ty = memref<4x16x64x4xf16, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func @pingpong_dt_large_f16(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : f16
+
+  %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
+  %nDim =  arith.divui %dim, %c4 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6], [7, 8], [9]] output_shape [1, %nDim, 2, 2, 8, 4, 4, 2, 2, 4] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 2, 4, 4, 4, 8, 2, 4] : !rhs_base_ty into !rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6, 7], [8, 9]] : !lhs_expand_ty into !in_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !rhs_expand_ty into !in_ty
+
+  %lhs_shared = memref.alloc() : !shared_ty
+  %rhs_shared = memref.alloc() : !shared_ty
+
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  gpu.barrier
+
+  %0 = tensor.empty() : !acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (2, 4, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %m_outer = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
+    %n_outer = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+
+    %glb:2 = affine.delinearize_index %id into (16, 32) : index, index
+    %glb_inner = arith.muli %glb#1, %c2 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<8x4x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<8x4x1x4xf32> {
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %lhs_vec_local_0_t = vector.shape_cast %lhs_vec_local_0 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %lhs_vec_local_1_t = vector.shape_cast %lhs_vec_local_1 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %lhs_thread_2 = tensor.extract_slice %lhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %lhs_vec_local_2_t = vector.shape_cast %lhs_vec_local_2 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %lhs_thread_3 = tensor.extract_slice %lhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %lhs_vec_local_3_t = vector.shape_cast %lhs_vec_local_3 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+      } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %rhs_vec_local_0_t = vector.shape_cast %rhs_vec_local_0 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %rhs_vec_local_1_t = vector.shape_cast %rhs_vec_local_1 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %rhs_vec_local_2_t = vector.shape_cast %rhs_vec_local_2 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 8] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x8xf16>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x8xf16>, vector<1x1x1x8xf16>
+      %rhs_vec_local_3_t = vector.shape_cast %rhs_vec_local_3 : vector<1x1x1x8xf16> to vector<1x1x2x4xf16>
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+      } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local loads of lhs and rhs.
+      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+      } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0_t, %rhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %rhs_vec_local_1_t, %rhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %rhs_vec_local_2_t, %rhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %rhs_vec_local_3_t, %rhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+
+      vector.transfer_write %lhs_vec_local_0_t, %lhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %lhs_vec_local_1_t, %lhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %lhs_vec_local_2_t, %lhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+      vector.transfer_write %lhs_vec_local_3_t, %lhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x4xf16>, !shared_ty
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+      } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot3 : vector<8x4x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+    } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+    } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+    } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x4xf16>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x4xf16>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x4xf16> to vector<8x1x1x4xf16>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x4xf16> to vector<4x1x1x4xf16>
+
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+    } : vector<8x1x1x4xf16>, vector<4x1x1x4xf16> into vector<8x4x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x1x8x4x1x1x4xf32>
+    %cast = vector.shape_cast %dot3 : vector<8x4x1x4xf32> to vector<1x1x1x1x8x4x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true, true]} : vector<1x1x1x1x8x4x1x1x4xf32>, tensor<1x1x1x1x8x4x1x1x4xf32>
+
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 1, 8, 4, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x8x4x1x1x4xf32> into !acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !acc_base_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
@@ -1,0 +1,436 @@
+//  RUN: iree-opt %s
+
+!acc_base_ty = tensor<1x1x2x4x8x4x4x16x4xf32>
+!lhs_base_ty = tensor<1x?x2x8x4x4x4x8xf8E4M3FNUZ>
+!lhs_expand_ty = tensor<1x?x4x2x8x4x4x2x2x8xf8E4M3FNUZ>
+!rhs_base_ty = tensor<1x?x4x4x4x16x8xf8E4M3FNUZ>
+!rhs_expand_ty = tensor<1x?x4x4x4x4x8x2x8xf8E4M3FNUZ>
+!in_ty = tensor<?x4x16x32x16xf8E4M3FNUZ>
+!shared_ty = memref<4x16x64x8xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+
+!m_acc_base_ty = tensor<1x1x8x8x2x4x16x4xf32>
+!m_lhs_base_ty = tensor<1x?x8x4x4x4x2x8xf8E4M3FNUZ>
+!m_lhs_expand_ty = tensor<1x?x2x8x4x4x4x2x8xf8E4M3FNUZ>
+!m_rhs_base_ty = tensor<1x?x8x2x4x16x2x8xf8E4M3FNUZ>
+!m_rhs_expand_ty = tensor<1x?x2x8x2x4x16x2x8xf8E4M3FNUZ>
+!m_lhs_ty = tensor<?x2x8x64x16xf8E4M3FNUZ>
+!m_rhs_ty = tensor<?x2x16x64x16xf8E4M3FNUZ>
+!m_lhs_shared_ty = memref<2x8x64x16xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+!m_rhs_shared_ty = memref<2x16x64x16xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+
+util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.0 : f8E4M3FNUZ
+
+  %dim = tensor.dim %rhs_base, %c1 : !rhs_base_ty
+  %nDim = arith.divui %dim, %c4 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6], [7, 8], [9]] output_shape [1, %nDim, 4, 2, 8, 4, 4, 2, 2, 8] : !lhs_base_ty into !lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6, 7], [8]] output_shape [1, %nDim, 4, 4, 4, 4, 8, 2, 8] : !rhs_base_ty into !rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3, 4], [5, 6, 7], [8, 9]] : !lhs_expand_ty into !in_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !rhs_expand_ty into !in_ty
+
+  %lhs_shared = memref.alloc() : !shared_ty
+  %rhs_shared = memref.alloc() : !shared_ty
+
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1]  : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+    %lhs_vec_local_t = vector.shape_cast %lhs_vec_local : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+    vector.transfer_write %lhs_vec_local_t, %lhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (4, 16, 32) : index, index, index
+    %inner = arith.muli %delin#2, %c2 overflow<nsw, nuw> : index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+    %rhs_vec_local_t = vector.shape_cast %rhs_vec_local : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+    vector.transfer_write %rhs_vec_local_t, %rhs_shared[%delin#0, %delin#1, %inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  %0 = tensor.empty() : !acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (2, 4, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %m_outer = arith.muli %ids#0, %c8 overflow<nsw, nuw> : index
+    %n_outer = arith.muli %ids#1, %c4 overflow<nsw, nuw> : index
+
+    %glb:2 = affine.delinearize_index %id into (16, 32) : index, index
+    %glb_inner = arith.muli %glb#1, %c2 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<8x4x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<8x4x1x4xf32> {
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] :  !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_0_t = vector.shape_cast %lhs_vec_local_0 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_1_t = vector.shape_cast %lhs_vec_local_1 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %lhs_thread_2 = tensor.extract_slice %lhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] :  !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_2 = vector.transfer_read %lhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_2_t = vector.shape_cast %lhs_vec_local_2 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %lhs_thread_3 = tensor.extract_slice %lhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_3 = vector.transfer_read %lhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_3_t = vector.shape_cast %lhs_vec_local_3 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+
+      // Local loads.
+      %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+      %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] :  !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_0_t = vector.shape_cast %rhs_vec_local_0 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c1, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_1_t = vector.shape_cast %rhs_vec_local_1 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c2, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] :  !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_2_t = vector.shape_cast %rhs_vec_local_2 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c3, %glb#0, %glb#1, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !in_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_3_t = vector.shape_cast %rhs_vec_local_3 : vector<1x1x1x16xf8E4M3FNUZ> to vector<1x1x2x8xf8E4M3FNUZ>
+
+      // Local loads.
+      %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+      %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+      %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+      %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local loads.
+      %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+      %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+      // Local loads.
+      %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+      %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+      %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+      %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0_t, %rhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %rhs_vec_local_1_t, %rhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %rhs_vec_local_2_t, %rhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %rhs_vec_local_3_t, %rhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+
+      vector.transfer_write %lhs_vec_local_0_t, %lhs_shared [%c0, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %lhs_vec_local_1_t, %lhs_shared [%c1, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %lhs_vec_local_2_t, %lhs_shared [%c2, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+      vector.transfer_write %lhs_vec_local_3_t, %lhs_shared [%c3, %glb#0, %glb_inner, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x2x8xf8E4M3FNUZ>, !shared_ty
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot3 : vector<8x4x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec_0 = vector.transfer_read %lhs_shared[%c0, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+    %rhs_vec_0 = vector.transfer_read %rhs_shared[%c0, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+    %lhs_vec_1 = vector.transfer_read %lhs_shared[%c1, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+    %rhs_vec_1 = vector.transfer_read %rhs_shared[%c1, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+    %lhs_vec_1_t = vector.shape_cast %lhs_vec_1 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+    %rhs_vec_1_t = vector.shape_cast %rhs_vec_1 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+    %dot1 = iree_codegen.inner_tiled ins(%lhs_vec_1_t, %rhs_vec_1_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+    %lhs_vec_2 = vector.transfer_read %lhs_shared[%c2, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+    %rhs_vec_2 = vector.transfer_read %rhs_shared[%c2, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot1) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+    %lhs_vec_3 = vector.transfer_read %lhs_shared[%c3, %m_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x8x1x8xf8E4M3FNUZ>
+    %rhs_vec_3 = vector.transfer_read %rhs_shared[%c3, %n_outer, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !shared_ty, vector<1x4x1x8xf8E4M3FNUZ>
+    %lhs_vec_3_t = vector.shape_cast %lhs_vec_3 : vector<1x8x1x8xf8E4M3FNUZ> to vector<8x1x1x8xf8E4M3FNUZ>
+    %rhs_vec_3_t = vector.shape_cast %rhs_vec_3 : vector<1x4x1x8xf8E4M3FNUZ> to vector<4x1x1x8xf8E4M3FNUZ>
+
+    %dot3 = iree_codegen.inner_tiled ins(%lhs_vec_3_t, %rhs_vec_3_t) outs(%dot2) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x1x1x8xf8E4M3FNUZ>, vector<4x1x1x8xf8E4M3FNUZ> into vector<8x4x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x1x8x4x1x1x4xf32>
+    %cast = vector.shape_cast %dot3 : vector<8x4x1x4xf32> to vector<1x1x1x1x8x4x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true, true]} : vector<1x1x1x1x8x4x1x1x4xf32>, tensor<1x1x1x1x8x4x1x1x4xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 1, 8, 4, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x8x4x1x1x4xf32> into !acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !acc_base_ty
+}
+
+util.func private @pingpong_dt_medium_f8E4M3FNUZ(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %c4096 = arith.constant 4096 : index
+  %cst = arith.constant 0.0 : f8E4M3FNUZ
+
+  %dim = tensor.dim %rhs_base, %c1 : !m_rhs_base_ty
+  %nDim = arith.divui %dim, %c2 : index
+
+  %lhs_expand = tensor.expand_shape %lhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, 8, 4, 4, 4, 2, 8] : !m_lhs_base_ty into !m_lhs_expand_ty
+  %rhs_expand = tensor.expand_shape %rhs_base [[0], [1, 2], [3], [4], [5], [6], [7], [8]] output_shape [1, %nDim, 2, 8, 2, 4, 16, 2, 8] : !m_rhs_base_ty into !m_rhs_expand_ty
+
+  %lhs = tensor.collapse_shape %lhs_expand [[0, 1], [2], [3], [4, 5, 6], [7, 8]] : !m_lhs_expand_ty into !m_lhs_ty
+  %rhs = tensor.collapse_shape %rhs_expand [[0, 1], [2], [3, 4], [5, 6], [7, 8]] : !m_rhs_expand_ty into !m_rhs_ty
+
+  %lhs_shared = memref.alloc() : !m_lhs_shared_ty
+  %rhs_shared = memref.alloc() : !m_rhs_shared_ty
+
+  scf.forall (%id) in (1024) {
+    %delin:3 = affine.delinearize_index %id into (2, 8, 64) : index, index, index
+    %lhs_thread_local = tensor.extract_slice %lhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1]  : !m_lhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+    %lhs_vec_local = vector.transfer_read %lhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+    vector.transfer_write %lhs_vec_local, %lhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_lhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  scf.forall (%id) in (2048) {
+    %delin:3 = affine.delinearize_index %id into (2, 16, 64) : index, index, index
+    %rhs_thread_local = tensor.extract_slice %rhs [%c0, %delin#0, %delin#1, %delin#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+    %rhs_vec_local = vector.transfer_read %rhs_thread_local [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+    vector.transfer_write %rhs_vec_local, %rhs_shared[%delin#0, %delin#1, %delin#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_rhs_shared_ty
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+
+  %0 = tensor.empty() : !m_acc_base_ty
+  %1 = scf.forall (%id) in (512) shared_outs(%out = %0) -> !m_acc_base_ty {
+    %ids:3 = affine.delinearize_index %id into (1, 8, 64) : index, index, index
+    %threads:2 = affine.delinearize_index %ids#2 into (4, 16) : index, index
+
+    %glb0_rhs = arith.muli %ids#1, %c2 overflow<nsw, nuw> : index
+    %glb1_rhs = arith.addi %glb0_rhs, %c1 overflow<nsw, nuw> : index
+
+    %2 = arith.constant dense<0.0> : vector<8x2x1x4xf32>
+
+    %cmp0 = arith.cmpi slt, %id, %c256 : index
+    %cmp1 = arith.cmpi sge, %id, %c256 : index
+    scf.if %cmp0 {
+      rocdl.s.barrier
+    }
+
+    %3 = scf.for %i = %c1 to %nDim step %c1 iter_args(%iter = %2) -> vector<8x2x1x4xf32> {
+      // Local loads of lhs.
+      %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x8x1x16xf8E4M3FNUZ>
+      %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, 8, 1, 16], strides = [1, 1, 1, 1]} : vector<2x8x1x16xf8E4M3FNUZ> to vector<1x8x1x16xf8E4M3FNUZ>
+      %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, 8, 1, 16], strides = [1, 1, 1, 1]} : vector<2x8x1x16xf8E4M3FNUZ> to vector<1x8x1x16xf8E4M3FNUZ>
+      %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x16xf8E4M3FNUZ> to vector<8x2x1x8xf8E4M3FNUZ>
+      %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x16xf8E4M3FNUZ> to vector<8x2x1x8xf8E4M3FNUZ>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of lhs.
+      %lhs_thread_0 = tensor.extract_slice %lhs [%i, %c0, %ids#1, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_0 = vector.transfer_read %lhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %lhs_thread_1 = tensor.extract_slice %lhs [%i, %c1, %ids#1, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_lhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %lhs_vec_local_1 = vector.transfer_read %lhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+
+      rocdl.sched.barrier 0
+
+      // Local loads of rhs.
+      %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x2x1x16xf8E4M3FNUZ>
+      %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, 2, 1, 16], strides = [1, 1, 1, 1]} : vector<2x2x1x16xf8E4M3FNUZ> to vector<1x2x1x16xf8E4M3FNUZ>
+      %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, 2, 1, 16], strides = [1, 1, 1, 1]} : vector<2x2x1x16xf8E4M3FNUZ> to vector<1x2x1x16xf8E4M3FNUZ>
+      %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x2x1x16xf8E4M3FNUZ> to vector<2x2x1x8xf8E4M3FNUZ>
+      %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x2x1x16xf8E4M3FNUZ> to vector<2x2x1x8xf8E4M3FNUZ>
+
+      rocdl.sched.barrier 0
+
+      // Global loads of rhs.
+      %rhs_thread_0 = tensor.extract_slice %rhs [%i, %c0, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_0 = vector.transfer_read %rhs_thread_0 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_thread_1 = tensor.extract_slice %rhs [%i, %c0, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_1 = vector.transfer_read %rhs_thread_1 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_thread_2 = tensor.extract_slice %rhs [%i, %c1, %glb0_rhs, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_2 = vector.transfer_read %rhs_thread_2 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+      %rhs_thread_3 = tensor.extract_slice %rhs [%i, %c1, %glb1_rhs, %ids#2, %c0] [1, 1, 1, 1, 16] [1, 1, 1, 1, 1] : !m_rhs_ty to tensor<1x1x1x16xf8E4M3FNUZ>
+      %rhs_vec_local_3 = vector.transfer_read %rhs_thread_3 [%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : tensor<1x1x1x16xf8E4M3FNUZ>, vector<1x1x1x16xf8E4M3FNUZ>
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%iter) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x2x1x8xf8E4M3FNUZ>, vector<2x2x1x8xf8E4M3FNUZ> into vector<8x2x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      // Local stores of lhs and rhs.
+      vector.transfer_write %rhs_vec_local_0, %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_1, %rhs_shared[%c0, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_2, %rhs_shared[%c1, %glb0_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_rhs_shared_ty
+      vector.transfer_write %rhs_vec_local_3, %rhs_shared[%c1, %glb1_rhs, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_rhs_shared_ty
+
+      vector.transfer_write %lhs_vec_local_0, %lhs_shared[%c0, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_lhs_shared_ty
+      vector.transfer_write %lhs_vec_local_1, %lhs_shared[%c1, %ids#1, %ids#2, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x16xf8E4M3FNUZ>, !m_lhs_shared_ty
+
+      gpu.barrier
+      rocdl.sched.barrier 0
+      rocdl.s.setprio 1 { iree_gpu.swap_mfma = 1 }
+
+      %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+        indexing_maps = #contraction_accesses,
+        iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+        kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+      } : vector<8x2x1x8xf8E4M3FNUZ>, vector<2x2x1x8xf8E4M3FNUZ> into vector<8x2x1x4xf32>
+
+      rocdl.s.setprio 0
+      gpu.barrier
+      rocdl.sched.barrier 0
+
+      scf.yield %dot2 : vector<8x2x1x4xf32>
+    }
+    scf.if %cmp1 {
+      rocdl.s.barrier
+    }
+
+    // Epilogue
+    %lhs_vec = vector.transfer_read %lhs_shared[%c0, %ids#0, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_lhs_shared_ty, vector<2x8x1x16xf8E4M3FNUZ>
+    %lhs_vec_0 = vector.extract_strided_slice %lhs_vec {offsets = [0, 0, 0, 0], sizes = [1, 8, 1, 16], strides = [1, 1, 1, 1]} : vector<2x8x1x16xf8E4M3FNUZ> to vector<1x8x1x16xf8E4M3FNUZ>
+    %lhs_vec_2 = vector.extract_strided_slice %lhs_vec {offsets = [1, 0, 0, 0], sizes = [1, 8, 1, 16], strides = [1, 1, 1, 1]} : vector<2x8x1x16xf8E4M3FNUZ> to vector<1x8x1x16xf8E4M3FNUZ>
+    %lhs_vec_0_t = vector.shape_cast %lhs_vec_0 : vector<1x8x1x16xf8E4M3FNUZ> to vector<8x2x1x8xf8E4M3FNUZ>
+    %lhs_vec_2_t = vector.shape_cast %lhs_vec_2 : vector<1x8x1x16xf8E4M3FNUZ> to vector<8x2x1x8xf8E4M3FNUZ>
+
+    %rhs_vec = vector.transfer_read %rhs_shared[%c0, %glb0_rhs, %ids#2, %c0], %cst {in_bounds = [true, true, true, true]} : !m_rhs_shared_ty, vector<2x2x1x16xf8E4M3FNUZ>
+    %rhs_vec_0 = vector.extract_strided_slice %rhs_vec {offsets = [0, 0, 0, 0], sizes = [1, 2, 1, 16], strides = [1, 1, 1, 1]} : vector<2x2x1x16xf8E4M3FNUZ> to vector<1x2x1x16xf8E4M3FNUZ>
+    %rhs_vec_2 = vector.extract_strided_slice %rhs_vec {offsets = [1, 0, 0, 0], sizes = [1, 2, 1, 16], strides = [1, 1, 1, 1]} : vector<2x2x1x16xf8E4M3FNUZ> to vector<1x2x1x16xf8E4M3FNUZ>
+    %rhs_vec_0_t = vector.shape_cast %rhs_vec_0 : vector<1x2x1x16xf8E4M3FNUZ> to vector<2x2x1x8xf8E4M3FNUZ>
+    %rhs_vec_2_t = vector.shape_cast %rhs_vec_2 : vector<1x2x1x16xf8E4M3FNUZ> to vector<2x2x1x8xf8E4M3FNUZ>
+
+    %dot0 = iree_codegen.inner_tiled ins(%lhs_vec_0_t, %rhs_vec_0_t) outs(%3) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x2x1x8xf8E4M3FNUZ>, vector<2x2x1x8xf8E4M3FNUZ> into vector<8x2x1x4xf32>
+
+    %dot2 = iree_codegen.inner_tiled ins(%lhs_vec_2_t, %rhs_vec_2_t) outs(%dot0) {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+      kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>
+    } : vector<8x2x1x8xf8E4M3FNUZ>, vector<2x2x1x8xf8E4M3FNUZ> into vector<8x2x1x4xf32>
+
+    %empty = tensor.empty() : tensor<1x1x1x8x2x1x1x4xf32>
+    %cast = vector.shape_cast %dot2 : vector<8x2x1x4xf32> to vector<1x1x1x8x2x1x1x4xf32>
+    %4 = vector.transfer_write %cast, %empty[%c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true, true, true, true, true]} : vector<1x1x1x8x2x1x1x4xf32>, tensor<1x1x1x8x2x1x1x4xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %4 into %out[%c0, %c0, %ids#1, %c0, %c0, %threads#0, %threads#1, %c0] [1, 1, 1, 8, 2, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1, 1] : tensor<1x1x1x8x2x1x1x4xf32> into !m_acc_base_ty
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  util.return %1 : !m_acc_base_ty
+}

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
@@ -178,3 +178,177 @@ pdl.pattern @annotate_matmul_like_f8E4M3FNUZ_large_expanded : benefit(2) {
     pdl.apply_native_rewrite "annotateOperation"(%generic_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
   }
 }
+
+pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_medium : benefit(1) {
+  %lhs_type = pdl.type
+  %rhs_type = pdl.type
+  %out_type = pdl.type
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %out_init = pdl.operand : %out_type
+
+  // Match the a inner_tiled with specific data layouts.
+  %generic_op = pdl.operation "iree_codegen.inner_tiled" (%lhs, %rhs, %out_init : !pdl.value, !pdl.value, !pdl.value) -> (%out_type : !pdl.type)
+
+  %attr_name = pdl.attribute = "iree_codegen.ukernel"
+  pdl.apply_native_constraint "hasAttr"(%generic_op, %attr_name : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  %lhs_cast_type = pdl.type : tensor<?x?x8x4x4x4x2x8xf8E4M3FNUZ>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%lhs, %lhs_cast_type : !pdl.value, !pdl.type)
+  %rhs_cast_type = pdl.type : tensor<?x?x8x2x4x16x2x8xf8E4M3FNUZ>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
+
+  // Pingpong on outer K dim, this kernel has 2 pingpong stages.
+  %empty = pdl.attribute = {}
+  %c1 = pdl.attribute = 1
+  %c2 = pdl.attribute = 2
+  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c2, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+
+  pdl.rewrite {
+    // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
+    // This modifies the operation in-place.
+    %annotation = pdl.attribute = #iree_codegen.ukernel_descriptor<"pingpong_dt_medium_f8E4M3FNUZ", tensor>
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %attr_name, %annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %config_name = pdl.attribute = "compilation_info"
+    %config = pdl.attribute = #iree_codegen.compilation_info<
+      lowering_config = #iree_gpu.lowering_config<{
+        workgroup = [1, 1, 0]
+      }>,
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+        workgroup_size = [512, 1, 1] subgroup_size = 64,
+        // This strategy uses the maximum amount of possible shared memory on
+        // all gfx942 architectures so shared memory padding to reduce bank
+        // conflicts must be disabled. Also prefetching is done manually in the
+        // above and is disabled here as well.
+        {gpu_pipeline_options =
+          #iree_gpu.pipeline_options<
+            prefetch_shared_memory = false,
+            no_reduce_shared_memory_bank_conflicts = true>,
+        // This strategy requires 2 waves per SIMD.
+          llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>
+    >
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %config_name, %config : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %builtin_attr = pdl.attribute = "rocm.builtin_name"
+    %builtin_annotation = pdl.attribute = "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}
+
+pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_large : benefit(2) {
+  %lhs_type = pdl.type
+  %rhs_type = pdl.type
+  %out_type = pdl.type
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %out_init = pdl.operand : %out_type
+
+  // Match the a inner_tiled with specific data layouts.
+  %generic_op = pdl.operation "iree_codegen.inner_tiled" (%lhs, %rhs, %out_init : !pdl.value, !pdl.value, !pdl.value) -> (%out_type : !pdl.type)
+
+  %attr_name = pdl.attribute = "iree_codegen.ukernel"
+  pdl.apply_native_constraint "hasAttr"(%generic_op, %attr_name : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  %lhs_cast_type = pdl.type : tensor<?x?x2x8x4x4x4x8xf8E4M3FNUZ>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%lhs, %lhs_cast_type : !pdl.value, !pdl.type)
+  %rhs_cast_type = pdl.type : tensor<?x?x4x4x4x16x8xf8E4M3FNUZ>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
+
+  // Pingpong on outer K dim, this kernel has 4 pingpong stages.
+  %empty = pdl.attribute = {}
+  %c1 = pdl.attribute = 1
+  %c4 = pdl.attribute = 4
+  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+
+  pdl.rewrite {
+    // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
+    // This modifies the operation in-place.
+    %annotation = pdl.attribute = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f8E4M3FNUZ", tensor>
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %attr_name, %annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %config_name = pdl.attribute = "compilation_info"
+    %config = pdl.attribute = #iree_codegen.compilation_info<
+      lowering_config = #iree_gpu.lowering_config<{
+        workgroup = [1, 1, 0]
+      }>,
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+        workgroup_size = [512, 1, 1] subgroup_size = 64,
+        // This strategy uses the maximum amount of possible shared memory on
+        // all gfx942 architectures so shared memory padding to reduce bank
+        // conflicts must be disabled. Also prefetching is done manually in the
+        // above and is disabled here as well.
+        {gpu_pipeline_options =
+          #iree_gpu.pipeline_options<
+            prefetch_shared_memory = false,
+            no_reduce_shared_memory_bank_conflicts = true>,
+        // This strategy requires 2 waves per SIMD.
+          llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>
+    >
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %config_name, %config : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %builtin_attr = pdl.attribute = "rocm.builtin_name"
+    %builtin_annotation = pdl.attribute = "iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir"
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}
+
+pdl.pattern @annotate_inner_tiled_f16_large : benefit(1) {
+  %lhs_type = pdl.type
+  %rhs_type = pdl.type
+  %out_type = pdl.type
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %out_init = pdl.operand : %out_type
+
+  // Match the a inner_tiled with specific data layouts.
+  %generic_op = pdl.operation "iree_codegen.inner_tiled" (%lhs, %rhs, %out_init : !pdl.value, !pdl.value, !pdl.value) -> (%out_type : !pdl.type)
+
+  %attr_name = pdl.attribute = "iree_codegen.ukernel"
+  pdl.apply_native_constraint "hasAttr"(%generic_op, %attr_name : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  %lhs_cast_type = pdl.type : tensor<?x?x2x8x4x4x4x4xf16>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%lhs, %lhs_cast_type : !pdl.value, !pdl.type)
+  %rhs_cast_type = pdl.type : tensor<?x?x4x4x4x16x4xf16>
+  pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
+
+  // Pingpong on outer K dim, this kernel has 4 pingpong stages.
+  %empty = pdl.attribute = {}
+  %c1 = pdl.attribute = 1
+  %c4 = pdl.attribute = 4
+  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+
+  pdl.rewrite {
+    // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
+    // This modifies the operation in-place.
+    %annotation = pdl.attribute = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f16", tensor>
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %attr_name, %annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %config_name = pdl.attribute = "compilation_info"
+    %config = pdl.attribute = #iree_codegen.compilation_info<
+      lowering_config = #iree_gpu.lowering_config<{
+        workgroup = [1, 1, 0]
+      }>,
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+        workgroup_size = [512, 1, 1] subgroup_size = 64,
+        // This strategy uses the maximum amount of possible shared memory on
+        // all gfx942 architectures so shared memory padding to reduce bank
+        // conflicts must be disabled. Also prefetching is done manually in the
+        // above and is disabled here as well.
+        {gpu_pipeline_options =
+          #iree_gpu.pipeline_options<
+            prefetch_shared_memory = false,
+            no_reduce_shared_memory_bank_conflicts = true>,
+        // This strategy requires 2 waves per SIMD.
+          llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>
+    >
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %config_name, %config : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+    %builtin_attr = pdl.attribute = "rocm.builtin_name"
+    %builtin_annotation = pdl.attribute = "iree_uk_amdgpu_dt_matmul_f16.mlir"
+    pdl.apply_native_rewrite "annotateOperation"(%generic_op, %builtin_attr, %builtin_annotation : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}


### PR DESCRIPTION
Add ping-pong ukernel support tuned specifically for llama (8B, prefill, FP8, seq length 2048). The implementation is similar to the non–data-tiling versions, except for the data layout and swizzling is not required in the data-tiling case. Subgroup sizes and intrinsic unroll factors can differ with the non–data-tiling versions, due to bank conflicts observed in “apple-to-apple” comparisons, and indexing overhead also becomes different.

Results:
|   | No Data Tiling+ ukernel | Data Tiling No uKernel | Data Tiling+ ukernel |
| ------------- | ------------- | ------------- | ------------- |
| Total latency | 243ms | 353ms | 242ms |
| dispatch_15_attention_4x8x4xDx128xf8  | 62.29 | 59.21 | 59.71 |
| dispatch_20_matmul_like_Dx14336x4096_f8xf8xf32  | 40.13 | 93.72 | 37.81 |
| dispatch_19_matmul_like_Dx14336x4096_f8xf8xf32  | 28.01 | 44.59 | 30.99 |
| dispatch_21_matmul_like_Dx4096x14336_f8xf8xf32  | 27.25 | 39.99 | 25.50 |
| dispatch_643_matmul_like_Dx128256x4096_f16xf16xf32  | 17.1 |  29.21 | 16.23 |
| dispatch_16_matmul_like_Dx4096x4096_f8xf8xf32 | 8.83 | 17.91 | 8.28 |
| dispatch_23_matmul_like_Dx4096x4096_f8xf8xf32 | 9.27 | 16.59 | 8.32 |

Note these results cannot be reproduced with this PR alone. They also require: a proper solution for [#21865](https://github.com/iree-org/iree/issues/21865), and support for encodings specialized for ukernels.