### PR TITLE
[Codegen] Tile map_scatter op for large vector sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -208,6 +208,7 @@ static void processRegion(RewriterBase &rewriter, Region *region,
         ArrayRef<int64_t> bounds = mapScatterOp.getInputType().getShape();
         tileToMaxVectorSize(rewriter, mapScatterOp, bounds,
                             std::max<int64_t>(maxVectorSize / 4, 1));
+        continue;
       }
 
       // Else recursively process all nested operations.

--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -50,12 +50,13 @@ int64_t getLargestFactorLessThan(int64_t val, int64_t upperBound) {
 /// If tiling fails this returns silently (tiling is best effort). Later
 /// verification steps will throw an error if distribution does not occur.
 static void tileToMaxVectorSize(RewriterBase &rewriter,
-                                linalg::LinalgOp linalgOp,
+                                TilingInterface tilingInterfaceOp,
+                                ArrayRef<int64_t> bounds,
                                 int64_t maxVectorSize) {
   assert(maxVectorSize >= 1 && "maximum vector size must be at least 1");
-  SmallVector<int64_t> staticTileSizes = linalgOp.getStaticLoopRanges();
+  SmallVector<int64_t> staticTileSizes(bounds);
   SmallVector<utils::IteratorType> iteratorTypes =
-      linalgOp.getIteratorTypesArray();
+      tilingInterfaceOp.getLoopIteratorTypes();
 
   // Collect the total statically known parallel iterations of the linalg op.
   // We expect this to be the minimum required vector size for the op
@@ -110,11 +111,11 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
   }
 
   // Check if nothing to do.
-  if (staticTileSizes == linalgOp.getStaticLoopRanges()) {
+  if (staticTileSizes == bounds) {
     return;
   }
 
-  rewriter.setInsertionPoint(linalgOp);
+  rewriter.setInsertionPoint(tilingInterfaceOp);
   SmallVector<OpFoldResult> tileSizes =
       getAsIndexOpFoldResult(rewriter.getContext(), staticTileSizes);
 
@@ -139,21 +140,21 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
   tileAndFuseOptions.setFusionControlFn(controlFn);
 
   FailureOr<scf::SCFTileAndFuseResult> tiledResults =
-      scf::tileConsumerAndFuseProducersUsingSCF(
-          rewriter, cast<TilingInterface>(&*linalgOp), tileAndFuseOptions);
+      scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilingInterfaceOp,
+                                                tileAndFuseOptions);
   if (failed(tiledResults)) {
     return;
   }
 
   // Perform the replacement of the tiling root.
-  for (OpResult res : linalgOp->getResults()) {
+  for (OpResult res : tilingInterfaceOp->getResults()) {
     if (auto replacement = tiledResults->replacements.lookup(res)) {
       rewriter.replaceAllUsesWith(res, replacement);
     }
   }
 
-  if (linalgOp->use_empty()) {
-    rewriter.eraseOp(linalgOp);
+  if (tilingInterfaceOp->use_empty()) {
+    rewriter.eraseOp(tilingInterfaceOp);
   }
 }
 
@@ -192,8 +193,21 @@ static void processRegion(RewriterBase &rewriter, Region *region,
         if (linalgOp.getNumParallelLoops() == 0) {
           continue;
         }
-        tileToMaxVectorSize(rewriter, linalgOp, maxVectorSize);
+        SmallVector<int64_t> bounds = linalgOp.getStaticLoopRanges();
+        tileToMaxVectorSize(rewriter, cast<TilingInterface>(&*linalgOp), bounds,
+                            maxVectorSize);
         continue;
+      }
+
+      // map_scatter creates a lot of register pressure because it carries an
+      // index for every element in the input. It is better to use a smaller
+      // vector size for map_scatter to avoid register spills, because there is
+      // not much benefit in using a larger vector size anyway. For now, keep
+      // the heuristic simple and just use a quarter of the maxVectorSize.
+      if (auto mapScatterOp = dyn_cast<IREE::LinalgExt::MapScatterOp>(op)) {
+        ArrayRef<int64_t> bounds = mapScatterOp.getInputType().getShape();
+        tileToMaxVectorSize(rewriter, mapScatterOp, bounds,
+                            std::max<int64_t>(maxVectorSize / 4, 1));
       }
 
       // Else recursively process all nested operations.


### PR DESCRIPTION
Enabling vectorization of map_scatter in https://github.com/iree-org/iree/pull/21890 causes some regressions (https://github.com/iree-org/iree/issues/21865) because we have too much register pressure, causing register spilling on the LLVMGPU backend. This fixes the issue by tiling map_scatter in the TileLargeTensors pass. The tile size used for tiling map_scatter is 1/4 of the regular tile size, because we want to be conservative with register usage in map_scatter. There is little benefit in having a large map_scatter tile size, and it is very bad if we end up with register spilling.

The PR also adds the `foldIdentitySlices` option to the `OptimizeTensorInsertExtractSlicesPass` in the LLVMGPUTileAndFuse pipeline, because tiling map_scatter creates a redundant insert_slice op, which needs to be folded before bufferization, or bufferization will fail. Successful compilation is already tested through e2e tests, so no new test is added for this change.