### PR TITLE
Parse pipeline options for iree-opt

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -376,41 +376,12 @@ void registerDispatchCreationPasses() {
 }
 
 void registerDispatchCreationPipelines() {
-
-  /// Helper struct when registering pass pipeline options.
-  struct DispatchCreationPipelineOptions
-      : public PassPipelineOptions<DispatchCreationPipelineOptions> {
-    Option<bool> aggressiveFusion{
-        *this,
-        "aggressive-fusion",
-        llvm::cl::desc(
-            "Enable aggressive fusion for dispatch creation pipeline"),
-        llvm::cl::init(false),
-    };
-    Option<bool> dataTiling{
-        *this,
-        "data-tiling",
-        llvm::cl::desc("Enable data-tiling for dispatch creation pipeline"),
-        llvm::cl::init(false),
-    };
-
-    std::unique_ptr<TransformOptions> toTransformOptions() const {
-      auto options = std::make_unique<TransformOptions>();
-      options->options.enableAggressiveFusion = aggressiveFusion;
-      options->options.dataTiling = dataTiling;
-      return options;
-    }
-  };
-
-  PassPipelineRegistration<DispatchCreationPipelineOptions>
-      dispatchCreationPipeline(
-          "iree-dispatch-creation-pipeline",
-          "Flag used to run passes that form dispatch regions",
-          [](OpPassManager &passManager,
-             const DispatchCreationPipelineOptions &options) {
-            buildDispatchCreationPassPipeline(passManager,
-                                              *(options.toTransformOptions()));
-          });
+  PassPipelineRegistration<TransformOptions> dispatchCreationPipeline(
+      "iree-dispatch-creation-pipeline",
+      "Flag used to run passes that form dispatch regions",
+      [](OpPassManager &passManager, const TransformOptions &options) {
+        buildDispatchCreationPassPipeline(passManager, options);
+      });
 
   PassPipelineRegistration<TransformOptions>
       dispatchCreationPreprocessingPipeline(

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -11,6 +11,7 @@
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "iree/compiler/Pipelines/Options.h"
+#include "iree/compiler/Pipelines/Pipelines.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -26,7 +27,7 @@ enum class EncodingOptions { Padding, MatmulK, Generic };
 
 /// This is a placeholder for future. We should pass all the options through the
 /// struct.
-struct TransformOptions : public PassPipelineOptions<TransformOptions> {
+struct TransformOptions : public IREEPipelineOptions<TransformOptions> {
   DispatchCreationOptions options;
 };
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{aggressive-fusion})" --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{--iree-dispatch-creation-enable-aggressive-fusion})" --mlir-print-local-scope %s | FileCheck %s
 
 util.func public @truncate_fusion(%arg0: tensor<2x64x64x320xi8>, %arg1: tensor<2x66x66x640xi8>, %arg2: tensor<3x3x640x640xi8>, %arg3: tensor<640xi32>, %arg4: tensor<640xf32>, %arg5: tensor<640x320xi8>, %arg6: tensor<640xi32>, %arg7: tensor<640xf32>) -> tensor<2x640x64x64xf16> {
   %c0_i32 = arith.constant 0 : i32

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{data-tiling})" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{--iree-dispatch-creation-data-tiling})" %s | FileCheck %s
 
 // Tests to make sure that the set encoding pass work as in the dispatch
 // creation pipeline. For example, we expect dimension collapsing to happen


### PR DESCRIPTION
This change adds `IREEPipelineOptions` which can be inherited from to share the options structs for both `iree-compile` and when running a single pipeline with `iree-opt`.