### PR TITLE
Marking stream.tensor.dispatch pure.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1917,7 +1917,7 @@ def Stream_TensorTraceOp : Stream_Op<"tensor.trace", [
   let hasVerifier = 1;
 }
 
-def Stream_TensorDispatchOp : Stream_Op<"tensor.dispatch", [
+def Stream_TensorDispatchOp : Stream_PureOp<"tensor.dispatch", [
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,


### PR DESCRIPTION
In #21989 stream.async.dispatch was marked pure but I missed the tensor variant. The load-bearing CSE was on the async dispatch (as that maps to the lower-level and un-CSEable stream.cmd.dispatch) so this should have no change in behavior but will make the IR easier to read.