### PR TITLE
[Codegen] Push up memref reshapes before empty tensor elimination

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -176,20 +176,6 @@ blockDynamicDimensionsOfValue(RewriterBase &rewriter,
   return ReshapeOps{expandShapeOp, collapseShapeOp};
 }
 
-void moveUpMemrefReshapeOps(RewriterBase &rewriter, Operation *op) {
-  DominanceInfo domInfo(op);
-  SmallVector<Operation *> reshapeOps;
-  op->walk([&](Operation *nestedOp) {
-    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp>(nestedOp)) {
-      reshapeOps.push_back(nestedOp);
-    }
-  });
-
-  for (Operation *reshapeOp : reshapeOps) {
-    moveOpAfterLastOperand(rewriter, domInfo, reshapeOp);
-  }
-}
-
 //===---------------------------------------------------------------------===//
 // Methods for blocking operands of operations
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -16,6 +16,20 @@
 
 namespace mlir::iree_compiler {
 
+void moveUpMemrefReshapeOps(RewriterBase &rewriter, Operation *op) {
+  DominanceInfo domInfo(op);
+  SmallVector<Operation *> reshapeOps;
+  op->walk([&](Operation *nestedOp) {
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp>(nestedOp)) {
+      reshapeOps.push_back(nestedOp);
+    }
+  });
+
+  for (Operation *reshapeOp : reshapeOps) {
+    moveOpAfterLastOperand(rewriter, domInfo, reshapeOp);
+  }
+}
+
 /// Fuse consumers of forall ops into it after checking that they are tilable.
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -92,6 +92,10 @@ LogicalResult normalizeLoopBounds(RewriterBase &rewriter, scf::ForOp forOp);
 LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
                                   scf::ForallOp forallOp);
 
+/// Move memref.expand_shape and memref.collapse_shape ops nested within the
+/// `op` up to just after their last operand producer.
+void moveUpMemrefReshapeOps(RewriterBase &rewriter, Operation *op);
+
 /// Populate patterns that fold tensor.expand/collapse_shape into the memref
 /// of iree_codegen.load_from_buffer or iree_codegen.store_to_buffer ops.
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns);


### PR DESCRIPTION
The SubsetInsertionOpInterface implementation for iree_codegen.store_to_buffer needs the output buffer to dominate the empty tensor that is going to be eliminated, so an iree_codegen.load_from_buffer can be created in place of the empty tensor. Reshape ops can end up at the bottom of the function due to reshape propagation + folding patterns, so this PR moves the reshapes up in the function before running empty tensor elimination.