### PR TITLE
[LinalgExt][NFC] Remove unused VectorOps include

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h
@@ -9,7 +9,6 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"


### PR DESCRIPTION
The issue is detected in local bazel build. I don't understand why the CI does not trigger the failure, but we follow IWYU.

The error message from my local bazel build:

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp:7:
compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h:12:10: error: module //compiler/src/iree/compiler/Dialect/LinalgExt/Utils:Utils does not depend on a module exporting 'mlir/Dialect/Vector/IR/VectorOps.h'
   12 | #include "mlir/Dialect/Vector/IR/VectorOps.h"
```