### PR TITLE
Adding interface support for stream.async.transfer result placement.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -205,6 +205,19 @@ def Stream_AffinityOp : OpInterface<"AffinityOpInterface"> {
         else $_op->removeAttr("affinity");
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the affinity of results from this operation. For most this will
+        be the same as their execution affinity.
+      }],
+      /*retTy=*/"IREE::Stream::AffinityAttr",
+      /*methodName=*/"getResultAffinityAttr",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getAffinityAttr();
+      }]
+    >,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -2201,7 +2201,7 @@ void AsyncBarrierOp::getCanonicalizationPatterns(RewritePatternSet &results,
 OpFoldResult AsyncTransferOp::fold(FoldAdaptor operands) {
   if (auto sourceTransferOp = getSource().getDefiningOp<AsyncTransferOp>()) {
     if (sourceTransferOp.getSource().getType() == getResult().getType() &&
-        sourceTransferOp.getSourceAffinity() == getResultAffinity()) {
+        sourceTransferOp.getSourceAffinity() == getTargetAffinity()) {
       return sourceTransferOp.getSource();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2587,7 +2587,7 @@ IREE::Stream::AffinityAttr AsyncTransferOp::getAffinityAttr() {
     // If result is staging then the op should execute on the producer.
     return getSourceAffinityAttr();
   } else {
-    // Default to result affinity.
+    // Default to source affinity (today we transfer from sources).
     return getSourceAffinityAttr();
   }
 }
@@ -2606,9 +2606,9 @@ void AsyncTransferOp::setAffinityAttr(IREE::Stream::AffinityAttr value) {
   } else if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging) {
     // If source is staging then the op should execute on the consumer.
     if (value) {
-      setResultAffinityAttr(value);
+      setTargetAffinityAttr(value);
     } else {
-      removeResultAffinityAttr();
+      removeTargetAffinityAttr();
     }
   } else if (resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
     // If result is staging then the op should execute on the producer.
@@ -2620,11 +2620,15 @@ void AsyncTransferOp::setAffinityAttr(IREE::Stream::AffinityAttr value) {
   } else {
     // Default to result affinity.
     if (value) {
-      setResultAffinityAttr(value);
+      setTargetAffinityAttr(value);
     } else {
-      removeResultAffinityAttr();
+      removeTargetAffinityAttr();
     }
   }
+}
+
+IREE::Stream::AffinityAttr AsyncTransferOp::getResultAffinityAttr() {
+  return getTargetAffinityAttr();
 }
 
 void AsyncTransferOp::getAsyncAccessRanges(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2525,6 +2525,7 @@ def Stream_AsyncTransferOp : Stream_PureOp<"async.transfer", [
   DeclareOpInterfaceMethods<Stream_AffinityOp, [
     "getAffinityAttr",
     "setAffinityAttr",
+    "getResultAffinityAttr",
   ]>,
   Stream_AsyncPhaseOp,
   Stream_StreamableOp,
@@ -2549,7 +2550,7 @@ def Stream_AsyncTransferOp : Stream_PureOp<"async.transfer", [
     Stream_Size:$source_size,
     Stream_Size:$result_size,
     OptionalAttr<Stream_AffinityAttr>:$source_affinity,
-    OptionalAttr<Stream_AffinityAttr>:$result_affinity
+    OptionalAttr<Stream_AffinityAttr>:$target_affinity
   );
   let results = (outs
     AnyTypeOf<[
@@ -2563,7 +2564,7 @@ def Stream_AsyncTransferOp : Stream_PureOp<"async.transfer", [
     `` `{` $source_size `}`
     (`from` `(` $source_affinity^ `)`)?
     `->`
-    (`to` `(` $result_affinity^ `)`)?
+    (`to` `(` $target_affinity^ `)`)?
     type($result) `` `{` $result_size `}`
     attr-dict-with-keyword
   }];

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -154,8 +154,8 @@ struct ExecutePartitionBuilder {
       if (transferOp.getSourceAffinityAttr() == partition->affinity) {
         transferOp.setSourceAffinityAttr(nullptr);
       }
-      if (transferOp.getResultAffinityAttr() == partition->affinity) {
-        transferOp.setResultAffinityAttr(nullptr);
+      if (transferOp.getTargetAffinityAttr() == partition->affinity) {
+        transferOp.setTargetAffinityAttr(nullptr);
       }
     } else if (auto affinityOp =
                    dyn_cast<IREE::Stream::AffinityOpInterface>(clonedOp)) {

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -76,6 +76,10 @@ struct OptionalOpAffinityAttrExternalModel
       op->removeAttr("stream.affinity");
     }
   }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
+  }
 };
 
 struct FlowBarrierTargetAffinityAttrExternalModel
@@ -100,6 +104,10 @@ struct FlowBarrierTargetAffinityAttrExternalModel
   void setAffinityAttr(Operation *op, IREE::Stream::AffinityAttr value) const {
     op->setAttr("target", value);
   }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
+  }
 };
 
 struct FlowTransferTargetAffinityAttrExternalModel
@@ -119,6 +127,10 @@ struct FlowTransferTargetAffinityAttrExternalModel
 
   void setAffinityAttr(Operation *op, IREE::Stream::AffinityAttr value) const {
     op->setAttr("target", value);
+  }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
   }
 };
 
@@ -147,6 +159,10 @@ struct HALTensorAffinityAttrExternalModel
     } else {
       op->removeAttr("affinity");
     }
+  }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
   }
 };
 
@@ -177,6 +193,10 @@ struct GlobalOpAffinityAttrExternalModel
       op->removeAttr("stream.affinity");
     }
   }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
+  }
 };
 
 template <typename OpT, bool kRequiresAffinity = true>
@@ -202,6 +222,10 @@ struct AffinityOpAttrExternalModel
     } else {
       op->removeAttr("stream.affinity");
     }
+  }
+
+  IREE::Stream::AffinityAttr getResultAffinityAttr(Operation *op) const {
+    return getAffinityAttr(op);
   }
 };
 


### PR DESCRIPTION
The comment and code did not match in the AsyncTransferOp::getAffinityAttr implementation, but the comment was the intent: the result of a transfer operation should have the affinity of the target of the transfer, not the source. The issue was that the AffinityOpInterface did not have a way to differentiate execution affinity (where the op should run) and the result affinity (where results should be placed) - now it does with `getResultAffinityAttr`. There's still some refinement required on the interface but this unblocks the immediate issue of passes not being able to get the result affinity based only on the interface.