### PR TITLE
[LinalgExt] Add canonicalization to fold memref cast into map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -353,6 +353,7 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$transformation_region);
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let assemblyFormat = [{
     attr-dict $input `into` $output
     $transformation_region


### PR DESCRIPTION
Folds a memref.cast on the output of map_scatter into the map_scatter op, as long as the shape is unchanged by the cast. This canonicalization will compose with the canonicalization here: https://github.com/iree-org/iree/blob/23b101781c56b1291a18c0e8e8143cb460969d8c/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp#L77

Without this canonicalization, the cast introduced by the referenced pattern will cause the later map_scatter decomposition to fail.