### PR TITLE
[Codegen][GPU] update the tuning spec using new transform ops

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -112,37 +112,21 @@ transform.named_sequence
   transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
 }
 
-transform.named_sequence @match_mmt_f16_f16_f32(%root: !transform.any_op {transform.readonly}) -> !transform.any_op {
-  transform.match.operation_name %root ["linalg.generic"] : !transform.any_op
-  %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %root {
-    ^bb0(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %out: tensor<?x?xf32>):
-    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
-                                          affine_map<(d0, d1, d2) -> (d1, d2)>,
-                                          affine_map<(d0, d1, d2) -> (d0, d1)>],
-                          iterator_types = ["parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x?xf16>, tensor<?x?xf16>) outs(%out : tensor<?x?xf32>) {
-      ^bb0(%in: f16, %in_0: f16, %acc: f32):
-        %8 = arith.extf %in : f16 to f32
-        %9 = arith.extf %in_0 : f16 to f32
-        %10 = arith.mulf %8, %9 : f32
-        %11 = arith.addf %acc, %10 : f32
-        linalg.yield %11 : f32
-      } -> tensor<?x?xf32>
-  } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-  transform.yield %root : !transform.any_op
-}
-
 transform.named_sequence
 @match_mmt_2048x1280x5120_f16_f16_f32(%matmul: !transform.any_op {transform.readonly})
   -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul)
-    : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<2048x5120xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<1280x5120xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [2048] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [5120] : !transform.param<i64>
+
   %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,

--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -121,8 +121,7 @@ transform.named_sequence
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [2048] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [5120] : !transform.param<i64>

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
@@ -22,8 +22,7 @@ module attributes {transform.with_named_sequence} {
     lhs_type = bf16, rhs_type = bf16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [4608] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [21504] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
@@ -38,8 +37,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [4608] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [15360] : !transform.param<i64>
@@ -54,9 +52,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [12288] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
@@ -71,8 +67,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [12288] : !transform.param<i64>
@@ -87,8 +82,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [72] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [128] : !transform.param<i64>
@@ -104,8 +98,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
@@ -120,8 +113,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [512] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [12288] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
@@ -136,8 +128,7 @@ module attributes {transform.with_named_sequence} {
       lhs_type = bf16, rhs_type = bf16, output_type = f32
       {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                         affine_map<(d0, d1, d2) -> (d1, d2)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %m, [512] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
     transform.iree.match.dims_equal %k, [12288] : !transform.param<i64>

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
@@ -18,35 +18,31 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_4608x21504x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<4608x3072xbf16>, %arg2: tensor<21504x3072xbf16>, %arg3: tensor<4608x21504xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4608x3072xbf16>, tensor<21504x3072xbf16>) outs(%arg3 : tensor<4608x21504xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<4608x21504xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+    lhs_type = bf16, rhs_type = bf16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [4608] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [21504] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [6, 4, 0], subgroup_basis = [[4, 2, 1], [0, 1, 2]], workgroup = [384, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
 
-  transform.named_sequence @match_contraction_4608x3072x4608_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.named_sequence @match_contraction_4608x3072x15360_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<15360x4608xbf16>, %arg2: tensor<3072x15360xbf16>, %arg3: tensor<4608x3072xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<15360x4608xbf16>, tensor<3072x15360xbf16>) outs(%arg3 : tensor<4608x3072xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<4608x3072xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [4608] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [15360] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 4, 0], subgroup_basis = [[4, 1, 1], [0, 1, 2]], workgroup = [256, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -54,17 +50,16 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_4096x12288x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<12288x3072xbf16>, %arg3: tensor<4096x12288xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<12288x3072xbf16>) outs(%arg3 : tensor<4096x12288xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<4096x12288xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+
+    transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [12288] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [2, 4, 0], subgroup_basis = [[4, 2, 1], [0, 1, 2]], workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -72,17 +67,15 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_4096x3072x12288_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<4096x12288xbf16>, %arg2: tensor<3072x12288xbf16>, %arg3: tensor<4096x3072xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x12288xbf16>, tensor<3072x12288xbf16>) outs(%arg3 : tensor<4096x3072xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<4096x3072xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [12288] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_basis = [[2, 4, 1], [0, 1, 2]], workgroup = [128, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -90,17 +83,16 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_72x4096x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<72x128x3072xbf16>, %arg3: tensor<72x4096x128xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<72x128x3072xbf16>) outs(%arg3 : tensor<72x4096x128xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<72x4096x128xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>,
+                        affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %batch, [72] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [128] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 0, 2], subgroup = [4, 2, 2, 0], subgroup_basis = [[8, 1, 1], [0, 1, 2]], workgroup = [4, 256, 32, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -108,17 +100,15 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_4096x3072x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<3072x3072xbf16>, %arg3: tensor<4096x3072xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<3072x3072xbf16>) outs(%arg3 : tensor<4096x3072xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<4096x3072xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [4096] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 6, 0], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [128, 192, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -126,17 +116,15 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_512x12288x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<512x3072xbf16>, %arg2: tensor<12288x3072xbf16>, %arg3: tensor<512x12288xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<512x3072xbf16>, tensor<12288x3072xbf16>) outs(%arg3 : tensor<512x12288xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<512x12288xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [512] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [12288] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [3072] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 1, 0], subgroup_basis = [[1, 4, 1], [0, 1, 2]], workgroup = [64, 64, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -144,17 +132,15 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_contraction_512x3072x12288_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
 
-    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
-    ^bb0(%arg1: tensor<512x12288xbf16>, %arg2: tensor<3072x12288xbf16>, %arg3: tensor<512x3072xf32>):
-      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<512x12288xbf16>, tensor<3072x12288xbf16>) outs(%arg3 : tensor<512x3072xf32>) {
-      ^bb0(%in: bf16, %in_0: bf16, %out: f32):
-        %2 = arith.extf %in : bf16 to f32
-        %3 = arith.extf %in_0 : bf16 to f32
-        %4 = arith.mulf %2, %3 : f32
-        %5 = arith.addf %out, %4 : f32
-        linalg.yield %5 : f32
-      } -> tensor<512x3072xf32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %arg0,
+      lhs_type = bf16, rhs_type = bf16, output_type = f32
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.iree.match.dims_equal %m, [512] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [3072] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [12288] : !transform.param<i64>
     %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 6], subgroup = [4, 2, 0], subgroup_basis = [[1, 3, 1], [0, 1, 2]], workgroup = [64, 96, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [192, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
     transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
   }
@@ -170,7 +156,7 @@ module attributes {transform.with_named_sequence} {
 
         // TUNING_MATCH_BEGIN DO NOT REMOVE
         @match_contraction_4608x21504x3072_bf16xbf16xf32 -> @apply_op_config // 588
-        , @match_contraction_4608x3072x4608_bf16xbf16xf32 -> @apply_op_config // 603
+        , @match_contraction_4608x3072x15360_bf16xbf16xf32 -> @apply_op_config // 603
         , @match_contraction_4096x12288x3072_bf16xbf16xf32 -> @apply_op_config // 40
         , @match_contraction_4096x3072x12288_bf16xbf16xf32 -> @apply_op_config // 41
         , @match_contraction_72x4096x3072_bf16xbf16xf32 -> @apply_op_config // 19

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -91,8 +91,7 @@ transform.named_sequence @match_mmt_2048x10240x1280(%matmul: !transform.any_op {
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [2048] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
@@ -116,8 +115,7 @@ transform.named_sequence @match_mmt_2048x1280x5120(%matmul: !transform.any_op {t
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [2048] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [5120] : !transform.param<i64>
@@ -141,8 +139,7 @@ transform.named_sequence @match_mmt_2048x1280x1280(%matmul: !transform.any_op {t
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [2048] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
@@ -167,8 +164,7 @@ transform.named_sequence @match_mmt_8192x640x640(%matmul: !transform.any_op {tra
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [8192] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
@@ -192,8 +188,7 @@ transform.named_sequence @match_mmt_8192x5120x640(%matmul: !transform.any_op {tr
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [8192] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [5120] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
@@ -217,8 +212,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     lhs_type = i8, rhs_type = i8, output_type = i32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [8192] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [2560] : !transform.param<i64>
@@ -254,8 +248,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
@@ -280,8 +273,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
@@ -307,8 +299,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
@@ -335,8 +326,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 4960] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
@@ -361,8 +351,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
@@ -387,8 +376,7 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
       lhs_type = i8, rhs_type = i8, output_type = i32
       {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
-      (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 4096] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [5120] : !transform.param<i64>
@@ -414,22 +402,15 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %cont : !transform.any_op
 
-    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
-    ^bb0(%lhs: tensor<?x1024x1280xi8>, %rhs: tensor<20x64x1280xi8>, %out: tensor<?x20x1024x64xi32>):
-      %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
-                            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x1024x1280xi8>, tensor<20x64x1280xi8>)
-        outs(%out : tensor<?x20x1024x64xi32>) {
-      ^bb0(%in: i8, %in_0: i8, %acc: i32):
-        %18 = arith.extsi %in : i8 to i32
-        %19 = arith.extsi %in_0 : i8 to i32
-        %20 = arith.muli %18, %19 : i32
-        %21 = arith.addi %acc, %20 : i32
-        linalg.yield %21 : i32
-      } -> tensor<?x20x1024x64xi32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %cont,
+    lhs_type = i8, rhs_type = i8, output_type = i32
+    {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>]} : !transform.any_op -> !transform.param<i64>
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [20, 64] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -451,22 +432,15 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %cont : !transform.any_op
 
-    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
-    ^bb0(%lhs: tensor<?x1024x1280xi8>, %rhs: tensor<20x64x1280xi8>, %out: tensor<?x20x64x1024xi32>):
-      %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
-                            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x1024x1280xi8>, tensor<20x64x1280xi8>)
-        outs(%out : tensor<?x20x64x1024xi32>) {
-      ^bb0(%in: i8, %in_0: i8, %acc: i32):
-        %18 = arith.extsi %in : i8 to i32
-        %19 = arith.extsi %in_0 : i8 to i32
-        %20 = arith.muli %18, %19 : i32
-        %21 = arith.addi %acc, %20 : i32
-        linalg.yield %21 : i32
-      } -> tensor<?x20x64x1024xi32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %batch, %m, %n, %k = transform.iree.match.contraction %cont,
+    lhs_type = i8, rhs_type = i8, output_type = i32
+    {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>]} : !transform.any_op -> !transform.param<i64>
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [20, 64] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -486,22 +460,15 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
     -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %cont : !transform.any_op
 
-    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
-    ^bb0(%lhs: tensor<?x64x2048xi8>, %rhs: tensor<20x64x2048xi8>, %out: tensor<?x20x64x64xi32>):
-      %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
-                            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x64x2048xi8>, tensor<20x64x2048xi8>)
-        outs(%out : tensor<?x20x64x64xi32>) {
-      ^bb0(%in: i8, %in_0: i8, %acc: i32):
-        %18 = arith.extsi %in : i8 to i32
-        %19 = arith.extsi %in_0 : i8 to i32
-        %20 = arith.muli %18, %19 : i32
-        %21 = arith.addi %acc, %20 : i32
-        linalg.yield %21 : i32
-      } -> tensor<?x20x64x64xi32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+  %batch, %m, %n, %k = transform.iree.match.contraction %cont,
+    lhs_type = i8, rhs_type = i8, output_type = i32
+    {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>]} : !transform.any_op -> !transform.param<i64>
+  transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+  transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [20, 64] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [2048] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -520,22 +487,15 @@ transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32
     -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %cont : !transform.any_op
 
-    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
-    ^bb0(%lhs: tensor<?x64x2048xi8>, %rhs: tensor<20x64x2048xi8>, %out: tensor<?x20x64x64xi32>):
-      %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
-                            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x64x2048xi8>, tensor<20x64x2048xi8>)
-        outs(%out : tensor<?x20x64x64xi32>) {
-      ^bb0(%in: i8, %in_0: i8, %acc: i32):
-        %18 = arith.extsi %in : i8 to i32
-        %19 = arith.extsi %in_0 : i8 to i32
-        %20 = arith.muli %18, %19 : i32
-        %21 = arith.addi %acc, %20 : i32
-        linalg.yield %21 : i32
-      } -> tensor<?x20x64x64xi32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+  %batch, %m, %n, %k = transform.iree.match.contraction %cont,
+    lhs_type = i8, rhs_type = i8, output_type = i32
+    {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>]} : !transform.any_op -> !transform.param<i64>
+  transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+  transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [20, 64] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [2048] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -553,22 +513,15 @@ transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32
     -> (!transform.any_op, !transform.any_param) {
     transform.iree.match.has_no_lowering_config %cont : !transform.any_op
 
-    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
-    ^bb0(%lhs: tensor<?x4096x640xi8>, %rhs: tensor<10x64x640xi8>, %out: tensor<?x10x4096x64xi32>):
-      %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
-                                             affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
-                            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x4096x640xi8>, tensor<10x64x640xi8>)
-        outs(%out : tensor<?x10x4096x64xi32>) {
-      ^bb0(%in: i8, %in_0: i8, %acc: i32):
-        %18 = arith.extsi %in : i8 to i32
-        %19 = arith.extsi %in_0 : i8 to i32
-        %20 = arith.muli %18, %19 : i32
-        %21 = arith.addi %acc, %20 : i32
-        linalg.yield %21 : i32
-      } -> tensor<?x10x4096x64xi32>
-    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+  %batch, %m, %n, %k = transform.iree.match.contraction %cont,
+    lhs_type = i8, rhs_type = i8, output_type = i32
+    {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                      affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>]} : !transform.any_op -> !transform.param<i64>
+  transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+  transform.iree.match.dims_equal %m, [-1, 4096] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [10, 64] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -256,10 +256,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x1024x1280xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<10240x1280xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -282,10 +282,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x1024x1280xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<1280x1280xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 1024] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -309,10 +309,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x64x2480xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<1280x2480xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [2480] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -337,10 +337,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x4960x640xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<640x640xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 4960] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -363,10 +363,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x64x2480xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<640x2480xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 64] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [2480] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
@@ -389,10 +389,10 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]} :
       (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
-    %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
-    %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
-    transform.iree.match.cast_compatible_type %lhs = tensor<?x4096x640xi8> : !transform.any_value
-    transform.iree.match.cast_compatible_type %rhs = tensor<5120x640xi8> : !transform.any_value
+    transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %m, [-1, 4096] : !transform.param<i64>
+    transform.iree.match.dims_equal %n, [5120] : !transform.param<i64>
+    transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
     %config = transform.param.constant #iree_codegen.compilation_info<
       lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                    mma_kind = #iree_gpu.mma_layout<MFMA_I32_32x32x16_I8>,

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -58,8 +58,7 @@ transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
@@ -84,8 +83,7 @@ transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {t
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
@@ -110,8 +108,7 @@ transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {t
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
@@ -136,8 +133,7 @@ transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {tr
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [5120] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
@@ -162,8 +158,7 @@ transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {tr
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [128] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [2048] : !transform.param<i64>
@@ -188,8 +183,7 @@ transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {tra
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
@@ -214,8 +208,7 @@ transform.named_sequence @match_mmt_7680x640x2560(%matmul: !transform.any_op {tr
     lhs_type = f16, rhs_type = f16, output_type = f32
     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                       affine_map<(d0, d1, d2) -> (d1, d2)>,
-                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
-    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} : !transform.any_op -> !transform.param<i64>
   transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
   transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
   transform.iree.match.dims_equal %k, [2560] : !transform.param<i64>

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -46,41 +46,23 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
 }
 
-transform.named_sequence @match_mmt_f16_f16_f32(%root: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-  transform.match.operation_name %root ["linalg.generic"] : !transform.any_op
-  // transform.print %root {name = "Generic"} : !transform.any_op
-  %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %root {
-    ^bb0(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %out: tensor<?x?xf32>):
-    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
-                                          affine_map<(d0, d1, d2) -> (d1, d2)>,
-                                          affine_map<(d0, d1, d2) -> (d0, d1)>],
-                         iterator_types = ["parallel", "parallel", "reduction"]}
-        ins(%lhs, %rhs : tensor<?x?xf16>, tensor<?x?xf16>) outs(%out : tensor<?x?xf32>) {
-      ^bb0(%in: f16, %in_0: f16, %acc: f32):
-        %18 = arith.extf %in : f16 to f32
-        %19 = arith.extf %in_0 : f16 to f32
-        %20 = arith.mulf %18, %19 : f32
-        %21 = arith.addf %acc, %20 : f32
-        linalg.yield %21 : f32
-      } -> tensor<?x?xf32>
-  } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-  transform.yield %root : !transform.any_op
-}
-
 // TUNING_SPEC_BEGIN DO NOT REMOVE
 
 //===----------------------------------------------------------------------===//
 // Matmul tuning
 //===----------------------------------------------------------------------===//
-
 transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<1920x1280xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<10240x1280xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -98,11 +80,15 @@ transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {
 transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<1920x1280xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<1280x1280xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [10240] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -120,11 +106,15 @@ transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {t
 transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<1920x5120xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<1280x5120xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [1920] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [1280] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -142,11 +132,15 @@ transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {t
 transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<7680x640xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<5120x640xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [5120] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -164,11 +158,15 @@ transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {tr
 transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<1280x2048xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<1280x2048xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [128] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [1280] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [2048] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
@@ -186,11 +184,15 @@ transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {tr
 transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<7680x640xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<640x640xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [640] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
@@ -208,11 +210,15 @@ transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {tra
 transform.named_sequence @match_mmt_7680x640x2560(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
   transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
 
-  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
-  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
-  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
-  transform.iree.match.cast_compatible_type %lhs = tensor<7680x2560xf16> : !transform.any_value
-  transform.iree.match.cast_compatible_type %rhs = tensor<640x2560xf16> : !transform.any_value
+  %batch, %m, %n, %k = transform.iree.match.contraction %matmul,
+    lhs_type = f16, rhs_type = f16, output_type = f32
+    {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                      affine_map<(d0, d1, d2) -> (d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>]} :
+    (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+  transform.iree.match.dims_equal %m, [7680] : !transform.param<i64>
+  transform.iree.match.dims_equal %n, [640] : !transform.param<i64>
+  transform.iree.match.dims_equal %k, [2560] : !transform.param<i64>
   %config = transform.param.constant #iree_codegen.compilation_info<
   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
                                                 mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,


### PR DESCRIPTION
This PR updates all tuning specs in IREE to use the newly introduced transform ops —
`transform.iree.match.contraction`, `transform.iree.match.convolution`, `transform.iree.match.attention`, and `transform.iree.match.dims_equal`, in order to replace the `transform.iree.match.cast_compatible_dag_from_root` op for more robust matching. 

ci-extra: windows_x64_msvc