### PR TITLE
[LLVMGPU] Annotate and propagate HAL-level writeonly function arguments

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -91,7 +91,8 @@ struct ConvertHalInterfaceBindingSubspan final
         rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
             op, newResultTy, adaptor.getLayout(), adaptor.getBinding(),
             adaptor.getByteOffset(), adaptor.getDynamicDims(),
-            adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
+            adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr(),
+            op.getWriteonlyAttr());
     LLVM_DEBUG(llvm::dbgs() << "Bf16Emulation: new op: " << newOp << "\n");
     (void)newOp;
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -83,7 +83,7 @@ struct ConvertHalInterfaceBindingSubspan final
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         op, newResultType, adaptor.getLayout(), adaptor.getBinding(),
         byteOffset, dynamicLinearizedSize, adaptor.getAlignmentAttr(),
-        adaptor.getDescriptorFlagsAttr());
+        adaptor.getDescriptorFlagsAttr(), op.getWriteonlyAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -292,7 +292,8 @@ struct FlattenBindingSubspan final
     auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, subspanOp.getLoc(), newType, subspanOp.getLayout(),
         subspanOp.getBinding(), newOffset, dynamicShape,
-        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr(),
+        subspanOp.getWriteonlyAttr());
 
     Value replacement = newOp;
     if (!isZeroInteger(elementOffset)) {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -205,7 +205,8 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
       newBinding = IREE::HAL::InterfaceBindingSubspanOp::create(
           rewriter, loc, newBufferType, binding.getLayoutAttr(),
           binding.getBindingAttr(), zero, dynamicLinearShape,
-          binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
+          binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr(),
+          binding.getWriteonlyAttr());
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -231,7 +231,7 @@ struct MaterializeInterfaceBindingEncoding final
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp, newResultType, subspanOp.getLayout(), subspanOp.getBinding(),
         subspanOp.getByteOffset(), newDynamicDims, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -531,7 +531,7 @@ struct MaterializeInterfaceBindingEncoding
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp, newResultType, subspanOp.getLayout(), subspanOp.getBinding(),
         subspanOp.getByteOffset(), newDynamicDims, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -131,7 +131,7 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -231,7 +231,8 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
     newSubspanOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicDims,
-        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr(),
+        subspanOp.getWriteonlyAttr());
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -316,7 +317,7 @@ struct FoldExpandShapeIntoInterfaceTensorStore
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
 
     rewriter.setInsertionPoint(storeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorStoreOp>(
@@ -499,7 +500,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
     auto newSubspanOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicShape,
-        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
 
     rewriter.setInsertionPoint(storeOp);
 
@@ -798,7 +799,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
           rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
           subspanOp.getBinding(), subspanOp.getByteOffset(),
           newSubspanDynamicDims, subspanOp.getAlignmentAttr(),
-          subspanOp.getDescriptorFlagsAttr());
+          subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
     }
 
     SmallVector<OpFoldResult> expandedStrides(reshapeSrcShape.size(),
@@ -875,7 +876,7 @@ struct FoldInnerBitcastIntoInterfaceTensorLoad
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
 
     rewriter.setInsertionPoint(bitcastOp);
     SmallVector<int64_t> newSizes(loadOp.getStaticSizes());
@@ -945,7 +946,7 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
 
     SmallVector<int64_t> newSizes(storeOp.getStaticSizes());
     newSizes.back() = newInnerSize;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -220,6 +220,7 @@ namespace {
 /// binding, which is read-only, unused, and in address space 0.
 struct BindingProperties {
   bool readonly = true;
+  bool writeonly = false;
   bool unused = true;
   unsigned addressSpace = 0;
 };
@@ -236,6 +237,7 @@ analyzeSubspans(llvm::SetVector<IREE::HAL::InterfaceBindingSubspanOp> &subspans,
     result[binding].readonly &= IREE::HAL::bitEnumContainsAny(
         subspan.getDescriptorFlags().value_or(IREE::HAL::DescriptorFlags::None),
         IREE::HAL::DescriptorFlags::ReadOnly);
+    result[binding].writeonly = subspan.getWriteonlyAttr() && !result[binding].readonly ? true : false;
     unsigned bindingAddrSpace = 0;
     auto bindingType = dyn_cast<BaseMemRefType>(subspan.getType());
     if (bindingType) {
@@ -360,6 +362,9 @@ public:
         // Setting the readonly attribute here will generate non-coherent cache
         // loads.
         newFuncOp.setArgAttr(idx, LLVM::LLVMDialect::getReadonlyAttrName(),
+                             unit);
+      } else if (info.writeonly) {
+        newFuncOp.setArgAttr(idx, LLVM::LLVMDialect::getWriteOnlyAttrName(),
                              unit);
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -15,7 +15,7 @@ hal.executable @abs_ex_dispatch_0 {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) writeonly : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
@@ -34,7 +34,7 @@ hal.executable @abs_ex_dispatch_0 {
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //  CHECK-SAME:  %[[ARG1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
-//  CHECK-SAME:  %[[ARG2:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef})
+//  CHECK-SAME:  %[[ARG2:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly})
 //  CHECK: %[[FADD:.+]] = llvm.fadd %{{.*}}, %{{.*}}  : f32
 //  CHECK: %[[ADDR:.+]] = llvm.getelementptr inbounds|nuw %[[ARG2]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //  CHECK: llvm.store %[[FADD]], %[[ADDR]] : f32, !llvm.ptr
@@ -174,7 +174,7 @@ hal.executable @mixed_type {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c128) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) writeonly : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
@@ -193,7 +193,7 @@ hal.executable @mixed_type {
 
 // CHECK-LABEL: llvm.func @mixed_type
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
-//  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef})
+//  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly})
 //       CHECK:   %[[BYTES_PER_BIT:.+]] = llvm.mlir.constant(8 : i64) : i64
 //       CHECK:   %[[BITS_PER_ELEM:.+]] = llvm.mlir.constant(32 : i64) : i64
 //       CHECK:   %[[BYTE_OFFSET:.+]] = llvm.mlir.constant(128 : index) : i64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -241,7 +241,7 @@ builtin.module {
     %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
     %1 = arith.index_castui %0 : i32 to index
     %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%1) flags(ReadOnly) : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
-    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<16xf32, #gpu.address_space<global>>
+    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) writeonly : memref<16xf32, #gpu.address_space<global>>
     %4 = memref.load %2[%c0] : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
     memref.store %4, %3[%c0] : memref<16xf32, #gpu.address_space<global>>
     return
@@ -250,7 +250,7 @@ builtin.module {
 //   CHECK-LABEL: llvm.func @missing_ptr_dispatch_copy_idx_0
 //    CHECK-SAME: (%[[arg0:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
 //    CHECK-SAME:  %[[arg1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone},
-//    CHECK-SAME:  %[[arg2:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
+//    CHECK-SAME:  %[[arg2:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly},
 //    CHECK-SAME:  %[[arg3:.+]]: i32 {llvm.noundef})
 //         CHECK:   llvm.zext %[[arg3]] : i32 to i64
 //         CHECK:   llvm.insertvalue %[[arg0]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -64,7 +64,8 @@ struct ConvertHalInterfaceBindingSubspan final
         rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
             op, newResultTy, adaptor.getLayout(), adaptor.getBinding(),
             adaptor.getByteOffset(), adaptor.getDynamicDims(),
-            adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
+            adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr(),
+            op.getWriteonlyAttr());
     LLVM_DEBUG(llvm::dbgs()
                << "WideIntegerEmulation: new op: " << newOp << "\n");
     (void)newOp;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -88,7 +88,8 @@ rewriteStorageBufferSubspanOp(RewriterBase &rewriter,
   auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
       rewriter, subspanOp.getLoc(), newType, subspanOp.getLayoutAttr(),
       subspanOp.getBindingAttr(), subspanOp.getByteOffset(), dynamicDims,
-      subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+      subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr(),
+      subspanOp.getWriteonlyAttr());
 
   LLVM_DEBUG({
     llvm::dbgs() << "Rewritten to: ";

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -662,7 +662,8 @@ public:
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp, *vecMemRef, subspanOp.getLayout(), subspanOp.getBinding(),
         subspanOp.getByteOffset(), subspanOp.getDynamicDims(),
-        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr(),
+        subspanOp.getWriteonlyAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1229,7 +1229,7 @@ Value findOrCreateSubspanBuffer(
       rewriter, subspanOp->getLoc(), memRefType, subspanOp.getLayout(),
       subspanOp.getBinding(), subspanOp.getByteOffset(),
       subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
-      subspanOp.getDescriptorFlagsAttr());
+      subspanOp.getDescriptorFlagsAttr(), subspanOp.getWriteonlyAttr());
   if (useRocdlBuffers) {
     buffer = amdgpu::FatRawBufferCastOp::create(
         rewriter, subspanOp->getLoc(), buffer, /*validBytes=*/Value{},

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -2228,20 +2228,18 @@ LogicalResult InterfaceConstantLoadOp::verify() {
 // hal.interface.binding.subspan
 //===----------------------------------------------------------------------===//
 
-void InterfaceBindingSubspanOp::build(OpBuilder &builder,
-                                      OperationState &result, Type resultType,
-                                      IREE::HAL::PipelineLayoutAttr layout,
-                                      APInt binding, Value byte_offset,
-                                      ValueRange dynamic_dims,
-                                      IntegerAttr alignment,
-                                      std::optional<DescriptorFlags> flags) {
+void InterfaceBindingSubspanOp::build(
+    OpBuilder &builder, OperationState &result, Type resultType,
+    IREE::HAL::PipelineLayoutAttr layout, APInt binding, Value byte_offset,
+    ValueRange dynamic_dims, IntegerAttr alignment,
+    std::optional<DescriptorFlags> flags, bool writeonly) {
   IREE::HAL::DescriptorFlagsAttr descriptorAttr;
   if (flags.has_value()) {
     descriptorAttr = IREE::HAL::DescriptorFlagsAttr::get(builder.getContext(),
                                                          flags.value());
   }
   build(builder, result, resultType, layout, binding, byte_offset, dynamic_dims,
-        alignment, descriptorAttr);
+        alignment, descriptorAttr, writeonly ? builder.getUnitAttr() : nullptr);
 }
 
 LogicalResult InterfaceBindingSubspanOp::verify() {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -3513,7 +3513,8 @@ def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan", [
     Optional<HAL_DeviceSize>:$byte_offset,
     HAL_ShapeDynamicDims:$dynamic_dims,
     OptionalAttr<IndexAttr>:$alignment,
-    OptionalAttr<HAL_DescriptorFlagsAttr>:$descriptor_flags
+    OptionalAttr<HAL_DescriptorFlagsAttr>:$descriptor_flags,
+    OptionalAttr<UnitAttr>:$writeonly
   );
   let results = (outs
     AnyType:$result
@@ -3525,6 +3526,7 @@ def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan", [
     (`alignment` `(` $alignment^ `)`)?
     (`offset` `(` $byte_offset^ `)`)?
     (`flags` `(` $descriptor_flags^ `)`)?
+    (`writeonly` $writeonly^)?
     attr-dict `:` type($result) (`{` $dynamic_dims^ `}`)?
   }];
 
@@ -3536,8 +3538,8 @@ def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan", [
       "Value":$byte_offset,
       "ValueRange":$dynamic_dims,
       "IntegerAttr":$alignment,
-      CArg<"std::optional<DescriptorFlags>", "std::nullopt">:$flags
-    )>,
+      CArg<"std::optional<DescriptorFlags>", "std::nullopt">:$flags,
+      CArg<"bool", "false">:$writeonly)>,
   ];
 
   let hasVerifier = 1;


### PR DESCRIPTION
Aims to address #22047 

As [discussed](https://github.com/iree-org/iree/issues/22047#issuecomment-3319984089) despite my initial idea of manipulating descriptors directly, we opted for adding the proper `writeonly` attribute embeded in the HAL binding by extracting the dispatch type from its respective dispatch tensor at Stream -> HAL conversion.

Coverage is perhaps where I'd like to get the most feedback from. I found it a bit complicated to navigate the vast ocean of tests and wasn't really to encounter a suite that would deal with binding conversion from Stream to HAL.

Besides that, I'm happy to finally push this forward, I expect to deliver more gpu-related patches in the future 🙂