### PR TITLE
🚧 Infer / propagate alignment attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/AlignMemRefOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/AlignMemRefOps.cpp
@@ -1,0 +1,187 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <numeric> // for std::gcd
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "Passes.h"
+namespace mlir {
+#define GEN_PASS_DEF_ALIGNMEMREFOPSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+unsigned getElementTypeSize(DataLayout datalayout, MemRefType memRefType) {
+  Type elemTy = memRefType.getElementType();
+  auto elemTySize = datalayout.getTypeSize(elemTy);
+  auto elemTySizeInBytes = elemTySize.getFixedValue();
+  return elemTySizeInBytes;
+}
+
+unsigned int gcd(const SmallVectorImpl<unsigned int> &coefficients) {
+  assert(!coefficients.empty() && "coefficients must not be empty");
+  auto i = coefficients.begin();
+  unsigned int GCD = *i;
+  i++;
+  auto e = coefficients.end();
+  while (i != e) {
+    GCD = std::gcd(GCD, *i);
+    i++;
+  }
+  return GCD;
+}
+
+unsigned int getGreatestPowerOfTwoDivisor(unsigned int value) {
+  return value & -value;
+}
+
+unsigned int
+getStaticAlignmentGuarantee(const SmallVectorImpl<unsigned int> &coefficients) {
+  assert(!coefficients.empty() && "coefficients must not be empty");
+  return getGreatestPowerOfTwoDivisor(gcd(coefficients));
+}
+
+unsigned int
+getStaticAlignmentGuarantee(unsigned int sourceAlignment,
+                           SmallVectorImpl<unsigned int> &coefficients) {
+  coefficients.push_back(sourceAlignment);
+  return getStaticAlignmentGuarantee(coefficients);
+}
+
+FailureOr<unsigned int> getStaticAlignmentGuarantee(vector::LoadOp op,
+                                                    RewriterBase &rewriter) {
+  if (op.getAlignment()) {
+    return rewriter.notifyMatchFailure(op, "already aligned");
+  }
+
+  auto base = op.getBase();
+  auto definition = base.getDefiningOp();
+  if (!definition) {
+    return rewriter.notifyMatchFailure(op, "no known definition for operation");
+  }
+
+  // TODO: generalize to all operations
+  std::optional<uint64_t> alignment;
+  {
+    if (auto alloc = dyn_cast<memref::AllocOp>(definition)) {
+      alignment = alloc.getAlignment();
+    }
+  }
+
+  if (!alignment) {
+    return rewriter.notifyMatchFailure(op, "nothing to be done");
+  }
+
+  auto memRefType = cast<mlir::MemRefType>(base.getType());
+  llvm::SmallVector<int64_t> strides;
+  int64_t memref_offset;
+  if (mlir::failed(memRefType.getStridesAndOffset(strides, memref_offset))) {
+    return rewriter.notifyMatchFailure(
+        op, "this memref does not have statically known strided layout");
+  }
+
+  // TODO: Generalize
+  if (memref_offset != 0) {
+    return rewriter.notifyMatchFailure(
+        op, "this memref has an offset, and we are not handling it yet");
+  }
+
+  auto datalayout = mlir::DataLayout::closest(op);
+  unsigned elemTySizeInBytes = getElementTypeSize(datalayout, memRefType);
+
+  SmallVector<uint64_t> stridesInBytes;
+  for (auto stride : strides) {
+    stridesInBytes.push_back(stride * elemTySizeInBytes);
+  }
+
+  SmallVector<int> staticIndices;
+  auto indices = op.getIndices();
+  for (auto index : indices) {
+    auto indexDefinition = index.getDefiningOp();
+    if (!indexDefinition) {
+      staticIndices.push_back(-1);
+      continue;
+    }
+
+    auto cst = dyn_cast<arith::ConstantOp>(indexDefinition);
+    if (!cst) {
+      staticIndices.push_back(-1);
+      continue;
+    }
+    auto ithOffset = cast<IntegerAttr>(cst.getValue()).getInt();
+    staticIndices.push_back(ithOffset);
+  }
+
+  SmallVector<unsigned int> coefficients;
+  for (auto [ithStaticIndex, ithStrideInBytes] :
+       llvm::reverse(llvm::zip(staticIndices, stridesInBytes))) {
+    bool staticallyKnownIndex = ithStaticIndex != -1;
+    if (staticallyKnownIndex) {
+      auto staticOffset = ithStaticIndex * ithStrideInBytes;
+      auto offsetOrAlignment = staticOffset == 0 ? *alignment : staticOffset;
+      coefficients.push_back(offsetOrAlignment);
+      continue;
+    }
+    // This is weird since it corresponds to a dimension of size zero.
+    auto offsetOrAlignment = ithStrideInBytes == 0 ? *alignment : ithStrideInBytes;
+    coefficients.push_back(offsetOrAlignment);
+  }
+
+  return getStaticAlignmentGuarantee(*alignment, coefficients);
+}
+
+struct AlignVectorLoad : public OpRewritePattern<vector::LoadOp> {
+  using OpRewritePattern<vector::LoadOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::LoadOp op,
+                                PatternRewriter &rewriter) const override {
+
+    auto maybeNewAlignment = getStaticAlignmentGuarantee(op, rewriter);
+    if (failed(maybeNewAlignment)) {
+      return failure();
+    }
+    auto newAlignment = *maybeNewAlignment;
+    rewriter.modifyOpInPlace(op, [&] { op.setAlignment(newAlignment); });
+    return success();
+  }
+};
+
+struct AlignMemRefOpsPass
+    : public impl::AlignMemRefOpsPassBase<AlignMemRefOpsPass> {
+  using impl::AlignMemRefOpsPassBase<
+      AlignMemRefOpsPass>::AlignMemRefOpsPassBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+
+    mlir::iree_compiler::populateAlignMemRefOpsPatterns(patterns);
+
+    GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Disabled);
+    config.enableFolding(false);
+    config.enableConstantCSE(false);
+    if (failed(
+            applyPatternsGreedily(getOperation(), std::move(patterns), config)))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+namespace mlir::iree_compiler {
+void populateAlignMemRefOpsPatterns(RewritePatternSet &patterns) {
+  patterns.insert<AlignVectorLoad>(patterns.getContext());
+}
+
+std::unique_ptr<Pass> createAlignMemRefOpsPass() {
+  return std::make_unique<AlignMemRefOpsPass>();
+}
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -85,6 +85,7 @@ iree_cc_library(
     "UserConfig.h"
   SRCS
     "AddFastMathFlags.cpp"
+    "AlignMemRefOps.cpp"
     "BlockDynamicDimensions.cpp"
     "BubbleUpOrdinalOps.cpp"
     "BufferizationAnalysis.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_add_alignment.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_add_alignment.mlir
@@ -70,3 +70,28 @@ func.func @dyn_idxs_right(%dynidx : index) -> vector<8xi64> {
   %0 = vector.load %alloc[%c0, %dynidx] : memref<8x8xi64>, vector<8xi64>
   return %0 : vector<8xi64>
 }
+
+// -----
+
+// CHECK-LABEL: @constant_one
+func.func @constant_one(%dynidx : index) -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8x8xi64>
+  %c1 = arith.constant 1 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 8
+  %0 = vector.load %alloc[%dynidx, %c1] : memref<8x8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @constant_two
+func.func @constant_two(%dynidx : index) -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8x8xi64>
+  %c1 = arith.constant 2 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 16
+  %0 = vector.load %alloc[%dynidx, %c1] : memref<8x8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_add_alignment.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_add_alignment.mlir
@@ -1,0 +1,72 @@
+// CHECK-LABEL: @vector_load_already_aligned
+func.func @vector_load_already_aligned() -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8xi64>
+  %c0 = arith.constant 0 : index
+  // Verify that we did not propagate alignment from the allocation
+  // to the load since the load is already annotated with an alignment.
+  //
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 32
+  %0 = vector.load %alloc[%c0] { alignment = 32 : i64 } : memref<8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @match_failure_no_definition
+func.func @match_failure_no_definition(%alloc : memref<8xi64>) -> vector<8xi64> {
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.load
+  // CHECK-NOT: alignment
+  %0 = vector.load %alloc[%c0] : memref<8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @trivial_case
+func.func @trivial_case() -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8xi64>
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 64
+  %0 = vector.load %alloc[%c0] : memref<8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @trivial_case_i8
+func.func @trivial_case_i8() -> vector<8xi8> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8xi8>
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 64
+  %0 = vector.load %alloc[%c0] : memref<8xi8>, vector<8xi8>
+  return %0 : vector<8xi8>
+}
+
+
+// -----
+
+// CHECK-LABEL: @dyn_idxs_left
+func.func @dyn_idxs_left(%dynidx : index) -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8x8xi64>
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 64
+  %0 = vector.load %alloc[%dynidx, %c0] : memref<8x8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @dyn_idxs_right
+func.func @dyn_idxs_right(%dynidx : index) -> vector<8xi64> {
+  %alloc = memref.alloc() { alignment = 64 : i64 } : memref<8x8xi64>
+  %c0 = arith.constant 0 : index
+  // CHECK: vector.load
+  // CHECK-SAME: alignment = 8
+  %0 = vector.load %alloc[%c0, %dynidx] : memref<8x8xi64>, vector<8xi64>
+  return %0 : vector<8xi64>
+}

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -142,6 +142,7 @@ void populateVectorTransferTensorSliceTransforms(RewritePatternSet &patterns,
                                                  PatternBenefit benefit = 1);
 
 void populateDecomposeMemrefsPatterns(RewritePatternSet &patterns);
+void populateAlignMemRefOpsPatterns(RewritePatternSet &patterns);
 
 /// Add a pattern to combine instructions across scf.for boundary. It is common
 /// when doing incremental lowering to generate transient ops that cancel each

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -219,6 +219,16 @@ def DecomposeMemrefsPass :
   let summary = "Decomposes memrefs";
 }
 
+def AlignMemRefOpsPass:
+    Pass<"iree-codegen-align-memref-ops", ""> {
+  let summary = "Aligns memref ops";
+
+  let dependentDialects = [
+      "memref::MemRefDialect"
+  ];
+}
+
+
 def DecomposeLinalgGenericPass :
     Pass<"iree-codegen-decompose-linalg-generic", ""> {
   let summary = "Decomposes linalg generic ops into individual ops";


### PR DESCRIPTION
This is a work in progress PR that propagates alignment attributes.

```mlir
// ... from ...
%memref = memref.alloc() { alignment = 64 : i64 } : memref<8xf32>
// … to …
%vector = vector.load %memref[%cst0] : memref<8xf32> into vector<8xf32>
```

At the moment, only `vector.load` is matched and a `memref.alloc` operation with an alignment attribute must be the source of the load.

For the general case of n-dimensional indexing

```
%vector = vector.load %memref[%dyn, %dyn, %cst0, %cst16, %dyn, %cst0] : … into vector…
```

Computing the new address looks like the following

```
// pseudocode
// indices here correspond to the dimension being accessed. 
%new_address = %memref + %cst0 * strides_in_bytes[0] + %dyn * strides_in_bytes[1]  + %cst_16 * strides_in_bytes[2] …
```

Which we can use the following mathematical property:

If c | a (read a is divisible by c) and c | b, then c | (k_0 x a + k_1 x b) (read c divides any linear combination of a and b)

Rewriting the formula above.

```
%new_address = %memref/alignment * alignment + %cst0 * strides_in_bytes[0] + %dyn * strides_in_bytes[1]  + %cst_16 * strides_in_bytes[2] …
```

And now what we are interested in finding is the greatest common denominator (which corresponds to the greatest possible alignment) which is also a power of two.

Note that we are also doing gcd in modulo the alignment attribute in the memref.alloc. This means that a zero constant index is the same as no displacement or a displacement by a unit of alignment.

For gcd(a, b) = c => c | a and c | b then for all constant indices we can get the gcd for the concrete offset and unknown indices the gcd of the strides in bytes

C = gcd(alignment, %cst * strides_in_bytes[i], …, strides_in_bytes[1], …)

Then C is the gcd for all accesses. C is not guaranteed to be a power of two, but we just need to find out the highest power level of two that is a divisor of C and that is our alignment.

This also shows that in case when we don’t know the inner-most dimension, the best alignment we can possibly have is just the size of the element type in bytes, which matches reality.
