### PR TITLE
[CPU] Add precondition to kernel dispatch method selection for gemm.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -2192,3 +2192,25 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 // CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
 // CHECK:         linalg.pack
 // CHECK-NOT:      lowering_config
+
+// -----
+
+#executable_target_embedded_elf_x86_64 = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", native_vector_size = 64 : i64, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d5, d6)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4, d5)>
+func.func @batch_mmt4d_generic_form(%lhs: tensor<128x10x32x8x1xf32>, %rhs: tensor<128x80x32x4x1xf32>, %acc: tensor<128x10x80x8x4xf32>) -> tensor<128x10x80x8x4xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64} {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%lhs, %rhs : tensor<128x10x32x8x1xf32>, tensor<128x80x32x4x1xf32>)
+    outs(%acc : tensor<128x10x80x8x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<128x10x80x8x4xf32>
+  return %0 : tensor<128x10x80x8x4xf32>
+}
+// CHECK:       #[[$CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 10, 20, 0, 8, 4, 0], vector_common_parallel = [1, 1, 1, 0, 1, 4, 0], vector_reduction = [0, 0, 0, 1, 0, 0, 0]>
+// CHECK-LABEL: func.func @batch_mmt4d_generic_form(
+// CHECK:         linalg.generic
+// CHECK-SAME:      {lowering_config = #[[$CONFIG]]}


### PR DESCRIPTION
The legacy code expects single reduction loop and being the innermost dimension. The revision moves the assertion to `precondition` method and use it in the entry.

This is a post-fix for downstream project failure: https://github.com/nod-ai/iree-amd-aie/actions/runs/17803131537/job/50609997300?pr=1354, which is caused by https://github.com/iree-org/iree/commit/ec1ce5e6b754b1ee865c3a7a546b3632fc7528ad