### PR TITLE
Adding VerifyStructuredControlFlowPass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -41,6 +41,7 @@ iree_compiler_cc_library(
         "StripDebugOps.cpp",
         "TestConversion.cpp",
         "TestFloatRangeAnalysis.cpp",
+        "VerifyStructuredControlFlow.cpp",
     ],
     hdrs = [
         "Passes.h",
@@ -67,6 +68,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithTransforms",
         "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:ControlFlowDialect",
+        "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     "StripDebugOps.cpp"
     "TestConversion.cpp"
     "TestFloatRangeAnalysis.cpp"
+    "VerifyStructuredControlFlow.cpp"
   DEPS
     ::PassesIncGen
     LLVMSupport
@@ -50,6 +51,7 @@ iree_cc_library(
     MLIRArithTransforms
     MLIRBytecodeWriter
     MLIRControlFlowDialect
+    MLIRControlFlowInterfaces
     MLIRFuncDialect
     MLIRFunctionInterfaces
     MLIRIR

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -71,6 +71,7 @@ createHoistIntoGlobalsPass(const ExprHoistingOptions &options);
 #define GEN_PASS_DECL_STRIPDEBUGOPSPASS
 #define GEN_PASS_DECL_TESTCONVERSIONPASS
 #define GEN_PASS_DECL_TESTFLOATRANGEANALYSISPASS
+#define GEN_PASS_DECL_VERIFYSTRUCTUREDCONTROLFLOWPASS
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h.inc" // IWYU pragma: keep
 
 void registerUtilPasses();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -144,6 +144,15 @@ def StripDebugOpsPass : Pass<"iree-util-strip-debug-ops", ""> {
   let summary = "Strips debug ops, like assertions.";
 }
 
+def VerifyStructuredControlFlowPass :
+    InterfacePass<"iree-util-verify-structured-control-flow", "mlir::FunctionOpInterface"> {
+  let summary = "Verifies that functions contain only structured control flow.";
+  let description = [{
+    Verifies that functions contain only structured control flow (no ops
+    implementing `BranchOpInterface` like `cf.br` or `cf.cond_br`).
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Globals
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyStructuredControlFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyStructuredControlFlow.cpp
@@ -1,0 +1,53 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::Util {
+
+#define GEN_PASS_DEF_VERIFYSTRUCTUREDCONTROLFLOWPASS
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h.inc"
+
+namespace {
+
+struct VerifyStructuredControlFlowPass
+    : public impl::VerifyStructuredControlFlowPassBase<
+          VerifyStructuredControlFlowPass> {
+  using Base::Base;
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    if (funcOp.empty()) {
+      // External function/declaration.
+      return;
+    }
+
+    // Walk the function and check for any branch operations.
+    // BranchOpInterface catches cf.br, cf.cond_br, cf.switch and any other
+    // operations that perform branching. Without these operations multi-block
+    // regions cannot form a control flow graph so we don't need to check for
+    // multiple blocks.
+    auto result = funcOp.walk([&](Operation *op) -> WalkResult {
+      if (isa<BranchOpInterface>(op)) {
+        return op->emitError()
+               << "unexpected branch operation in function after structured "
+                  "control flow conversion";
+      }
+      return WalkResult::advance();
+    });
+
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "strip_debug_ops.mlir",
             "test_float_range_analysis.mlir",
             "test_float_range_analysis_linalg.mlir",
+            "verify_structured_control_flow.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "strip_debug_ops.mlir"
     "test_float_range_analysis.mlir"
     "test_float_range_analysis_linalg.mlir"
+    "verify_structured_control_flow.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/verify_structured_control_flow.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/verify_structured_control_flow.mlir
@@ -1,0 +1,115 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-util-verify-structured-control-flow))" --split-input-file --verify-diagnostics %s
+
+// Tests that external functions are ignored.
+
+util.func private @external_func()
+
+// -----
+
+// Tests that a valid structured control flow passes verification.
+
+util.func public @valid_scf_if(%cond: i1) -> i32 {
+  %result = scf.if %cond -> i32 {
+    %c1 = arith.constant 1 : i32
+    scf.yield %c1 : i32
+  } else {
+    %c2 = arith.constant 2 : i32
+    scf.yield %c2 : i32
+  }
+  util.return %result : i32
+}
+
+// -----
+
+// Tests that a valid scf.index_switch passes verification.
+
+util.func public @valid_scf_index_switch(%idx: index) -> i32 {
+  %result = scf.index_switch %idx -> i32
+  case 0 {
+    %c10 = arith.constant 10 : i32
+    scf.yield %c10 : i32
+  }
+  case 1 {
+    %c20 = arith.constant 20 : i32
+    scf.yield %c20 : i32
+  }
+  default {
+    %c30 = arith.constant 30 : i32
+    scf.yield %c30 : i32
+  }
+  util.return %result : i32
+}
+
+// -----
+
+// Tests that a valid single-block scf.execute_region passes verification.
+
+util.func public @valid_scf_execute_region() {
+  scf.execute_region {
+    %c_true = arith.constant true
+    %cond = util.optimization_barrier %c_true : i1
+    scf.if %cond {
+      %c1 = arith.constant 1 : i32
+      util.optimization_barrier %c1 : i32
+    } else {
+      %c2 = arith.constant 2 : i32
+      util.optimization_barrier %c2 : i32
+    }
+    scf.yield
+  }
+  util.return
+}
+
+// -----
+
+// Tests that nested scf.execute_regions pass verification.
+
+util.func public @nested_scf_execute_region(%cond: i1) {
+  scf.if %cond {
+    scf.execute_region {
+      scf.execute_region {
+        %c42 = arith.constant 42 : i32
+        util.optimization_barrier %c42 : i32
+        scf.yield
+      }
+      scf.yield
+    }
+  }
+  util.return
+}
+
+// -----
+
+// Tests that branch operations in functions trigger an error.
+// The presence of cf.br creates a multi-block function with CFG.
+
+util.func public @invalid_branch_in_function() {
+  // expected-error @+1 {{unexpected branch operation in function after structured control flow conversion}}
+  cf.br ^bb1
+^bb1:
+  util.return
+}
+
+// -----
+
+// Tests that cf.cond_br operations inside scf.execute_regions trigger an error.
+
+util.func public @invalid_cond_br_in_execute_region() {
+  scf.execute_region {
+    %c_true = arith.constant true
+    %cond = util.optimization_barrier %c_true : i1
+    // expected-error @+1 {{unexpected branch operation in function after structured control flow conversion}}
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    %c1 = arith.constant 1 : i32
+    util.optimization_barrier %c1 : i32
+    cf.br ^bb3
+  ^bb2:
+    %c2 = arith.constant 2 : i32
+    util.optimization_barrier %c2 : i32
+    cf.br ^bb3
+  ^bb3:
+    scf.yield
+  }
+  util.return
+}


### PR DESCRIPTION
This simply verifies there are no ops implementing `BranchOpInterface`. Regions are still allowed to have multiple blocks (as that may be used by ops for custom behavior) but cannot use branches to access them.