### PR TITLE
[Codegen][RISCV] Do not lower vector.gather to branches in the presence of RVV

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -987,13 +987,21 @@ void ConvertToLLVMPass::runOnOperation() {
   moduleOp->setAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
                     StringAttr::get(moduleOp->getContext(), dataLayoutStr));
 
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
+  DictionaryAttr targetConfig =
+      targetAttr ? targetAttr.getConfiguration() : nullptr;
+
   // Run Vector -> Vector transformations ahead of conversion to LLVM.
   {
     RewritePatternSet patterns(&getContext());
     vector::populateVectorToVectorCanonicalizationPatterns(patterns);
     vector::populateBubbleVectorBitCastOpPatterns(patterns);
     vector::populateVectorBroadcastLoweringPatterns(patterns);
-    vector::populateVectorGatherToConditionalLoadPatterns(patterns);
+    // RVV should be able to lower most of the gather / scatter with indexed
+    // load / store.
+    if (!targetConfig || !isRISCV(targetConfig) ||
+        !hasAnyVFeature(targetConfig))
+      vector::populateVectorGatherToConditionalLoadPatterns(patterns);
     vector::populateVectorInterleaveLoweringPatterns(patterns);
     // TODO: doubtful that the "default" does what one want here, it is likely
     // better to use outerproduct.
@@ -1041,9 +1049,6 @@ void ConvertToLLVMPass::runOnOperation() {
   //
   // TODO(bjacob): Use a lowering that uses specific ARM/X86 intrinsics.
   bool use32BitImpl = false;
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
-  DictionaryAttr targetConfig =
-      targetAttr ? targetAttr.getConfiguration() : nullptr;
   if (targetConfig && isRISCV(targetConfig)) {
     // Use the 32-bit lowering for RISC-V if 'zve32*' is specified and there is
     // no 64-bit integer vector support.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -55,9 +55,10 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
           .setVectorMultiReductionLowering(vectorMultiReductionLowering)
           .setVectorTransferSplit(vectorTransferSplit);
 
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-  DictionaryAttr targetConfig =
-      targetAttr ? targetAttr.getConfiguration() : nullptr;
+  DictionaryAttr targetConfig;
+  if (auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp)) {
+    targetConfig = targetAttr.getConfiguration();
+  }
 
   // Target-dependenet patterns.
   {
@@ -75,8 +76,9 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     // RVV should be able to lower most of the gather / scatter with indexed
     // load / store.
     if (!targetConfig || !isRISCV(targetConfig) ||
-        !hasAnyVFeature(targetConfig))
+        !hasAnyVFeature(targetConfig)) {
       vector::populateVectorGatherToConditionalLoadPatterns(patterns);
+    }
     vector::populateVectorGatherLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(
         patterns, vectorTransformOptions.vectorContractLowering,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "mlir/Dialect/ArmNeon/ArmNeonDialect.h"
 #include "mlir/Dialect/ArmNeon/Transforms.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -54,6 +55,10 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
           .setVectorMultiReductionLowering(vectorMultiReductionLowering)
           .setVectorTransferSplit(vectorTransferSplit);
 
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+  DictionaryAttr targetConfig =
+      targetAttr ? targetAttr.getConfiguration() : nullptr;
+
   // Target-dependenet patterns.
   {
     if (enableArmI8mm) {
@@ -67,7 +72,11 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
   {
     RewritePatternSet patterns(ctx);
     vector::populateVectorToVectorCanonicalizationPatterns(patterns);
-    vector::populateVectorGatherToConditionalLoadPatterns(patterns);
+    // RVV should be able to lower most of the gather / scatter with indexed
+    // load / store.
+    if (!targetConfig || !isRISCV(targetConfig) ||
+        !hasAnyVFeature(targetConfig))
+      vector::populateVectorGatherToConditionalLoadPatterns(patterns);
     vector::populateVectorGatherLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(
         patterns, vectorTransformOptions.vectorContractLowering,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
@@ -114,15 +114,4 @@ module attributes {
 }
 
 // CHECK-LABEL:   llvm.func @negative_no_gather_lowering(
-// CHECK-SAME:                                           %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !llvm.ptr,
-// CHECK-SAME:                                           %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !llvm.ptr,
-// CHECK-SAME:                                           %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
-// CHECK-SAME:                                           %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
-// CHECK-SAME:                                           %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i64,
-// CHECK-SAME:                                           %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: vector<64xi64>,
-// CHECK-SAME:                                           %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: vector<64xi1>) -> vector<64xf32> attributes {sym_visibility = "private"} {
-// CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(dense<0.000000e+00> : vector<64xf32>) : vector<64xf32>
-// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, vector<64xi64>) -> vector<64x!llvm.ptr>, f32
-// CHECK:           %[[VAL_9:.*]] = llvm.intr.masked.gather %[[VAL_8]], %[[VAL_6]], %[[VAL_7]] {alignment = 4 : i32} : (vector<64x!llvm.ptr>, vector<64xi1>, vector<64xf32>) -> vector<64xf32>
-// CHECK:           llvm.return %[[VAL_9]] : vector<64xf32>
-// CHECK:         }
+// CHECK: llvm.intr.masked.gather {{.*}} : (vector<64x!llvm.ptr>, vector<64xi1>, vector<64xf32>) -> vector<64xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
@@ -246,21 +246,6 @@ module attributes {
   }
 }
 
-// CHECK: #[[$ATTR_79:.+]] = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {cpu_features = "+v", target_triple = "riscv64-unknown-elf"}>
 // CHECK-LABEL:   func.func private @negative_no_gather_lowering(
-// CHECK-SAME:      %[[ARG0:.*]]: memref<32000x2048xf32>,
-// CHECK-SAME:      %[[ARG1:.*]]: vector<2x64xindex>,
-// CHECK-SAME:      %[[ARG2:.*]]: vector<2x64xi1>) -> vector<2x64xf32> {
-// CHECK:           %[[VAL_0:.*]] = arith.constant dense<0.000000e+00> : vector<64xf32>
-// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = vector.extract %[[ARG1]][0] : vector<64xindex> from vector<2x64xindex>
-// CHECK:           %[[VAL_3:.*]] = vector.extract %[[ARG2]][0] : vector<64xi1> from vector<2x64xi1>
-// CHECK:           %[[VAL_4:.*]] = vector.gather %[[ARG0]]{{\[}}%[[VAL_1]], %[[VAL_1]]] {{\[}}%[[VAL_2]]], %[[VAL_3]], %[[VAL_0]] : memref<32000x2048xf32>, vector<64xindex>, vector<64xi1>, vector<64xf32> into vector<64xf32>
-// CHECK:           %[[VAL_5:.*]] = vector.extract %[[ARG1]][1] : vector<64xindex> from vector<2x64xindex>
-// CHECK:           %[[VAL_6:.*]] = vector.extract %[[ARG2]][1] : vector<64xi1> from vector<2x64xi1>
-// CHECK:           %[[VAL_7:.*]] = vector.gather %[[ARG0]]{{\[}}%[[VAL_1]], %[[VAL_1]]] {{\[}}%[[VAL_5]]], %[[VAL_6]], %[[VAL_0]] : memref<32000x2048xf32>, vector<64xindex>, vector<64xi1>, vector<64xf32> into vector<64xf32>
-// CHECK:           %[[VAL_8:.*]]:64 = vector.to_elements %[[VAL_4]] : vector<64xf32>
-// CHECK:           %[[VAL_9:.*]]:64 = vector.to_elements %[[VAL_7]] : vector<64xf32>
-// CHECK:           %[[VAL_10:.*]] = vector.from_elements %[[VAL_8]]#0, %[[VAL_8]]#1, %[[VAL_8]]#2, %[[VAL_8]]#3, %[[VAL_8]]#4, %[[VAL_8]]#5, %[[VAL_8]]#6, %[[VAL_8]]#7, %[[VAL_8]]#8, %[[VAL_8]]#9, %[[VAL_8]]#10, %[[VAL_8]]#11, %[[VAL_8]]#12, %[[VAL_8]]#13, %[[VAL_8]]#14, %[[VAL_8]]#15, %[[VAL_8]]#16, %[[VAL_8]]#17, %[[VAL_8]]#18, %[[VAL_8]]#19, %[[VAL_8]]#20, %[[VAL_8]]#21, %[[VAL_8]]#22, %[[VAL_8]]#23, %[[VAL_8]]#24, %[[VAL_8]]#25, %[[VAL_8]]#26, %[[VAL_8]]#27, %[[VAL_8]]#28, %[[VAL_8]]#29, %[[VAL_8]]#30, %[[VAL_8]]#31, %[[VAL_8]]#32, %[[VAL_8]]#33, %[[VAL_8]]#34, %[[VAL_8]]#35, %[[VAL_8]]#36, %[[VAL_8]]#37, %[[VAL_8]]#38, %[[VAL_8]]#39, %[[VAL_8]]#40, %[[VAL_8]]#41, %[[VAL_8]]#42, %[[VAL_8]]#43, %[[VAL_8]]#44, %[[VAL_8]]#45, %[[VAL_8]]#46, %[[VAL_8]]#47, %[[VAL_8]]#48, %[[VAL_8]]#49, %[[VAL_8]]#50, %[[VAL_8]]#51, %[[VAL_8]]#52, %[[VAL_8]]#53, %[[VAL_8]]#54, %[[VAL_8]]#55, %[[VAL_8]]#56, %[[VAL_8]]#57, %[[VAL_8]]#58, %[[VAL_8]]#59, %[[VAL_8]]#60, %[[VAL_8]]#61, %[[VAL_8]]#62, %[[VAL_8]]#63, %[[VAL_9]]#0, %[[VAL_9]]#1, %[[VAL_9]]#2, %[[VAL_9]]#3, %[[VAL_9]]#4, %[[VAL_9]]#5, %[[VAL_9]]#6, %[[VAL_9]]#7, %[[VAL_9]]#8, %[[VAL_9]]#9, %[[VAL_9]]#10, %[[VAL_9]]#11, %[[VAL_9]]#12, %[[VAL_9]]#13, %[[VAL_9]]#14, %[[VAL_9]]#15, %[[VAL_9]]#16, %[[VAL_9]]#17, %[[VAL_9]]#18, %[[VAL_9]]#19, %[[VAL_9]]#20, %[[VAL_9]]#21, %[[VAL_9]]#22, %[[VAL_9]]#23, %[[VAL_9]]#24, %[[VAL_9]]#25, %[[VAL_9]]#26, %[[VAL_9]]#27, %[[VAL_9]]#28, %[[VAL_9]]#29, %[[VAL_9]]#30, %[[VAL_9]]#31, %[[VAL_9]]#32, %[[VAL_9]]#33, %[[VAL_9]]#34, %[[VAL_9]]#35, %[[VAL_9]]#36, %[[VAL_9]]#37, %[[VAL_9]]#38, %[[VAL_9]]#39, %[[VAL_9]]#40, %[[VAL_9]]#41, %[[VAL_9]]#42, %[[VAL_9]]#43, %[[VAL_9]]#44, %[[VAL_9]]#45, %[[VAL_9]]#46, %[[VAL_9]]#47, %[[VAL_9]]#48, %[[VAL_9]]#49, %[[VAL_9]]#50, %[[VAL_9]]#51, %[[VAL_9]]#52, %[[VAL_9]]#53, %[[VAL_9]]#54, %[[VAL_9]]#55, %[[VAL_9]]#56, %[[VAL_9]]#57, %[[VAL_9]]#58, %[[VAL_9]]#59, %[[VAL_9]]#60, %[[VAL_9]]#61, %[[VAL_9]]#62, %[[VAL_9]]#63 : vector<2x64xf32>
-// CHECK:           return %[[VAL_10]] : vector<2x64xf32>
-// CHECK:         }
+// CHECK: vector.gather {{.+}} : memref<32000x2048xf32>, vector<64xindex>, vector<64xi1>, vector<64xf32> into vector<64xf32>
+// CHECK-NOT: scf.if


### PR DESCRIPTION
RISC-V V extension (RVV) should be able to use indexed load / store, and sometimes strided load / store, to lower vector.gather / scatter. Using those instructions is almost always more optimal than a collection of branches (not to mention each of those branches operates on really short, if not single-element vectors). 

-----

Slightly tangent: shouldn't X86 with vgather instruction (AVX2) disable this lowering too?