### PR TITLE
[ROCm] Fix up gfx1250 definitions

### DIFF
--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -91,7 +91,7 @@
 
 // Note: The gfx1250 target is experimental and contains placeholder values.
 // GFX1250: target_info = #iree_gpu.target<arch = "gfx1250",
-// GFX1250-SAME:        subgroup_size_choices = [32, 64]
+// GFX1250-SAME:        subgroup_size_choices = [32]
 // GFX1250-SAME:        max_load_instruction_bits = 128, simds_per_wgp = 4
 
 stream.executable public @reduce_dispatch {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -451,7 +451,7 @@ const WgpDetails *getGfx1250WgpDetails() {
                                         /*mmaOps=*/nullptr,
                                         /*scaledMmaCount=*/0,
                                         /*scaledMmaOps=*/nullptr,
-                                        {32, 64},
+                                        {32, 32},
                                         {1024, 1024, 1024},
                                         1024,
                                         64 * 1024,


### PR DESCRIPTION
* Support HIP globals for gfx1250
* Disallow wave64 for now, as many features are not available
* Remove needless dynamic memory allocation in surrounding code.