### PR TITLE
Revert "[PassUtils] Allow passing overload constructors to `addPredicatedPass`"

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -156,14 +156,17 @@ static void addDispatchRegionCreationPreprocessingPasses(
   FunctionLikeNest(passManager)
       // 5. After all the reshape propagations, fuse elementwise operations
       //    even if the producer has multiple uses.
-      .addPredicatedPass(
-          dispatchOptions.enableFuseMultiUse,
-          DispatchCreation::createFuseMultiUseElementwiseProducerPass)
+      .addPredicatedPass(dispatchOptions.enableFuseMultiUse,
+                         [&]() {
+                           return DispatchCreation::
+                               createFuseMultiUseElementwiseProducerPass();
+                         })
 
       // 6. Some more "post elementwise fusion passes".
       //    a. Detensorize.
       //       TODO: This is probably not in the right place.
-      .addPredicatedPass(clDetensoring, mlir::createLinalgDetensorizePass)
+      .addPredicatedPass(clDetensoring,
+                         [&]() { return mlir::createLinalgDetensorizePass(); })
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
 

--- a/compiler/src/iree/compiler/Utils/PassUtils.h
+++ b/compiler/src/iree/compiler/Utils/PassUtils.h
@@ -30,15 +30,20 @@ public:
     addNest<0, OpTys...>();
   }
 
-  // We give the template param a default to support passing overload
-  // constructors (i.e. createCanonicalizerPass).
-  template <typename F = std::unique_ptr<Pass> (*)()>
+  template <typename F>
   MultiOpNest &addPass(F constructor) {
     addPassInternal(constructor);
     return *this;
   }
 
-  template <typename F = std::unique_ptr<Pass> (*)()>
+  // We have an explicit overload for a concrete function to support
+  // passing overload constructors (i.e. createCanonicalizerPass).
+  MultiOpNest &addPass(std::unique_ptr<Pass> (*constructor)()) {
+    addPassInternal(constructor);
+    return *this;
+  }
+
+  template <typename F>
   MultiOpNest &addPredicatedPass(bool enable, F constructor) {
     if (enable) {
       addPassInternal(constructor);


### PR DESCRIPTION
Seems to hit a failure on mi305/gfx942 https://github.com/iree-org/iree/actions/runs/17808626009/job/50627253192

Reverts iree-org/iree#22021