### PR TITLE
[GPU] Fix bug in shared memory computation for scaled intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -509,10 +509,15 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
   SmallVector<int64_t> kTileSizes =
       getBestKTileSizes(problem, intrinsic, seeds);
 
-  return GPUMMASchedule{
-      intrinsic.mmaKind,   intrinsic.mSizes[0], intrinsic.nSizes[0],
-      intrinsic.kSizes[0], mSubgroupCounts,     nSubgroupCounts,
-      mTileSizes,          nTileSizes,          kTileSizes};
+  return GPUMMASchedule{intrinsic.mmaKind,
+                        prod(intrinsic.mSizes),
+                        prod(intrinsic.nSizes),
+                        prod(intrinsic.kSizes),
+                        mSubgroupCounts,
+                        nSubgroupCounts,
+                        mTileSizes,
+                        nTileSizes,
+                        kTileSizes};
 }
 
 /// Compare the MMA intrinsics by following precedence rules:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -9,11 +9,11 @@
 #scale_n = affine_map<(M, N, Ko, Kb) -> (N, Ko)>
 #out_map = affine_map<(M, N, Ko, Kb) -> (M, N)>
 func.func @scaled_matmul(
-    %A: tensor<1024x32x32xf4E2M1FN>, %B: tensor<1024x32x32xf4E2M1FN>, %A_scales: tensor<1024x32xf8E8M0FNU>, %B_scales: tensor<1024x32xf8E8M0FNU>, %C: tensor<1024x1024xf32>) -> tensor<1024x1024xf32> {
+    %A: tensor<1024x512x32xf4E2M1FN>, %B: tensor<1024x512x32xf4E2M1FN>, %A_scales: tensor<1024x512xf8E8M0FNU>, %B_scales: tensor<1024x512xf8E8M0FNU>, %C: tensor<1024x1024xf32>) -> tensor<1024x1024xf32> {
   %0 = linalg.generic {
     indexing_maps = [#lhs_map, #rhs_map, #scale_m, #scale_n, #out_map],
     iterator_types = ["parallel", "parallel", "reduction", "reduction"]
-  } ins(%A, %B, %A_scales, %B_scales : tensor<1024x32x32xf4E2M1FN>, tensor<1024x32x32xf4E2M1FN>, tensor<1024x32xf8E8M0FNU>, tensor<1024x32xf8E8M0FNU>) outs(%C : tensor<1024x1024xf32>) {
+  } ins(%A, %B, %A_scales, %B_scales : tensor<1024x512x32xf4E2M1FN>, tensor<1024x512x32xf4E2M1FN>, tensor<1024x512xf8E8M0FNU>, tensor<1024x512xf8E8M0FNU>) outs(%C : tensor<1024x1024xf32>) {
   ^bb0(%a: f4E2M1FN, %b: f4E2M1FN, %a_scale: f8E8M0FNU, %b_scale: f8E8M0FNU, %out: f32):
     %1 = arith.scaling_extf %a, %a_scale : f4E2M1FN, f8E8M0FNU to f32
     %2 = arith.scaling_extf %b, %b_scale : f4E2M1FN, f8E8M0FNU to f32
@@ -30,9 +30,9 @@ func.func @scaled_matmul(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//  CHECK-SAME:     reduction = [0, 0, 8, 1]
-//  CHECK-SAME:     subgroup = [2, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [64, 128, 0, 0]
+//  CHECK-SAME:     reduction = [0, 0, 32, 1]
+//  CHECK-SAME:     subgroup = [1, 1, 0, 0]
+//  CHECK-SAME:     workgroup = [32, 32, 0, 0]
 
 // -----
 
@@ -42,11 +42,11 @@ func.func @scaled_matmul(
 #scale_n = affine_map<(B, M, N, Ko, Kb) -> (B, N, Ko)>
 #out_map = affine_map<(B, M, N, Ko, Kb) -> (B, M, N)>
 func.func @scaled_matmul_with_batch(
-    %A: tensor<4x1024x32x32xf4E2M1FN>, %B: tensor<4x1024x32x32xf4E2M1FN>, %A_scales: tensor<4x1024x32xf8E8M0FNU>, %B_scales: tensor<4x1024x32xf8E8M0FNU>, %C: tensor<4x1024x1024xf32>) -> tensor<4x1024x1024xf32> {
+    %A: tensor<4x1024x512x32xf4E2M1FN>, %B: tensor<4x1024x512x32xf4E2M1FN>, %A_scales: tensor<4x1024x512xf8E8M0FNU>, %B_scales: tensor<4x1024x512xf8E8M0FNU>, %C: tensor<4x1024x1024xf32>) -> tensor<4x1024x1024xf32> {
   %0 = linalg.generic {
     indexing_maps = [#lhs_map, #rhs_map, #scale_m, #scale_n, #out_map],
     iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
-  } ins(%A, %B, %A_scales, %B_scales : tensor<4x1024x32x32xf4E2M1FN>, tensor<4x1024x32x32xf4E2M1FN>, tensor<4x1024x32xf8E8M0FNU>, tensor<4x1024x32xf8E8M0FNU>) outs(%C : tensor<4x1024x1024xf32>) {
+  } ins(%A, %B, %A_scales, %B_scales : tensor<4x1024x512x32xf4E2M1FN>, tensor<4x1024x512x32xf4E2M1FN>, tensor<4x1024x512xf8E8M0FNU>, tensor<4x1024x512xf8E8M0FNU>) outs(%C : tensor<4x1024x1024xf32>) {
   ^bb0(%a: f4E2M1FN, %b: f4E2M1FN, %a_scale: f8E8M0FNU, %b_scale: f8E8M0FNU, %out: f32):
     %1 = arith.scaling_extf %a, %a_scale : f4E2M1FN, f8E8M0FNU to f32
     %2 = arith.scaling_extf %b, %b_scale : f4E2M1FN, f8E8M0FNU to f32
@@ -63,9 +63,9 @@ func.func @scaled_matmul_with_batch(
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
-//  CHECK-SAME:     reduction = [0, 0, 0, 8, 1]
-//  CHECK-SAME:     subgroup = [0, 2, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [1, 64, 128, 0, 0]
+//  CHECK-SAME:     reduction = [0, 0, 0, 32, 1]
+//  CHECK-SAME:     subgroup = [0, 1, 1, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 32, 32, 0, 0]
 
 // -----
 


### PR DESCRIPTION
The shared memory calculation was not taking into account both of the K dimensions (K and the block dim) when computing shared memory tiles, so it was underestimating shared memory use for schedules, and selecting tile sizes that do not fit in shared memory. This fixes the issue by properly setting the `kSize` field in the `GPUMMASchedule` to the product of all intrinsic K dimensions.

The lit tests for TileAndFuse configs are updated, because the shapes in the tests were too small to detect this bug. The shapes are made large to test the logic.