### PR TITLE
`using Base::Base` in tablegen passes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/AddFastMathFlags.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/AddFastMathFlags.cpp
@@ -33,8 +33,7 @@ namespace {
 struct AddFastMathFlagsPass final
     : impl::AddFastMathFlagsPassBase<AddFastMathFlagsPass> {
 public:
-  using impl::AddFastMathFlagsPassBase<
-      AddFastMathFlagsPass>::AddFastMathFlagsPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     getOperation()->walk([](Operation *op) { addContractFMF(op); });

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -38,8 +38,7 @@ namespace {
 struct BufferizeCopyOnlyDispatchesPass final
     : impl::BufferizeCopyOnlyDispatchesPassBase<
           BufferizeCopyOnlyDispatchesPass> {
-  using impl::BufferizeCopyOnlyDispatchesPassBase<
-      BufferizeCopyOnlyDispatchesPass>::BufferizeCopyOnlyDispatchesPassBase;
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
         .insert<affine::AffineDialect, bufferization::BufferizationDialect,

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -62,8 +62,7 @@ namespace {
 class CPULowerToUKernelsPass
     : public impl::CPULowerToUKernelsPassBase<CPULowerToUKernelsPass> {
 public:
-  using impl::CPULowerToUKernelsPassBase<
-      CPULowerToUKernelsPass>::CPULowerToUKernelsPassBase;
+  using Base::Base;
   explicit CPULowerToUKernelsPass(bool skipIntermediateRoundings) {
     this->skipIntermediateRoundings = skipIntermediateRoundings;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -681,8 +681,7 @@ namespace {
 struct CombineLayoutTransformationPass final
     : impl::CombineLayoutTransformationPassBase<
           CombineLayoutTransformationPass> {
-  using impl::CombineLayoutTransformationPassBase<
-      CombineLayoutTransformationPass>::CombineLayoutTransformationPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     CombineRelayoutOpsControlFn controlFn =

--- a/compiler/src/iree/compiler/Codegen/Common/ConfigTrackingCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConfigTrackingCanonicalizer.cpp
@@ -69,8 +69,7 @@ struct ConfigTrackingCanonicalizerPass final
     : impl::ConfigTrackingCanonicalizerPassBase<
           ConfigTrackingCanonicalizerPass> {
 public:
-  using impl::ConfigTrackingCanonicalizerPassBase<
-      ConfigTrackingCanonicalizerPass>::ConfigTrackingCanonicalizerPassBase;
+  using Base::Base;
   /// Initialize the canonicalizer by building the set of patterns used during
   /// execution.
   LogicalResult initialize(MLIRContext *context) override {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -238,8 +238,7 @@ struct PromoteBF16ToF32Converter
 
 struct ConvertBf16ArithToF32Pass final
     : impl::ConvertBf16ArithToF32PassBase<ConvertBf16ArithToF32Pass> {
-  using impl::ConvertBf16ArithToF32PassBase<
-      ConvertBf16ArithToF32Pass>::ConvertBf16ArithToF32PassBase;
+  using Base::Base;
   void runOnOperation() override {
     MLIRContext *context = &this->getContext();
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -260,8 +260,7 @@ static LogicalResult commonRunOnOperation(
 
 struct DecomposePackUnPackOpsPass final
     : impl::DecomposePackUnPackOpsPassBase<DecomposePackUnPackOpsPass> {
-  using impl::DecomposePackUnPackOpsPassBase<
-      DecomposePackUnPackOpsPass>::DecomposePackUnPackOpsPassBase;
+  using Base::Base;
 
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
@@ -118,8 +118,7 @@ static LogicalResult convertSoftmaxToGenerics(mlir::FunctionOpInterface funcOp,
 
 struct DecomposeSoftmaxPass
     : impl::DecomposeSoftmaxPassBase<DecomposeSoftmaxPass> {
-  using impl::DecomposeSoftmaxPassBase<
-      DecomposeSoftmaxPass>::DecomposeSoftmaxPassBase;
+  using Base::Base;
   explicit DecomposeSoftmaxPass(bool useFusion) { this->useFusion = useFusion; }
 
   void getDependentDialects(DialectRegistry &registry) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
@@ -21,8 +21,7 @@ namespace {
 class DropVectorUnitDimsPass
     : public impl::DropVectorUnitDimsPassBase<DropVectorUnitDimsPass> {
 public:
-  using impl::DropVectorUnitDimsPassBase<
-      DropVectorUnitDimsPass>::DropVectorUnitDimsPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<memref::MemRefDialect, vector::VectorDialect>();

--- a/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
@@ -22,8 +22,7 @@ class EraseDeadAllocAndStoresPass final
     : public impl::EraseDeadAllocAndStoresPassBase<
           EraseDeadAllocAndStoresPass> {
 public:
-  using impl::EraseDeadAllocAndStoresPassBase<
-      EraseDeadAllocAndStoresPass>::EraseDeadAllocAndStoresPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, vector::VectorDialect>();

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
@@ -342,8 +342,7 @@ struct FlattenSubview : public OpRewritePattern<memref::SubViewOp> {
 
 struct DecomposeMemrefsPass
     : public impl::DecomposeMemrefsPassBase<DecomposeMemrefsPass> {
-  using impl::DecomposeMemrefsPassBase<
-      DecomposeMemrefsPass>::DecomposeMemrefsPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, arith::ArithDialect,

--- a/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
@@ -86,7 +86,7 @@ static LogicalResult forallToForLoop(RewriterBase &rewriter,
 
 namespace {
 struct ForallToForPass : impl::ForallToForPassBase<ForallToForPass> {
-  using impl::ForallToForPassBase<ForallToForPass>::ForallToForPassBase;
+  using Base::Base;
   void runOnOperation() override {
     auto funcOp = getOperation();
     IRRewriter rewriter(funcOp->getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -126,8 +126,7 @@ static LogicalResult isWithinVectorSizeLimit(linalg::LinalgOp linalgOp,
 class GenericVectorizationPass final
     : public impl::GenericVectorizationPassBase<GenericVectorizationPass> {
 public:
-  using impl::GenericVectorizationPassBase<
-      GenericVectorizationPass>::GenericVectorizationPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
@@ -96,8 +96,7 @@ public:
 struct IREECodegenCanonicalizerPass final
     : impl::IREECodegenCanonicalizerPassBase<IREECodegenCanonicalizerPass> {
 public:
-  using impl::IREECodegenCanonicalizerPassBase<
-      IREECodegenCanonicalizerPass>::IREECodegenCanonicalizerPassBase;
+  using Base::Base;
   /// Initialize the canonicalizer by building the set of patterns used during
   /// execution.
   LogicalResult initialize(MLIRContext *context) override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -94,8 +94,7 @@ class IREEComprehensiveBufferizePass final
     : public impl::IREEComprehensiveBufferizePassBase<
           IREEComprehensiveBufferizePass> {
 public:
-  using impl::IREEComprehensiveBufferizePassBase<
-      IREEComprehensiveBufferizePass>::IREEComprehensiveBufferizePassBase;
+  using Base::Base;
   explicit IREEComprehensiveBufferizePass(
       BufferizationOptions::AllocationFn allocationFn,
       BufferizationOptions::MemCpyFn memCpyFn)
@@ -131,8 +130,7 @@ private:
 class IREEBufferizeConstantsPass final
     : public impl::IREEBufferizeConstantsPassBase<IREEBufferizeConstantsPass> {
 public:
-  using impl::IREEBufferizeConstantsPassBase<
-      IREEBufferizeConstantsPass>::IREEBufferizeConstantsPassBase;
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, bufferization::BufferizationDialect,
                     memref::MemRefDialect>();

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -253,8 +253,7 @@ struct ConvertCodegenIREEExtractMetadataToMemRef
 
 struct IREEExpandStridedMetadataPass final
     : impl::IREEExpandStridedMetadataPassBase<IREEExpandStridedMetadataPass> {
-  using impl::IREEExpandStridedMetadataPassBase<
-      IREEExpandStridedMetadataPass>::IREEExpandStridedMetadataPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, arith::ArithDialect,

--- a/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/NormalizeLoopBounds.cpp
@@ -169,8 +169,7 @@ LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
 namespace {
 struct NormalizeLoopBoundsPass final
     : impl::NormalizeLoopBoundsPassBase<NormalizeLoopBoundsPass> {
-  using impl::NormalizeLoopBoundsPassBase<
-      NormalizeLoopBoundsPass>::NormalizeLoopBoundsPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     Operation *op = getOperation();

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -62,8 +62,7 @@ static void loopInvariantCodeMotion(mlir::FunctionOpInterface funcOp) {
 
 struct OptimizeVectorTransferPass final
     : impl::OptimizeVectorTransferPassBase<OptimizeVectorTransferPass> {
-  using impl::OptimizeVectorTransferPassBase<
-      OptimizeVectorTransferPass>::OptimizeVectorTransferPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     auto funcOp = getOperation();

--- a/compiler/src/iree/compiler/Codegen/Common/ReplaceSlowMinMaxOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReplaceSlowMinMaxOps.cpp
@@ -60,8 +60,7 @@ struct ReplaceSlowWithFastReductionMinMaxOpPattern final
 struct ReplaceSlowMinMaxOpsPass final
     : impl::ReplaceSlowMinMaxOpsPassBase<ReplaceSlowMinMaxOpsPass> {
 public:
-  using impl::ReplaceSlowMinMaxOpsPassBase<
-      ReplaceSlowMinMaxOpsPass>::ReplaceSlowMinMaxOpsPassBase;
+  using Base::Base;
   void runOnOperation() override;
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/SplitFullPartialTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SplitFullPartialTransferPass.cpp
@@ -22,8 +22,7 @@ namespace {
 
 struct SplitFullPartialTransferPass final
     : impl::SplitFullPartialTransferPassBase<SplitFullPartialTransferPass> {
-  using impl::SplitFullPartialTransferPassBase<
-      SplitFullPartialTransferPass>::SplitFullPartialTransferPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();

--- a/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
@@ -234,8 +234,7 @@ struct VectorizePadWithConditions final
 
 struct TensorToVectorVectorizePadPass final
     : impl::TensorToVectorVectorizePadPassBase<TensorToVectorVectorizePadPass> {
-  using impl::TensorToVectorVectorizePadPassBase<
-      TensorToVectorVectorizePadPass>::TensorToVectorVectorizePadPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, arith::ArithDialect,

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -268,8 +268,7 @@ namespace {
 struct TileAndDistributeToWorkgroupsPass final
     : impl::TileAndDistributeToWorkgroupsPassBase<
           TileAndDistributeToWorkgroupsPass> {
-  using impl::TileAndDistributeToWorkgroupsPassBase<
-      TileAndDistributeToWorkgroupsPass>::TileAndDistributeToWorkgroupsPassBase;
+  using Base::Base;
 
   TileAndDistributeToWorkgroupsPass(
       int32_t maxWorkgroupParallelDims,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -27,8 +27,7 @@ class TransformDialectInterpreterPass final
     : public impl::TransformDialectInterpreterPassBase<
           TransformDialectInterpreterPass> {
 public:
-  using impl::TransformDialectInterpreterPassBase<
-      TransformDialectInterpreterPass>::TransformDialectInterpreterPassBase;
+  using Base::Base;
 
   TransformDialectInterpreterPass(StringRef libraryFileName,
                                   StringRef entryPoint) {

--- a/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
@@ -25,8 +25,7 @@ namespace {
 class VectorTransferLoweringPass
     : public impl::VectorTransferLoweringPassBase<VectorTransferLoweringPass> {
 public:
-  using impl::VectorTransferLoweringPassBase<
-      VectorTransferLoweringPass>::VectorTransferLoweringPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, scf::SCFDialect,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -927,7 +927,7 @@ public:
 class ConvertToLLVMPass
     : public impl::ConvertToLLVMPassBase<ConvertToLLVMPass> {
 public:
-  using impl::ConvertToLLVMPassBase<ConvertToLLVMPass>::ConvertToLLVMPassBase;
+  using Base::Base;
   explicit ConvertToLLVMPass(bool reassociateFpReductions) {
     this->reassociateFpReductions = reassociateFpReductions;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -81,8 +81,7 @@ class LLVMCPU2DScalableTo1DScalablePass
     : public impl::LLVMCPU2DScalableTo1DScalablePassBase<
           LLVMCPU2DScalableTo1DScalablePass> {
 public:
-  using impl::LLVMCPU2DScalableTo1DScalablePassBase<
-      LLVMCPU2DScalableTo1DScalablePass>::LLVMCPU2DScalableTo1DScalablePassBase;
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
         .insert<arith::ArithDialect, linalg::LinalgDialect, scf::SCFDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -33,8 +33,7 @@ namespace {
 struct LLVMCPUMmt4dVectorLoweringPass
     : public impl::LLVMCPUMmt4dVectorLoweringPassBase<
           LLVMCPUMmt4dVectorLoweringPass> {
-  using impl::LLVMCPUMmt4dVectorLoweringPassBase<
-      LLVMCPUMmt4dVectorLoweringPass>::LLVMCPUMmt4dVectorLoweringPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<vector::VectorDialect, LLVM::LLVMDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -159,8 +159,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
 class LLVMCPUSplitReductionPass
     : public impl::LLVMCPUSplitReductionPassBase<LLVMCPUSplitReductionPass> {
 public:
-  using impl::LLVMCPUSplitReductionPassBase<
-      LLVMCPUSplitReductionPass>::LLVMCPUSplitReductionPassBase;
+  using Base::Base;
   explicit LLVMCPUSplitReductionPass(bool fpReductionReordering) {
     this->enableFpReductionReordering = fpReductionReordering;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -35,7 +35,7 @@ namespace {
 /// be specified. It picks the `tilingLevel`-th list as tiling sizes from
 /// lowering_config.
 struct LLVMCPUTilePass : impl::LLVMCPUTilePassBase<LLVMCPUTilePass> {
-  using impl::LLVMCPUTilePassBase<LLVMCPUTilePass>::LLVMCPUTilePassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, affine::AffineDialect,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileToVectorSize.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileToVectorSize.cpp
@@ -34,8 +34,7 @@ namespace {
 
 struct LLVMCPUTileToVectorSizePass final
     : impl::LLVMCPUTileToVectorSizePassBase<LLVMCPUTileToVectorSizePass> {
-  using impl::LLVMCPUTileToVectorSizePassBase<
-      LLVMCPUTileToVectorSizePass>::LLVMCPUTileToVectorSizePassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<arith::ArithDialect, scf::SCFDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -25,8 +25,7 @@ class LLVMCPUVirtualVectorLoweringPass
     : public impl::LLVMCPUVirtualVectorLoweringPassBase<
           LLVMCPUVirtualVectorLoweringPass> {
 public:
-  using impl::LLVMCPUVirtualVectorLoweringPassBase<
-      LLVMCPUVirtualVectorLoweringPass>::LLVMCPUVirtualVectorLoweringPassBase;
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, vector::VectorDialect,
                     arm_neon::ArmNeonDialect>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -50,7 +50,7 @@ namespace {
 /// code.
 struct ConvertToNVVMPass final
     : impl::ConvertToNVVMPassBase<ConvertToNVVMPass> {
-  using impl::ConvertToNVVMPassBase<ConvertToNVVMPass>::ConvertToNVVMPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -204,8 +204,7 @@ struct LowerToElementsPattern : public OpRewritePattern<vector::ToElementsOp> {
 /// code.
 struct ConvertToROCDLPass final
     : impl::ConvertToROCDLPassBase<ConvertToROCDLPass> {
-  using impl::ConvertToROCDLPassBase<
-      ConvertToROCDLPass>::ConvertToROCDLPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::GPU::IREEGPUDialect, LLVM::LLVMDialect,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
@@ -58,8 +58,7 @@ static bool allowRenamingPrivateLLVMSymbols(Operation *op) {
 
 struct LLVMGPULinkExecutablesPass
     : public impl::LLVMGPULinkExecutablesPassBase<LLVMGPULinkExecutablesPass> {
-  using impl::LLVMGPULinkExecutablesPassBase<
-      LLVMGPULinkExecutablesPass>::LLVMGPULinkExecutablesPassBase;
+  using Base::Base;
   void runOnOperation() override {
     auto moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -53,8 +53,7 @@ class LLVMGPULowerExecutableTargetPass final
     : public impl::LLVMGPULowerExecutableTargetPassBase<
           LLVMGPULowerExecutableTargetPass> {
 public:
-  using impl::LLVMGPULowerExecutableTargetPassBase<
-      LLVMGPULowerExecutableTargetPass>::LLVMGPULowerExecutableTargetPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -25,8 +25,7 @@ class LLVMGPUSelectLoweringStrategyPass final
     : public impl::LLVMGPUSelectLoweringStrategyPassBase<
           LLVMGPUSelectLoweringStrategyPass> {
 public:
-  using impl::LLVMGPUSelectLoweringStrategyPassBase<
-      LLVMGPUSelectLoweringStrategyPass>::LLVMGPUSelectLoweringStrategyPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -203,8 +203,7 @@ private:
   bool distributeToWarp = false;
 
 public:
-  using impl::LLVMGPUTileAndDistributePassBase<
-      LLVMGPUTileAndDistributePass>::LLVMGPUTileAndDistributePassBase;
+  using Base::Base;
   LLVMGPUTileAndDistributePass(bool distributeToWarp)
       : distributeToWarp(distributeToWarp) {}
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -42,8 +42,7 @@ static void swizzleSharedMemory(mlir::FunctionOpInterface funcOp) {
 namespace {
 struct LLVMGPUVectorToGPUPass final
     : impl::LLVMGPUVectorToGPUPassBase<LLVMGPUVectorToGPUPass> {
-  using impl::LLVMGPUVectorToGPUPassBase<
-      LLVMGPUVectorToGPUPass>::LLVMGPUVectorToGPUPassBase;
+  using Base::Base;
   LLVMGPUVectorToGPUPass(GPUTensorCoreType tensorCoreType)
       : tensorCoreType(tensorCoreType) {}
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -533,8 +533,7 @@ struct RemoveIdentityConversionCast final
 class ConvertToSPIRVPass final
     : public impl::ConvertToSPIRVPassBase<ConvertToSPIRVPass> {
 public:
-  using impl::ConvertToSPIRVPassBase<
-      ConvertToSPIRVPass>::ConvertToSPIRVPassBase;
+  using Base::Base;
   explicit ConvertToSPIRVPass(unsigned indexBits) : indexBits(indexBits) {}
 
   void getDependentDialects(DialectRegistry &registry) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateWinogradLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateWinogradLoops.cpp
@@ -19,8 +19,7 @@ class SPIRVAnnotateWinogradLoopsPass final
     : public impl::SPIRVAnnotateWinogradLoopsPassBase<
           SPIRVAnnotateWinogradLoopsPass> {
 public:
-  using impl::SPIRVAnnotateWinogradLoopsPassBase<
-      SPIRVAnnotateWinogradLoopsPass>::SPIRVAnnotateWinogradLoopsPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     auto funcOp = getOperation();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -46,8 +46,7 @@ class SPIRVLowerExecutableTargetPass final
     : public impl::SPIRVLowerExecutableTargetPassBase<
           SPIRVLowerExecutableTargetPass> {
 public:
-  using impl::SPIRVLowerExecutableTargetPassBase<
-      SPIRVLowerExecutableTargetPass>::SPIRVLowerExecutableTargetPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
@@ -29,8 +29,7 @@ class SPIRVSelectLoweringStrategyPass final
     : public impl::SPIRVSelectLoweringStrategyPassBase<
           SPIRVSelectLoweringStrategyPass> {
 public:
-  using impl::SPIRVSelectLoweringStrategyPassBase<
-      SPIRVSelectLoweringStrategyPass>::SPIRVSelectLoweringStrategyPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -109,8 +109,7 @@ namespace {
 class SPIRVTileAndDistributePass final
     : public impl::SPIRVTileAndDistributePassBase<SPIRVTileAndDistributePass> {
 public:
-  using impl::SPIRVTileAndDistributePassBase<
-      SPIRVTileAndDistributePass>::SPIRVTileAndDistributePassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, gpu::GPUDialect,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -111,8 +111,7 @@ namespace {
 class SPIRVTileAndPromotePass final
     : public impl::SPIRVTileAndPromotePassBase<SPIRVTileAndPromotePass> {
 public:
-  using impl::SPIRVTileAndPromotePassBase<
-      SPIRVTileAndPromotePass>::SPIRVTileAndPromotePassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<gpu::GPUDialect, IREE::GPU::IREEGPUDialect>();

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
@@ -921,8 +921,7 @@ struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
 class VMVXLowerLinalgMicrokernelsPass
     : public impl::VMVXLowerLinalgMicrokernelsPassBase<
           VMVXLowerLinalgMicrokernelsPass> {
-  using impl::VMVXLowerLinalgMicrokernelsPassBase<
-      VMVXLowerLinalgMicrokernelsPass>::VMVXLowerLinalgMicrokernelsPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Util::UtilDialect, IREE::VMVX::VMVXDialect,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -407,8 +407,7 @@ private:
 /// ```
 struct ConvertConv2DToWinogradPass final
     : impl::ConvertConv2DToWinogradPassBase<ConvertConv2DToWinogradPass> {
-  using impl::ConvertConv2DToWinogradPassBase<
-      ConvertConv2DToWinogradPass>::ConvertConv2DToWinogradPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAttention.cpp
@@ -19,8 +19,7 @@ namespace {
 
 struct DecomposeAttentionPass final
     : impl::DecomposeAttentionPassBase<DecomposeAttentionPass> {
-  using impl::DecomposeAttentionPassBase<
-      DecomposeAttentionPass>::DecomposeAttentionPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -62,8 +62,7 @@ static LogicalResult decomposeIm2col(Im2colOp im2colOp, RewriterBase &rewriter,
 namespace {
 struct DecomposeIm2colPass final
     : impl::DecomposeIm2colPassBase<DecomposeIm2colPass> {
-  using impl::DecomposeIm2colPassBase<
-      DecomposeIm2colPass>::DecomposeIm2colPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -218,8 +218,7 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
 namespace {
 struct DecomposeMapScatterPass final
     : impl::DecomposeMapScatterPassBase<DecomposeMapScatterPass> {
-  using impl::DecomposeMapScatterPassBase<
-      DecomposeMapScatterPass>::DecomposeMapScatterPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/FoldUnitExtentDims.cpp
@@ -20,8 +20,7 @@ namespace {
 
 struct FoldUnitExtentDimsPass final
     : impl::FoldUnitExtentDimsPassBase<FoldUnitExtentDimsPass> {
-  using impl::FoldUnitExtentDimsPassBase<
-      FoldUnitExtentDimsPass>::FoldUnitExtentDimsPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
@@ -89,8 +89,7 @@ namespace {
 
 struct PadContractionToBlockSizePass final
     : impl::PadContractionToBlockSizePassBase<PadContractionToBlockSizePass> {
-  using impl::PadContractionToBlockSizePassBase<
-      PadContractionToBlockSizePass>::PadContractionToBlockSizePassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Util::UtilDialect>();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -297,8 +297,7 @@ void setSplitReductionDepth(TopkOp topkOp, RewriterBase &rewriter,
 namespace {
 struct TopkSplitReductionPass final
     : impl::TopkSplitReductionPassBase<TopkSplitReductionPass> {
-  using impl::TopkSplitReductionPassBase<
-      TopkSplitReductionPass>::TopkSplitReductionPassBase;
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -117,8 +117,7 @@ struct DecomposeNonOuterDimConcats : public OpRewritePattern<tensor::ConcatOp> {
 
 struct DecomposeConcatPass
     : public impl::DecomposeConcatPassBase<DecomposeConcatPass> {
-  using impl::DecomposeConcatPassBase<
-      DecomposeConcatPass>::DecomposeConcatPassBase;
+  using Base::Base;
   explicit DecomposeConcatPass(bool enableConcatTransposition) {
     this->enableConcatTransposition = enableConcatTransposition;
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
@@ -140,8 +140,7 @@ class DemoteContractionInputsToBF16Pass
     : public impl::DemoteContractionInputsToBF16PassBase<
           DemoteContractionInputsToBF16Pass> {
 public:
-  using impl::DemoteContractionInputsToBF16PassBase<
-      DemoteContractionInputsToBF16Pass>::DemoteContractionInputsToBF16PassBase;
+  using Base::Base;
   explicit DemoteContractionInputsToBF16Pass(const DemotionOption &option) {
     this->demoteOnly = option;
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -967,8 +967,7 @@ namespace {
 struct PropagateLinalgTransposePass
     : public impl::PropagateLinalgTransposePassBase<
           PropagateLinalgTransposePass> {
-  using impl::PropagateLinalgTransposePassBase<
-      PropagateLinalgTransposePass>::PropagateLinalgTransposePassBase;
+  using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, tensor::TensorDialect>();
   }

--- a/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/AutoInputConversionPipeline.cpp
@@ -22,8 +22,7 @@ class AutoInputConversionPipelinePass final
     : public impl::AutoInputConversionPipelinePassBase<
           AutoInputConversionPipelinePass> {
 public:
-  using impl::AutoInputConversionPipelinePassBase<
-      AutoInputConversionPipelinePass>::AutoInputConversionPipelinePassBase;
+  using Base::Base;
   AutoInputConversionPipelinePass(PipelineExtensions *pipelineExtensions)
       : pipelineExtensions(pipelineExtensions) {}
   void runOnOperation() override;

--- a/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
@@ -17,8 +17,7 @@ namespace mlir::iree_compiler::Preprocessing {
 namespace {
 struct TransposeMatmulPass
     : public impl::TransposeMatmulPassBase<TransposeMatmulPass> {
-  using impl::TransposeMatmulPassBase<
-      TransposeMatmulPass>::TransposeMatmulPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     bool transposeLHS = input == Preprocessing::TransposeMatmulInput::Lhs;


### PR DESCRIPTION
@kuhar pointed out this works (maybe it didn't before?) so cleaning up our passes to avoid the annoying expanded using line.