### PR TITLE
[ROCm] Add an experimental target for gfx1250

### DIFF
--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -43,6 +43,9 @@
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=r9700 %s | FileCheck %s --check-prefixes=GFX1201,R9700
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=gfx1250 %s | FileCheck %s --check-prefixes=GFX1250
 
 // GFX942: target_info = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
@@ -85,6 +88,11 @@
 // RX9070XT: chip = <wgp_count = 32, sku = "rx9070xt", memory_bandwidth_tbps = 6.400000e-01 : f32, perf_tflops = {fp16 = 1.950000e+02 : f32, fp32 = 4.870000e+01 : f32, fp8 = 3.890000e+02 : f32, int8 = 3.890000e+02 : f32}>>
 // RX9070:   chip = <wgp_count = 28, sku = "rx9070", memory_bandwidth_tbps = 6.400000e-01 : f32, perf_tflops = {fp16 = 1.450000e+02 : f32, fp32 = 3.610000e+01 : f32, fp8 = 2.890000e+02 : f32, int8 = 2.890000e+02 : f32}>>
 // R9700:    chip = <wgp_count = 32, sku = "r9700", memory_bandwidth_tbps = 6.400000e-01 : f32, perf_tflops = {fp16 = 1.910000e+02 : f32, fp32 = 4.780000e+01 : f32, fp8 = 3.830000e+02 : f32, int8 = 3.830000e+02 : f32}>>
+
+// Note: The gfx1250 target is experimental and contains placeholder values.
+// GFX1250: target_info = #iree_gpu.target<arch = "gfx1250",
+// GFX1250-SAME:        subgroup_size_choices = [32, 64]
+// GFX1250-SAME:        max_load_instruction_bits = 128, simds_per_wgp = 4
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -441,6 +441,27 @@ const WgpDetails *getRDNA1WgpDetails() {
   return &rdna1Wgp;
 }
 
+// Experimental gfx1250 WGP details. This uses placeholder values from RDNA4.
+const WgpDetails *getGfx1250WgpDetails() {
+  static const WgpDetails gfx1250Wgp = {allComputeBits,
+                                        allStorageBits,
+                                        allSubgroupOps,
+                                        DotProductOps::None,
+                                        /*mmaCount=*/0,
+                                        /*mmaOps=*/nullptr,
+                                        /*scaledMmaCount=*/0,
+                                        /*scaledMmaOps=*/nullptr,
+                                        {32, 64},
+                                        {1024, 1024, 1024},
+                                        1024,
+                                        64 * 1024,
+                                        {0x7fffffff, 0x7fffffff, 0x7fffffff},
+                                        /*maxLoadInstructionBits=*/128,
+                                        /*simdsPerWgp=*/4,
+                                        /*vgprSpaceBits=*/256 * 32};
+  return &gfx1250Wgp;
+}
+
 std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   const WgpDetails *cdna4Wgp = getCDNA4WgpDetails();
   const WgpDetails *cdna3Wgp = getCDNA3WgpDetails();
@@ -450,6 +471,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   const WgpDetails *rdna3Wgp = getRDNA3WgpDetails();
   const WgpDetails *rdna2Wgp = getRDNA2WgpDetails();
   const WgpDetails *rdna1Wgp = getRDNA1WgpDetails();
+  const WgpDetails *gfx1250Wgp = getGfx1250WgpDetails(); // Experimental.
 
   // --- CDNA --- //
   // "AMD Instinct MI350 Series Product Offerings" in Page 18 of
@@ -646,6 +668,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
              "gfx1035", "gfx1036", TargetDetails{rdna2Wgp, nullptr})
       .Cases("rdna1", "gfx1010", "gfx1011", "gfx1012", "gfx1013",
              TargetDetails{rdna1Wgp, nullptr})
+      .Case("gfx1250", TargetDetails{gfx1250Wgp, nullptr})
       .Default(std::nullopt);
 }
 
@@ -662,6 +685,7 @@ StringRef normalizeAMDGPUTarget(StringRef target) {
              /*Value=*/"gfx1100")
       .Cases("rx7800xt", "rx7700xt", "v710", "w7700", "gfx1101",
              /*Value=*/"gfx1101")
+      .Case("gfx1250", /*Value=*/"gfx1250")
       .Default("");
 }
 


### PR DESCRIPTION
This is so that `gfx1250` gets recognized as a hip target and we can codegen simple programs. Use placeholder values from RDNA4 for now.