### PR TITLE
[NFC][GlobalOpt] Update function names in LIT

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/test/generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/generalize_named_ops.mlir
@@ -116,7 +116,7 @@ util.func public @generalize_1x1_group_conv_2d(%input: tensor<1x2x3x4x5xf32>, %f
 
 // -----
 
-util.func public @no_generalize_1x1_conv_2d_strides(%input: tensor<1x7x7x2xf32>, %filter: tensor<1x1x2x7xf32>) -> tensor<1x4x4x7xf32> {
+util.func public @generalize_1x1_conv_2d_strides(%input: tensor<1x7x7x2xf32>, %filter: tensor<1x1x2x7xf32>) -> tensor<1x4x4x7xf32> {
     %0 = tensor.empty() : tensor<1x4x4x7xf32>
     %1 = linalg.conv_2d_nhwc_hwcf {
         dilations = dense<1> : tensor<2xi64>,
@@ -125,13 +125,13 @@ util.func public @no_generalize_1x1_conv_2d_strides(%input: tensor<1x7x7x2xf32>,
     util.return %1 : tensor<1x4x4x7xf32>
 }
 
-// CHECK-LABEL: @no_generalize_1x1_conv_2d_strides
+// CHECK-LABEL: @generalize_1x1_conv_2d_strides
 //       CHECK:   linalg.generic
 //       CHECK:   util.return
 
 // -----
 
-util.func public @no_generalize_1x1_depthwise_conv(%input: tensor<1x2x3x4xf32>, %filter: tensor<1x1x4xf32>) -> tensor<1x2x3x4xf32> {
+util.func public @generalize_1x1_depthwise_conv(%input: tensor<1x2x3x4xf32>, %filter: tensor<1x1x4xf32>) -> tensor<1x2x3x4xf32> {
     %0 = tensor.empty() : tensor<1x2x3x4xf32>
     %1 = linalg.depthwise_conv_2d_nhwc_hwc {
         dilations = dense<1> : tensor<2xi64>,
@@ -140,6 +140,6 @@ util.func public @no_generalize_1x1_depthwise_conv(%input: tensor<1x2x3x4xf32>, 
     util.return %1 : tensor<1x2x3x4xf32>
 }
 
-// CHECK-LABEL: @no_generalize_1x1_depthwise_conv
+// CHECK-LABEL: @generalize_1x1_depthwise_conv
 //       CHECK:   linalg.generic
 //       CHECK:   util.return


### PR DESCRIPTION
Following up on commit dd684c4, rename the MLIR functions in the test, echoing the newly supported generalizations.

Signed-off-by: Artem Gindinson <gindinson@roofline.ai>