### PR TITLE
[DataTiling] Implement naive materialization for scaled matmul encodings

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -57,6 +57,9 @@ updateFuncSignature(FunctionOpInterface funcOp,
   SmallVector<Type> newResults =
       llvm::map_to_vector(funcOp.getResultTypes(), convertType);
   funcOp.setType(FunctionType::get(funcOp.getContext(), newInputs, newResults));
+  for (auto [arg, newType] : llvm::zip(funcOp.getArguments(), newInputs)) {
+    arg.setType(newType);
+  }
 }
 
 static LogicalResult
@@ -131,12 +134,31 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     MaterializeEncodingConversionTarget target(*ctx);
     populateMaterializeEncodingPatterns(patterns, target, typeConverter);
 
+    // Replace any unrealized conversions to tensor.cast ops if they come from
+    // block arguments. The function signature is updated to match the converted
+    // types after the partial conversion. This is used in testing, where
+    // function arguments have encodings to reduce the amount of IR, but we do
+    // not expect function arguments to have encodings in practice.
+    auto castFnArguments = [](OpBuilder &builder, Type resultTy,
+                              ValueRange inputs, Location loc) -> Value {
+      if (inputs.size() != 1) {
+        return Value();
+      }
+      Value input = inputs[0];
+      if (!isa<BlockArgument>(input) ||
+          !isa<RankedTensorType>(input.getType())) {
+        return Value();
+      }
+      return tensor::CastOp::create(builder, loc, resultTy, input);
+    };
+    typeConverter.addTargetMaterialization(castFnArguments);
+    typeConverter.addSourceMaterialization(castFnArguments);
+
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
       return funcOp.emitOpError("materialization failed");
     }
 
-    // The update is required for testing purposes, which results in fewer IRs.
-    // We do not expect inputs and outputs from `funcOp` in practice.
+    // Update the function signature to match the converted types.
     updateFuncSignature(funcOp, typeConverter);
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/SmallVectorExtras.h"
@@ -882,6 +883,43 @@ public:
   }
 };
 
+/// Pattern to convert contraction operations.
+class MaterializeScaledContractionOp
+    : public OpInterfaceConversionPattern<linalg::LinalgOp> {
+public:
+  MaterializeScaledContractionOp(
+      const MaterializeEncodingTypeConverter &typeConverter,
+      MLIRContext *context, PatternBenefit benefit = 1)
+      : OpInterfaceConversionPattern<linalg::LinalgOp>(typeConverter, context,
+                                                       benefit) {}
+
+  LogicalResult
+  matchAndRewrite(linalg::LinalgOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!IREE::LinalgExt::isaScaledContractionOpInterface(op)) {
+      return rewriter.notifyMatchFailure(
+          op, "does not implement ScaledContractionOpInterface");
+    }
+
+    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
+        this->getTypeConverter());
+
+    IREE::Encoding::LayoutMaterializerAttr layoutAttr =
+        converter->getLayoutAttr();
+    SmallVector<Type> convertedResTypes;
+    for (auto init : op.getDpsInits()) {
+      convertedResTypes.push_back(converter->convertType(init.getType()));
+    }
+    Operation *newOp =
+        layoutAttr.lowerOp(rewriter, op, convertedResTypes, operands);
+    if (!newOp) {
+      return failure();
+    }
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
 static bool isRankedTensorTypeWithEncoding(Type type) {
   auto rankedTensorType = dyn_cast<RankedTensorType>(type);
   if (!rankedTensorType) {
@@ -941,15 +979,15 @@ void populateMaterializeEncodingPatterns(
                          isRankedTensorTypeWithEncoding);
   });
 
-  patterns.insert<MaterializeContractionOp, SetEncodingOpLoweringConversion,
-                  UnsetEncodingOpLoweringConversion,
-                  MaterializeDPSOperation<linalg::FillOp>,
-                  MaterializeDPSOperation<linalg::GenericOp>,
-                  MaterializeOperation<tensor::EmptyOp>,
-                  MaterializeOptimizationBarrierOp,
-                  MaterializeTensorExtDispatchTensorLoadOp,
-                  MaterializeTensorExtDispatchTensorStoreOp,
-                  MaterializeInterfaceBindingEncoding, MaterializeFuncReturnOp>(
+  patterns.insert<
+      MaterializeContractionOp, MaterializeScaledContractionOp,
+      SetEncodingOpLoweringConversion, UnsetEncodingOpLoweringConversion,
+      MaterializeDPSOperation<linalg::FillOp>,
+      MaterializeDPSOperation<linalg::GenericOp>,
+      MaterializeOperation<tensor::EmptyOp>, MaterializeOptimizationBarrierOp,
+      MaterializeTensorExtDispatchTensorLoadOp,
+      MaterializeTensorExtDispatchTensorStoreOp,
+      MaterializeInterfaceBindingEncoding, MaterializeFuncReturnOp>(
       typeConverter, context);
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -907,7 +907,7 @@ public:
     IREE::Encoding::LayoutMaterializerAttr layoutAttr =
         converter->getLayoutAttr();
     SmallVector<Type> convertedResTypes;
-    for (auto init : op.getDpsInits()) {
+    for (Value init : op.getDpsInits()) {
       convertedResTypes.push_back(converter->convertType(init.getType()));
     }
     Operation *newOp =

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -346,7 +346,7 @@ func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127x
   return %0 : tensor<255x127x32xf4E2M1FN, #encoding>
 }
 
-// CHECK-LABEL: func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-LABEL: func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [1, 2]
@@ -375,7 +375,7 @@ func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127x
   return %0 : tensor<513x127x32xf4E2M1FN, #encoding>
 }
 
-// CHECK-LABEL: func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-LABEL: func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [1, 2]
@@ -404,7 +404,7 @@ func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<2
   return %0 : tensor<255x127xf8E8M0FNU, #encoding>
 }
 
-// CHECK-LABEL: func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-LABEL: func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [1]
@@ -437,7 +437,7 @@ func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<5
   return %0 : tensor<513x127xf8E8M0FNU, #encoding>
 }
 
-// CHECK-LABEL: func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-LABEL: func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [1]
@@ -470,7 +470,7 @@ func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x513x
   return %0 : tensor<255x513xf32, #encoding>
 }
 
-// CHECK-LABEL: func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-LABEL: func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(
 // CHECK-SAME:         %[[ARG0:.+]]: tensor<255x513xf32>
 // CHECK:         return %[[ARG0]]
 
@@ -517,7 +517,7 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d5, d4)>
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5, d4)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>
-// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32
+// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
 // CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>
 // CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>
 // CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?xf32>
@@ -535,14 +535,14 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
 #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
-#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
-#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
-#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
 
-func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32(
-    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
+    %arg0: tensor<?x?x32xf8E4M3FN, #encoding_lhs>,
     %arg1: tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
     %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
     %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
@@ -552,11 +552,11 @@ func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32(
       indexing_maps = [#map, #map1, #map2, #map3, #map4],
       iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
       ins(%arg0, %arg1, %arg2, %arg3
-           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
+           : tensor<?x?x32xf8E4M3FN, #encoding_lhs>, tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
              tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
       outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
-  ^bb0(%in: f4E2M1FN, %in_0: f8E4M3FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
-    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+  ^bb0(%in: f8E4M3FN, %in_0: f8E4M3FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f8E4M3FN, f8E8M0FNU to f32
     %12 = arith.scaling_extf %in_0, %in_2 : f8E4M3FN, f8E8M0FNU to f32
     %13 = arith.mulf %11, %12 : f32
     %14 = arith.addf %out, %13 : f32
@@ -570,9 +570,78 @@ func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32(
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d5, d4)>
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5, d4)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>
-// CHECK:     func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x32xf8E4M3FN>
+// CHECK:     func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x32xf8E4M3FN>
 // CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = linalg.generic
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction", "reduction", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]]
+// CHECK-SAME:    outs(%[[RESULT]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<
+    arch = "gfx950", features = "",
+    wgp = <compute = fp16, storage =  b16,
+           scaled_mma = [
+             <intrinsic = MFMA_SCALE_F32_32x32x64_B32,
+              lhs_elem_type = f4E2M1FN,
+              rhs_elem_type = f4E2M1FN,
+              acc_elem_type = f32>],
+           subgroup =  none, subgroup_size_choices = [64],
+           max_workgroup_sizes = [1024, 1024, 1024],
+           max_thread_count_per_workgroup = 1024,
+           max_workgroup_memory_bytes = 163840,
+           max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>}>
+func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
+    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result>
+    attributes { hal.executable.target = #executable_target } {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d5, d4)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x2x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x2x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x2x4xf8E8M0FNU>
 // CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = linalg.generic
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -4,7 +4,7 @@
 
 // Contains tests that differ from gfx942/MI-300
 
-//----------------------------------------------//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // 1. MFMA_I32_16x16x64_I8
 //-----------------------------------------------------------------------------
 
@@ -322,3 +322,260 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16() {
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
 // CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+
+// -----
+
+//-----------------------------------------------------------------------------
+// 1. Scaled MFMA
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 0 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127x32xf4E2M1FN>) -> tensor<255x127x32xf4E2M1FN, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x127x32xf4E2M1FN> -> tensor<255x127x32xf4E2M1FN, #encoding>
+  return %0 : tensor<255x127x32xf4E2M1FN, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [1, 2]
+// CHECK-SAME:      inner_tiles = [16, 32]
+// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<255x8x1x16x32xf4E2M1FN>
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<255x8x1x16x32xf4E2M1FN> into tensor<255x8x1x4x4x32xf4E2M1FN>
+// CHECK:         return %[[EXPANDED]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 1 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127x32xf4E2M1FN>) -> tensor<513x127x32xf4E2M1FN, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x127x32xf4E2M1FN> -> tensor<513x127x32xf4E2M1FN, #encoding>
+  return %0 : tensor<513x127x32xf4E2M1FN, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [1, 2]
+// CHECK-SAME:      inner_tiles = [16, 32]
+// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<513x8x1x16x32xf4E2M1FN>
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<513x8x1x16x32xf4E2M1FN> into tensor<513x8x1x4x4x32xf4E2M1FN>
+// CHECK:         return %[[EXPANDED]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 2 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127xf8E8M0FNU>) -> tensor<255x127xf8E8M0FNU, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x127xf8E8M0FNU> -> tensor<255x127xf8E8M0FNU, #encoding>
+  return %0 : tensor<255x127xf8E8M0FNU, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
+// CHECK-SAME:      outer_dims_perm = [0, 1]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [16]
+// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<255x8x16xf8E8M0FNU>
+// CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<255x8x16xf8E8M0FNU> into tensor<255x8x4x4xf8E8M0FNU>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<255x8x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs({{.*}} : tensor<255x8x4x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 3, 2]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 3 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127xf8E8M0FNU>) -> tensor<513x127xf8E8M0FNU, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x127xf8E8M0FNU> -> tensor<513x127xf8E8M0FNU, #encoding>
+  return %0 : tensor<513x127xf8E8M0FNU, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
+// CHECK-SAME:      outer_dims_perm = [0, 1]
+// CHECK-SAME:      inner_dims_pos = [1]
+// CHECK-SAME:      inner_tiles = [16]
+// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<513x8x16xf8E8M0FNU>
+// CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<513x8x16xf8E8M0FNU> into tensor<513x8x4x4xf8E8M0FNU>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<513x8x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs({{.*}} : tensor<513x8x4x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 3, 2]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 4 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x513xf32>) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32
+// CHECK-SAME:         %[[ARG0:.+]]: tensor<255x513xf32>
+// CHECK:         return %[[ARG0]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
+    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d5, d4)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = linalg.generic
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction", "reduction", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]]
+// CHECK-SAME:    outs(%[[RESULT]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32(
+    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f8E4M3FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f8E4M3FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d3, d4, d5, d6)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d5, d4)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f4_f8_f8_f8_f32
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x32xf8E4M3FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = linalg.generic
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction", "reduction", "reduction", "reduction"]
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]]
+// CHECK-SAME:    outs(%[[RESULT]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1644,7 +1644,7 @@ LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
   Value zeroScales = arith::ConstantOp::create(
       builder, loc,
       SplatElementsAttr::get(
-          VectorType::get({4}, f8E8M0),
+          VectorType::get({getScalesVectorSize()}, f8E8M0),
           llvm::APFloat::getSmallest(f8E8M0.getFloatSemantics())));
   auto padScales = [&](Value scales) {
     Value scale = vector::ExtractOp::create(builder, loc, scales, 0);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -391,6 +391,13 @@ def IREEGPU_ScaledMMAAttr :
     static SmallVector<Type> getSupportedInputTypes(MLIRContext *ctx);
     static SmallVector<Type> getSupportedOutputTypes(MLIRContext *ctx);
 
+    /// For scaled MFMA intrinsics, the scales are packed into a 32 bit register.
+    /// Since scales are 8 bits, the intrinsic takes a vector of 4 scales, along
+    /// with a selector to indicate which scale is used.
+    int64_t getScalesVectorSize() const {
+      return 4;
+    }
+
     // Return the number of elements per shared scale.
     int64_t getBlockSize() const;
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Encoding::Utils
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -40,6 +40,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
@@ -57,6 +58,31 @@ using IREE::Codegen::MaterializeEncodingInfo;
 using IREE::Codegen::TileMxNxK;
 
 namespace {
+
+/// Chooses a ScaledMMAAttr that supports the given element types. Currently
+/// just selects the first ScaledMMAAttr that is compatible with the given
+/// element types.
+/// TODO(#21923): This is a placeholder for now. We want a better heuristic
+/// in the future.
+static ScaledMMAAttr chooseScaledIntrinsicMMAAttr(TypeRange eTypes,
+                                                  TargetWgpAttr wgp) {
+  ScaledMMAAttr candidateMma;
+  for (ScaledMMAAttr mma : wgp.getScaledMma()) {
+    // Filter out intrinsics that don't match the element types of this matmul.
+    SetVector<Type> supportedInTypes, supportedOutTypes;
+    supportedInTypes.insert_range(mma.getSupportedInputTypes(wgp.getContext()));
+    supportedOutTypes.insert_range(
+        mma.getSupportedOutputTypes(wgp.getContext()));
+    if (!supportedInTypes.contains(eTypes[0]) ||
+        !supportedInTypes.contains(eTypes[1]) ||
+        !supportedOutTypes.contains(eTypes[4])) {
+      continue;
+    }
+    candidateMma = mma;
+    break;
+  }
+  return candidateMma;
+}
 
 static MMAAttr chooseIntrinsicMMAAttr(TypeRange eTypes, TargetWgpAttr wgp) {
   MMAAttr candidateMma;
@@ -309,6 +335,198 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   return mmaOp;
 }
 
+/// Lower a scaled contraction op to the data tiled layout. This lowering does
+/// not introduce an iree_codegen.inner_tiled op because we do not pack the
+/// LHR or RHS operands.
+/// TODO(#21923): This is naive a placeholder lowering. It should generate an
+/// inner_tiled op based on the selected ScaledMMAAttr.
+static Operation *lowerScaledContractionOpToDataTiledOp(
+    OpBuilder &builder, linalg::LinalgOp linalgOp, ValueRange operands,
+    TargetAttr targetAttr) {
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return nullptr;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(linalgOp.getOperation());
+  if (!genericOp) {
+    return nullptr;
+  }
+  if (!IREE::LinalgExt::isaScaledContractionOpInterface(genericOp)) {
+    return nullptr;
+  }
+  FailureOr<IREE::LinalgExt::ScaledContractionDimensions> contractionDims =
+      IREE::LinalgExt::inferScaledContractionDims(genericOp);
+  if (failed(contractionDims)) {
+    return nullptr;
+  }
+
+  auto inputs = genericOp.getDpsInputOperands();
+  auto outputs = genericOp.getDpsInits();
+
+  auto lhsType = cast<RankedTensorType>(inputs[0]->get().getType());
+  auto rhsType = cast<RankedTensorType>(inputs[1]->get().getType());
+  auto lhsScalesType = cast<RankedTensorType>(inputs[2]->get().getType());
+  auto rhsScalesType = cast<RankedTensorType>(inputs[3]->get().getType());
+  auto resultType = cast<RankedTensorType>(outputs[0].getType());
+  auto lhsEncoding = IREE::Encoding::getEncodingAttr(lhsType);
+  auto rhsEncoding = IREE::Encoding::getEncodingAttr(rhsType);
+  auto lhsScalesEncoding = IREE::Encoding::getEncodingAttr(lhsScalesType);
+  auto rhsScalesEncoding = IREE::Encoding::getEncodingAttr(rhsScalesType);
+  auto resultEncoding = IREE::Encoding::getEncodingAttr(resultType);
+  if (!lhsEncoding || !rhsEncoding || !lhsScalesEncoding ||
+      !rhsScalesEncoding || !resultEncoding) {
+    return nullptr;
+  }
+
+  if (lhsEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::SCALED_MATMUL_LHS ||
+      rhsEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::SCALED_MATMUL_RHS ||
+      lhsScalesEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::SCALED_MATMUL_LHS_SCALES ||
+      rhsScalesEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::SCALED_MATMUL_RHS_SCALES ||
+      resultEncoding.getOperandIndex().getValue() !=
+          IREE::Encoding::SCALED_MATMUL_RESULT) {
+    return nullptr;
+  }
+
+  // One extra dim for packing the kBDim, and 2 extra dims for packing and
+  // swizzling the kDim.
+  int64_t originalRank = genericOp.getStaticLoopRanges().size();
+  int64_t convertedRank = originalRank + 3;
+  SmallVector<utils::IteratorType> convertedIteratorTypes =
+      genericOp.getIteratorTypesArray();
+  convertedIteratorTypes.append(3, utils::IteratorType::reduction);
+  SmallVector<AffineMap> convertedMaps;
+  AffineExpr kInnerCrossIntrinsic = builder.getAffineDimExpr(originalRank);
+  AffineExpr kInnerInternal = builder.getAffineDimExpr(originalRank + 1);
+  AffineExpr kBInner = builder.getAffineDimExpr(originalRank + 2);
+  for (auto [idx, map] : llvm::enumerate(genericOp.getIndexingMapsArray())) {
+    // Only the reduction dimensions are tiled/swizzled. The result operand
+    // remains unchanged.
+    SmallVector<AffineExpr> results(map.getResults());
+    if (idx == IREE::Encoding::SCALED_MATMUL_LHS ||
+        idx == IREE::Encoding::SCALED_MATMUL_RHS) {
+      results.append({kInnerCrossIntrinsic, kInnerInternal, kBInner});
+    } else if (idx == IREE::Encoding::SCALED_MATMUL_LHS_SCALES ||
+               idx == IREE::Encoding::SCALED_MATMUL_RHS_SCALES) {
+      // The kDim tile has been swizzled so that the crossIntrinsic dimension is
+      // innermost.
+      results.append({kInnerInternal, kInnerCrossIntrinsic});
+    }
+    convertedMaps.push_back(
+        AffineMap::get(convertedRank, 0, results, builder.getContext()));
+  }
+  SmallVector<Value> convertedInputOperands(operands);
+  SmallVector<Value> convertedOutputOperands(
+      {convertedInputOperands.pop_back_val()});
+  Type convertedResultType = convertedOutputOperands[0].getType();
+  // TODO(#21923): We should directly create an inner_tiled op, but we currently
+  // do not materialize the packed layout for the LHS, RHS, or ACC operands, so
+  // we can't lower directly to the inner_tiled op. Fix this once we have packed
+  // layouts for all operands.
+  auto convertedScaledContraction = linalg::GenericOp::create(
+      builder, genericOp.getLoc(), TypeRange{convertedResultType},
+      convertedInputOperands, convertedOutputOperands, convertedMaps,
+      convertedIteratorTypes, /*bodyBuilder=*/nullptr,
+      linalg::getPrunedAttributeList(genericOp));
+  convertedScaledContraction.getRegion().takeBody(genericOp->getRegion(0));
+  return convertedScaledContraction;
+}
+
+/// Gets the MaterializeEncodingInfo for a scaled matmul encoding. Currently,
+/// this only packs the scales into a layout where scales for 4 consecutive
+/// MFMA instructions can be loaded into a single 32 bit register.
+/// TODO(#21923): This is a placeholder layout implementation. We should also be
+/// packing the LHS and RHS operands.
+static MaterializeEncodingInfo
+getScaledMatmulPackedLayoutEncodingInfo(IREE::Encoding::EncodingAttr encoding,
+                                        DictionaryAttr config) {
+  MaterializeEncodingInfo info;
+  SmallVector<AffineMap> maps = encoding.getRootMaps();
+  FailureOr<IREE::LinalgExt::ScaledContractionDimensions> cDims =
+      IREE::LinalgExt::inferScaledContractionDims(maps);
+  assert(!failed(cDims) && cDims->k.size() == 1 && cDims->kB.size() == 1 &&
+         "Unsupported: multiple k or kB dimension");
+  IREE::GPU::TargetAttr gpuAttr = getGPUTargetAttr(config);
+  if (!gpuAttr) {
+    return info;
+  }
+  SmallVector<Type> elementTypes = encoding.getElementTypesArray();
+  assert(elementTypes.size() == 5 &&
+         "Scaled matmul expected to have 5 element types");
+  assert(elementTypes[2].getIntOrFloatBitWidth() ==
+             elementTypes[3].getIntOrFloatBitWidth() &&
+         "Scaled matmul expected to have scales of the same bit width");
+  ScaledMMAAttr mmaAttr =
+      chooseScaledIntrinsicMMAAttr(elementTypes, gpuAttr.getWgp());
+  if (!mmaAttr) {
+    return info;
+  }
+  unsigned kDim = cDims->k.front();
+  std::optional<int64_t> operandKDim = encoding.mapDimToOperandIndex(kDim);
+  if (!operandKDim.has_value()) {
+    return info;
+  }
+
+  // Scales are packed into a vector of 4 scales, and a selector is used to
+  // indicate which scale is used. For performance, we want to be able to load
+  // the scales for multiple instructions at once into a single 32 bit register,
+  // and use the same register for a series of MFMA instructions. However, based
+  // on the row-major layout of the scales, consecutive scale elements will be
+  // loaded by separate threads cooperating on the same instruction within a
+  // subgroup. Instead, we want consecutive scale elements to be loaded by a
+  // single thread, so we need to swizzle the inner K tile such that an outer
+  // dimension of the `scalesVectorSize` becomes innermost.
+  unsigned scalesVectorSize = mmaAttr.getScalesVectorSize();
+  int64_t kIntrSize, kBIntrSize;
+  std::tie(std::ignore, std::ignore, kIntrSize, kBIntrSize) =
+      mmaAttr.getScaledMNKShape();
+  info.innerTileSizes = {scalesVectorSize * kIntrSize};
+  info.innerDimsPos = {operandKDim.value()};
+  AffineMap operandMap = encoding.getLastMapForOperandIndex();
+  info.outerDimsPerm =
+      llvm::to_vector(llvm::seq<int64_t>(operandMap.getNumResults()));
+  // Start building the swizzle for the first inner tile dim. For scales, the
+  // row major layout is [scalesVectorSize, kIntrSize]. We want to swizzle to
+  // [kIntrSize, scalesVectorSize].
+  Codegen::TileSwizzle swizzle;
+  Codegen::TileSwizzle::ExpandShapeType expandShape;
+  auto internal = Codegen::TileSwizzle::Dim::Kind::Internal;
+  auto crossIntrinsic = Codegen::TileSwizzle::Dim::Kind::CrossIntrinsic;
+  expandShape.push_back(Codegen::TileSwizzle::ExpandShapeDimVectorType(
+      {Codegen::TileSwizzle::Dim(crossIntrinsic, 4),
+       Codegen::TileSwizzle::Dim(internal, 4)}));
+  swizzle.expandShape = expandShape;
+  // Only scales will have a permutation, which is adjusted below. We want to
+  // avoid complicated layout transformations on the LHS and RHS for simplicity,
+  // and we do not need to swizzle the LHS or RHS to get good contiguous vector
+  // loads, since the block dimension is typically already innermost.
+  swizzle.permutation = SmallVector<int64_t>({0, 1});
+
+  // If there is a kBDim, add an inner tile dim for it. Only the LHS and RHS
+  // will have the kBDim.
+  unsigned kBDim = cDims->kB.front();
+  std::optional<int64_t> operandKBDim = encoding.mapDimToOperandIndex(kBDim);
+  if (operandKBDim.has_value()) {
+    info.innerDimsPos.push_back(operandKBDim.value());
+    info.innerTileSizes.push_back(mmaAttr.getBlockSize());
+    swizzle.permutation.push_back(2);
+    swizzle.expandShape.push_back(
+        Codegen::TileSwizzle::ExpandShapeDimVectorType(
+            {Codegen::TileSwizzle::Dim(crossIntrinsic, 32)}));
+  }
+  int64_t encodingOperandIdx = encoding.getOperandIndex().getInt();
+  if (encodingOperandIdx == IREE::Encoding::SCALED_MATMUL_LHS_SCALES ||
+      encodingOperandIdx == IREE::Encoding::SCALED_MATMUL_RHS_SCALES) {
+    // Permute the kDim tile to put the crossIntrinsic innermost.
+    swizzle.permutation[0] = 1;
+    swizzle.permutation[1] = 0;
+  }
+  info.swizzle = swizzle;
+  return info;
+}
+
 struct GPUEncodingPackedLayoutMaterializerAttr
     : public PackedLayoutMaterializerAttrExternalModelBase<
           GPUEncodingPackedLayoutMaterializerAttr, GPUEncodingResolverAttr> {
@@ -327,6 +545,10 @@ struct GPUEncodingPackedLayoutMaterializerAttr
     MaterializeEncodingInfo info;
     if (!encoding) {
       return info;
+    }
+    if (encoding.getOpType().getValue() ==
+        IREE::Encoding::EncodingOpType::scaled_matmul) {
+      return getScaledMatmulPackedLayoutEncodingInfo(encoding, config);
     }
 
     IREE::GPU::TargetAttr gpuAttr = getGPUTargetAttr(config);
@@ -377,8 +599,12 @@ struct GPUEncodingResolverMaterializerAttr
     if (!gpuAttr) {
       return nullptr;
     }
-    return lowerContractionOpToMultiMmaOp(b, linalgOp, convertedOperands,
-                                          gpuAttr);
+    if (linalg::isaContractionOpInterface(linalgOp)) {
+      return lowerContractionOpToMultiMmaOp(b, linalgOp, convertedOperands,
+                                            gpuAttr);
+    }
+    return lowerScaledContractionOpToDataTiledOp(b, linalgOp, convertedOperands,
+                                                 gpuAttr);
   }
 };
 


### PR DESCRIPTION
Implements the encoding materialization for scaled matmul encodings with a simple, naive layout. Currently, only the scales are being swizzled, while the transformations of the LHS and RHS should simply become a pad + reshape. The layout is not important in this PR, since the main point is to plumb through the materialization implementation. We still have not decided what the best layout should be, so we are tracking the work in https://github.com/iree-org/iree/issues/21923.

This PR also includes a small fix to allow materialization of function arguments, which simplifies the lit tests.