### PR TITLE
Rewriting CombineInitializersPass to not make incorrect programs.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertShardToFlow.cpp
@@ -219,10 +219,12 @@ static void buildGlobalChannelCreation(shard::GridOp grid,
   builder.setInsertionPointToStart(&module.getBodyRegion().getBlocks().front());
 
   auto channelName = getGridChannelName(grid, gridAxes);
-  IREE::Util::GlobalOp::create(
+  auto globalOp = IREE::Util::GlobalOp::create(
       builder, builder.getStringAttr("private"), channelName,
       builder.getType<IREE::Flow::ChannelType>(), false, TypedAttr(),
       builder.getAttr<IREE::Util::InlineNeverAttr>());
+  // Ensure initializer comes after the global.
+  builder.setInsertionPointAfter(globalOp);
   buildChannelInitializer(grid, gridAxes, useNamedDefaultChannels, builder);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -70,6 +70,8 @@ createBufferLikeGlobalOp(std::string name, Location loc, Type globalType,
   // Create an initializer that allocates the buffer storage.
   // We do this by splatting and exporting to a buffer so that it looks like it
   // was created by the user.
+  // Ensure initializer comes after the global.
+  moduleBuilder.setInsertionPointAfter(globalOp);
   auto initializerOp = IREE::Util::InitializerOp::create(moduleBuilder, loc);
   auto initializerBuilder =
       OpBuilder::atBlockBegin(initializerOp.addEntryBlock());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -110,8 +110,13 @@ static void addCleanupPatterns(OpPassManager &passManager) {
 
 void buildFlowTransformPassPipeline(OpPassManager &passManager,
                                     const TransformOptions &transformOptions) {
-  // Start of Flow pipeline, verify input legality.
+  // Start of Flow pipeline: verify semantics legality of the input.
   passManager.addPass(IREE::Flow::createVerifyInputLegalityPass());
+
+  // Verify module initialization order - subsequent passes and pipelines rely
+  // on it being correct (and we maintain it as correct from this point on, so
+  // this is our gate).
+  passManager.addPass(IREE::Util::createVerifyInitializationOrderPass());
 
   FunctionLikeNest(passManager)
       .addPass([&]() {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -189,6 +189,8 @@ static IREE::Util::GlobalOp appendGlobalBuffer(
   }
 
   // Build an initializer to allocate the buffer.
+  // Ensure the initializer comes after the global by advancing insertion point.
+  moduleBuilder.setInsertionPointAfter(globalOp);
   auto initOp = IREE::Util::InitializerOp::create(moduleBuilder, loc);
   auto initBuilder = OpBuilder::atBlockBegin(initOp.addEntryBlock());
   IndexSet indexSet(loc, initBuilder);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeDispatchInstrumentation.cpp
@@ -138,6 +138,9 @@ struct MaterializeDispatchInstrumentationPass
         moduleBuilder.getType<IREE::Stream::ResourceType>(
             IREE::Stream::Lifetime::External));
     {
+      // Ensure initializer comes after the global.
+      OpBuilder::InsertionGuard moduleGuard(moduleBuilder);
+      moduleBuilder.setInsertionPointAfter(globalOp);
       auto initializerOp =
           IREE::Util::InitializerOp::create(moduleBuilder, loc);
       auto initializerBuilder =

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceSelection.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceSelection.cpp
@@ -81,6 +81,7 @@ static LogicalResult memoizeAllocatorSelectOp(
   selectedQueueAffinityGlobalOp.setPrivate();
 
   // Build initializer for the globals.
+  moduleBuilder.setInsertionPointAfter(selectedQueueAffinityGlobalOp);
   auto initializerOp =
       IREE::Util::InitializerOp::create(moduleBuilder, fusedLoc);
   {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
@@ -270,7 +270,8 @@ static SmallVector<IREE::Util::GlobalOpInterface> createMemoizedDeviceGlobals(
   }
 
   // Create an initializer to call the apply function and store the results into
-  // globals.
+  // globals. Ensure it's placed after the globals it initializes.
+  moduleBuilder.setInsertionPointAfter(resultGlobalOps.back());
   auto initializerOp =
       IREE::Util::InitializerOp::create(moduleBuilder, memoizeOp.getLoc());
   auto initializerBuilder =

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -316,6 +316,15 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
                                    PipelinePhase compileFrom,
                                    PipelinePhase compileTo) {
   //----------------------------------------------------------------------------
+  // Precondition verification
+  //----------------------------------------------------------------------------
+
+  // Verify module initialization order - subsequent passes rely on it being
+  // correct (and we maintain it as correct from this point on, so this is our
+  // gate).
+  passManager.addPass(IREE::Util::createVerifyInitializationOrderPass());
+
+  //----------------------------------------------------------------------------
   // Device assignment and interface materialization
   //----------------------------------------------------------------------------
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -248,6 +248,10 @@ struct GlobalOpExpansion
 
     // Materialize the initializer if we need to setup a tensor-like constant.
     if (tensorInitializerRequired) {
+      // Use an insertion guard to ensure the initializer is placed after the
+      // globals it initializes, then restore the rewriter's insertion point.
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointAfter(resourceSizeOp);
       auto initializerOp =
           IREE::Util::InitializerOp::create(rewriter, globalOp.getLoc());
       auto *entryBlock = rewriter.createBlock(&initializerOp.getBody());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -416,6 +416,15 @@ void buildStreamOptimizationPassPipeline(
 void buildStreamTransformPassPipeline(
     OpPassManager &passManager, const TransformOptions &transformOptions) {
   //----------------------------------------------------------------------------
+  // Precondition verification
+  //----------------------------------------------------------------------------
+
+  // Verify module initialization order - subsequent passes and pipelines rely
+  // on it being correct (and we maintain it as correct from this point on, so
+  // this is our gate).
+  passManager.addPass(IREE::Util::createVerifyInitializationOrderPass());
+
+  //----------------------------------------------------------------------------
   // Primary pipeline stages (required)
   //----------------------------------------------------------------------------
 

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -134,6 +134,8 @@ struct ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
         rewriter.getType<IREE::Util::BufferType>());
     newOp.setPrivate();
 
+    // Ensure initializer comes after the global.
+    rewriter.setInsertionPointAfter(newOp);
     auto initializerOp =
         IREE::Util::InitializerOp::create(rewriter, globalOp.getLoc());
     auto initializerBuilder =

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -278,9 +278,8 @@ def Util_GlobalOpInterface : OpInterface<"GlobalOpInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Returns true if the global is mutable outside of initializers. Even if
-        immutable initializers can store to the global and may do so multiple
-        times.
+        Returns true if the global is mutable. Immutable globals are only
+        allowed in initializers or initializer-only functions.
       }],
       /*retTy=*/"bool",
       /*methodName=*/"isGlobalMutable",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -591,6 +591,40 @@ def Util_InitializerOp : Util_Op<"initializer", [
     A function that is called in definition order upon module initialization.
     Must not load any globals that are defined or initialized after it in the
     module.
+
+    Module initialization follows a strict execution order to ensure
+    correctness:
+    * Initialization points: two types of operations define initialization:
+      - `util.initializer` ops: explicit initialization functions
+      - `util.global` ops with initial values: implicit initialization via
+        attributes
+    * Execution order: initialization proceeds in exact module definition order:
+      - Operations execute sequentially from top to bottom
+      - Each `util.global` with an initial value conceptually materializes its
+        value and stores it before the next initialization point
+      - Each `util.initializer` executes its entire body before proceeding
+    * Dependency rules:
+      - Initializers may only access globals defined before them in module order
+      - Globals with initial values are considered "initialized" at their
+        definition point, not when first accessed
+      - Function calls within initializers observe the current initialization
+        state when the call is made
+    * Transformation guarantees:
+      - Combining passes preserve exact initialization order
+      - Globals with initial values may be converted to explicit initialization
+        while maintaining their position in the initialization sequence
+      - The final initialization state must be identical to sequential execution
+
+    Example execution:
+    ```mlir
+    util.global @A = 1 : i32           // A = 1
+    util.initializer { ... }           // Executes with A = 1
+    util.global @B = 2 : i32           // B = 2
+    util.initializer {
+      %a = util.global.load @A : i32   // Loads 1
+      %b = util.global.load @B : i32   // Loads 2
+    }
+    ```
   }];
 
   let arguments = (ins
@@ -968,6 +1002,57 @@ def Util_GlobalOp : Util_Op<"global", [
     Declares a global variable that maintains its value across invocations.
     The value is tied to the execution context of the module and different
     contexts will have different variable storage.
+
+    Globals can be initialized with an `initial_value` attribute that specifies
+    their value at module initialization time. This initial value is evaluated
+    in module definition order: a global with an initial value is considered
+    initialized at its definition point in the module, not when first accessed.
+
+    During module initialization:
+    * Globals with `initial_value` attributes conceptually have their value
+      materialized and stored before any subsequent initialization points
+    * Initialization order follows module definition order exactly
+    * Globals are visible to initializers but only after their definition point
+
+    Example:
+    ```mlir
+    // A is initialized to 1 at this point in module initialization.
+    util.global @A = 1 : i32
+
+    // This initializer can read A (it's defined above).
+    util.initializer {
+      %a = util.global.load @A : i32  // Loads 1
+    }
+
+    // B is initialized to 2 here, after the above initializer runs.
+    util.global @B = 2 : i32
+    ```
+
+    Globals marked as mutable can be modified by stores anywhere in the program.
+    Immutable globals have strict initialization rules:
+    * Can only be initialized once - either by `initial_value` or by stores
+      in initializers, never both.
+    * Stores to immutable globals are only allowed in:
+      - `util.initializer` ops directly
+      - Functions that are only called from initializers (initializer-only)
+    * Stores from externally-reachable functions are forbidden.
+    * Initialization must respect module order - initializers can only
+      access globals defined before them.
+
+    Stores to immutable globals inside control flow regions (scf.if, scf.for,
+    scf.while, etc) in initializer-only functions will generate warnings as
+    they may indicate complex initialization patterns that could be fragile:
+    ```mlir
+    util.func private @init_func() {
+      scf.if %cond {
+        // Warning: conditional store in initializer-only function
+        util.global.store %val, @immutable_global : i32
+      }
+    }
+    ```
+    While such patterns are allowed they should be used with caution as the
+    initialization behavior depends on runtime control flow and the compiler
+    may disable optimizations on those globals.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -109,6 +109,13 @@ bool isValueUsableForOp(Value value, Operation *op);
 // Returns true if the move was successful.
 bool tryMoveProducerBefore(Value value, Operation *consumerOp);
 
+// Materializes a constant value as an operation.
+// Tries multiple approaches: arith::ConstantOp for compatible types,
+// then attribute dialect materialization, then type dialect materialization.
+// Returns nullptr if materialization fails.
+Operation *materializeConstant(OpBuilder &builder, Location loc,
+                               TypedAttr attr);
+
 // Returns true if the given callable op is public or external (no body).
 // Such callables cannot have their signature changed without (potentially)
 // breaking linking.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -41,6 +41,7 @@ iree_compiler_cc_library(
         "StripDebugOps.cpp",
         "TestConversion.cpp",
         "TestFloatRangeAnalysis.cpp",
+        "VerifyInitializationOrder.cpp",
         "VerifyStructuredControlFlow.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     "StripDebugOps.cpp"
     "TestConversion.cpp"
     "TestFloatRangeAnalysis.cpp"
+    "VerifyInitializationOrder.cpp"
     "VerifyStructuredControlFlow.cpp"
   DEPS
     ::PassesIncGen

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Inliner.h"

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -4,24 +4,17 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <algorithm>
-#include <iterator>
-
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/IR/Matchers.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Inliner.h"
 #include "mlir/Transforms/InliningUtils.h"
-
-#define DEBUG_TYPE "iree-util-combine-initializers"
 
 namespace mlir::iree_compiler::IREE::Util {
 
@@ -30,51 +23,289 @@ namespace mlir::iree_compiler::IREE::Util {
 
 namespace {
 
-class CombineInitializersPass
-    : public impl::CombineInitializersPassBase<CombineInitializersPass> {
-public:
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<IREE::Util::UtilDialect>();
+// Returns true if |attr| can be materialized as a constant op.
+static bool canMaterializeConstant(TypedAttr attr) {
+  OpBuilder testBuilder(attr.getContext());
+  auto *testOp = IREE::Util::materializeConstant(
+      testBuilder, testBuilder.getUnknownLoc(), attr);
+  const bool canMaterialize = testOp != nullptr;
+  if (testOp) {
+    testOp->erase();
+  }
+  return canMaterialize;
+}
+
+// Hoists all globals and initializers in |ops| to the first position in the
+// module, maintaining their relative order. Sets the builder insertion point
+// after the last hoisted operation.
+static void hoistGlobalsAndInitializersToFirst(ArrayRef<Operation *> ops,
+                                               OpBuilder &builder) {
+  if (ops.empty()) {
+    return;
   }
 
+#ifndef NDEBUG
+  // Sanity check all ops are in the correct order.
+  Operation *firstOp = ops.front();
+  for (auto *op : ops) {
+    if (op->isBeforeInBlock(firstOp)) {
+      firstOp = op;
+    }
+  }
+  assert(firstOp == ops.front() && "expected ops to be in the correct order");
+#endif // !NDEBUG
+
+  // Move all ops to first position, maintaining relative order.
+  Operation *insertionPointOp = ops.front();
+  for (auto *op : ops) {
+    if (op != insertionPointOp) {
+      op->moveAfter(insertionPointOp);
+      insertionPointOp = op;
+    }
+  }
+
+  // Set builder insertion point after the last op.
+  builder.setInsertionPointAfter(insertionPointOp);
+}
+
+// Collects all globals transitively accessed by an initializer, including
+// through function calls. Uses a worklist algorithm to avoid stack overflow.
+static SmallVector<Operation *>
+collectTransitiveGlobalDeps(IREE::Util::InitializerOpInterface initOp,
+                            SymbolTable &symbolTable) {
+  // Start with the initializer's region and work depth-first.
+  //
+  // Note that we maintain discovery order as that'll be our final total global
+  // order.
+  llvm::SetVector<Operation *> globals;
+  llvm::DenseSet<Operation *> visitedFuncs;
+  SmallVector<Region *> worklist;
+  worklist.push_back(&initOp.getInitializerRegion());
+  while (!worklist.empty()) {
+    Region *region = worklist.pop_back_val();
+    region->walk([&](Operation *op) {
+      // Collect direct global accesses.
+      if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
+        if (auto globalOp = symbolTable.lookup<IREE::Util::GlobalOpInterface>(
+                loadOp.getGlobalName())) {
+          globals.insert(globalOp.getOperation());
+        }
+      } else if (auto storeOp =
+                     dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
+        if (auto globalOp = symbolTable.lookup<IREE::Util::GlobalOpInterface>(
+                storeOp.getGlobalName())) {
+          globals.insert(globalOp.getOperation());
+        }
+      } else if (auto addrOp =
+                     dyn_cast<IREE::Util::GlobalAddressOpInterface>(op)) {
+        if (auto globalOp = symbolTable.lookup<IREE::Util::GlobalOpInterface>(
+                addrOp.getGlobalName())) {
+          globals.insert(globalOp.getOperation());
+        }
+      }
+
+      // Handle transitive dependencies through function calls.
+      if (auto callOp = dyn_cast<CallOpInterface>(op)) {
+        auto callee = callOp.getCallableForCallee();
+        if (auto symRef = dyn_cast<SymbolRefAttr>(callee)) {
+          if (auto calleeOp = symbolTable.lookup<FunctionOpInterface>(
+                  symRef.getRootReference())) {
+            // Avoid infinite recursion by tracking visited functions.
+            if (visitedFuncs.insert(calleeOp.getOperation()).second) {
+              worklist.push_back(&calleeOp.getFunctionBody());
+            }
+          }
+        }
+      }
+    });
+  }
+
+  return globals.takeVector();
+}
+
+struct CombineInitializersPass
+    : public impl::CombineInitializersPassBase<CombineInitializersPass> {
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
 
-    // Gather all of the initializers in the module.
-    // Build a fused loc from all initializers we are combining.
-    SmallVector<IREE::Util::InitializerOp> initializerOps;
+    // Gather all initialization points in module order.
+    // This includes both util.initializer ops and util.global ops with initial
+    // values.
+    SmallVector<Operation *> initPoints;
     SmallVector<Location> locs;
-    for (auto initializerOp : moduleOp.getOps<IREE::Util::InitializerOp>()) {
-      initializerOps.push_back(initializerOp);
-      locs.push_back(initializerOp.getLoc());
-    }
-    if (initializerOps.size() <= 1)
-      return;
-    auto fusedLoc = FusedLoc::get(&getContext(), locs);
-
-    // Make the new initializer op in the same location as the first initializer
-    // we are combining - this ensures that module initialization order is
-    // preserved.
-    OpBuilder builder(initializerOps.front());
-    auto newOp = IREE::Util::InitializerOp::create(builder, fusedLoc);
-    builder.setInsertionPointToStart(newOp.addEntryBlock());
-    InlinerInterface inlinerInterface(&getContext());
-    for (auto initializerOp : initializerOps) {
-      if (failed(mlir::inlineRegion(
-              inlinerInterface, InlinerConfig{}.getCloneCallback(),
-              &initializerOp.getBody(), builder.getInsertionBlock(),
-              builder.getInsertionPoint(),
-              /*inlinedOperands=*/ValueRange{},
-              /*resultsToReplace=*/ValueRange{}, /*inlineLoc=*/std::nullopt,
-              /*shouldCloneInlinedRegion=*/false))) {
-        initializerOp.emitOpError()
-            << "failed to inline into combined initializer";
-        return signalPassFailure();
+    bool hasInitializers = false;
+    for (auto &op : moduleOp.getOps()) {
+      if (isa<IREE::Util::InitializerOpInterface>(&op)) {
+        initPoints.push_back(&op);
+        locs.push_back(op.getLoc());
+        hasInitializers = true;
+      } else if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(&op)) {
+        auto initialValue = globalOp.getGlobalInitialValue();
+        if (initialValue && !isa<IREE::Util::UninitializedAttr>(initialValue)) {
+          initPoints.push_back(&op);
+          locs.push_back(op.getLoc());
+        }
       }
-      builder.setInsertionPointToEnd(&newOp.back());
-      initializerOp.erase();
     }
-    IREE::Util::ReturnOp::create(builder, fusedLoc);
+
+    // We only proceed if we have initializers - if we only have globals with
+    // initial values the module is already in a stable state.
+    if (!hasInitializers || initPoints.size() <= 1) {
+      return;
+    }
+
+    // Simple symbol table for lookups.
+    // We are otherwise performing local operations and do not need a full
+    // GlobalTable analysis.
+    SymbolTable symbolTable(moduleOp);
+
+    // Process initialization points, potentially creating multiple combined
+    // initializers if we encounter non-materializable constants that we can't
+    // place inside our combined initializer. Initialization order of the
+    // program will be preserved.
+    InlinerInterface inlinerInterface(&getContext());
+    SmallVector<IREE::Util::InitializerOp> createdInitializers;
+    llvm::SetVector<Operation *> currentBatch;
+    SmallVector<Location> currentLocs;
+    auto finalizeBatch = [&]() {
+      if (currentBatch.empty()) {
+        return;
+      }
+
+      // Check if we have any actual initializers in this batch or just globals.
+      SmallVector<Operation *> batchGlobalOps;
+      SmallVector<Operation *> batchInitializerOps;
+      for (auto *op : currentBatch) {
+        if (isa<IREE::Util::GlobalOpInterface>(op)) {
+          batchGlobalOps.push_back(op);
+        } else if (isa<IREE::Util::InitializerOpInterface>(op)) {
+          batchInitializerOps.push_back(op);
+        }
+      }
+
+      // Only create a combined initializer if we have initializers to combine.
+      // If we only have globals with initial values leave them as-is.
+      if (batchInitializerOps.empty()) {
+        currentBatch.clear();
+        currentLocs.clear();
+        return;
+      }
+
+      // Pull all globals in the batch to the first position to ensure they
+      // are defined before the combined initializer that will initialize them.
+      // This implements the "pull-up-to-first" principle: moving
+      // globals/initializers upward is always safe (dependencies flow forward).
+      //
+      // Sort the batch by module order first to maintain relative ordering.
+      SmallVector<Operation *> sortedBatch = currentBatch.takeVector();
+      llvm::sort(sortedBatch, [](Operation *a, Operation *b) {
+        return a->isBeforeInBlock(b);
+      });
+
+      OpBuilder builder(&getContext());
+      hoistGlobalsAndInitializersToFirst(sortedBatch, builder);
+
+      // Create the new combined initializer after the globals.
+      auto fusedLoc = currentLocs.size() == 1
+                          ? currentLocs[0]
+                          : FusedLoc::get(&getContext(), currentLocs);
+      auto newOp = IREE::Util::InitializerOp::create(builder, fusedLoc);
+      createdInitializers.push_back(newOp);
+      builder.setInsertionPointToStart(newOp.addEntryBlock());
+
+      // Process each initialization point in the current batch.
+      for (auto *initPoint : sortedBatch) {
+        if (auto initializerOp =
+                dyn_cast<IREE::Util::InitializerOpInterface>(initPoint)) {
+          // Inline existing initializer.
+          if (failed(mlir::inlineRegion(
+                  inlinerInterface, InlinerConfig{}.getCloneCallback(),
+                  &initializerOp.getInitializerRegion(),
+                  builder.getInsertionBlock(), builder.getInsertionPoint(),
+                  /*inlinedOperands=*/ValueRange{},
+                  /*resultsToReplace=*/ValueRange{}, /*inlineLoc=*/std::nullopt,
+                  /*shouldCloneInlinedRegion=*/false))) {
+            initializerOp.emitOpError()
+                << "failed to inline into combined initializer";
+            return signalPassFailure();
+          }
+          // After inlining, set insertion point to the end of the combined
+          // initializer's block to continue appending operations.
+          builder.setInsertionPointToEnd(&newOp.back());
+        } else if (auto globalOp =
+                       dyn_cast<IREE::Util::GlobalOpInterface>(initPoint)) {
+          // Only materialize if this global has an initial value that can be
+          // materialized. Globals added via transitive dependency collection
+          // or non-materializable constants are left as-is.
+          auto initialValue = globalOp.getGlobalInitialValue();
+          if (initialValue &&
+              !isa<IREE::Util::UninitializedAttr>(initialValue)) {
+            auto typedAttr = cast<TypedAttr>(initialValue);
+
+            // Skip non-materializable constants (e.g., #util.byte_pattern).
+            if (!canMaterializeConstant(typedAttr)) {
+              continue;
+            }
+
+            auto *constantOp = IREE::Util::materializeConstant(
+                builder, initPoint->getLoc(), typedAttr);
+            assert(constantOp && "unexpected materialization failure");
+
+            // Store the materialized value to the global.
+            globalOp.createStoreOp(initPoint->getLoc(),
+                                   constantOp->getResult(0), builder);
+
+            // Clear the initial value from the global.
+            globalOp.setGlobalInitialValue(nullptr);
+          }
+        }
+      }
+
+      // Add the return terminator at the end of the initializer.
+      IREE::Util::ReturnOp::create(builder, fusedLoc);
+
+      currentBatch.clear();
+      currentLocs.clear();
+    };
+
+    // Process each initialization point, collecting all into a single batch.
+    // Non-materializable constants are included to preserve relative ordering
+    // with related globals (e.g., resource+size pairs).
+    for (auto *initPoint : initPoints) {
+      // Add to current batch and collect any transitive dependencies for
+      // initializers.
+      if (auto initializerOp =
+              dyn_cast<IREE::Util::InitializerOpInterface>(initPoint)) {
+        // Collect all globals this initializer depends on (direct +
+        // transitive). Warning that this could spider the whole program and we
+        // currently don't cache partial results for functions called repeatedly
+        // (as we tend not to have those... yet).
+        auto dependentGlobals =
+            collectTransitiveGlobalDeps(initializerOp, symbolTable);
+
+        // Insert dependent globals BEFORE the initializer in the batch.
+        // SetVector maintains insertion order and handles duplicates.
+        currentBatch.insert(dependentGlobals.begin(), dependentGlobals.end());
+
+        // Now add the initializer itself.
+        currentBatch.insert(initPoint);
+        currentLocs.push_back(initPoint->getLoc());
+      } else {
+        // Global with initial value - just add it (no materialization needed).
+        currentBatch.insert(initPoint);
+        currentLocs.push_back(initPoint->getLoc());
+      }
+    }
+
+    // Finalize any remaining batch.
+    finalizeBatch();
+
+    // Erase original initializers (but not the globals).
+    for (auto *initPoint : initPoints) {
+      if (isa<IREE::Util::InitializerOpInterface>(initPoint)) {
+        initPoint->erase();
+      }
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -71,6 +71,7 @@ createHoistIntoGlobalsPass(const ExprHoistingOptions &options);
 #define GEN_PASS_DECL_STRIPDEBUGOPSPASS
 #define GEN_PASS_DECL_TESTCONVERSIONPASS
 #define GEN_PASS_DECL_TESTFLOATRANGEANALYSISPASS
+#define GEN_PASS_DECL_VERIFYINITIALIZATIONORDERPASS
 #define GEN_PASS_DECL_VERIFYSTRUCTUREDCONTROLFLOWPASS
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h.inc" // IWYU pragma: keep
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -19,6 +19,9 @@ def ApplyPatternsPass : Pass<"iree-util-apply-patterns", ""> {
 
 def CombineInitializersPass : Pass<"iree-util-combine-initializers", "mlir::ModuleOp"> {
   let summary = "Combines global initializers into one.";
+  let dependentDialects = [
+    "::mlir::iree_compiler::IREE::Util::UtilDialect"
+  ];
 }
 
 def DropCompilerHintsPass : Pass<"iree-util-drop-compiler-hints", ""> {
@@ -142,6 +145,27 @@ def StripAndSplatConstantsPass :
 
 def StripDebugOpsPass : Pass<"iree-util-strip-debug-ops", ""> {
   let summary = "Strips debug ops, like assertions.";
+}
+
+def VerifyInitializationOrderPass :
+    Pass<"iree-util-verify-initialization-order", "mlir::ModuleOp"> {
+  let summary = "Verifies module initialization order constraints.";
+  let description = [{
+    Verifies that module initialization follows the rules documented in the
+    util.initializer and util.global operations:
+
+    1. Initializers can only access globals defined before them in module order.
+    2. Immutable globals can only be initialized once (either by initial_value
+       OR by stores in initializers, never both).
+    3. Globals with initial values cannot be modified by initializers that
+       precede them in module order.
+    4. Stores to immutable globals must occur in initializers or functions
+       only reachable from initializers.
+
+    The pass uses conservative analysis and emits warnings for patterns it
+    cannot definitively verify (e.g. conditional stores in initializer-only
+    functions).
+  }];
 }
 
 def VerifyStructuredControlFlowPass :

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyInitializationOrder.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyInitializationOrder.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
@@ -27,6 +28,379 @@ struct InitializerReachability {
   DenseSet<Operation *> externallyReachableFunctions;
 };
 
+// Collects all initialization points (initializers and globals) in order.
+static void collectInitializationOrder(
+    mlir::ModuleOp moduleOp,
+    SmallVector<IREE::Util::InitializerOpInterface> &initializerOps,
+    DenseMap<Operation *, size_t> &opOrdinalMap) {
+  size_t ordinal = 0;
+  for (auto &op : moduleOp.getOps()) {
+    opOrdinalMap[&op] = ordinal++;
+    if (auto initializerOp =
+            dyn_cast<IREE::Util::InitializerOpInterface>(&op)) {
+      initializerOps.push_back(initializerOp);
+    }
+  }
+}
+
+// Recursively checks a function for global accesses and function calls.
+// Ensures all accessed globals are defined before the given initializer
+// ordinal.
+static LogicalResult checkFunctionGlobalAccesses(
+    Operation *funcOp, size_t initOrdinal, DenseSet<Operation *> &visitedFuncs,
+    GlobalTable &globalTable, DenseMap<Operation *, size_t> &opOrdinalMap,
+    mlir::ModuleOp moduleOp) {
+  // Avoid infinite recursion on circular calls.
+  if (!visitedFuncs.insert(funcOp).second) {
+    return success();
+  }
+
+  // Walk the function body checking for global accesses.
+  auto result = funcOp->walk([&](Operation *op) -> WalkResult {
+    // Check global loads.
+    if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
+      auto globalName = loadOp.getGlobalName();
+      auto &global = globalTable.lookup(globalName);
+      size_t globalOrdinal = opOrdinalMap[global.op];
+      if (globalOrdinal > initOrdinal) {
+        op->emitError("initializer at position ")
+            << initOrdinal << " transitively accesses global '@" << globalName
+            << "' defined at position " << globalOrdinal
+            << " through function call";
+        return WalkResult::interrupt();
+      }
+    }
+
+    // Check global stores.
+    if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
+      auto globalName = storeOp.getGlobalName();
+      auto &global = globalTable.lookup(globalName);
+      size_t globalOrdinal = opOrdinalMap[global.op];
+      if (globalOrdinal > initOrdinal) {
+        op->emitError("initializer at position ")
+            << initOrdinal << " transitively stores to global '@" << globalName
+            << "' defined at position " << globalOrdinal
+            << " through function call";
+        return WalkResult::interrupt();
+      }
+    }
+
+    // Recursively check function calls.
+    if (auto callOp = dyn_cast<IREE::Util::CallOp>(op)) {
+      auto calleeAttr = callOp.getCalleeAttr();
+      auto *calleeOp =
+          SymbolTable::lookupNearestSymbolFrom(moduleOp, calleeAttr);
+      if (!calleeOp) {
+        op->emitError("call to undefined function '@") << calleeAttr << "'";
+        return WalkResult::interrupt();
+      }
+      if (failed(checkFunctionGlobalAccesses(calleeOp, initOrdinal,
+                                             visitedFuncs, globalTable,
+                                             opOrdinalMap, moduleOp))) {
+        return WalkResult::interrupt();
+      }
+    }
+
+    return WalkResult::advance();
+  });
+
+  return result.wasInterrupted() ? failure() : success();
+}
+
+// Verifies that initializers only access globals defined before them.
+static LogicalResult verifyModuleOrderDependencies(
+    GlobalTable &globalTable,
+    ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
+    DenseMap<Operation *, size_t> &opOrdinalMap, mlir::ModuleOp moduleOp) {
+  DenseSet<Operation *> visitedFuncs; // Reused.
+  for (auto initializerOp : initializerOps) {
+    size_t initOrdinal = opOrdinalMap[initializerOp];
+
+    // Check all global accesses in the initializer.
+    auto result = initializerOp.walk([&](Operation *op) -> WalkResult {
+      if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
+        auto globalName = loadOp.getGlobalName();
+        auto &global = globalTable.lookup(globalName);
+        size_t globalOrdinal = opOrdinalMap[global.op];
+        if (globalOrdinal > initOrdinal) {
+          op->emitError("initializer at position ")
+              << initOrdinal << " accesses global '@" << globalName
+              << "' defined at position " << globalOrdinal;
+          return WalkResult::interrupt();
+        }
+      }
+
+      // Also check stores for forward references.
+      if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
+        auto globalName = storeOp.getGlobalName();
+        auto &global = globalTable.lookup(globalName);
+        size_t globalOrdinal = opOrdinalMap[global.op];
+        if (globalOrdinal > initOrdinal) {
+          op->emitError("initializer at position ")
+              << initOrdinal << " stores to global '@" << globalName
+              << "' defined at position " << globalOrdinal;
+          return WalkResult::interrupt();
+        }
+      }
+
+      // Check function calls for transitive dependencies.
+      if (auto callOp = dyn_cast<IREE::Util::CallOp>(op)) {
+        auto calleeAttr = callOp.getCalleeAttr();
+        auto *calleeOp =
+            SymbolTable::lookupNearestSymbolFrom(moduleOp, calleeAttr);
+        if (!calleeOp) {
+          op->emitError("call to undefined function '@") << calleeAttr << "'";
+          return WalkResult::interrupt();
+        }
+        // Recursively check the called function for global accesses.
+        visitedFuncs.clear();
+        if (failed(checkFunctionGlobalAccesses(calleeOp, initOrdinal,
+                                               visitedFuncs, globalTable,
+                                               opOrdinalMap, moduleOp))) {
+          return WalkResult::interrupt();
+        }
+      }
+
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+// Verifies that immutable globals are only initialized once.
+static LogicalResult verifyDoubleInitialization(
+    GlobalTable &globalTable,
+    ArrayRef<IREE::Util::InitializerOpInterface> initializerOps) {
+  // Track which immutable globals have been initialized.
+  llvm::StringMap<Location> immutableGlobalInitializations;
+
+  // First pass: check globals with initial values.
+  for (size_t i = 0; i < globalTable.size(); ++i) {
+    auto globalName = globalTable.lookupByOrdinal(i);
+    auto &global = globalTable.lookup(globalName);
+    if (!global.op.isGlobalMutable() && global.op.getGlobalInitialValue()) {
+      // Immutable global with initial value.
+      immutableGlobalInitializations.try_emplace(globalName,
+                                                 global.op->getLoc());
+    }
+  }
+
+  // Second pass: check for stores in initializers.
+  for (auto initializerOp : initializerOps) {
+    auto result = initializerOp.walk(
+        [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
+          auto globalName = storeOp.getGlobalName();
+          auto &global = globalTable.lookup(globalName);
+          if (!global.op.isGlobalMutable()) {
+            // Check if already initialized.
+            if (immutableGlobalInitializations.contains(globalName)) {
+              storeOp->emitError("immutable global '@")
+                  << globalName
+                  << "' is initialized both by initial value and "
+                     "by store in initializer";
+              return WalkResult::interrupt();
+            }
+            immutableGlobalInitializations.try_emplace(globalName,
+                                                       storeOp->getLoc());
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted()) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+// Verifies that globals with initial values aren't modified by earlier
+// initializers.
+static LogicalResult verifyInitialValueConflicts(
+    GlobalTable &globalTable,
+    ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
+    DenseMap<Operation *, size_t> &opOrdinalMap) {
+  // Check each initializer for stores to globals that come after it.
+  for (auto initializerOp : initializerOps) {
+    size_t initOrdinal = opOrdinalMap[initializerOp];
+    auto result = initializerOp.walk(
+        [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
+          auto globalName = storeOp.getGlobalName();
+          auto &global = globalTable.lookup(globalName);
+          if (global.op.getGlobalInitialValue()) {
+            // Global has an initial value. Check if it comes after this
+            // initializer.
+            size_t globalOrdinal = opOrdinalMap[global.op];
+            if (globalOrdinal > initOrdinal) {
+              storeOp->emitError("global '@")
+                  << globalName << "' with initial value at position "
+                  << globalOrdinal
+                  << " is modified by earlier initializer at position "
+                  << initOrdinal;
+              return WalkResult::interrupt();
+            }
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted()) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+// Computes which functions are only reachable from initializers.
+static InitializerReachability
+computeInitializerReachability(mlir::ModuleOp moduleOp) {
+  InitializerReachability result;
+
+  // Build the call graph.
+  CallGraph callGraph(moduleOp);
+
+  // Find externally reachable functions and initializers.
+  SetVector<CallGraphNode *> externalWorklist;
+  SetVector<CallGraphNode *> initializerWorklist;
+  for (CallGraphNode *node : callGraph) {
+    if (node->isExternal()) {
+      continue;
+    }
+    auto *callableOp = node->getCallableRegion()->getParentOp();
+    if (isa<IREE::Util::InitializerOpInterface>(callableOp)) {
+      // Initializers are not externally reachable.
+      initializerWorklist.insert(node);
+      continue;
+    }
+    if (auto funcOp = dyn_cast<FunctionOpInterface>(callableOp)) {
+      if (funcOp.isPublic()) {
+        // Public function - externally reachable.
+        result.externallyReachableFunctions.insert(callableOp);
+        externalWorklist.insert(node);
+      }
+    }
+  }
+
+  // Transitively mark all functions called from external entry points.
+  while (!externalWorklist.empty()) {
+    auto *node = externalWorklist.pop_back_val();
+    for (auto &edge : *node) {
+      auto *targetNode = edge.getTarget();
+      if (!targetNode->isExternal()) {
+        auto *targetOp = targetNode->getCallableRegion()->getParentOp();
+        if (result.externallyReachableFunctions.insert(targetOp).second) {
+          externalWorklist.insert(targetNode);
+        }
+      }
+    }
+  }
+
+  // Mark all functions transitively called from initializers.
+  DenseSet<Operation *> initializerReachable;
+  while (!initializerWorklist.empty()) {
+    auto *node = initializerWorklist.pop_back_val();
+    for (auto &edge : *node) {
+      auto *targetNode = edge.getTarget();
+      if (!targetNode->isExternal()) {
+        auto *targetOp = targetNode->getCallableRegion()->getParentOp();
+        if (initializerReachable.insert(targetOp).second) {
+          initializerWorklist.insert(targetNode);
+        }
+      }
+    }
+  }
+
+  // Functions that are initializer-reachable but NOT externally reachable
+  // are initializer-only.
+  for (auto *op : initializerReachable) {
+    if (!result.externallyReachableFunctions.contains(op)) {
+      result.initializerOnlyFunctions.insert(op);
+    }
+  }
+
+  return result;
+}
+
+// Verifies stores to immutable globals with appropriate warnings.
+static LogicalResult
+verifyImmutableStoresWithWarnings(GlobalTable &globalTable,
+                                  const InitializerReachability &reachability) {
+  bool hadError = false;
+  globalTable.forEach([&](Global &global) {
+    if (global.op.isGlobalMutable()) {
+      // Mutable global - stores are allowed from anywhere.
+      return GlobalAction::PRESERVE;
+    }
+
+    // Immutable global - check all stores.
+    for (auto storeOp : global.storeOps) {
+      Operation *parent = storeOp->getParentOp();
+
+      // Walk up to find the containing function or initializer.
+      while (parent && !isa<FunctionOpInterface>(parent) &&
+             !isa<IREE::Util::InitializerOpInterface>(parent)) {
+        parent = parent->getParentOp();
+      }
+
+      if (!parent) {
+        storeOp->emitError("store to immutable global '@")
+            << global.getName()
+            << "' outside of function or initializer context";
+        hadError = true;
+        continue;
+      }
+
+      if (isa<IREE::Util::InitializerOpInterface>(parent)) {
+        // Store directly in initializer - always OK.
+        continue;
+      }
+
+      // Check if the function is initializer-only.
+      if (reachability.externallyReachableFunctions.contains(parent)) {
+        // Function is externally reachable - this is an error.
+        auto funcOp = cast<FunctionOpInterface>(parent);
+        storeOp->emitError("store to immutable global '@")
+            << global.getName() << "' in function '" << funcOp.getName()
+            << "' which is reachable from non-initializer contexts";
+        hadError = true;
+      } else if (!reachability.initializerOnlyFunctions.contains(parent)) {
+        // Function reachability is unknown - shouldn't happen but be
+        // defensive.
+        auto funcOp = cast<FunctionOpInterface>(parent);
+        storeOp->emitWarning("store to immutable global '@")
+            << global.getName() << "' in function '" << funcOp.getName()
+            << "' with unknown reachability"
+            << " (verification may be overly conservative)";
+      } else {
+        // Function is initializer-only. Check if it's in a conditional
+        // context by looking for ops that implement RegionBranchOpInterface.
+        bool inConditional = false;
+        Operation *checkOp = storeOp;
+        while (checkOp != parent) {
+          checkOp = checkOp->getParentOp();
+          if (isa<RegionBranchOpInterface>(checkOp)) {
+            inConditional = true;
+            break;
+          }
+        }
+
+        // Else: unconditional store in initializer-only function - OK.
+        if (inConditional) {
+          auto funcOp = cast<FunctionOpInterface>(parent);
+          storeOp->emitWarning("conditional store to immutable global '@")
+              << global.getName() << "' in initializer-only function '"
+              << funcOp.getName()
+              << "' may indicate complex initialization pattern"
+              << " (verification may be overly conservative)";
+        }
+      }
+    }
+
+    return GlobalAction::PRESERVE;
+  });
+
+  return hadError ? failure() : success();
+}
+
 class VerifyInitializationOrderPass
     : public impl::VerifyInitializationOrderPassBase<
           VerifyInitializationOrderPass> {
@@ -43,7 +417,7 @@ public:
 
     // Phase 1: simple checks (no CFG analysis needed).
     if (failed(verifyModuleOrderDependencies(globalTable, initializerOps,
-                                             opOrdinalMap))) {
+                                             opOrdinalMap, moduleOp))) {
       return;
     }
 
@@ -61,344 +435,6 @@ public:
     if (failed(verifyImmutableStoresWithWarnings(globalTable, reachability))) {
       return;
     }
-  }
-
-private:
-  enum DiagnosticLevel { ERROR, WARNING, INFO };
-
-  void emitDiagnostic(DiagnosticLevel level, Location loc, const Twine &msg) {
-    switch (level) {
-    case ERROR:
-      emitError(loc) << msg;
-      signalPassFailure();
-      break;
-    case WARNING:
-      emitWarning(loc) << msg << " (verification may be overly conservative)";
-      break;
-    case INFO:
-      emitRemark(loc) << msg;
-      break;
-    }
-  }
-
-  // Collects all initialization points (initializers and globals) in order.
-  void collectInitializationOrder(
-      mlir::ModuleOp moduleOp,
-      SmallVector<IREE::Util::InitializerOpInterface> &initializerOps,
-      DenseMap<Operation *, size_t> &opOrdinalMap) {
-    size_t ordinal = 0;
-    for (auto &op : moduleOp.getOps()) {
-      opOrdinalMap[&op] = ordinal++;
-      if (auto initializerOp =
-              dyn_cast<IREE::Util::InitializerOpInterface>(&op)) {
-        initializerOps.push_back(initializerOp);
-      }
-    }
-  }
-
-  // Verifies that initializers only access globals defined before them.
-  LogicalResult verifyModuleOrderDependencies(
-      GlobalTable &globalTable,
-      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
-      DenseMap<Operation *, size_t> &opOrdinalMap) {
-    for (auto initializerOp : initializerOps) {
-      size_t initOrdinal = opOrdinalMap[initializerOp];
-
-      // Check all global accesses in the initializer.
-      auto result = initializerOp.walk([&](Operation *op) -> WalkResult {
-        if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
-          auto globalName = loadOp.getGlobalName();
-          auto &global = globalTable.lookup(globalName);
-          if (global.op) {
-            size_t globalOrdinal = opOrdinalMap[global.op];
-            if (globalOrdinal > initOrdinal) {
-              emitDiagnostic(ERROR, op->getLoc(),
-                             "initializer at position " + Twine(initOrdinal) +
-                                 " accesses global '@" + globalName +
-                                 "' defined at position " +
-                                 Twine(globalOrdinal));
-              return WalkResult::interrupt();
-            }
-          }
-        }
-
-        // Also check stores for forward references.
-        if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
-          auto globalName = storeOp.getGlobalName();
-          auto &global = globalTable.lookup(globalName);
-          if (global.op) {
-            size_t globalOrdinal = opOrdinalMap[global.op];
-            if (globalOrdinal > initOrdinal) {
-              emitDiagnostic(ERROR, op->getLoc(),
-                             "initializer at position " + Twine(initOrdinal) +
-                                 " stores to global '@" + globalName +
-                                 "' defined at position " +
-                                 Twine(globalOrdinal));
-              return WalkResult::interrupt();
-            }
-          }
-        }
-
-        // Check function calls for transitive dependencies.
-        if (auto callOp = dyn_cast<IREE::Util::CallOp>(op)) {
-          // We'll verify the called functions separately in a more
-          // sophisticated pass. For now, just ensure the function exists. DO
-          // NOT SUBMIT
-        }
-
-        return WalkResult::advance();
-      });
-      if (result.wasInterrupted()) {
-        return failure();
-      }
-    }
-    return success();
-  }
-
-  // Verifies that immutable globals are only initialized once.
-  LogicalResult verifyDoubleInitialization(
-      GlobalTable &globalTable,
-      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps) {
-    // Track which immutable globals have been initialized.
-    llvm::StringMap<Location> immutableGlobalInitializations;
-
-    // First pass: check globals with initial values.
-    for (size_t i = 0; i < globalTable.size(); ++i) {
-      auto globalName = globalTable.lookupByOrdinal(i);
-      auto &global = globalTable.lookup(globalName);
-      if (global.op && !global.op.isGlobalMutable() &&
-          global.op.getGlobalInitialValue()) {
-        // Immutable global with initial value.
-        immutableGlobalInitializations.try_emplace(globalName,
-                                                   global.op->getLoc());
-      }
-    }
-
-    // Second pass: check for stores in initializers.
-    for (auto initializerOp : initializerOps) {
-      auto result = initializerOp.walk(
-          [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
-            auto globalName = storeOp.getGlobalName();
-            auto &global = globalTable.lookup(globalName);
-            if (global.op && !global.op.isGlobalMutable()) {
-              // Check if already initialized.
-              auto it = immutableGlobalInitializations.find(globalName);
-              if (it != immutableGlobalInitializations.end()) {
-                emitDiagnostic(ERROR, storeOp->getLoc(),
-                               "immutable global '@" + globalName +
-                                   "' is initialized both by initial value and "
-                                   "by store in initializer");
-                return WalkResult::interrupt();
-              }
-              immutableGlobalInitializations.try_emplace(globalName,
-                                                         storeOp->getLoc());
-            }
-            return WalkResult::advance();
-          });
-      if (result.wasInterrupted()) {
-        return failure();
-      }
-    }
-    return success();
-  }
-
-  // Verifies that globals with initial values aren't modified by earlier
-  // initializers.
-  LogicalResult verifyInitialValueConflicts(
-      GlobalTable &globalTable,
-      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
-      DenseMap<Operation *, size_t> &opOrdinalMap) {
-    // Check each initializer for stores to globals that come after it.
-    for (auto initializerOp : initializerOps) {
-      size_t initOrdinal = opOrdinalMap[initializerOp];
-      auto result = initializerOp.walk(
-          [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
-            auto globalName = storeOp.getGlobalName();
-            auto &global = globalTable.lookup(globalName);
-            if (global.op && global.op.getGlobalInitialValue()) {
-              // Global has an initial value. Check if it comes after this
-              // initializer.
-              size_t globalOrdinal = opOrdinalMap[global.op];
-              if (globalOrdinal > initOrdinal) {
-                emitDiagnostic(
-                    ERROR, storeOp->getLoc(),
-                    "global '@" + globalName +
-                        "' with initial value at position " +
-                        Twine(globalOrdinal) +
-                        " is modified by earlier initializer at position " +
-                        Twine(initOrdinal));
-                return WalkResult::interrupt();
-              }
-            }
-            return WalkResult::advance();
-          });
-      if (result.wasInterrupted()) {
-        return failure();
-      }
-    }
-    return success();
-  }
-
-  // Computes which functions are only reachable from initializers.
-  InitializerReachability
-  computeInitializerReachability(mlir::ModuleOp moduleOp) {
-    InitializerReachability result;
-
-    // Build the call graph.
-    CallGraph callGraph(moduleOp);
-
-    // Find all externally reachable functions.
-    SetVector<CallGraphNode *> externalWorklist;
-    for (CallGraphNode *node : callGraph) {
-      if (node->isExternal()) {
-        continue;
-      }
-      auto *callableOp = node->getCallableRegion()->getParentOp();
-      if (isa<IREE::Util::InitializerOpInterface>(callableOp)) {
-        // Initializers are not externally reachable.
-        continue;
-      }
-      if (auto funcOp = dyn_cast<FunctionOpInterface>(callableOp)) {
-        if (funcOp.isPublic()) {
-          // Public function - externally reachable.
-          result.externallyReachableFunctions.insert(callableOp);
-          externalWorklist.insert(node);
-        }
-      }
-    }
-
-    // Transitively mark all functions called from external entry points.
-    while (!externalWorklist.empty()) {
-      auto *node = externalWorklist.pop_back_val();
-      for (auto &edge : *node) {
-        auto *targetNode = edge.getTarget();
-        if (!targetNode->isExternal()) {
-          auto *targetOp = targetNode->getCallableRegion()->getParentOp();
-          if (result.externallyReachableFunctions.insert(targetOp).second) {
-            externalWorklist.insert(targetNode);
-          }
-        }
-      }
-    }
-
-    // Find functions only called from initializers.
-    SetVector<CallGraphNode *> initializerWorklist;
-    for (CallGraphNode *node : callGraph) {
-      if (node->isExternal()) {
-        continue;
-      }
-      auto *callableOp = node->getCallableRegion()->getParentOp();
-      if (isa<IREE::Util::InitializerOpInterface>(callableOp)) {
-        initializerWorklist.insert(node);
-      }
-    }
-
-    // Mark all functions transitively called from initializers.
-    DenseSet<Operation *> initializerReachable;
-    while (!initializerWorklist.empty()) {
-      auto *node = initializerWorklist.pop_back_val();
-      for (auto &edge : *node) {
-        auto *targetNode = edge.getTarget();
-        if (!targetNode->isExternal()) {
-          auto *targetOp = targetNode->getCallableRegion()->getParentOp();
-          if (initializerReachable.insert(targetOp).second) {
-            initializerWorklist.insert(targetNode);
-          }
-        }
-      }
-    }
-
-    // Functions that are initializer-reachable but NOT externally reachable
-    // are initializer-only.
-    for (auto *op : initializerReachable) {
-      if (!result.externallyReachableFunctions.contains(op)) {
-        result.initializerOnlyFunctions.insert(op);
-      }
-    }
-
-    return result;
-  }
-
-  // Verifies stores to immutable globals with appropriate warnings.
-  LogicalResult verifyImmutableStoresWithWarnings(
-      GlobalTable &globalTable, const InitializerReachability &reachability) {
-    bool hadError = false;
-    globalTable.forEach([&](Global &global) {
-      if (global.op.isGlobalMutable()) {
-        // Mutable global - stores are allowed from anywhere.
-        return GlobalAction::PRESERVE;
-      }
-
-      // Immutable global - check all stores.
-      for (auto storeOp : global.storeOps) {
-        Operation *parent = storeOp->getParentOp();
-
-        // Walk up to find the containing function or initializer.
-        while (parent && !isa<FunctionOpInterface>(parent) &&
-               !isa<IREE::Util::InitializerOpInterface>(parent)) {
-          parent = parent->getParentOp();
-        }
-
-        if (!parent) {
-          emitDiagnostic(ERROR, storeOp->getLoc(),
-                         "store to immutable global '@" + global.getName() +
-                             "' outside of function or initializer context");
-          hadError = true;
-          continue;
-        }
-
-        if (isa<IREE::Util::InitializerOpInterface>(parent)) {
-          // Store directly in initializer - always OK.
-          continue;
-        }
-
-        // Check if the function is initializer-only.
-        if (reachability.externallyReachableFunctions.contains(parent)) {
-          // Function is externally reachable - this is an error.
-          auto funcOp = cast<FunctionOpInterface>(parent);
-          emitDiagnostic(
-              ERROR, storeOp->getLoc(),
-              "store to immutable global '@" + global.getName() +
-                  "' in function '" + funcOp.getName() +
-                  "' which is reachable from non-initializer contexts");
-          hadError = true;
-        } else if (!reachability.initializerOnlyFunctions.contains(parent)) {
-          // Function reachability is unknown - shouldn't happen but be
-          // defensive.
-          auto funcOp = cast<FunctionOpInterface>(parent);
-          emitDiagnostic(WARNING, storeOp->getLoc(),
-                         "store to immutable global '@" + global.getName() +
-                             "' in function '" + funcOp.getName() +
-                             "' with unknown reachability");
-        } else {
-          // Function is initializer-only. Check if it's in a conditional
-          // context by looking for ops that implement RegionBranchOpInterface.
-          bool inConditional = false;
-          Operation *checkOp = storeOp;
-          while (checkOp != parent) {
-            checkOp = checkOp->getParentOp();
-            if (isa<RegionBranchOpInterface>(checkOp)) {
-              inConditional = true;
-              break;
-            }
-          }
-
-          // Else: unconditional store in initializer-only function - OK.
-          if (inConditional) {
-            auto funcOp = cast<FunctionOpInterface>(parent);
-            emitDiagnostic(
-                WARNING, storeOp->getLoc(),
-                "conditional store to immutable global '@" + global.getName() +
-                    "' in initializer-only function '" + funcOp.getName() +
-                    "' may indicate complex initialization pattern");
-          }
-        }
-      }
-
-      return GlobalAction::PRESERVE;
-    });
-
-    return hadError ? failure() : success();
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyInitializationOrder.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyInitializationOrder.cpp
@@ -1,0 +1,407 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "mlir/Analysis/CallGraph.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::Util {
+
+#define GEN_PASS_DEF_VERIFYINITIALIZATIONORDERPASS
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h.inc"
+
+namespace {
+
+// Tracks which functions are only reachable from initializers.
+struct InitializerReachability {
+  // Functions that are only callable from initializers (not from external).
+  DenseSet<Operation *> initializerOnlyFunctions;
+  // Functions reachable from external entry points.
+  DenseSet<Operation *> externallyReachableFunctions;
+};
+
+class VerifyInitializationOrderPass
+    : public impl::VerifyInitializationOrderPassBase<
+          VerifyInitializationOrderPass> {
+public:
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    GlobalTable globalTable(moduleOp);
+    globalTable.rebuild();
+
+    // Collect initialization points in module order.
+    SmallVector<IREE::Util::InitializerOpInterface> initializerOps;
+    DenseMap<Operation *, size_t> opOrdinalMap;
+    collectInitializationOrder(moduleOp, initializerOps, opOrdinalMap);
+
+    // Phase 1: simple checks (no CFG analysis needed).
+    if (failed(verifyModuleOrderDependencies(globalTable, initializerOps,
+                                             opOrdinalMap))) {
+      return;
+    }
+
+    if (failed(verifyDoubleInitialization(globalTable, initializerOps))) {
+      return;
+    }
+
+    if (failed(verifyInitialValueConflicts(globalTable, initializerOps,
+                                           opOrdinalMap))) {
+      return;
+    }
+
+    // Phase 2: conservative reachability analysis with warnings.
+    auto reachability = computeInitializerReachability(moduleOp);
+    if (failed(verifyImmutableStoresWithWarnings(globalTable, reachability))) {
+      return;
+    }
+  }
+
+private:
+  enum DiagnosticLevel { ERROR, WARNING, INFO };
+
+  void emitDiagnostic(DiagnosticLevel level, Location loc, const Twine &msg) {
+    switch (level) {
+    case ERROR:
+      emitError(loc) << msg;
+      signalPassFailure();
+      break;
+    case WARNING:
+      emitWarning(loc) << msg << " (verification may be overly conservative)";
+      break;
+    case INFO:
+      emitRemark(loc) << msg;
+      break;
+    }
+  }
+
+  // Collects all initialization points (initializers and globals) in order.
+  void collectInitializationOrder(
+      mlir::ModuleOp moduleOp,
+      SmallVector<IREE::Util::InitializerOpInterface> &initializerOps,
+      DenseMap<Operation *, size_t> &opOrdinalMap) {
+    size_t ordinal = 0;
+    for (auto &op : moduleOp.getOps()) {
+      opOrdinalMap[&op] = ordinal++;
+      if (auto initializerOp =
+              dyn_cast<IREE::Util::InitializerOpInterface>(&op)) {
+        initializerOps.push_back(initializerOp);
+      }
+    }
+  }
+
+  // Verifies that initializers only access globals defined before them.
+  LogicalResult verifyModuleOrderDependencies(
+      GlobalTable &globalTable,
+      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
+      DenseMap<Operation *, size_t> &opOrdinalMap) {
+    for (auto initializerOp : initializerOps) {
+      size_t initOrdinal = opOrdinalMap[initializerOp];
+
+      // Check all global accesses in the initializer.
+      auto result = initializerOp.walk([&](Operation *op) -> WalkResult {
+        if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
+          auto globalName = loadOp.getGlobalName();
+          auto &global = globalTable.lookup(globalName);
+          if (global.op) {
+            size_t globalOrdinal = opOrdinalMap[global.op];
+            if (globalOrdinal > initOrdinal) {
+              emitDiagnostic(ERROR, op->getLoc(),
+                             "initializer at position " + Twine(initOrdinal) +
+                                 " accesses global '@" + globalName +
+                                 "' defined at position " +
+                                 Twine(globalOrdinal));
+              return WalkResult::interrupt();
+            }
+          }
+        }
+
+        // Also check stores for forward references.
+        if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
+          auto globalName = storeOp.getGlobalName();
+          auto &global = globalTable.lookup(globalName);
+          if (global.op) {
+            size_t globalOrdinal = opOrdinalMap[global.op];
+            if (globalOrdinal > initOrdinal) {
+              emitDiagnostic(ERROR, op->getLoc(),
+                             "initializer at position " + Twine(initOrdinal) +
+                                 " stores to global '@" + globalName +
+                                 "' defined at position " +
+                                 Twine(globalOrdinal));
+              return WalkResult::interrupt();
+            }
+          }
+        }
+
+        // Check function calls for transitive dependencies.
+        if (auto callOp = dyn_cast<IREE::Util::CallOp>(op)) {
+          // We'll verify the called functions separately in a more
+          // sophisticated pass. For now, just ensure the function exists. DO
+          // NOT SUBMIT
+        }
+
+        return WalkResult::advance();
+      });
+      if (result.wasInterrupted()) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  // Verifies that immutable globals are only initialized once.
+  LogicalResult verifyDoubleInitialization(
+      GlobalTable &globalTable,
+      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps) {
+    // Track which immutable globals have been initialized.
+    llvm::StringMap<Location> immutableGlobalInitializations;
+
+    // First pass: check globals with initial values.
+    for (size_t i = 0; i < globalTable.size(); ++i) {
+      auto globalName = globalTable.lookupByOrdinal(i);
+      auto &global = globalTable.lookup(globalName);
+      if (global.op && !global.op.isGlobalMutable() &&
+          global.op.getGlobalInitialValue()) {
+        // Immutable global with initial value.
+        immutableGlobalInitializations.try_emplace(globalName,
+                                                   global.op->getLoc());
+      }
+    }
+
+    // Second pass: check for stores in initializers.
+    for (auto initializerOp : initializerOps) {
+      auto result = initializerOp.walk(
+          [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
+            auto globalName = storeOp.getGlobalName();
+            auto &global = globalTable.lookup(globalName);
+            if (global.op && !global.op.isGlobalMutable()) {
+              // Check if already initialized.
+              auto it = immutableGlobalInitializations.find(globalName);
+              if (it != immutableGlobalInitializations.end()) {
+                emitDiagnostic(ERROR, storeOp->getLoc(),
+                               "immutable global '@" + globalName +
+                                   "' is initialized both by initial value and "
+                                   "by store in initializer");
+                return WalkResult::interrupt();
+              }
+              immutableGlobalInitializations.try_emplace(globalName,
+                                                         storeOp->getLoc());
+            }
+            return WalkResult::advance();
+          });
+      if (result.wasInterrupted()) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  // Verifies that globals with initial values aren't modified by earlier
+  // initializers.
+  LogicalResult verifyInitialValueConflicts(
+      GlobalTable &globalTable,
+      ArrayRef<IREE::Util::InitializerOpInterface> initializerOps,
+      DenseMap<Operation *, size_t> &opOrdinalMap) {
+    // Check each initializer for stores to globals that come after it.
+    for (auto initializerOp : initializerOps) {
+      size_t initOrdinal = opOrdinalMap[initializerOp];
+      auto result = initializerOp.walk(
+          [&](IREE::Util::GlobalStoreOpInterface storeOp) -> WalkResult {
+            auto globalName = storeOp.getGlobalName();
+            auto &global = globalTable.lookup(globalName);
+            if (global.op && global.op.getGlobalInitialValue()) {
+              // Global has an initial value. Check if it comes after this
+              // initializer.
+              size_t globalOrdinal = opOrdinalMap[global.op];
+              if (globalOrdinal > initOrdinal) {
+                emitDiagnostic(
+                    ERROR, storeOp->getLoc(),
+                    "global '@" + globalName +
+                        "' with initial value at position " +
+                        Twine(globalOrdinal) +
+                        " is modified by earlier initializer at position " +
+                        Twine(initOrdinal));
+                return WalkResult::interrupt();
+              }
+            }
+            return WalkResult::advance();
+          });
+      if (result.wasInterrupted()) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  // Computes which functions are only reachable from initializers.
+  InitializerReachability
+  computeInitializerReachability(mlir::ModuleOp moduleOp) {
+    InitializerReachability result;
+
+    // Build the call graph.
+    CallGraph callGraph(moduleOp);
+
+    // Find all externally reachable functions.
+    SetVector<CallGraphNode *> externalWorklist;
+    for (CallGraphNode *node : callGraph) {
+      if (node->isExternal()) {
+        continue;
+      }
+      auto *callableOp = node->getCallableRegion()->getParentOp();
+      if (isa<IREE::Util::InitializerOpInterface>(callableOp)) {
+        // Initializers are not externally reachable.
+        continue;
+      }
+      if (auto funcOp = dyn_cast<FunctionOpInterface>(callableOp)) {
+        if (funcOp.isPublic()) {
+          // Public function - externally reachable.
+          result.externallyReachableFunctions.insert(callableOp);
+          externalWorklist.insert(node);
+        }
+      }
+    }
+
+    // Transitively mark all functions called from external entry points.
+    while (!externalWorklist.empty()) {
+      auto *node = externalWorklist.pop_back_val();
+      for (auto &edge : *node) {
+        auto *targetNode = edge.getTarget();
+        if (!targetNode->isExternal()) {
+          auto *targetOp = targetNode->getCallableRegion()->getParentOp();
+          if (result.externallyReachableFunctions.insert(targetOp).second) {
+            externalWorklist.insert(targetNode);
+          }
+        }
+      }
+    }
+
+    // Find functions only called from initializers.
+    SetVector<CallGraphNode *> initializerWorklist;
+    for (CallGraphNode *node : callGraph) {
+      if (node->isExternal()) {
+        continue;
+      }
+      auto *callableOp = node->getCallableRegion()->getParentOp();
+      if (isa<IREE::Util::InitializerOpInterface>(callableOp)) {
+        initializerWorklist.insert(node);
+      }
+    }
+
+    // Mark all functions transitively called from initializers.
+    DenseSet<Operation *> initializerReachable;
+    while (!initializerWorklist.empty()) {
+      auto *node = initializerWorklist.pop_back_val();
+      for (auto &edge : *node) {
+        auto *targetNode = edge.getTarget();
+        if (!targetNode->isExternal()) {
+          auto *targetOp = targetNode->getCallableRegion()->getParentOp();
+          if (initializerReachable.insert(targetOp).second) {
+            initializerWorklist.insert(targetNode);
+          }
+        }
+      }
+    }
+
+    // Functions that are initializer-reachable but NOT externally reachable
+    // are initializer-only.
+    for (auto *op : initializerReachable) {
+      if (!result.externallyReachableFunctions.contains(op)) {
+        result.initializerOnlyFunctions.insert(op);
+      }
+    }
+
+    return result;
+  }
+
+  // Verifies stores to immutable globals with appropriate warnings.
+  LogicalResult verifyImmutableStoresWithWarnings(
+      GlobalTable &globalTable, const InitializerReachability &reachability) {
+    bool hadError = false;
+    globalTable.forEach([&](Global &global) {
+      if (global.op.isGlobalMutable()) {
+        // Mutable global - stores are allowed from anywhere.
+        return GlobalAction::PRESERVE;
+      }
+
+      // Immutable global - check all stores.
+      for (auto storeOp : global.storeOps) {
+        Operation *parent = storeOp->getParentOp();
+
+        // Walk up to find the containing function or initializer.
+        while (parent && !isa<FunctionOpInterface>(parent) &&
+               !isa<IREE::Util::InitializerOpInterface>(parent)) {
+          parent = parent->getParentOp();
+        }
+
+        if (!parent) {
+          emitDiagnostic(ERROR, storeOp->getLoc(),
+                         "store to immutable global '@" + global.getName() +
+                             "' outside of function or initializer context");
+          hadError = true;
+          continue;
+        }
+
+        if (isa<IREE::Util::InitializerOpInterface>(parent)) {
+          // Store directly in initializer - always OK.
+          continue;
+        }
+
+        // Check if the function is initializer-only.
+        if (reachability.externallyReachableFunctions.contains(parent)) {
+          // Function is externally reachable - this is an error.
+          auto funcOp = cast<FunctionOpInterface>(parent);
+          emitDiagnostic(
+              ERROR, storeOp->getLoc(),
+              "store to immutable global '@" + global.getName() +
+                  "' in function '" + funcOp.getName() +
+                  "' which is reachable from non-initializer contexts");
+          hadError = true;
+        } else if (!reachability.initializerOnlyFunctions.contains(parent)) {
+          // Function reachability is unknown - shouldn't happen but be
+          // defensive.
+          auto funcOp = cast<FunctionOpInterface>(parent);
+          emitDiagnostic(WARNING, storeOp->getLoc(),
+                         "store to immutable global '@" + global.getName() +
+                             "' in function '" + funcOp.getName() +
+                             "' with unknown reachability");
+        } else {
+          // Function is initializer-only. Check if it's in a conditional
+          // context by looking for ops that implement RegionBranchOpInterface.
+          bool inConditional = false;
+          Operation *checkOp = storeOp;
+          while (checkOp != parent) {
+            checkOp = checkOp->getParentOp();
+            if (isa<RegionBranchOpInterface>(checkOp)) {
+              inConditional = true;
+              break;
+            }
+          }
+
+          // Else: unconditional store in initializer-only function - OK.
+          if (inConditional) {
+            auto funcOp = cast<FunctionOpInterface>(parent);
+            emitDiagnostic(
+                WARNING, storeOp->getLoc(),
+                "conditional store to immutable global '@" + global.getName() +
+                    "' in initializer-only function '" + funcOp.getName() +
+                    "' may indicate complex initialization pattern");
+          }
+        }
+      }
+
+      return GlobalAction::PRESERVE;
+    });
+
+    return hadError ? failure() : success();
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "strip_debug_ops.mlir",
             "test_float_range_analysis.mlir",
             "test_float_range_analysis_linalg.mlir",
+            "verify_initialization_order.mlir",
             "verify_structured_control_flow.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "strip_debug_ops.mlir"
     "test_float_range_analysis.mlir"
     "test_float_range_analysis_linalg.mlir"
+    "verify_initialization_order.mlir"
     "verify_structured_control_flow.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
@@ -1,4 +1,8 @@
-// RUN: iree-opt --split-input-file --iree-util-combine-initializers %s | FileCheck %s
+// RUN: iree-opt --split-input-file \
+// RUN:     --iree-util-verify-initialization-order \
+// RUN:     --iree-util-combine-initializers \
+// RUN:     --iree-util-verify-initialization-order \
+// RUN:     %s | FileCheck %s
 
 // Tests that multiple initializers are combined in their module order.
 
@@ -6,6 +10,10 @@ util.func private @extern() -> index
 
 // CHECK: util.global private mutable @global0 : index
 util.global private mutable @global0 : index
+// CHECK-NEXT: util.global private @global1 : index
+util.global private @global1 : index
+// CHECK-NEXT: util.global private @global2 : index
+util.global private @global2 : index
 // CHECK-NEXT: util.initializer {
 // CHECK-NEXT: %[[VALUE0:.+]] = util.call @extern()
 // CHECK-NEXT: util.global.store %[[VALUE0]], @global0
@@ -19,10 +27,6 @@ util.initializer {
   util.global.store %value0, @global0 : index
   util.return
 }
-// CHECK: util.global private @global1 : index
-util.global private @global1 : index
-// CHECK-NEXT: util.global private @global2 : index
-util.global private @global2 : index
 // CHECK-NOT: util.initializer
 util.initializer {
   %value1 = util.call @extern() : () -> index
@@ -33,7 +37,7 @@ util.initializer {
 }
 
 // CHECK-LABEL: @orderedCombining
-util.func @orderedCombining(%arg0: index) -> (index, index, index) {
+util.func public @orderedCombining(%arg0: index) -> (index, index, index) {
   util.global.store %arg0, @global0 : index
   %value0 = util.global.load @global0 : index
   %value1 = util.global.load @global1 : index
@@ -48,6 +52,8 @@ util.func @orderedCombining(%arg0: index) -> (index, index, index) {
 
 // CHECK: util.global private mutable @globalA : index
 util.global private mutable @globalA : index
+// CHECK: util.global private @globalB : index
+util.global private @globalB : index
 // CHECK: util.initializer {
 // CHECK: ^bb1:
 // CHECK:   cf.br ^bb3
@@ -72,11 +78,564 @@ util.initializer {
 ^bb3:
   util.return
 }
-// CHECK-NEXT: util.global private @globalB : index
-util.global private @globalB : index
 // CHECK-NOT: util.initializer
 util.initializer {
   %c300 = arith.constant 300 : index
   util.global.store %c300, @globalB : index
   util.return
 }
+
+// -----
+
+// Tests that globals with initial values are materialized and combined with
+// initializers in the correct order.
+
+util.func private @side_effect() -> index
+
+// CHECK: util.global private mutable @globalWithInit : index
+// CHECK-NOT: = 42
+util.global private mutable @globalWithInit = 42 : index
+
+// CHECK-NEXT: util.global private mutable @globalFromInit : index
+util.global private mutable @globalFromInit : index
+
+// CHECK-NEXT: util.global private @immutableWithInit : index
+// CHECK-NOT: = 100
+util.global private @immutableWithInit = 100 : index
+
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[C42:.+]] = arith.constant 42 : index
+// CHECK-NEXT:   util.global.store %[[C42]], @globalWithInit
+// CHECK-NEXT:   %[[C100:.+]] = arith.constant 100 : index
+// CHECK-NEXT:   util.global.store %[[C100]], @immutableWithInit
+// CHECK-NEXT:   %[[SIDE:.+]] = util.call @side_effect()
+// CHECK-NEXT:   util.global.store %[[SIDE]], @globalFromInit
+// CHECK-NEXT:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  %side = util.call @side_effect() : () -> index
+  util.global.store %side, @globalFromInit : index
+  util.return
+}
+
+// CHECK-LABEL: @interleavedGlobalsAndInits
+util.func public @interleavedGlobalsAndInits() -> (index, index, index) {
+  %v1 = util.global.load @globalWithInit : index
+  %v2 = util.global.load @globalFromInit : index
+  %v3 = util.global.load @immutableWithInit : index
+  util.return %v1, %v2, %v3 : index, index, index
+}
+
+// -----
+
+// Tests complex interleaving of globals with initial values and initializers.
+// This verifies that order dependencies are correctly preserved.
+
+// CHECK: util.global private @A : i32
+util.global private @A = 1 : i32
+
+// CHECK-NEXT: util.global private mutable @B : i32
+util.global private mutable @B : i32
+
+// CHECK-NEXT: util.global private @C : i32
+util.global private @C = 3 : i32
+
+// CHECK-NEXT: util.global private mutable @D : i32
+util.global private mutable @D : i32
+
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:   util.global.store %[[C1]], @A
+// CHECK-NEXT:   %[[C3:.+]] = arith.constant 3 : i32
+// CHECK-NEXT:   util.global.store %[[C3]], @C
+// CHECK-NEXT:   %[[A:.+]] = util.global.load @A
+// CHECK-NEXT:   %[[C10:.+]] = arith.constant 10 : i32
+// CHECK-NEXT:   %[[B_VAL:.+]] = arith.addi %[[A]], %[[C10]]
+// CHECK-NEXT:   util.global.store %[[B_VAL]], @B
+// CHECK-NEXT:   %[[B:.+]] = util.global.load @B
+// CHECK-NEXT:   %[[C:.+]] = util.global.load @C
+// CHECK-NEXT:   %[[D_VAL:.+]] = arith.muli %[[B]], %[[C]]
+// CHECK-NEXT:   util.global.store %[[D_VAL]], @D
+// CHECK-NEXT:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  // B = A + 10 (expects A = 1)
+  %a = util.global.load @A : i32
+  %c10 = arith.constant 10 : i32
+  %b_val = arith.addi %a, %c10 : i32
+  util.global.store %b_val, @B : i32
+  util.return
+}
+util.initializer {
+  // D = B * C (expects B = 11, C = 3)
+  %b = util.global.load @B : i32
+  %c = util.global.load @C : i32
+  %d_val = arith.muli %b, %c : i32
+  util.global.store %d_val, @D : i32
+  util.return
+}
+
+// CHECK-LABEL: @verifyOrderDependencies
+util.func public @verifyOrderDependencies() -> (i32, i32, i32, i32) {
+  %a = util.global.load @A : i32
+  %b = util.global.load @B : i32
+  %c = util.global.load @C : i32
+  %d = util.global.load @D : i32
+  util.return %a, %b, %c, %d : i32, i32, i32, i32
+}
+
+// -----
+
+// Tests that tensor initial values are properly materialized when combined
+// with initializers.
+
+// CHECK: util.global private @tensor_global : tensor<2xi32>
+util.global private @tensor_global = dense<[100, 200]> : tensor<2xi32>
+
+// CHECK: util.global private mutable @mutable_tensor : tensor<3xf32>
+util.global private mutable @mutable_tensor : tensor<3xf32>
+
+// CHECK: util.initializer {
+// CHECK-DAG:   %[[TENSOR1:.+]] = arith.constant dense<[100, 200]> : tensor<2xi32>
+// CHECK-DAG:   util.global.store %[[TENSOR1]], @tensor_global
+// CHECK-DAG:   %[[TENSOR2:.+]] = arith.constant dense<[1.{{.*}}, 2.{{.*}}, 3.{{.*}}]> : tensor<3xf32>
+// CHECK-DAG:   util.global.store %[[TENSOR2]], @mutable_tensor
+// CHECK:   util.return
+// CHECK: }
+util.initializer {
+  %tensor2 = arith.constant dense<[1.0, 2.0, 3.0]> : tensor<3xf32>
+  util.global.store %tensor2, @mutable_tensor : tensor<3xf32>
+  util.return
+}
+
+// CHECK-LABEL: @tensorGlobals
+util.func public @tensorGlobals() -> (tensor<2xi32>, tensor<3xf32>) {
+  %t1 = util.global.load @tensor_global : tensor<2xi32>
+  %t2 = util.global.load @mutable_tensor : tensor<3xf32>
+  util.return %t1, %t2 : tensor<2xi32>, tensor<3xf32>
+}
+
+// -----
+
+// Tests that we handle the case with no initializers (only globals with
+// initial values) - we should not create an initializer in this case.
+
+// CHECK: util.global private @only_global1 = 42 : i32
+util.global private @only_global1 = 42 : i32
+
+// CHECK: util.global private @only_global2 = 100 : i32
+util.global private @only_global2 = 100 : i32
+
+// CHECK-NOT: util.initializer
+
+// CHECK-LABEL: @onlyGlobalsWithInitialValues
+util.func public @onlyGlobalsWithInitialValues() -> (i32, i32) {
+  %v1 = util.global.load @only_global1 : i32
+  %v2 = util.global.load @only_global2 : i32
+  util.return %v1, %v2 : i32, i32
+}
+
+// -----
+
+// Tests single initializer (no combination needed).
+
+// CHECK: util.global private mutable @single : index
+util.global private mutable @single : index
+
+// CHECK: util.initializer
+// CHECK-NOT: util.initializer
+util.initializer {
+  %c42 = arith.constant 42 : index
+  util.global.store %c42, @single : index
+  util.return
+}
+
+// -----
+
+// Tests empty module (no initializers or globals with initial values).
+
+// CHECK-LABEL: util.func public @emptyModule
+// CHECK-NOT: util.initializer
+util.func public @emptyModule() {
+  util.return
+}
+
+// -----
+
+// Tests empty initializers (just util.return) are handled correctly.
+
+// CHECK: util.global private @emptyInitGlobal : i32
+util.global private @emptyInitGlobal = 123 : i32
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[C123:.+]] = arith.constant 123 : i32
+// CHECK-NEXT:   util.global.store %[[C123]], @emptyInitGlobal
+// CHECK-NEXT:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  // Empty initializer - just returns.
+  util.return
+}
+util.initializer {
+  // Another empty initializer.
+  util.return
+}
+
+// -----
+
+// Tests initializers with side effects that must preserve order.
+
+util.func private @print(%arg0: i32)
+util.func private @get_value() -> i32
+
+// CHECK: util.global private mutable @sideEffectGlobal : i32
+util.global private mutable @sideEffectGlobal = 0 : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  %c1 = arith.constant 1 : i32
+  // CHECK: util.call @print(%c1_i32)
+  util.call @print(%c1) : (i32) -> ()
+  util.return
+}
+util.initializer {
+  %c2 = arith.constant 2 : i32
+  // CHECK: util.call @print(%c2_i32)
+  util.call @print(%c2) : (i32) -> ()
+  %val = util.call @get_value() : () -> i32
+  // CHECK-NEXT: %[[VAL:.+]] = util.call @get_value
+  // CHECK-NEXT: util.global.store %[[VAL]], @sideEffectGlobal
+  util.global.store %val, @sideEffectGlobal : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests initializers with scf operations (loops and conditionals).
+
+// CHECK: util.global private mutable @loopGlobal : index
+util.global private mutable @loopGlobal : index
+// CHECK-NEXT: util.initializer
+util.initializer {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  // CHECK: %[[SUM:.+]] = scf.for
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %c0) -> index {
+    %new_acc = arith.addi %acc, %i : index
+    scf.yield %new_acc : index
+  }
+  // CHECK: util.global.store %[[SUM]], @loopGlobal
+  util.global.store %sum, @loopGlobal : index
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests many initializers to ensure scalability.
+
+// CHECK: util.global private mutable @many0 : i32
+util.global private mutable @many0 = 0 : i32
+// CHECK-NEXT: util.global private mutable @many1 : i32
+util.global private mutable @many1 = 1 : i32
+// CHECK-NEXT: util.global private mutable @many2 : i32
+util.global private mutable @many2 = 2 : i32
+// CHECK-NEXT: util.global private mutable @many3 : i32
+util.global private mutable @many3 = 3 : i32
+// CHECK-NEXT: util.global private mutable @many4 : i32
+util.global private mutable @many4 = 4 : i32
+// CHECK-NEXT: util.initializer
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
+// CHECK-DAG: %[[C3:.+]] = arith.constant 3 : i32
+// CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i32
+util.initializer {
+  %c10 = arith.constant 10 : i32
+  util.global.store %c10, @many0 : i32
+  util.return
+}
+util.initializer {
+  %c11 = arith.constant 11 : i32
+  util.global.store %c11, @many1 : i32
+  util.return
+}
+util.initializer {
+  %c12 = arith.constant 12 : i32
+  util.global.store %c12, @many2 : i32
+  util.return
+}
+util.initializer {
+  %c13 = arith.constant 13 : i32
+  util.global.store %c13, @many3 : i32
+  util.return
+}
+util.initializer {
+  %c14 = arith.constant 14 : i32
+  util.global.store %c14, @many4 : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests initializers with util.unreachable operations.
+
+// CHECK: util.global private mutable @unreachableGlobal : i32
+util.global private mutable @unreachableGlobal : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  %cond = arith.constant false
+  // CHECK: scf.if %{{.+}} {
+  scf.if %cond {
+    // This should never execute.
+    // CHECK: util.scf.unreachable "impossible"
+    util.scf.unreachable "impossible"
+  } else {
+    %c42 = arith.constant 42 : i32
+    // CHECK: util.global.store %{{.+}}, @unreachableGlobal
+    util.global.store %c42, @unreachableGlobal : i32
+  }
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests transitive dependencies through function calls in initializers.
+
+util.func private @modify_globals() {
+  %c999 = arith.constant 999 : i32
+  util.global.store %c999, @transitiveA : i32
+  util.return
+}
+
+// CHECK: util.global private mutable @transitiveA : i32
+util.global private mutable @transitiveA = 1 : i32
+// CHECK-NEXT: util.global private mutable @transitiveB : i32
+util.global private mutable @transitiveB : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  // First set transitiveA to 1.
+  // CHECK: %[[C1:.+]] = arith.constant 1 : i32
+  // CHECK-NEXT: util.global.store %[[C1]], @transitiveA
+  // Then call function that modifies it.
+  // CHECK-NEXT: util.call @modify_globals()
+  util.call @modify_globals() : () -> ()
+  util.return
+}
+util.initializer {
+  // Now read the modified value.
+  // CHECK-NEXT: %[[LOADED:.+]] = util.global.load @transitiveA
+  %val = util.global.load @transitiveA : i32
+  // CHECK-NEXT: util.global.store %[[LOADED]], @transitiveB
+  util.global.store %val, @transitiveB : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests initializers that modify globals before reading them (read-after-write).
+
+// CHECK: util.global private mutable @rawGlobal : i32
+util.global private mutable @rawGlobal = 5 : i32
+// CHECK-NEXT: util.global private mutable @rawResult : i32
+util.global private mutable @rawResult : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  // CHECK: %[[C5:.+]] = arith.constant 5 : i32
+  // CHECK-NEXT: util.global.store %[[C5]], @rawGlobal
+  // Write a different value.
+  %c10 = arith.constant 10 : i32
+  // CHECK-NEXT: %[[C10:.+]] = arith.constant 10 : i32
+  // CHECK-NEXT: util.global.store %[[C10]], @rawGlobal
+  util.global.store %c10, @rawGlobal : i32
+  // Read back the value we just wrote.
+  // CHECK-NEXT: %[[READ:.+]] = util.global.load @rawGlobal
+  %val = util.global.load @rawGlobal : i32
+  %c2 = arith.constant 2 : i32
+  // CHECK-NEXT: %[[C2:.+]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[MUL:.+]] = arith.muli %[[READ]], %[[C2]]
+  %result = arith.muli %val, %c2 : i32
+  // CHECK-NEXT: util.global.store %[[MUL]], @rawResult
+  util.global.store %result, @rawResult : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests initializers with nested function calls and complex dependencies.
+
+util.func private @level1() -> i32 {
+  %val = util.global.load @nestedA : i32
+  %c1 = arith.constant 1 : i32
+  %result = arith.addi %val, %c1 : i32
+  util.return %result : i32
+}
+
+util.func private @level2() -> i32 {
+  %val = util.call @level1() : () -> i32
+  %c10 = arith.constant 10 : i32
+  %result = arith.muli %val, %c10 : i32
+  util.return %result : i32
+}
+
+// CHECK: util.global private @nestedA : i32
+util.global private @nestedA = 5 : i32
+// CHECK-NEXT: util.global private mutable @nestedB : i32
+util.global private mutable @nestedB : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  // CHECK: %[[C5:.+]] = arith.constant 5 : i32
+  // CHECK-NEXT: util.global.store %[[C5]], @nestedA
+  // CHECK-NEXT: %[[RES:.+]] = util.call @level2()
+  %result = util.call @level2() : () -> i32
+  // CHECK-NEXT: util.global.store %[[RES]], @nestedB
+  util.global.store %result, @nestedB : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests interaction with util.optimization_barrier operations.
+
+// CHECK: util.global private mutable @barrierGlobal : i32
+util.global private mutable @barrierGlobal : i32
+// CHECK-NEXT: util.initializer
+util.initializer {
+  %c42 = arith.constant 42 : i32
+  // CHECK: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-NEXT: %[[BARRIER:.+]] = util.optimization_barrier %[[C42]]
+  %barrier_val = util.optimization_barrier %c42 : i32
+  // CHECK-NEXT: util.global.store %[[BARRIER]], @barrierGlobal
+  util.global.store %barrier_val, @barrierGlobal : i32
+  util.return
+}
+// CHECK: util.return
+
+// -----
+
+// Tests a non-materializable global alone keeps its initial value.
+
+// CHECK: util.global private @non_mat = #util.byte_pattern<42> : i32
+util.global private @non_mat = #util.byte_pattern<42> : i32
+// CHECK-NOT: util.initializer
+
+// -----
+
+// Tests a non-materializable global before an initializer is preserved.
+
+// CHECK: util.global private @non_mat = #util.byte_pattern<1> : i32
+util.global private @non_mat = #util.byte_pattern<1> : i32
+// CHECK-NEXT: util.global private mutable @g0 : i32
+util.global private mutable @g0 : i32
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[C10:.+]] = arith.constant 10 : i32
+// CHECK-NEXT:   util.global.store %[[C10]], @g0
+// CHECK-NEXT:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  %c10 = arith.constant 10 : i32
+  util.global.store %c10, @g0 : i32
+  util.return
+}
+
+// -----
+
+// Tests that non-materialized globals are included in the batch to preserve
+// ordering. Since @non_mat appears before the initializer in module order it
+// gets pulled into the batch with @g0 even though it is not used in the
+// initializer.
+
+// CHECK: util.global private mutable @g0 : i32
+util.global private mutable @g0 : i32
+// CHECK-NEXT: util.global private @non_mat = #util.byte_pattern<2> : i32
+util.global private @non_mat = #util.byte_pattern<2> : i32
+// CHECK-NEXT: util.initializer {
+// CHECK-NEXT:   %[[C20:.+]] = arith.constant 20 : i32
+// CHECK-NEXT:   util.global.store %[[C20]], @g0
+// CHECK-NEXT:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  %c20 = arith.constant 20 : i32
+  util.global.store %c20, @g0 : i32
+  util.return
+}
+
+// -----
+
+// Tests an initializer + non-materializable + initializer should combine both.
+// Non-materializable globals are included in the batch to demonstrate
+// preservation of relative ordering.
+
+// CHECK: util.global private mutable @g0 : i32
+util.global private mutable @g0 : i32
+// CHECK-NEXT: util.global private @non_mat = #util.byte_pattern<3> : i32
+util.global private @non_mat = #util.byte_pattern<3> : i32
+// CHECK-NEXT: util.global private mutable @g1 : i32
+util.global private mutable @g1 : i32
+// CHECK-NEXT: util.initializer {
+// CHECK-DAG:   %[[C30:.+]] = arith.constant 30 : i32
+// CHECK-DAG:   util.global.store %[[C30]], @g0
+// CHECK-DAG:   %[[C40:.+]] = arith.constant 40 : i32
+// CHECK-DAG:   util.global.store %[[C40]], @g1
+// CHECK:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  %c30 = arith.constant 30 : i32
+  util.global.store %c30, @g0 : i32
+  util.return
+}
+// CHECK-NOT: util.initializer
+util.initializer {
+  %c40 = arith.constant 40 : i32
+  util.global.store %c40, @g1 : i32
+  util.return
+}
+
+// -----
+
+// Tests that non-materializable globals maintain their relative position
+// when combined with materializable globals.
+
+// CHECK: util.global private @g0 : i32
+// CHECK-NOT: = 5
+util.global private @g0 = 5 : i32
+// CHECK-NEXT: util.global private @non_mat = #util.byte_pattern<4> : i32
+util.global private @non_mat = #util.byte_pattern<4> : i32
+// CHECK-NEXT: util.global private @g1 : i32
+// CHECK-NOT: = 6
+util.global private @g1 = 6 : i32
+// CHECK-NEXT: util.global private mutable @g2 : i32
+util.global private mutable @g2 : i32
+// CHECK-NEXT: util.initializer {
+// CHECK-DAG:   %[[C5:.+]] = arith.constant 5 : i32
+// CHECK-DAG:   util.global.store %[[C5]], @g0
+// CHECK-DAG:   %[[C6:.+]] = arith.constant 6 : i32
+// CHECK-DAG:   util.global.store %[[C6]], @g1
+// CHECK-DAG:   %[[C7:.+]] = arith.constant 7 : i32
+// CHECK-DAG:   util.global.store %[[C7]], @g2
+// CHECK:   util.return
+// CHECK-NEXT: }
+util.initializer {
+  %c7 = arith.constant 7 : i32
+  util.global.store %c7, @g2 : i32
+  util.return
+}
+
+// -----
+
+// Tests multiple non-materializable globals with no initializer stay as-is.
+
+// CHECK: util.global private @non_mat1 = #util.byte_pattern<5> : i32
+util.global private @non_mat1 = #util.byte_pattern<5> : i32
+// CHECK-NEXT: util.global private @g0 = 8 : i32
+util.global private @g0 = 8 : i32
+// CHECK-NEXT: util.global private @non_mat2 = #util.byte_pattern<6> : i32
+util.global private @non_mat2 = #util.byte_pattern<6> : i32
+// CHECK-NEXT: util.global private @g1 = 9 : i32
+util.global private @g1 = 9 : i32
+// CHECK-NOT: util.initializer

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/verify_initialization_order.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/verify_initialization_order.mlir
@@ -1,0 +1,326 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics --iree-util-verify-initialization-order %s
+
+// -----
+// Valid: Basic module with correct initialization order.
+
+util.global private @global1 = 1 : i32
+util.global private @global2 : i32
+util.initializer {
+  %val = util.global.load @global1 : i32
+  util.global.store %val, @global2 : i32
+  util.return
+}
+
+// -----
+// Valid: Immutable global initialized by initial value only.
+
+util.global private @immutable_with_value = 42 : i32
+
+// -----
+// Valid: Immutable global initialized by store in initializer only.
+
+util.global private @immutable_no_value : i32
+util.initializer {
+  %c42 = arith.constant 42 : i32
+  util.global.store %c42, @immutable_no_value : i32
+  util.return
+}
+
+// -----
+// Valid: Mutable global can be stored from anywhere.
+
+util.global private mutable @mutable_global : i32
+util.initializer {
+  %c1 = arith.constant 1 : i32
+  util.global.store %c1, @mutable_global : i32
+  util.return
+}
+util.func public @store_mutable() {
+  %c2 = arith.constant 2 : i32
+  util.global.store %c2, @mutable_global : i32
+  util.return
+}
+
+// -----
+// Valid: Store to immutable global in initializer-only function.
+
+util.func private @init_only_func() {
+  %c42 = arith.constant 42 : i32
+  util.global.store %c42, @immutable_in_func : i32
+  util.return
+}
+
+util.global private @immutable_in_func : i32
+util.initializer {
+  util.call @init_only_func() : () -> ()
+  util.return
+}
+
+// -----
+// Valid: Complex transitive case through multiple functions.
+
+util.func private @leaf_func() {
+  %val = util.global.load @early_global : i32
+  util.global.store %val, @late_global : i32
+  util.return
+}
+
+util.func private @middle_func() {
+  util.call @leaf_func() : () -> ()
+  util.return
+}
+
+util.global private @early_global = 1 : i32
+util.global private @late_global : i32
+
+util.initializer {
+  util.call @middle_func() : () -> ()
+  util.return
+}
+
+// -----
+// Valid: Multiple initializers in correct order.
+
+util.global private @g1 = 1 : i32
+util.global private @g2 : i32
+util.initializer {
+  %val = util.global.load @g1 : i32
+  util.global.store %val, @g2 : i32
+  util.return
+}
+util.global private @g3 : i32
+util.initializer {
+  %val = util.global.load @g2 : i32
+  util.global.store %val, @g3 : i32
+  util.return
+}
+
+// -----
+// Error: Forward reference in initializer.
+
+util.initializer {
+  // expected-error @+1 {{initializer at position 0 accesses global '@later_global' defined at position 1}}
+  %val = util.global.load @later_global : i32
+  util.return
+}
+util.global private @later_global = 42 : i32
+
+// -----
+// Error: Store to forward global in initializer.
+
+util.initializer {
+  %c42 = arith.constant 42 : i32
+  // expected-error @+1 {{initializer at position 0 stores to global '@forward_store' defined at position 1}}
+  util.global.store %c42, @forward_store : i32
+  util.return
+}
+util.global private @forward_store : i32
+
+// -----
+// Error: Double initialization of immutable global.
+
+util.global private @double_init = 10 : i32
+util.initializer {
+  %c20 = arith.constant 20 : i32
+  // expected-error @+1 {{immutable global '@double_init' is initialized both by initial value and by store in initializer}}
+  util.global.store %c20, @double_init : i32
+  util.return
+}
+
+// -----
+// Error: Global with initial value modified by earlier initializer.
+
+util.initializer {
+  %c99 = arith.constant 99 : i32
+  // expected-error @+1 {{initializer at position 0 stores to global '@modified_init_value' defined at position 1}}
+  util.global.store %c99, @modified_init_value : i32
+  util.return
+}
+util.global private @modified_init_value = 42 : i32
+
+// -----
+// Error: Store to immutable global in externally reachable function.
+
+util.func public @public_func() {
+  %c42 = arith.constant 42 : i32
+  // expected-error @+1 {{store to immutable global '@no_external_store' in function 'public_func' which is reachable from non-initializer contexts}}
+  util.global.store %c42, @no_external_store : i32
+  util.return
+}
+util.global private @no_external_store : i32
+
+// -----
+// Warning: Conditional store to immutable global in initializer-only function.
+
+util.func private @conditional_store(%cond: i1) {
+  scf.if %cond {
+    %c42 = arith.constant 42 : i32
+    // expected-warning @+1 {{conditional store to immutable global '@cond_store' in initializer-only function 'conditional_store' may indicate complex initialization pattern (verification may be overly conservative)}}
+    util.global.store %c42, @cond_store : i32
+  }
+  util.return
+}
+
+util.global private @cond_store : i32
+util.initializer {
+  %true = arith.constant true
+  util.call @conditional_store(%true) : (i1) -> ()
+  util.return
+}
+
+// -----
+// Warning: Store in loop within initializer-only function.
+
+util.func private @loop_store() {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %c10 step %c1 {
+    %val = arith.index_cast %i : index to i32
+    // expected-warning @+1 {{conditional store to immutable global '@loop_store_global' in initializer-only function 'loop_store' may indicate complex initialization pattern (verification may be overly conservative)}}
+    util.global.store %val, @loop_store_global : i32
+  }
+  util.return
+}
+
+util.global private @loop_store_global : i32
+util.initializer {
+  util.call @loop_store() : () -> ()
+  util.return
+}
+
+// -----
+// Valid: Multiple stores in same initializer (last one wins).
+
+util.global private mutable @multi_store : i32
+util.initializer {
+  %c1 = arith.constant 1 : i32
+  util.global.store %c1, @multi_store : i32
+  %c2 = arith.constant 2 : i32
+  util.global.store %c2, @multi_store : i32
+  %c3 = arith.constant 3 : i32
+  util.global.store %c3, @multi_store : i32
+  util.return
+}
+
+// -----
+// Error: Store to immutable global in function called by both initializer and external.
+
+util.func public @external_entry() {
+  util.call @shared_func() : () -> ()
+  util.return
+}
+
+util.func private @shared_func() {
+  %c42 = arith.constant 42 : i32
+  // expected-error @+1 {{store to immutable global '@shared_global' in function 'shared_func' which is reachable from non-initializer contexts}}
+  util.global.store %c42, @shared_global : i32
+  util.return
+}
+
+util.global private @shared_global : i32
+util.initializer {
+  util.call @shared_func() : () -> ()
+  util.return
+}
+
+// -----
+// Valid: Empty module with no initializers or globals.
+
+util.func public @empty_module() {
+  util.return
+}
+
+// -----
+// Valid: Module with only globals, no initializers.
+
+util.global private @only_global1 = 1 : i32
+util.global private @only_global2 = 2 : i32
+util.global private mutable @only_global3 : i32
+
+// -----
+// Valid: Empty initializer.
+
+util.initializer {
+  util.return
+}
+
+// -----
+// Valid: Nested function calls all initializer-only.
+
+util.func private @deep3() {
+  %c3 = arith.constant 3 : i32
+  util.global.store %c3, @deep_global : i32
+  util.return
+}
+
+util.func private @deep2() {
+  util.call @deep3() : () -> ()
+  util.return
+}
+
+util.func private @deep1() {
+  util.call @deep2() : () -> ()
+  util.return
+}
+
+util.global private @deep_global : i32
+util.initializer {
+  util.call @deep1() : () -> ()
+  util.return
+}
+
+// -----
+// Warning: Store in while loop in initializer-only function.
+
+util.func private @while_store() {
+  %c0 = arith.constant 0 : i32
+  %c10 = arith.constant 10 : i32
+  %result = scf.while (%arg = %c0) : (i32) -> i32 {
+    %cond = arith.cmpi slt, %arg, %c10 : i32
+    scf.condition(%cond) %arg : i32
+  } do {
+  ^bb0(%arg: i32):
+    // expected-warning @+1 {{conditional store to immutable global '@while_global' in initializer-only function 'while_store' may indicate complex initialization pattern (verification may be overly conservative)}}
+    util.global.store %arg, @while_global : i32
+    %c1 = arith.constant 1 : i32
+    %next = arith.addi %arg, %c1 : i32
+    scf.yield %next : i32
+  }
+  util.return
+}
+
+util.global private @while_global : i32
+util.initializer {
+  util.call @while_store() : () -> ()
+  util.return
+}
+
+// -----
+// Warning: Store in index_switch in initializer-only function.
+
+util.func private @switch_store(%idx: index) {
+  scf.index_switch %idx
+  case 0 {
+    %c10 = arith.constant 10 : i32
+    util.global.store %c10, @switch_global : i32
+    scf.yield
+  }
+  case 1 {
+    %c20 = arith.constant 20 : i32
+    util.global.store %c20, @switch_global : i32
+    scf.yield
+  }
+  default {
+    %c30 = arith.constant 30 : i32
+    util.global.store %c30, @switch_global : i32
+  }
+  util.return
+}
+
+util.global private mutable @switch_global : i32
+util.initializer {
+  %c0 = arith.constant 0 : index
+  util.call @switch_store(%c0) : (index) -> ()
+  util.return
+}

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -148,37 +148,43 @@ class GlobalInitializationPass
     std::tie(deinitFuncOp, deinitBuilder) = appendOrCreateInitFuncOp(
         moduleOp, "__deinit", symbolTable, moduleBuilder);
 
-    // Build out the functions with logic from all globals.
-    // Note that the initialization order here is undefined (in that it's just
-    // module op order). If we ever want to make this more deterministic we
-    // could gather the ops, sort them (by some rule), and then build the
-    // initialization function.
+    // Build out the functions with logic from all globals and initializers.
+    // We use a two-phase approach to ensure correct initialization order:
+    // Phase 1: Initialize all globals with initial values in module order.
+    // Phase 2: Execute all initializers in module order.
+    //
+    // This ensures that initializers can safely reference globals even if the
+    // initializer appears before the global in module order, which can happen
+    // after passes like CombineInitializersPass reorder operations.
     InlinerInterface inlinerInterface(&getContext());
-    SmallVector<Operation *> deadOps;
-    for (auto &op : moduleOp.getBlock().getOperations()) {
-      if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
-        if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
-          if (failed(appendRefInitialization(globalOp, initBuilder))) {
-            globalOp.emitOpError()
-                << "ref-type global unable to be initialized";
-            return signalPassFailure();
-          }
-        } else {
-          if (failed(appendPrimitiveInitialization(globalOp, initBuilder))) {
-            globalOp.emitOpError()
-                << "primitive global unable to be initialized";
-            return signalPassFailure();
-          }
-        }
-      } else if (auto initializerOp = dyn_cast<IREE::VM::InitializerOp>(op)) {
-        if (failed(appendInitializer(initializerOp, inlinerInterface,
-                                     initBuilder))) {
-          initializerOp.emitOpError() << "unable to be initialized";
+
+    // Phase 1: Initialize all globals with initial values.
+    // This ensures all globals reach a valid state before any initializers run.
+    for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
+      if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
+        if (failed(appendRefInitialization(globalOp, initBuilder))) {
+          globalOp.emitOpError() << "ref-type global unable to be initialized";
           return signalPassFailure();
         }
-        deadOps.push_back(initializerOp);
-        initBuilder.setInsertionPointToEnd(&initFuncOp.back());
+      } else {
+        if (failed(appendPrimitiveInitialization(globalOp, initBuilder))) {
+          globalOp.emitOpError() << "primitive global unable to be initialized";
+          return signalPassFailure();
+        }
       }
+    }
+
+    // Phase 2: Execute all initializers in module order.
+    // Initializers can now safely reference globals initialized in phase 1.
+    SmallVector<Operation *> deadOps;
+    for (auto initializerOp : moduleOp.getOps<IREE::VM::InitializerOp>()) {
+      if (failed(appendInitializer(initializerOp, inlinerInterface,
+                                   initBuilder))) {
+        initializerOp.emitOpError() << "unable to be initialized";
+        return signalPassFailure();
+      }
+      deadOps.push_back(initializerOp);
+      initBuilder.setInsertionPointToEnd(&initFuncOp.back());
     }
     for (auto *deadOp : deadOps) {
       deadOp->erase();

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -84,6 +84,11 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(mlir::createInlinerPass());
   passManager.addPass(mlir::createSymbolDCEPass());
 
+  // Verify module initialization order - subsequent passes rely on it being
+  // correct (and we maintain it as correct from this point on, so this is our
+  // gate).
+  passManager.addPass(IREE::Util::createVerifyInitializationOrderPass());
+
   // Combine the initializers for all globals to allow us to optimize them
   // together.
   passManager.addPass(IREE::Util::createCombineInitializersPass());

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
@@ -228,3 +228,100 @@ vm.module @existing_init {
     // CHECK-NEXT: vm.return
   }
 }
+
+// -----
+
+// Tests that initializers can reference globals even when the initializer
+// appears before the global in module order. This is a regression test for
+// a bug where GlobalInitializationPass processed ops in module order,
+// causing initializers to run before globals were initialized.
+
+// CHECK-LABEL: @initializer_before_global
+vm.module @initializer_before_global {
+  // Initializer appears first in module order but should run AFTER @g0 is initialized.
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %g0 = vm.global.load.i32 @g0 : i32
+    vm.global.store.i32 %g0, @result : i32
+    vm.return
+  }
+
+  // Global with initial value appears second in module order.
+  // CHECK: vm.global.i32 private mutable @g0 : i32
+  vm.global.i32 private @g0 = 42 : i32
+
+  // Result global
+  // CHECK: vm.global.i32 private mutable @result : i32
+  vm.global.i32 private @result : i32
+
+  // CHECK: vm.export @__init
+  // CHECK-NEXT: vm.func private @__init() {
+  // Phase 1: Initialize globals with initial values
+  // CHECK-NEXT:   %c42 = vm.const.i32 42
+  // CHECK-NEXT:   vm.global.store.i32 %c42, @g0
+  // Phase 2: Execute initializers in module order
+  // CHECK-NEXT:   %[[G0:.+]] = vm.global.load.i32 @g0
+  // CHECK-NEXT:   vm.global.store.i32 %[[G0]], @result
+  // CHECK-NEXT:   vm.return
+  // CHECK-NEXT: }
+}
+
+// -----
+
+// Tests complex interleaving of globals and initializers.
+
+// CHECK-LABEL: @mixed_order
+vm.module @mixed_order {
+  // Initializer 1 (references g1 which appears later)
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %g1 = vm.global.load.i32 @g1 : i32
+    vm.global.store.i32 %g1, @result1 : i32
+    vm.return
+  }
+
+  // Global 1 (referenced by initializer 1)
+  // CHECK: vm.global.i32 private mutable @g1 : i32
+  vm.global.i32 private @g1 = 100 : i32
+
+  // Global 2 (no initial value)
+  // CHECK: vm.global.i32 private mutable @g2 : i32
+  vm.global.i32 private @g2 : i32
+
+  // Initializer 2 (stores to g2)
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %c200 = vm.const.i32 200
+    vm.global.store.i32 %c200, @g2 : i32
+    vm.return
+  }
+
+  // Initializer 3 (loads g2 set by initializer 2)
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %g2 = vm.global.load.i32 @g2 : i32
+    vm.global.store.i32 %g2, @result2 : i32
+    vm.return
+  }
+
+  // Result globals
+  // CHECK: vm.global.i32 private mutable @result1 : i32
+  vm.global.i32 private @result1 : i32
+  // CHECK: vm.global.i32 private mutable @result2 : i32
+  vm.global.i32 private @result2 : i32
+
+  // CHECK: vm.export @__init
+  // CHECK-NEXT: vm.func private @__init() {
+  // Phase 1: Initialize globals with initial values
+  // CHECK-NEXT:   %c100 = vm.const.i32 100
+  // CHECK-NEXT:   vm.global.store.i32 %c100, @g1
+  // Phase 2: Execute initializers in module order
+  // CHECK-NEXT:   %[[G1:.+]] = vm.global.load.i32 @g1
+  // CHECK-NEXT:   vm.global.store.i32 %[[G1]], @result1
+  // CHECK-NEXT:   %c200 = vm.const.i32 200
+  // CHECK-NEXT:   vm.global.store.i32 %c200, @g2
+  // CHECK-NEXT:   %[[G2:.+]] = vm.global.load.i32 @g2
+  // CHECK-NEXT:   vm.global.store.i32 %[[G2]], @result2
+  // CHECK-NEXT:   vm.return
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
It was kinda janky and could produce incorrect programs by changing the global/initializer ordering particularly if there were function calls in the initializers (such as is common with memoized command buffers). It was only working because the calls were inlined before any analysis took place (which is also broken and will be fixed in future changes).

To finally fix this I had to codify the initialization rules and add a more sophisticated verification than we had before ("is store in init? ok"). The verification showed that we were violating the (implicit) rules in several places so they've been hardened here or at least clarified with code/comments to ensure they don't regress. Each major pipeline stage now runs the verifier to gate inputs that have bad ordering.

A bonus here is that we now do a better job of preserving the readability of modules across the pipelines as now we move the globals deterministically and preserve order when possible (really useful for models with a lot of block weights and such).