### PR TITLE
[CPU] Adjust tile sizes for mmt4d dispatches that have relayout ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
@@ -2918,7 +2919,6 @@ adjustTileSizesForPackOp(mlir::FunctionOpInterface entryPointFn,
                          linalg::PackOp packOp,
                          SmallVector<int64_t> &distTileSizes,
                          SmallVector<int64_t> &parallelVecTileSizes) {
-
   ArrayRef<int64_t> innerDimsPos = packOp.getInnerDimsPos();
   ArrayRef<int64_t> innerTiles = packOp.getStaticInnerTiles();
   // Currently we only handle pack op with static inner tile sizes.
@@ -2961,10 +2961,40 @@ adjustTileSizesForPackOp(mlir::FunctionOpInterface entryPointFn,
   return success();
 }
 
+/// Forces the packed domain tile sizes to be the inner tile sizes of
+/// `unpackOp`. Otherwise, the consumer fusion is not available.
+/// Note: the method is designed for fusion cases in data-tiling, like
+/// `matmul->generic->unpack`.
+static void
+adjustTileSizesForUnPackOp(linalg::UnPackOp unpackOp,
+                           SmallVector<int64_t> &parallelVecTileSizes) {
+  auto linalgOp = unpackOp.getSource().getDefiningOp<linalg::LinalgOp>();
+  if (!linalgOp) {
+    return;
+  }
+  AffineMap indexingMap = linalgOp.getIndexingMapMatchingResult(
+      cast<OpResult>(unpackOp.getSource()));
+  int numPackedDims = unpackOp.getInnerDimsPos().size();
+  for (auto [expr, tileSize] :
+       llvm::zip_equal(indexingMap.getResults().take_back(numPackedDims),
+                       unpackOp.getStaticInnerTiles())) {
+    if (ShapedType::isDynamic(tileSize)) {
+      continue;
+    }
+    auto dimExpr = dyn_cast<AffineDimExpr>(expr);
+    if (!dimExpr) {
+      continue;
+    }
+    parallelVecTileSizes[dimExpr.getPosition()] = tileSize;
+  }
+}
+
 /// Adjusts the tile sizes (carried by `rootOp`) to be aligned with
 /// linalg.unpack inner tile sizes, if there are linalg.unpack producers. If the
 /// tile sizes are not aligned, a stack buffer is needed because of
 /// linalg.unpack tiling implementations.
+/// Note: the method is designed for the case that unpack op is not fused with
+/// mmt4d ops.
 static LogicalResult
 adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
                            Operation *rootOp) {
@@ -3254,6 +3284,8 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
         return failure();
       }
       hasSeenPackOp = true;
+    } else if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op)) {
+      adjustTileSizesForUnPackOp(unpackOp, parallelVecTileSizes);
     } else if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
       SmallVector<int64_t> reductionTileSizes;
       SmallVector<bool> reductionScalableFlags;
@@ -3461,6 +3493,15 @@ lowerUsingDefaultPipeline(mlir::FunctionOpInterface entryPointFn) {
 ///   - `linalg.pack` ops whose producer is a `tensor.collapse_shape`,
 ///     as they will be lowered together into a `map_scatter` later in the
 ///     pipeline.
+///   - `linalg.pack` ops whos producer is a `linalg.unpack`. It is hard to
+///     propagate lowering configs because the tile size is scaled with
+///     UnPackOp's inner tile sizes. The current infra is hard to handle the
+///     case, so we ignore it for now. In practice, it is driven by mmt4d inner
+///     dimensions, so it is usually fine to not have the lowering config.
+///     An exception may be that the pack op is for matvec/vecmat which chooses
+///     larger inner tiles, but it is not a common case atm. The tile size
+///     adjustment logic should be revisited anyway, so it is a fair stopgap
+///     today.
 static bool shouldSetLoweringConfig(Operation *op) {
   if (isa_and_nonnull<IREE::LinalgExt::CustomOp>(op->getParentOp()) &&
       getLoweringConfig(op) != nullptr) {
@@ -3468,7 +3509,7 @@ static bool shouldSetLoweringConfig(Operation *op) {
   }
 
   if (auto packOp = dyn_cast<linalg::PackOp>(op)) {
-    if (isa_and_nonnull<tensor::CollapseShapeOp>(
+    if (isa_and_nonnull<tensor::CollapseShapeOp, linalg::UnPackOp>(
             packOp.getSource().getDefiningOp())) {
       return false;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3493,11 +3493,11 @@ lowerUsingDefaultPipeline(mlir::FunctionOpInterface entryPointFn) {
 ///   - `linalg.pack` ops whose producer is a `tensor.collapse_shape`,
 ///     as they will be lowered together into a `map_scatter` later in the
 ///     pipeline.
-///   - `linalg.pack` ops whos producer is a `linalg.unpack`. It is hard to
+///   - `linalg.pack` ops whose producer is a `linalg.unpack`. It is hard to
 ///     propagate lowering configs because the tile size is scaled with
-///     UnPackOp's inner tile sizes. The current infra is hard to handle the
-///     case, so we ignore it for now. In practice, it is driven by mmt4d inner
-///     dimensions, so it is usually fine to not have the lowering config.
+///     UnPackOp's inner tile sizes. With the current infra it's hard to handle
+///     the case, so we ignore it for now. In practice, it is driven by mmt4d
+///     inner dimensions, so it is usually fine to not have the lowering config.
 ///     An exception may be that the pack op is for matvec/vecmat which chooses
 ///     larger inner tiles, but it is not a common case atm. The tile size
 ///     adjustment logic should be revisited anyway, so it is a fair stopgap


### PR DESCRIPTION
It disables the lowering config propagation for pack op, if its producer is unpack op. The current infra is not able to handle the case, as it requires tracking the dimension sizes.

E.g., although the tiling sizes from the root op (mmt4d) is [1, 1], the subproblem sizes for pack op is still 16x16.

```mlir
func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<640x4096x16x1xf16>) -> tensor<5x10240x16x1xf16> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
  %cst = arith.constant 0.000000e+00 : f16
  %cst_0 = arith.constant 0.000000e+00 : f32
  %0 = tensor.empty() : tensor<5x640x16x16xf16>
  %1 = tensor.empty() : tensor<5x640x16x16xf32>
  %2 = linalg.fill ins(%cst_0 : f32) outs(%1 : tensor<5x640x16x16xf32>) -> tensor<5x640x16x16xf32>
  %3 = linalg.mmt4d ins(%arg0, %arg1 : tensor<5x4096x16x1xf16>, tensor<640x4096x16x1xf16>) outs(%2 : tensor<5x640x16x16xf32>) -> tensor<5x640x16x16xf32>
  %4 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%3 : tensor<5x640x16x16xf32>) outs(%0 : tensor<5x640x16x16xf16>) {
  ^bb0(%in: f32, %out: f16):
    %7 = arith.truncf %in : f32 to f16
    linalg.yield %7 : f16
  } -> tensor<5x640x16x16xf16>
  %5 = tensor.empty() : tensor<77x10240xf16>
  %unpack = linalg.unpack %4 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into %5 : tensor<5x640x16x16xf16> -> tensor<77x10240xf16>
  %6 = tensor.empty() : tensor<5x10240x16x1xf16>
  %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %6 : tensor<77x10240xf16> -> tensor<5x10240x16x1xf16>
  return %pack : tensor<5x10240x16x1xf16>
}
```

The other change in the revision is that it adjusts the tile sizes for unpack ops, because we don't tile packed dimensions in CPU backends.