### PR TITLE
[DispatchCreation] Propagate and fuse encodings in default path

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
@@ -68,12 +68,6 @@ struct FuseEncodingOpsIntoDispatchRegionsPass final
     MLIRContext *context = &getContext();
     IRRewriter rewriter(context);
 
-    // Run CSE to eliminate common encoding ops.
-    if (enableCSE) {
-      DominanceInfo domInfo;
-      mlir::eliminateCommonSubExpressions(rewriter, domInfo, funcOp);
-    }
-
     SmallVector<IREE::Encoding::SetEncodingOp> encodingOps;
     funcOp->walk([&](IREE::Encoding::SetEncodingOp encodingOp) {
       if (IREE::Flow::isNonNullAndOutsideDispatch(encodingOp)) {
@@ -123,7 +117,7 @@ struct FuseEncodingOpsIntoDispatchRegionsPass final
     }
 
     // Dynamic dims may have dominance issues after pulling encoding ops into
-    // producer dispatch regions, so we need to resolve tensor.dim ops. Also
+    // producer dispatch regions, so we need to resolve tensor.dim ops., Also
     // run the canonicalization patterns to remove redundantly returned results.
     GreedyRewriteConfig config;
     config.enableConstantCSE(false);

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -184,7 +184,8 @@ static void addDispatchRegionCreationPreprocessingPasses(
       //     c. Transpose generic ops to
       //        - help with dispatch region formation.
       //        - move reduction iterators to be innermost.
-      .addPass(DispatchCreation::createTransposeGenericOpsPass);
+      .addPass(DispatchCreation::createTransposeGenericOpsPass)
+      .addPass(DispatchCreation::createPropagateEncodingsPass);
 
   // Run constant expression hoisting just before dispatch creation in case
   // there are any new hoisting opportunities (e.g. transpose generics or
@@ -276,11 +277,13 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
     // SetEncodingOps through special operations like bit-extending ops and
     // broadcasting ops.
     passManager.addPass(DispatchCreation::createHoistEncodingOpsPass());
-    FunctionLikeNest(passManager)
-        .addPass(
-            DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass);
   }
   FunctionLikeNest(passManager)
+      .addPass([&]() {
+        return DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass(
+            DispatchCreation::FuseEncodingOpsIntoDispatchRegionsPassOptions{
+                /*enableCSE=*/options.dataTiling.getValue()});
+      })
       .addPass(DispatchCreation::createConvertEncodingToFlowPass);
   // Hoist encoding operations into initializers when possible.
   IREE::Util::ExprHoistingOptions hoistingOptions;

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -279,11 +279,7 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
     passManager.addPass(DispatchCreation::createHoistEncodingOpsPass());
   }
   FunctionLikeNest(passManager)
-      .addPass([&]() {
-        return DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass(
-            DispatchCreation::FuseEncodingOpsIntoDispatchRegionsPassOptions{
-                /*enableCSE=*/options.dataTiling.getValue()});
-      })
+      .addPass(DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass)
       .addPass(DispatchCreation::createConvertEncodingToFlowPass);
   // Hoist encoding operations into initializers when possible.
   IREE::Util::ExprHoistingOptions hoistingOptions;

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -314,10 +314,6 @@ def FormSplitReductionDispatchesPass :
 def FuseEncodingOpsIntoDispatchRegionsPass :
     InterfacePass<"iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass", "mlir::FunctionOpInterface"> {
   let summary = "Fuses set_encoding ops into producer dispatch regions, or forms new dispatches around them.";
-  let options = [
-    Option<"enableCSE", "enable-cse", "bool",
-        /*default=*/"false", "Enable CSE to eliminate common encoding ops">
-  ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "IREE::Flow::FlowDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -314,6 +314,10 @@ def FormSplitReductionDispatchesPass :
 def FuseEncodingOpsIntoDispatchRegionsPass :
     InterfacePass<"iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass", "mlir::FunctionOpInterface"> {
   let summary = "Fuses set_encoding ops into producer dispatch regions, or forms new dispatches around them.";
+  let options = [
+    Option<"enableCSE", "enable-cse", "bool",
+        /*default=*/"false", "Enable CSE to eliminate common encoding ops">
+  ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "IREE::Flow::FlowDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -149,7 +149,7 @@ util.func public @multi_encoding_fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: i
 // CHECK-DAG:      #[[$ENCODING:.+]] = #iree_encoding.testing<>
 // CHECK-LABEL:    @multi_encoding_fusion_dynamic
 // CHECK-SAME:       {{.+}}: tensor<?x?x?xf32>, %[[D0:.+]]: index, %[[D1:.+]]: index, %[[D2:.+]]: index)
-// CHECK:          %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32, #[[$ENCODING]]>
+// CHECK:          %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32>
 // CHECK-SAME:         {%[[D0]], %[[D1]], %[[D2]]}
 // CHECK:            %[[ADD:.+]] = linalg.generic
 // CHECK:            flow.return %[[ADD]] :

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -1,7 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass))" \
-// RUN:   --split-input-file %s | FileCheck %s --check-prefixes=CHECK,NO-CSE
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass{enable-cse=true}))" \
-// RUN:   --split-input-file %s | FileCheck %s --check-prefixes=CHECK,CSE
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass))" --split-input-file %s | FileCheck %s
 
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #encoding = #iree_encoding.testing<>
@@ -149,19 +146,15 @@ util.func public @multi_encoding_fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: i
   %3 = iree_encoding.set_encoding %1 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding>
   util.return %2, %3 : tensor<?x?x?xf32, #encoding>, tensor<?x?x?xf32, #encoding>
 }
-// CHECK-DAG:       #[[$ENCODING:.+]] = #iree_encoding.testing<>
-// CHECK-LABEL:     @multi_encoding_fusion_dynamic
-// CHECK-SAME:        {{.+}}: tensor<?x?x?xf32>, %[[D0:.+]]: index, %[[D1:.+]]: index, %[[D2:.+]]: index)
-// CSE:             %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32, #[[$ENCODING]]>
-// NO-CSE:          %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32>
-// CHECK-SAME:          {%[[D0]], %[[D1]], %[[D2]]}
-// CHECK:             %[[ADD:.+]] = linalg.generic
-// CSE:               %[[SET_ENCODING:.+]] = iree_encoding.set_encoding
-// CSE:               flow.return %[[SET_ENCODING]] :
-// NO-CSE:            flow.return %[[ADD]] :
-// CHECK:           }
-// CSE:             util.return %[[DISPATCH]], %[[DISPATCH]]
-// NO-CSE-COUNT-2:  iree_encoding.set_encoding %[[DISPATCH]]
+// CHECK-DAG:      #[[$ENCODING:.+]] = #iree_encoding.testing<>
+// CHECK-LABEL:    @multi_encoding_fusion_dynamic
+// CHECK-SAME:       {{.+}}: tensor<?x?x?xf32>, %[[D0:.+]]: index, %[[D1:.+]]: index, %[[D2:.+]]: index)
+// CHECK:          %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32, #[[$ENCODING]]>
+// CHECK-SAME:         {%[[D0]], %[[D1]], %[[D2]]}
+// CHECK:            %[[ADD:.+]] = linalg.generic
+// CHECK:            flow.return %[[ADD]] :
+// CHECK:          }
+// CHECK-COUNT-2:  iree_encoding.set_encoding %[[DISPATCH]]
 
 // -----
 


### PR DESCRIPTION
Adds the `FuseEncodingOpsIntoDispatchRegions` pass and `PropagateEncodings` pass to the default path in DispatchCreation. For `FuseEncodingOpsIntoDispatchRegions`, there are issues with running CSE in the DispatchCreation pipeline, so it is removed from the pass.

This will enable propagation and fusion of layout encodings that are set in the source IR, which can be blocked by certain operations (so far just tensor.cast) like we've seen in llama 405b.