### PR TITLE
[Codegen] Add bufferization support for new `iree_gpu.coalesced_gather_dma` op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -243,6 +243,8 @@ LogicalResult CoalescedGatherDMAOp::verify() {
         !isa<MemRefType>(getSource().getType())) {
       return emitOpError("all operands must be memrefs when init is a memref");
     }
+  } else {
+    return emitOpError("input types must either be all tensors or memrefs");
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -233,6 +233,10 @@ LogicalResult CoalescedGatherDMAOp::verify() {
   bool hasTensor = isa<RankedTensorType>(initType);
   bool hasMemRef = isa<MemRefType>(initType);
 
+  if (!hasTensor && !hasMemRef) {
+    return emitOpError("input type must either be a tensor or a memref");
+  }
+
   if (hasTensor) {
     if (!isa<RankedTensorType>(getIndices().getType()) ||
         !isa<RankedTensorType>(getSource().getType())) {
@@ -243,8 +247,6 @@ LogicalResult CoalescedGatherDMAOp::verify() {
         !isa<MemRefType>(getSource().getType())) {
       return emitOpError("all operands must be memrefs when init is a memref");
     }
-  } else {
-    return emitOpError("input types must either be all tensors or memrefs");
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -194,27 +194,55 @@ MutableOperandRange CoalescedGatherDMAOp::getDpsInitsMutable() {
 
 // ParallelCombiningOpInterface implementation
 MutableOperandRange CoalescedGatherDMAOp::getUpdatedDestinations() {
+  // Only relevant for tensor operands
+  if (!isa<RankedTensorType>(getInit().getType())) {
+    return MutableOperandRange(getOperation(), /*start=*/0, /*length=*/0);
+  }
   // Return the init operand as the destination being updated
   return getInitMutable();
 }
 
 Operation *CoalescedGatherDMAOp::getIteratingParent() {
+  // Only relevant for tensor operands
+  if (!isa<RankedTensorType>(getInit().getType())) {
+    return nullptr;
+  }
   // Return the parent scf.forall operation
   return getOperation()->getParentOfType<scf::ForallOp>();
 }
 
 LogicalResult CoalescedGatherDMAOp::verify() {
-  auto initType = cast<RankedTensorType>(getInit().getType());
-  auto resultType = cast<RankedTensorType>(getResult().getType());
+  auto initType = getInit().getType();
+  auto resultType = getResult().getType();
 
   // Verify that this op is nested within an InParallelOpInterface op
-  if (!isa_and_nonnull<InParallelOpInterface>(getOperation()->getParentOp())) {
-    return emitOpError("must be nested within an operation implementing "
-                       "InParallelOpInterface");
+  // Note: This constraint only applies when working with tensors
+  if (isa<RankedTensorType>(initType)) {
+    if (!isa_and_nonnull<InParallelOpInterface>(
+            getOperation()->getParentOp())) {
+      return emitOpError("must be nested within an operation implementing "
+                         "InParallelOpInterface when using tensor operands");
+    }
   }
 
   if (initType != resultType) {
     return emitOpError("init and result must have the same type and shape");
+  }
+
+  // Ensure all operands are either all tensors or all memrefs
+  bool hasTensor = isa<RankedTensorType>(initType);
+  bool hasMemRef = isa<MemRefType>(initType);
+
+  if (hasTensor) {
+    if (!isa<RankedTensorType>(getIndices().getType()) ||
+        !isa<RankedTensorType>(getSource().getType())) {
+      return emitOpError("all operands must be tensors when init is a tensor");
+    }
+  } else if (hasMemRef) {
+    if (!isa<MemRefType>(getIndices().getType()) ||
+        !isa<MemRefType>(getSource().getType())) {
+      return emitOpError("all operands must be memrefs when init is a memref");
+    }
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -280,8 +280,6 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     accesses. It implements ParallelCombiningOpInterface and must live inside an
     op implementing `InParallelOpInterface`, such as `scf.forall.in_parallel`.
 
-
-
     ## Lowering Paths
 
     Two lowering strategies are supported:
@@ -349,6 +347,7 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
       if (auto memrefType = ::llvm::dyn_cast<MemRefType>(getResult().getType()))
         return memrefType.getRank();
       assert(false && "expected ranked tensor or memref type");
+      return 0;
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -17,6 +17,9 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
 
+// Type constraint for operations that support both tensor and memref types
+def AnyRankedTensorOrMemRef : AnyTypeOf<[AnyRankedTensor, AnyMemRef]>;
+
 //===----------------------------------------------------------------------===//
 // BarrierRegionOp
 //===----------------------------------------------------------------------===//
@@ -311,12 +314,12 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
   }];
 
   let arguments = (ins
-    RankedTensorOf<[Index]>:$indices,
-    AnyRankedTensor:$source,
-    AnyRankedTensor:$init
+    AnyTypeOf<[RankedTensorOf<[Index]>, MemRefOf<[Index]>]>:$indices,
+    AnyRankedTensorOrMemRef:$source,
+    AnyRankedTensorOrMemRef:$init
   );
 
-  let results = (outs AnyRankedTensor:$result);
+  let results = (outs AnyRankedTensorOrMemRef:$result);
 
   let assemblyFormat = [{
     $indices `,` $source `into` $init attr-dict
@@ -326,9 +329,13 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    // Get the rank of the result tensor
+    // Get the rank of the result tensor/memref
     unsigned getResultRank() {
-      return ::llvm::cast<RankedTensorType>(getResult().getType()).getRank();
+      if (auto tensorType = ::llvm::dyn_cast<RankedTensorType>(getResult().getType()))
+        return tensorType.getRank();
+      if (auto memrefType = ::llvm::dyn_cast<MemRefType>(getResult().getType()))
+        return memrefType.getRank();
+      return 0;
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -265,35 +265,48 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
        ["getUpdatedDestinations", "getIteratingParent"]>]> {
   let summary = "Coalesced gather DMA operation for efficient GPU memory access";
   let description = [{
-    Performs a coalesced gather operation that reads elements from a source tensor
-    based on indices and produces a result tensor with the gathered data. The operation is
-    specifically designed for subgroup-level parallelism, where threads within a
-    subgroup cooperatively gather data with coalesced memory accesses. It implements
-    `ParallelCombiningOpInterface` and must live inside an op implementing
-    `InParallelOpInterface`, such as `scf.forall.in_parallel`.
+    Performs a coalesced gather operation.
+    This operation can exist in two forms: a tensor-based (value-semantic) form
+    and a buffer-based (memref-semantic) form.
+
+    In both forms, it reads elements from a source operand based on indices.
+    * When the source is a tensor, the operation produces a new result tensor
+      containing the gathered data.
+    * When the source is a memref, the operation writes the gathered data into
+      a destination out memref operand.
+
+    The operation is specifically designed for subgroup-level parallelism, where
+    threads within a subgroup cooperatively gather data with coalesced memory
+    accesses. It implements ParallelCombiningOpInterface and must live inside an
+    op implementing `InParallelOpInterface`, such as `scf.forall.in_parallel`.
+
+
 
     ## Lowering Paths
 
     Two lowering strategies are supported:
-    1. Lowers to `amdgpu.gather_to_lds` operations when lowering requirements are met.
+    1. Lowers to `amdgpu.gather_to_lds` operations when lowering requirements
+       are met.
     2. Default lowering using `vector.gather` operations.
 
     ## Operands and Results
 
-    * `$indices`: Tensor of index type specifying gather locations in the source tensor
-    * `$source`: Source tensor containing the data to be gathered
-    * `$init`: Destination tensor receiving the gathered data (destination-passing style)
-    * `$result`: Output tensor with gathered data (same type as `$init`)
+    * `$indices`: Tensor/memref of index type specifying gather locations in
+      the source tensor
+    * `$source`: Source tensor/memref containing the data to be gathered
+    * `$init`: Destination tensor/memref receiving the gathered data
+      (destination-passing style)
+    * `$result`: Output tensor/memref with gathered data (same type as `$init`)
 
     ## Example
 
-    The following example shows how this op is designed to be used in a tiled scenario, which sets up
-    lowering path for efficient gathering.
+    The following example shows how this op is designed to be used in a tiled
+    scenario, which sets up lowering path for efficient gathering.
 
     1. Outer `scf.forall` represents workgroup-level parallelism.
     2. Inner `scf.forall` represents subgroup-level parallelism.
-    3. Each thread in the subgroup coalesces its memory accesses when gathering data and writes to
-       its lane-offset in the destination tensor.
+    3. Each thread in the subgroup coalesces its memory accesses when
+       gathering data and writes to its lane-offset in the destination tensor.
 
     ```mlir
     %result = scf.forall (%wg_i, %wg_j) in (16, 1) shared_outs(%wg_out = %dest) -> (tensor<128x16xf32>) {
@@ -335,7 +348,7 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
         return tensorType.getRank();
       if (auto memrefType = ::llvm::dyn_cast<MemRefType>(getResult().getType()))
         return memrefType.getRank();
-      return 0;
+      assert(false && "expected ranked tensor or memref type");
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "bufferize_coalesced_gather_dma.mlir",
             "canonicalize.mlir",
             "iree_gpu_attrs.mlir",
             "iree_gpu_inner_tiled_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "bufferize_coalesced_gather_dma.mlir"
     "canonicalize.mlir"
     "iree_gpu_attrs.mlir"
     "iree_gpu_inner_tiled_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
@@ -37,7 +37,6 @@ func.func @bufferize_coalesced_gather_dma_dynamic(%indices: tensor<?x?xindex>,
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_dynamic
 //       CHECK:   scf.forall
 //       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<?x?xindex, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>
-
 // -----
 
 // Test bufferization with different element types

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
@@ -1,0 +1,116 @@
+// RUN: iree-opt %s --one-shot-bufferize="bufferize-function-boundaries" --split-input-file | FileCheck %s
+
+// Test bufferization of coalesced_gather_dma with static shapes
+func.func @bufferize_coalesced_gather_dma_static(%indices: tensor<64x32xindex>,
+                                                  %source: tensor<1024x64xf32>,
+                                                  %dest: tensor<64x32xf32> {bufferization.writable = true}) -> tensor<64x32xf32> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64x32xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %indices, %source into %out
+        : tensor<64x32xindex>, tensor<1024x64xf32>, tensor<64x32xf32> -> tensor<64x32xf32>
+    }
+  }
+  return %result : tensor<64x32xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_static
+//       CHECK:   scf.forall
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<64x32xindex, strided<[?, ?], offset: ?>>, memref<1024x64xf32, strided<[?, ?], offset: ?>>, memref<64x32xf32, strided<[?, ?], offset: ?>>
+
+// -----
+
+// Test bufferization of coalesced_gather_dma with dynamic shapes
+func.func @bufferize_coalesced_gather_dma_dynamic(%indices: tensor<?x?xindex>,
+                                                   %source: tensor<?x?xf32>,
+                                                   %dest: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<?x?xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %indices, %source into %out
+        : tensor<?x?xindex>, tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+    }
+  }
+  return %result : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_dynamic
+//       CHECK:   scf.forall
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<?x?xindex, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>
+
+// -----
+
+// Test bufferization with different element types
+func.func @bufferize_coalesced_gather_dma_f16(%indices: tensor<128x64xindex>,
+                                               %source: tensor<2048x64xf16>,
+                                               %dest: tensor<128x64xf16>) -> tensor<128x64xf16> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<128x64xf16>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %indices, %source into %out
+        : tensor<128x64xindex>, tensor<2048x64xf16>, tensor<128x64xf16> -> tensor<128x64xf16>
+    }
+  }
+  return %result : tensor<128x64xf16>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_f16
+//       CHECK:   scf.forall
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<128x64xindex, strided<[?, ?], offset: ?>>, memref<2048x64xf16, strided<[?, ?], offset: ?>>, memref<128x64xf16, strided<[?, ?], offset: ?>>
+
+// -----
+
+// Test bufferization with 1D tensors
+func.func @bufferize_coalesced_gather_dma_1d(%indices: tensor<32xindex>,
+                                              %source: tensor<1024xf32>,
+                                              %dest: tensor<1024xf32> {bufferization.writable = true}) -> tensor<1024xf32> {
+  %c32 = arith.constant 32 : index
+  %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<1024xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %indices, %source into %out
+        : tensor<32xindex>, tensor<1024xf32>, tensor<1024xf32> -> tensor<1024xf32>
+    }
+  }
+  return %result : tensor<1024xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_1d
+//       CHECK:   %[[C32:.+]] = arith.constant 32 : index
+//       CHECK:   scf.forall (%{{.+}}) in (%[[C32]])
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<32xindex, strided<[?], offset: ?>>, memref<1024xf32, strided<[?], offset: ?>>, memref<1024xf32, strided<[?], offset: ?>>
+
+// -----
+
+// Test bufferization in nested forall loops (workgroup and subgroup levels)
+func.func @bufferize_coalesced_gather_dma_nested(%indices: tensor<16x32xindex>,
+                                                  %source: tensor<2048x64xf32>,
+                                                  %dest: tensor<128x16xf32> {bufferization.writable = true}) -> tensor<128x16xf32> {
+  %result = scf.forall (%wg_i, %wg_j) in (16, 1) shared_outs(%wg_out = %dest) -> (tensor<128x16xf32>) {
+    %c8 = arith.constant 8 : index
+    %wg_offset = arith.muli %wg_i, %c8 : index
+    %indices_wg_slice = tensor.extract_slice %indices[%wg_offset, 0] [1, 32] [1, 1]
+      : tensor<16x32xindex> to tensor<1x32xindex>
+    %dest_wg_slice = tensor.extract_slice %wg_out[%wg_offset, 0] [8, 16] [1, 1]
+      : tensor<128x16xf32> to tensor<8x16xf32>
+
+    %inner_result = scf.forall (%sg_i, %sg_j) in (32, 1) shared_outs(%sg_out = %dest_wg_slice) -> (tensor<8x16xf32>) {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %indices_wg_slice, %source into %sg_out
+          : tensor<1x32xindex>, tensor<2048x64xf32>, tensor<8x16xf32> -> tensor<8x16xf32>
+      }
+    } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner_result into %wg_out[%wg_offset, 0] [8, 16] [1, 1]
+        : tensor<8x16xf32> into tensor<128x16xf32>
+    }
+  } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  return %result : tensor<128x16xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_nested
+//       CHECK:   scf.forall (%{{.+}}, %{{.+}}) in (16, 1)
+//       CHECK:     %{{.+}} = memref.subview
+//       CHECK:     %{{.+}} = memref.subview
+//       CHECK:     scf.forall (%{{.+}}, %{{.+}}) in (32, 1)
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<1x32xindex, strided<[?, ?], offset: ?>>, memref<2048x64xf32, strided<[?, ?], offset: ?>>, memref<8x16xf32, strided<[?, ?], offset: ?>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Bufferization/Transforms/Transforms.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 
@@ -293,6 +294,85 @@ struct YieldOpBufferizationInterface
   }
 };
 
+/// Bufferization of iree_gpu.coalesced_gather_dma. This op bufferizes to itself
+/// with memref operands instead of tensor operands.
+struct CoalescedGatherDMAOpBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<
+          CoalescedGatherDMAOpBufferizationInterface,
+          IREE::GPU::CoalescedGatherDMAOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    // This op reads from the source and indices tensors
+    auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
+    return opOperand.get() == gatherOp.getIndices() ||
+           opOperand.get() == gatherOp.getSource();
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    // This op writes to the init/destination tensor
+    auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
+    return opOperand.get() == gatherOp.getInit();
+  }
+
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *op, OpOperand &opOperand,
+                    const AnalysisState &state) const {
+    auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
+    SmallVector<bufferization::AliasingValue> alist;
+    // The result aliases with the init operand
+    if (opOperand.get() == gatherOp.getInit()) {
+      alist.push_back({gatherOp.getResult(), BufferRelation::Equivalent});
+    }
+    return alist;
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
+
+    // Get the bufferized operands
+    FailureOr<Value> indicesBuffer =
+        getBuffer(rewriter, gatherOp.getIndices(), options, state);
+    FailureOr<Value> sourceBuffer =
+        getBuffer(rewriter, gatherOp.getSource(), options, state);
+    FailureOr<Value> initBuffer =
+        getBuffer(rewriter, gatherOp.getInit(), options, state);
+
+    if (failed(indicesBuffer) || failed(sourceBuffer) || failed(initBuffer)) {
+      return failure();
+    }
+
+    // Check if we're inside an scf.forall.in_parallel block
+    // If so, we need to move the op outside of it
+    Operation *parentOp = gatherOp->getParentOp();
+    if (isa_and_nonnull<scf::InParallelOp>(parentOp)) {
+      // Get the forall op containing the in_parallel
+      auto forallOp = parentOp->getParentOfType<scf::ForallOp>();
+      if (forallOp) {
+        // Insert the memref version before the in_parallel block
+        rewriter.setInsertionPoint(parentOp);
+        rewriter.create<IREE::GPU::CoalescedGatherDMAOp>(
+            gatherOp.getLoc(), initBuffer->getType(), *indicesBuffer,
+            *sourceBuffer, *initBuffer);
+        // The result is the same as the init buffer (in-place update)
+        bufferization::replaceOpWithBufferizedValues(rewriter, op, *initBuffer);
+        return success();
+      }
+    }
+
+    // Otherwise, create the op in place
+    rewriter.create<IREE::GPU::CoalescedGatherDMAOp>(
+        gatherOp.getLoc(), initBuffer->getType(), *indicesBuffer, *sourceBuffer,
+        *initBuffer);
+
+    // The result is the same as the init buffer (in-place update)
+    bufferization::replaceOpWithBufferizedValues(rewriter, op, *initBuffer);
+    return success();
+  }
+};
+
 /// AMD Specific Ops
 
 static bool hasStorageBufferMemSpace(BaseMemRefType m) {
@@ -412,6 +492,8 @@ void registerIREEGPUBufferizationInterfaces(DialectRegistry &registry) {
             ValueBarrierOpBufferizationInterface>(*context);
         IREE::GPU::YieldOp::attachInterface<YieldOpBufferizationInterface>(
             *context);
+        IREE::GPU::CoalescedGatherDMAOp::attachInterface<
+            CoalescedGatherDMAOpBufferizationInterface>(*context);
 
         IREE::GPU::BufferResourceCastOp::attachInterface<
             BufferResourceCastOpBufferizationInterface>(*context);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     MLIRGPUDialect
     MLIRIR
     MLIRMemRefDialect
+    MLIRSCFDialect
     MLIRSupport
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Dialect::HAL::IR


### PR DESCRIPTION
The next step for supporting `iree_gpu.coalesced_gather_dma` op.

The flow is as follows:
* Custom tile/lower `linalg_ext.gather` to subgroup level ,and use `iree_gpu.coalesced_gather_dma` for subgroup loads.
* bufferize
* lower `coalesced_gather_dma` op to `amdgpu.gather_to_lds`.