### PR TITLE
Respect user `FILECHECK_OPTS`/`LIT_OPTS` environment variables when running through ctest

### DIFF
--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -78,7 +78,7 @@ function(iree_lit_test)
   set_property(TEST ${_NAME_PATH} PROPERTY REQUIRED_FILES "${_TEST_FILE_PATH}")
   set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT_MODIFICATION
     "LIT_OPTS=string_prepend:-v "
-    "FILECHECK_OPTS=string_prepend:--enable-var-scope --color ")
+    "FILECHECK_OPTS=string_prepend:--enable-var-scope ")
   set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
   iree_configure_test(${_NAME_PATH})
 

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -76,9 +76,9 @@ function(iree_lit_test)
   list(APPEND _RULE_LABELS "test-type=lit-test")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_NAME_PATH} PROPERTY REQUIRED_FILES "${_TEST_FILE_PATH}")
-  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
-    "LIT_OPTS=-v"
-    "FILECHECK_OPTS=--enable-var-scope")
+  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT_MODIFICATION
+    "LIT_OPTS=string_prepend:-v "
+    "FILECHECK_OPTS=string_prepend:--enable-var-scope --color ")
   set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
   iree_configure_test(${_NAME_PATH})
 


### PR DESCRIPTION
This changes the cmake logic to prepend to the existing env var rather than overriding it.

My main use case is to set `FILECHECK_OPTS=--color` locally to get colour output in test errors.