### PR TITLE
[DispatchCreation] Fix `iree-compile` split-reduction flag name

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -318,8 +318,7 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::desc("Enables data tiling path."),
                    llvm::cl::cat(category));
   binder.opt<bool>(
-      "iree-dispatch-creation-split-reduction-target-size",
-      enableSplitReduction,
+      "iree-dispatch-creation-enable-split-reduction", enableSplitReduction,
       llvm::cl::desc(
           "Enable split-reduction for certain reduction operations."),
       llvm::cl::cat(category));


### PR DESCRIPTION
This is a fix for #21731. The name and behaviour of the flag were changed during review, but I accidentally dropped the name change at some point.