### PR TITLE
[LLVMGPU] Enable iree-llvmgpu-test-combine-layout-transformation by default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -85,7 +85,7 @@ static llvm::cl::opt<bool> clDistributeToWorkgroupsUsingForall(
 static llvm::cl::opt<bool> clCombineLayoutTransformation(
     "iree-llvmgpu-test-combine-layout-transformation",
     llvm::cl::desc("Combine relayout ops during dispatch configuration"),
-    llvm::cl::init(false), llvm::cl::Hidden);
+    llvm::cl::init(true), llvm::cl::Hidden);
 
 static llvm::cl::opt<IREE::Codegen::WorkgroupId>
     clSetWorkgroupDistributionAlong(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
@@ -32,6 +32,6 @@ module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} 
 }
 
 // CHECK:      @set_encoding()
-// CHECK:        linalg.pack
-// CHECK:        tensor.expand_shape
-// CHECK:        linalg.generic
+// CHECK:        %[[INPUT:.+]] = iree_codegen.load_from_buffer
+// CHECK:        %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter{{.*}} %[[INPUT]] into %{{.*}}
+// CHECK:        iree_codegen.store_to_buffer %[[MAP_SCATTER]]


### PR DESCRIPTION
Enables the relayout op combination and early bufferization paths by default. The major change after this PR is all `iree_tensor_ext.dispatch.tensor.load/store` ops will be bufferized to `iree_codegen.load_from_buffer/store_to_buffer`, and the binding subspans will be fully bufferized to memrefs.

In special cases, map_scatter may be used by default now, but in most common circumstances, there will be no map_scatter. Most cases where map_scatter is used will be for the data tiling fusion path, which has been using the flag already.

closes https://github.com/iree-org/iree/issues/20530