### PR TITLE
Disable data-tiling flag by default and refresh the CPU docs.

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -158,9 +158,11 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::desc("Transposes all concatenations to happen"
                                   "along the outer most dimension."),
                    llvm::cl::cat(category));
-  binder.opt<bool>("iree-opt-data-tiling", dataTiling,
-                   llvm::cl::desc("Enables data tiling path."),
-                   llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-opt-data-tiling", dataTiling,
+      llvm::cl::desc(
+          "Enables data tiling path starting from GlobalOptimization phase."),
+      llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-opt-const-eval", constEval,
       llvm::cl::desc("Enables eager evaluation of constants using the full "
@@ -314,9 +316,11 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
   binder.opt<bool>("iree-dispatch-creation-fuse-multi-use", enableFuseMultiUse,
                    llvm::cl::desc("Fuse operations with multiple uses."),
                    llvm::cl::cat(category));
-  binder.opt<bool>("iree-dispatch-creation-data-tiling", dataTiling,
-                   llvm::cl::desc("Enables data tiling path."),
-                   llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-dispatch-creation-data-tiling", dataTiling,
+      llvm::cl::desc(
+          "Enables data tiling path starting from DispatchCreationPhase."),
+      llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-dispatch-creation-split-reduction-target-size",
       enableSplitReduction,

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -319,7 +319,7 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
   binder.opt<bool>(
       "iree-dispatch-creation-data-tiling", dataTiling,
       llvm::cl::desc(
-          "Enables data tiling path starting from DispatchCreationPhase."),
+          "Enables data tiling path starting from DispatchCreation phase."),
       llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-dispatch-creation-split-reduction-target-size",

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -124,7 +124,7 @@ struct GlobalOptimizationOptions {
   // Enables data tiling in global optimization phase. There are two data-tiling
   // flags during the transition state. The other has to be off if this one is
   // enabled. Any feature built on top of this path will be deprecated.
-  bool dataTiling = true;
+  bool dataTiling = false;
 
   // Enables const-expr hoisting into globals.
   bool constExprHoisting = true;

--- a/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
+++ b/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
@@ -53,7 +53,6 @@ Compilation command, that targets gfx942 AMDGPU:
 iree-compile matmul.mlir -o /tmp/matmul.mlir \
   --iree-hal-target-device=hip \
   --iree-hip-target=gfx942 \
-  --iree-opt-data-tiling=false \
   --iree-dispatch-creation-data-tiling \
   --iree-hip-encoding-layout-resolver=data-tiling \
   --iree-llvmgpu-test-combine-layout-transformation=true
@@ -88,7 +87,6 @@ iree-compile matmul.mlir -o /tmp/matmul.mlir \
   --iree-hal-target-device=local \
   --iree-hal-local-target-device-backends=llvm-cpu \
   --iree-llvmcpu-target-cpu-features=host \
-  --iree-opt-data-tiling=false \
   --iree-dispatch-creation-data-tiling
 ```
 

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -109,14 +109,16 @@ With the requirements out of the way, we can now compile a model and run it.
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
-Then run the following command to compile with the `local` device and `llvm-cpu`
-target compilation backend:
+Then run the following command to compile with the `local` device, `llvm-cpu`
+target compilation backend, and recommanded optimization flags:
 
 ``` shell hl_lines="2-4"
 iree-compile \
     --iree-hal-target-device=local \
     --iree-hal-local-target-device-backends=llvm-cpu \
     --iree-llvmcpu-target-cpu=host \
+    --iree-opt-level=O2 \
+    --iree-opt-data-tiling \
     mobilenetv2.mlir -o mobilenet_cpu.vmfb
 ```
 
@@ -133,6 +135,14 @@ iree-compile \
     usually sufficient on most devices.
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-optimization-options.md"
+
+???+ tip "Tip - Data-Tiling"
+
+    Use `--iree-opt-data-tiling` to enable the optimization that IREE developers
+    have been working on. The option is default off for many reasons, but it has
+    been used for performance when users target CPU. See
+    [Data-Tiling](../../reference/optimization-options.md#data-tiling-iree-opt-data-tiling-off)
+    for more details.
 
 #### Choosing CPU targets
 

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -110,7 +110,7 @@ With the requirements out of the way, we can now compile a model and run it.
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
 Then run the following command to compile with the `local` device, `llvm-cpu`
-target compilation backend, and recommanded optimization flags:
+target compilation backend, and recommended optimization flags:
 
 ``` shell hl_lines="2-4"
 iree-compile \

--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -92,6 +92,37 @@ overridden.
 
 ## High level program optimizations
 
+### Data-Tiling (`--iree-opt-data-tiling` (off))
+
+Modifies data layout of operands for certain operations, such as matrix
+multiplication, that prefer specifics layouts. These layout preferences depend
+on the operations and the target hardware.
+
+The layout changes can be propagated as far as possible across the workload, so
+the entire workload can use the updated layouts, as opposed to having to perform
+layout transformations at runtime. This may involve fusions or
+constant-evaluation that can amortize or remove layout-transformation overheads.
+
+Data-tiling is an optional optimization technique, and it is not supported by
+all backends. Any backend does not develop data-tiling may result in worse
+performance if it is enabled. The targets that support data-tiling are:
+
+* CPU (x86)
+* CPU (AArch64)
+* CPU (RISC-V)
+* GPU (ROCm)
+* VMVX
+
+See the [blog post](https://iree.dev/community/blog/2025-08-25-data-tiling-walkthrough/)
+to learn more about details.
+
+!!! question - "Something missing or broken?"
+
+    Don't see the target here that you think should be? Reach out to [our
+    data-tiling Discord channel](https://discord.com/channels/689900678990135345/1254843174111678555);
+    we welcome contributions on
+    [our GitHub page](https://github.com/iree-org/iree)!
+
 ### Constant evaluation (`--iree-opt-const-eval` (on))
 
 Performs compile-time evaluation of any global initializers which produce

--- a/tests/external/iree-test-suites/onnx_models/onnx_models_cpu_llvm_task.json
+++ b/tests/external/iree-test-suites/onnx_models/onnx_models_cpu_llvm_task.json
@@ -3,7 +3,8 @@
   "iree_compile_flags": [
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",
-    "--iree-llvmcpu-target-cpu=host"
+    "--iree-llvmcpu-target-cpu=host",
+    "--iree-opt-data-tiling"
   ],
   "iree_run_module_flags": [
     "--device=local-task"

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
@@ -4,7 +4,8 @@
     "--iree-hal-target-device=local",
     "--iree-hal-local-target-device-backends=llvm-cpu",
     "--iree-input-demote-f64-to-f32=false",
-    "--iree-opt-level=O2"
+    "--iree-opt-level=O2",
+    "--iree-opt-data-tiling"
   ],
   "iree_run_module_flags": [
     "--device=local-sync"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/clip_cpu.json
@@ -42,7 +42,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O1"
+        "--iree-opt-level=O1",
+        "--iree-opt-data-tiling"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.15f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_cpu.json
@@ -30,7 +30,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-opt-data-tiling"
     ],
     "run_function": "run_forward",
     "run_test_expecting_to_fail": true

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
@@ -19,6 +19,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
+        "--iree-opt-data-tiling",
         "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/clip_cpu.json
@@ -35,6 +35,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O1",
+        "--iree-opt-data-tiling",
         "--iree-llvmcpu-distribution-size=32",
         "--iree-scheduling-dump-statistics-format=json",
         "--iree-scheduling-dump-statistics-file=compilation_info.json"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/scheduler_cpu.json
@@ -4,7 +4,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-opt-data-tiling"
     ],
     "compile_only": true
 }

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
@@ -32,6 +32,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
+        "--iree-opt-data-tiling",
         "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
@@ -32,6 +32,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
+        "--iree-opt-data-tiling",
         "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "pipeline_compiler_flags": [

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
@@ -19,6 +19,7 @@
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
         "--iree-opt-level=O3",
+        "--iree-opt-data-tiling",
         "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [


### PR DESCRIPTION
We made the decision that turns data-tiling on by default for CPU only in the past; we realized that it is a mistake today. 

The motivation was reducing questions like how do we get good performance in CPU backend; people can discover the data-tiling technique easily. However, it's a very involved to enable data-tiling by default, especially when some backends do not support/use data-tiling. That means data-tiling is not ready for O2 atm. Even for CPU backend, it can result in additional memory uses that we don't have good control yet, which is another data point that data-tiling is not ready for O2.

To address the discoverability issue, the revision updates the CPU docs. It is the start point for new users, and they can copy the recommended commands from the doc. For the active existing users, they're tagged in the PR and they will discover the change in the future release note. For the hidden existing users, they can only find it in the release note.

The revision updates all the external_tests suite to use the `--iree-opt-data-tiling` flag.

Preview of CPU doc: https://hanhanw.github.io/iree/guides/deployment-configurations/cpu/#compile-a-program

Preview of data-tiling optimization option: https://hanhanw.github.io/iree/reference/optimization-options/#data-tiling-iree-opt-data-tiling-off