### PR TITLE
Adding util.list.construct pseudo-op.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -2195,11 +2195,11 @@ LogicalResult ListConstructOp::verify() {
   Operation *op = getOperation();
   auto listType = cast<IREE::Util::ListType>(getResult().getType());
   Type elementType = listType.getElementType();
-  for (auto value : llvm::enumerate(getValues())) {
-    Type valueType = value.value().getType();
+  for (auto [idx, value] : llvm::enumerate(getValues())) {
+    Type valueType = value.getType();
     if (!ListType::canImplicitlyCast(valueType, elementType)) {
       return op->emitError()
-             << "list[" << value.index() << "] type " << valueType
+             << "list[" << idx << "] type " << valueType
              << " cannot be be cast to list type " << elementType;
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -2088,6 +2088,38 @@ LogicalResult GlobalStoreIndirectOp::verify() {
 // !util.list<T>
 //===----------------------------------------------------------------------===//
 
+static ParseResult
+parseValueTypeList(OpAsmParser &parser,
+                   SmallVectorImpl<OpAsmParser::UnresolvedOperand> &values,
+                   SmallVectorImpl<Type> &types) {
+  if (parser.parseLSquare()) {
+    return failure();
+  }
+  if (succeeded(parser.parseOptionalRSquare())) {
+    return success(); // empty list
+  }
+  do {
+    OpAsmParser::UnresolvedOperand value;
+    Type type;
+    if (parser.parseOperand(value) || parser.parseColon() ||
+        parser.parseType(type)) {
+      return failure();
+    }
+    values.push_back(value);
+    types.push_back(type);
+  } while (succeeded(parser.parseOptionalComma()));
+  return parser.parseRSquare();
+}
+
+static void printValueTypeList(OpAsmPrinter &p, Operation *,
+                               OperandRange values, TypeRange types) {
+  p << "[";
+  llvm::interleaveComma(llvm::zip(values, types), p, [&](auto pair) {
+    p << std::get<0>(pair) << " : " << std::get<1>(pair);
+  });
+  p << "]";
+}
+
 static ParseResult parseListTypeGet(OpAsmParser &parser, Type &listType,
                                     Type &elementType) {
   if (failed(parser.parseType(listType))) {
@@ -2157,6 +2189,21 @@ static void printListTypeSet(OpAsmPrinter &printer, Operation *, Type listType,
   } else {
     printer.printType(listType);
   }
+}
+
+LogicalResult ListConstructOp::verify() {
+  Operation *op = getOperation();
+  auto listType = cast<IREE::Util::ListType>(getResult().getType());
+  Type elementType = listType.getElementType();
+  for (auto value : llvm::enumerate(getValues())) {
+    Type valueType = value.value().getType();
+    if (!ListType::canImplicitlyCast(valueType, elementType)) {
+      return op->emitError()
+             << "list[" << value.index() << "] type " << valueType
+             << " cannot be be cast to list type " << elementType;
+    }
+  }
+  return success();
 }
 
 LogicalResult ListGetOp::verify() {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -1127,6 +1127,32 @@ def Util_ListCreateOp : Util_PureOp<"list.create", [
   let assemblyFormat = "($initial_capacity^)? attr-dict `:` qualified(type($result))";
 }
 
+def Util_ListConstructOp : Util_PureOp<"list.construct", [
+  MemoryEffects<[MemAlloc]>,
+]> {
+  let summary = [{Constructs a list with the given initial values.}];
+  let description = [{
+    Creates a new list with the given values added in order. The list will be
+    allocated with an initial capacity equal to the number of values. This is a
+    pseudo-operation that expands to a list create, resize, and a series of
+    sets.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$values
+  );
+  let results = (outs
+    Util_AnyListType:$result
+  );
+
+  let assemblyFormat = [{
+    custom<ValueTypeList>($values, type($values))
+    attr-dict `:` qualified(type($result))
+  }];
+
+  let hasVerifier = 1;
+}
+
 def Util_ListSizeOp : Util_Op<"list.size", [
   MemoryEffects<[MemRead]>,
 ]> {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/list_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/list_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: @list_init_ops
 util.func public @list_init_ops() {
@@ -15,6 +15,36 @@ util.func public @list_init_ops() {
   // CHECK: util.list.resize %[[LIST]], %[[NEW_SIZE]] : !util.list<?>
   util.list.resize %list, %new_size : !util.list<?>
 
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @list_construct
+util.func public @list_construct() {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0
+  %c0 = arith.constant 0 : i64
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1
+  %c1 = arith.constant 1 : i64
+
+  // CHECK: %[[EMPTY:.+]] = util.list.construct [] : !util.list<?>
+  %empty = util.list.construct [] : !util.list<?>
+
+  // CHECK: = util.list.construct [%[[C0]] : i64, %[[C1]] : i64] : !util.list<i64>
+  %list_i64 = util.list.construct [%c0 : i64, %c1 : i64] : !util.list<i64>
+
+  // CHECK: = util.list.construct [%[[C0]] : i64, %[[EMPTY]] : !util.list<?>] : !util.list<?>
+  %list_any = util.list.construct [%c0 : i64, %empty : !util.list<?>] : !util.list<?>
+
+  util.return
+}
+
+// -----
+
+util.func public @list_construct_type_mismatch() {
+  %c0 = arith.constant 0 : i64
+  // @expected-error@+1 {{list[0] type 'i64' cannot be be cast to list type 'i32'}}
+  util.list.construct [%c0 : i64] : !util.list<i32>
   util.return
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/list_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/list_ops.mlir
@@ -1,41 +1,87 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-vm-conversion{index-bits=32})' %s | FileCheck %s
 
-// CHECK-LABEL: @list_ops
-module @list_ops { module {
-  // CHECK: vm.func private @my_fn
-  // CHECK-SAME: (%[[BUFFER_VIEW:.+]]: !vm.ref<!hal.buffer_view>)
-  func.func @my_fn(%buffer_view: !hal.buffer_view) {
-    // CHECK: %[[CAPACITY:.+]] = vm.const.i32 5
-    %capacity = arith.constant 5 : index
-    // CHECK: %[[LIST:.+]] = vm.list.alloc %[[CAPACITY]] : (i32) -> !vm.list<?>
-    %list = util.list.create %capacity : !util.list<?>
+// CHECK-LABEL: vm.func private @my_fn
+// CHECK-SAME: (%[[BUFFER_VIEW:.+]]: !vm.ref<!hal.buffer_view>)
+func.func @my_fn(%buffer_view: !hal.buffer_view) {
+  // CHECK: %[[CAPACITY:.+]] = vm.const.i32 5
+  %capacity = arith.constant 5 : index
+  // CHECK: %[[LIST:.+]] = vm.list.alloc %[[CAPACITY]] : (i32) -> !vm.list<?>
+  %list = util.list.create %capacity : !util.list<?>
 
-    // CHECK: %[[NEW_SIZE:.+]] = vm.const.i32 100
-    %new_size = arith.constant 100 : index
-    // CHECK: vm.list.resize %[[LIST]], %[[NEW_SIZE]] : (!vm.list<?>, i32)
-    util.list.resize %list, %new_size : !util.list<?>
+  // CHECK: %[[NEW_SIZE:.+]] = vm.const.i32 100
+  %new_size = arith.constant 100 : index
+  // CHECK: vm.list.resize %[[LIST]], %[[NEW_SIZE]] : (!vm.list<?>, i32)
+  util.list.resize %list, %new_size : !util.list<?>
 
-    %c10 = arith.constant 10 : index
-    %c11 = arith.constant 11 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
 
-    // CHECK: = vm.list.get.i32 %[[LIST]], %c10 : (!vm.list<?>, i32) -> i32
-    %0 = util.list.get %list[%c10] : !util.list<?> -> i32
+  // CHECK: = vm.list.get.i32 %[[LIST]], %c10 : (!vm.list<?>, i32) -> i32
+  %0 = util.list.get %list[%c10] : !util.list<?> -> i32
 
-    // CHECK: %[[NEW_I32_VALUE:.+]] = vm.const.i32 101
-    %new_i32_value = arith.constant 101 : i32
-    // CHECK: vm.list.set.i32 %[[LIST]], %c10, %[[NEW_I32_VALUE]] : (!vm.list<?>, i32, i32)
-    util.list.set %list[%c10], %new_i32_value : i32 -> !util.list<?>
+  // CHECK: %[[NEW_I32_VALUE:.+]] = vm.const.i32 101
+  %new_i32_value = arith.constant 101 : i32
+  // CHECK: vm.list.set.i32 %[[LIST]], %c10, %[[NEW_I32_VALUE]] : (!vm.list<?>, i32, i32)
+  util.list.set %list[%c10], %new_i32_value : i32 -> !util.list<?>
 
-    // CHECK: = vm.list.get.ref %[[LIST]], %c11 : (!vm.list<?>, i32) -> !vm.ref<!hal.buffer_view>
-    %1 = util.list.get %list[%c11] : !util.list<?> -> !hal.buffer_view
+  // CHECK: = vm.list.get.ref %[[LIST]], %c11 : (!vm.list<?>, i32) -> !vm.ref<!hal.buffer_view>
+  %1 = util.list.get %list[%c11] : !util.list<?> -> !hal.buffer_view
 
-    // CHECK: vm.list.set.ref %[[LIST]], %c11, %[[BUFFER_VIEW]] : (!vm.list<?>, i32, !vm.ref<!hal.buffer_view>)
-    util.list.set %list[%c11], %buffer_view : !hal.buffer_view -> !util.list<?>
+  // CHECK: vm.list.set.ref %[[LIST]], %c11, %[[BUFFER_VIEW]] : (!vm.list<?>, i32, !vm.ref<!hal.buffer_view>)
+  util.list.set %list[%c11], %buffer_view : !hal.buffer_view -> !util.list<?>
 
-    // CHECK: %[[ZERO_CAPACITY:.+]] = vm.const.i32 0
-    // CHECK: %[[LIST:.+]] = vm.list.alloc %[[ZERO_CAPACITY]] : (i32) -> !vm.list<?>
-    %list_no_capacity = util.list.create : !util.list<?>
+  // CHECK: %[[ZERO_CAPACITY:.+]] = vm.const.i32 0
+  // CHECK: %[[LIST:.+]] = vm.list.alloc %[[ZERO_CAPACITY]] : (i32) -> !vm.list<?>
+  %list_no_capacity = util.list.create : !util.list<?>
 
-    return
-  }
-} }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @list_construct_empty
+func.func @list_construct_empty() {
+  // CHECK: %[[CAPACITY:.+]] = vm.const.i32 0
+  // CHECK: %[[EMPTY:.+]] = vm.list.alloc %[[CAPACITY]] : (i32) -> !vm.list<?>
+  %empty = util.list.construct [] : !util.list<?>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @list_construct_i64
+func.func @list_construct_i64() {
+  // CHECK-DAG: %[[C100:.+]] = vm.const.i64 100
+  %c100 = arith.constant 100 : i64
+  // CHECK-DAG: %[[C200:.+]] = vm.const.i64 200
+  %c200 = arith.constant 200 : i64
+  // CHECK-DAG: %[[SIZE:.+]] = vm.const.i32 2
+  // CHECK: %[[LIST:.+]] = vm.list.alloc %[[SIZE]] : (i32) -> !vm.list<i64>
+  // CHECK: vm.list.resize %[[LIST]], %[[SIZE]]
+  // CHECK: %[[I0:.+]] = vm.const.i32 0
+  // CHECK: vm.list.set.i64 %[[LIST]], %[[I0]], %[[C100]]
+  // CHECK: %[[I1:.+]] = vm.const.i32 1
+  // CHECK: vm.list.set.i64 %[[LIST]], %[[I1]], %[[C200]]
+  %list_i64 = util.list.construct [%c100 : i64, %c200 : i64] : !util.list<i64>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @list_construct_mixed
+func.func @list_construct_mixed() {
+  // CHECK-DAG: %[[C1_0:.+]] = vm.const.f64 1.0
+  %c1_0 = arith.constant 1.0 : f64
+  // CHECK-DAG: %[[NESTED_SIZE:.+]] = vm.const.i32 0
+  // CHECK: %[[NESTED:.+]] = vm.list.alloc %[[NESTED_SIZE]]
+  %nested = util.list.construct [] : !util.list<?>
+  // CHECK-DAG: %[[SIZE:.+]] = vm.const.i32 2
+  // CHECK: %[[LIST:.+]] = vm.list.alloc %[[SIZE]] : (i32) -> !vm.list<?>
+  // CHECK: vm.list.resize %[[LIST]], %[[SIZE]]
+  // CHECK: %[[I0:.+]] = vm.const.i32 0
+  // CHECK: vm.list.set.f64 %[[LIST]], %[[I0]], %[[C1_0]]
+  // CHECK: %[[I1:.+]] = vm.const.i32 1
+  // CHECK: vm.list.set.ref %[[LIST]], %[[I1]], %[[NESTED]]
+  %list_any = util.list.construct [%c1_0 : f64, %nested : !util.list<?>] : !util.list<?>
+  return
+}


### PR DESCRIPTION
This makes it 100x cleaner to construct struct-like lists. It still expands to a bunch of ops in VM but is much less IR at the higher levels and allows for DCE.