### PR TITLE
[CPU] Add an experimental flag to disable linalg.conv generalization.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -23,6 +23,13 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
+// TODO: Adapts the transformations to work with linalg::LinalgOp, but not a
+// named op. E.g., DownscaleSizeOneWindowed2DConvolution patterns.
+static llvm::cl::opt<bool> clDisableConvGeneralization(
+    "iree-global-opt-experimental-disable-conv-generalization",
+    llvm::cl::desc("Disable generalization for some conv ops (experimental)."),
+    llvm::cl::init(false));
+
 #define GEN_PASS_DEF_GENERALIZELINALGNAMEDOPSPASS
 #include "iree/compiler/GlobalOptimization/Passes.h.inc"
 
@@ -47,6 +54,16 @@ void GeneralizeLinalgNamedOpsPass::runOnOperation() {
       namedOpCandidates.push_back(linalgOp);
       return;
     }
+    bool generalizeConvOps = linalg::isaConvolutionOpInterface(linalgOp);
+    if (clDisableConvGeneralization &&
+        isa<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
+            linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+            linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+            linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
+            linalg::PoolingNchwMaxOp, linalg::DepthwiseConv2DNhwcHwcOp>(
+            linalgOp)) {
+      generalizeConvOps = false;
+    }
     if (isa_and_nonnull<linalg::AbsOp, linalg::AddOp, linalg::BroadcastOp,
                         linalg::CeilOp, linalg::CopyOp, linalg::DivOp,
                         linalg::DivUnsignedOp, linalg::ExpOp, linalg::FloorOp,
@@ -54,7 +71,7 @@ void GeneralizeLinalgNamedOpsPass::runOnOperation() {
                         linalg::MulOp, linalg::NegFOp, linalg::ReduceOp,
                         linalg::SubOp, linalg::TransposeOp>(
             linalgOp.getOperation()) ||
-        linalg::isaConvolutionOpInterface(linalgOp)) {
+        generalizeConvOps) {
       namedOpCandidates.push_back(linalgOp);
     }
   });

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -23,8 +23,9 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-// TODO: Adapts the transformations to work with linalg::LinalgOp, but not a
-// named op. E.g., DownscaleSizeOneWindowed2DConvolution patterns.
+// TODO(#21955): Adapts the convolution transformations to work with generalized
+// linalg.generic form, but not only when they are named ops. E.g.,
+// DownscaleSizeOneWindowed2DConvolution patterns.
 static llvm::cl::opt<bool> clDisableConvGeneralization(
     "iree-global-opt-experimental-disable-conv-generalization",
     llvm::cl::desc("Disable generalization for some conv ops (experimental)."),

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/vae_cpu.json
@@ -18,7 +18,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [
         "--expected_f32_threshold=0.01f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_cpu.json
@@ -31,7 +31,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.8f"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_cpu.json
@@ -31,7 +31,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "pipeline_compiler_flags": [
         "--iree-hal-local-target-device-backends=llvm-cpu",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/vae_cpu.json
@@ -18,7 +18,8 @@
         "--iree-hal-local-target-device-backends=llvm-cpu",
         "--iree-hal-target-device=local",
         "--iree-llvmcpu-target-cpu-features=host",
-        "--iree-opt-level=O3"
+        "--iree-opt-level=O3",
+        "--iree-global-opt-experimental-disable-conv-generalization"
     ],
     "threshold_args": [
         "--expected_f16_threshold=0.02f"


### PR DESCRIPTION
CPU backends only support conv named ops, but not linalg.generic ops. To support the case, it requires few matchers and adapts few upstream transformations to use linalg::LinalgOp op in the implementation. E.g., https://github.com/llvm/llvm-project/blob/580fdeb6ff55fcd54be16ed8555eaaa6a9aee1c0/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp#L1487-L1490

Issue: https://github.com/iree-org/iree/issues/21955