### PR TITLE
[GPU][DT] Add data-tiling resolver by default. 

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -81,7 +81,8 @@ struct ROCMOptions {
   std::string bitcodeDirectory = getDefaultBitcodeDirectory();
   int wavesPerEu = 0;
   std::string enableROCMUkernels = "none";
-  std::string encodingLayoutResolver = GPU::kNoEncodingLayoutResolverName;
+  std::string encodingLayoutResolver =
+      GPU::kDataTilingEncodingLayoutResolverName;
   bool slpVectorization = true;
   bool globalISel = false;
   bool specializeDispatches = false;

--- a/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
+++ b/compiler/plugins/target/ROCM/test/gpu_encoding_attrs.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=gfx942 --iree-hip-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
-//
+
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=pad %s | FileCheck %s --check-prefix=PAD
 
@@ -10,11 +10,17 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=gfx90a --iree-hip-encoding-layout-resolver=none %s | FileCheck %s --check-prefix=NONE
 
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=gfx90a %s | FileCheck %s --check-prefix=DEFAULT
+
 // PAD:      #hal.executable.target<"rocm"
 // PAD-SAME:   iree.encoding.resolver = #iree_gpu.gpu_padding_resolver<>
 
 // DATA-TILING:      #hal.executable.target<"rocm"
 // DATA-TILING-SAME:   iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
+
+// DEFAULT:      #hal.executable.target<"rocm"
+// DEFAULT-SAME:   iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>
 
 // NONE:      #hal.executable.target<"rocm"
 // NONE-NOT:    iree.encoding.resolver

--- a/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
+++ b/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
@@ -54,7 +54,6 @@ iree-compile matmul.mlir -o /tmp/matmul.mlir \
   --iree-hal-target-device=hip \
   --iree-hip-target=gfx942 \
   --iree-dispatch-creation-data-tiling \
-  --iree-hip-encoding-layout-resolver=data-tiling \
   --iree-llvmgpu-test-combine-layout-transformation=true
 ```
 

--- a/tests/e2e/encoding/BUILD.bazel
+++ b/tests/e2e/encoding/BUILD.bazel
@@ -18,7 +18,6 @@ iree_check_single_backend_test_suite(
     srcs = ["encoding.mlir"],
     compiler_flags = [
         "--iree-global-opt-enable-early-materialization=false",
-        "--iree-hip-encoding-layout-resolver=data-tiling",
         "--iree-llvmgpu-test-combine-layout-transformation=true",
     ],
     driver = "hip",

--- a/tests/e2e/encoding/CMakeLists.txt
+++ b/tests/e2e/encoding/CMakeLists.txt
@@ -21,7 +21,6 @@ iree_check_single_backend_test_suite(
     "hip"
   COMPILER_FLAGS
     "--iree-global-opt-enable-early-materialization=false"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
 )
 

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1319,7 +1319,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1349,7 +1348,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1379,7 +1377,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1410,7 +1407,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-hip-enable-ukernels=multi_mma"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1440,7 +1436,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1470,7 +1465,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1500,7 +1494,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1532,7 +1525,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
@@ -1565,7 +1557,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
@@ -1597,7 +1588,6 @@ iree_generated_e2e_runner_test(
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
@@ -1720,7 +1710,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
     "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
@@ -1882,7 +1871,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -1914,7 +1902,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"
     "nomsan"
@@ -2105,7 +2092,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -2137,7 +2123,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
     "--acceptable_fp_delta=1e-04"
@@ -2169,7 +2154,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-hip-encoding-layout-resolver=data-tiling"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_data_tiling_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_data_tiling_rocm.json
@@ -25,7 +25,6 @@
         "--iree-stream-resource-memory-model=discrete",
         "--iree-opt-data-tiling=false",
         "--iree-dispatch-creation-data-tiling",
-        "--iree-hip-encoding-layout-resolver=data-tiling",
         "--iree-llvmgpu-test-combine-layout-transformation"
     ],
     "run_function": "decode_bs4"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_data_tiling_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_data_tiling_rocm.json
@@ -22,7 +22,6 @@
         "--iree-stream-resource-memory-model=discrete",
         "--iree-opt-data-tiling=false",
         "--iree-dispatch-creation-data-tiling",
-        "--iree-hip-encoding-layout-resolver=data-tiling",
         "--iree-llvmgpu-test-combine-layout-transformation"
     ],
     "run_function": "prefill_bs4"


### PR DESCRIPTION
The resolver was not added for a few main reasons:
* It took some time to finish the work. It was not easy to make it default when data-tiling was on by default.
* There are three approaches (none, pad, data-tiling). Since data-tiling is off by default, `none` is redundant in the context. We prefer `data-tiling` over `pad`, so it makes sense to make `data-tiling` be used by default.

It is a step toward reducing required flags for data-tiling. The issue was identified in https://github.com/iree-org/iree/issues/22073. It is what we want, but it is not the proper fix to the issue.

It does not matter if we've already materialized the encoding with a resolver. E.g.,

```mlir
#encoding = #iree_encoding.layout<[#iree_gpu.gpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [64, 16], outerDimsPerm = [0, 1], swizzle = {expandShape = [[["CrossThread", 16 : i16], ["CrossIntrinsic", 4 : i16]], [["Internal", 16 : i16]]], permutation = [1, 0, 2]}}}>]>
#encoding1 = #iree_encoding.layout<[#iree_gpu.gpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [64, 16], outerDimsPerm = [0, 1], swizzle = {expandShape = [[["CrossThread", 4 : i16], ["CrossThread", 16 : i16]], [["Internal", 16 : i16]]], permutation = [0, 1, 2]}}}>]>
```

However, it does not apply to all the cases. We still need the resolver to materialize unserialized encodings. It is a missing feature in current implementation. The correct implementation is checking if an encoding is serialized or not:
* If so, do the materialization through interface methods.
* If not, grab the resolver from executable target, if any, and materialize the encodings.
