### PR TITLE
[Encoding] set default option for scaled matmul encodings to false

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
@@ -29,7 +29,7 @@ namespace mlir::iree_compiler::DispatchCreation {
 /// is implemented.
 static llvm::cl::opt<bool> clTestSetScaledMatmulEncodings(
     "iree-dispatch-creation-test-set-scaled-matmul-encodings",
-    llvm::cl::desc("Set encodings on scaled matmul ops"), llvm::cl::init(true),
+    llvm::cl::desc("Set encodings on scaled matmul ops"), llvm::cl::init(false),
     llvm::cl::Hidden);
 
 namespace {


### PR DESCRIPTION
There isn't support in `MaterializeEncodings` pass for scaled matmuls yet. Have this option off by default.