### PR TITLE
[Vulkan][spirv] Disable failing e2e matmul test

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -407,8 +407,8 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     test_type = "matmul",
 ) for (lhs_rhs_type, acc_type) in [
     ("i8", "i32"),
-    ("f16", "f32"),
     ("f32", "f32"),
 ]]
 
-# TODO(#19465): add large matmul tests for rdna3 and rdna4.
+# TODO(#22108): Reenable large ampere matmul f16.
+# TODO(#19465): Add large matmul tests for rdna3 and rdna4.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1090,30 +1090,6 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_vulkan_f16_large_ampere
-  TEST_TYPE
-    matmul
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=easy_large_static"
-  TEST_RUNNER
-    iree_tools_testing_e2e_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "vulkan-spirv"
-  DRIVERS
-    "vulkan"
-  COMPILER_FLAGS
-    "--iree-vulkan-target=ampere"
-  LABELS
-    "requires-gpu-sm80"
-    "vulkan_uses_vk_khr_shader_float16_int8"
-)
-
-iree_generated_e2e_runner_test(
-  NAME
     e2e_matmul_vulkan_f32_large_ampere
   TEST_TYPE
     matmul


### PR DESCRIPTION
This started failing after we removed the explicit compilation info in https://github.com/iree-org/iree/pull/22085.

Issue: https://github.com/iree-org/iree/issues/22108