### PR TITLE
Revert "Apply UnsignedWhenEquivalent at the ModuleOp level. (#21743)"

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -107,9 +107,8 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
       // Remove if it is added there.
       // https://github.com/llvm/llvm-project/issues/78458
       .addPass(affine::createAffineExpandIndexOpsPass)
-      .addPass(mlir::createLowerAffinePass);
-
-  passManager.addPass(mlir::arith::createArithUnsignedWhenEquivalentPass());
+      .addPass(mlir::createLowerAffinePass)
+      .addPass(mlir::arith::createArithUnsignedWhenEquivalentPass);
 
   // Propagate buffer subranges throughout the program - this should remove any
   // remaining subspans and give us a smaller surface area during conversion.


### PR DESCRIPTION
This reverts commit e5b0780e7338445c8cad5ea9640ab62cf5caaca2.

After https://github.com/llvm/llvm-project/pull/155088 landed upstream the workaround of making arith-unsigned-when-equivalent running on a module level can be reverted.