### PR TITLE
[Codegen] Add transform ops for matching contraction ops

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -316,7 +316,8 @@ func.func @op_fill(%dest: tensor<32x64xf32>, %value: f32) -> tensor<32x64xf32> {
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op : !transform.any_op
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -366,7 +367,10 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %inpu
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_correct_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} : !transform.any_op
+   %batch, %m, %n, %k = transform.iree.match.is_contraction %op
+    {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} :
+    (!transform.any_op) ->
+    (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -405,7 +409,7 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_different_count(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} : !transform.any_op
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -476,11 +480,11 @@ func.func @test_type_matching(
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_f16_f32_types(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op {
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
       indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
       input_types = [f16, f16],
       output_type = f32
-    } : !transform.any_op
+    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -541,10 +545,10 @@ func.func @test_input_type_matching(
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_f16_inputs_only(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op {
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
       indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
       input_types = [f16, f16]
-    } : !transform.any_op
+    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -605,10 +609,10 @@ func.func @test_output_type_matching(
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_f32_output_only(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_contraction %op {
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
       indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
       output_type = f32
-    } : !transform.any_op
+    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -274,6 +274,8 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// Verify that the basic contraction matcher works without indexing maps.
+
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -327,6 +329,125 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%module: !transform.any_op) {
     transform.foreach_match in %module
         @match_contraction -> @annotate
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+// Verify that operations with exact same matching indexing maps are matched correctly.
+
+#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @op_matmul
+func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest: tensor<32x32xi32>) -> tensor<32x32xi32> {
+  // CHECK-NEXT: linalg.matmul
+  // CHECK-SAME:   indexing_maps_match = "matched"
+  %res = linalg.matmul
+        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
+        ins(%input0, %input1 : tensor<32x64xi8>, tensor<32x64xi8>)
+        outs(%dest : tensor<32x32xi32>) {indexing_maps_match = "unmatched"} -> tensor<32x32xi32>
+  return %res : tensor<32x32xi32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_correct_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} : !transform.any_op
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "indexing_maps_match" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    transform.foreach_match in %module
+        @match_correct_maps -> @annotate_matched
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+// Verify that operations with different number of indexing maps are correctly not matched.
+
+#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @op_matmul
+func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest: tensor<32x32xi32>) -> tensor<32x32xi32> {
+  // CHECK-NEXT: linalg.matmul
+  // CHECK-SAME:   indexing_maps_match = "unmatched"
+  %res = linalg.matmul
+        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
+        ins(%input0, %input1 : tensor<32x64xi8>, tensor<32x64xi8>)
+        outs(%dest : tensor<32x32xi32>) {indexing_maps_match = "unmatched"} -> tensor<32x32xi32>
+  return %res : tensor<32x32xi32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_different_count(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} : !transform.any_op
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "indexing_maps_match" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+     // Should NOT match: operation has 3 indexing maps but matcher expects 4.
+    transform.foreach_match in %module
+        @match_different_count -> @annotate_matched
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+// Verify that operations with different indexing map patterns are correctly not matched.
+
+#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @op_matmul
+func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest: tensor<32x32xi32>) -> tensor<32x32xi32> {
+  // CHECK-NEXT: linalg.matmul
+  // CHECK-SAME:   indexing_maps_match = "unmatched"
+  %res = linalg.matmul
+        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
+        ins(%input0, %input1 : tensor<32x64xi8>, tensor<32x64xi8>)
+        outs(%dest : tensor<32x32xi32>) {indexing_maps_match = "unmatched"} -> tensor<32x32xi32>
+  return %res : tensor<32x32xi32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_different_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul0]} : !transform.any_op
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "indexing_maps_match" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+     // Should NOT match: operation has different indexing maps pattern than expected (last map is different).
+    transform.foreach_match in %module
+        @match_different_maps -> @annotate_matched
       : (!transform.any_op) -> (!transform.any_op)
     transform.yield
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -315,7 +315,7 @@ func.func @op_fill(%dest: tensor<32x64xf32>, %value: f32) -> tensor<32x64xf32> {
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_matmul(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op,
+    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.contraction %op,
       lhs_type = i8, rhs_type = i8, output_type = i32 :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     %c32 = transform.param.constant 32 : i64 -> !transform.param<i64>
@@ -325,7 +325,7 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_batch_matmul(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op,
+    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.contraction %op,
       lhs_type = i8, rhs_type = i8, output_type = i32 :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     %c2 = transform.param.constant 2 : i64 -> !transform.param<i64>
@@ -383,7 +383,7 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %inpu
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_correct_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-   %batch, %m, %n, %k = transform.iree.match.is_contraction %op,
+   %batch, %m, %n, %k = transform.iree.match.contraction %op,
     lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} :
     (!transform.any_op) ->
     (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
@@ -425,7 +425,7 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_different_count(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %n, %k = transform.iree.match.is_contraction %op,
+    %batch, %m, %n, %k = transform.iree.match.contraction %op,
       lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
@@ -477,7 +477,7 @@ func.func @test_mma_layout_config(%a: tensor<64x64xf32>, %b: tensor<64x64xf32>, 
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_matmul(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op,
+    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.contraction %op,
       lhs_type = f32, rhs_type = f32, output_type = f32 :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -281,15 +281,6 @@ module attributes {transform.with_named_sequence} {
 #map_batch0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map_batch1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 #map_batch2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#map_attn0 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-#map_attn1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
-#map_attn2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
-#map_attn3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
-#map_attn4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
-
-// The above test actually will search the whole module.
-// The "op_" prefix ensures these functions are processed after existing
-// test functions in alphabetical order, avoiding FileCheck pattern conflicts.
 
 // CHECK-LABEL: func.func @op_matmul
 func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest: tensor<32x32xi32>) -> tensor<32x32xi32> {
@@ -313,31 +304,6 @@ func.func @op_batch_matmul(%input0: tensor<2x32x64xi8>, %input1: tensor<2x32x64x
   return %res : tensor<2x32x32xi32>
 }
 
-// CHECK-LABEL: func.func @op_conv2d
-func.func @op_conv2d(%input: tensor<1x230x230x3xf32>, %filter: tensor<7x7x3x64xf32>, %dest: tensor<1x224x224x64xf32>) -> tensor<1x224x224x64xf32> {
-  // CHECK-NEXT: linalg.conv_2d_nhwc_hwcf
-  // CHECK-SAME:   match_status = "matched"
-  %res = linalg.conv_2d_nhwc_hwcf
-        {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-        ins(%input, %filter : tensor<1x230x230x3xf32>, tensor<7x7x3x64xf32>)
-        outs(%dest : tensor<1x224x224x64xf32>) {match_status = "unmatched"} -> tensor<1x224x224x64xf32>
-  return %res : tensor<1x224x224x64xf32>
-}
-
-// CHECK-LABEL: func.func @op_attention
-func.func @op_attention(%query: tensor<1x16x512xf32>, %key: tensor<1x16x512xf32>, %value: tensor<1x16x512xf32>, %scale: f32, %dest: tensor<1x16x512xf32>) -> tensor<1x16x512xf32> {
-  // CHECK-NEXT: iree_linalg_ext.attention
-  // CHECK-SAME:   match_status = "matched"
-  %res = iree_linalg_ext.attention
-        {indexing_maps = [#map_attn0, #map_attn1, #map_attn2, #map_attn3, #map_attn4], match_status = "unmatched"}
-        ins(%query, %key, %value, %scale : tensor<1x16x512xf32>, tensor<1x16x512xf32>, tensor<1x16x512xf32>, f32)
-        outs(%dest : tensor<1x16x512xf32>) {
-  ^bb0(%in: f32):
-    iree_linalg_ext.yield %in : f32
-  } -> tensor<1x16x512xf32>
-  return %res : tensor<1x16x512xf32>
-}
-
 // CHECK-LABEL: func.func @op_fill
 func.func @op_fill(%dest: tensor<32x64xf32>, %value: f32) -> tensor<32x64xf32> {
   // CHECK-NEXT: linalg.fill
@@ -352,16 +318,6 @@ module attributes {transform.with_named_sequence} {
     transform.yield %op : !transform.any_op
   }
 
-  transform.named_sequence @match_convolution(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_convolution %op : !transform.any_op
-    transform.yield %op : !transform.any_op
-  }
-
-  transform.named_sequence @match_attention(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    transform.iree.match.is_attention %op : !transform.any_op
-    transform.yield %op : !transform.any_op
-  }
-
   transform.named_sequence @annotate(%op: !transform.any_op {transform.readonly}) {
     %0 = transform.param.constant "matched" -> !transform.any_param
     transform.annotate %op "match_status" = %0 : !transform.any_op, !transform.any_param
@@ -370,9 +326,7 @@ module attributes {transform.with_named_sequence} {
 
   transform.named_sequence @__transform_main(%module: !transform.any_op) {
     transform.foreach_match in %module
-        @match_contraction -> @annotate,
-        @match_convolution -> @annotate,
-        @match_attention -> @annotate
+        @match_contraction -> @annotate
       : (!transform.any_op) -> (!transform.any_op)
     transform.yield
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -315,7 +315,8 @@ func.func @op_fill(%dest: tensor<32x64xf32>, %value: f32) -> tensor<32x64xf32> {
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_matmul(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op :
+    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op,
+      lhs_type = i8, rhs_type = i8, output_type = i32 :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     %c32 = transform.param.constant 32 : i64 -> !transform.param<i64>
     transform.match.param.cmpi eq %m_dims, %c32 : !transform.param<i64>
@@ -324,7 +325,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_batch_matmul(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op :
+    %batch_dims, %m_dims, %n_dims, %k_dims = transform.iree.match.is_contraction %op,
+      lhs_type = i8, rhs_type = i8, output_type = i32 :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     %c2 = transform.param.constant 2 : i64 -> !transform.param<i64>
     %c32 = transform.param.constant 32 : i64 -> !transform.param<i64>
@@ -381,8 +383,8 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %inpu
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_correct_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-   %batch, %m, %n, %k = transform.iree.match.is_contraction %op
-    {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} :
+   %batch, %m, %n, %k = transform.iree.match.is_contraction %op,
+    lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} :
     (!transform.any_op) ->
     (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
@@ -423,7 +425,9 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_different_count(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    %batch, %m, %n, %k = transform.iree.match.is_contraction %op,
+      lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }
 
@@ -437,210 +441,6 @@ module attributes {transform.with_named_sequence} {
      // Should NOT match: operation has 3 indexing maps but matcher expects 4.
     transform.foreach_match in %module
         @match_different_count -> @annotate_matched
-      : (!transform.any_op) -> (!transform.any_op)
-    transform.yield
-  }
-}
-
-// -----
-
-// Verify type matching with various input and output types.
-
-#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
-#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-// CHECK-LABEL: func.func @test_type_matching
-func.func @test_type_matching(
-    %input0_f16: tensor<32x64xf16>, %input1_f16: tensor<32x64xf16>,
-    %input0_i8: tensor<32x64xi8>, %input1_i8: tensor<32x64xi8>,
-    %input0_mixed: tensor<32x64xf16>, %input1_mixed: tensor<32x64xf32>,
-    %dest_f32: tensor<32x32xf32>, %dest_i32: tensor<32x32xi32>, %dest_f16: tensor<32x32xf16>
-) -> tensor<32x32xf32> {
-  // Case 1: f16 inputs, f32 output - should match.
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   type_match = "matched"
-  %res1 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f32 : tensor<32x32xf32>) {type_match = "unmatched"} -> tensor<32x32xf32>
-
-  // Case 2: i8 inputs, i32 output - should NOT match (different input types).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   type_match = "unmatched"
-  %res2 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_i8, %input1_i8 : tensor<32x64xi8>, tensor<32x64xi8>)
-        outs(%dest_i32 : tensor<32x32xi32>) {type_match = "unmatched"} -> tensor<32x32xi32>
-
-  // Case 3: Mixed f16/f32 inputs, f32 output - should NOT match (mixed input types).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   type_match = "unmatched"
-  %res3 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_mixed, %input1_mixed : tensor<32x64xf16>, tensor<32x64xf32>)
-        outs(%dest_f32 : tensor<32x32xf32>) {type_match = "unmatched"} -> tensor<32x32xf32>
-
-  // Case 4: f16 inputs, f16 output - should NOT match (wrong output type).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   type_match = "unmatched"
-  %res4 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f16 : tensor<32x32xf16>) {type_match = "unmatched"} -> tensor<32x32xf16>
-
-  return %res1 : tensor<32x32xf32>
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @match_f16_f32_types(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
-      indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
-      lhs_type = f16,
-      rhs_type = f16,
-      output_type = f32
-    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    transform.yield %op : !transform.any_op
-  }
-
-  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
-    %0 = transform.param.constant "matched" -> !transform.any_param
-    transform.annotate %op "type_match" = %0 : !transform.any_op, !transform.any_param
-    transform.yield
-  }
-
-  transform.named_sequence @__transform_main(%module: !transform.any_op) {
-    transform.foreach_match in %module
-        @match_f16_f32_types -> @annotate_matched
-      : (!transform.any_op) -> (!transform.any_op)
-    transform.yield
-  }
-}
-
-// -----
-
-// Verify matching with only input types specified.
-
-#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
-#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-// CHECK-LABEL: func.func @test_input_type_matching
-func.func @test_input_type_matching(
-    %input0_f16: tensor<32x64xf16>, %input1_f16: tensor<32x64xf16>,
-    %input0_i8: tensor<32x64xi8>, %input1_i8: tensor<32x64xi8>,
-    %dest_f32: tensor<32x32xf32>, %dest_f16: tensor<32x32xf16>
-) -> tensor<32x32xf32> {
-  // Case 1: f16 inputs, f32 output - should match (checking inputs).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   input_type_match = "matched"
-  %res1 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f32 : tensor<32x32xf32>) {input_type_match = "unmatched"} -> tensor<32x32xf32>
-
-  // Case 2: f16 inputs, f16 output - should also match (checking inputs).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   input_type_match = "matched"
-  %res2 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f16 : tensor<32x32xf16>) {input_type_match = "unmatched"} -> tensor<32x32xf16>
-
-  // Case 3: i8 inputs, f32 output - should NOT match (wrong input types).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   input_type_match = "unmatched"
-  %res3 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_i8, %input1_i8 : tensor<32x64xi8>, tensor<32x64xi8>)
-        outs(%dest_f32 : tensor<32x32xf32>) {input_type_match = "unmatched"} -> tensor<32x32xf32>
-
-  return %res1 : tensor<32x32xf32>
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @match_f16_inputs_only(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
-      indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
-      lhs_type = f16,
-      rhs_type = f16
-    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    transform.yield %op : !transform.any_op
-  }
-
-  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
-    %0 = transform.param.constant "matched" -> !transform.any_param
-    transform.annotate %op "input_type_match" = %0 : !transform.any_op, !transform.any_param
-    transform.yield
-  }
-
-  transform.named_sequence @__transform_main(%module: !transform.any_op) {
-    transform.foreach_match in %module
-        @match_f16_inputs_only -> @annotate_matched
-      : (!transform.any_op) -> (!transform.any_op)
-    transform.yield
-  }
-}
-
-// -----
-
-// Verify matching with only output type specified.
-
-#map_matmul0 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map_matmul1 = affine_map<(d0, d1, d2) -> (d1, d2)>
-#map_matmul2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-// CHECK-LABEL: func.func @test_output_type_matching
-func.func @test_output_type_matching(
-    %input0_f16: tensor<32x64xf16>, %input1_f16: tensor<32x64xf16>,
-    %input0_i8: tensor<32x64xi8>, %input1_i8: tensor<32x64xi8>,
-    %dest_f32: tensor<32x32xf32>, %dest_f16: tensor<32x32xf16>
-) -> tensor<32x32xf32> {
-  // Case 1: f16 inputs, f32 output - should match.
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   output_type_match = "matched"
-  %res1 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f32 : tensor<32x32xf32>) {output_type_match = "unmatched"} -> tensor<32x32xf32>
-
-  // Case 2: i8 inputs, f32 output - should match (checking output).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   output_type_match = "matched"
-  %res2 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_i8, %input1_i8 : tensor<32x64xi8>, tensor<32x64xi8>)
-        outs(%dest_f32 : tensor<32x32xf32>) {output_type_match = "unmatched"} -> tensor<32x32xf32>
-
-  // Case 3: f16 inputs, f16 output - should NOT match (wrong output type).
-  // CHECK-NEXT: linalg.matmul
-  // CHECK-SAME:   output_type_match = "unmatched"
-  %res3 = linalg.matmul
-        indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]
-        ins(%input0_f16, %input1_f16 : tensor<32x64xf16>, tensor<32x64xf16>)
-        outs(%dest_f16 : tensor<32x32xf16>) {output_type_match = "unmatched"} -> tensor<32x32xf16>
-
-  return %res1 : tensor<32x32xf32>
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @match_f32_output_only(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
-      indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
-      output_type = f32
-    } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    transform.yield %op : !transform.any_op
-  }
-
-  transform.named_sequence @annotate_matched(%op: !transform.any_op {transform.readonly}) {
-    %0 = transform.param.constant "matched" -> !transform.any_param
-    transform.annotate %op "output_type_match" = %0 : !transform.any_op, !transform.any_param
-    transform.yield
-  }
-
-  transform.named_sequence @__transform_main(%module: !transform.any_op) {
-    transform.foreach_match in %module
-        @match_f32_output_only -> @annotate_matched
       : (!transform.any_op) -> (!transform.any_op)
     transform.yield
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -496,7 +496,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_f16_f32_types(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
       indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
-      input_types = [f16, f16],
+      lhs_type = f16,
+      rhs_type = f16,
       output_type = f32
     } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
@@ -561,7 +562,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_f16_inputs_only(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %m, %n, %k = transform.iree.match.is_contraction %op {
       indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2],
-      input_types = [f16, f16]
+      lhs_type = f16,
+      rhs_type = f16
     } : (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
     transform.yield %op : !transform.any_op
   }

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
@@ -56,11 +56,13 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PreprocessingExtensionsOpGen",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:PDLDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformDialect",

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
@@ -56,7 +56,6 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PreprocessingExtensionsOpGen",
-        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
@@ -35,12 +35,14 @@ iree_cc_library(
     IREELinalgTransformDialect
     LLVMSupport
     MLIRIR
+    MLIRLinalgInterfacesIncGenLib
     MLIRPDLDialect
     MLIRSupport
     MLIRTransformDialect
     MLIRTransformDialectInterfaces
     MLIRTransformUtils
     MLIRValueBoundsOpInterface
+    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
@@ -42,7 +42,6 @@ iree_cc_library(
     MLIRTransformDialectInterfaces
     MLIRTransformUtils
     MLIRValueBoundsOpInterface
-    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -326,11 +326,14 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
         }));
   };
 
-  results.setParams(cast<OpResult>(getBatch()),
+  results.setParams(cast<OpResult>(getBatchDims()),
                     iterationSizes(contractionDims.batch));
-  results.setParams(cast<OpResult>(getM()), iterationSizes(contractionDims.m));
-  results.setParams(cast<OpResult>(getN()), iterationSizes(contractionDims.n));
-  results.setParams(cast<OpResult>(getK()), iterationSizes(contractionDims.k));
+  results.setParams(cast<OpResult>(getMDims()),
+                    iterationSizes(contractionDims.m));
+  results.setParams(cast<OpResult>(getNDims()),
+                    iterationSizes(contractionDims.n));
+  results.setParams(cast<OpResult>(getKDims()),
+                    iterationSizes(contractionDims.k));
 
   return DiagnosedSilenceableFailure::success();
 }

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.h"
 
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Utils/EquivalenceUtils.h"
 #include "iree/compiler/Utils/ShapeUtils.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
@@ -239,38 +238,6 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
   }
   return emitSilenceableFailure(current->getLoc())
          << "Operation " << *current << " is not a contraction operation.";
-}
-
-//===----------------------------------------------------------------------===//
-// MatchConvolutionOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure
-IREE::transform_dialect::MatchConvolutionOp::matchOperation(
-    Operation *current, transform::TransformResults &results,
-    transform::TransformState &state) {
-  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(current)) {
-    if (linalg::isaConvolutionOpInterface(linalgOp)) {
-      return DiagnosedSilenceableFailure::success();
-    }
-  }
-  return emitSilenceableFailure(current->getLoc())
-         << "Operation " << *current << " is not a convolution operation.";
-}
-
-//===----------------------------------------------------------------------===//
-// MatchAttentionOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure
-IREE::transform_dialect::MatchAttentionOp::matchOperation(
-    Operation *current, transform::TransformResults &results,
-    transform::TransformState &state) {
-  if (isa<iree_compiler::IREE::LinalgExt::AttentionOp>(current)) {
-    return DiagnosedSilenceableFailure::success();
-  }
-  return emitSilenceableFailure(current->getLoc())
-         << "Operation " << *current << " is not an attention operation.";
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -245,7 +245,6 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
   if (std::optional<ArrayAttr> indexingMaps = getIndexingMaps()) {
     ArrayAttr currentIndexingMaps = linalgOp.getIndexingMaps();
     ArrayAttr targetIndexingMaps = *indexingMaps;
-
     if (currentIndexingMaps.size() != targetIndexingMaps.size()) {
       return emitSilenceableFailure(current->getLoc())
              << "indexing maps count mismatch: expected "
@@ -257,7 +256,6 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
          llvm::zip(currentIndexingMaps, targetIndexingMaps)) {
       AffineMapAttr currentMap = cast<AffineMapAttr>(currentMapAttr);
       AffineMapAttr targetMap = cast<AffineMapAttr>(targetMapAttr);
-
       if (currentMap.getValue() != targetMap.getValue()) {
         return emitSilenceableFailure(current->getLoc())
                << "indexing maps don't match: expected " << targetMap
@@ -266,28 +264,23 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
     }
   }
 
-  if (std::optional<ArrayAttr> inputTypes = getInputTypes()) {
-    ArrayAttr targetInputTypes = *inputTypes;
-    SmallVector<Type> currentInputTypes;
-    for (Value input : linalgOp.getDpsInputs()) {
-      currentInputTypes.push_back(getElementTypeOrSelf(input.getType()));
-    }
-
-    if (currentInputTypes.size() != targetInputTypes.size()) {
+  if (std::optional<Type> lhsType = getLhsType()) {
+    Type targetLhsType = *lhsType;
+    Type currentLhsType = getElementTypeOrSelf(linalgOp.getDpsInputs()[0]);
+    if (currentLhsType != targetLhsType) {
       return emitSilenceableFailure(current->getLoc())
-             << "input types count mismatch: expected "
-             << targetInputTypes.size() << ", got " << currentInputTypes.size();
+             << "LHS type doesn't match: expected " << targetLhsType << ", got "
+             << currentLhsType;
     }
+  }
 
-    for (auto [currentType, targetTypeAttr] :
-         llvm::zip(currentInputTypes, targetInputTypes)) {
-      Type targetType = cast<TypeAttr>(targetTypeAttr).getValue();
-
-      if (currentType != targetType) {
-        return emitSilenceableFailure(current->getLoc())
-               << "input types don't match: expected " << targetType << ", got "
-               << currentType;
-      }
+  if (std::optional<Type> rhsType = getRhsType()) {
+    Type targetRhsType = *rhsType;
+    Type currentRhsType = getElementTypeOrSelf(linalgOp.getDpsInputs()[1]);
+    if (currentRhsType != targetRhsType) {
+      return emitSilenceableFailure(current->getLoc())
+             << "RHS type doesn't match: expected " << targetRhsType << ", got "
+             << currentRhsType;
     }
   }
 

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -6,9 +6,10 @@
 
 #include "iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.h"
 
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Utils/EquivalenceUtils.h"
 #include "iree/compiler/Utils/ShapeUtils.h"
-#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -221,6 +222,55 @@ IREE::transform_dialect::MatchCastCompatibleDagFromRootOp::verify() {
   }
   // TODO: Region verification that it includes a single DAG.
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MatchContractionOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchContractionOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(current)) {
+    if (linalg::isaContractionOpInterface(linalgOp)) {
+      return DiagnosedSilenceableFailure::success();
+    }
+  }
+  return emitSilenceableFailure(current->getLoc())
+         << "Operation " << *current << " is not a contraction operation.";
+}
+
+//===----------------------------------------------------------------------===//
+// MatchConvolutionOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchConvolutionOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(current)) {
+    if (linalg::isaConvolutionOpInterface(linalgOp)) {
+      return DiagnosedSilenceableFailure::success();
+    }
+  }
+  return emitSilenceableFailure(current->getLoc())
+         << "Operation " << *current << " is not a convolution operation.";
+}
+
+//===----------------------------------------------------------------------===//
+// MatchAttentionOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchAttentionOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  if (isa<iree_compiler::IREE::LinalgExt::AttentionOp>(current)) {
+    return DiagnosedSilenceableFailure::success();
+  }
+  return emitSilenceableFailure(current->getLoc())
+         << "Operation " << *current << " is not an attention operation.";
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -228,33 +228,6 @@ IREE::transform_dialect::MatchCastCompatibleDagFromRootOp::verify() {
 // MatchContractionOp
 //===----------------------------------------------------------------------===//
 
-// Helper function to get indexing maps for matmul variants.
-static ArrayAttr getMatmulIndexingMaps(StringAttr variant,
-                                       MLIRContext *context) {
-  Builder builder(context);
-  AffineExpr d0 = builder.getAffineDimExpr(0);
-  AffineExpr d1 = builder.getAffineDimExpr(1);
-  AffineExpr d2 = builder.getAffineDimExpr(2);
-
-  // Default indexing maps (NN case).
-  AffineMap mapA = AffineMap::get(3, 0, {d0, d2}, context); // (M, K).
-  AffineMap mapB = AffineMap::get(3, 0, {d2, d1}, context); // (K, N).
-  AffineMap mapC = AffineMap::get(3, 0, {d0, d1}, context); // (M, N).
-
-  StringRef variantStr = variant.getValue();
-  if (variantStr[0] == 'T') { // Transpose A.
-    mapA = AffineMap::get(3, 0, {d2, d0}, context);
-  }
-
-  if (variantStr[1] == 'T') { // Transpose B.
-    mapB = AffineMap::get(3, 0, {d1, d2}, context);
-  }
-
-  return builder.getArrayAttr({AffineMapAttr::get(mapA),
-                               AffineMapAttr::get(mapB),
-                               AffineMapAttr::get(mapC)});
-}
-
 DiagnosedSilenceableFailure
 IREE::transform_dialect::MatchContractionOp::matchOperation(
     Operation *current, transform::TransformResults &results,

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -182,14 +182,19 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
     Matches operations that implement the ContractionOpInterface.
     This includes operations like linalg.matmul, linalg.batch_matmul, etc.
 
+    Optionally matches specific indexing maps patterns.
+
     #### Return modes
 
     Succeeds if the operation is a contraction operation, and
     produces a silenceable failure otherwise.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
-  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
+  let arguments = (ins
+    TransformHandleTypeInterface:$operand_handle,
+    OptionalAttr<AffineMapArrayAttr>:$indexing_maps
+  );
+  let assemblyFormat = "$operand_handle (`indexing_maps` $indexing_maps^)? attr-dict `:` type($operand_handle)";
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -195,49 +195,4 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.is_convolution",
-    [IsolatedFromAbove,
-     MatchOpInterface,
-     SingleOpMatcher,
-     MemoryEffectsOpInterface]> {
-  let summary = [{Check whether the op is a convolution operation.}];
-  let description = [{
-    Matches operations that implement the ConvolutionOpInterface.
-    This includes operations like linalg.conv_2d_nhwc_hwcf, etc.
-
-    #### Return modes
-
-    Succeeds if the operation is a convolution operation, and
-    produces a silenceable failure otherwise.
-  }];
-
-  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
-  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
-  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
-
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-}
-
-def MatchAttentionOp : Op<Transform_Dialect, "iree.match.is_attention",
-    [IsolatedFromAbove,
-     MatchOpInterface,
-     SingleOpMatcher,
-     MemoryEffectsOpInterface]> {
-  let summary = [{Check whether the op is an attention operation.}];
-  let description = [{
-    Matches attention operations like iree_linalg_ext.attention.
-
-    #### Return modes
-
-    Succeeds if the operation is an attention operation, and
-    produces a silenceable failure otherwise.
-  }];
-
-  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
-  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
-  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
-
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-}
-
 #endif // IREE_COMPILER_DIALECT_PREPROCESSING_TRANSFORMEXTENSIONS_PREPROCESSINGEXTENSIONS

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -172,4 +172,72 @@ def MatchRegionsOp : Op<Transform_Dialect, "iree.match.regions",
   let hasVerifier = 1;
 }
 
+def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
+    [IsolatedFromAbove,
+     MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
+  let summary = [{Check whether the op is a contraction operation.}];
+  let description = [{
+    Matches operations that implement the ContractionOpInterface.
+    This includes operations like linalg.matmul, linalg.batch_matmul, etc.
+
+    #### Return modes
+
+    Succeeds if the operation is a contraction operation, and
+    produces a silenceable failure otherwise.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
+  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.is_convolution",
+    [IsolatedFromAbove,
+     MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
+  let summary = [{Check whether the op is a convolution operation.}];
+  let description = [{
+    Matches operations that implement the ConvolutionOpInterface.
+    This includes operations like linalg.conv_2d_nhwc_hwcf, etc.
+
+    #### Return modes
+
+    Succeeds if the operation is a convolution operation, and
+    produces a silenceable failure otherwise.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
+  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def MatchAttentionOp : Op<Transform_Dialect, "iree.match.is_attention",
+    [IsolatedFromAbove,
+     MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
+  let summary = [{Check whether the op is an attention operation.}];
+  let description = [{
+    Matches attention operations like iree_linalg_ext.attention.
+
+    #### Return modes
+
+    Succeeds if the operation is an attention operation, and
+    produces a silenceable failure otherwise.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
+  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
 #endif // IREE_COMPILER_DIALECT_PREPROCESSING_TRANSFORMEXTENSIONS_PREPROCESSINGEXTENSIONS

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -187,6 +187,14 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
 
     Succeeds if the operation is a contraction operation, and
     produces a silenceable failure otherwise.
+
+    #### Results
+
+    Returns arrays of dimension sizes for each contraction dimension:
+    - batch_dims: Array of batch dimension sizes.
+    - m_dims: Array of M dimension sizes.
+    - n_dims: Array of N dimension sizes.
+    - k_dims: Array of K dimension sizes.
   }];
 
   let arguments = (ins
@@ -197,10 +205,10 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
   );
 
   let results = (outs
-    TransformParamTypeInterface:$batch,
-    TransformParamTypeInterface:$m,
-    TransformParamTypeInterface:$n,
-    TransformParamTypeInterface:$k
+    TransformParamTypeInterface:$batch_dims,
+    TransformParamTypeInterface:$m_dims,
+    TransformParamTypeInterface:$n_dims,
+    TransformParamTypeInterface:$k_dims
   );
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -200,8 +200,9 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
   let arguments = (ins
     TransformHandleTypeInterface:$operand_handle,
     OptionalAttr<AffineMapArrayAttr>:$indexing_maps,
-    OptionalAttr<TypeArrayAttr>:$input_types,        // [LHS_type, RHS_type].
-    OptionalAttr<TypeAttr>:$output_type              // Single output type.
+    OptionalAttr<TypeAttr>:$lhs_type,                 // LHS input type.
+    OptionalAttr<TypeAttr>:$rhs_type,                 // RHS input type.
+    OptionalAttr<TypeAttr>:$output_type               // Output type.
   );
 
   let results = (outs
@@ -214,7 +215,8 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
   let assemblyFormat = [{
     $operand_handle
     (`indexing_maps` $indexing_maps^)?
-    (`input_types` $input_types^)?
+    (`lhs_type` $lhs_type^)?
+    (`rhs_type` $rhs_type^)?
     (`output_type` $output_type^)?
     attr-dict `:` functional-type(operands, results)
   }];

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -192,9 +192,17 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
 
   let arguments = (ins
     TransformHandleTypeInterface:$operand_handle,
-    OptionalAttr<AffineMapArrayAttr>:$indexing_maps
+    OptionalAttr<AffineMapArrayAttr>:$indexing_maps,
+    OptionalAttr<TypeArrayAttr>:$input_types,        // [LHS_type, RHS_type].
+    OptionalAttr<TypeAttr>:$output_type              // Single output type.
   );
-  let assemblyFormat = "$operand_handle (`indexing_maps` $indexing_maps^)? attr-dict `:` type($operand_handle)";
+  let assemblyFormat = [{
+    $operand_handle
+    (`indexing_maps` $indexing_maps^)?
+    (`input_types` $input_types^)?
+    (`output_type` $output_type^)?
+    attr-dict `:` type($operand_handle)
+  }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -199,10 +199,10 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
 
   let arguments = (ins
     TransformHandleTypeInterface:$operand_handle,
-    OptionalAttr<AffineMapArrayAttr>:$indexing_maps,
-    OptionalAttr<TypeAttr>:$lhs_type,                 // LHS input type.
-    OptionalAttr<TypeAttr>:$rhs_type,                 // RHS input type.
-    OptionalAttr<TypeAttr>:$output_type               // Output type.
+    TypeAttr:$lhs_type,                    // LHS input type.
+    TypeAttr:$rhs_type,                    // RHS input type.
+    TypeAttr:$output_type,                 // Output type.
+    OptionalAttr<AffineMapArrayAttr>:$indexing_maps
   );
 
   let results = (outs
@@ -214,10 +214,10 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
 
   let assemblyFormat = [{
     $operand_handle
+    `,` `lhs_type` `=` $lhs_type
+    `,` `rhs_type` `=` $rhs_type
+    `,` `output_type` `=` $output_type
     (`indexing_maps` $indexing_maps^)?
-    (`lhs_type` $lhs_type^)?
-    (`rhs_type` $rhs_type^)?
-    (`output_type` $output_type^)?
     attr-dict `:` functional-type(operands, results)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -172,7 +172,7 @@ def MatchRegionsOp : Op<Transform_Dialect, "iree.match.regions",
   let hasVerifier = 1;
 }
 
-def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
+def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
     [MatchOpInterface,
      SingleOpMatcher,
      MemoryEffectsOpInterface]> {

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -173,8 +173,7 @@ def MatchRegionsOp : Op<Transform_Dialect, "iree.match.regions",
 }
 
 def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
-    [IsolatedFromAbove,
-     MatchOpInterface,
+    [MatchOpInterface,
      SingleOpMatcher,
      MemoryEffectsOpInterface]> {
   let summary = [{Check whether the op is a contraction operation.}];
@@ -196,12 +195,20 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.is_contraction",
     OptionalAttr<TypeArrayAttr>:$input_types,        // [LHS_type, RHS_type].
     OptionalAttr<TypeAttr>:$output_type              // Single output type.
   );
+
+  let results = (outs
+    TransformParamTypeInterface:$batch,
+    TransformParamTypeInterface:$m,
+    TransformParamTypeInterface:$n,
+    TransformParamTypeInterface:$k
+  );
+
   let assemblyFormat = [{
     $operand_handle
     (`indexing_maps` $indexing_maps^)?
     (`input_types` $input_types^)?
     (`output_type` $output_type^)?
-    attr-dict `:` type($operand_handle)
+    attr-dict `:` functional-type(operands, results)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
 


### PR DESCRIPTION
> Create friendlier TransformDialect ops for tuning. We currently use transform.iree.match.cast_compatible_dag_from_root to match the operation, but this op is very sensitive to extra attributes, and we need to be careful about what attributes are present in the TD spec. Ideally there should be a TD op designed for tuning spec matching, which is less sensitive to extraneous attributes.

Issue: https://github.com/nod-ai/shark-ai/issues/814

This PR adds `transform.iree.match.contraction` operation that matches contraction operations (matmul, batch_matmul, etc.) and extracts their dimension information.
- Matches operations implementing ContractionOpInterface.
- Validates LHS, RHS, and output element types.
- Optional indexing map pattern matching
- Returns batch, M, N, K dimension sizes as transform parameters.

Refer to the added tests for usage examples.