### PR TITLE
Fix the Windows build: portably set environment variable PYTHONPATH.

### DIFF
--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -255,7 +255,7 @@ function(iree_single_backend_e2e_runner_test)
 
   add_custom_command(
     COMMAND
-      "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+      "${CMAKE_COMMAND}" -E env "PYTHONPATH=${PROJECT_SOURCE_DIR}"
       "${Python3_EXECUTABLE}"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_GENERATOR}"
       ${_GENERATOR_STANDARD_FLAGS}


### PR DESCRIPTION
This fixes the breakage in https://github.com/iree-org/iree/actions/runs/18060514263/job/51396076814#step:9:11510 which was caused by setting the PYTHONPATH environment variable in Bash-like syntax on Windows. Using `cmake -E env` should be the portable way to do that.

I tried the alternative of setting the working directory for this comment instead of PYTHONPATH, but no luck with that.