### PR TITLE
[Codegen] Unroll instead of linearize vector.to_elements.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -177,26 +177,6 @@ static LogicalResult validateDataTypes(Operation *op,
   return success();
 }
 
-/// TODO(hanchung): Delete the pattern once it is upstreamed:
-/// https://github.com/llvm/llvm-project/pull/156992
-struct LowerToElementsPattern : public OpRewritePattern<vector::ToElementsOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(vector::ToElementsOp op,
-                                PatternRewriter &rewriter) const override {
-    VectorType vecType = op.getSource().getType();
-    if (vecType.getRank() == 1 || vecType.getNumScalableDims() > 0) {
-      return failure();
-    }
-    auto vec1DType =
-        VectorType::get({vecType.getNumElements()}, vecType.getElementType());
-    Value shapeCast = vector::ShapeCastOp::create(rewriter, op.getLoc(),
-                                                  vec1DType, op.getSource());
-    rewriter.replaceOpWithNewOp<vector::ToElementsOp>(op, op.getResultTypes(),
-                                                      shapeCast);
-    return success();
-  }
-};
-
 /// A pass that replaces all occurrences of GPU device operations with their
 /// corresponding ROCDL equivalent.
 ///
@@ -281,7 +261,9 @@ struct ConvertToROCDLPass final
       vector::populateVectorInterleaveToShufflePatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
           patterns, options.vectorContractLowering);
+
       vector::populateVectorFromElementsLoweringPatterns(patterns);
+      vector::populateVectorToElementsLoweringPatterns(patterns);
       vector::populateVectorGatherLoweringPatterns(patterns);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
@@ -295,7 +277,6 @@ struct ConvertToROCDLPass final
           patterns, options.vectorTransposeLowering);
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
-      patterns.insert<LowerToElementsPattern>(&getContext());
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }


### PR DESCRIPTION
After:

* https://github.com/llvm/llvm-project/pull/157740
* https://github.com/llvm/llvm-project/pull/157142

the linearization of vector.to_elements pattern
can be changed to either the one now upstream
or to the unrolling version.

This commit changes the strategy from linearizing
to unrolling.