### PR TITLE
[Dispatch Creation] Fuse bcast with attention instead of producer

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -167,6 +167,7 @@ void ElementwiseOpFusionPass::runOnOperation() {
         ElementwiseOpsFusabilityOptions options;
         options.fuseMultiReduction = fuseMultiReduction;
         options.fuseTruncateOps = fuseTruncateOps;
+        options.fuseBroadcastConsumers = fuseBroadcastOps;
         return areFusableAsElementwiseOps(context, fusedOperand, options);
       };
 

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -60,6 +60,11 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
     return false;
   }
 
+  if (!options.fuseBroadcastConsumers &&
+      IREE::LinalgExt::isBroadcastingOp(linalgConsumerOp)) {
+    return false;
+  }
+
   // Do no fuse bitextend-like operations with producers. Such ops are cloned
   // into all their use dispatches. So fusing producer with consumer here would
   // then result in producer also getting cloned into many dispatches which is

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
@@ -22,6 +22,8 @@ struct ElementwiseOpsFusabilityOptions {
   bool fuseMultiReduction = false;
   // Control fusion with producer that is a truncate-like operation.
   bool fuseTruncateOps = false;
+  // Control fusion with a consumer that is broadcast-like.
+  bool fuseBroadcastConsumers = false;
 };
 bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *operand,
                                 ElementwiseOpsFusabilityOptions options);

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -118,7 +118,8 @@ static void addDispatchRegionCreationPreprocessingPasses(
             ElementwiseOpFusionPassOptions{
                 /*intraDispatch=*/false,
                 /*fuseMultiReduction=*/clEnableElementWiseFuseMultiReduction,
-                /*fuseTruncateOps=*/clEnableEarlyTruncFusion});
+                /*fuseTruncateOps=*/clEnableEarlyTruncFusion,
+                /*fuseBroadcastOps=*/false});
       })
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
@@ -137,7 +138,8 @@ static void addDispatchRegionCreationPreprocessingPasses(
             ElementwiseOpFusionPassOptions{
                 /*intraDispatch=*/false,
                 /*fuseMultiReduction=*/clEnableElementWiseFuseMultiReduction,
-                /*fuseTruncateOps=*/clEnableEarlyTruncFusion});
+                /*fuseTruncateOps=*/clEnableEarlyTruncFusion,
+                /*fuseBroadcastOps=*/false});
       })
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
@@ -221,7 +223,8 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
         return DispatchCreation::createElementwiseOpFusionPass(
             ElementwiseOpFusionPassOptions{/*intraDispatch=*/true,
                                            /*fuseMultiReduction=*/false,
-                                           /*fuseTruncateOps=*/true});
+                                           /*fuseTruncateOps=*/true,
+                                           /*fuseBroadcastOps=*/true});
       })
       // 5. After all the reshape propagations, fuse elementwise operations
       //    even if the producer has multiple uses.

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -51,11 +51,15 @@ def ElementwiseOpFusionPass :
   let summary = "Fuse elementwise operations.";
   let options = [
     Option<"intraDispatch", "intra-dispatch", "bool",
-           /*default=*/"false", "Fuse operations within a dispatch only (default is to fuse only operations outside of a dispatch)">,
+           /*default=*/"false",
+           "Fuse operations within a dispatch only (default is to fuse only operations outside of a dispatch)">,
     Option<"fuseMultiReduction", "fuse-multi-reduction", "bool",
            /*default=*/"true", "Fuse ops that have multiple reduction iterators">,
     Option<"fuseTruncateOps", "fuse-truncate-ops", "bool",
-           /*default=*/"false", "Fuse producer truncate-like operations with consumers">,
+           /*default=*/"false",
+           "Fuse producer truncate-like operations with consumers">,
+    Option<"fuseBroadcastOps", "fuse-broadcast-ops", "bool",
+           /*default=*/"false", "Fuse broadcast-like ops with producers">,
   ];
   let dependentDialects = [
     "mlir::affine::AffineDialect",


### PR DESCRIPTION
This change waits to fuse broadcasts until after reshape propagation allowing broadcasts to fuse with consumers. This is important because it allows codegen to better infer the dims of the attention op. More generally, fusing a broadcast with consumer is better since it reduces the chance of materializing the broadcasted tensor.


Closes https://github.com/iree-org/iree/issues/22005