### PR TITLE
[Dispatch Creation] Create more multi-use dispatches

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -149,10 +149,8 @@ void ElementwiseOpFusionPass::runOnOperation() {
           return false;
         }
 
-        // Limit the number of operands. We have hard limit (32) of bindings
-        // passing down to HAL. Set the number to be as same as the limit --
-        // IREE_HAL_MODULE_MAX_DESCRIPTOR_BINDING_COUNT.
-        constexpr int64_t kIreeMaxOperandCount = 32;
+        // Limit the number of operands to avoid exceeding backend binding
+        // limits.
         DenseSet<Value> operands;
         operands.insert(producer->operand_begin(), producer->operand_end());
         operands.insert(consumer->operand_begin(),

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -717,17 +717,6 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
         continue;
       }
 
-      // For now prune the fusable uses due to codegen failures. Ideally we
-      // should just be taking the whole set of fusable uses.
-      if (IREE::LinalgExt::isBitTruncateOp(fusableUses.front()->getOwner())) {
-        fusableUses =
-            llvm::filter_to_vector(fusableUses, [](OpOperand *operand) {
-              return IREE::LinalgExt::isBitTruncateOp(operand->getOwner());
-            });
-      } else {
-        fusableUses.resize(1);
-      }
-
       // Analyse the use to see if it is fusable.
       for (OpOperand *fusableUse : fusableUses) {
         Operation *consumerOp = fusableUse->getOwner();

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -50,9 +50,6 @@
 
 namespace mlir::iree_compiler::DispatchCreation {
 
-// Maximum number of operands allowed for a dispatch region.
-constexpr int kIreeMaxOperandCount = 16;
-
 #define GEN_PASS_DEF_FORMDISPATCHREGIONSPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
 

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -1089,7 +1089,8 @@ createFusionGroups(TensorDimTrackingRewriter &rewriter,
       auto newRegionOp = IREE::Flow::moveFollowingOpIntoDispatchRegion(
           rewriter, consumer, regionOp);
       if (failed(newRegionOp)) {
-        return consumer->emitOpError("failed to move consumer into region");
+        consumer->emitWarning("failed to move consumer into region");
+        continue;
       }
       regionOp = *newRegionOp;
     }

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -606,7 +606,9 @@ isFusableWithConsumer(OpOperand &fusedOperand, const FusionTracker &tracker,
 
   // If consumer is a dequant operation, dont fuse it. These get cloned
   // into their consumers.
-  if (IREE::LinalgExt::isBitExtendOp(consumer)) {
+  IREE::Flow::ClonableIntoDispatchOptions clonableOptions;
+  clonableOptions.aggressive = options.aggressiveFusion;
+  if (IREE::Flow::isClonableIntoDispatchOp(consumer, clonableOptions)) {
     return false;
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.h
@@ -10,10 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cstdint>
+
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir::iree_compiler::DispatchCreation {
+
+// Maximum number of operands/bindings allowed for a dispatch region.
+// This is constrained by the most restrictive GPU backends (CUDA, HIP/ROCm,
+// Metal) which all have a limit of 16 bindings. See:
+// - IREE_HAL_CUDA_MAX_DISPATCH_BINDING_COUNT = 16
+// - IREE_HAL_HIP_MAX_DISPATCH_BINDING_COUNT = 16
+constexpr int64_t kIreeMaxOperandCount = 16;
 
 /// Return true of the producer and consumer of `operand` are fusable
 /// using elementwise op fusion transformation.

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -247,6 +247,7 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
       .addPass([] {
         FuseMultiUseElementwiseProducerPassOptions options;
         options.intraDispatch = true;
+        options.numIterations = 32;
         return DispatchCreation::createFuseMultiUseElementwiseProducerPass(
             options);
       })

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -1897,7 +1897,6 @@ util.func public @dont_fuse_no_shared_parallel_loops(%arg0: tensor<16x16x24xf32>
   } -> (tensor<64x3x32xf32>, tensor<32x64x3xf32>)
   util.return %5#0, %5#1 : tensor<64x3x32xf32>, tensor<32x64x3xf32>
 }
-
 // CHECK-LABEL: util.func public @dont_fuse_no_shared_parallel_loops(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<16x16x24xf32>
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<64x3x32xf32>)
@@ -1910,3 +1909,55 @@ util.func public @dont_fuse_no_shared_parallel_loops(%arg0: tensor<16x16x24xf32>
 //  CHECK-SAME:       ins(%[[ARG1]], %[[DISPATCH0]]
 //       CHECK:     flow.return %[[GENERIC]]#0, %[[GENERIC]]#1
 //       CHECK:   util.return %[[DISPATCH1]]#0, %[[DISPATCH1]]#1
+
+// -----
+
+util.func public @fuse_reduction_with_two_consumers(%arg0 : tensor<?x?xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %empty = tensor.empty(%d0) : tensor<?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?xf32>) -> tensor<?xf32>
+  %reduction = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<?x?xf32>) outs(%fill : tensor<?xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32):
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<?xf32>
+  %consumer1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%reduction : tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32):
+      %0 = arith.mulf %b0, %b0 : f32
+      linalg.yield %0 : f32
+  } -> tensor<?xf32>
+  %consumer2 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%reduction : tensor<?xf32>) outs(%empty : tensor<?xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32):
+      %0 = arith.addf %b0, %b0 : f32
+      linalg.yield %0 : f32
+  } -> tensor<?xf32>
+  util.return %consumer1, %consumer2 : tensor<?xf32>, tensor<?xf32>
+}
+// CHECK-LABEL: util.func public @fuse_reduction_with_two_consumers
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//       CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.region
+//       CHECK:     %[[REDUCTION:.+]] = linalg.generic
+//  CHECK-SAME:         iterator_types = ["parallel", "reduction"]
+//  CHECK-SAME:         ins(%[[ARG0]] :
+//       CHECK:     %[[CONSUMER1:.+]] = linalg.generic
+//  CHECK-SAME:         iterator_types = ["parallel"]
+//  CHECK-SAME:         ins(%[[REDUCTION]] :
+//       CHECK:     %[[CONSUMER2:.+]] = linalg.generic
+//  CHECK-SAME:         iterator_types = ["parallel"]
+//  CHECK-SAME:         ins(%[[REDUCTION]] :
+//       CHECK:     flow.return %[[CONSUMER1]], %[[CONSUMER2]]
+//       CHECK:   util.return %[[DISPATCH]]#0, %[[DISPATCH]]#1

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 17.0
+    "golden_time_ms": 18.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 20.0
+    "golden_time_ms": 21.0
 }


### PR DESCRIPTION
This change allows producers to try to fuse with all consumers. Previously, fusing with multiple consumers was only allowed if the consumers were all truncate ops. This has been removed.

This has some side effects that require a few other accompanying changes:
1. This PR can lead to dispatches with many ops and many operands to the dispatch. To prevent forming dispatches with more operands than the runtime can handle, `wouldExceedOperandLimit` was added to limit the number of operands to 16.
2. The golden times for datatiling llama decode were slightly increased. See https://github.com/iree-org/iree/issues/22841 for more details.
3. `options.numIterations = 32` was added to more aggressively fuse multi-use elementwise ops in the same dispatch to prevent codegen issues.
4. Changed check to prevent fusion from `IREE::LinalgExt::isBitExtendOp()` to `IREE::Flow::isClonableIntoDispatchOp()` to prevent fusing with scatter's index producer when it should be cloned.
5. Changed error to warning when `IREE::Flow::moveFollowingOpIntoDispatchRegion` fails. This can occur because `hasTransitiveDependencyOnFusionGroup` does not account for moving ops into dispatch regions. For example, A and B have no use-def relation and A does have a "transitive dep on the fusion group" but B doesn't. If you place A and B in the same dispatch, then asking if B `hasTransitiveDependencyOnFusionGroup` you must also consider all ops in the dispatch too. Which is currently unaccounted for. Side note: this change was supposed to be made in https://github.com/iree-org/iree/pull/22708, but I think I merged without actually making this change.

Related: https://github.com/iree-org/iree/issues/22528
Closes: https://github.com/iree-org/iree/issues/22462

ci-extra: test_torch