### PR TITLE
[Stream] Replicate globals per affinity before Stream conversion.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -44,6 +44,7 @@ iree_compiler_cc_library(
         "Passes.h.inc",
         "PropagateTimepoints.cpp",
         "RefineUsage.cpp",
+        "ReplicateGlobalsPerAffinity.cpp",
         "ReuseAllocations.cpp",
         "ScheduleAllocation.cpp",
         "ScheduleConcurrency.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "Passes.h.inc"
     "PropagateTimepoints.cpp"
     "RefineUsage.cpp"
+    "ReplicateGlobalsPerAffinity.cpp"
     "ReuseAllocations.cpp"
     "ScheduleAllocation.cpp"
     "ScheduleConcurrency.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -22,6 +22,12 @@ static llvm::cl::opt<bool> clAnnotateInputAffinities(
                    "the pipeline for debugging."),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clReplicateGlobalsPerAffinity(
+    "iree-stream-experimental-replicate-globals-per-affinity",
+    llvm::cl::desc(
+        "Replicates globals for each unique affinity they are used with."),
+    llvm::cl::init(false));
+
 namespace mlir::iree_compiler::IREE::Stream {
 
 using FunctionLikeNest =
@@ -98,6 +104,10 @@ void buildStreamTensorPassPipeline(OpPassManager &passManager,
   // debugging of analysis errors in end-user tooling.
   if (clAnnotateInputAffinities) {
     passManager.addPass(IREE::Stream::createAnnotateAffinitiesPass());
+  }
+
+  if (clReplicateGlobalsPerAffinity) {
+    passManager.addPass(IREE::Stream::createReplicateGlobalsPerAffinityPass());
   }
 
   // Converts from all input dialects into various levels of the stream dialect.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -13,6 +13,21 @@ include "mlir/Pass/PassBase.td"
 // Tensor lowering and resource management
 //===----------------------------------------------------------------------===//
 
+def ReplicateGlobalsPerAffinityPass :
+    Pass<"iree-stream-replicate-globals-per-affinity", "mlir::ModuleOp"> {
+  let summary = "Replicates globals for each unique affinity and rewires their uses.";
+  let description = [{
+    Replicates IREE::Util::GlobalOps that are used on multiple affinities
+    and rewires their uses to the associated global. This allows for
+    specialization of globals for each affinity instead of having unspecialized
+    and a copy each use.
+  }];
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+    "IREE::Util::UtilDialect",
+  ];
+}
+
 def ConvertToStreamPass :
     Pass<"iree-stream-conversion", "mlir::ModuleOp"> {
   let summary = "Converts from flow and other input dialects into the stream dialect.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReplicateGlobalsPerAffinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReplicateGlobalsPerAffinity.cpp
@@ -1,0 +1,494 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define DEBUG_TYPE "iree-stream-replicate-globals-per-affinity"
+
+#define GEN_PASS_DEF_REPLICATEGLOBALSPERAFFINITYPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+// Helper class to manage the creation of operations per affinity.
+// Each global op is cloned per affinity it is used with. The new global op
+// will be initialized in the initializer region to hold a copy of the original
+// global op's value, but transferred to the target affinity.
+// When an op operand is requested for a specific affinity it will be cloned,
+// unless the operand already matches the affinity. Operations will be cloned
+// as needed to wrap the new operands. Global load ops will be cloned to load
+// from the new global op for the requested affinity.
+class ValuePerAffinityHelper {
+public:
+  explicit ValuePerAffinityHelper(mlir::ModuleOp moduleOp)
+      : builder(moduleOp), symbolTable(moduleOp) {}
+  ~ValuePerAffinityHelper() = default;
+
+  using OpAffinityPair = std::tuple<Operation *, IREE::Stream::AffinityAttr>;
+  using ValueAffinityPair = std::tuple<Value, IREE::Stream::AffinityAttr>;
+
+  // Returns new or cached value for the given affinity.
+  Value getOrCreateValueForAffinity(OpOperand *opOperand,
+                                    IREE::Stream::AffinityAttr affinityAttr);
+
+  // Returns new or existing global op for the given affinity. It loads the data
+  // from the original global op and transfers it to the target affinity in a
+  // new initializer op.
+  IREE::Util::GlobalOpInterface
+  getOrCreateGlobalForAffinity(StringRef globalName,
+                               IREE::Stream::AffinityAttr affinityAttr);
+
+private:
+  // Returns new global load op for the given affinity. If the source global op
+  // does not match the affinity, a new global op will be created.
+  Value
+  getOrCreateGlobalLoadForAffinity(IREE::Util::GlobalLoadOpInterface loadOp,
+                                   IREE::Stream::AffinityAttr affinityAttr);
+
+  // Returns new or cached affinity op for the given affinity.
+  Value
+  getOrCreateAffinityOpForAffinity(IREE::Stream::AffinityOpInterface affinityOp,
+                                   OpResult opResult,
+                                   IREE::Stream::AffinityAttr affinityAttr);
+
+  OpBuilder builder;
+  SymbolTable symbolTable;
+  DenseMap<OpAffinityPair, IREE::Util::GlobalOpInterface> cachedGlobals;
+  DenseMap<ValueAffinityPair, Value> cachedValuePerAffinity;
+};
+
+Value ValuePerAffinityHelper::getOrCreateValueForAffinity(
+    OpOperand *opOperand, IREE::Stream::AffinityAttr affinityAttr) {
+  ValueAffinityPair key = {opOperand->get(), affinityAttr};
+  if (cachedValuePerAffinity.contains(key)) {
+    return cachedValuePerAffinity.lookup(key);
+  }
+
+  return TypeSwitch<Operation *, Value>(opOperand->get().getDefiningOp())
+      .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
+        return getOrCreateGlobalLoadForAffinity(loadOp, affinityAttr);
+      })
+      .Case<IREE::Stream::AffinityOpInterface>([&](auto affinityOp) {
+        return getOrCreateAffinityOpForAffinity(
+            affinityOp, cast<OpResult>(opOperand->get()), affinityAttr);
+      })
+      .Case<IREE::Flow::TensorReshapeOp>([&](auto reshapeOp) {
+        builder.setInsertionPoint(reshapeOp);
+        Value source = getOrCreateValueForAffinity(
+            &reshapeOp.getSourceMutable(), affinityAttr);
+        cachedValuePerAffinity[key] = IREE::Flow::TensorReshapeOp::create(
+            builder, reshapeOp.getLoc(), reshapeOp.getResult().getType(),
+            source, reshapeOp.getSourceDims(), reshapeOp.getResultDims());
+        return cachedValuePerAffinity[key];
+      })
+      .Default([&](Operation *op) {
+        LDBG() << "unsupported op in GlobalPerAffinityHelper: " << *op;
+        assert(false && "unsupported op");
+        return Value();
+      });
+}
+
+static std::string getNewGlobalName(StringRef originalName,
+                                    IREE::Stream::AffinityAttr affinityAttr) {
+  std::string resul = originalName.str();
+  llvm::raw_string_ostream sstream(resul);
+  sstream << "_" << affinityAttr;
+  return resul;
+}
+
+IREE::Util::GlobalOpInterface
+ValuePerAffinityHelper::getOrCreateGlobalForAffinity(
+    StringRef globalName, IREE::Stream::AffinityAttr affinityAttr) {
+  auto globalOp = symbolTable.lookup<IREE::Util::GlobalOpInterface>(globalName);
+  auto affinityOp = dyn_cast_if_present<IREE::Stream::AffinityOpInterface>(
+      globalOp.getOperation());
+  if (affinityOp.getAffinityAttr() == affinityAttr) {
+    return globalOp;
+  }
+
+  OpAffinityPair key = {globalOp, affinityAttr};
+  if (cachedGlobals.contains(key)) {
+    return cachedGlobals.lookup(key);
+  }
+
+  // Create an initializer right after the global op.
+  Location loc = globalOp.getLoc();
+  builder.setInsertionPointAfter(globalOp);
+  std::string newGlobalName = getNewGlobalName(globalName, affinityAttr);
+  auto newGlobalOp = IREE::Util::GlobalOp::create(builder, loc, newGlobalName,
+                                                  /*isMutable=*/false,
+                                                  globalOp.getGlobalType());
+  newGlobalOp.setPrivate();
+  symbolTable.insert(newGlobalOp);
+  auto initializerOp = IREE::Util::InitializerOp::create(builder, loc);
+
+  // Create transfer op and store op in the initializer.
+  builder.setInsertionPointToStart(initializerOp.addEntryBlock());
+  Value loadedValue =
+      globalOp.createLoadOp(loc, builder).getLoadedGlobalValue();
+  Value transferOp = IREE::Flow::TensorTransferOp::create(
+      builder, loc, loadedValue, affinityAttr);
+  IREE::Util::GlobalStoreOp::create(builder, loc, transferOp, newGlobalOp);
+  IREE::Util::ReturnOp::create(builder, loc);
+
+  cachedGlobals[key] = newGlobalOp;
+  return newGlobalOp;
+}
+
+Value ValuePerAffinityHelper::getOrCreateGlobalLoadForAffinity(
+    IREE::Util::GlobalLoadOpInterface loadOp,
+    IREE::Stream::AffinityAttr affinityAttr) {
+  IREE::Util::GlobalOpInterface globalOp =
+      getOrCreateGlobalForAffinity(loadOp.getGlobalName(), affinityAttr);
+  builder.setInsertionPoint(loadOp);
+  auto newLoadOp =
+      IREE::Util::GlobalLoadOp::create(builder, loadOp.getLoc(), globalOp);
+  newLoadOp.setIsImmutable(true);
+  ValueAffinityPair key = {loadOp.getLoadedGlobalValue(), affinityAttr};
+  cachedValuePerAffinity[key] = newLoadOp.getLoadedGlobalValue();
+  return newLoadOp.getLoadedGlobalValue();
+}
+
+Value ValuePerAffinityHelper::getOrCreateAffinityOpForAffinity(
+    IREE::Stream::AffinityOpInterface affinityOp, OpResult opResult,
+    IREE::Stream::AffinityAttr affinityAttr) {
+  ValueAffinityPair key = {opResult, affinityAttr};
+  if (affinityOp.getAffinityAttr() == affinityAttr) {
+    return opResult;
+  }
+  SmallVector<Value> newOperands;
+  for (OpOperand &operand : affinityOp->getOpOperands()) {
+    if (!isa<IREE::Stream::AffinityTypeInterface>(operand.get().getType())) {
+      newOperands.push_back(operand.get());
+      continue;
+    }
+    newOperands.push_back(getOrCreateValueForAffinity(&operand, affinityAttr));
+  }
+  builder.setInsertionPoint(affinityOp);
+  Operation *newAffinityOp =
+      clone(builder, affinityOp, affinityOp->getResultTypes(), newOperands);
+  newAffinityOp->setDiscardableAttrs(
+      affinityOp->getDiscardableAttrDictionary());
+  cachedValuePerAffinity[key] =
+      newAffinityOp->getResult(opResult.getResultNumber());
+  return cachedValuePerAffinity[key];
+}
+
+// Tracks which operands of an operation are avaialble for affinity analysis.
+// Some operands may come from globals that do not have specified affinity. It
+// can be used to prioritize the operand affinities for the operation.
+class OpOperandAffinityState {
+public:
+  OpOperandAffinityState() {}
+  explicit OpOperandAffinityState(Operation *op) {
+    availableOperands.resize(op->getNumOperands(), true);
+    for (auto &operand : op->getOpOperands()) {
+      if (!isa<IREE::Stream::AffinityTypeInterface>(operand.get().getType())) {
+        availableOperands.reset(operand.getOperandNumber());
+      }
+    }
+  }
+  ~OpOperandAffinityState() = default;
+
+  void setUnavailableOperand(int idx) { availableOperands.reset(idx); }
+  bool isAvailableOperand(int idx) const { return availableOperands.test(idx); }
+  bool hasAnyAvailableOperand() const { return availableOperands.any(); }
+
+private:
+  llvm::BitVector availableOperands;
+};
+
+// Manages the operand affinity state of operations. The op state is initialized
+// when it is first accessed.
+class OpOperandAffinityStateMap {
+public:
+  OpOperandAffinityStateMap() = default;
+  ~OpOperandAffinityStateMap() = default;
+
+  OpOperandAffinityState &operator[](Operation *op) {
+    return operandAvailableStateMap[op];
+  }
+
+  // Marks the operand of the given op as not having affinity information.
+  void setUnavailableOperand(Operation *op, int idx) {
+    if (!operandAvailableStateMap.contains(op)) {
+      operandAvailableStateMap[op] = OpOperandAffinityState(op);
+    }
+    operandAvailableStateMap[op].setUnavailableOperand(idx);
+  }
+
+  // Returns true if the operand of the given op is known to have affinity.
+  bool isAvailableOperand(Operation *op, int idx) {
+    // Still initialize the state because the op might not have any
+    // IREE::Stream::AffinityTypeInterface operand type.
+    if (!operandAvailableStateMap.contains(op)) {
+      operandAvailableStateMap.insert({op, OpOperandAffinityState(op)});
+    }
+    return operandAvailableStateMap[op].isAvailableOperand(idx);
+  }
+
+  // Returns true if the op can get affinity information from its operands.
+  bool hasAnyAvailableOperand(Operation *op) {
+    if (!operandAvailableStateMap.contains(op)) {
+      operandAvailableStateMap.insert({op, OpOperandAffinityState(op)});
+    }
+    return operandAvailableStateMap[op].hasAnyAvailableOperand();
+  }
+
+  // Dumps the operand affinity state of the given op.
+  void dump(Operation *op, llvm::raw_ostream &os) {
+    if (!operandAvailableStateMap.contains(op)) {
+      os << "no state\n";
+      return;
+    }
+    auto &state = operandAvailableStateMap[op];
+    os << "known operand affinity: ";
+    for (int i = 0; i < op->getNumOperands(); ++i) {
+      if (state.isAvailableOperand(i)) {
+        os << i << " ";
+      }
+    }
+    os << "\n";
+  }
+
+private:
+  DenseMap<Operation *, OpOperandAffinityState> operandAvailableStateMap;
+};
+
+struct ReplicateGlobalsPerAffinityPass
+    : public impl::ReplicateGlobalsPerAffinityPassBase<
+          ReplicateGlobalsPerAffinityPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+// Dumps the operand affinities and result usage affinities of the given op.
+static void
+dumpOpAffinityStatus(IREE::Stream::AffinityOpInterface affinityOp,
+                     ArrayRef<IREE::Stream::AffinityAttr> affinityAttrs,
+                     IREE::Stream::AffinityAnalysis &affinityAnalysis,
+                     OpOperandAffinityStateMap &opOperandAffinityStateMap) {
+  LDBG_OS([&](raw_ostream &os) {
+    os << "multiple/empty affinities: [";
+    llvm::interleaveComma(affinityAttrs, os);
+    os << "]";
+  });
+  LDBG() << " where the corresponding globals are:";
+  for (OpOperand &opOperand : affinityOp->getOpOperands()) {
+    int idx = opOperand.getOperandNumber();
+    Value value = opOperand.get();
+    if (!isa<IREE::Stream::AffinityTypeInterface>(value.getType())) {
+      LDBG() << "\toperand #" << idx << " type: " << value.getType();
+      continue;
+    }
+    if (!opOperandAffinityStateMap.isAvailableOperand(affinityOp, idx)) {
+      LDBG() << "\toperand #" << idx << " affinity: ignored";
+      continue;
+    }
+    auto attr = affinityAnalysis.lookupResourceAffinity(value);
+    LDBG() << "\toperand #" << idx << " affinity: " << attr;
+  }
+  for (auto result : affinityOp->getResults()) {
+    SmallVector<IREE::Stream::AffinityAttr> usageAffinities;
+    if (affinityAnalysis.tryLookupResourceUsageAffinity(result,
+                                                        usageAffinities)) {
+      LDBG_OS([&](raw_ostream &os) {
+        os << "\tresult type: " << result.getType() << " affinities: [";
+        llvm::interleaveComma(usageAffinities, os);
+        os << "]";
+      });
+    } else {
+      LDBG_OS([&](raw_ostream &os) {
+        os << "\tresult type: " << result.getType() << " affinities: failed";
+      });
+    }
+  }
+}
+
+void ReplicateGlobalsPerAffinityPass::runOnOperation() {
+  mlir::ModuleOp moduleOp = getOperation();
+  IREE::Stream::AffinityAnalysis affinityAnalysis(moduleOp);
+  if (failed(affinityAnalysis.run())) {
+    LDBG() << "failed on running affinity analysis";
+    return;
+  }
+
+  Explorer explorer(moduleOp.getOperation(), TraversalAction::RECURSE);
+  explorer.setOpInterfaceAction<mlir::FunctionOpInterface>(
+      TraversalAction::RECURSE);
+  explorer.setDialectAction<mlir::scf::SCFDialect>(TraversalAction::RECURSE);
+  explorer.setDialectAction<IREE::Flow::FlowDialect>(TraversalAction::RECURSE);
+  explorer.setDialectAction<IREE::Util::UtilDialect>(TraversalAction::RECURSE);
+  explorer.initialize();
+
+  SetVector<Operation *> worklist;
+  explorer.forEachGlobal([&](const Explorer::GlobalInfo *globalInfo) {
+    if (globalInfo->isIndirect || globalInfo->op.isGlobalMutable()) {
+      return;
+    }
+    // Scalars are expected to be used on host, so we do not need to replicate
+    // them.
+    if (globalInfo->op.getGlobalType().isIntOrIndexOrFloat()) {
+      return;
+    }
+    worklist.insert(globalInfo->op);
+  });
+
+  // List of operands that the source is from global ops.
+  //   [Operation, [(operand number, maybe global op)]].
+  // If the global op is null, it means that the operand is not directly from a
+  // load op. It is important to track the global op, so we can support cross
+  // functions/branches cases.
+  DenseMap<Operation *,
+           SmallVector<std::tuple<OpOperand *, IREE::Util::GlobalOpInterface>>>
+      opToGlobalUseMap;
+  OpOperandAffinityStateMap opOperandAffinityStateMap;
+  SymbolTable symbolTable(moduleOp);
+  while (!worklist.empty()) {
+    Operation *currentOp = *worklist.begin();
+    LDBG() << "processing op: " << *currentOp;
+    worklist.erase(worklist.begin());
+    TypeSwitch<Operation *>(currentOp)
+        .Case<IREE::Util::GlobalOpInterface>([&](auto globalOp) {
+          const Explorer::GlobalInfo *globalInfo =
+              explorer.getGlobalInfo(globalOp);
+          for (auto loadOp : globalInfo->getLoads()) {
+            worklist.insert(loadOp);
+          }
+        })
+        .Case<IREE::Util::GlobalLoadOpInterface>([&](auto loadOp) {
+          explorer.walkTransitiveUses(
+              loadOp.getLoadedGlobalValue(), [&](OpOperand &operand) {
+                if (isa<IREE::Util::InitializerOp>(
+                        operand.getOwner()->getParentOp())) {
+                  return WalkResult::advance();
+                }
+                LDBG() << "\tuse: " << *operand.getOwner();
+                Operation *consumerOp = operand.getOwner();
+                auto globalOp =
+                    symbolTable.lookup<IREE::Util::GlobalOpInterface>(
+                        loadOp.getGlobalName());
+                opToGlobalUseMap[consumerOp].push_back({&operand, globalOp});
+
+                // Do not query from affinityAnalysis here because it could
+                // select the default affinity, while we want to prioritize
+                // the use and specialize the global op per affinity.
+                auto affinityAttr = cast<IREE::Stream::AffinityOpInterface>(
+                                        globalOp.getOperation())
+                                        .getAffinityAttr();
+                if (!affinityAttr) {
+                  opOperandAffinityStateMap.setUnavailableOperand(
+                      consumerOp, operand.getOperandNumber());
+                }
+                if (!opOperandAffinityStateMap.hasAnyAvailableOperand(
+                        consumerOp)) {
+                  worklist.insert(consumerOp);
+                }
+                return WalkResult::advance();
+              });
+        })
+        .Case<IREE::Stream::AffinityOpInterface, IREE::Flow::TensorReshapeOp>(
+            [&](auto affinityOp) {
+              for (OpResult result : affinityOp->getResults()) {
+                if (!isa<IREE::Stream::AffinityTypeInterface>(
+                        result.getType())) {
+                  continue;
+                }
+                explorer.walkTransitiveUses(result, [&](OpOperand &operand) {
+                  LDBG() << "\tuse: " << *operand.getOwner();
+                  Operation *consumerOp = operand.getOwner();
+                  opOperandAffinityStateMap.setUnavailableOperand(
+                      consumerOp, operand.getOperandNumber());
+                  opToGlobalUseMap[consumerOp].push_back({&operand, {}});
+                  if (!opOperandAffinityStateMap.hasAnyAvailableOperand(
+                          consumerOp)) {
+                    worklist.insert(consumerOp);
+                  }
+                  return WalkResult::advance();
+                });
+              }
+            })
+        .Default([&](Operation *) {});
+  }
+
+  SetVector<Operation *> sortedAffinityOps(opToGlobalUseMap.keys().begin(),
+                                           opToGlobalUseMap.keys().end());
+  sortedAffinityOps = mlir::topologicalSort(sortedAffinityOps);
+  ValuePerAffinityHelper globalPerAffinityHelper(moduleOp);
+
+  IRRewriter rewriter(&getContext());
+  for (auto operation : sortedAffinityOps) {
+    auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(operation);
+    if (!affinityOp) {
+      LDBG() << "skipping non-affinity op: " << *operation;
+      continue;
+    }
+    LDBG() << "updating: " << affinityOp;
+    LDBG_OS([&](raw_ostream &os) {
+      os << "\tavailable operand state: ";
+      opOperandAffinityStateMap.dump(affinityOp, os);
+    });
+
+    // All the operands are from globals. It needs to be updated by consumers.
+    if (!opOperandAffinityStateMap.hasAnyAvailableOperand(affinityOp)) {
+      continue;
+    }
+
+    llvm::SmallSetVector<AffinityAttr, 4> affinityAttrs;
+    for (auto [idx, operand] : llvm::enumerate(affinityOp->getOperands())) {
+      if (!opOperandAffinityStateMap.isAvailableOperand(affinityOp, idx)) {
+        continue;
+      }
+      if (auto attr = affinityAnalysis.lookupResourceAffinity(operand)) {
+        affinityAttrs.insert(attr);
+      } else {
+        LDBG() << "failed to get affinity from operand #" << idx
+               << " of op: " << operand;
+      }
+    }
+
+    // It is very bad if it happens. Something might be wrong in the input
+    // program or something is missing in the implementation.
+    if (affinityAttrs.size() != 1) {
+      LDBG() << "skipping affinity op: " << affinityOp;
+      dumpOpAffinityStatus(affinityOp, affinityAttrs.getArrayRef(),
+                           affinityAnalysis, opOperandAffinityStateMap);
+      continue;
+    }
+
+    IREE::Stream::AffinityAttr executionAffinityAttr = *affinityAttrs.begin();
+    LDBG() << "updating operands with the affinity: " << executionAffinityAttr;
+    for (auto [operand, maybeGlobalOp] : opToGlobalUseMap[affinityOp]) {
+      if (maybeGlobalOp) {
+        rewriter.setInsertionPoint(affinityOp);
+        IREE::Util::GlobalOpInterface newGlobalOp =
+            globalPerAffinityHelper.getOrCreateGlobalForAffinity(
+                maybeGlobalOp.getGlobalName(), executionAffinityAttr);
+        auto newLoadOp = IREE::Util::GlobalLoadOp::create(
+            rewriter, affinityOp.getLoc(), newGlobalOp);
+        newLoadOp.setIsImmutable(true);
+        operand->assign(newLoadOp.getLoadedGlobalValue());
+      } else {
+        operand->assign(globalPerAffinityHelper.getOrCreateValueForAffinity(
+            operand, executionAffinityAttr));
+      }
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReplicateGlobalsPerAffinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ReplicateGlobalsPerAffinity.cpp
@@ -426,6 +426,10 @@ void ReplicateGlobalsPerAffinityPass::runOnOperation() {
         .Default([&](Operation *) {});
   }
 
+  // We have to update the operands in topological order, because they may
+  // depend on each other. It can lead to ambigious affinity if an op queries
+  // the affinity from unresolved operations. In this context, it can return
+  // multiple affinities and fail to replicate the global for its uses.
   SetVector<Operation *> sortedAffinityOps(opToGlobalUseMap.keys().begin(),
                                            opToGlobalUseMap.keys().end());
   sortedAffinityOps = mlir::topologicalSort(sortedAffinityOps);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -47,6 +47,7 @@ iree_lit_test_suite(
             "propagate_subviews.mlir",
             "propagate_timepoints.mlir",
             "refine_usage.mlir",
+            "replicate_globals_per_affinity.mlir",
             "reuse_allocations.mlir",
             "schedule_allocation.mlir",
             "schedule_concurrency.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "propagate_subviews.mlir"
     "propagate_timepoints.mlir"
     "refine_usage.mlir"
+    "replicate_globals_per_affinity.mlir"
     "reuse_allocations.mlir"
     "schedule_allocation.mlir"
     "schedule_concurrency.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/replicate_globals_per_affinity.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/replicate_globals_per_affinity.mlir
@@ -1,0 +1,333 @@
+// RUN: iree-opt --iree-stream-replicate-globals-per-affinity --split-input-file %s | FileCheck %s
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+
+// CHECK: util.global private @[[$GLOBAL:.+]] : tensor<10xf32>
+// CHECK: util.global private @[[$GLOBAL_B:.+]] : tensor<10xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+// CHECK:   util.global.store %[[TRANSFER_B]], @[[$GLOBAL_B]]
+// CHECK: }
+// CHECK: util.global private @[[$GLOBAL_A:.+]] : tensor<10xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+// CHECK:   util.global.store %[[TRANSFER_A]], @[[$GLOBAL_A]]
+// CHECK: }
+util.global private @global : tensor<10xf32>
+
+// CHECK-LABEL: @unknown_global_device(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+util.func private @unknown_global_device(%arg0: tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+  // CHECK: %[[OPERAND_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<10xf32> to #hal.device.affinity<@device_a>
+
+  // CHECK: %[[LOAD_A:.+]] = util.global.load immutable @[[$GLOBAL_A]]
+  %global = util.global.load immutable @global : tensor<10xf32>
+
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_A]], %[[LOAD_A]])
+  %1 = flow.dispatch @dispatch(%0, %global) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+
+  // CHECK: %[[OPERAND_B:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %2 = flow.tensor.transfer %arg0 : tensor<10xf32> to #hal.device.affinity<@device_b>
+
+  // CHECK: %[[LOAD_B:.+]] = util.global.load immutable @[[$GLOBAL_B]]
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_B]], %[[LOAD_B]])
+  %3 = flow.dispatch @dispatch(%2, %global) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+  util.return %1, %3 : tensor<10xf32>, tensor<10xf32>
+}
+
+// -----
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+
+// CHECK: util.global private @[[$GLOBAL:.+]] : tensor<f32>
+// CHECK: util.global private @[[$GLOBAL_B:.+]] : tensor<f32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+// CHECK:   util.global.store %[[TRANSFER_B]], @[[$GLOBAL_B]]
+// CHECK: }
+// CHECK: util.global private @[[$GLOBAL_A:.+]] : tensor<f32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+// CHECK:   util.global.store %[[TRANSFER_A]], @[[$GLOBAL_A]]
+// CHECK: }
+util.global private @global : tensor<f32>
+
+// CHECK-LABEL: @ambiguous_indirect_global_load(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+util.func private @ambiguous_indirect_global_load(%arg0: tensor<f32>, %arg1: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
+  %global = util.global.load immutable @global : tensor<f32>
+
+  // CHECK-DAG: %[[LOAD_A:.+]] = util.global.load immutable @[[$GLOBAL_A]]
+  // CHECK-DAG: %[[LOAD_B:.+]] = util.global.load immutable @[[$GLOBAL_B]]
+  // CHECK-DAG: %[[LHS_A:.+]] = flow.dispatch @dispatch0(%[[LOAD_A]])
+  // CHECK-DAG: %[[LHS_B:.+]] = flow.dispatch @dispatch0(%[[LOAD_B]])
+  %0 = flow.dispatch @dispatch0(%global) : (tensor<f32>) -> tensor<f32>
+
+  // CHECK: %[[RHS_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %1 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+
+  // CHECK: %[[RES_A:.+]] = flow.dispatch @dispatch1(%[[LHS_A]], %[[RHS_A]])
+  %2 = flow.dispatch @dispatch1(%0, %1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+
+  // CHECK: %[[RHS_B:.+]] = flow.tensor.transfer %[[ARG1]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %3 = flow.tensor.transfer %arg1 : tensor<f32> to #hal.device.affinity<@device_b>
+
+  // CHECK: %[[RES_B:.+]] = flow.dispatch @dispatch2(%[[LHS_B]], %[[RHS_B]])
+  %4 = flow.dispatch @dispatch2(%0, %3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+
+  // CHECK: util.return %[[RES_A]], %[[RES_B]]
+  util.return %2, %4 : tensor<f32>, tensor<f32>
+}
+
+// -----
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+
+// CHECK: util.global private @[[$FOO:.+]] : tensor<2x5xf32>
+// CHECK: util.global private @[[$FOO_B:.+]] : tensor<2x5xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$FOO]]
+// CHECK:   %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+// CHECK:   util.global.store %[[TRANSFER_B]], @[[$FOO_B]]
+// CHECK: }
+// CHECK: util.global private @[[$FOO_A:.+]] : tensor<2x5xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$FOO]]
+// CHECK:   %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+// CHECK:   util.global.store %[[TRANSFER_A]], @[[$FOO_A]]
+// CHECK: }
+util.global private @foo : tensor<2x5xf32>
+
+// CHECK:  util.global private @[[$BAR:.+]] : tensor<10xf32>
+// CHECK: util.global private @[[$BAR_B:.+]] : tensor<10xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$BAR]]
+// CHECK:   %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+// CHECK:   util.global.store %[[TRANSFER_B]], @[[$BAR_B]]
+// CHECK: }
+// CHECK: util.global private @[[$BAR_A:.+]] : tensor<10xf32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$BAR]]
+// CHECK:   %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+// CHECK:   util.global.store %[[TRANSFER_A]], @[[$BAR_A]]
+// CHECK: }
+util.global private @bar : tensor<10xf32>
+
+// CHECK-LABEL: @ambiguous_indirect_global_load_multi_levels(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+util.func private @ambiguous_indirect_global_load_multi_levels(%arg0: tensor<10xf32>, %arg1: tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+  %foo = util.global.load immutable @foo : tensor<2x5xf32>
+  %bar = util.global.load immutable @bar : tensor<10xf32>
+
+  // CHECK-DAG: %[[LOAD_FOO_A:.+]] = util.global.load immutable @[[$FOO_A]]
+  // CHECK-DAG: %[[LOAD_FOO_B:.+]] = util.global.load immutable @[[$FOO_B]]
+  // CHECK-DAG: %[[VAL_A:.+]] = flow.dispatch @dispatch0(%[[LOAD_FOO_A]])
+  // CHECK-DAG: %[[RESHAPE_A:.+]] = flow.tensor.reshape %[[VAL_A]] : tensor<2x5xf32> -> tensor<10xf32>
+  // CHECK-DAG: %[[VAL_B:.+]] = flow.dispatch @dispatch0(%[[LOAD_FOO_B]])
+  // CHECK-DAG: %[[RESHAPE_B:.+]] = flow.tensor.reshape %[[VAL_B]] : tensor<2x5xf32> -> tensor<10xf32>
+  %0 = flow.dispatch @dispatch0(%foo) : (tensor<2x5xf32>) -> tensor<2x5xf32>
+  %1 = flow.tensor.reshape %0 : tensor<2x5xf32> -> tensor<10xf32>
+
+  // CHECK-DAG: %[[LOAD_BAR_A:.+]] = util.global.load immutable @[[$BAR_A]]
+  // CHECK-DAG: %[[LOAD_BAR_B:.+]] = util.global.load immutable @[[$BAR_B]]
+  // CHECK-DAG: %[[LHS_A:.+]] = flow.dispatch @dispatch1(%[[RESHAPE_A]], %[[LOAD_BAR_A]])
+  // CHECK-DAG: %[[LHS_B:.+]] = flow.dispatch @dispatch1(%[[RESHAPE_B]], %[[LOAD_BAR_B]])
+  %2 = flow.dispatch @dispatch1(%1, %bar) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+
+  // CHECK: %[[RHS_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %3 = flow.tensor.transfer %arg0 : tensor<10xf32> to #hal.device.affinity<@device_a>
+
+  // CHECK: %[[RES_A:.+]] = flow.dispatch @dispatch2(%[[LHS_A]], %[[RHS_A]])
+  %4 = flow.dispatch @dispatch2(%2, %3) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+
+  // CHECK: %[[RHS_B:.+]] = flow.tensor.transfer %[[ARG1]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %5 = flow.tensor.transfer %arg1 : tensor<10xf32> to #hal.device.affinity<@device_b>
+
+  // CHECK: %[[RES_B:.+]] = flow.dispatch @dispatch3(%[[LHS_B]], %[[RHS_B]])
+  %6 = flow.dispatch @dispatch3(%2, %5) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+
+  // CHECK: util.return %[[RES_A]], %[[RES_B]]
+  util.return %4, %6 : tensor<10xf32>, tensor<10xf32>
+}
+
+// -----
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+// CHECK: util.global private @[[$GLOBAL:.+]] : tensor<f32>
+// CHECK: util.global private @[[$GLOBAL_B:.+]] : tensor<f32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+// CHECK:   util.global.store %[[TRANSFER_B]], @[[$GLOBAL_B]]
+// CHECK: }
+// CHECK: util.global private @[[$GLOBAL_A:.+]] : tensor<f32>
+// CHECK: util.initializer {
+// CHECK:   %[[LOAD:.+]] = util.global.load @[[$GLOBAL]]
+// CHECK:   %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[LOAD]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+// CHECK:   util.global.store %[[TRANSFER_A]], @[[$GLOBAL_A]]
+// CHECK: }
+util.global private @global : tensor<f32>
+
+// CHECK-LABEL: @launch_on_device_a(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+util.func private @launch_on_device_a(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+  // CHECK: %[[OPERAND0:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+  // CHECK: %[[OPERAND1:.+]] = util.global.load immutable @[[$GLOBAL_A]]
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND0]], %[[OPERAND1]])
+  %1 = flow.dispatch @dispatch(%0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1 : tensor<f32>
+}
+
+util.func private @launch_on_device_b(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+  // CHECK: %[[OPERAND0:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_b>
+  // CHECK: %[[OPERAND1:.+]] = util.global.load immutable @[[$GLOBAL_B]]
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND0]], %[[OPERAND1]])
+  %1 = flow.dispatch @dispatch(%0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1 : tensor<f32>
+}
+
+// CHECK-LABEL: @unknown_global_affinity_cross_functions(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+util.func private @unknown_global_affinity_cross_functions(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
+  // CHECK: %[[LOAD:.+]] = util.global.load immutable @[[$GLOBAL]]
+  %global = util.global.load immutable @global : tensor<f32>
+
+  // CHECK: util.call @launch_on_device_a(%[[ARG0]], %[[LOAD]])
+  %1 = util.call @launch_on_device_a(%arg0, %global) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+
+  // CHECK: util.call @launch_on_device_b(%[[ARG0]], %[[LOAD]])
+  %2 = util.call @launch_on_device_b(%arg0, %global) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1, %2 : tensor<f32>, tensor<f32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative tests. IR is not mutated after running the pass.
+//===----------------------------------------------------------------------===//
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+util.global private @global {stream.affinity = #hal.device.affinity<@device_b>} : tensor<f32>
+
+// CHECK-LABEL: @load
+util.func private @load() -> tensor<f32> {
+  // CHECK: %[[LOAD:.+]] = util.global.load immutable @[[$GLOBAL]]
+  %global = util.global.load immutable @global : tensor<f32>
+  // CHECK: util.return %[[LOAD]]
+  util.return %global : tensor<f32>
+}
+
+// CHECK-LABEL: @negative_affinity_mismatch_cross_functions(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+util.func private @negative_affinity_mismatch_cross_functions(%arg0: tensor<f32>) -> tensor<f32> {
+  // CHECK: %[[OPERAND_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+
+  // CHECK: %[[CALL:.+]] = util.call @load()
+  %1 = util.call @load() : () -> tensor<f32>
+
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_A]], %[[CALL]])
+  %2 = flow.dispatch @dispatch(%0, %1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1 : tensor<f32>
+}
+
+// -----
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[DEVICE_B:.+]] : !hal.device
+// CHECK: util.global private @[[$GLOBAL:.+]] {stream.affinity = #hal.device.affinity<@[[DEVICE_B]]>} : tensor<f32>
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+util.global private @global {stream.affinity = #hal.device.affinity<@device_b>} : tensor<f32>
+
+// CHECK-LABEL: @negative_invalid_program(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+util.func private @negative_invalid_program(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
+  // CHECK: %[[OPERAND0:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+  // CHECK: %[[OPERAND1:.+]] = flow.tensor.transfer %[[ARG1]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %1 = flow.tensor.transfer %arg1 : tensor<f32> to #hal.device.affinity<@device_b>
+  // CHECK: %[[LOAD:.+]] = util.global.load immutable @[[$GLOBAL]]
+  %global = util.global.load immutable @global : tensor<f32>
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND0]], %[[OPERAND1]], %[[LOAD]])
+  %2 = flow.dispatch @dispatch(%0, %1, %global) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1 : tensor<f32>
+}
+
+// -----
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+util.global private @global {stream.affinity = #hal.device.affinity<@device_b>} : tensor<f32>
+
+// CHECK-LABEL: @negative_affinity_mismatch_with_known_global_affinity(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+util.func private @negative_affinity_mismatch_with_known_global_affinity(%arg0: tensor<f32>) -> tensor<f32> {
+  // CHECK: %[[OPERAND_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+  %global = util.global.load immutable @global : tensor<f32>
+
+  // CHECK: %[[LOAD_B:.+]] = util.global.load immutable @[[$GLOBAL]]
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_A]], %[[LOAD_B]])
+  %1 = flow.dispatch @dispatch(%0, %global) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  util.return %1 : tensor<f32>
+}
+
+// -----
+
+// Note: it is an invalid/unoptimized program because scalars are supposed to be
+// used on host code.
+
+// CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
+// CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device
+util.global private @device_a : !hal.device
+util.global private @device_b : !hal.device
+util.global private @global : f32
+
+// CHECK-LABEL: @negative_scalar_global_with_unknown_global_affinity(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+util.func private @negative_scalar_global_with_unknown_global_affinity(%arg0: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
+  // CHECK: %[[OPERAND_A:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_A]]>
+  %0 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_a>
+
+  // CHECK: %[[LOAD:.+]] = util.global.load immutable @[[$GLOBAL]]
+  %global = util.global.load immutable @global : f32
+
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_A]], %[[LOAD]])
+  %1 = flow.dispatch @dispatch(%0, %global) : (tensor<f32>, f32) -> tensor<f32>
+
+  // CHECK: %[[OPERAND_B:.+]] = flow.tensor.transfer %[[ARG0]] {{.+}} to #hal.device.affinity<@[[$DEVICE_B]]>
+  %2 = flow.tensor.transfer %arg0 : tensor<f32> to #hal.device.affinity<@device_b>
+
+  // CHECK: flow.dispatch @dispatch(%[[OPERAND_B]], %[[LOAD]])
+  %3 = flow.dispatch @dispatch(%2, %global) : (tensor<f32>, f32) -> tensor<f32>
+  util.return %1, %3 : tensor<f32>, tensor<f32>
+}


### PR DESCRIPTION
Replicates `IREE::Util::GlobalOps` that are used on multiple affinities and rewires their uses to the associated global. This will allow for specialization of globals for each affinity instead of having unspecialized and a copy each use.

The pass is added right before stream conversion; it is guarded under an experimental flag. The proper implementation is using topology information.

It is a workaround for https://github.com/iree-org/iree/issues/22081