### PR TITLE
[compiler][NFC] Update remaining code to free create functions.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -167,12 +167,11 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     if (auto deviceAffinityAttr =
             dyn_cast_if_present<IREE::HAL::DeviceAffinityAttr>(
                 defaultAffinityAttr)) {
-      device = entryBuilder
-                   .create<IREE::HAL::DeviceResolveOp>(
-                       importOp.getLoc(),
-                       entryBuilder.getType<IREE::HAL::DeviceType>(),
-                       deviceAffinityAttr)
-                   .getResult(0);
+      device =
+          IREE::HAL::DeviceResolveOp::create(
+              entryBuilder, importOp.getLoc(),
+              entryBuilder.getType<IREE::HAL::DeviceType>(), deviceAffinityAttr)
+              .getResult(0);
     } else {
       // HACK: if no devices are available we get the first one available at
       // runtime. This is suboptimal but we expect most usage to have affinities

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -345,12 +345,10 @@ private:
     for (unsigned i = 0; i < shapeType.getRank(); ++i) {
       if (!shapeType.isDynamicDim(i))
         continue;
-      auto dimValue =
-          builder
-              .create<IREE::Util::ListGetOp>(
-                  loc, builder.getIndexType(), listValue,
-                  builder.createOrFold<arith::ConstantIndexOp>(loc, i))
-              .getResult();
+      auto dimValue = IREE::Util::ListGetOp::create(
+                          builder, loc, builder.getIndexType(), listValue,
+                          builder.createOrFold<arith::ConstantIndexOp>(loc, i))
+                          .getResult();
       dynamicDims.globalOps[dynamicDimIdx++].createStoreOp(loc, dimValue,
                                                            builder);
     }

--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -169,9 +169,8 @@ blockDynamicDimensionsOfValue(RewriterBase &rewriter,
 
   auto expandShapeOp = tensor::ExpandShapeOp::create(
       rewriter, loc, outputType, v, reassociation, outputShape);
-  Value barrier = rewriter
-                      .create<IREE::Util::OptimizationBarrierOp>(
-                          loc, expandShapeOp.getResult())
+  Value barrier = IREE::Util::OptimizationBarrierOp::create(
+                      rewriter, loc, expandShapeOp.getResult())
                       .getResult(0);
   auto collapseShapeOp = tensor::CollapseShapeOp::create(
       rewriter, loc, tensorType, barrier, reassociation);

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -196,9 +196,8 @@ struct ConvertBatchMmt4DtoMmt4DPattern
       auto newInit = tensor::createCanonicalRankReducingExtractSliceOp(
           rewriter, loc, initTensor, reducedOutType);
       reducedOut =
-          rewriter
-              .create<linalg::FillOp>(loc, ValueRange{oldFillOp.value()},
-                                      ValueRange{newInit})
+          linalg::FillOp::create(rewriter, loc, ValueRange{oldFillOp.value()},
+                                 ValueRange{newInit})
               .result();
 
       auto loweringConfig =

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.cpp
@@ -32,9 +32,8 @@ static FailureOr<Value> cpuAllocationFn(OpBuilder &builder, Location loc,
       return hoistedAllocation.value();
     }
   }
-  return builder
-      .create<memref::AllocaOp>(loc, memRefType, dynamicSizes,
-                                builder.getI64IntegerAttr(alignment))
+  return memref::AllocaOp::create(builder, loc, memRefType, dynamicSizes,
+                                  builder.getI64IntegerAttr(alignment))
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -219,9 +219,8 @@ foldExtractSliceIntoMapScatter(RewriterBase &rewriter,
   for (auto [bound, srcIdx] : llvm::zip_equal(bounds, srcIndices)) {
     Value boundValue = getValueOrCreateConstantIndexOp(rewriter, loc, bound);
     auto isOutOfBounds =
-        rewriter
-            .create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult, srcIdx,
-                                   boundValue)
+        arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult, srcIdx,
+                              boundValue)
             ->getResult(0);
     mask = arith::AndIOp::create(rewriter, loc, mask, isOutOfBounds);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -139,10 +139,8 @@ static Value staticallyExtractSubvector(OpBuilder &rewriter, Location loc,
 
   auto resultVectorType =
       VectorType::get({numElemsToExtract}, vectorType.getElementType());
-  return rewriter
-      .create<vector::ExtractStridedSliceOp>(loc, resultVectorType, src,
-                                             offsets, sizes, strides)
-      ->getResult(0);
+  return vector::ExtractStridedSliceOp::create(rewriter, loc, resultVectorType,
+                                               src, offsets, sizes, strides);
 }
 
 /// Inserts 1-D subvector into a 1-D vector.

--- a/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.h
@@ -61,12 +61,12 @@ struct StoreLoadLikeOpRewriter : public OpRewritePattern<StoreLoadLikeOp> {
            "Expected one size per load dimension");
     Location loc = storeLoadLikeOp.getLoc();
     auto subview =
-        rewriter.create<memref::SubViewOp>(loc, /*source=*/srcMemRef,
-                                           /*offsets=*/indices,
-                                           /*sizes=*/sizes, /*strides=*/ones);
+        memref::SubViewOp::create(rewriter, loc, /*source=*/srcMemRef,
+                                  /*offsets=*/indices,
+                                  /*sizes=*/sizes, /*strides=*/ones);
     // Rewrite the load with the subview as the base pointer.
     SmallVector<Value> zeros(storeLoadRank,
-                             rewriter.create<arith::ConstantIndexOp>(loc, 0));
+                             arith::ConstantIndexOp::create(rewriter, loc, 0));
     StoreLoadLikeOp newLoad = rebuildOpFromAddressAndIndices(
         rewriter, storeLoadLikeOp, subview.getResult(), zeros);
     rewriter.replaceOp(storeLoadLikeOp, newLoad->getResults());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeCopyUsingForall.cpp
@@ -94,13 +94,11 @@ static void distributeCopyToThreads(RewriterBase &rewriter, memref::CopyOp copy,
       sizes.push_back(tileSize);
     } else {
       sizes.push_back(
-          rewriter
-              .create<affine::AffineMinOp>(
-                  loc, rewriter.getIndexType(), minMap,
-                  ValueRange{
-                      getValueOrCreateConstantIndexOp(rewriter, loc, tileSize),
-                      getValueOrCreateConstantIndexOp(rewriter, loc, ub),
-                      iterator})
+          affine::AffineMinOp::create(
+              rewriter, loc, rewriter.getIndexType(), minMap,
+              ValueRange{
+                  getValueOrCreateConstantIndexOp(rewriter, loc, tileSize),
+                  getValueOrCreateConstantIndexOp(rewriter, loc, ub), iterator})
               .getResult());
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
@@ -92,12 +92,11 @@ LogicalResult resolveGPUMappedForallOp(RewriterBase &rewriter,
       return forallOp->emitOpError(
           "found warp mapped forall with non-multiple workgroup size");
     }
-    flatId = rewriter
-                 .create<affine::AffineDelinearizeIndexOp>(
-                     loc, flatId,
-                     ArrayRef<int64_t>{flatWorkgroupSize / subgroupSize,
-                                       subgroupSize})
-                 .getResult(0);
+    flatId =
+        affine::AffineDelinearizeIndexOp::create(
+            rewriter, loc, flatId,
+            ArrayRef<int64_t>{flatWorkgroupSize / subgroupSize, subgroupSize})
+            .getResult(0);
   }
 
   SmallVector<Value> delinSizes;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
@@ -67,9 +67,8 @@ struct DistributeLoop final : OpRewritePattern<scf::ForOp> {
     Value count =
         useBlockDims ? gpu::BlockDimOp::create(rewriter, loc, indexType, symDim)
                            .getResult()
-                     : rewriter
-                           .create<arith::ConstantIndexOp>(
-                               loc, workgroupSize[numDimAttr.getInt()])
+                     : arith::ConstantIndexOp::create(
+                           rewriter, loc, workgroupSize[numDimAttr.getInt()])
                            .getResult();
 
     MLIRContext *context = getContext();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1405,16 +1405,14 @@ struct DistributeContract final
       VectorValue interleavedMaskRhs =
           getInterleavedPackedForm(rewriter, maskRhs, rhsLayout);
 
-      disLhs = cast<VectorValue>(
-          rewriter
-              .create<arith::SelectOp>(loc, interleavedMaskLhs, disLhs,
-                                       passThruLhs)
-              .getResult());
-      disRhs = cast<VectorValue>(
-          rewriter
-              .create<arith::SelectOp>(loc, interleavedMaskRhs, disRhs,
-                                       passThruRhs)
-              .getResult());
+      disLhs = cast<VectorValue>(arith::SelectOp::create(rewriter, loc,
+                                                         interleavedMaskLhs,
+                                                         disLhs, passThruLhs)
+                                     .getResult());
+      disRhs = cast<VectorValue>(arith::SelectOp::create(rewriter, loc,
+                                                         interleavedMaskRhs,
+                                                         disRhs, passThruRhs)
+                                     .getResult());
     }
 
     Value acc = contractOp.getAcc();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -90,10 +90,9 @@ static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
   Value c0 = arith::ConstantIndexOp::create(b, tensor.getLoc(), 0);
   SmallVector<Value> indices(vectorType.getRank(), c0);
   SmallVector<bool> inBounds(vectorType.getRank(), true);
-  return b
-      .create<vector::TransferReadOp>(tensor.getLoc(), vectorType, tensor,
-                                      indices, /*padding=*/std::nullopt,
-                                      inBounds)
+  return vector::TransferReadOp::create(b, tensor.getLoc(), vectorType, tensor,
+                                        indices, /*padding=*/std::nullopt,
+                                        inBounds)
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -192,9 +192,8 @@ static Value simpleWarpShuffleFunction(Location loc, OpBuilder &builder,
   Value srcIdxI32 = arith::IndexCastOp::create(builder, loc, i32Type, srcIdx);
   Value warpSzI32 = arith::ConstantOp::create(
       builder, loc, builder.getIntegerAttr(i32Type, warpSz));
-  Value result = builder
-                     .create<gpu::ShuffleOp>(loc, val, srcIdxI32, warpSzI32,
-                                             gpu::ShuffleMode::IDX)
+  Value result = gpu::ShuffleOp::create(builder, loc, val, srcIdxI32, warpSzI32,
+                                        gpu::ShuffleMode::IDX)
                      .getResult(0);
   return result;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -354,11 +354,10 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
 
     // Surpress silenceable errors so that failures to match in child tuning
     // specs can be ignored.
-    operand = builder
-                  .create<transform::IncludeOp>(
-                      loc, anyOpType, symbol,
-                      transform::FailurePropagationMode::Suppress, operand,
-                      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr)
+    operand = transform::IncludeOp::create(
+                  builder, loc, anyOpType, symbol,
+                  transform::FailurePropagationMode::Suppress, operand,
+                  /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr)
                   .getResults()
                   .front();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -70,10 +70,9 @@ FailureOr<Value> lowerSetEncodingOpToPackOp(
       encodingInfo.outerDimsPerm);
   auto emptyOp = tensor::EmptyOp::create(rewriter, loc, resultDims,
                                          resultType.getElementType());
-  return rewriter
-      .create<linalg::PackOp>(loc, source, emptyOp, encodingInfo.innerDimsPos,
-                              *innerTileSizesOfr, paddingValue,
-                              encodingInfo.outerDimsPerm)
+  return linalg::PackOp::create(rewriter, loc, source, emptyOp,
+                                encodingInfo.innerDimsPos, *innerTileSizesOfr,
+                                paddingValue, encodingInfo.outerDimsPerm)
       .getResult();
 }
 
@@ -103,10 +102,9 @@ FailureOr<Value> lowerUnsetEncodingToUnpackOp(
     return rewriter.notifyMatchFailure(
         encodingOp, "failed to generate runtime tile size query");
   }
-  return rewriter
-      .create<linalg::UnPackOp>(loc, packedValue, emptyOp,
-                                encodingInfo.innerDimsPos, *innerTileSizesOfr,
-                                encodingInfo.outerDimsPerm)
+  return linalg::UnPackOp::create(rewriter, loc, packedValue, emptyOp,
+                                  encodingInfo.innerDimsPos, *innerTileSizesOfr,
+                                  encodingInfo.outerDimsPerm)
       .getResult();
 }
 
@@ -121,9 +119,8 @@ lowerOpWithEncoding(RewriterBase &rewriter, tensor::EmptyOp emptyOp,
       typeConverter.getEncodingInfo(emptyType);
   Location loc = emptyOp.getLoc();
   if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
-    return rewriter
-        .create<tensor::EmptyOp>(loc, emptyOp.getMixedSizes(),
-                                 emptyType.getElementType())
+    return tensor::EmptyOp::create(rewriter, loc, emptyOp.getMixedSizes(),
+                                   emptyType.getElementType())
         .getOperation();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -315,13 +315,11 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
   numWorkgroupsList.resize(forallOp.getRank());
   for (auto [index, mapping] : llvm::enumerate(workgroupMapping.value())) {
     int64_t mappingID = mapping.getMappingId();
-    OpFoldResult procId = rewriter
-                              .create<IREE::HAL::InterfaceWorkgroupIDOp>(
-                                  loc, static_cast<unsigned>(mappingID))
+    OpFoldResult procId = IREE::HAL::InterfaceWorkgroupIDOp::create(
+                              rewriter, loc, static_cast<unsigned>(mappingID))
                               .getResult();
-    OpFoldResult nprocs = rewriter
-                              .create<IREE::HAL::InterfaceWorkgroupCountOp>(
-                                  loc, static_cast<unsigned>(mappingID))
+    OpFoldResult nprocs = IREE::HAL::InterfaceWorkgroupCountOp::create(
+                              rewriter, loc, static_cast<unsigned>(mappingID))
                               .getResult();
 
     mappedProcIds.push_back(procId);
@@ -434,9 +432,8 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
   for (SmallVector<OpFoldResult> numWorkgroupsList : numWorkgroupsLists) {
     for (auto [idx, numWorkgroups] : llvm::enumerate(numWorkgroupsList)) {
       maxNumWorkgroups[idx] =
-          rewriter
-              .create<arith::MaxUIOp>(loc, asValue(numWorkgroups),
-                                      asValue(maxNumWorkgroups[idx]))
+          arith::MaxUIOp::create(rewriter, loc, asValue(numWorkgroups),
+                                 asValue(maxNumWorkgroups[idx]))
               .getResult();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -355,11 +355,10 @@ static void specializeExportedFunction(
           auto ordinalOp = cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
               mapping.lookup(assumedSize.assumptionOrOrdinal.getOwner()));
           builder.setInsertionPoint(ordinalOp);
-          Value assumedOperand =
-              builder
-                  .create<IREE::Util::AssumeIntOp>(loc, ordinalOp.getOperand(),
-                                                   builder.getArrayAttr(range))
-                  .getResult(0);
+          Value assumedOperand = IREE::Util::AssumeIntOp::create(
+                                     builder, loc, ordinalOp.getOperand(),
+                                     builder.getArrayAttr(range))
+                                     .getResult(0);
           ordinalOp.setOperand(assumedOperand);
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -768,9 +768,8 @@ void transform_dialect::IREEBufferizeOp::build(OpBuilder &builder,
 static FailureOr<Value> cpuComprehensiveBufferizeAllocationFn(
     OpBuilder &builder, Location loc, MemRefType memRefType,
     ValueRange dynamicSizes, unsigned alignment) {
-  return builder
-      .create<memref::AllocaOp>(loc, memRefType, dynamicSizes,
-                                builder.getI64IntegerAttr(alignment))
+  return memref::AllocaOp::create(builder, loc, memRefType, dynamicSizes,
+                                  builder.getI64IntegerAttr(alignment))
       .getResult();
 }
 
@@ -795,9 +794,8 @@ static FailureOr<Value> gpuComprehensiveBufferizeAllocationFn(
   MemRefType allocType =
       MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
                       AffineMap(), addressSpaceAttr);
-  return builder
-      .create<memref::AllocOp>(loc, allocType, dynamicSizes,
-                               builder.getI64IntegerAttr(alignment))
+  return memref::AllocOp::create(builder, loc, allocType, dynamicSizes,
+                                 builder.getI64IntegerAttr(alignment))
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -306,10 +306,10 @@ swapExpandShapeWithSlice(RewriterBase &rewriter,
         llvm::map_to_vector(delinOffsets, [&](OpFoldResult ofr) {
           return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
         });
-    OpFoldResult newOffset = rewriter
-                                 .create<affine::AffineLinearizeIndexOp>(
-                                     loc, offsetVals, basis, /*disjoint=*/true)
-                                 .getResult();
+    OpFoldResult newOffset =
+        affine::AffineLinearizeIndexOp::create(rewriter, loc, offsetVals, basis,
+                                               /*disjoint=*/true)
+            .getResult();
     newOffsets.push_back(newOffset);
     newLengths.push_back(newSize);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -527,9 +527,8 @@ static OpFoldResult getMinimumConstantOffsetValue(OpBuilder &b, Location loc,
   Value modOffset = arith::ConstantIndexOp::create(b, loc, baseMod);
   // If the original add is nsw/nuw, then the new add must also be given we're
   // adding a smaller value.
-  return b
-      .create<arith::AddIOp>(loc, add.getLhs(), modOffset,
-                             add.getOverflowFlags())
+  return arith::AddIOp::create(b, loc, add.getLhs(), modOffset,
+                               add.getOverflowFlags())
       .getResult();
 }
 
@@ -581,9 +580,8 @@ OpFoldResult RotateRowsAttr::swizzleOffset(OpBuilder &b, Location loc,
   // multiple accesses to a memref only differ by a constant value (very common
   // when working with statically shaped memrefs like shared/scratch memory).
   Value diff = arith::SubIOp::create(b, loc, swizzledId, idVal);
-  return b
-      .create<arith::AddIOp>(
-          loc, getValueOrCreateConstantIndexOp(b, loc, offset), diff)
+  return arith::AddIOp::create(
+             b, loc, getValueOrCreateConstantIndexOp(b, loc, offset), diff)
       .getResult();
 }
 
@@ -695,9 +693,8 @@ OpFoldResult XORShuffleAttr::swizzleOffset(OpBuilder &b, Location loc,
   Value swizzledIdVal =
       updateCol(b, loc, idVal, colSwizzled, rowAlignmentVal, accessWidthVal);
   Value diff = arith::SubIOp::create(b, loc, swizzledIdVal, idVal);
-  return b
-      .create<arith::AddIOp>(
-          loc, getValueOrCreateConstantIndexOp(b, loc, offset), diff)
+  return arith::AddIOp::create(
+             b, loc, getValueOrCreateConstantIndexOp(b, loc, offset), diff)
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -645,10 +645,9 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
     if (colMajor) {
       std::swap(lhs, rhs);
     }
-    return builder
-        .create<amdgpu::MFMAOp>(loc, resultType, layout.mSize, layout.nSize,
-                                layout.kSize, getBlockSize(intrinsic), lhs, rhs,
-                                acc)
+    return amdgpu::MFMAOp::create(builder, loc, resultType, layout.mSize,
+                                  layout.nSize, layout.kSize,
+                                  getBlockSize(intrinsic), lhs, rhs, acc)
         .getResult();
   }
   if (is_AMD_WMMA(intrinsic)) {
@@ -947,10 +946,9 @@ LogicalResult DataTiledMMAAttr::populateOperandOffsetsSizesStrides(
   // Use a delinearize without outer bound and throw away its initial result
   // to get clamping behavior.
   SmallVector<OpFoldResult> tileOffsets =
-      builder
-          .create<affine::AffineDelinearizeIndexOp>(
-              loc, getValueOrCreateConstantIndexOp(builder, loc, threadId),
-              distributionThreadSizes, /*hasOuterBound=*/false)
+      affine::AffineDelinearizeIndexOp::create(
+          builder, loc, getValueOrCreateConstantIndexOp(builder, loc, threadId),
+          distributionThreadSizes, /*hasOuterBound=*/false)
           ->getResults()
           .drop_front();
 
@@ -1309,10 +1307,9 @@ LogicalResult VirtualMMAAttr::buildUnderlyingOperations(
       if (getColMajor()) {
         std::swap(sliced_lhs, sliced_rhs);
       }
-      acc = builder
-                .create<amdgpu::MFMAOp>(loc, outputs[0].getType(), m, n,
-                                        nativeKSize, getBlockSize(), sliced_lhs,
-                                        sliced_rhs, acc)
+      acc = amdgpu::MFMAOp::create(builder, loc, outputs[0].getType(), m, n,
+                                   nativeKSize, getBlockSize(), sliced_lhs,
+                                   sliced_rhs, acc)
                 .getResult();
     }
     results.push_back(acc);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -148,11 +148,10 @@ struct BarrierRegionOpBufferizationInterface
         continue;
       }
       tensorizedOperands.push_back(
-          rewriter
-              .create<bufferization::ToTensorOp>(
-                  replacement.getLoc(),
-                  memref::getTensorTypeFromMemRefType(replacement.getType()),
-                  replacement)
+          bufferization::ToTensorOp::create(
+              rewriter, replacement.getLoc(),
+              memref::getTensorTypeFromMemRefType(replacement.getType()),
+              replacement)
               .getResult());
     }
 
@@ -389,12 +388,11 @@ struct BufferResourceCastOpBufferizationInterface
         cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
                                                         maybeIndexCacheSwizzle);
       }
-      buffer = rewriter
-                   .create<amdgpu::FatRawBufferCastOp>(
-                       loc, buffer.value(), /*validBytes=*/Value{},
-                       /*cacheSwizzleStride=*/cacheSwizzleStride,
-                       /*boundsCheck=*/true,
-                       /*resetOffset=*/true)
+      buffer = amdgpu::FatRawBufferCastOp::create(
+                   rewriter, loc, buffer.value(), /*validBytes=*/Value{},
+                   /*cacheSwizzleStride=*/cacheSwizzleStride,
+                   /*boundsCheck=*/true,
+                   /*resetOffset=*/true)
                    .getResult();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -577,9 +577,8 @@ collapseParallelInsertOp(RewriterBase &rewriter,
           return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
         });
     OpFoldResult collapsedOffset =
-        rewriter
-            .create<affine::AffineLinearizeIndexOp>(loc, offsetVals, basis,
-                                                    /*disjoint=*/true)
+        affine::AffineLinearizeIndexOp::create(rewriter, loc, offsetVals, basis,
+                                               /*disjoint=*/true)
             .getResult();
     ArrayRef<OpFoldResult> groupSizes(sizes.begin() + group.front(),
                                       sizes.begin() + group.back() + 1);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -159,15 +159,14 @@ static Value createElementWiseExtUIOp(OpBuilder &builder, Value input,
       tensor::getMixedSizes(builder, loc, input);
   Value init =
       tensor::EmptyOp::create(builder, loc, inputMixedSizes, outElemType);
-  return builder
-      .create<linalg::GenericOp>(
-          loc, castedType, input, init, maps, iteratorTypes,
-          [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
-            Value castRes =
-                arith::ExtUIOp::create(b, nestedLoc, outElemType, args[0])
-                    ->getResult(0);
-            linalg::YieldOp::create(b, nestedLoc, castRes);
-          })
+  return linalg::GenericOp::create(
+             builder, loc, castedType, input, init, maps, iteratorTypes,
+             [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+               Value castRes =
+                   arith::ExtUIOp::create(b, nestedLoc, outElemType, args[0])
+                       ->getResult(0);
+               linalg::YieldOp::create(b, nestedLoc, castRes);
+             })
       .getResult(0);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -517,9 +517,8 @@ static Value simpleWarpShuffleFunction(Location loc, OpBuilder &builder,
   Value srcIdxI32 = arith::IndexCastOp::create(builder, loc, i32Type, srcIdx);
   Value warpSzI32 = arith::ConstantOp::create(
       builder, loc, builder.getIntegerAttr(i32Type, warpSz));
-  Value result = builder
-                     .create<gpu::ShuffleOp>(loc, val, srcIdxI32, warpSzI32,
-                                             gpu::ShuffleMode::IDX)
+  Value result = gpu::ShuffleOp::create(builder, loc, val, srcIdxI32, warpSzI32,
+                                        gpu::ShuffleMode::IDX)
                      .getResult(0);
   return result;
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -817,8 +817,8 @@ struct ScalarizeVectorTransferRead final
       }
 
       auto thenCond = [&](OpBuilder &b, Location loc) {
-        return b
-            .create<memref::LoadOp>(loc, readOp.getBase(), readOp.getIndices())
+        return memref::LoadOp::create(b, loc, readOp.getBase(),
+                                      readOp.getIndices())
             .getResult();
       };
       auto elseCond = [&](OpBuilder &b, Location loc) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1006,7 +1006,7 @@ Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
 
 template <typename OpTy>
 static Value buildHALWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
-  return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
+  return OpTy::create(b, b.getInsertionPoint()->getLoc(), dim);
 }
 
 linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
@@ -119,9 +119,8 @@ splitAxis(TypedValue<RankedTensorType> tensor, int64_t splitAxis,
   std::optional<SmallVector<ReassociationIndices>> reassociation =
       getReassociationIndicesForReshape(tensor.getType(), resultType);
   return cast<TypedValue<RankedTensorType>>(
-      builder
-          .create<tensor::ExpandShapeOp>(resultType, tensor,
-                                         reassociation.value())
+      tensor::ExpandShapeOp::create(builder, resultType, tensor,
+                                    reassociation.value())
           .getResult());
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -459,13 +459,11 @@ struct ExpandDynamicShapeConstant
     SmallVector<Value> dynamicDims;
     for (int64_t i = 0; i < dynamicType.getRank(); ++i) {
       if (dynamicType.isDynamicDim(i)) {
-        auto dimValue = rewriter
-                            .create<arith::ConstantIndexOp>(
-                                op.getLoc(), staticType.getDimSize(i))
+        auto dimValue = arith::ConstantIndexOp::create(rewriter, op.getLoc(),
+                                                       staticType.getDimSize(i))
                             .getResult();
-        dynamicDims.push_back(rewriter
-                                  .create<IREE::Util::OptimizationBarrierOp>(
-                                      op.getLoc(), dimValue)
+        dynamicDims.push_back(IREE::Util::OptimizationBarrierOp::create(
+                                  rewriter, op.getLoc(), dimValue)
                                   .getResult(0));
       }
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -1616,16 +1616,14 @@ struct ChannelCreateOpPattern
     }
     Value group =
         adaptor.getGroupAttr()
-            ? rewriter
-                  .create<IREE::Util::BufferConstantOp>(
-                      createOp.getLoc(),
-                      /*name=*/StringAttr{}, /*value=*/adaptor.getGroupAttr(),
-                      /*alignment=*/IntegerAttr{}, /*mime_type=*/StringAttr{})
+            ? IREE::Util::BufferConstantOp::create(
+                  rewriter, createOp.getLoc(),
+                  /*name=*/StringAttr{}, /*value=*/adaptor.getGroupAttr(),
+                  /*alignment=*/IntegerAttr{}, /*mime_type=*/StringAttr{})
                   .getResult()
-            : rewriter
-                  .create<IREE::Util::NullOp>(
-                      createOp.getLoc(),
-                      rewriter.getType<IREE::Util::BufferType>())
+            : IREE::Util::NullOp::create(
+                  rewriter, createOp.getLoc(),
+                  rewriter.getType<IREE::Util::BufferType>())
                   .getResult();
     Value rank = adaptor.getRank()
                      ? arith::IndexCastOp::create(rewriter, createOp.getLoc(),

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1486,10 +1486,10 @@ LogicalResult DeviceQueryOp::verify() {
 Value DeviceQueryOp::createI1(Location loc, Value device, StringRef category,
                               StringRef key, OpBuilder &builder) {
   auto i1Type = builder.getI1Type();
-  return builder
-      .create<IREE::HAL::DeviceQueryOp>(
-          loc, i1Type, i1Type, device, builder.getStringAttr(category),
-          builder.getStringAttr(key), builder.getIntegerAttr(i1Type, 0))
+  return IREE::HAL::DeviceQueryOp::create(builder, loc, i1Type, i1Type, device,
+                                          builder.getStringAttr(category),
+                                          builder.getStringAttr(key),
+                                          builder.getIntegerAttr(i1Type, 0))
       .getValue();
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -278,12 +278,11 @@ static void appendDispatchBenchmark(IREE::Stream::AffinityAttr affinityAttr,
       IREE::HAL::CommandBufferModeBitfield::OneShot |
       IREE::HAL::CommandBufferModeBitfield::AllowInlineExecution;
   auto commandBuffer =
-      funcBuilder
-          .create<IREE::HAL::CommandBufferCreateOp>(
-              loc, funcBuilder.getType<IREE::HAL::CommandBufferType>(), device,
-              commandBufferModes, IREE::HAL::CommandCategoryBitfield::Dispatch,
-              queueAffinity,
-              /*binding_capacity=*/Value{})
+      IREE::HAL::CommandBufferCreateOp::create(
+          funcBuilder, loc, funcBuilder.getType<IREE::HAL::CommandBufferType>(),
+          device, commandBufferModes,
+          IREE::HAL::CommandCategoryBitfield::Dispatch, queueAffinity,
+          /*binding_capacity=*/Value{})
           .getResult();
 
   // Constant values.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
@@ -266,8 +266,8 @@ struct MaterializeDispatchInstrumentationPass
           // deduplication.
           uint32_t dispatchSiteId = dispatchSiteCount++;
           dispatchOp.getUniformOperandsMutable().append(
-              parentBuilder
-                  .create<arith::ConstantIntOp>(loc, dispatchSiteId, 32)
+              arith::ConstantIntOp::create(parentBuilder, loc, dispatchSiteId,
+                                           32)
                   .getResult());
 
           // Record dispatch site to the host-side metadata.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -522,10 +522,9 @@ struct ConvertGatherToExtract
       indices.back() = arith::ConstantIndexOp::create(rewriter, loc, i);
       Value elem = tensor::ExtractOp::create(rewriter, loc,
                                              gatherOp.getIndices(), indices);
-      offsets[i] =
-          rewriter
-              .create<arith::IndexCastOp>(loc, rewriter.getIndexType(), elem)
-              .getResult();
+      offsets[i] = arith::IndexCastOp::create(rewriter, loc,
+                                              rewriter.getIndexType(), elem)
+                       .getResult();
     }
 
     applyPermutationToVector(offsets, gatherOp.getDimensionMap());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1761,16 +1761,15 @@ static void generatePackOpScalarImplementationBody(PackOp packOp,
           idx, getDimValue(builder, loc, packOp.getInput(), dim));
       isInBounds = dim == 0 ? cond : arithBuilder._and(isInBounds, cond);
     }
-    scalar = builder
-                 .create<scf::IfOp>(
-                     loc, isInBounds, /*thenBuilder=*/
-                     [&](OpBuilder &b, Location l) {
-                       scf::YieldOp::create(b, l, createLoad());
-                     },
-                     /*elseBuilder=*/
-                     [&](OpBuilder &b, Location l) {
-                       scf::YieldOp::create(b, l, paddingValue);
-                     })
+    scalar = scf::IfOp::create(
+                 builder, loc, isInBounds, /*thenBuilder=*/
+                 [&](OpBuilder &b, Location l) {
+                   scf::YieldOp::create(b, l, createLoad());
+                 },
+                 /*elseBuilder=*/
+                 [&](OpBuilder &b, Location l) {
+                   scf::YieldOp::create(b, l, paddingValue);
+                 })
                  .getResult(0);
   } else {
     scalar = createLoad();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -208,10 +208,9 @@ public:
     const std::array<int64_t, 2> kernelDims =
         isNchwFchw ? fchwKernelDims : hwcfKernelDims;
     Value winogradFilter =
-        rewriter
-            .create<IREE::LinalgExt::WinogradFilterTransformOp>(
-                loc, kernelInit.getType(), ValueRange{kernel},
-                ValueRange{kernelInit}, outputTileSize, kernelSize, kernelDims)
+        IREE::LinalgExt::WinogradFilterTransformOp::create(
+            rewriter, loc, kernelInit.getType(), ValueRange{kernel},
+            ValueRange{kernelInit}, outputTileSize, kernelSize, kernelDims)
             .getResults()[0];
 
     // Add collapse shape
@@ -260,10 +259,9 @@ public:
     const std::array<int64_t, 2> imageDims =
         isNchwFchw ? nchwImageDims : nhwcImageDims;
     Value winogradInput =
-        rewriter
-            .create<IREE::LinalgExt::WinogradInputTransformOp>(
-                loc, inputTfInit.getType(), ValueRange{input},
-                ValueRange{inputTfInit}, outputTileSize, kernelSize, imageDims)
+        IREE::LinalgExt::WinogradInputTransformOp ::create(
+            rewriter, loc, inputTfInit.getType(), ValueRange{input},
+            ValueRange{inputTfInit}, outputTileSize, kernelSize, imageDims)
             .getResults()[0];
 
     // Add collapse shape
@@ -317,10 +315,10 @@ public:
     Value outputTfInit =
         tensor::EmptyOp::create(rewriter, loc, paddedResultShape, outElemType);
     Value paddedOutput =
-        rewriter
-            .create<IREE::LinalgExt::WinogradOutputTransformOp>(
-                loc, outputTfInit.getType(), ValueRange{expandedBmmResult},
-                ValueRange{outputTfInit}, outputTileSize, kernelSize, imageDims)
+        IREE::LinalgExt::WinogradOutputTransformOp::create(
+            rewriter, loc, outputTfInit.getType(),
+            ValueRange{expandedBmmResult}, ValueRange{outputTfInit},
+            outputTileSize, kernelSize, imageDims)
             .getResults()[0];
 
     // Extract slice

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -266,11 +266,10 @@ public:
     Value colTensor = tensor::EmptyOp::create(rewriter, loc, colTensorShape,
                                               inputType.getElementType());
     Value img2ColTensor =
-        rewriter
-            .create<IREE::LinalgExt::Im2colOp>(
-                loc, input, /*output=*/colTensor, convDims.strides,
-                convDims.dilations, kernelSizes, mOffset, mBasis, kOffset,
-                kBasis, batchPos, mPos, kPos, inputKPerm)
+        IREE::LinalgExt::Im2colOp::create(
+            rewriter, loc, input, /*output=*/colTensor, convDims.strides,
+            convDims.dilations, kernelSizes, mOffset, mBasis, kOffset, kBasis,
+            batchPos, mPos, kPos, inputKPerm)
             .getResult(0);
 
     Value reshapedFilter = tensor::CollapseShapeOp::create(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -72,8 +72,8 @@ struct FoldSubViewIntoMapScatter final : OpRewritePattern<MapScatterOp> {
           rewriter, subViewOp.getLoc(), subViewOffset);
       Value yieldedIdxVal = getValueOrCreateConstantIndexOp(
           rewriter, mapScatterBodyYield.getLoc(), yieldedIdx);
-      yieldedIdx = rewriter.create<arith::AddIOp>(
-          subViewOp.getLoc(), yieldedIdxVal, subViewOffsetVal);
+      yieldedIdx = arith::AddIOp::create(rewriter, subViewOp.getLoc(),
+                                         yieldedIdxVal, subViewOffsetVal);
     }
     SmallVector<Value> newYieldedValues(yieldedIndices);
     newYieldedValues.push_back(yieldedMask);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -538,9 +538,8 @@ FailureOr<Value> rankReduceOperand(RewriterBase &rewriter, Location loc,
     std::optional<SmallVector<ReassociationIndices>> reassoc =
         getReassociationIndicesForCollapse(shape, targetShape);
     assert(reassoc.has_value());
-    return rewriter
-        .create<tensor::CollapseShapeOp>(loc, ty.clone(targetShape), operand,
-                                         reassoc.value())
+    return tensor::CollapseShapeOp::create(rewriter, loc, ty.clone(targetShape),
+                                           operand, reassoc.value())
         .getResult();
   }
   llvm_unreachable("unhandled rank reduction strategy");
@@ -888,12 +887,12 @@ static Value getCollapsedOpOperand(Location loc, AttentionOp op,
 
   // Insert a reshape to collapse the dimensions.
   if (isa<MemRefType>(operand.getType())) {
-    return builder
-        .create<memref::CollapseShapeOp>(loc, operand, operandReassociation)
+    return memref::CollapseShapeOp::create(builder, loc, operand,
+                                           operandReassociation)
         .getResult();
   }
-  return builder
-      .create<tensor::CollapseShapeOp>(loc, operand, operandReassociation)
+  return tensor::CollapseShapeOp::create(builder, loc, operand,
+                                         operandReassociation)
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -213,23 +213,22 @@ Value offsetParallelIndices(Location loc, RewriterBase &rewriter,
                                              utils::IteratorType::parallel);
   Value mSplitVal = arith::ConstantIntOp::create(
       rewriter, loc, parallelIndicesType.getElementType(), kDimParallelSize);
-  return rewriter
-      .create<linalg::GenericOp>(
-          loc,
-          /*resultType=*/parallelIndicesType,
-          /*inputs=*/ValueRange{},
-          /*outputs=*/ValueRange{parallelIndices}, indexingMaps, iterators,
-          [&](OpBuilder &b, Location loc, ValueRange args) {
-            Value splitIndex =
-                linalg::IndexOp::create(b, loc, splitDimParallel);
-            Value splitIndexInt = arith::IndexCastOp::create(
-                b, loc, parallelIndicesType.getElementType(), splitIndex);
-            Value mOffset =
-                arith::MulIOp::create(b, loc, mSplitVal, splitIndexInt);
-            Value updatedParallelIndex =
-                arith::AddIOp::create(b, loc, mOffset, args[0]);
-            linalg::YieldOp::create(b, loc, updatedParallelIndex);
-          })
+  return linalg::GenericOp::create(
+             rewriter, loc,
+             /*resultType=*/parallelIndicesType,
+             /*inputs=*/ValueRange{},
+             /*outputs=*/ValueRange{parallelIndices}, indexingMaps, iterators,
+             [&](OpBuilder &b, Location loc, ValueRange args) {
+               Value splitIndex =
+                   linalg::IndexOp::create(b, loc, splitDimParallel);
+               Value splitIndexInt = arith::IndexCastOp::create(
+                   b, loc, parallelIndicesType.getElementType(), splitIndex);
+               Value mOffset =
+                   arith::MulIOp::create(b, loc, mSplitVal, splitIndexInt);
+               Value updatedParallelIndex =
+                   arith::AddIOp::create(b, loc, mOffset, args[0]);
+               linalg::YieldOp::create(b, loc, updatedParallelIndex);
+             })
       .getResult(0);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -96,9 +96,8 @@ public:
       if (resultType.isDynamicDim(i)) {
         Value staticDim = arith::ConstantIndexOp::create(
             rewriter, constantOp.getLoc(), attrType.getDimSize(i));
-        Value dynamicDim = rewriter
-                               .create<IREE::Util::OptimizationBarrierOp>(
-                                   constantOp.getLoc(), staticDim)
+        Value dynamicDim = IREE::Util::OptimizationBarrierOp::create(
+                               rewriter, constantOp.getLoc(), staticDim)
                                .getResult(0);
         dynamicDims.push_back(dynamicDim);
       }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -78,10 +78,9 @@ struct ConvertTensorImportOp
           rewriter, op.getLoc(),
           rewriter.getType<IREE::Stream::TimepointType>(),
           ValueRange{waitFence}, executionAffinityAttr);
-      resource = rewriter
-                     .create<IREE::Stream::TimepointAwaitOp>(
-                         op.getLoc(), ValueRange{resource},
-                         ValueRange{resultSize}, waitTimepoint)
+      resource = IREE::Stream::TimepointAwaitOp::create(
+                     rewriter, op.getLoc(), ValueRange{resource},
+                     ValueRange{resultSize}, waitTimepoint)
                      .getResult(0);
     }
 
@@ -231,10 +230,9 @@ struct ConvertTensorAliasOp
           rewriter, op.getLoc(),
           rewriter.getType<IREE::Stream::TimepointType>(),
           ValueRange{waitFence}, executionAffinityAttr);
-      storage = rewriter
-                    .create<IREE::Stream::TimepointAwaitOp>(
-                        op.getLoc(), ValueRange{storage},
-                        ValueRange{storageSize}, waitTimepoint)
+      storage = IREE::Stream::TimepointAwaitOp::create(
+                    rewriter, op.getLoc(), ValueRange{storage},
+                    ValueRange{storageSize}, waitTimepoint)
                     .getResult(0);
     }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -307,15 +307,13 @@ struct GlobalLoadOpExpansion
     // Insert a load/transfer to the unknown resource lifetime.
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
     auto resource =
-        rewriter
-            .create<IREE::Util::GlobalLoadOp>(
-                loadOp.getLoc(), expandedGlobal.resourceOp.getType(),
-                expandedGlobal.resourceOp.getSymName())
+        IREE::Util::GlobalLoadOp::create(rewriter, loadOp.getLoc(),
+                                         expandedGlobal.resourceOp.getType(),
+                                         expandedGlobal.resourceOp.getSymName())
             .getResult();
-    auto resourceSize = rewriter
-                            .create<IREE::Util::GlobalLoadOp>(
-                                loadOp.getLoc(), rewriter.getIndexType(),
-                                expandedGlobal.resourceSizeOp.getSymName())
+    auto resourceSize = IREE::Util::GlobalLoadOp::create(
+                            rewriter, loadOp.getLoc(), rewriter.getIndexType(),
+                            expandedGlobal.resourceSizeOp.getSymName())
                             .getResult();
     auto transferOp = IREE::Stream::AsyncTransferOp::create(
         rewriter, loadOp.getLoc(), unknownType, resource, resourceSize,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1445,10 +1445,10 @@ ResourceAllocOp::createSuballocations(
   SmallVector<Value> results;
   for (auto [loc, subviewOffset, subviewLength] :
        llvm::zip_equal(locs, packOp.getPackedOffsets(), storageSizes)) {
-    results.push_back(builder
-                          .create<IREE::Stream::ResourceSubviewOp>(
-                              loc, slab, slabSize, subviewOffset, subviewLength)
-                          .getResult());
+    results.push_back(
+        IREE::Stream::ResourceSubviewOp::create(builder, loc, slab, slabSize,
+                                                subviewOffset, subviewLength)
+            .getResult());
   }
   return {allocOp, results};
 }
@@ -1511,10 +1511,10 @@ ResourceAllocaOp::createSuballocations(Type timepointType, Type resourceType,
   SmallVector<Value> results;
   for (auto [loc, subviewOffset, subviewLength] :
        llvm::zip_equal(locs, packOp.getPackedOffsets(), storageSizes)) {
-    results.push_back(builder
-                          .create<IREE::Stream::ResourceSubviewOp>(
-                              loc, slab, slabSize, subviewOffset, subviewLength)
-                          .getResult());
+    results.push_back(
+        IREE::Stream::ResourceSubviewOp::create(builder, loc, slab, slabSize,
+                                                subviewOffset, subviewLength)
+            .getResult());
   }
   return {allocaOp, results};
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -188,11 +188,10 @@ struct GenericResourcePattern : public ConversionPattern {
     // If needed insert a transfer to the target lifetime.
     Value result = importOp.getResult();
     if (targetType != externalType) {
-      result = builder
-                   .create<IREE::Stream::AsyncTransferOp>(
-                       loc, targetType, result, resultSize, resultSize,
-                       /*source_affinity=*/executionAffinityAttr,
-                       /*result_affinity=*/executionAffinityAttr)
+      result = IREE::Stream::AsyncTransferOp::create(
+                   builder, loc, targetType, result, resultSize, resultSize,
+                   /*source_affinity=*/executionAffinityAttr,
+                   /*result_affinity=*/executionAffinityAttr)
                    .getResult();
     }
 
@@ -270,12 +269,11 @@ struct ConvertToStreamPass final
       auto resourceValue = inputs[0];
       auto resourceSize = inputs[1];
       assert(inputs.size() == 2 && "expecting 2 operands (resource + size)");
-      Value cast = builder
-                       .create<IREE::Stream::AsyncTransferOp>(
-                           loc, resourceValue.getType(), resourceValue,
-                           resourceSize, resourceSize,
-                           /*source_affinity=*/nullptr,
-                           /*result_affinity=*/nullptr)
+      Value cast = IREE::Stream::AsyncTransferOp::create(
+                       builder, loc, resourceValue.getType(), resourceValue,
+                       resourceSize, resourceSize,
+                       /*source_affinity=*/nullptr,
+                       /*result_affinity=*/nullptr)
                        .getResult();
       return UnrealizedConversionCastOp::create(builder, loc, resultType, cast)
           .getResult(0);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -195,14 +195,13 @@ static void insertConstantTableLookup(mlir::FunctionOpInterface funcOp,
       unsigned operandIdx = operandValues.value().first;
       unsigned argIdx = operandToArgMap[operandIdx];
       auto arg = entryBlock.getArgument(argIdx);
-      auto extractedValue = builder
-                                .create<tensor::ExtractOp>(
-                                    arg.getLoc(), tableTensor,
+      auto extractedValue =
+          tensor::ExtractOp::create(builder, arg.getLoc(), tableTensor,
                                     ValueRange{
                                         siteId,
                                         indexSet.get(operandValues.index()),
                                     })
-                                .getResult();
+              .getResult();
       if (extractedValue.getType() != arg.getType()) {
         extractedValue = arith::IndexCastOp::create(
             builder, arg.getLoc(), arg.getType(), extractedValue);

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h
@@ -45,8 +45,8 @@ struct GenericConvertTypesPattern : public OpConversionPattern<T> {
       return rewriter.notifyMatchFailure(op, "op does not need transformation");
     }
 
-    auto newOp = rewriter.create<T>(op.getLoc(), newResultTypes,
-                                    adaptor.getOperands(), newAttrs);
+    auto newOp = T::create(rewriter, op.getLoc(), newResultTypes,
+                           adaptor.getOperands(), newAttrs);
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -270,9 +270,8 @@ struct ConvertMemRefStoreOp : public OpConversionPattern<memref::StoreOp> {
       // conversion target widens). Insert an unrealized conversion cast to
       // preserve the original semantic. Presumably, something will clear this
       // with additional lowering.
-      newValue = rewriter
-                     .create<UnrealizedConversionCastOp>(
-                         loc, storeOp.getValue().getType(), newValue)
+      newValue = UnrealizedConversionCastOp::create(
+                     rewriter, loc, storeOp.getValue().getType(), newValue)
                      .getResult(0);
     }
     rewriter.replaceOpWithNewOp<IREE::Util::BufferStoreOp>(

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -741,7 +741,7 @@ def Util_NumericCastOpInterface : OpInterface<"NumericCastOpInterface"> {
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
           return llvm::cast<NumericCastOpInterface>(
-            builder.create<ConcreteOp>($_op->getLoc(), resultType, input)
+            ConcreteOp::create(builder,$_op->getLoc(), resultType, input)
               .getOperation());
       }]
     >,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -640,11 +640,10 @@ struct FuseFMAOp : public OpRewritePattern<AddOp> {
         return failure();
       }
       rewriter.replaceOp(
-          addOp,
-          rewriter
-              .create<FMAOp>(rewriter.getFusedLoc({a.getLoc(), c.getLoc()}),
-                             a.getType(), a, b, c)
-              .getResult());
+          addOp, FMAOp::create(rewriter,
+                               rewriter.getFusedLoc({a.getLoc(), c.getLoc()}),
+                               a.getType(), a, b, c)
+                     .getResult());
       return success();
     };
     if (auto mulOp = dyn_cast_or_null<MulOp>(addOp.getLhs().getDefiningOp())) {

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -247,13 +247,11 @@ struct ConvertHALInterfaceBindingSubspanOp
     IndexSet indexSet(op.getLoc(), rewriter);
     auto bindingType = llvm::cast<IREE::Util::ListType>(bindingsArg.getType())
                            .getElementType();
-    auto sourceBuffer =
-        rewriter
-            .create<IREE::Util::ListGetOp>(
-                op.getLoc(), bindingType, bindingsArg,
-                rewriter.createOrFold<arith::ConstantIndexOp>(
-                    op.getLoc(), op.getBinding().getSExtValue()))
-            .getResult();
+    auto sourceBuffer = IREE::Util::ListGetOp::create(
+                            rewriter, op.getLoc(), bindingType, bindingsArg,
+                            rewriter.createOrFold<arith::ConstantIndexOp>(
+                                op.getLoc(), op.getBinding().getSExtValue()))
+                            .getResult();
 
     if (op.getByteOffset() && !matchPattern(op.getByteOffset(), m_Zero())) {
       // Offsetted binding: replace with a BufferSubspanOp.

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -312,12 +312,10 @@ struct FromHalInterfaceBindingSubspan
 
     // Base buffer.
     rewriter.replaceAllUsesWith(
-        op.getBaseBuffer(),
-        rewriter
-            .create<IREE::VMVX::GetRawInterfaceBindingBufferOp>(
-                loc, op.getBaseBuffer().getType(), binding.getLayout(),
-                binding.getBindingAttr())
-            .getResult());
+        op.getBaseBuffer(), IREE::VMVX::GetRawInterfaceBindingBufferOp::create(
+                                rewriter, loc, op.getBaseBuffer().getType(),
+                                binding.getLayout(), binding.getBindingAttr())
+                                .getResult());
 
     rewriter.eraseOp(op);
     return success();
@@ -330,9 +328,8 @@ static Value
 getBaseBufferReplacementForDescriptor(GetBufferDescriptorOp descriptorOp,
                                       RewriterBase &rewriter, Location loc,
                                       Value source) {
-  return rewriter
-      .create<UnrealizedConversionCastOp>(
-          loc, descriptorOp.getBaseBuffer().getType(), source)
+  return UnrealizedConversionCastOp::create(
+             rewriter, loc, descriptorOp.getBaseBuffer().getType(), source)
       .getResult(0);
 }
 
@@ -365,12 +362,10 @@ struct FromMemRefAssumeAlignment
 
     // Base buffer.
     rewriter.replaceAllUsesWith(
-        op.getBaseBuffer(),
-        rewriter
-            .create<IREE::VMVX::GetRawInterfaceBindingBufferOp>(
-                loc, op.getBaseBuffer().getType(), binding.getLayout(),
-                binding.getBindingAttr())
-            .getResult());
+        op.getBaseBuffer(), IREE::VMVX::GetRawInterfaceBindingBufferOp::create(
+                                rewriter, loc, op.getBaseBuffer().getType(),
+                                binding.getLayout(), binding.getBindingAttr())
+                                .getResult());
 
     rewriter.eraseOp(op);
     return success();

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -97,9 +97,8 @@ collapseExtractSlice(tensor::ExtractSliceOp sliceOp,
   Value newSliceOp = tensor::ExtractSliceOp::create(
       rewriter, loc, collapseOp, collapsedOffsets, collapsedSizes,
       collapsedStrides);
-  return rewriter
-      .create<tensor::ExpandShapeOp>(loc, resultType, newSliceOp, reassociation,
-                                     expandedSizes)
+  return tensor::ExpandShapeOp::create(rewriter, loc, resultType, newSliceOp,
+                                       reassociation, expandedSizes)
       .getResult();
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
@@ -94,9 +94,9 @@ static LogicalResult createDefaultWorkgroupCountRegion(
             rewriter.getContext(), forallOp.getLoc(), mapping->getValue()))) {
       return failure();
     }
-    defaultCountOp = rewriter.create<
-        IREE::TensorExt::DispatchWorkgroupCountSplitReductionModifierOp>(
-        loc, defaultCountOp->getResults(), block->getArguments());
+    defaultCountOp =
+        IREE::TensorExt::DispatchWorkgroupCountSplitReductionModifierOp::create(
+            rewriter, loc, defaultCountOp->getResults(), block->getArguments());
   }
   IREE::Flow::ReturnOp::create(rewriter, loc, defaultCountOp->getResults());
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -190,15 +190,14 @@ struct GlobalOpInterfaceExternalModel
     auto globalOp = cast<ml_program::GlobalOp>(op);
     if (globalOp.getIsMutable()) {
       return cast<IREE::Util::GlobalLoadOpInterface>(
-          builder
-              .create<ml_program::GlobalLoadOp>(
-                  loc, globalOp.getType(), FlatSymbolRefAttr::get(globalOp))
+          ml_program::GlobalLoadOp::create(builder, loc, globalOp.getType(),
+                                           FlatSymbolRefAttr::get(globalOp))
               .getOperation());
     } else {
       return cast<IREE::Util::GlobalLoadOpInterface>(
-          builder
-              .create<ml_program::GlobalLoadConstOp>(
-                  loc, globalOp.getType(), FlatSymbolRefAttr::get(globalOp))
+          ml_program::GlobalLoadConstOp::create(
+              builder, loc, globalOp.getType(),
+              FlatSymbolRefAttr::get(globalOp))
               .getOperation());
     }
   }
@@ -208,9 +207,8 @@ struct GlobalOpInterfaceExternalModel
                                                    OpBuilder &builder) const {
     auto globalOp = cast<ml_program::GlobalOp>(op);
     return cast<IREE::Util::GlobalStoreOpInterface>(
-        builder
-            .create<ml_program::GlobalStoreOp>(
-                loc, FlatSymbolRefAttr::get(globalOp), value)
+        ml_program::GlobalStoreOp ::create(
+            builder, loc, FlatSymbolRefAttr::get(globalOp), value)
             .getOperation());
   }
 };

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -30,8 +30,8 @@ static Value createTranspose(OpBuilder &builder, Value source,
   Value empty =
       tensor::EmptyOp::create(builder, source.getLoc(), mixedSizes, elemType)
           .getResult();
-  return builder
-      .create<linalg::TransposeOp>(source.getLoc(), source, empty, perm)
+  return linalg::TransposeOp::create(builder, source.getLoc(), source, empty,
+                                     perm)
       ->getResult(0);
 }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
@@ -68,15 +68,14 @@ struct DemoteContractionInputsToBF16Pattern
         Value empty = tensor::EmptyOp::create(rewriter, loc, mixedSizes,
                                               rewriter.getBF16Type());
         demotedInputs.push_back(
-            rewriter
-                .create<linalg::GenericOp>(
-                    loc, TypeRange{demotedInputType}, ValueRange{input},
-                    ValueRange{empty}, maps, iteratorTypes,
-                    [&](OpBuilder &b, Location loc, ValueRange args) {
-                      Value result = arith::TruncFOp::create(
-                          b, loc, rewriter.getBF16Type(), args[0]);
-                      linalg::YieldOp::create(b, loc, result);
-                    })
+            linalg::GenericOp::create(
+                rewriter, loc, TypeRange{demotedInputType}, ValueRange{input},
+                ValueRange{empty}, maps, iteratorTypes,
+                [&](OpBuilder &b, Location loc, ValueRange args) {
+                  Value result = arith::TruncFOp::create(
+                      b, loc, rewriter.getBF16Type(), args[0]);
+                  linalg::YieldOp::create(b, loc, result);
+                })
                 ->getResults()[0]);
       }
       auto namedOp = cast<std::remove_pointer_t<decltype(typePtr)>>(

--- a/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
@@ -166,9 +166,8 @@ struct DetachSplatConstantOutsOperands
       Value scalarConstantOp =
           arith::ConstantOp::create(rewriter, loc, elementType, constValue);
 
-      Value fillOp = rewriter
-                         .create<linalg::FillOp>(
-                             loc, resultType, scalarConstantOp, emptyTensorOp)
+      Value fillOp = linalg::FillOp::create(rewriter, loc, resultType,
+                                            scalarConstantOp, emptyTensorOp)
                          .getResult(0);
       rewriter.modifyOpInPlace(dpsInterfaceOp, [&]() {
         dpsInterfaceOp.setDpsInitOperand(outOperand.index(), fillOp);

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -504,9 +504,8 @@ static void expandSelectOp(mlir::arith::SelectOp op, IndexSet &indexSet,
   for (auto [trueDynamicDims, falseDynamicDims] :
        llvm::zip_equal(trueValue.dynamicDims, falseValue.dynamicDims)) {
     selectedDims.push_back(
-        builder
-            .create<arith::SelectOp>(op.getLoc(), op.getCondition(),
-                                     trueDynamicDims, falseDynamicDims)
+        arith::SelectOp::create(builder, op.getLoc(), op.getCondition(),
+                                trueDynamicDims, falseDynamicDims)
             .getResult());
   }
   auto tieShapeOp = IREE::Flow::TensorTieShapeOp::create(

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -76,8 +76,8 @@ static Value createTranspose(OpBuilder &builder, Value source,
                                    elementType);
   }
   Value empty = createTransposeInit(builder, source, perm);
-  return builder
-      .create<linalg::TransposeOp>(source.getLoc(), source, empty, perm)
+  return linalg::TransposeOp::create(builder, source.getLoc(), source, empty,
+                                     perm)
       ->getResult(0);
 }
 

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
@@ -59,13 +59,11 @@ struct QuantizedMatmulToMatmul
     unsigned lhsRank = lhsTy.getRank();
     Value acc = op.getDpsInits()[0];
     // Compute the matmul part.
-    Value matmul = batch ? builder
-                               .create<linalg::BatchMatmulOp>(
-                                   ValueRange{lhs, rhs}, ValueRange{acc})
+    Value matmul = batch ? linalg::BatchMatmulOp::create(
+                               builder, ValueRange{lhs, rhs}, ValueRange{acc})
                                .getResult(0)
-                         : builder
-                               .create<linalg::MatmulOp>(ValueRange{lhs, rhs},
-                                                         ValueRange{acc})
+                         : linalg::MatmulOp::create(
+                               builder, ValueRange{lhs, rhs}, ValueRange{acc})
                                .getResult(0);
     bool lhsZpIsConstantZero = isConstantZero(lhsZp);
     bool rhsZpIsConstantZero = isConstantZero(rhsZp);

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -931,10 +931,9 @@ static Value createCatNegateAndSlice(RewriterBase &rewriter, Value outTensor,
   };
 
   Value result =
-      rewriter
-          .create<linalg::GenericOp>(loc, expandedOutTensor.getType(),
-                                     ValueRange(), expandedOutTensor,
-                                     indexingMaps, iteratorTypes, bodyBuilder)
+      linalg::GenericOp::create(rewriter, loc, expandedOutTensor.getType(),
+                                ValueRange(), expandedOutTensor, indexingMaps,
+                                iteratorTypes, bodyBuilder)
           .getResult(0);
 
   return tensor::CollapseShapeOp::create(rewriter, loc, outTensor.getType(),

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -151,10 +151,8 @@ struct FoldAttentionAndTranspose
       dispatchIndexOpFoldResults(outputShape, dynamicShape, staticShape);
       Type resultType = RankedTensorType::get(
           staticShape, cast<RankedTensorType>(v.getType()).getElementType());
-      return rewriter
-          .create<tensor::ExpandShapeOp>(loc, resultType, v, reassociation,
-                                         outputShape)
-          .getResult();
+      return tensor::ExpandShapeOp::create(rewriter, loc, resultType, v,
+                                           reassociation, outputShape);
     };
 
     Value expandedQuery = getReshape(attentionOp.getQuery(), {{0, 1}, {2}, {3}},

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -542,10 +542,10 @@ static void padContractionLikeOp(
       sizes;
   for (auto [dimIdx, dimSize] : llvm::enumerate(resultShape)) {
     if (ShapedType::isDynamic(dimSize))
-      sizes.push_back(rewriter
-                          .create<tensor::DimOp>(
-                              loc, linalgOp.getDpsInitOperand(0)->get(), dimIdx)
-                          .getResult());
+      sizes.push_back(
+          tensor::DimOp::create(rewriter, loc,
+                                linalgOp.getDpsInitOperand(0)->get(), dimIdx)
+              .getResult());
     else
       sizes.push_back(rewriter.getIndexAttr(dimSize));
   }

--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceLinalgOnTensorsDelta.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceLinalgOnTensorsDelta.cpp
@@ -106,10 +106,8 @@ void mlir::iree_compiler::Reducer::reduceLinalgOnTensorsDelta(
     Type elType = outType.getElementType();
     // Build a constant 0 of the type.
     builder.setInsertionPoint(linalgOp);
-    auto zero = builder
-                    .create<arith::ConstantOp>(linalgOp.getLoc(),
-                                               builder.getZeroAttr(elType))
-                    .getResult();
+    Value zero = arith::ConstantOp::create(builder, linalgOp.getLoc(),
+                                           builder.getZeroAttr(elType));
 
     // Build linalg.fill for this out.
     newOut = linalg::FillOp::create(builder, linalgOp.getLoc(), zero, init)

--- a/compiler/src/iree/compiler/Utils/IntegerSet.h
+++ b/compiler/src/iree/compiler/Utils/IntegerSet.h
@@ -27,8 +27,8 @@ public:
     if (it != memoizedValues.end()) {
       return it->second;
     }
-    Value memoizedValue = builder.create<arith::ConstantIntOp>(
-        loc, *value.getRawData(), value.getBitWidth());
+    Value memoizedValue = arith::ConstantIntOp::create(
+        builder, loc, *value.getRawData(), value.getBitWidth());
     memoizedValues[value] = memoizedValue;
     return memoizedValue;
   }
@@ -39,7 +39,7 @@ public:
     if (matchPattern(lhs, m_ConstantInt(&lhsValue))) {
       return add(lhsValue.getSExtValue(), rhs);
     }
-    return builder.create<arith::AddIOp>(loc, lhs, get(rhs));
+    return arith::AddIOp::create(builder, loc, lhs, get(rhs));
   }
 
   void populate(ValueRange values) {
@@ -69,7 +69,7 @@ public:
     if (it != memoizedIndices.end()) {
       return it->second;
     }
-    Value memoizedValue = builder.create<arith::ConstantIndexOp>(loc, value);
+    Value memoizedValue = arith::ConstantIndexOp::create(builder, loc, value);
     memoizedIndices[value] = memoizedValue;
     return memoizedValue;
   }
@@ -81,7 +81,7 @@ public:
     if (matchPattern(lhs, m_ConstantInt(&lhsValue))) {
       return add(lhsValue.getSExtValue(), rhs);
     }
-    return builder.create<arith::AddIOp>(loc, lhs, get(rhs));
+    return arith::AddIOp::create(builder, loc, lhs, get(rhs));
   }
 
   void populate(ValueRange values) {


### PR DESCRIPTION
They are missed maybe because they are a couple lines. E.g.,

```
rewriter
  .create<...
```

The rest of code that uses `OpBuilder(op).create<...>` can not be updated because the `Op::create` method expects an lvalue for the builder. E.g.,

https://github.com/iree-org/iree/blob/88d8316c54814cc036efabf6785db041bc99cf67/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp#L1066-L1067