### PR TITLE
Don't inline immutable globals with non-util dialect attrs.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -98,6 +98,21 @@ util.func @foo(%arg0: index) -> (index, index, index) {
 
 // -----
 
+// Tests that we don't inline immutable globals with dialect attrs.
+// We could support this with an attr interface but today are conservative. The
+// loss here is that CSE is unlikely to fold identical globals in local scopes.
+
+// CHECK: util.global private @dont_inline
+util.global private @dont_inline {some.attr = "hello!"} = 5 : index
+// CHECK: @ignore_dialect_attrs
+util.func @ignore_dialect_attrs() -> index {
+  // CHECK: util.global.load immutable @dont_inline
+  %0 = util.global.load immutable @dont_inline : index
+  util.return %0 : index
+}
+
+// -----
+
 // CHECK: util.global private @immutable_initializer_local
 util.global private mutable @immutable_initializer_local : index
 // CHECK: util.global private @immutable_initializer_callee


### PR DESCRIPTION
`mlir::Dialect::materializeConstant` does not have a way for us to pass these and preserve them on the new op and we don't (yet) have an attr interface that lets us control the behavior. For now any non-util dialect attr will prevent inlining. Inlining is most useful early on for CSE and local folding but given that the predominate dialect attr near the frontend is an explicitly-specified `stream.affinity` and that's really bad to drop the conservative behavior is fine for now.

(we do have `IREE::Util::InliningPolicyAttrInterface` we could add some methods to, but the way FoldGlobalsPass works today doesn't really allow it to have the control it needs - whenever FoldGlobalsPass does finally get rewritten properly it should use it)

Fixes #21946.