### PR TITLE
[Test] Trim data-tiling compile flags from tests.

### DIFF
--- a/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
+++ b/docs/website/docs/community/blog/posts/data-tiling-walkthrough.md
@@ -53,8 +53,7 @@ Compilation command, that targets gfx942 AMDGPU:
 iree-compile matmul.mlir -o /tmp/matmul.mlir \
   --iree-hal-target-device=hip \
   --iree-hip-target=gfx942 \
-  --iree-dispatch-creation-data-tiling \
-  --iree-llvmgpu-test-combine-layout-transformation=true
+  --iree-dispatch-creation-data-tiling
 ```
 
 Test source program, matmul.mlir:

--- a/tests/e2e/encoding/BUILD.bazel
+++ b/tests/e2e/encoding/BUILD.bazel
@@ -18,7 +18,6 @@ iree_check_single_backend_test_suite(
     srcs = ["encoding.mlir"],
     compiler_flags = [
         "--iree-global-opt-enable-early-materialization=false",
-        "--iree-llvmgpu-test-combine-layout-transformation=true",
     ],
     driver = "hip",
     target_backend = "rocm",

--- a/tests/e2e/encoding/CMakeLists.txt
+++ b/tests/e2e/encoding/CMakeLists.txt
@@ -21,7 +21,6 @@ iree_check_single_backend_test_suite(
     "hip"
   COMPILER_FLAGS
     "--iree-global-opt-enable-early-materialization=false"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -52,14 +52,14 @@ iree_check_single_backend_test_suite(
     target_backend = "llvm-cpu",
 )
 
-# TODO(#19378): Delete the test suite once data-tiling fusion is default on.
+# TODO(#19378): Delete the test suite after we switch to data-tiling fusion for
+# tests/e2e/matmul test suite.
 iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_dt_fusion_local-task",
     srcs = ["narrow_n_matmuls.mlir"],
     compiler_flags = [
         "--iree-dispatch-creation-data-tiling",
         "--iree-llvmcpu-target-cpu=generic",
-        "--iree-opt-data-tiling=false",
     ],
     driver = "local-task",
     tags = [

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -46,7 +46,6 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "--iree-dispatch-creation-data-tiling"
     "--iree-llvmcpu-target-cpu=generic"
-    "--iree-opt-data-tiling=false"
   LABELS
     "nowasm"
 )

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1390,9 +1390,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1419,9 +1417,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1448,9 +1444,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1477,10 +1471,8 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-hip-enable-ukernels=multi_mma"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1507,9 +1499,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1536,9 +1526,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1565,9 +1553,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1596,9 +1582,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
     "noasan"
@@ -1628,9 +1612,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
     "noasan"
@@ -1658,10 +1640,8 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
     "--iree-input-demote-f64-to-f32=false"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
   LABELS
     "noasan"
     "nomsan"
@@ -1688,7 +1668,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
     "--iree-hip-encoding-layout-resolver=pad"
@@ -1718,7 +1697,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
     "--iree-hip-encoding-layout-resolver=pad"
@@ -1781,9 +1759,7 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
-    "--iree-llvmgpu-test-combine-layout-transformation=true"
     "--iree-hip-enable-tensor-ukernels"
   LABELS
     "noasan"
@@ -1939,7 +1915,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -1970,7 +1945,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
   LABELS
     "noasan"
@@ -2155,7 +2129,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -2186,7 +2159,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
   RUNNER_ARGS
     "--require_exact_results=false"
@@ -2217,7 +2189,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling=false"
     "--iree-dispatch-creation-data-tiling"
   LABELS
     "noasan"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_data_tiling_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_decode_data_tiling_rocm.json
@@ -23,9 +23,7 @@
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
         "--iree-stream-resource-memory-model=discrete",
-        "--iree-opt-data-tiling=false",
-        "--iree-dispatch-creation-data-tiling",
-        "--iree-llvmgpu-test-combine-layout-transformation"
+        "--iree-dispatch-creation-data-tiling"
     ],
     "run_function": "decode_bs4"
 }

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_data_tiling_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/llama/8b_f16_prefill_data_tiling_rocm.json
@@ -20,9 +20,7 @@
         "--iree-hal-target-device=hip",
         "--iree-opt-level=O3",
         "--iree-stream-resource-memory-model=discrete",
-        "--iree-opt-data-tiling=false",
-        "--iree-dispatch-creation-data-tiling",
-        "--iree-llvmgpu-test-combine-layout-transformation"
+        "--iree-dispatch-creation-data-tiling"
     ],
     "run_function": "prefill_bs4"
 }

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sd3/mmdit_rocm.json
@@ -32,7 +32,6 @@
         "--iree-opt-const-eval=false",
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)"

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
@@ -41,7 +41,6 @@
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
@@ -41,7 +41,6 @@
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_960_1024_rocm.json
@@ -34,7 +34,6 @@
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/unet_fp16_rocm.json
@@ -34,7 +34,6 @@
         "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-vm-target-truncate-unsupported-floats",
         "--iree-llvmgpu-enable-prefetch=true",
-        "--iree-opt-data-tiling=false",
         "--iree-hip-waves-per-eu=2",
         "--iree-execution-model=async-external",
         "--iree-scheduling-dump-statistics-format=json",

--- a/tests/transform_dialect/cpu/matmul_library_call.mlir
+++ b/tests/transform_dialect/cpu/matmul_library_call.mlir
@@ -15,7 +15,6 @@ module {
 // RUN: iree-compile %s \
 // RUN:   --iree-hal-target-device=local \
 // RUN:   --iree-hal-local-target-device-backends=llvm-cpu \
-// RUN:   --iree-opt-data-tiling=false \
 // RUN:   --iree-codegen-transform-dialect-library=%p/transform_library.mlir@custom_matmul \
 // RUN:   --compile-to=executable-targets | \
 // RUN: FileCheck %s --check-prefixes=CODEGEN-DEFAULT
@@ -28,7 +27,6 @@ module {
 // RUN: iree-compile %s \
 // RUN:   --iree-hal-target-device=local \
 // RUN:   --iree-hal-local-target-device-backends=llvm-cpu \
-// RUN:   --iree-opt-data-tiling=false \
 // RUN:   --iree-codegen-transform-dialect-library=%p/transform_library.mlir@custom_matmul | \
 // RUN: iree-run-module --module=- --function=matmul_static \
 // RUN:   --input="3x5xf32=1" \


### PR DESCRIPTION
Starting from https://github.com/iree-org/iree/commit/a5f8939bf8897a50b7c8d0dd96184c87917acea5, data-tiling is not default on for many reasons. Unless the test suites are designed for a specific combination, we don't add data-tiling flags. E.g., [cpu tests](https://github.com/iree-org/iree/blob/ec4e3677e0d59572b3d54be1aa3e7c6b16643b6c/tests/e2e/matmul/BUILD.bazel#L132-L199).

The revision removes two flags:
* `iree-opt-data-tiling`, which is off by default.
* `iree-llvmgpu-test-combine-layout-transformation`, which is on by default.