### PR TITLE
[Test] Disable AMDGPU onnx_ops test suite (O0) job.

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -36,16 +36,17 @@ jobs:
             runs-on: ubuntu-24.04
 
           # AMD GPU
-          - name: amdgpu_hip_rdna3_O0
-            numprocesses: 1
-            config-file: onnx_ops_gpu_hip_rdna3_O0.json
-            runs-on: nodai-amdgpu-w7900-x86-64
           # TODO(#21928): Enable the test suite after we fix the slow tests or
-          # have more machines.
-          # - name: amdgpu_hip_rdna3_O3
+          # have more machines. Developers care O3 more, so we remain the O3
+          # test suite.
+          # - name: amdgpu_hip_rdna3_O0
           #   numprocesses: 1
-          #   config-file: onnx_ops_gpu_hip_rdna3_O3.json
+          #   config-file: onnx_ops_gpu_hip_rdna3_O0.json
           #   runs-on: nodai-amdgpu-w7900-x86-64
+          - name: amdgpu_hip_rdna3_O3
+            numprocesses: 1
+            config-file: onnx_ops_gpu_hip_rdna3_O3.json
+            runs-on: nodai-amdgpu-w7900-x86-64
           - name: amdgpu_vulkan_O0
             numprocesses: 4
             config-file: onnx_ops_gpu_vulkan_O0.json

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -40,10 +40,12 @@ jobs:
             numprocesses: 1
             config-file: onnx_ops_gpu_hip_rdna3_O0.json
             runs-on: nodai-amdgpu-w7900-x86-64
-          - name: amdgpu_hip_rdna3_O3
-            numprocesses: 1
-            config-file: onnx_ops_gpu_hip_rdna3_O3.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+          # TODO(#21928): Enable the test suite after we fix the slow tests or
+          # have more machines.
+          # - name: amdgpu_hip_rdna3_O3
+          #   numprocesses: 1
+          #   config-file: onnx_ops_gpu_hip_rdna3_O3.json
+          #   runs-on: nodai-amdgpu-w7900-x86-64
           - name: amdgpu_vulkan_O0
             numprocesses: 4
             config-file: onnx_ops_gpu_vulkan_O0.json


### PR DESCRIPTION
It takes ~10 mins to finish the job, which may cause jobs waiting for runners hours. The guess is that there are slow tests because of inefficient codegen artifacts.

The job is disabled until we figure the root causes or have more machines in CI.

See https://github.com/iree-org/iree/issues/21928 for more details.