### PR TITLE
Fix Dispatch Creation TransformOptions

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -10,7 +10,6 @@
 #include <functional>
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
-#include "iree/compiler/Pipelines/Options.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -24,10 +23,25 @@ enum class EncodingOptions { Padding, MatmulK, Generic };
 // Pipelines
 //===----------------------------------------------------------------------===//
 
-/// This is a placeholder for future. We should pass all the options through the
-/// struct.
 struct TransformOptions : public PassPipelineOptions<TransformOptions> {
-  DispatchCreationOptions options;
+  Option<bool> enableAggressiveFusion{
+      *this,
+      "aggressive-fusion",
+      llvm::cl::desc("Enable aggressive fusion for dispatch creation pipeline"),
+      llvm::cl::init(false),
+  };
+  Option<bool> enableFuseMultiUse{
+      *this,
+      "fuse-multi-use",
+      llvm::cl::desc("Fuse operations with multiple uses."),
+      llvm::cl::init(true),
+  };
+  Option<bool> dataTiling{
+      *this,
+      "data-tiling",
+      llvm::cl::desc("Enable data-tiling for dispatch creation pipeline"),
+      llvm::cl::init(false),
+  };
 };
 
 void buildDispatchCreationPassPipeline(

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -277,7 +277,11 @@ void buildIREEVMTransformPassPipeline(
     break;
   default:
     DispatchCreation::TransformOptions dispatchTransformOptions;
-    dispatchTransformOptions.options = dispatchCreationOptions;
+    dispatchTransformOptions.enableAggressiveFusion =
+        dispatchCreationOptions.enableAggressiveFusion;
+    dispatchTransformOptions.enableFuseMultiUse =
+        dispatchCreationOptions.enableFuseMultiUse;
+    dispatchTransformOptions.dataTiling = dispatchCreationOptions.dataTiling;
     if (compileFrom < IREEVMPipelinePhase::DispatchCreation) { // late-entry
       IREE_TRACE_ADD_BEGIN_FRAME_PASS(passManager, "DispatchCreation");
       if (hooks.beforePhase)


### PR DESCRIPTION
Moves all the members from `DispatchCreationPipelineOptions` into `TransformOptions` and removes `DispatchCreationOptions` member, similar to what is done in Stream. `TransformOptions` can now be used to directly parse pipeline flags into the struct.