### PR TITLE
[Codegen][GPU] Fix MMA Intrinsics Sorting

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -572,7 +572,7 @@ bool compareIntrinsics(const GPUMatmulShapeType &problem,
 static SmallVector<GPUIntrinsicType>
 sortMMAIntrinsics(GPUMatmulShapeType problem,
                   ArrayRef<GPUIntrinsicType> intrinsics) {
-  SmallVector<GPUIntrinsicType> sortedIntrinsics;
+  SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
   llvm::sort(sortedIntrinsics,
              [&](const GPUMatmulShapeType &lhs, const GPUMatmulShapeType &rhs) {
                return compareIntrinsics(problem, lhs, rhs);
@@ -635,9 +635,10 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     bool transposedRhs, bool canUpcastAcc, bool mustBeAligned,
     bool doCPromotion) {
 
-  sortMMAIntrinsics(problem, intrinsics);
+  SmallVector<GPUIntrinsicType> sortedIntrinsics =
+      sortMMAIntrinsics(problem, intrinsics);
 
-  for (const GPUIntrinsicType &intrinsic : intrinsics) {
+  for (const GPUIntrinsicType &intrinsic : sortedIntrinsics) {
     if (failed(canTargetIntrinsic(problem, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cstdint>
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "mlir/IR/Types.h"
 
@@ -22,6 +23,11 @@ struct GPUMatmulShapeType {
   Type cType;
   GemmSize gemmSize = GemmSize::NotSet;
 
+  // Number of horizontally fused operations.
+  // Horizontal fusion: C1,C2 = fused_matmul(A, B1, B2) where A is shared.
+  // Default 1 for regular matmul: C = A @ B.
+  int64_t numHorizontallyFusedOps = 1;
+
   GPUMatmulShapeType(int64_t m, int64_t n, int64_t k, Type a, Type b, Type c)
       : mSizes({m}), nSizes({n}), kSizes({k}), batchSizes({}), aType(a),
         bType(b), cType(c) {}
@@ -30,6 +36,18 @@ struct GPUMatmulShapeType {
                      Type b, Type c)
       : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
         cType(c) {}
+
+  // Constructor with the num_rhs parameter.
+  GPUMatmulShapeType(int64_t m, int64_t n, int64_t k, Type a, Type b, Type c,
+                     int64_t numHorizontallyFusedOps)
+      : mSizes({m}), nSizes({n}), kSizes({k}), batchSizes({}), aType(a),
+        bType(b), cType(c), numHorizontallyFusedOps(numHorizontallyFusedOps) {}
+
+  GPUMatmulShapeType(ArrayRef<int64_t> m, ArrayRef<int64_t> n,
+                     ArrayRef<int64_t> k, ArrayRef<int64_t> batch, Type a,
+                     Type b, Type c, int64_t numHorizontallyFusedOps)
+      : mSizes(m), nSizes(n), kSizes(k), batchSizes(batch), aType(a), bType(b),
+        cType(c), numHorizontallyFusedOps(numHorizontallyFusedOps) {}
 };
 
 /// Struct containing information about a GPU MMA intrinsic type.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -78,14 +78,14 @@ func.func @group_conv_hwgc_gfhwc_unaligned(%arg0: tensor<61x93x16x56xbf16>, %arg
 }
 
 // CHECK-LABEL: func.func @group_conv_hwgc_gfhwc_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
-//  CHECK-SAME:     padding_conv = [1, 32, 1, 64, 0, 0, 64]
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_BF16>
+//  CHECK-SAME:     padding_conv = [1, 32, 1, 64, 0, 0, 8]
 //  CHECK-SAME:     promote_operands = [0, 1]
-//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 4]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
 //  CHECK-SAME:     subgroup = [0, 1, 0, 1, 0, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 32, 1, 64, 0, 0, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -39,8 +39,8 @@ func.func @expanded_matmul_transpose_b() {
 
 // CHECK-LABEL: func.func @expanded_matmul_transpose_b()
 // CHECK: linalg.generic {{.*}}lowering_config =  #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 128]
+// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 256]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 64, 0]
 
@@ -70,9 +70,9 @@ func.func @conv_nhwc() {
 
 // CHECK-LABEL: func.func @conv_nhwc()
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 32]
-// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]
+// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 64]
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 128, 0, 0, 0]
 
 // -----
@@ -134,8 +134,8 @@ func.func @mfma_matmul_1024x1024x1024() {
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 64]
+// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 128]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
@@ -184,12 +184,14 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 32]
+// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]
 
 // -----
+
+//       CHECK: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 
 #pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -219,8 +221,14 @@ func.func @matmul_dynamic_dim() {
   iree_tensor_ext.dispatch.tensor.store %15, %10, offsets = [0, 0], sizes = [%8, 256], strides = [1, 1] : tensor<?x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x256xf32>>{%8}
   return
 }
-// Check that we have unhandled dynamic dimension.
-//       CHECK-NOT: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+
+// CHECK-LABEL: func.func @matmul_dynamic_dim()
+// CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME{LITERAL}:                          lane_basis = [[1, 1, 64], [0, 1, 2]]
+// CHECK-SAME:                                   partial_reduction = [0, 0, 256]
+// CHECK-SAME{LITERAL}:                          subgroup_basis = [[1, 1, 1], [0, 1, 2]]
+// CHECK-SAME:                                   thread = [0, 0, 4]
+// CHECK-SAME:                                   workgroup = [1, 1, 0]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -151,7 +151,7 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
 // CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
@@ -74,7 +74,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
+// GFX942-SAME:      mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]
@@ -276,7 +276,7 @@ func.func @fused_contraction_4(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
+// GFX942-SAME:       mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
 // GFX950-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]


### PR DESCRIPTION
This PR fixes the issue in the function `sortMMAIntrinsics `,  in which `sortedIntrinsics ` ends up empty. 
To fix the ci errors, this PR also corrects the calculation of shared memory usage for horizontally fused contractions along vector distribute pipeline.

Issue: #22114  
