### PR TITLE
[ROCM] Add back specialization pattern tests

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/BUILD.bazel
@@ -12,14 +12,15 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-ukernel_pdl_patterns_files = [
+pdl_pattern_test_files = [
+    "apply_builtin_pdl_patterns.mlir",
     "apply_builtin_ukernel_pdl_patterns.mlir",
     "apply_builtin_ukernel_pdl_patterns_driver.mlir",
 ]
 
 iree_lit_test_suite(
     name = "lit",
-    srcs = ukernel_pdl_patterns_files,
+    srcs = pdl_pattern_test_files,
     cfg = "//compiler:lit.cfg.py",
     tools = [
         "//tools:iree-opt",

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "apply_builtin_pdl_patterns.mlir"
     "apply_builtin_ukernel_pdl_patterns.mlir"
     "apply_builtin_ukernel_pdl_patterns_driver.mlir"
   TOOLS


### PR DESCRIPTION
Add back the ROCM specialization pattern tests which were accidentally removed in: https://github.com/iree-org/iree/pull/21856.