### PR TITLE
[PassUtils] Allow passing overload constructors to `addPredicatedPass`

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -156,17 +156,14 @@ static void addDispatchRegionCreationPreprocessingPasses(
   FunctionLikeNest(passManager)
       // 5. After all the reshape propagations, fuse elementwise operations
       //    even if the producer has multiple uses.
-      .addPredicatedPass(dispatchOptions.enableFuseMultiUse,
-                         [&]() {
-                           return DispatchCreation::
-                               createFuseMultiUseElementwiseProducerPass();
-                         })
+      .addPredicatedPass(
+          dispatchOptions.enableFuseMultiUse,
+          DispatchCreation::createFuseMultiUseElementwiseProducerPass)
 
       // 6. Some more "post elementwise fusion passes".
       //    a. Detensorize.
       //       TODO: This is probably not in the right place.
-      .addPredicatedPass(clDetensoring,
-                         [&]() { return mlir::createLinalgDetensorizePass(); })
+      .addPredicatedPass(clDetensoring, mlir::createLinalgDetensorizePass)
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -30,20 +30,15 @@ public:
     addNest<0, OpTys...>();
   }
 
-  template <typename F>
+  // We give the template param a default to support passing overload
+  // constructors (i.e. createCanonicalizerPass).
+  template <typename F = std::unique_ptr<Pass> (*)()>
   MultiOpNest &addPass(F constructor) {
     addPassInternal(constructor);
     return *this;
   }
 
-  // We have an explicit overload for a concrete function to support
-  // passing overload constructors (i.e. createCanonicalizerPass).
-  MultiOpNest &addPass(std::unique_ptr<Pass> (*constructor)()) {
-    addPassInternal(constructor);
-    return *this;
-  }
-
-  template <typename F>
+  template <typename F = std::unique_ptr<Pass> (*)()>
   MultiOpNest &addPredicatedPass(bool enable, F constructor) {
     if (enable) {
       addPassInternal(constructor);


### PR DESCRIPTION
`addPass` already had an overload to handle this, this just transfers the idea over to `addPredicatedPass`.