### PR TITLE
[Util] Allow varying types in optimization barrier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -1413,26 +1413,6 @@ void OptimizationBarrierOp::build(OpBuilder &builder, OperationState &state,
   state.addAttributes(attributes);
 }
 
-LogicalResult OptimizationBarrierOp::verify() {
-  Operation *op = getOperation();
-  if (op->getNumOperands() != op->getNumResults()) {
-    return op->emitOpError()
-           << "must have same number of operands and results, but has "
-           << op->getNumOperands() << " and " << op->getNumResults()
-           << ", respectively";
-  }
-
-  for (int i = 0, e = op->getNumOperands(); i < e; ++i) {
-    if (op->getOperand(i).getType() != op->getResult(i).getType()) {
-      op->emitOpError() << "must have same operand and result types, but they "
-                           "differ at index "
-                        << i;
-    }
-  }
-
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // util.unfoldable_constant
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -525,7 +525,7 @@ def Util_AssumeIntOp : Util_PureOp<"assume.int", [
 }
 
 def Util_OptimizationBarrierOp : Util_Op<"optimization_barrier", [
-  SameOperandsAndResultType,
+  AllTypesMatch<["operands", "results"]>,
 ]> {
   let summary = [{Prevents compiler optimizations across a value.}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -547,8 +547,6 @@ def Util_OptimizationBarrierOp : Util_Op<"optimization_barrier", [
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes
     )>,
   ];
-
-  let hasVerifier = 1;
 }
 
 def Util_UnfoldableConstantOp : Util_Op<"unfoldable_constant"> {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/hint_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/hint_folding.mlir
@@ -38,7 +38,7 @@ util.func public @fold_add() -> (i32) {
 // -----
 
 util.func public @result_operand_count_mismatch(%arg0 : tensor<i32>, %arg1 : tensor<i32>) {
-  // expected-error@+1 {{must have same number of operands and results}}
+  // expected-error@+1 {{failed to verify that all of {operands, results} have same type}}
   %1 = "util.optimization_barrier"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   util.return
 }
@@ -46,7 +46,7 @@ util.func public @result_operand_count_mismatch(%arg0 : tensor<i32>, %arg1 : ten
 // -----
 
 util.func public @result_operand_type_mismatch(%arg0 : tensor<i32>, %arg1 : tensor<i32>) {
-  // expected-error@+1 {{must have same operand and result types, but they differ at index 1}}
+  // expected-error@+1 {{failed to verify that all of {operands, results} have same type}}
   %1:2 = "util.optimization_barrier"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> (tensor<i32>, memref<i32>)
   util.return
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/hint_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/hint_ops.mlir
@@ -3,12 +3,12 @@
 // CHECK-LABEL: @parse_print_barrier
 // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
 // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
-util.func public @parse_print_barrier(%arg0 : tensor<i32>, %arg1 : tensor<i32>) {
+util.func public @parse_print_barrier(%arg0 : tensor<i32>, %arg1 : tensor<f32>) {
   // CHECK-NEXT: util.optimization_barrier %[[ARG0]] : tensor<i32>
   %1 = util.optimization_barrier %arg0 : tensor<i32>
 
-  // CHECK-NEXT: util.optimization_barrier %[[ARG0]], %[[ARG1]] : tensor<i32>, tensor<i32>
-  %2:2 = util.optimization_barrier %arg0, %arg1 : tensor<i32>, tensor<i32>
+  // CHECK-NEXT: util.optimization_barrier %[[ARG0]], %[[ARG1]] : tensor<i32>, tensor<f32>
+  %2:2 = util.optimization_barrier %arg0, %arg1 : tensor<i32>, tensor<f32>
 
   // CHECK-NEXT: util.optimization_barrier {some_unit} %[[ARG0]] : tensor<i32>
   %has_attr = util.optimization_barrier {some_unit} %arg0 : tensor<i32>


### PR DESCRIPTION
SameOperandsAndResultType trait requires that all of the operands share the same type and all the results share the same type rather than just the operand and result that correspond with one another. Use `AllTypesMatch` instead.