### PR TITLE
Integrate LLVM at llvm/llvm-project@0648c5183f32

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -341,7 +341,7 @@ struct DistributeTrivialExtract final
           extractOp, "Only 0-rank vector extractions supported");
     }
 
-    VectorValue source = extractOp.getVector();
+    VectorValue source = extractOp.getSource();
     VectorLayoutInterface sourceLayout = signature[source];
 
     Value distributed = vector::ExtractOp::create(

--- a/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
@@ -127,11 +127,11 @@ static scf::ForOp hoistVectorExtractInsertSlice(
   // BBArgs are updated.
   for (auto extractStridedSliceOp : extractOps) {
     extractStridedSliceOp->moveBefore(forOp);
-    if (!forOp.isDefinedOutsideOfLoop(extractStridedSliceOp.getVector())) {
-      assert(extractStridedSliceOp.getVector() == tensorBBArg &&
+    if (!forOp.isDefinedOutsideOfLoop(extractStridedSliceOp.getSource())) {
+      assert(extractStridedSliceOp.getSource() == tensorBBArg &&
              "extractSlice source not defined above must be the tracked bbArg");
       rewriter.startOpModification(extractStridedSliceOp);
-      extractStridedSliceOp.getVectorMutable().assign(
+      extractStridedSliceOp.getSourceMutable().assign(
           forOp.getInitArgs()[initArgNumber]);
       rewriter.finalizeOpModification(extractStridedSliceOp);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -68,11 +68,9 @@ struct ConvertToNVVMPass final
         converter, [](gpu::AddressSpace space) -> unsigned {
           switch (space) {
           case gpu::AddressSpace::Global:
-            return static_cast<unsigned>(
-                NVVM::NVVMMemorySpace::kGlobalMemorySpace);
+            return static_cast<unsigned>(NVVM::NVVMMemorySpace::Global);
           case gpu::AddressSpace::Workgroup:
-            return static_cast<unsigned>(
-                NVVM::NVVMMemorySpace::kSharedMemorySpace);
+            return static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared);
           case gpu::AddressSpace::Private:
             return 0;
           }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -89,7 +89,7 @@ static MaskResult getMask(Operation *op) {
       transferRead.getMask().getDefiningOp<vector::ExtractOp>();
   auto maskOp =
       maybeExtractOp
-          ? maybeExtractOp.getVector().getDefiningOp<vector::CreateMaskOp>()
+          ? maybeExtractOp.getSource().getDefiningOp<vector::CreateMaskOp>()
           : transferRead.getMask().getDefiningOp<vector::CreateMaskOp>();
   if (maybeExtractOp) {
     if (maybeExtractOp.getStaticPosition().size() + 1 !=

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
@@ -70,7 +70,7 @@ struct BreakDownCastExtractExtend final : OpRewritePattern<arith::ExtUIOp> {
     if (!extractOp)
       return failure();
 
-    auto bitCastOp = extractOp.getVector().getDefiningOp<vector::BitCastOp>();
+    auto bitCastOp = extractOp.getSource().getDefiningOp<vector::BitCastOp>();
     if (!bitCastOp)
       return failure();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -100,7 +100,7 @@ Operation *stripElementBitPatternPreservingParents(Value op) {
               return broadcast.getVector();
             })
             .Case<vector::ExtractOp, vector::ExtractStridedSliceOp>(
-                [](auto extract) { return extract.getVector(); })
+                [](auto extract) { return extract.getSource(); })
             .Case<vector::InsertOp, vector::InsertStridedSliceOp>(
                 [](auto insert) { return insert.getValueToStore(); })
             .Case<vector::TransposeOp>([](vector::TransposeOp transpose) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -1015,7 +1015,7 @@ struct ReifyExtractOfCreateMask final
     if (isa<VectorType>(extractOp.getResult().getType())) {
       return failure();
     }
-    auto maskOp = extractOp.getVector().getDefiningOp<vector::CreateMaskOp>();
+    auto maskOp = extractOp.getSource().getDefiningOp<vector::CreateMaskOp>();
     if (!maskOp) {
       return failure();
     }


### PR DESCRIPTION
`vector.extract` op `getVector` was deprecated for `getSource`.
NVVMMemorySpace constants were renamed and shortened.