### PR TITLE
Remove AffineExpandIndexOps from VMTransformPassPipeline

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -103,10 +103,6 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   FunctionLikeNest(passManager)
       .addPass(mlir::createLoopInvariantCodeMotionPass)
       .addPass(mlir::createSCFToControlFlowPass)
-      // TODO: Maybe this should be a part of Affine lowering pass.
-      // Remove if it is added there.
-      // https://github.com/llvm/llvm-project/issues/78458
-      .addPass(affine::createAffineExpandIndexOpsPass)
       .addPass(mlir::createLowerAffinePass);
 
   passManager.addPass(mlir::arith::createArithUnsignedWhenEquivalentPass());


### PR DESCRIPTION
The AffineExpandIndexOps patterns have been added to LowerAffinePass

https://github.com/llvm/llvm-project/pull/82189