### PR TITLE
[LLVMGPU] Move masked load optimizations after vector lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1015,15 +1015,18 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass);
 
+  // This pass needs to run before SCF -> CF.
+  addLowerAndOptimizeAddressComputationPasses(funcPassManager);
+  funcPassManager.addPass(createLLVMGPUVectorLoweringPass)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass);
+
   if (forROCDL) {
+    // This pass needs to run after the LLVMGPUVectorLoweringPass.
     funcPassManager.addPass(amdgpu::createAmdgpuMaskedloadToLoadPass);
     // This pass needs to run before the ResolveSwizzleHints pass.
     funcPassManager.addPass(amdgpu::createAmdgpuFoldMemRefOpsPass);
   }
-
-  // This pass needs to run before SCF -> CF.
-  addLowerAndOptimizeAddressComputationPasses(funcPassManager);
-  funcPassManager.addPass(createLLVMGPUVectorLoweringPass);
 
   funcPassManager
       // Run checks on shared memory usage.


### PR DESCRIPTION
The LLVMGPUVectorLoweringPass was moved after the int arithmetic optimization passes, which caused the `AmdgpuMaskedloadToLoadPass` to be running before we had masked loads. This PR reorders the passes to avoid this issue, which fixes the regression in https://github.com/iree-org/iree/issues/21956.

The PR also adds a canonicalizer and CSE pass after LLVMGPUVectorLowering, which helps simplify the IR before the following optimization passes.