### PR TITLE
[Codegen][GPU] Perfer MMA over VirtualMMA in Sorting. 

### DIFF
--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -255,7 +255,7 @@ function(iree_single_backend_e2e_runner_test)
 
   add_custom_command(
     COMMAND
-      "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+      "${CMAKE_COMMAND}" -E env "PYTHONPATH=${PROJECT_SOURCE_DIR}"
       "${Python3_EXECUTABLE}"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_GENERATOR}"
       ${_GENERATOR_STANDARD_FLAGS}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -151,7 +151,7 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
 // CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]


### PR DESCRIPTION
This PR adds virtual vs non-virtual preference (prefer non-virtual) in the `compareIntrinsic `function,  in order to make MMA intrinsic sorting deterministic across platforms.

More details:

both VMFMA_F32_16x16x32_F16 and FMA_F32_16x16x32_F16 exist. We do not have code in `comapreIntrinsics `function to do this tie-breaker for them when sorting MMA intrinsics, and then it causes non-deterministic behaviors across platforms. 

ci-extra: windows_x64_msvc