### PR TITLE
Using explicit operation types in passes.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
@@ -316,15 +316,15 @@ LogicalResult convertFunction(func::FuncOp oldFunction,
 struct FlattenTuplesInCFG final
     : impl::FlattenTuplesInCFGBase<FlattenTuplesInCFG> {
   void runOnOperation() override {
-    ModuleOp module = getOperation();
-    MLIRContext *ctx = module.getContext();
+    mlir::ModuleOp moduleOp = getOperation();
+    MLIRContext *ctx = moduleOp.getContext();
     Builder builder(ctx);
 
     // Build a list of (oldFunction, newFunction) for all functions we need to
     // replace. This will ensure that when we go to convert function bodies we
     // have only new functions defined.
     SmallVector<std::pair<func::FuncOp, func::FuncOp>> convertedFunctions;
-    for (auto oldFunction : module.getOps<func::FuncOp>()) {
+    for (auto oldFunction : moduleOp.getOps<func::FuncOp>()) {
       FunctionType oldFunctionType = oldFunction.getFunctionType();
 
       llvm::SmallVector<Type> newInputTypes;
@@ -349,7 +349,7 @@ struct FlattenTuplesInCFG final
     // Replace functions in the module.
     for (auto [oldFunction, newFunction] : convertedFunctions) {
       oldFunction.erase();
-      module.push_back(newFunction);
+      moduleOp.push_back(newFunction);
     }
 
     // Run canonicalization patterns to cancel out remaining tuple ops. We need

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
@@ -243,8 +243,7 @@ struct FlattenTuplesInSCF final
   }
 
   void runOnOperation() override {
-    ModuleOp module = getOperation();
-    MLIRContext *ctx = module.getContext();
+    MLIRContext *ctx = &getContext();
     Builder b(ctx);
 
     // Run canonicalization patterns to cancel out remaining tuple ops. We need

--- a/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
@@ -166,14 +166,14 @@ void Converti48Toi64Pass::runOnOperation() {
   });
 
   auto *ctx = &getContext();
-  auto func = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   RewritePatternSet patterns(&getContext());
   patterns.add<GenericTypeConvert>(ctx, converter);
   populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                  converter);
 
-  if (failed(applyFullConversion(func, target, std::move(patterns)))) {
+  if (failed(applyFullConversion(funcOp, target, std::move(patterns)))) {
     signalPassFailure();
   }
 }

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -158,9 +158,9 @@ public:
     target.addIllegalOp<tosa::ScatterOp>();
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
-    FunctionOpInterface func = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     mlir::iree_compiler::populateTosaToLinalgExtPatterns(&patterns);
-    if (failed(applyFullConversion(func, target, std::move(patterns))))
+    if (failed(applyFullConversion(funcOp, target, std::move(patterns))))
       signalPassFailure();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -51,7 +51,7 @@ struct BufferizeCopyOnlyDispatchesPass final
 } // namespace
 
 void BufferizeCopyOnlyDispatchesPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   /// Check if the dispatch has all sources for
   /// `iree_tensor_ext.dispatch.tensor.store` operations coming from

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -412,7 +412,7 @@ struct CPUPrepareUkernelsPass
 void CPUPrepareUkernelsPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   RewritePatternSet patterns(ctx);
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(ctx);
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
 

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -134,7 +134,7 @@ class ConcretizePadResultShapePass final
 public:
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     ConfigTrackingListener listener;
     GreedyRewriteConfig config;

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -599,7 +599,7 @@ struct SwitchStoreOfIfResultValue
 } // namespace
 
 void ConvertToDestinationPassingStylePass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
 
   // Dont do anything for functions that have multiple blocks for now.

--- a/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
@@ -31,7 +31,7 @@ public:
 
 void DropVectorUnitDimsPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   // Apply transfer ops write to read forwarding and dead transfer write
   // optimizations.

--- a/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
@@ -31,7 +31,7 @@ public:
 };
 
 void EraseDeadAllocAndStoresPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(&getContext());
   memref::eraseDeadAllocAndStores(rewriter, funcOp);
 }

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -313,7 +313,7 @@ struct ForOpCanonicalizationPass final
   }
 
   void runOnOperation() override {
-    auto fn = getOperation();
+    mlir::FunctionOpInterface fn = getOperation();
     // These patterns collide so we apply them one after another. The
     // canonicalization pattern will be blocked by the packing pattern
     // so we apply that first.

--- a/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForallToFor.cpp
@@ -88,7 +88,7 @@ namespace {
 struct ForallToForPass : impl::ForallToForPassBase<ForallToForPass> {
   using Base::Base;
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     IRRewriter rewriter(funcOp->getContext());
 
     // Find `scf.forall` ops we want to convert.

--- a/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
@@ -20,7 +20,7 @@ struct FuseTensorPadWithConsumerPass final
     : impl::FuseTensorPadWithConsumerPassBase<FuseTensorPadWithConsumerPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     RewritePatternSet patterns(context);
     patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
@@ -199,7 +199,7 @@ decomposeHorizontallyFusedGemmOperations(RewriterBase &rewriter,
 }
 
 void DecomposeHorizontallyFusedGemmsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(&getContext());
   SmallVector<linalg::LinalgOp> horizontallyFusedOps;
   funcOp.walk([&](linalg::LinalgOp linalgOp) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
@@ -69,7 +69,7 @@ DiagnosedSilenceableFailure static mapNestedForallToThreadsImpl(
 struct GPUDistributePass final
     : impl::GPUDistributePassBase<GPUDistributePass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     IRRewriter rewriter(funcOp->getContext());
 
     // First map all lane level forall loops to lanes.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
@@ -137,7 +137,7 @@ struct GPUDistributeCopyUsingForallPass final
           GPUDistributeCopyUsingForallPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     SmallVector<memref::CopyOp> copies;
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
@@ -160,7 +160,7 @@ LogicalResult resolveGPUMappedForallOp(RewriterBase &rewriter,
 }
 
 void GPUDistributeForallPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   // First map all lane level forall loops to lanes.
   IRRewriter rewriter(funcOp->getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -458,7 +458,7 @@ struct GPUDistributeSharedMemoryCopyPass final
     : impl::GPUDistributeSharedMemoryCopyPassBase<
           GPUDistributeSharedMemoryCopyPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     if (failed(gpuDistributeSharedMemoryCopy(funcOp))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGreedilyDistributeToThreads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGreedilyDistributeToThreads.cpp
@@ -154,7 +154,7 @@ static void processRegion(RewriterBase &rewriter, Region *region) {
 }
 
 void GPUGreedilyDistributeToThreadsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   IRRewriter rewriter(funcOp->getContext());
   for (auto &region : funcOp->getRegions()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToGlobalLoads.cpp
@@ -201,7 +201,7 @@ struct GPULowerToGlobalLoadsPass final
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     std::optional<SmallVector<int64_t>> workgroupSize =
         mlir::iree_compiler::getWorkgroupSize(funcOp);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -244,7 +244,7 @@ struct PackDestinationForOp final : OpRewritePattern<scf::YieldOp> {
 
 void GPUPackToIntrinsicsPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   // Step 1. Pack candidate linalg ops to specified shapes.
   IRRewriter rewriter(funcOp);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
@@ -94,7 +94,7 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
 
 void GPUTileAndConvertConvToMatmulPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   // Collect candiates that need to be tiled to convert to matmul.
   IRRewriter rewriter(funcOp);
   SmallVector<linalg::LinalgOp> convCandidates;

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -138,7 +138,7 @@ public:
 
 void GenericVectorizationPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   IRRewriter rewriter(context);
   SmallVector<Operation *> candidates;

--- a/compiler/src/iree/compiler/Codegen/Common/HoistStaticallyBoundAllocations.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistStaticallyBoundAllocations.cpp
@@ -33,7 +33,7 @@ struct HoistStaticallyBoundAllocationsPass
 } // namespace
 
 void HoistStaticallyBoundAllocationsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp->getContext());
 
   std::optional<vector::VscaleRange> vscaleRange;

--- a/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
@@ -216,7 +216,7 @@ public:
 };
 
 void HoistUnrolledVectorExtractInsertSlicePass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp->getContext());
   funcOp.walk([&](scf::ForOp forOp) {
     hoistUnrolledVectorExtractInsert(rewriter, forOp);

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -181,7 +181,7 @@ eliminateEmptyTensors(RewriterBase &rewriter, Operation *op,
 }
 
 void EliminateEmptyTensorsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
 
   OpBuilder b(context);
@@ -230,7 +230,7 @@ runIREEOneShotBufferize(Operation *op,
 
 /// Run comprehensive bufferize.
 void IREEComprehensiveBufferizePass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IREEOneShotBufferizationOptions options = getBufferizationOptions();
   options.testAnalysisOnly = testAnalysisOnly;
   options.printConflicts = printConflicts;

--- a/compiler/src/iree/compiler/Codegen/Common/LowerExecutableUsingTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerExecutableUsingTransformDialect.cpp
@@ -22,7 +22,7 @@ public:
 } // namespace
 
 void LowerExecutableUsingTransformDialectPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   auto funcOps = moduleOp.getOps<FunctionOpInterface>();
 
   if (funcOps.empty() || !llvm::hasSingleElement(funcOps)) {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -365,7 +365,7 @@ static Operation *getEarliestInsertionPointInsideBlock(Block *block,
 }
 
 void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp->getContext());
 
   // TODO: This is a temporary hack enabled for bufferization to

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -65,7 +65,7 @@ struct OptimizeVectorTransferPass final
   using Base::Base;
 
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     LDBG() << "before optimize vector transfer\n" << funcOp;
     // Generate vector.shape_cast for dropping leading one dimensions in vector
     // ops. This increases the chance that we can forward more transfer writes

--- a/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
@@ -110,7 +110,7 @@ namespace {
 struct PadDynamicAllocPass final
     : impl::PadDynamicAllocPassBase<PadDynamicAllocPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
 
     DataFlowSolver solver;

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -714,7 +714,7 @@ getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo) {
 }
 
 void ReconcileTranslationInfoPass::runOnOperation() {
-  auto variantOp = getOperation();
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
   auto innerModuleOp = variantOp.getInnerModule();
   MLIRContext *context = &getContext();
 

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -80,7 +80,7 @@ struct RematerializeParallelOpsPattern
 struct RematerializeParallelOpsPass final
     : impl::RematerializeParallelOpsPassBase<RematerializeParallelOpsPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     RewritePatternSet fusionPatterns(funcOp.getContext());
     fusionPatterns.insert<RematerializeParallelOpsPattern>(funcOp.getContext());
     linalg::populateEraseUnusedOperandsAndResultsPatterns(fusionPatterns);

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
@@ -36,7 +36,7 @@ class RemoveSingleIterationLoopPass final
     : public impl::RemoveSingleIterationLoopPassBase<
           RemoveSingleIterationLoopPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     if (failed(removeOneTripTiledLoops(funcOp))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -290,7 +290,7 @@ struct TileAndDistributeToWorkgroupsPass final
 void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   {
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -223,7 +223,7 @@ static bool isUsedAsInit(Operation *producer, Operation *user) {
 }
 
 void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   auto *context = &getContext();
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -205,7 +205,7 @@ static void processRegion(RewriterBase &rewriter, Region *region,
 }
 
 void TileLargeTensorsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   IRRewriter rewriter(funcOp->getContext());
   for (auto &region : funcOp->getRegions()) {

--- a/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
@@ -36,7 +36,7 @@ public:
 
 void VectorTransferLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   RewritePatternSet patterns(ctx);
   // Explicitly materialize the mask on transfer_read/transfer_write.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeInnerTiledToLanes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeInnerTiledToLanes.cpp
@@ -84,7 +84,7 @@ LogicalResult fuseProducersGreedily(RewriterBase &rewriter,
 
 void DistributeInnerTiledToLanesPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   // Distribute inner_tiled ops to lanes where possible and greedily fuse
   // producers.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignConstantOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignConstantOrdinals.cpp
@@ -19,7 +19,7 @@ struct LLVMCPUAssignConstantOrdinalsPass
     : public impl::LLVMCPUAssignConstantOrdinalsPassBase<
           LLVMCPUAssignConstantOrdinalsPass> {
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
 
     // Get a constant key -> ordinal mapping.
     auto keyOrdinals = variantOp.gatherConstantOrdinals();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
@@ -20,7 +20,7 @@ struct LLVMCPUAssignImportOrdinalsPass
     : public impl::LLVMCPUAssignImportOrdinalsPassBase<
           LLVMCPUAssignImportOrdinalsPass> {
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
 
     auto *context = variantOp.getContext();
     auto unitAttr = UnitAttr::get(context);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -114,7 +114,7 @@ void LLVMCPUCheckIRBeforeLLVMConversionPass::runOnOperation() {
     return;
   }
 
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   if (failed(checkStackAllocationSize(funcOp))) {
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUEmitVectorizationRemarks.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUEmitVectorizationRemarks.cpp
@@ -22,7 +22,7 @@ struct LLVMCPUEmitVectorizationRemarksPass
 } // namespace
 
 void LLVMCPUEmitVectorizationRemarksPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   bool dump = false;
   funcOp.walk([&](linalg::LinalgOp op) {
     op.emitWarning("op is not vectorized");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
@@ -22,7 +22,7 @@ struct LLVMCPULinkExecutablesPass
   using impl::LLVMCPULinkExecutablesPassBase<
       LLVMCPULinkExecutablesPass>::LLVMCPULinkExecutablesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
 
     auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -78,7 +78,7 @@ getRootLoweringConfig(FunctionOpInterface funcOp) {
 }
 
 void LLVMCPULowerExecutableTargetPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
   if (!target) {
     // Do nothing without target

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -44,7 +44,7 @@ struct LLVMCPUMmt4dVectorLoweringPass
 
 void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   std::optional<int64_t> numLoops;
   funcOp.walk([&](vector::ContractionOp op) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -63,7 +63,7 @@ public:
 
 void LLVMCPUPeelPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   llvm::SmallSetVector<scf::ForOp, 8> uniqueLoopsToPeel;
   funcOp.walk([&](Operation *op) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -232,7 +232,7 @@ static LogicalResult verifyLoweringConfiguration(FunctionOpInterface funcOp,
 }
 
 void LLVMCPUSelectLoweringStrategyPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     // Set the strategy with default heuristics.
     if (failed(initCPULaunchConfig(funcOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -171,7 +171,7 @@ public:
 
 void LLVMCPUSplitReductionPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   IRRewriter rewriter(context);
   SmallVector<linalg::GenericOp> candidates;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSynchronizeSymbolVisibility.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSynchronizeSymbolVisibility.cpp
@@ -34,7 +34,7 @@ struct LLVMCPUSynchronizeSymbolVisibilityPass
     : public impl::LLVMCPUSynchronizeSymbolVisibilityPassBase<
           LLVMCPUSynchronizeSymbolVisibilityPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     for (auto &op : moduleOp.getOps()) {
       if (auto globalOp = dyn_cast<LLVM::GlobalOp>(op)) {
         setVisibilityFromLinkage(globalOp, globalOp.getLinkage());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -52,7 +52,7 @@ void LLVMCPUTilePass::runOnOperation() {
     return;
   }
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   for (auto computeOp : computeOps) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
@@ -228,7 +228,7 @@ struct LLVMCPUTileAndFuseProducerConsumer
 
 void LLVMCPUTileAndFuseProducerConsumer::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp);
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -53,7 +53,7 @@ void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
 }
 
 void LLVMCPUUnfuseFMAOpsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   auto context = funcOp.getContext();
   RewritePatternSet patterns(&getContext());
   populateUnfusedFMAOpsPassPatterns(context, patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorShapeCastLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorShapeCastLowering.cpp
@@ -34,7 +34,7 @@ public:
 
 void LLVMCPUVectorShapeCastLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   RewritePatternSet patterns(ctx);
   vector::populateVectorShapeCastLoweringPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
@@ -53,7 +53,7 @@ public:
 
 void LLVMCPUVectorTransposeLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   auto vectorTransformOptions =
       vector::VectorTransformsOptions().setVectorTransposeLowering(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -35,7 +35,7 @@ public:
 
 void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   auto vectorMultiReductionLowering =
       vector::VectorMultiReductionLowering::InnerReduction;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -1129,7 +1129,7 @@ public:
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
     populateVectorContractCustomKernelsPatterns(target, patterns);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VerifyLinalgTransformLegality.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VerifyLinalgTransformLegality.cpp
@@ -24,7 +24,7 @@ struct VerifyLinalgTransformLegalityPass
 } // namespace
 
 void VerifyLinalgTransformLegalityPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   // For now only check that there are no Linalg transform markers.
   auto walkResult = funcOp.walk([](linalg::LinalgOp op) -> WalkResult {
     if (op->hasAttr(LinalgTransforms::kLinalgTransformMarker)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUAssignConstantOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUAssignConstantOrdinals.cpp
@@ -19,7 +19,7 @@ struct LLVMGPUAssignConstantOrdinalsPass
     : public impl::LLVMGPUAssignConstantOrdinalsPassBase<
           LLVMGPUAssignConstantOrdinalsPass> {
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
 
     // Get a constant key -> ordinal mapping.
     auto keyOrdinals = variantOp.gatherConstantOrdinals();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -119,16 +119,17 @@ struct LLVMGPUCastTypeToFitMMAPass final
   }
 
   void runOnOperation() override {
-    auto func = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     // Set MMA type from config embedded in toLayoutOp of contraction.
-    func.walk([&](vector::ContractionOp contract) { inferMmaKind(contract); });
+    funcOp.walk(
+        [&](vector::ContractionOp contract) { inferMmaKind(contract); });
 
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<UpcastContractOutput>(context);
 
-    if (failed(applyPatternsGreedily(func, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -763,34 +763,34 @@ struct LLVMGPUConfigureTensorLayoutsPass final
   }
 
   void runOnOperation() override {
-    FunctionOpInterface func = getOperation();
-    IRRewriter rewriter(func);
+    mlir::FunctionOpInterface funcOp = getOperation();
+    IRRewriter rewriter(funcOp);
 
     std::optional<SmallVector<int64_t>> maybeWorkgroupSize =
-        getWorkgroupSize(func);
+        getWorkgroupSize(funcOp);
     if (!maybeWorkgroupSize) {
-      func->emitOpError()
+      funcOp->emitOpError()
           << "unable to query workgroup_size information from entry point";
       return signalPassFailure();
     }
 
-    if (failed(setLayoutsFromLoweringConfig(func, maybeWorkgroupSize.value(),
+    if (failed(setLayoutsFromLoweringConfig(funcOp, maybeWorkgroupSize.value(),
                                             rewriter))) {
       return signalPassFailure();
     }
 
     auto attentionQKMatmul = dyn_cast_or_null<linalg::LinalgOp>(
-        getOpWithAttr(func, "attention_qk_matmul"));
+        getOpWithAttr(funcOp, "attention_qk_matmul"));
     auto attentionPVMatmul = dyn_cast_or_null<linalg::LinalgOp>(
-        getOpWithAttr(func, "attention_pv_matmul"));
+        getOpWithAttr(funcOp, "attention_pv_matmul"));
 
     if (attentionQKMatmul && !attentionPVMatmul) {
-      func->emitError("Expected attention attributes to be set properly");
+      funcOp->emitError("Expected attention attributes to be set properly");
       return signalPassFailure();
     }
 
     if (!attentionQKMatmul && attentionPVMatmul) {
-      func->emitError("Expected attention attributes to be set properly");
+      funcOp->emitError("Expected attention attributes to be set properly");
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
@@ -60,7 +60,7 @@ struct LLVMGPULinkExecutablesPass
     : public impl::LLVMGPULinkExecutablesPassBase<LLVMGPULinkExecutablesPass> {
   using Base::Base;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
 
     auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -74,7 +74,7 @@ verifyEntryPoint(FunctionOpInterface funcOp,
 }
 
 void LLVMGPUSelectLoweringStrategyPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     if (failed(initGPULaunchConfig(funcOp))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -86,7 +86,7 @@ public:
     registry.insert<vector::VectorDialect>();
   }
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     LLVM_DEBUG({
       llvm::dbgs() << "LLVMGPUTensorCoreVectorizationPass runOnOperation():\n";
       funcOp->dump();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -212,7 +212,7 @@ public:
   }
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     // Promote C matrix and propagate the potential  fill producer into the temp
     // allocation. This needs to be done before reduction tiling.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -193,7 +193,7 @@ struct LLVMGPUVectorLoweringPass final
     registry.insert<math::MathDialect>();
   }
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     MLIRContext *ctx = &getContext();
 
     // Uplift arith ops to math.fma before lowering high level vector ops.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -52,7 +52,7 @@ struct LLVMGPUVectorToGPUPass final
   }
 
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     bool targetMmaSync = tensorCoreType == GPUTensorCoreType::MMA_SYNC;
     RewritePatternSet flatternpatterns(funcOp.getContext());
     populateVectorTransferToGPUMMAPreparationPatterns(flatternpatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLConfigureBufferInstructions.cpp
@@ -120,9 +120,9 @@ struct ROCDLConfigureBufferInstructionsPass final
   void runOnOperation() override {
     if (!clROCDLlEnableBufferInstructions)
       return;
-    FunctionOpInterface func = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     // Is this really he best way to skip this pass on non-rocdl targets?
-    IREE::GPU::TargetAttr target = getGPUTargetAttr(func);
+    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
     if (!target || !target.isAMD())
       return;
     auto *gpuDialect =
@@ -130,7 +130,7 @@ struct ROCDLConfigureBufferInstructionsPass final
     auto annotationHelper =
         gpuDialect->getUseRocdlBufferInstructionsAttrHelper();
     auto unitAttr = UnitAttr::get(&getContext());
-    func.walk([&](IREE::HAL::InterfaceBindingSubspanOp binding) {
+    funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp binding) {
       Value offset = binding.getByteOffset();
       if (offset && !isDefinitelyWorkgroupUniform(offset)) {
         LDBG() << "Binding offset " << offset

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateWinogradLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateWinogradLoops.cpp
@@ -22,7 +22,7 @@ public:
   using Base::Base;
 
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     SmallVector<scf::ForOp> forOps;
     funcOp.walk([&](scf::ForOp forOp) {
       if (!isTiledAndDistributedLoop(forOp))

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -232,7 +232,7 @@ struct SPIRVEmulateI64Pass final
   }
 
   void runOnOperation() override {
-    auto op = getOperation();
+    mlir::FunctionOpInterface op = getOperation();
     if (supportsI64(op))
       return;
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
@@ -54,7 +54,7 @@ public:
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     // Lower vector transfer permutation map.
     {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -63,7 +63,7 @@ public:
 } // namespace
 
 void SPIRVLowerExecutableTargetPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   IREE::Codegen::TranslationInfoAttr translationInfo =
       getTranslationInfo(funcOp);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableUsingTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableUsingTransformDialect.cpp
@@ -23,7 +23,7 @@ public:
 } // namespace
 
 void SPIRVLowerExecutableUsingTransformDialectPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   auto funcOps = moduleOp.getOps<FunctionOpInterface>();
 
   if (funcOps.empty() || !llvm::hasSingleElement(funcOps)) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
@@ -87,7 +87,7 @@ verifyTranslationInfo(FunctionOpInterface funcOp,
 }
 
 void SPIRVSelectLoweringStrategyPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     if (failed(initSPIRVLaunchConfig(funcOp))) {
       funcOp.emitOpError("failed to set lowering configuration");

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -127,7 +127,7 @@ public:
 
 void SPIRVTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   if (!isEntryPoint(funcOp))
     return;
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -129,7 +129,7 @@ private:
 
 void SPIRVTileAndPromotePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   auto threadTileComputeFn = getSPIRVTileSizeComputeFn(funcOp, 1);
   if (failed(threadTileComputeFn))

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -335,7 +335,7 @@ public:
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     // First we need to discover the CodeGen lowering configuration. It was
     // decided earlier and attached to a linalg op as an attribute.
@@ -402,7 +402,7 @@ public:
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     // First discover the chosen cooperative matrix shape. It was decided
     // earlier and attached to the export op as an attribute.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
@@ -28,7 +28,7 @@ struct SPIRVVectorToGPUSubgroupMMAPass final
   }
 
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     RewritePatternSet flatternpatterns(funcOp.getContext());
     populateVectorTransferToGPUMMAPreparationPatterns(flatternpatterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -1062,7 +1062,7 @@ private:
 void SPIRVVectorizeLoadStorePass::runOnOperation() {
   // Uses the signature conversion methodology of the dialect conversion
   // framework to implement the conversion.
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
 
   // Prior pass should have unrolled and broken down vectors with rank > 1.

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXAssignConstantOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXAssignConstantOrdinals.cpp
@@ -19,7 +19,7 @@ struct VMVXAssignConstantOrdinalsPass
     : public impl::VMVXAssignConstantOrdinalsPassBase<
           VMVXAssignConstantOrdinalsPass> {
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
 
     // Ignore non-VMVX variants.
     // TODO(benvanik): a way to nest this in the pipeline via dynamic passes.

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
@@ -21,7 +21,7 @@ namespace {
 struct VMVXLinkExecutablesPass
     : public impl::VMVXLinkExecutablesPassBase<VMVXLinkExecutablesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
 
     auto sourceExecutableOps = gatherExecutablesForTarget(moduleOp, "vmvx");

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerExecutableTargetPass.cpp
@@ -51,7 +51,7 @@ public:
 } // namespace
 
 void VMVXLowerExecutableTargetPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   auto translationInfo = getTranslationInfo(funcOp);
   if (!translationInfo)

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXSelectLoweringStrategy.cpp
@@ -34,7 +34,7 @@ public:
 } // namespace
 
 void VMVXSelectLoweringStrategyPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     // Set the strategy with default heuristics.
     if (failed(initVMVXLaunchConfig(funcOp))) {

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -721,7 +721,7 @@ public:
 
   void runOnOperation() override {
     llvm::TimerGroup tg("iree-consteval-jit", "Consteval Jit");
-    auto outerModule = getOperation();
+    mlir::ModuleOp outerModuleOp = getOperation();
 
     // Set the target.
     if (!targetDevice) {
@@ -758,14 +758,14 @@ public:
     }
 
     // Build the program.
-    ProgramBuilder programBuilder(outerModule, *deviceTargetAttr,
+    ProgramBuilder programBuilder(outerModuleOp, *deviceTargetAttr,
                                   supportedTypes,
                                   getAnalysis<IREE::Util::ConstExprAnalysis>());
 
     // Iterate over initializers.
     llvm::SmallVector<IREE::Util::InitializerOp> initializerOps;
     llvm::SmallVector<IREE::Util::InitializerOp> deadInitOps;
-    for (auto childOp : outerModule.getOps<IREE::Util::InitializerOp>()) {
+    for (auto childOp : outerModuleOp.getOps<IREE::Util::InitializerOp>()) {
       initializerOps.push_back(childOp);
     }
     for (auto initializerOp : initializerOps) {
@@ -806,7 +806,7 @@ public:
 
     // Process the functions.
     if (failed(processFunctions(binary, programBuilder.getJitFunctions(),
-                                outerModule, tg))) {
+                                outerModuleOp, tg))) {
       signalPassFailure();
       return;
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -153,7 +153,7 @@ class DeduplicateExecutablesPass
           DeduplicateExecutablesPass> {
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SmallVector<Operation *> allObjects;
     for (auto &op : moduleOp.getOps()) {
       if (op.hasTrait<OpTrait::IREE::Util::ObjectLike>())

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -274,7 +274,7 @@ struct ExportBenchmarkFuncsPass
     : public IREE::Flow::impl::ExportBenchmarkFuncsPassBase<
           ExportBenchmarkFuncsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // For analysis required on arguments and results.
     Explorer explorer(moduleOp, TraversalAction::SHALLOW);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -72,7 +72,7 @@ struct InjectDispatchTracingPass
     : public IREE::Flow::impl::InjectDispatchTracingPassBase<
           InjectDispatchTracingPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     auto appendDecodedValuesToLabel = [](std::string str,
                                          SmallVector<int64_t> decodedIndices) {
       llvm::raw_string_ostream os(str);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
@@ -72,7 +72,7 @@ struct InjectTensorTracingPass
           InjectTensorTracingPass> {
   void runOnOperation() override {
     auto attrName = StringAttr::get(&getContext(), "iree.tensor.trace");
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     funcOp.walk([&](Operation *op) {
       if (auto attr = op->getAttr(attrName)) {
         std::string traceKey;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
@@ -114,7 +114,7 @@ static std::string getConstantName(ConstantDef &def) {
 struct OutlineConstantsPass
     : public IREE::Flow::impl::OutlineConstantsPassBase<OutlineConstantsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty())
       return;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
@@ -45,7 +45,7 @@ struct AssignLegacyTargetDevicesPass
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto *context = moduleOp.getContext();
 
     // If no targets are specified we can't do anything - another pass earlier

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
@@ -193,7 +193,7 @@ struct AssignTargetDevicesPass
       AssignTargetDevicesPass>::AssignTargetDevicesPassBase;
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // If no targets are specified we can't do anything - another pass earlier
     // in the pipeline will have had to add the targets.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
@@ -60,7 +60,7 @@ struct CaptureExecutableSourcesPass
   using IREE::HAL::impl::CaptureExecutableSourcesPassBase<
       CaptureExecutableSourcesPass>::CaptureExecutableSourcesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleName = moduleOp.getName().value_or("module");
 
     for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConfigureExecutables.cpp
@@ -48,7 +48,7 @@ class ConfigureTargetExecutableVariantsPass
   }
 
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
     if (variantOp.getTarget().getBackend().getValue() != target)
       return;
 
@@ -97,7 +97,7 @@ struct ConfigureExecutablesPass
   }
 
   void runOnOperation() override {
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     OpPassManager passManager(executableOp.getOperationName());
     for (const auto &targetName : gatherExecutableTargetNames(executableOp)) {
       passManager.addNestedPass<IREE::HAL::ExecutableVariantOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
@@ -62,7 +62,7 @@ struct ConvertToHALPass
     : public IREE::HAL::impl::ConvertToHALPassBase<ConvertToHALPass> {
   void runOnOperation() override {
     auto *context = &getContext();
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Gather all interfaces from registered dialects.
     // These will perform the tensor->buffer mapping for their ops.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -472,7 +472,7 @@ struct DumpExecutableBenchmarksPass
   using IREE::HAL::impl::DumpExecutableBenchmarksPassBase<
       DumpExecutableBenchmarksPass>::DumpExecutableBenchmarksPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleName = moduleOp.getName().value_or("module");
     SymbolTable symbolTable(moduleOp);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableSources.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableSources.cpp
@@ -42,7 +42,7 @@ struct DumpExecutableSourcesPass
   using IREE::HAL::impl::DumpExecutableSourcesPassBase<
       DumpExecutableSourcesPass>::DumpExecutableSourcesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleName = moduleOp.getName().value_or("module");
 
     // Help people out and mkdir if needed.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/InitializeDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/InitializeDevices.cpp
@@ -95,7 +95,7 @@ struct InitializeDevicesPass
   using IREE::HAL::impl::InitializeDevicesPassBase<
       InitializeDevicesPass>::InitializeDevicesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
       auto initialValue =
           dyn_cast_if_present<IREE::HAL::DeviceInitializationAttrInterface>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
@@ -47,7 +47,7 @@ struct LinkTargetExecutablesPass
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto targetBackend = targetRegistry->getTargetBackend(target);
     if (!targetBackend) {
       moduleOp.emitError() << "unregistered target backend '" << target << "'";
@@ -75,7 +75,7 @@ struct LinkAllExecutablesPass
   using IREE::HAL::impl::LinkAllExecutablesPassBase<
       LinkAllExecutablesPass>::LinkAllExecutablesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Add pipelines for each target backend used in the module.
     // These will create/rearrange executables.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
@@ -110,7 +110,7 @@ struct MaterializeDispatchInstrumentationPass
       MaterializeDispatchInstrumentationPass>::
       MaterializeDispatchInstrumentationPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty())
       return;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -572,7 +572,7 @@ struct MaterializeInterfacesPass
     : public IREE::HAL::impl::MaterializeInterfacesPassBase<
           MaterializeInterfacesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
     BindingLayoutAnalysis layoutAnalysis(moduleOp, symbolTable);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -470,7 +470,7 @@ struct MaterializeResourceCachesPass
     : public IREE::HAL::impl::MaterializeResourceCachesPassBase<
           MaterializeResourceCachesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
 
     // Analyze the module to determine which devices are used where.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
@@ -180,7 +180,7 @@ struct MaterializeTargetDevicesPass
       MaterializeTargetDevicesPass>::MaterializeTargetDevicesPassBase;
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Only materialize devices if there's a module-level attribute specified.
     FlatSymbolRefAttr defaultDeviceRef;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -63,7 +63,7 @@ struct MemoizeDeviceQueriesPass
     : public IREE::HAL::impl::MemoizeDeviceQueriesPassBase<
           MemoizeDeviceQueriesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Analyze the module to determine which devices are used where.
     DeviceAnalysis deviceAnalysis(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceSelection.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceSelection.cpp
@@ -147,7 +147,7 @@ struct MemoizeDeviceSelectionPass
     : public IREE::HAL::impl::MemoizeDeviceSelectionPassBase<
           MemoizeDeviceSelectionPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
 
     DeviceAnalysis deviceAnalysis(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
@@ -576,7 +576,7 @@ struct OutlineMemoizeRegionsPass
     : public IREE::HAL::impl::OutlineMemoizeRegionsPassBase<
           OutlineMemoizeRegionsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Analyze the module to determine which devices are used where.
     DeviceAnalysis deviceAnalysis(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PreprocessExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PreprocessExecutables.cpp
@@ -244,7 +244,7 @@ struct PreprocessExecutablesWithPipelinePass
   void runOnOperation() override {
     if (!pipeline.hasValue())
       return;
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     OpPassManager passManager(executableOp.getOperationName());
     if (failed(buildPassPipeline(pipeline, passManager))) {
       llvm::errs() << "ERROR: failed to parse preprocessing pipeline `"
@@ -272,7 +272,7 @@ struct PreprocessExecutablesWithToolPass
   void runOnOperation() override {
     if (!command.hasValue())
       return;
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     if (failed(preprocessWithCommand(executableOp, command))) {
       llvm::errs() << "ERROR: failed to preprocess executable `"
                    << executableOp.getName() << "` using command `" << command

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
@@ -96,7 +96,7 @@ static void eraseOps(ArrayRef<Attribute> symbolRefAttrs,
 struct PruneExecutablesPass
     : public IREE::HAL::impl::PruneExecutablesPassBase<PruneExecutablesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Gather all executable op symbols into a map that we can quickly check
     // while walking ops.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
@@ -117,7 +117,7 @@ struct ResolveDeviceAliasesPass
       ResolveDeviceAliasesPass>::ResolveDeviceAliasesPassBase;
   void runOnOperation() override {
     // Walks all device globals and resolve any aliases found.
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
       if (!isa<IREE::HAL::DeviceType>(globalOp.getGlobalType())) {
         continue;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDevicePromises.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDevicePromises.cpp
@@ -34,7 +34,7 @@ struct ResolveDevicePromisesPass
       ResolveDevicePromisesPass>::ResolveDevicePromisesPassBase;
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Resolves a #hal.device.promise attr to a #hal.device.affinity. Fails if
     // the referenced device is not found.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
@@ -25,7 +25,7 @@ struct ResolveExportOrdinalsPass
     : public IREE::HAL::impl::ResolveExportOrdinalsPassBase<
           ResolveExportOrdinalsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
       funcOp.walk([&](IREE::HAL::ExecutableExportOrdinalOp ordinalOp) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveTopologyQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveTopologyQueries.cpp
@@ -209,7 +209,7 @@ resolveMemoryPropertiesOp(AllocatorResolveMemoryPropertiesOp op,
 struct ResolveTopologyQueriesPass
     : public impl::ResolveTopologyQueriesPassBase<ResolveTopologyQueriesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     DeviceAnalysis deviceAnalysis(moduleOp);
     if (failed(deviceAnalysis.run())) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
@@ -48,7 +48,7 @@ struct SerializeTargetExecutablesPass
   }
 
   void runOnOperation() override {
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     auto moduleOp = executableOp->getParentOfType<mlir::ModuleOp>();
 
     auto targetBackend = targetRegistry->getTargetBackend(target);
@@ -105,7 +105,7 @@ struct SerializeAllExecutablesPass
   using IREE::HAL::impl::SerializeAllExecutablesPassBase<
       SerializeAllExecutablesPass>::SerializeAllExecutablesPassBase;
   void runOnOperation() override {
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     OpPassManager passManager(executableOp.getOperationName());
     for (const auto &targetName : gatherExecutableTargetNames(executableOp)) {
       passManager.addPass(IREE::HAL::createSerializeTargetExecutablesPass(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/SubstituteExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/SubstituteExecutables.cpp
@@ -216,7 +216,7 @@ struct SubstituteExecutablesPass
   using IREE::HAL::impl::SubstituteExecutablesPassBase<
       SubstituteExecutablesPass>::SubstituteExecutablesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto moduleName = moduleOp.getName().value_or("module");
     SymbolTable symbolTable(moduleOp);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -50,7 +50,7 @@ struct TranslateTargetExecutableVariantsPass
   }
 
   void runOnOperation() override {
-    auto variantOp = getOperation();
+    IREE::HAL::ExecutableVariantOp variantOp = getOperation();
     if (variantOp.getTarget().getBackend().getValue() != target)
       return;
     if (variantOp.isExternal())
@@ -97,7 +97,7 @@ struct TranslateAllExecutablesPass
   }
 
   void runOnOperation() override {
-    auto executableOp = getOperation();
+    IREE::HAL::ExecutableOp executableOp = getOperation();
     OpPassManager passManager(executableOp.getOperationName());
     for (const auto &targetName : gatherExecutableTargetNames(executableOp)) {
       passManager.addNestedPass<IREE::HAL::ExecutableVariantOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
@@ -103,7 +103,7 @@ struct VerifyDevicesPass
   using IREE::HAL::impl::VerifyDevicesPassBase<
       VerifyDevicesPass>::VerifyDevicesPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Devices are required if we need to convert host code or executables.
     // If we only have hal.executables as input then we can bypass this.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -76,7 +76,7 @@ struct DecomposeIm2colPass final
 
 void DecomposeIm2colPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   SmallVector<Im2colOp> candidates;
   funcOp->walk([&](Im2colOp op) { candidates.push_back(op); });

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -222,7 +222,7 @@ struct DecomposeMapScatterPass final
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
 
     RewritePatternSet patterns(context);
     patterns.add<FoldSubViewIntoMapScatter>(context);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -321,7 +321,7 @@ struct TopkSplitReductionPass final
     };
 
     IRRewriter rewriter(&getContext());
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     SmallVector<LinalgExt::TopkOp> topkCandidates;
     funcOp->walk([&](LinalgExt::TopkOp op) { topkCandidates.push_back(op); });
     for (auto op : topkCandidates) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AutomaticReferenceCounting.cpp
@@ -717,7 +717,7 @@ struct AutomaticReferenceCountingPass
     : public IREE::Stream::impl::AutomaticReferenceCountingPassBase<
           AutomaticReferenceCountingPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
       if (funcOp.isExternal()) {
         continue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CloneToConsumers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CloneToConsumers.cpp
@@ -169,7 +169,7 @@ struct CloneToConsumersPass
     : public IREE::Stream::impl::CloneToConsumersPassBase<
           CloneToConsumersPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty()) {
       return;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -596,7 +596,7 @@ struct DumpStatisticsPass
     auto os = openOutputFile(outputFile);
 
     // Walk the module once to accumulate everything we care about.
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     UsageInfo usageInfo;
     usageInfo.analyze(moduleOp);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -688,7 +688,7 @@ struct ElideAsyncCopiesPass
     : public IREE::Stream::impl::ElideAsyncCopiesPassBase<
           ElideAsyncCopiesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty()) {
       return;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncTransfers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncTransfers.cpp
@@ -93,7 +93,7 @@ struct ElideAsyncTransfersPass
           ElideAsyncTransfersPass> {
   using ElideAsyncTransfersPassBase::ElideAsyncTransfersPassBase;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Get the topology attribute from the module.
     auto topologyAttr =

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
@@ -888,7 +888,7 @@ static bool tryElideTimepointsInRegion(Region &region,
 struct ElideTimepointsPass
     : public IREE::Stream::impl::ElideTimepointsPassBase<ElideTimepointsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty())
       return;
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/LayoutSlices.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/LayoutSlices.cpp
@@ -221,7 +221,7 @@ packDynamicSlicesConservatively(IREE::Stream::ResourcePackOp packOp,
 struct LayoutSlicesPass
     : public IREE::Stream::impl::LayoutSlicesPassBase<LayoutSlicesPass> {
   void runOnOperation() override {
-    auto parentOp = getOperation();
+    mlir::CallableOpInterface parentOp = getOperation();
     if (!parentOp.getCallableRegion() ||
         parentOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
@@ -350,7 +350,7 @@ struct MaterializeBuiltinsPass
     : public IREE::Stream::impl::MaterializeBuiltinsPassBase<
           MaterializeBuiltinsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty())
       return;
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
@@ -656,7 +656,7 @@ static Value generateUploads(Value awaitTimepoint,
 struct PackConstantsPass
     : public IREE::Stream::impl::PackConstantsPassBase<PackConstantsPass> {
   void runOnOperation() override {
-    auto parentOp = getOperation();
+    mlir::CallableOpInterface parentOp = getOperation();
     if (!parentOp || !parentOp.getCallableRegion() ||
         parentOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -657,7 +657,7 @@ struct PropagateTimepointsPass
     : public IREE::Stream::impl::PropagateTimepointsPassBase<
           PropagateTimepointsPass> {
   void runOnOperation() override {
-    auto rootOp = getOperation();
+    mlir::ModuleOp rootOp = getOperation();
     SymbolTable symbolTable(rootOp);
 
     // Expand all util.global ops holding resources into (timepoint, resource).

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -457,7 +457,7 @@ static void insertUsageRefinementPatterns(MLIRContext *context,
 struct RefineUsagePass
     : public IREE::Stream::impl::RefineUsagePassBase<RefineUsagePass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty())
       return;
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReuseAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReuseAllocations.cpp
@@ -111,7 +111,7 @@ struct ReuseAllocationsPass
     : public IREE::Stream::impl::ReuseAllocationsPassBase<
           ReuseAllocationsPass> {
   void runOnOperation() override {
-    auto parentOp = getOperation();
+    mlir::CallableOpInterface parentOp = getOperation();
     if (!parentOp.getCallableRegion() ||
         parentOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -2064,7 +2064,7 @@ struct ScheduleAllocationPass
     : public IREE::Stream::impl::ScheduleAllocationPassBase<
           ScheduleAllocationPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     AffinityAnalysis affinityAnalysis(moduleOp);
     if (failed(affinityAnalysis.run())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
@@ -181,7 +181,7 @@ struct ScheduleConcurrencyPass
     : public IREE::Stream::impl::ScheduleConcurrencyPassBase<
           ScheduleConcurrencyPass> {
   void runOnOperation() override {
-    auto parentOp = getOperation();
+    mlir::CallableOpInterface parentOp = getOperation();
     if (!parentOp.getCallableRegion() ||
         parentOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -336,7 +336,7 @@ struct ScheduleExecutionPass
           ScheduleExecutionPass> {
   void runOnOperation() override {
     auto *context = &getContext();
-    auto parentOp = getOperation();
+    mlir::CallableOpInterface parentOp = getOperation();
     if (!parentOp.getCallableRegion() ||
         parentOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SyncInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SyncInitializers.cpp
@@ -33,7 +33,7 @@ struct SyncInitializersPass
     : public IREE::Stream::impl::SyncInitializersPassBase<
           SyncInitializersPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp.getBody()->empty()) {
       return;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAffinities.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAffinities.cpp
@@ -43,7 +43,7 @@ struct VerifyAffinitiesPass
     : public IREE::Stream::impl::VerifyAffinitiesPassBase<
           VerifyAffinitiesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     if (moduleOp
             .walk<WalkOrder::PreOrder>([&](Operation *op) {
               if (isa<mlir::ModuleOp>(op)) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAsyncAccessRanges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAsyncAccessRanges.cpp
@@ -116,7 +116,7 @@ struct VerifyAsyncAccessRangesPass
     : public IREE::Stream::impl::VerifyAsyncAccessRangesPassBase<
           VerifyAsyncAccessRangesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     // TODO(benvanik): do whole-program data flow analysis to get bounded sizes
     // for range checking. Today we just do static checks.
     if (moduleOp

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -38,7 +38,7 @@ public:
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Gather all of the initializers in the module.
     // Build a fused loc from all initializers we are combining.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -367,7 +367,7 @@ struct FoldGlobalsPass : public impl::FoldGlobalsPassBase<FoldGlobalsPass> {
     }
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
 
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     GlobalTable globalTable(moduleOp);
     beforeFoldingGlobals = globalTable.size();
     bool didChangeAny = false;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -56,7 +56,7 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 class FuseGlobalsPass : public impl::FuseGlobalsPassBase<FuseGlobalsPass> {
 public:
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     GlobalTable globalTable(moduleOp);
     globalTable.rebuild();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -654,7 +654,7 @@ static bool isFuncEmpty(FunctionOpInterface funcOp) {
 class IPOPass : public impl::IPOPassBase<IPOPass> {
 public:
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // TODO(benvanik): find a nice way of skipping embedded executables. Maybe
     // an op interface like the inliner control interface. For now we recurse

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -639,7 +639,7 @@ class PropagateSubrangesPass
     : public impl::PropagateSubrangesPassBase<PropagateSubrangesPass> {
 public:
   void runOnOperation() override {
-    auto rootOp = getOperation();
+    mlir::ModuleOp rootOp = getOperation();
     SymbolTable symbolTable(rootOp);
 
     // Expand all util.global ops holding resources into resource and subrange.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
@@ -260,7 +260,7 @@ class SimplifyGlobalAccessesPass
     : public impl::SimplifyGlobalAccessesPassBase<SimplifyGlobalAccessesPass> {
 public:
   void runOnOperation() override {
-    auto callableOp = getOperation();
+    mlir::CallableOpInterface callableOp = getOperation();
     if (!callableOp.getCallableRegion() ||
         callableOp.getCallableRegion()->empty()) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/StripAndSplatConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/StripAndSplatConstants.cpp
@@ -26,7 +26,7 @@ class StripAndSplatConstantsPass
     : public impl::StripAndSplatConstantsPassBase<StripAndSplatConstantsPass> {
 public:
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Give each splatted value a module-unique byte value so that it's easier
     // to track back to where it came from in the final output.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4778,17 +4778,17 @@ public:
   }
 
   void runOnOperation() override {
-    IREE::VM::ModuleOp module = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
 
     ConversionTarget target(getContext());
-    EmitCTypeConverter typeConverter(module);
+    EmitCTypeConverter typeConverter(moduleOp);
 
     // Convert vm.func ops to emitc.func with the calling convention used by
     // EmitC. We convert these upfront to make sure vm.call ops always
     // reference emitc.func ops with the correct calling convention during the
     // conversion.
     SmallVector<IREE::VM::FuncOp> funcsToRemove;
-    for (auto funcOp : module.getOps<IREE::VM::FuncOp>()) {
+    for (auto funcOp : moduleOp.getOps<IREE::VM::FuncOp>()) {
       if (failed(convertFuncOp(funcOp, typeConverter))) {
         return signalPassFailure();
       }
@@ -4805,7 +4805,7 @@ public:
     // import ops to be rewritten to compiler generated shim functions. To
     // ensure this we only rewrite `import` ops first.
     ImportOpConverter importOpConverter(typeConverter, importShims);
-    for (auto importOp : module.getOps<IREE::VM::ImportOp>()) {
+    for (auto importOp : moduleOp.getOps<IREE::VM::ImportOp>()) {
       if (failed(importOpConverter(importOp))) {
         return signalPassFailure();
       }
@@ -4831,11 +4831,11 @@ public:
     // This op is needed in the printer to emit an array holding the data.
     target.addLegalOp<IREE::VM::RodataOp>();
 
-    if (failed(applyFullConversion(module, target, std::move(patterns)))) {
+    if (failed(applyFullConversion(moduleOp, target, std::move(patterns)))) {
       return signalPassFailure();
     }
 
-    if (failed(createModuleStructure(module, typeConverter))) {
+    if (failed(createModuleStructure(moduleOp, typeConverter))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/DeduplicateRodata.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/DeduplicateRodata.cpp
@@ -25,7 +25,7 @@ class DeduplicateRodataPass
     : public IREE::VM::impl::DeduplicateRodataPassBase<DeduplicateRodataPass> {
   using RodataKey = std::tuple<StringRef, Attribute>;
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
 
     // Gather all rodata ops with the same value.
     DenseMap<RodataKey, SmallVector<IREE::VM::RodataOp>> bucketedOps;

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/DropEmptyModuleInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/DropEmptyModuleInitializers.cpp
@@ -29,7 +29,7 @@ class DropEmptyModuleInitializersPass
     : public IREE::VM::impl::DropEmptyModuleInitializersPassBase<
           DropEmptyModuleInitializersPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
 
     // Find all export ops so they are easier to remove.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/DropUnusedCalls.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/DropUnusedCalls.cpp
@@ -59,7 +59,7 @@ struct EraseUnusedCallOp : public OpRewritePattern<T> {
 class DropUnusedCallsPass
     : public IREE::VM::impl::DropUnusedCallsPassBase<DropUnusedCallsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
 
     // Find all top-level symbols that have no side effects.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -129,7 +129,7 @@ class GlobalInitializationPass
     : public IREE::VM::impl::GlobalInitializationPassBase<
           GlobalInitializationPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
 
     // Create the __init and __deinit functions. They may be empty if there are

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
@@ -25,7 +25,7 @@ class HoistInlinedRodataPass
     : public IREE::VM::impl::HoistInlinedRodataPassBase<
           HoistInlinedRodataPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
     SymbolTable moduleSymbolTable(moduleOp);
 
     // Find all inline byte buffers in the module.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -91,7 +91,7 @@ static void reifyRodataTable(RewriterBase &rewriter,
 class ReifyRodataTablesPass
     : public IREE::VM::impl::ReifyRodataTablesPassBase<ReifyRodataTablesPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
 
     // Walk all of the rodata table ops and convert to rodata.inline
     IRRewriter rewriter(moduleOp.getContext());

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
@@ -115,7 +115,7 @@ class ResolveRodataLoadsPass
     : public IREE::VM::impl::ResolveRodataLoadsPassBase<
           ResolveRodataLoadsPass> {
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    IREE::VM::ModuleOp moduleOp = getOperation();
 
     Explorer explorer(moduleOp, TraversalAction::SHALLOW);
     explorer.setOpInterfaceAction<mlir::FunctionOpInterface>(

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -327,7 +327,7 @@ struct FoldUnitExtentDimsForFuncPass final
 } // namespace
 
 void FoldUnitExtentDimsPass::runOnOperation() {
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   MLIRContext *context = &getContext();
 
   SymbolTable moduleSymbols(moduleOp);

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -516,7 +516,7 @@ namespace {
 struct SetEncodingPass final : impl::SetEncodingPassBase<SetEncodingPass> {
   using Base::Base;
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    mlir::FunctionOpInterface funcOp = getOperation();
     MLIRContext *context = &getContext();
     IRRewriter rewriter(context);
     RewritePatternSet postPatterns(context);

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -637,7 +637,7 @@ public:
   }
 
   void runOnOperation() override {
-    auto rootOp = getOperation();
+    mlir::ModuleOp rootOp = getOperation();
     SymbolTable symbolTable(rootOp);
 
     // Expand all util.global ops holding tensor into tensor + dynamic dims.

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
@@ -784,7 +784,7 @@ struct FuseDequantizationMatmulPass
 
 void FuseDequantizationMatmulPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
 
   int quantizeBitWidth = 16;
   SmallVector<std::pair<linalg::GenericOp, linalg::GenericOp>> candidates;

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -44,7 +44,7 @@ struct GeneralizeLinalgNamedOpsPass
 } // namespace
 
 void GeneralizeLinalgNamedOpsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   SmallVector<linalg::LinalgOp> namedOpCandidates;
   funcOp.walk([&](linalg::LinalgOp linalgOp) {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(linalgOp) ||

--- a/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
@@ -36,7 +36,7 @@ struct MaterializeHomogeneousEncodingsPass final
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     IREE::HAL::DeviceAnalysis deviceAnalysis(moduleOp);
     if (failed(deviceAnalysis.run()))
       return signalPassFailure();

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1009,7 +1009,7 @@ populateCommonCanonicalizationPatterns(MLIRContext *context,
 
 void PropagateLinalgTransposePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   // First, specialize all transposes to `linalg.transpose`. This dramatically
   // simplifies all subsequent propagation patterns, both in matching and
   // rewriting.

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -89,7 +89,7 @@ struct RemoveZeroExtentTensorsPass
 } // namespace
 
 void RemoveZeroExtentTensorsPass::runOnOperation() {
-  auto funcOp = getOperation();
+  mlir::FunctionOpInterface funcOp = getOperation();
   MLIRContext *context = &getContext();
   SmallVector<Operation *> opWithZeroExtentTensorOperands;
   SmallVector<tensor::InsertSliceOp> insertSliceOps;

--- a/compiler/src/iree/compiler/InputConversion/Common/SanitizeModuleNames.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/SanitizeModuleNames.cpp
@@ -28,7 +28,7 @@ public:
     // IREE VM modules use the `.` (period) character for namespacing, so
     // replace any occurrences of `.` with `_`.
 
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     auto optionalName = moduleOp.getName();
     if (!optionalName.has_value())
       return;

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -38,7 +38,7 @@ public:
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
 
     // Inline variants and produce a function map.
     DenseMap<Attribute, Attribute> exportToFuncMap;

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
@@ -26,7 +26,7 @@ public:
   }
 
   void runOnOperation() override {
-    auto moduleOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
     SymbolTable symbolTable(moduleOp);
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
       funcOp.walk([&](IREE::HAL::Loader::ExecutableExportOrdinalOp ordinalOp) {

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -565,7 +565,7 @@ void PadToIntrinsicsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
 
-  auto moduleOp = getOperation();
+  mlir::ModuleOp moduleOp = getOperation();
   IREE::Stream::AffinityAnalysis affinityAnalysis(moduleOp);
   if (failed(affinityAnalysis.run())) {
     return signalPassFailure();


### PR DESCRIPTION
@kuhar noted that using `auto op = getOperation();` can mask errors if the Passes.td changes and I've personally had that happen before - updating all our usage to use the explicit types so that we'll get compile errors if types don't match (or aren't downcast-compatible).