### PR TITLE
[LinalgExt] Add canonicalization to convert identity map_scatter to copy

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -27,6 +27,9 @@ def IREELinalgExt_Dialect : Dialect {
     A dialect designed for experimenting with non-structured operations that
     cannot be represented efficiently/directly by the Linalg dialect.
   }];
+  let dependentDialects = [
+    "linalg::LinalgDialect"
+  ];
   let useDefaultAttributePrinterParser = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -353,6 +353,7 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$transformation_region);
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let assemblyFormat = [{
     attr-dict $input `into` $output
     $transformation_region

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -213,3 +213,22 @@ func.func public @staticize_online_attention_from_cast(%arg0: tensor<?x4096x16xf
 //      CHECK:   %[[ATTENTION:.+]]:3 = iree_linalg_ext.online_attention
 // CHECK-SAME:       ins(%[[CAST]], %[[ARG1]], %[[ARG2]], %[[ARG3]] :
 //      CHECK:   return %[[ATTENTION]]#0
+
+// -----
+
+func.func public @convert_identity_map_scatter_into_copy(
+    %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>
+) -> tensor<?x?xf32> {
+  %true = arith.constant true
+  %map_scatter = iree_linalg_ext.map_scatter %arg0 into %arg1 {
+  ^bb0(%arg2: index, %arg3: index):
+    iree_linalg_ext.yield %arg2, %arg3, %true : index, index, i1
+  } : tensor<?x?xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
+  return %map_scatter : tensor<?x?xf32>
+}
+//CHECK-LABEL: func public @convert_identity_map_scatter_into_copy(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-NOT:   iree_linalg_ext.map_scatter
+//      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
+//      CHECK:   return %[[COPY]]


### PR DESCRIPTION
Adds a canonicalization pattern to fold identity map_scatter ops into linalg copy. The copy is a better form because it is a much simpler representation of the computation. Currently, this only affects the e2e tests for map_scatter, since we currently only introduce map_scatter if the transformation is non-trivial. If we end up with a copy-like map_scatter, then it is better to canonicalize it early to simplify code generation.