### PR TITLE
Update llama 3.1 8B mlir source to 2025-09-11

### DIFF
--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_rocm.json
@@ -18,7 +18,7 @@
     ],
     "device": "hip",
     "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
-    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.mlir",
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random-2025-09-11.mlir",
     "compiler_flags": [
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_rocm.json
@@ -15,7 +15,7 @@
     ],
     "device": "hip",
     "real_weights": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
-    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.mlir",
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random-2025-09-11.mlir",
     "compiler_flags": [
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",


### PR DESCRIPTION
Draft PR to verify the latest exported IR for llama3.1 8B model.

https://github.com/pravg-amd/iree/pull/4

Context: This PR is generated from shark-ai, with the idea to keep the IR updated with the latest changes