### PR TITLE
Adding hal.executable `lazy` flag.

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -698,10 +698,12 @@ public:
     iree_hal_cuda_ExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.
-    IREE::HAL::ExecutableBinaryOp::create(
+    auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(),
         builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.setMimeTypeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
 
     return success();
   }

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -835,9 +835,11 @@ public:
     }
 
     // Add the binary data to the target executable.
-    iree_compiler::IREE::HAL::ExecutableBinaryOp::create(
+    auto binaryOp = IREE::HAL::ExecutableBinaryOp::create(
         executableBuilder, variantOp.getLoc(), variantOp.getSymName(),
         variantOp.getTarget().getFormat(), binaryContainer.value());
+    binaryOp.setMimeTypeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
 
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
@@ -17,63 +17,79 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+static LogicalResult linkAllTargetExecutables(StringRef target, bool lazy,
+                                              ModuleOp moduleOp,
+                                              OpBuilder &moduleBuilder) {
+  auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);
+  if (sourceExecutableOps.size() <= 1) {
+    return success();
+  }
+
+  // Guess a module name, if needed, to make the output files readable.
+  auto moduleName = guessModuleName(moduleOp, "module");
+
+  // Create our new "linked" hal.executable.
+  SymbolTable moduleTable(moduleOp);
+  std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
+  auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+      moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
+  linkedExecutableOp.setVisibility(sourceExecutableOps.front().getVisibility());
+  moduleTable.insert(linkedExecutableOp);
+  auto executableBuilder =
+      OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
+
+  // Gather all unique executable targets - we may have multiple.
+  auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
+  for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
+    // Only link the target specified. If none specified link all.
+    if (!target.empty() && targetAttr.getBackend().getValue() != target) {
+      continue; // not linking this target
+    }
+
+    // Add our hal.executable.variant with an empty module.
+    std::string linkedVariantName =
+        executableTargetAttrs.size() == 1
+            ? targetAttr.getSymbolNameFragment()
+            : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(), index);
+    auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+        executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
+    auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
+    mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
+
+    auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
+                            mlir::ModuleOp linkedInnerModule,
+                            DenseMap<StringRef, Operation *> &symbolMap) {
+      return mergeModuleInto(sourceInnerModule, linkedInnerModule, symbolMap);
+    };
+
+    // Try linking together all executables in moduleOp.
+    if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
+                                   linkedExecutableOp, linkedTargetOp,
+                                   mergeModuleFn))) {
+      return failure();
+    }
+  }
+
+  // Remove if we didn't add anything.
+  if (linkedExecutableOp.getBody().empty()) {
+    linkedExecutableOp.erase();
+  }
+  return success();
+}
+
 struct LLVMCPULinkExecutablesPass
     : public impl::LLVMCPULinkExecutablesPassBase<LLVMCPULinkExecutablesPass> {
-  using impl::LLVMCPULinkExecutablesPassBase<
-      LLVMCPULinkExecutablesPass>::LLVMCPULinkExecutablesPassBase;
+  using Base::Base;
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
-
-    auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);
-    if (sourceExecutableOps.size() <= 1)
-      return;
-
-    // Guess a module name, if needed, to make the output files readable.
-    auto moduleName = guessModuleName(moduleOp, "module");
-
-    // Create our new "linked" hal.executable.
-    SymbolTable moduleTable(moduleOp);
-    std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
-    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
-        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
-    linkedExecutableOp.setVisibility(
-        sourceExecutableOps.front().getVisibility());
-    moduleTable.insert(linkedExecutableOp);
-    auto executableBuilder =
-        OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
-
-    // Gather all unique executable targets - we may have multiple.
-    auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
-    for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
-      // Only link the target specified. If none specified link all.
-      if (!target.empty() && targetAttr.getBackend().getValue() != target) {
-        continue; // not linking this target
-      }
-
-      // Add our hal.executable.variant with an empty module.
-      std::string linkedVariantName =
-          executableTargetAttrs.size() == 1
-              ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
-                              index);
-      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
-          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
-      auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
-
-      auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
-                              mlir::ModuleOp linkedInnerModule,
-                              DenseMap<StringRef, Operation *> &symbolMap) {
-        return mergeModuleInto(sourceInnerModule, linkedInnerModule, symbolMap);
-      };
-
-      // Try linking together all executables in moduleOp.
-      if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
-                                     linkedExecutableOp, linkedTargetOp,
-                                     mergeModuleFn))) {
-        return signalPassFailure();
-      }
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/false, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
+    }
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/true, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
@@ -56,68 +56,81 @@ static bool allowRenamingPrivateLLVMSymbols(Operation *op) {
          SymbolTable::Visibility::Private;
 }
 
+static LogicalResult linkAllTargetExecutables(StringRef target, bool lazy,
+                                              ModuleOp moduleOp,
+                                              OpBuilder &moduleBuilder) {
+  auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target, lazy);
+  if (sourceExecutableOps.size() <= 1) {
+    return success();
+  }
+
+  // Guess a module name, if needed, to make the output files readable.
+  auto moduleName = guessModuleName(moduleOp, "module");
+
+  // Create our new "linked" hal.executable.
+  SymbolTable moduleTable(moduleOp);
+  std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
+  auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+      moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
+  linkedExecutableOp.setVisibility(sourceExecutableOps.front().getVisibility());
+  linkedExecutableOp.setLazy(lazy);
+  moduleTable.insert(linkedExecutableOp);
+  auto executableBuilder =
+      OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
+
+  // Gather all unique executable targets - we may have multiple.
+  auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
+  for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
+    // Only link the target specified. If none specified link all.
+    if (!target.empty() && targetAttr.getBackend().getValue() != target) {
+      continue; // not linking this target
+    }
+
+    // Add our hal.executable.variant with an empty module.
+    std::string linkedVariantName =
+        executableTargetAttrs.size() == 1
+            ? targetAttr.getSymbolNameFragment()
+            : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(), index);
+    auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+        executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
+    auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
+    mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
+
+    auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
+                            mlir::ModuleOp linkedInnerModule,
+                            DenseMap<StringRef, Operation *> &symbolMap) {
+      return mergeModuleInto(sourceInnerModule, linkedInnerModule, symbolMap,
+                             allowRenamingPrivateLLVMSymbols);
+    };
+
+    // Try linking together all executables in moduleOp.
+    if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
+                                   linkedExecutableOp, linkedTargetOp,
+                                   mergeModuleFn))) {
+      return failure();
+    }
+  }
+
+  // Remove if we didn't add anything.
+  if (linkedExecutableOp.getBody().empty()) {
+    linkedExecutableOp.erase();
+  }
+  return success();
+}
+
 struct LLVMGPULinkExecutablesPass
     : public impl::LLVMGPULinkExecutablesPassBase<LLVMGPULinkExecutablesPass> {
   using Base::Base;
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
-
-    auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);
-    if (sourceExecutableOps.size() <= 1)
-      return;
-
-    // Guess a module name, if needed, to make the output files readable.
-    auto moduleName = guessModuleName(moduleOp, "module");
-
-    // Create our new "linked" hal.executable.
-    SymbolTable moduleTable(moduleOp);
-    std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
-    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
-        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
-    linkedExecutableOp.setVisibility(
-        sourceExecutableOps.front().getVisibility());
-    moduleTable.insert(linkedExecutableOp);
-    auto executableBuilder =
-        OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
-
-    // Gather all unique executable targets - we may have multiple.
-    auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
-    for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
-      // Only link the target specified. If none specified link all.
-      if (!target.empty() && targetAttr.getBackend().getValue() != target) {
-        continue; // not linking this target
-      }
-
-      // Add our hal.executable.variant with an empty module.
-      std::string linkedVariantName =
-          executableTargetAttrs.size() == 1
-              ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
-                              index);
-      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
-          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
-      auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      mlir::ModuleOp::create(targetBuilder, moduleOp.getLoc());
-
-      auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
-                              mlir::ModuleOp linkedInnerModule,
-                              DenseMap<StringRef, Operation *> &symbolMap) {
-        return mergeModuleInto(sourceInnerModule, linkedInnerModule, symbolMap,
-                               allowRenamingPrivateLLVMSymbols);
-      };
-
-      // Try linking together all executables in moduleOp.
-      if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
-                                     linkedExecutableOp, linkedTargetOp,
-                                     mergeModuleFn))) {
-        return signalPassFailure();
-      }
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/false, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
     }
-
-    // Remove if we didn't add anything.
-    if (linkedExecutableOp.getBody().empty()) {
-      linkedExecutableOp.erase();
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/true, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -29,10 +29,12 @@ gatherExecutableTargets(ArrayRef<IREE::HAL::ExecutableOp> executableOps) {
 }
 
 SmallVector<IREE::HAL::ExecutableOp>
-gatherExecutablesForTarget(mlir::ModuleOp moduleOp, StringRef targetName) {
+gatherExecutablesForTarget(mlir::ModuleOp moduleOp, StringRef targetName,
+                           bool lazy) {
   SmallVector<IREE::HAL::ExecutableOp> result;
   for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
-    if (llvm::any_of(executableOp.getOps<IREE::HAL::ExecutableVariantOp>(),
+    if (executableOp.getLazy() == lazy &&
+        llvm::any_of(executableOp.getOps<IREE::HAL::ExecutableVariantOp>(),
                      [&](IREE::HAL::ExecutableVariantOp variantOp) {
                        return variantOp.getTarget().getBackend().getValue() ==
                               targetName;

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.h
@@ -17,9 +17,11 @@ SetVector<IREE::HAL::ExecutableTargetAttr>
 gatherExecutableTargets(ArrayRef<IREE::HAL::ExecutableOp> executableOps);
 
 // Returns a set of executables that contain one or more variants for the given
-// target backend name.
+// target backend name. |lazy| determines whether only lazy-loaded or preloaded
+// executables are returned.
 SmallVector<IREE::HAL::ExecutableOp>
-gatherExecutablesForTarget(mlir::ModuleOp moduleOp, StringRef targetName);
+gatherExecutablesForTarget(mlir::ModuleOp moduleOp, StringRef targetName,
+                           bool lazy = false);
 
 static inline bool allowRenamingPrivateSymbols(Operation *op) {
   return SymbolTable::getSymbolVisibility(op) ==

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
@@ -18,62 +18,80 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+static LogicalResult linkAllTargetExecutables(StringRef target, bool lazy,
+                                              ModuleOp moduleOp,
+                                              OpBuilder &moduleBuilder) {
+  auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);
+  if (sourceExecutableOps.size() <= 1) {
+    return success();
+  }
+
+  // Guess a module name, if needed, to make the output files readable.
+  auto moduleName = guessModuleName(moduleOp, "module");
+
+  // Create our new "linked" hal.executable.
+  std::string linkedExecutableName =
+      llvm::formatv("{}_linked_{}", moduleName, target);
+  auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
+      moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
+  linkedExecutableOp.setVisibility(sourceExecutableOps.front().getVisibility());
+  auto executableBuilder =
+      OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
+
+  // Gather all unique executable targets - we may have multiple.
+  auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
+  for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
+    // Add our VMVX hal.executable.variant with an empty module.
+    std::string linkedVariantName =
+        executableTargetAttrs.size() == 1
+            ? targetAttr.getSymbolNameFragment()
+            : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(), index);
+    auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
+        executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
+    auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
+    auto linkedModuleOp = ModuleOp::create(targetBuilder, moduleOp.getLoc());
+
+    // Add an empty vm.module to that module as our vm.funcs must live in it.
+    auto nestedBuilder = OpBuilder::atBlockBegin(linkedModuleOp.getBody());
+    IREE::VM::ModuleOp::create(nestedBuilder, moduleOp.getLoc(),
+                               "linked_module");
+
+    auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
+                            mlir::ModuleOp linkedInnerModule,
+                            DenseMap<StringRef, Operation *> &symbolMap) {
+      auto srcModule = sourceInnerModule.getOps<IREE::VM::ModuleOp>().begin();
+      auto dstModule = linkedInnerModule.getOps<IREE::VM::ModuleOp>().begin();
+      return mergeModuleInto(*srcModule, *dstModule, symbolMap);
+    };
+
+    // Try linking together all executable variants for this target.
+    if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
+                                   linkedExecutableOp, linkedTargetOp,
+                                   mergeModuleFn))) {
+      return failure();
+    }
+  }
+
+  // Remove if we didn't add anything.
+  if (linkedExecutableOp.getBody().empty()) {
+    linkedExecutableOp.erase();
+  }
+  return success();
+}
+
 struct VMVXLinkExecutablesPass
     : public impl::VMVXLinkExecutablesPassBase<VMVXLinkExecutablesPass> {
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
-
-    auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, "vmvx");
-    if (sourceExecutableOps.size() <= 1)
-      return;
-
-    // Guess a module name, if needed, to make the output files readable.
-    auto moduleName = guessModuleName(moduleOp, "vmvx_module");
-
-    // Create our new "linked" hal.executable.
-    std::string linkedExecutableName =
-        llvm::formatv("{}_linked_{}", moduleName, "vmvx");
-    auto linkedExecutableOp = IREE::HAL::ExecutableOp::create(
-        moduleBuilder, moduleOp.getLoc(), linkedExecutableName);
-    linkedExecutableOp.setVisibility(
-        sourceExecutableOps.front().getVisibility());
-    auto executableBuilder =
-        OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
-
-    // Gather all unique executable targets - we may have multiple.
-    auto executableTargetAttrs = gatherExecutableTargets(sourceExecutableOps);
-    for (auto [index, targetAttr] : llvm::enumerate(executableTargetAttrs)) {
-      // Add our VMVX hal.executable.variant with an empty module.
-      std::string linkedVariantName =
-          executableTargetAttrs.size() == 1
-              ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
-                              index);
-      auto linkedTargetOp = IREE::HAL::ExecutableVariantOp::create(
-          executableBuilder, moduleOp.getLoc(), linkedVariantName, targetAttr);
-      auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
-      auto linkedModuleOp = ModuleOp::create(targetBuilder, moduleOp.getLoc());
-
-      // Add an empty vm.module to that module as our vm.funcs must live in it.
-      auto nestedBuilder = OpBuilder::atBlockBegin(linkedModuleOp.getBody());
-      IREE::VM::ModuleOp::create(nestedBuilder, moduleOp.getLoc(),
-                                 "linked_module");
-
-      auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
-                              mlir::ModuleOp linkedInnerModule,
-                              DenseMap<StringRef, Operation *> &symbolMap) {
-        auto srcModule = sourceInnerModule.getOps<IREE::VM::ModuleOp>().begin();
-        auto dstModule = linkedInnerModule.getOps<IREE::VM::ModuleOp>().begin();
-        return mergeModuleInto(*srcModule, *dstModule, symbolMap);
-      };
-
-      // Try linking together all executable variants for this target.
-      if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
-                                     linkedExecutableOp, linkedTargetOp,
-                                     mergeModuleFn))) {
-        return signalPassFailure();
-      }
+    StringRef target = "vmvx";
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/false, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
+    }
+    if (failed(linkAllTargetExecutables(target, /*lazy=*/true, moduleOp,
+                                        moduleBuilder))) {
+      return signalPassFailure();
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2614,19 +2614,29 @@ def HAL_ExecutableOp : HAL_Op<"executable", [
   let summary = [{Target-specific executable module.}];
   let description = [{
     An executable module representing a target-specific compiled
-    kernel/shader/etc.
+    kernel/shader/etc. Executables are treated as independent compilation units
+    and may contain multiple exported entry points that are able to share code
+    internally. To support multi-targeting each executable may have one or more
+    target-specific variants that are lowered independently during compilation
+    while still appearing as one executable at runtime (ala fat binaries).
+
+    At runtime executables are loaded during module initialization and cached
+    for the lifetime of the module. If the `lazy` attribute is set the
+    executable _may_ have its loading deferred until first use.
   }];
 
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
-    SymbolNameAttr:$sym_name
+    SymbolNameAttr:$sym_name,
     // TODO(benvanik): entry point types for verification.
+    UnitAttr:$lazy
   );
 
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
     custom<SymbolVisibility>($sym_visibility)
+    (`lazy` $lazy^)?
     $sym_name
     attr-dict-with-keyword
     regions

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -75,8 +75,8 @@ static std::string getDeviceNamePrefix(IREE::Util::GlobalOpInterface deviceOp) {
     // Already prefixed.
     return deviceName.str();
   }
-  auto prefixedName = "__" + deviceName;
-  return prefixedName.str();
+  std::string prefixedName = ("__" + deviceName).str();
+  return prefixedName;
 }
 
 static void declareDeviceExecutable(IREE::Util::GlobalOpInterface deviceOp,


### PR DESCRIPTION
This allows for executables to be hinted as lazy-loadable. Frontends lowering into IREE IR can set this flag if it knows certain executables will only be used on certain cold code paths. Currently the initialization behavior is unchanged but in the future a new pass or modification to MaterializeResourceCachesPass will take the flag into account to (possibly) wrap the executable initialization in a `hal.device.memoize` op. More plumbing/expressiveness is required to do this so this just adds the flag for frontends to target and we'll light it up in the future when required.

(this will be used by parameter encoding modules that multi-target and don't need to load all encoding executables for all targets just to encode for one)