### PR TITLE
Re-enable lds_barrier on RDNA4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -69,13 +69,8 @@ struct ReplaceGPUBarrierWithLDSBarrier
   }
 };
 
-static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns,
-                                               const amdgpu::Chipset &chipset) {
-  // TODO(kdrewnia): This if statement is an emergency fix for an incorrect
-  // lowering of amdgpu.lds_barrier.
-  if (chipset.majorVersion != 12) {
-    patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
-  }
+static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns) {
+  patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
 }
 
 /// Hacky pattern to swap `s_setprio` operations with `amdgpu.mfma` ops.
@@ -255,7 +250,7 @@ struct ConvertToROCDLPass final
           /*chipset=*/*maybeChipset);
       arith::populateCeilFloorDivExpandOpsPatterns(patterns);
       populateSwapSetPrioWithMFMAPatterns(patterns);
-      populateConvertGPUToAMDGPUPatterns(patterns, *maybeChipset);
+      populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);


### PR DESCRIPTION
Now that `amdgpu.lds_barrier` emits the correct fences, we can restore usage of `lds_barrier` and not need the `__syncthreads`-type everything-fence
