### PR TITLE
[TensorExt] Fix dynamic dim canonicalization in bitcast folder

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -80,6 +80,7 @@ struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
         newResultSizes[resDynamicDim] = castSize;
       }
       ++intermediateDynamicDim;
+      ++resDynamicDim;
     }
 
     auto newType =

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
@@ -12,12 +12,12 @@ util.func public @tensorBitCastEmptyProducer(%arg0: index, %arg1: index, %arg2:i
 // -----
 
 // CHECK-LABEL: @tensorBitCastCastProducer
-util.func public @tensorBitCastCastProducer(%arg0: tensor<3x6xi8>, %arg1: index) -> tensor<?x3xi16> {
-  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<3x6xi8>
-  %0 = tensor.cast %arg0 : tensor<3x6xi8> to tensor<?x6xi8>
-  // CHECK-NEXT: %[[BITCAST:.+]] = iree_tensor_ext.bitcast %[[ARG0]] : tensor<3x6xi8> -> tensor<3x3xi16>
-  %1 = iree_tensor_ext.bitcast %0 : tensor<?x6xi8>{%arg1} -> tensor<?x3xi16>{%arg1}
-  // CHECK-NEXT: %[[CAST:.+]] = tensor.cast %[[BITCAST]] : tensor<3x3xi16> to tensor<?x3xi16>
-  util.return %1 : tensor<?x3xi16>
+util.func public @tensorBitCastCastProducer(%arg0: tensor<10x3x6xi8>, %arg1: index, %arg2: index) -> tensor<?x?x3xi16> {
+  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<10x3x6xi8>
+  %0 = tensor.cast %arg0 : tensor<10x3x6xi8> to tensor<?x?x6xi8>
+  // CHECK-NEXT: %[[BITCAST:.+]] = iree_tensor_ext.bitcast %[[ARG0]] : tensor<10x3x6xi8> -> tensor<10x3x3xi16>
+  %1 = iree_tensor_ext.bitcast %0 : tensor<?x?x6xi8>{%arg1, %arg2} -> tensor<?x?x3xi16>{%arg1, %arg2}
+  // CHECK-NEXT: %[[CAST:.+]] = tensor.cast %[[BITCAST]] : tensor<10x3x3xi16> to tensor<?x?x3xi16>
+  util.return %1 : tensor<?x?x3xi16>
   // CHECK-NEXT: util.return %[[CAST]]
 }


### PR DESCRIPTION
Fixes a bug causing the wrong dimensions being updated in case of a `iree_tensor_ext.bitcast` with multiple dynamic dimensions on corresponding static dimensions in the preceding `tensor.cast`. I just updated an existing lit test to also check for this case to avoid adding a new test.