### PR TITLE
[Codegen][GenericVectorization] Fix incorrect usage of std::accumulation that led to overflow

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -178,7 +178,7 @@ void GenericVectorizationPass::runOnOperation() {
       // Do not vectorize the op if the vector size is greater than or equal
       // to limit.
       if (enableVectorMasking) {
-        if (std::accumulate(vectorSizes.begin(), vectorSizes.end(), 1,
+        if (std::accumulate(vectorSizes.begin(), vectorSizes.end(), 1LL,
                             std::multiplies<int64_t>()) >= maxVectorSize)
           continue;
       } else {


### PR DESCRIPTION
The `std::accumulation` for checking if the vector exceeds size limit uses literal integer '1' as the initial value, which effectively makes the entire calculation to use int32_t (on most platforms) as the accumulator data type.
This might lead to sign overflow when one of the dimension sizes is between 32 bits and 64 bits, and bypass the check.

------

This issue was originally observed with tensor with dynamic shape like `<1x8x?xf32>`, in which case the ValueBoundConstraintSet somehow think the upper bound for this was enormously large, hence overflowing the check fixed in this PR. One might argue that something went wrong in ValueBoundConstraintSet which I kind of agree. Nevertheless, the `std::multiplies<int64_t>()` used in `std::accumulate` in this case hints that we _do_ want to use int64_t as the accumulator type. So we should fix this issue anyway.