### PR TITLE
[CI] Disabling WebGPU build due to CI failures.

### DIFF
--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -29,7 +29,7 @@ IREE_TARGET_BACKEND_ROCM="${IREE_TARGET_BACKEND_ROCM:-${OFF_IF_DARWIN}}"
 # Enable WebGPU compiler builds and tests by default. All deps get fetched as
 # needed, but some of the deps are too large to enable by default for all
 # developers.
-IREE_TARGET_BACKEND_WEBGPU_SPIRV="${IREE_TARGET_BACKEND_WEBGPU_SPIRV:-ON}"
+IREE_TARGET_BACKEND_WEBGPU_SPIRV="${IREE_TARGET_BACKEND_WEBGPU_SPIRV:-${OFF_IF_DARWIN}}"
 # Enable building the `iree-test-deps` target.
 IREE_BUILD_TEST_DEPS="${IREE_BUILD_TEST_DEPS:-1}"
 


### PR DESCRIPTION
There seems to be an error when installing `Tint` dependencies needed for MacOS. The error is 
```
FAILED: [code=1] _deps/tint-build/src/tint/CMakeFiles/tint_diagnostic_utils.dir/debug.cc.o 
/usr/local/bin/ccache /usr/bin/c++ -DTINT_BUILD_GLSL_WRITER=0 -DTINT_BUILD_HLSL_WRITER=0 -DTINT_BUILD_IR=1 -DTINT_BUILD_MSL_WRITER=0 -DTINT_BUILD_SPV_READER=1 -DTINT_BUILD_SPV_WRITER=0 -DTINT_BUILD_WGSL_READER=0 -DTINT_BUILD_WGSL_WRITER=1 -I/Users/runner/work/iree/iree/build-macos/_deps/tint-src/third_party/vulkan-deps/spirv-tools/src/include -I/Users/runner/work/iree/iree/build-macos/_deps/tint-src -I/Users/runner/work/iree/iree/build-macos/_deps/tint-src/include -I/Users/runner/work/iree/iree/build-macos/_deps/tint-src/third_party/vulkan-deps/spirv-headers/src/include -O2 -g  -std=gnu++17 -fPIC -std=c++17 -fno-exceptions -fno-rtti -pedantic-errors -Wall -Werror -Wextra -Wno-documentation-unknown-command -Wno-padded -Wno-switch-enum -Wno-unknown-pragmas -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-format-pedantic -Wno-return-std-move-in-c++11 -Wno-unknown-warning-option -Wno-undefined-var-template -Wno-used-but-marked-unused -Weverything -MD -MT _deps/tint-build/src/tint/CMakeFiles/tint_diagnostic_utils.dir/debug.cc.o -MF _deps/tint-build/src/tint/CMakeFiles/tint_diagnostic_utils.dir/debug.cc.o.d -o _deps/tint-build/src/tint/CMakeFiles/tint_diagnostic_utils.dir/debug.cc.o -c /Users/runner/work/iree/iree/build-macos/_deps/tint-src/src/tint/debug.cc
error: include location '/usr/local/include' is unsafe for cross-compilation [-Werror,-Wpoison-system-directories]
1 error generated.
```

See https://github.com/iree-org/iree/actions/runs/17792972687/job/50574065806 

Disabling the webGPU build seems to avoid the error and makes the test green.

https://github.com/iree-org/iree/actions/runs/17813010018