### PR TITLE
Marking `stream.async.dispatch` as pure.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2660,7 +2660,7 @@ def Stream_AsyncStoreOp : Stream_PureOp<"async.store", [
   let hasCanonicalizer = 1;
 }
 
-def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
+def Stream_AsyncDispatchOp : Stream_PureOp<"async.dispatch", [
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,


### PR DESCRIPTION
At the async phase of IR it _should_ be legal to DCE/CSE dispatches, even if they in-place as tensors are still treated as immutable SSA values and we don't support side-effecting dispatches (today). If we did want side-effecting dispatches we'd want to annotate them as such and leave the default as non-side-effecting.

Combined with running canonicalizer/CSE after SperializeEncodingPass (to CSE stream.tensor.encode) this reduces duplication when data tiling is enabled. In non-data-tiling compilation the CSE happens in the flow dialect on dispatch regions and by construction we end up with few opportunities to CSE at the head of stream. With data tiling we introduce a lot of new dispatches that may be redundant and need to clean them up.

Concretely, the llama3 8b fp8 model with data-tiling enabled before these changes has 18,162,413,632 bytes of constants initailized on startup and after only 10,131,880,000 (which is much more in line with the expected size).