### PR TITLE
[CodeGen][LLVMGPU]  Propagate HAL subspan `writeonly` access to LLVM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -39,6 +39,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenAttrs",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Utils",

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -92,8 +93,8 @@ struct ConvertHalInterfaceBindingSubspan final
             op, newResultTy, adaptor.getLayout(), adaptor.getBinding(),
             adaptor.getByteOffset(), adaptor.getDynamicDims(),
             adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
-    if (auto accessAttr = op->getDiscardableAttr("iree.codegen.access")) {
-      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = op->getDiscardableAttr(kSubspanAccessAttrName)) {
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
     }
     LLVM_DEBUG(llvm::dbgs() << "Bf16Emulation: new op: " << newOp << "\n");
     (void)newOp;

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -92,6 +92,7 @@ struct ConvertHalInterfaceBindingSubspan final
             op, newResultTy, adaptor.getLayout(), adaptor.getBinding(),
             adaptor.getByteOffset(), adaptor.getDynamicDims(),
             adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
+    newOp->setAttrs(op->getAttrs());
     LLVM_DEBUG(llvm::dbgs() << "Bf16Emulation: new op: " << newOp << "\n");
     (void)newOp;
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -92,7 +92,9 @@ struct ConvertHalInterfaceBindingSubspan final
             op, newResultTy, adaptor.getLayout(), adaptor.getBinding(),
             adaptor.getByteOffset(), adaptor.getDynamicDims(),
             adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
-    newOp->setAttrs(op->getAttrs());
+    if (auto accessAttr = op->getDiscardableAttr("iree.codegen.access")) {
+      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    }
     LLVM_DEBUG(llvm::dbgs() << "Bf16Emulation: new op: " << newOp << "\n");
     (void)newOp;
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -80,10 +80,15 @@ struct ConvertHalInterfaceBindingSubspan final
           rewriter, loc, linearizedMemRefInfo.linearizedSize));
     }
 
-    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
-        op, newResultType, adaptor.getLayout(), adaptor.getBinding(),
+    auto oldAttrs = op->getAttrs();
+
+    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+        op.getLoc(), newResultType, adaptor.getLayout(), adaptor.getBinding(),
         byteOffset, dynamicLinearizedSize, adaptor.getAlignmentAttr(),
         adaptor.getDescriptorFlagsAttr());
+
+    newOp->setAttrs(oldAttrs);
+    rewriter.replaceOp(op, newOp->getResults());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -85,8 +85,8 @@ struct ConvertHalInterfaceBindingSubspan final
         adaptor.getBinding(), byteOffset, dynamicLinearizedSize,
         adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
 
-    if (auto accessAttr = op->getDiscardableAttr("iree.codegen.access"))
-      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = op->getDiscardableAttr(kSubspanAccessAttrName))
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
 
     rewriter.replaceOp(op, newOp->getResults());
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -80,12 +80,12 @@ struct ConvertHalInterfaceBindingSubspan final
           rewriter, loc, linearizedMemRefInfo.linearizedSize));
     }
 
-    auto oldAttrs = op->getAttrs();
+    llvm::ArrayRef<NamedAttribute> oldAttrs = op->getAttrs();
 
-    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        op.getLoc(), newResultType, adaptor.getLayout(), adaptor.getBinding(),
-        byteOffset, dynamicLinearizedSize, adaptor.getAlignmentAttr(),
-        adaptor.getDescriptorFlagsAttr());
+    auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
+        rewriter, op.getLoc(), newResultType, adaptor.getLayout(),
+        adaptor.getBinding(), byteOffset, dynamicLinearizedSize,
+        adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
 
     newOp->setAttrs(oldAttrs);
     rewriter.replaceOp(op, newOp->getResults());

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -80,14 +80,14 @@ struct ConvertHalInterfaceBindingSubspan final
           rewriter, loc, linearizedMemRefInfo.linearizedSize));
     }
 
-    llvm::ArrayRef<NamedAttribute> oldAttrs = op->getAttrs();
-
     auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, op.getLoc(), newResultType, adaptor.getLayout(),
         adaptor.getBinding(), byteOffset, dynamicLinearizedSize,
         adaptor.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
 
-    newOp->setAttrs(oldAttrs);
+    if (auto accessAttr = op->getDiscardableAttr("iree.codegen.access"))
+      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -293,6 +293,7 @@ struct FlattenBindingSubspan final
         rewriter, subspanOp.getLoc(), newType, subspanOp.getLayout(),
         subspanOp.getBinding(), newOffset, dynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+    newOp->setAttrs(subspanOp->getAttrs());
 
     Value replacement = newOp;
     if (!isZeroInteger(elementOffset)) {

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -293,7 +293,8 @@ struct FlattenBindingSubspan final
         rewriter, subspanOp.getLoc(), newType, subspanOp.getLayout(),
         subspanOp.getBinding(), newOffset, dynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    newOp->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = newOp->getDiscardableAttr("iree.codegen.access"))
+      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
 
     Value replacement = newOp;
     if (!isZeroInteger(elementOffset)) {

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -293,8 +293,8 @@ struct FlattenBindingSubspan final
         rewriter, subspanOp.getLoc(), newType, subspanOp.getLayout(),
         subspanOp.getBinding(), newOffset, dynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = newOp->getDiscardableAttr("iree.codegen.access"))
-      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = newOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
 
     Value replacement = newOp;
     if (!isZeroInteger(elementOffset)) {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -206,6 +206,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
           rewriter, loc, newBufferType, binding.getLayoutAttr(),
           binding.getBindingAttr(), zero, dynamicLinearShape,
           binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
+      newBinding->setAttrs(binding->getAttrs());
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -206,7 +206,8 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
           rewriter, loc, newBufferType, binding.getLayoutAttr(),
           binding.getBindingAttr(), zero, dynamicLinearShape,
           binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
-      newBinding->setAttrs(binding->getAttrs());
+      if (auto accessAttr = binding->getDiscardableAttr("iree.codegen.access"))
+        newBinding->setDiscardableAttr("iree.codegen.access", accessAttr);
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -206,8 +206,8 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
           rewriter, loc, newBufferType, binding.getLayoutAttr(),
           binding.getBindingAttr(), zero, dynamicLinearShape,
           binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
-      if (auto accessAttr = binding->getDiscardableAttr("iree.codegen.access"))
-        newBinding->setDiscardableAttr("iree.codegen.access", accessAttr);
+      if (auto accessAttr = binding->getDiscardableAttr(kSubspanAccessAttrName))
+        newBinding->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -228,9 +228,9 @@ struct MaterializeInterfaceBindingEncoding final
     }
     auto newResultType = getTypeConverter()->convertType(resultType);
     SmallVector<Value> newDynamicDims = subspanOp.getDynamicDims();
-    auto oldAttrs = subspanOp->getAttrs();
-    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
+    llvm::ArrayRef<NamedAttribute> oldAttrs = subspanOp->getAttrs();
+    auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
+        rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
     newOp->setAttrs(oldAttrs);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -228,12 +228,12 @@ struct MaterializeInterfaceBindingEncoding final
     }
     auto newResultType = getTypeConverter()->convertType(resultType);
     SmallVector<Value> newDynamicDims = subspanOp.getDynamicDims();
-    llvm::ArrayRef<NamedAttribute> oldAttrs = subspanOp->getAttrs();
     auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    newOp->setAttrs(oldAttrs);
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
     rewriter.replaceOp(subspanOp, newOp.getResult());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -232,8 +232,8 @@ struct MaterializeInterfaceBindingEncoding final
         rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
     rewriter.replaceOp(subspanOp, newOp.getResult());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -228,10 +228,13 @@ struct MaterializeInterfaceBindingEncoding final
     }
     auto newResultType = getTypeConverter()->convertType(resultType);
     SmallVector<Value> newDynamicDims = subspanOp.getDynamicDims();
-    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp, newResultType, subspanOp.getLayout(), subspanOp.getBinding(),
-        subspanOp.getByteOffset(), newDynamicDims, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+    auto oldAttrs = subspanOp->getAttrs();
+    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+        subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
+        subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+    newOp->setAttrs(oldAttrs);
+    rewriter.replaceOp(subspanOp, newOp.getResult());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -528,10 +528,13 @@ struct MaterializeInterfaceBindingEncoding
 
     auto newResultType = IREE::TensorExt::DispatchTensorType::get(
         resultType.getAccess(), convertedBoundType);
-    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp, newResultType, subspanOp.getLayout(), subspanOp.getBinding(),
-        subspanOp.getByteOffset(), newDynamicDims, subspanOp.getAlignmentAttr(),
-        subspanOp.getDescriptorFlagsAttr());
+    auto oldAttrs = subspanOp->getAttrs();
+    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+        subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
+        subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
+        subspanOp.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
+    newOp->setAttrs(oldAttrs);
+    rewriter.replaceOp(subspanOp, newOp->getResults());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -528,9 +528,9 @@ struct MaterializeInterfaceBindingEncoding
 
     auto newResultType = IREE::TensorExt::DispatchTensorType::get(
         resultType.getAccess(), convertedBoundType);
-    auto oldAttrs = subspanOp->getAttrs();
-    auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
+    llvm::ArrayRef<NamedAttribute> oldAttrs = subspanOp->getAttrs();
+    auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
+        rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
     newOp->setAttrs(oldAttrs);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -532,8 +532,8 @@ struct MaterializeInterfaceBindingEncoding
         rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
     rewriter.replaceOp(subspanOp, newOp->getResults());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -528,12 +528,12 @@ struct MaterializeInterfaceBindingEncoding
 
     auto newResultType = IREE::TensorExt::DispatchTensorType::get(
         resultType.getAccess(), convertedBoundType);
-    llvm::ArrayRef<NamedAttribute> oldAttrs = subspanOp->getAttrs();
     auto newOp = IREE::HAL::InterfaceBindingSubspanOp::create(
         rewriter, subspanOp->getLoc(), newResultType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), newDynamicDims,
         subspanOp.getAlignmentAttr(), adaptor.getDescriptorFlagsAttr());
-    newOp->setAttrs(oldAttrs);
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newOp->setDiscardableAttr("iree.codegen.access", accessAttr);
     rewriter.replaceOp(subspanOp, newOp->getResults());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -132,7 +132,9 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                       accessAttr);
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -233,7 +235,9 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                       accessAttr);
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -319,7 +323,9 @@ struct FoldExpandShapeIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                       accessAttr);
 
     rewriter.setInsertionPoint(storeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorStoreOp>(
@@ -503,7 +509,8 @@ struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    newSubspanOp->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp->setDiscardableAttr("iree.codegen.access", accessAttr);
 
     rewriter.setInsertionPoint(storeOp);
 
@@ -803,7 +810,10 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
           subspanOp.getBinding(), subspanOp.getByteOffset(),
           newSubspanDynamicDims, subspanOp.getAlignmentAttr(),
           subspanOp.getDescriptorFlagsAttr());
-      newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+      if (auto accessAttr =
+              subspanOp->getDiscardableAttr("iree.codegen.access"))
+        newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                         accessAttr);
     }
 
     SmallVector<OpFoldResult> expandedStrides(reshapeSrcShape.size(),
@@ -882,7 +892,9 @@ struct FoldInnerBitcastIntoInterfaceTensorLoad
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
 
-    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                       accessAttr);
 
     rewriter.setInsertionPoint(bitcastOp);
     SmallVector<int64_t> newSizes(loadOp.getStaticSizes());
@@ -953,7 +965,9 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                                       accessAttr);
 
     SmallVector<int64_t> newSizes(storeOp.getStaticSizes());
     newSizes.back() = newInnerSize;

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -132,8 +132,8 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                        accessAttr);
 
     rewriter.setInsertionPoint(reshapeOp);
@@ -235,8 +235,8 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                        accessAttr);
 
     rewriter.setInsertionPoint(reshapeOp);
@@ -323,8 +323,8 @@ struct FoldExpandShapeIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                        accessAttr);
 
     rewriter.setInsertionPoint(storeOp);
@@ -509,8 +509,8 @@ struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp->setDiscardableAttr("iree.codegen.access", accessAttr);
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp->setDiscardableAttr(kSubspanAccessAttrName, accessAttr);
 
     rewriter.setInsertionPoint(storeOp);
 
@@ -811,8 +811,8 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
           newSubspanDynamicDims, subspanOp.getAlignmentAttr(),
           subspanOp.getDescriptorFlagsAttr());
       if (auto accessAttr =
-              subspanOp->getDiscardableAttr("iree.codegen.access"))
-        newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+              subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+        newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                          accessAttr);
     }
 
@@ -892,8 +892,8 @@ struct FoldInnerBitcastIntoInterfaceTensorLoad
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
 
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                        accessAttr);
 
     rewriter.setInsertionPoint(bitcastOp);
@@ -965,8 +965,8 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
-    if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-      newSubspanOp.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+    if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+      newSubspanOp.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                        accessAttr);
 
     SmallVector<int64_t> newSizes(storeOp.getStaticSizes());

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -132,6 +132,7 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
+    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -232,6 +233,7 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicDims,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
 
     rewriter.setInsertionPoint(reshapeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
@@ -317,6 +319,7 @@ struct FoldExpandShapeIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         collapsedDynamicShape, subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
+    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
 
     rewriter.setInsertionPoint(storeOp);
     rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorStoreOp>(
@@ -500,6 +503,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStoreFullSlice
         rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
         subspanOp.getBinding(), subspanOp.getByteOffset(), expandedDynamicShape,
         subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
+    newSubspanOp->setAttrs(subspanOp->getAttrs());
 
     rewriter.setInsertionPoint(storeOp);
 
@@ -799,6 +803,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
           subspanOp.getBinding(), subspanOp.getByteOffset(),
           newSubspanDynamicDims, subspanOp.getAlignmentAttr(),
           subspanOp.getDescriptorFlagsAttr());
+      newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
     }
 
     SmallVector<OpFoldResult> expandedStrides(reshapeSrcShape.size(),
@@ -877,6 +882,8 @@ struct FoldInnerBitcastIntoInterfaceTensorLoad
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
 
+    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+
     rewriter.setInsertionPoint(bitcastOp);
     SmallVector<int64_t> newSizes(loadOp.getStaticSizes());
     newSizes.back() = newInnerSize;
@@ -946,6 +953,7 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
         subspanOp.getBinding(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
         subspanOp.getDescriptorFlagsAttr());
+    newSubspanOp.getDefiningOp()->setAttrs(subspanOp->getAttrs());
 
     SmallVector<int64_t> newSizes(storeOp.getStaticSizes());
     newSizes.back() = newInnerSize;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -54,6 +54,7 @@ constexpr StringLiteral kSerializedTuningSpecAttrName =
 constexpr StringLiteral kKernelConfigSpecName = "__kernel_config";
 constexpr StringLiteral kUkernelAttrName = "iree_codegen.ukernel";
 constexpr StringLiteral kUKernelProviderName = "iree_codegen.ukernel_provider";
+constexpr StringLiteral kSubspanAccessAttrName = "iree_codegen.access";
 
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting iree_codegen.translation_info attribute on a

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -238,7 +238,7 @@ analyzeSubspans(llvm::SetVector<IREE::HAL::InterfaceBindingSubspanOp> &subspans,
         subspan.getDescriptorFlags().value_or(IREE::HAL::DescriptorFlags::None),
         IREE::HAL::DescriptorFlags::ReadOnly);
     result[binding].writeonly =
-        subspan->getDiscardableAttr("iree.codegen.access") ? true : false;
+        subspan->getDiscardableAttr(kSubspanAccessAttrName) ? true : false;
     unsigned bindingAddrSpace = 0;
     auto bindingType = dyn_cast<BaseMemRefType>(subspan.getType());
     if (bindingType) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -15,7 +15,7 @@ hal.executable @abs_ex_dispatch_0 {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree.codegen.access = "writeonly"} : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
@@ -34,7 +34,7 @@ hal.executable @abs_ex_dispatch_0 {
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
 //  CHECK-SAME:  %[[ARG1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
-//  CHECK-SAME:  %[[ARG2:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef})
+//  CHECK-SAME:  %[[ARG2:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly})
 //  CHECK: %[[FADD:.+]] = llvm.fadd %{{.*}}, %{{.*}}  : f32
 //  CHECK: %[[ADDR:.+]] = llvm.getelementptr inbounds|nuw %[[ARG2]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //  CHECK: llvm.store %[[FADD]], %[[ADDR]] : f32, !llvm.ptr
@@ -174,7 +174,7 @@ hal.executable @mixed_type {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c128) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) {iree.codegen.access = "writeonly"} : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
@@ -193,7 +193,7 @@ hal.executable @mixed_type {
 
 // CHECK-LABEL: llvm.func @mixed_type
 //  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
-//  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef})
+//  CHECK-SAME:  %{{.*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly})
 //       CHECK:   %[[BYTES_PER_BIT:.+]] = llvm.mlir.constant(8 : i64) : i64
 //       CHECK:   %[[BITS_PER_ELEM:.+]] = llvm.mlir.constant(32 : i64) : i64
 //       CHECK:   %[[BYTE_OFFSET:.+]] = llvm.mlir.constant(128 : index) : i64

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -15,7 +15,7 @@ hal.executable @abs_ex_dispatch_0 {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) offset(%c128) flags(ReadOnly) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree.codegen.access = "writeonly"} : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree_codegen.access = "writeonly"} : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x
@@ -174,7 +174,7 @@ hal.executable @mixed_type {
         %c128 = arith.constant 128 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c128) : memref<16xf32, strided<[1], offset: ?>>
         %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c0) : memref<16xi32>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) {iree.codegen.access = "writeonly"} : memref<16xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) {iree_codegen.access = "writeonly"} : memref<16xf32>
         %3 = gpu.block_id x
         %4 = gpu.block_dim x
         %5 = gpu.thread_id x

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -241,7 +241,7 @@ builtin.module {
     %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
     %1 = arith.index_castui %0 : i32 to index
     %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%1) flags(ReadOnly) : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
-    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<16xf32, #gpu.address_space<global>>
+    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree.codegen.access = "writeonly"} : memref<16xf32, #gpu.address_space<global>>
     %4 = memref.load %2[%c0] : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
     memref.store %4, %3[%c0] : memref<16xf32, #gpu.address_space<global>>
     return
@@ -250,7 +250,7 @@ builtin.module {
 //   CHECK-LABEL: llvm.func @missing_ptr_dispatch_copy_idx_0
 //    CHECK-SAME: (%[[arg0:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
 //    CHECK-SAME:  %[[arg1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone},
-//    CHECK-SAME:  %[[arg2:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
+//    CHECK-SAME:  %[[arg2:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.writeonly},
 //    CHECK-SAME:  %[[arg3:.+]]: i32 {llvm.noundef})
 //         CHECK:   llvm.zext %[[arg3]] : i32 to i64
 //         CHECK:   llvm.insertvalue %[[arg0]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -241,7 +241,7 @@ builtin.module {
     %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
     %1 = arith.index_castui %0 : i32 to index
     %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%1) flags(ReadOnly) : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
-    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree.codegen.access = "writeonly"} : memref<16xf32, #gpu.address_space<global>>
+    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) {iree_codegen.access = "writeonly"} : memref<16xf32, #gpu.address_space<global>>
     %4 = memref.load %2[%c0] : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
     memref.store %4, %3[%c0] : memref<16xf32, #gpu.address_space<global>>
     return

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1230,7 +1230,9 @@ Value findOrCreateSubspanBuffer(
       subspanOp.getBinding(), subspanOp.getByteOffset(),
       subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
       subspanOp.getDescriptorFlagsAttr());
-  buffer.getDefiningOp()->setAttrs(subspanOp->getAttrs());
+  if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
+    buffer.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+                                               accessAttr);
   if (useRocdlBuffers) {
     buffer = amdgpu::FatRawBufferCastOp::create(
         rewriter, subspanOp->getLoc(), buffer, /*validBytes=*/Value{},

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1230,6 +1230,7 @@ Value findOrCreateSubspanBuffer(
       subspanOp.getBinding(), subspanOp.getByteOffset(),
       subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
       subspanOp.getDescriptorFlagsAttr());
+  buffer.getDefiningOp()->setAttrs(subspanOp->getAttrs());
   if (useRocdlBuffers) {
     buffer = amdgpu::FatRawBufferCastOp::create(
         rewriter, subspanOp->getLoc(), buffer, /*validBytes=*/Value{},

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1230,8 +1230,8 @@ Value findOrCreateSubspanBuffer(
       subspanOp.getBinding(), subspanOp.getByteOffset(),
       subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
       subspanOp.getDescriptorFlagsAttr());
-  if (auto accessAttr = subspanOp->getDiscardableAttr("iree.codegen.access"))
-    buffer.getDefiningOp()->setDiscardableAttr("iree.codegen.access",
+  if (auto accessAttr = subspanOp->getDiscardableAttr(kSubspanAccessAttrName))
+    buffer.getDefiningOp()->setDiscardableAttr(kSubspanAccessAttrName,
                                                accessAttr);
   if (useRocdlBuffers) {
     buffer = amdgpu::FatRawBufferCastOp::create(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -75,6 +75,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/Target/Devices",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/Transforms",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR:IR",
         "//compiler/src/iree/compiler/Dialect/Util/Conversion",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -17,7 +17,6 @@
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -306,7 +305,6 @@ convertBindingUsage(mlir::FunctionOpInterface sourceFuncOp, BlockArgument arg,
     auto alignmentAttr = sourceFuncOp.getArgAttrOfType<IntegerAttr>(
         arg.getArgNumber(), "stream.alignment");
 
-    constexpr llvm::StringRef subSpanAccessAttr = "iree.codegen.access";
     StringAttr subspanAccessAttr;
 
     if (auto dispatchTensorType =
@@ -323,7 +321,7 @@ convertBindingUsage(mlir::FunctionOpInterface sourceFuncOp, BlockArgument arg,
         oldOp.getDynamicDims(), alignmentAttr, bindingAttr.getFlags());
 
     if (subspanAccessAttr)
-      newOp->setDiscardableAttr(subSpanAccessAttr, subspanAccessAttr);
+      newOp->setDiscardableAttr(kSubspanAccessAttrName, subspanAccessAttr);
 
     oldOp.replaceAllUsesWith(newOp.getResult());
     oldOp.erase();

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -16,7 +16,7 @@
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
-#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -97,6 +97,33 @@ stream.executable private @ex {
   }
 }
 
+// Expect materialize-interfaces to replace stream.subspan with HAL subspan,
+// preserving writeonly access and assigning binding(2) to the 3rd parameter.
+  stream.executable public @dispatch_lowering {
+    stream.executable.export public @entry workgroups(%n: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%n)
+      stream.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // Three bindings; the 3rd is writeonly.
+      func.func @entry(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: !stream.binding) {
+        %c0 = arith.constant 0 : index
+        %out = stream.binding.subspan %arg2[%c0]
+          : !stream.binding
+          -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+        %zeros = arith.constant dense<0.0> : tensor<16xf32>
+        iree_tensor_ext.dispatch.tensor.store %zeros, %out,
+          offsets = [0], sizes = [16], strides = [1]
+          : tensor<16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+        return
+      }
+    }
+  }
+// CHECK: hal.interface.binding.subspan
+// CHECK-SAME: binding(2)
+// CHECK-SAME: {iree.codegen.access = "writeonly"}
+// CHECK-SAME: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
+
 // This function uses the default HAL device targeting arm_64 and x86_64.
 // CHECK-LABEL: @using_default
 util.func public @using_default(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint attributes {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -121,7 +121,7 @@ stream.executable private @ex {
   }
 // CHECK: hal.interface.binding.subspan
 // CHECK-SAME: binding(2)
-// CHECK-SAME: {iree.codegen.access = "writeonly"}
+// CHECK-SAME: {iree_codegen.access = "writeonly"}
 // CHECK-SAME: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16xf32>>
 
 // This function uses the default HAL device targeting arm_64 and x86_64.


### PR DESCRIPTION
Related: #22047
This PR addresses an issue where memory access properties specified at the HAL dialect level were being lost during the codegen pipeline. as it could not distinguish write-only memory accesses after performing bufferization.

As discussed with @benvanik , this solution correctly associates the access property with the subspan operation itself, not the abstract binding or function argument.

To make this incremental, I'm merely handling writeonly tensor dispatches. Perhaps in a future PR we can address any design problems related to `DescriptorFlags` in the current logic.

Let me know if more test coverage is needed to prove the proper attribute propagation.