### PR TITLE
[LLVMGPU] Don't use DMA for scaled matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -733,7 +733,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   SmallVector<Attribute> promotionArray = {useGlobalDma, useGlobalDma};
   SmallVector<int64_t> promotionList = {0, 1};
   if (scaled) {
-    promotionArray.append({useGlobalDma, useGlobalDma});
+    // TODO(Max191): We don't use global load DMA for scaled matmuls, because
+    // compilation doesn't support it. Once this is fixed, we should use global
+    // load DMA here when possible.
+    promotionArray = {};
     promotionList.append({2, 3});
   }
   ArrayRef<Attribute> promotionTypes = useDirectLoad

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -733,7 +733,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   SmallVector<Attribute> promotionArray = {useGlobalDma, useGlobalDma};
   SmallVector<int64_t> promotionList = {0, 1};
   if (scaled) {
-    // TODO(Max191): We don't use global load DMA for scaled matmuls, because
+    // TODO(#22119): We don't use global load DMA for scaled matmuls, because
     // compilation doesn't support it. Once this is fixed, we should use global
     // load DMA here when possible.
     promotionArray = {};

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -30,6 +30,7 @@ func.func @scaled_matmul(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //  CHECK-SAME:     reduction = [0, 0, 32, 1]
 //  CHECK-SAME:     subgroup = [1, 1, 0, 0]
 //  CHECK-SAME:     workgroup = [32, 32, 0, 0]
@@ -60,9 +61,11 @@ func.func @scaled_matmul_with_batch(
 // CHECK-LABEL: func.func @scaled_matmul_with_batch
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
+//   CHECK-NOT:   promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //  CHECK-SAME:     reduction = [0, 0, 0, 32, 1]
 //  CHECK-SAME:     subgroup = [0, 1, 1, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 32, 32, 0, 0]
@@ -124,6 +127,7 @@ func.func @small_scaled_matmul(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     subgroup = [1, 1, 0, 0]
 //  CHECK-SAME:     workgroup = [16, 16, 0, 0]


### PR DESCRIPTION
Using DMA promotion for scaled GEMM is fails to compile, so don't use it. We should eventually turn it on when we can guarantee compilation.