### PR TITLE
[iree][codegen] Add gpu occupancy optimization attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -701,12 +701,13 @@ static FailureOr<int64_t> reconcileSubgroupSize(
 /// Helper function to retrieve the target-func-attrs value from translation
 /// info.
 static DictionaryAttr
-getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo) {
+getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo,
+                   StringRef key) {
   auto translationConfig = translationInfo.getConfiguration();
   if (!translationConfig) {
     return nullptr;
   }
-  auto attr = translationConfig.getAs<DictionaryAttr>("llvm_func_attrs");
+  auto attr = translationConfig.getAs<DictionaryAttr>(key);
   if (!attr) {
     return nullptr;
   }
@@ -801,9 +802,14 @@ void ReconcileTranslationInfoPass::runOnOperation() {
       // translation info into the func-like op. This is not the best
       // place to do this, but the intent is after this pass all the
       // lowering configs and translation infos will be deleted.
-      DictionaryAttr targetFuncAttrs = getTargetFuncAttrs(translationInfo);
+      DictionaryAttr targetFuncAttrs =
+          getTargetFuncAttrs(translationInfo, "llvm_func_attrs");
       if (targetFuncAttrs) {
         funcOp->setAttr("llvm_func_attrs", targetFuncAttrs);
+      }
+      if (DictionaryAttr targetFuncAttrs =
+              getTargetFuncAttrs(translationInfo, kFuncAttrsName)) {
+        funcOp->setAttr(kFuncAttrsName, targetFuncAttrs);
       }
     }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -52,6 +52,7 @@ constexpr StringLiteral kSerializedTuningSpecAttrName =
     "iree_codegen.tuning_spec_mlirbc";
 constexpr StringLiteral kKernelConfigSpecName = "__kernel_config";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
+constexpr StringLiteral kFuncAttrsName = "func_attrs";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -727,4 +727,26 @@ def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOption
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GPU Occupancy Optimization Attribute
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_OptimizeOccupancyAttr : AttrDef<IREEGPU_Dialect, "OptimizeOccupancy"> {
+  let mnemonic = "optimize_occupancy";
+  let summary = [{An attribute indicating GPU occupancy needs to be optimized.}];
+  let description = [{
+    This attribute can be attached to operations to indicate that GPU occupancy
+    should be optimized during code generation.
+  }];
+  let assemblyFormat = "";
+  let parameters = (ins);
+  let extraClassDeclaration = [{
+    // Returns the key name for OptimizeOccupancyAttr in the translation info
+    // config dictionary.
+    static StringRef getDictKeyName() {
+      return "iree_gpu.optimize_occupancy";
+    }
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1326,6 +1326,23 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
       targetSubgroupSize, pipelineConfig);
 }
 
+/// Sets attention specific pipeline attributes. Currently, this only affects
+/// AMD targets.
+static void
+setAttentionPipelineAttributes(IREE::GPU::TargetAttr target,
+                               SmallVectorImpl<NamedAttribute> &pipelineAttrs) {
+  if (!target.isAMD()) {
+    return;
+  }
+  Builder b(target.getContext());
+  NamedAttrList funcAttrs;
+  funcAttrs.append(IREE::Codegen::DenormalFpMathAttr::getFP32DictKeyName(),
+                   b.getAttr<IREE::Codegen::DenormalFpMathAttr>(
+                       IREE::Codegen::DenormalFpMath::PreserveSign));
+  pipelineAttrs.emplace_back(kFuncAttrsName,
+                             funcAttrs.getDictionary(b.getContext()));
+}
+
 static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
     IREE::GPU::TargetAttr target, mlir::FunctionOpInterface entryPoint,
     IREE::LinalgExt::AttentionOp op) {
@@ -1576,6 +1593,8 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   SmallVector<NamedAttribute, 1> pipelineAttrs;
+
+  setAttentionPipelineAttributes(target, pipelineAttrs);
 
   // TODO: We do not turn prefetching on even when requested by the prefetching
   // flag because there is a shared memory allocation the two matmuls, which

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1336,6 +1336,8 @@ setAttentionPipelineAttributes(IREE::GPU::TargetAttr target,
   }
   Builder b(target.getContext());
   NamedAttrList funcAttrs;
+  funcAttrs.append(IREE::GPU::OptimizeOccupancyAttr::getDictKeyName(),
+                   b.getAttr<IREE::GPU::OptimizeOccupancyAttr>());
   funcAttrs.append(IREE::Codegen::DenormalFpMathAttr::getFP32DictKeyName(),
                    b.getAttr<IREE::Codegen::DenormalFpMathAttr>(
                        IREE::Codegen::DenormalFpMath::PreserveSign));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
@@ -90,6 +90,12 @@ annotateKernelForTranslation(LLVM::LLVMFuncOp funcOp,
         attr && attr.getValue() != IREE::Codegen::DenormalFpMath::None) {
       funcOp.setDenormalFpMathF32(
           IREE::Codegen::stringifyDenormalFpMath(attr.getValue()));
+      if (dict.getAs<IREE::GPU::OptimizeOccupancyAttr>(
+              IREE::GPU::OptimizeOccupancyAttr::getDictKeyName())) {
+        // TODO: use a heuristic to compute the value.
+        rocdlDialect->getWavesPerEuAttrHelper().setAttr(
+            funcOp, builder.getI64IntegerAttr(2));
+      }
     }
 
     // Update the function, discarding any unhandled attributes.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -214,7 +214,7 @@ builtin.module {
       } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
       builtin.module {
         llvm.func @test_kern_arg(%arg0: i32) attributes {
-            func_attrs = {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">},
+            func_attrs = {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">, iree_gpu.optimize_occupancy = #iree_gpu.optimize_occupancy},
             llvm_func_attrs = {check_attr}
           } {
           llvm.return
@@ -228,6 +228,7 @@ builtin.module {
 // CHECK:       denormal_fp_math_f32 = "preserve-sign"
 // CHECK-NOT:   func_attrs
 // CHECK:       llvm_func_attrs = {check_attr
+// CHECK:       rocdl.waves_per_eu = 2 : i64
 
 
 // -----
@@ -271,3 +272,4 @@ builtin.module {
 // CHECK-NOT:   denormal_fp_math_f32
 // CHECK-NOT:   func_attrs
 // CHECK:       llvm_func_attrs = {check_attr
+// CHECK-NOT:       rocdl.waves_per_eu = 2 : i64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -186,3 +186,88 @@ builtin.module {
     }
   }
 }
+
+// -----
+
+// Check that we handle the `func_attrs` appropriately
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none,
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
+      builtin.module {
+        llvm.func @test_kern_arg(%arg0: i32) attributes {
+            func_attrs = {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">},
+            llvm_func_attrs = {check_attr}
+          } {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_kern_arg
+// CHECK:       denormal_fp_math_f32 = "preserve-sign"
+// CHECK-NOT:   func_attrs
+// CHECK:       llvm_func_attrs = {check_attr
+
+
+// -----
+
+// Check that we handle the `func_attrs` appropriately
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none,
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
+      builtin.module {
+        llvm.func @test_kern_arg(%arg0: i32) attributes {
+            func_attrs = {iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<none>},
+            llvm_func_attrs = {check_attr}
+          } {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_kern_arg
+// CHECK-NOT:   denormal_fp_math_f32
+// CHECK-NOT:   func_attrs
+// CHECK:       llvm_func_attrs = {check_attr

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -242,6 +242,7 @@ func.func @attention_20x4096x64x4096x64() {
 // CHECK-NOT:   prefetch_shared_memory = true
 // CHECK:       func_attrs = {
 // CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
+// CHECK:       iree_gpu.optimize_occupancy = #iree_gpu.optimize_occupancy
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 
@@ -296,6 +297,7 @@ func.func @attention_large_head_dim_shared_mem() {
 //       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
 // CHECK:       func_attrs = {
 // CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
+// CHECK:       iree_gpu.optimize_occupancy = #iree_gpu.optimize_occupancy
 // CHECK-LABEL: func.func @attention_check_mma_accs_compatable
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -240,6 +240,8 @@ func.func @attention_20x4096x64x4096x64() {
 
 // CHECK:       #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-NOT:   prefetch_shared_memory = true
+// CHECK:       func_attrs = {
+// CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 
@@ -291,7 +293,9 @@ func.func @attention_large_head_dim_shared_mem() {
 // and the QK matmul used MFMA_F32_32x32x64_F8E4M3FN. Vector distribution failed
 // to distribute these layouts to threads.
 
-//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK:       func_attrs = {
+// CHECK:       denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
 // CHECK-LABEL: func.func @attention_check_mma_accs_compatable
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>


### PR DESCRIPTION
This commit adds support for `#iree_gpu.optimize_occupancy`. This attribute uses the same `func_attrs` mechanism to get propagated through the compiler pipeline until it reaches the *AnnotateKernelForTranslation passes.

A `#iree_gpu.optimize_occupancy` attribute specifies that better resource utilization should be employed when compiling the program.

Currently this attribute is only set for attention dispatches on AMD targets.