### PR TITLE
Fixing CSE of hoisted encoding ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -64,8 +64,8 @@ ConvertedTensor transferTensorOperands(
   Value resource = convertedOperand[0];
   Value resourceSize = convertedOperand[1];
   auto affinityAttr = affinityAnalysis->lookupResourceAffinity(originalOperand);
-  bool isBarrier = resource.getDefiningOp() &&
-                   isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
+  bool isBarrier =
+      isa_and_nonnull<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
   if (affinityAttr != requiredAffinityAttr && !isBarrier) {
     resource = IREE::Stream::AsyncTransferOp::create(
         builder, loc, resource.getType(), resource, resourceSize, resourceSize,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2521,7 +2521,7 @@ def Stream_AsyncBarrierOp : Stream_Op<"async.barrier", [
   let hasCanonicalizer = 1;
 }
 
-def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
+def Stream_AsyncTransferOp : Stream_PureOp<"async.transfer", [
   DeclareOpInterfaceMethods<Stream_AffinityOp, [
     "getAffinityAttr",
     "setAffinityAttr",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "iree/compiler/Utils/PassUtils.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/SmallVector.h"
@@ -233,6 +234,10 @@ public:
     }
     for (auto globalName : deadGlobalNames) {
       globalTable.eraseGlobal(globalName);
+    }
+
+    if (!deadGlobalNames.empty()) {
+      signalFixedPointModified(moduleOp);
     }
   }
 };


### PR DESCRIPTION
A bug in the fixed-point iteration applying cleanup during the stream phase and the `IREE::Stream::AsyncTransferOp` not being marked pure were preventing us from CSEing entire DAGs of work in hoisted initializers.

Example before (same parameter encoded twice and then stored in memory as two distinct buffers):
```
  util.initializer {
    %cst = stream.tensor.constant on(#hal.device.affinity<@__device_0>) : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<constant> = #stream.parameter.named<"model"::"blk.0.attn_q.weight:qs"> : tensor<4096x4096xf8E4M3FNUZ>
    %0 = stream.resource.size %cst : !stream.resource<constant>
    util.global.store %cst, @"__auto.blk.0.attn_q.weight:qs" : !stream.resource<constant>
    util.global.store %0, @"__auto.blk.0.attn_q.weight:qs__size" : index
    %__auto.blk.0.attn_q.weight3Aqs__size = util.global.load @"__auto.blk.0.attn_q.weight:qs__size" : index
    %__auto.blk.0.attn_q.weight3Aqs = util.global.load @"__auto.blk.0.attn_q.weight:qs" : !stream.resource<constant>
    %1 = stream.async.transfer %__auto.blk.0.attn_q.weight3Aqs : !stream.resource<constant>{%__auto.blk.0.attn_q.weight3Aqs__size} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<*>{%__auto.blk.0.attn_q.weight3Aqs__size}
    %2 = stream.tensor.sizeof on(#hal.device.affinity<@__device_0>) tensor<4096x4096xf8E4M3FNUZ, #encoding> : index
    %3 = stream.tensor.encode on(#hal.device.affinity<@__device_0>) %1 : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<*>{%__auto.blk.0.attn_q.weight3Aqs__size} -> tensor<4096x4096xf8E4M3FNUZ, #encoding> in !stream.resource<*>{%2}
    %4 = stream.async.transfer %3 : !stream.resource<*>{%2} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<constant>{%2}
    util.global.store %4, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded : !stream.resource<constant>
    util.global.store %2, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded__size : index
    %__auto.blk.0.attn_q.weight3Aqs__size_0 = util.global.load @"__auto.blk.0.attn_q.weight:qs__size" : index
    %__auto.blk.0.attn_q.weight3Aqs_1 = util.global.load @"__auto.blk.0.attn_q.weight:qs" : !stream.resource<constant>
    %5 = stream.async.transfer %__auto.blk.0.attn_q.weight3Aqs_1 : !stream.resource<constant>{%__auto.blk.0.attn_q.weight3Aqs__size_0} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<*>{%__auto.blk.0.attn_q.weight3Aqs__size_0}
    %6 = stream.tensor.sizeof on(#hal.device.affinity<@__device_0>) tensor<4096x4096xf8E4M3FNUZ, #encoding> : index
    %7 = stream.tensor.encode on(#hal.device.affinity<@__device_0>) %5 : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<*>{%__auto.blk.0.attn_q.weight3Aqs__size_0} -> tensor<4096x4096xf8E4M3FNUZ, #encoding> in !stream.resource<*>{%6}
    %8 = stream.async.transfer %7 : !stream.resource<*>{%6} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<constant>{%6}
    util.global.store %8, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded_0 : !stream.resource<constant>
    util.global.store %6, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded_0__size : index
    util.return
  }
```

Example after (parameter encoded once and stored in memory once):
```
  util.initializer {
    %cst = stream.tensor.constant on(#hal.device.affinity<@__device_0>) : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<constant> = #stream.parameter.named<"model"::"blk.0.attn_q.weight:qs"> : tensor<4096x4096xf8E4M3FNUZ>
    %0 = stream.resource.size %cst : !stream.resource<constant>
    %1 = stream.async.transfer %cst : !stream.resource<constant>{%0} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<*>{%0}
    %2 = stream.tensor.sizeof on(#hal.device.affinity<@__device_0>) tensor<4096x4096xf8E4M3FNUZ, #encoding> : index
    %3 = stream.tensor.encode on(#hal.device.affinity<@__device_0>) %1 : tensor<4096x4096xf8E4M3FNUZ> in !stream.resource<*>{%0} -> tensor<4096x4096xf8E4M3FNUZ, #encoding> in !stream.resource<*>{%2}
    %4 = stream.async.transfer %3 : !stream.resource<*>{%2} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<constant>{%2}
    util.global.store %4, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded : !stream.resource<constant>
    util.global.store %2, @__hoisted_tensor_4096x4096xf8E4M3FNUZ__encoded__size : index
    util.return
  }
```

The fixed-point change should be safe but the AsyncTransferOp change may have some unforeseen impacts due to how long it has not been marked pure. There's several places where we treat AsyncTransferOp as pure (removing duplicates, folding chains of transfers, etc) so my hope is this is more of an inconsistency we never noticed.

Fixes part of #21659 (duplication of the same encoded parameter).