### PR TITLE
[GPU] Support iree_codegen.load_from_buffer in GPUBubbleResourceCasts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -5,11 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -26,26 +31,68 @@ struct GPUBubbleResourceCastsPass final
 } // namespace
 
 /// Walk the producers of |input| and return the hal.interface.binding_subspan
-/// that produces it if the binding is readonly.
-static Operation *isTriviallyProducedByReadOnlyViewLike(Value input) {
+/// that produces it if the binding is readonly. If the binding is already
+/// bufferized, then check that there is at most one FatRawBufferCastOp in its
+/// use chain, and add it to |rawBufferCasts| if found.
+static Operation *isTriviallyProducedByReadOnlyViewLike(
+    Value input, SetVector<amdgpu::FatRawBufferCastOp> &rawBufferCasts) {
   Value next = input;
   while (auto slice = next.getDefiningOp<tensor::ExtractSliceOp>()) {
     next = slice.getSource();
   }
 
+  // Case 1: Subspan is not bufferized.
   auto tensorLoad = next.getDefiningOp<IREE::TensorExt::DispatchTensorLoadOp>();
-  if (!tensorLoad) {
-    return nullptr;
+  if (tensorLoad) {
+    IREE::HAL::InterfaceBindingSubspanOp binding =
+        tensorLoad.getSource()
+            .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
+    if (!binding ||
+        cast<IREE::TensorExt::DispatchTensorType>(binding.getType())
+                .getAccess() != IREE::TensorExt::TensorAccess::ReadOnly) {
+      return nullptr;
+    }
+    return binding;
   }
 
-  auto binding = tensorLoad.getSource()
-                     .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
-  if (!binding ||
-      cast<IREE::TensorExt::DispatchTensorType>(binding.getType())
-              .getAccess() != IREE::TensorExt::TensorAccess::ReadOnly) {
+  // Case 2: Subspan is bufferized.
+  auto loadFromBuffer = next.getDefiningOp<IREE::Codegen::LoadFromBufferOp>();
+  if (!loadFromBuffer) {
     return nullptr;
   }
-  return binding;
+  std::optional<IREE::HAL::InterfaceBindingSubspanOp> binding =
+      getSourceSubspanMemref(cast<MemrefValue>(loadFromBuffer.getBuffer()));
+  if (!binding) {
+    return nullptr;
+  }
+  std::optional<IREE::HAL::DescriptorFlags> descriptorFlags =
+      binding->getDescriptorFlags();
+  if (!descriptorFlags.has_value() ||
+      !bitEnumContainsAll(*descriptorFlags,
+                          IREE::HAL::DescriptorFlags::ReadOnly)) {
+    return nullptr;
+  }
+  // Check that the binding has at most one FatRawBufferCastOp in its use
+  // chain.
+  ForwardSliceOptions options;
+  options.filter = [&](Operation *op) {
+    // Only follow memref results.
+    if (llvm::none_of(op->getOpResults(), [](OpResult result) {
+          return isa<MemRefType>(result.getType());
+        })) {
+      return false;
+    }
+    if (isa<amdgpu::FatRawBufferCastOp>(op)) {
+      rawBufferCasts.insert(cast<amdgpu::FatRawBufferCastOp>(op));
+    }
+    return true;
+  };
+  SetVector<Operation *> slice;
+  getForwardSlice(binding->getOperation(), &slice, options);
+  if (rawBufferCasts.size() > 1) {
+    return nullptr;
+  }
+  return binding.value();
 }
 
 namespace {
@@ -171,14 +218,22 @@ void GPUBubbleResourceCastsPass::runOnOperation() {
   auto *ireeGpuDialect = context->getLoadedDialect<IREE::GPU::IREEGPUDialect>();
 
   SmallVector<IREE::GPU::BufferResourceCastOp> castsToDrop;
+  IRRewriter rewriter(op);
   op->walk([&](IREE::GPU::BufferResourceCastOp castOp) {
     // Skip ops without cache swizzle values set. There is no need to drop
     // these because we will try to bubble them up.
     if (!castOp.getCacheSwizzleStride()) {
       return;
     }
-    if (Operation *binding =
-            isTriviallyProducedByReadOnlyViewLike(castOp.getInput())) {
+    SetVector<amdgpu::FatRawBufferCastOp> rawBufferCasts;
+    if (Operation *binding = isTriviallyProducedByReadOnlyViewLike(
+            castOp.getInput(), rawBufferCasts)) {
+      for (amdgpu::FatRawBufferCastOp rawBufferCast : rawBufferCasts) {
+        replaceMemrefUsesAndPropagateType(rewriter, rawBufferCast.getLoc(),
+                                          rawBufferCast.getResult(),
+                                          rawBufferCast.getSource());
+        rewriter.eraseOp(rawBufferCast);
+      }
       if (ireeGpuDialect->getUseRocdlBufferInstructionsAttrHelper()
               .isAttrPresent(binding)) {
         // TODO: Support updating buffer structs so we don't have to replace

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -14,7 +14,6 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
-#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -61,7 +60,8 @@ static Operation *isTriviallyProducedByReadOnlyViewLike(
     return nullptr;
   }
   std::optional<IREE::HAL::InterfaceBindingSubspanOp> binding =
-      getSourceSubspanMemref(cast<MemrefValue>(loadFromBuffer.getBuffer()));
+      getSourceSubspanMemref(
+          cast<TypedValue<MemRefType>>(loadFromBuffer.getBuffer()));
   if (!binding) {
     return nullptr;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_bubble_resource_casts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_bubble_resource_casts.mlir
@@ -169,3 +169,40 @@ func.func @bufferized_subspan_multiple_buffer_casts() -> (tensor<2xf32>, tensor<
 //       CHECK:   %[[LOAD0:.+]] = iree_codegen.load_from_buffer %[[CAST0]]
 //       CHECK:   %[[LOAD1:.+]] = iree_codegen.load_from_buffer %[[CAST1]]
 //       CHECK:   return %[[LOAD0]], %[[LOAD1]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+func.func @bufferized_subspan_not_readonly() -> (tensor<2xf32>, tensor<2xf32>) {
+  %c0 = arith.constant 0 : index
+  %c4096 = arith.constant 4096 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("Indirect") : memref<2xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = amdgpu.fat_raw_buffer_cast %0 : memref<2xf32, #hal.descriptor_type<storage_buffer>> to memref<2xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %2 = iree_codegen.load_from_buffer %1 : memref<2xf32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<2xf32>
+  %3 = iree_gpu.buffer_resource_cast %2 cacheSwizzleStride(%c4096) : tensor<2xf32>
+  return %2, %3 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func.func @bufferized_subspan_not_readonly
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   %[[BUFFER_CAST:.+]] = amdgpu.fat_raw_buffer_cast %[[BINDING]]
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER_CAST]]
+//       CHECK:   return %[[LOAD]], %[[LOAD]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+func.func @bufferized_subspan_no_buffer_cast() -> (tensor<2xf32>, tensor<2xf32>) {
+  %c0 = arith.constant 0 : index
+  %c4096 = arith.constant 4096 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly") : memref<2xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = iree_codegen.load_from_buffer %0 : memref<2xf32, #hal.descriptor_type<storage_buffer>> -> tensor<2xf32>
+  %2 = iree_gpu.buffer_resource_cast %1 cacheSwizzleStride(%c4096) : tensor<2xf32>
+  return %1, %2 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func.func @bufferized_subspan_no_buffer_cast
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BINDING]]
+//       CHECK:   %[[CAST:.+]] = iree_gpu.buffer_resource_cast %[[LOAD]]
+//       CHECK:   return %[[LOAD]], %[[CAST]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_bubble_resource_casts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_bubble_resource_casts.mlir
@@ -126,3 +126,46 @@ func.func @keep_swizzle_cast() -> tensor<1xf32> {
 //       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[LOAD]]
 //       CHECK:   %[[CAST:.+]] = iree_gpu.buffer_resource_cast %[[EXTRACT]]
 //       CHECK:   return %[[CAST]] : tensor<1xf32>
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+func.func @bufferized_subspan_drop_buffer_cast() -> (tensor<2xf32>, tensor<2xf32>) {
+  %c0 = arith.constant 0 : index
+  %c4096 = arith.constant 4096 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly") : memref<2xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = amdgpu.fat_raw_buffer_cast %0 : memref<2xf32, #hal.descriptor_type<storage_buffer>> to memref<2xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %2 = iree_codegen.load_from_buffer %1 : memref<2xf32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<2xf32>
+  %3 = iree_gpu.buffer_resource_cast %2 cacheSwizzleStride(%c4096) : tensor<2xf32>
+  return %2, %3 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func.func @bufferized_subspan_drop_buffer_cast
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//   CHECK-NOT:   amdgpu.fat_raw_buffer_cast
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BINDING]]
+//       CHECK:   %[[CAST:.+]] = iree_gpu.buffer_resource_cast %[[LOAD]]
+//       CHECK:   return %[[LOAD]], %[[CAST]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+func.func @bufferized_subspan_multiple_buffer_casts() -> (tensor<2xf32>, tensor<2xf32>) {
+  %c0 = arith.constant 0 : index
+  %c4096 = arith.constant 4096 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly") : memref<2xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = amdgpu.fat_raw_buffer_cast %0 : memref<2xf32, #hal.descriptor_type<storage_buffer>> to memref<2xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %2 = amdgpu.fat_raw_buffer_cast %0 : memref<2xf32, #hal.descriptor_type<storage_buffer>> to memref<2xf32, #amdgpu.address_space<fat_raw_buffer>>
+  %3 = iree_codegen.load_from_buffer %1 : memref<2xf32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<2xf32>
+  %4 = iree_codegen.load_from_buffer %2 : memref<2xf32, #amdgpu.address_space<fat_raw_buffer>> -> tensor<2xf32>
+  %5 = iree_gpu.buffer_resource_cast %4 cacheSwizzleStride(%c4096) : tensor<2xf32>
+  return %3, %5 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func.func @bufferized_subspan_multiple_buffer_casts
+//       CHECK:   %[[BINDING:.+]] = hal.interface.binding.subspan
+//       CHECK:   %[[CAST0:.+]] = amdgpu.fat_raw_buffer_cast %[[BINDING]]
+//       CHECK:   %[[CAST1:.+]] = amdgpu.fat_raw_buffer_cast %[[BINDING]]
+//       CHECK:   %[[LOAD0:.+]] = iree_codegen.load_from_buffer %[[CAST0]]
+//       CHECK:   %[[LOAD1:.+]] = iree_codegen.load_from_buffer %[[CAST1]]
+//       CHECK:   return %[[LOAD0]], %[[LOAD1]]

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -176,7 +176,8 @@ struct LoadFromBufferOpInterface
     // buffer, and check if the subspan is read only.
     auto loadFromBufferOp = cast<IREE::Codegen::LoadFromBufferOp>(op);
     std::optional<IREE::HAL::InterfaceBindingSubspanOp> subspanOp =
-        getSourceSubspanMemref(cast<MemrefValue>(loadFromBufferOp.getBuffer()));
+        getSourceSubspanMemref(
+            cast<TypedValue<MemRefType>>(loadFromBufferOp.getBuffer()));
     // Conservatively return false if the subspan is not found.
     if (!subspanOp)
       return false;

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -172,36 +172,19 @@ struct LoadFromBufferOpInterface
           LoadFromBufferOpInterface, IREE::Codegen::LoadFromBufferOp> {
   bool isWritable(Operation *op, Value value,
                   const AnalysisState &state) const {
-    // Walk memref Value producers until a hal.interface.binding.subspan op is
-    // found, and check if the subspan is read only.
-    Operation *currentOp = op;
-    while (currentOp) {
-      if (auto subspanOp =
-              dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(currentOp)) {
-        std::optional<IREE::HAL::DescriptorFlags> descriptorFlags =
-            subspanOp.getDescriptorFlags();
-        return !descriptorFlags.has_value() ||
-               descriptorFlags.value() != IREE::HAL::DescriptorFlags::ReadOnly;
-      }
-      // There is expected to be only a single memref source for a given memref
-      // OpResult, because producers of memref Values are expected to be
-      // view-like or cast-like operations. If multiple operands have a memref
-      // type, then conservatively return not writable.
-      if (llvm::count_if(currentOp->getOperandTypes(),
-                         llvm::IsaPred<MemRefType>) != 1) {
-        return false;
-      }
-      // Otherwise, follow the memref operand to find the source buffer.
-      for (Value operand : currentOp->getOperands()) {
-        if (isa<MemRefType>(operand.getType())) {
-          currentOp = operand.getDefiningOp();
-          break;
-        }
-      }
-    }
-    // Conservatively default to not writable if the source of the buffer is
-    // not found.
-    return false;
+    // Search for a hal.interface.binding.subspan op that is the source of the
+    // buffer, and check if the subspan is read only.
+    auto loadFromBufferOp = cast<IREE::Codegen::LoadFromBufferOp>(op);
+    std::optional<IREE::HAL::InterfaceBindingSubspanOp> subspanOp =
+        getSourceSubspanMemref(cast<MemrefValue>(loadFromBufferOp.getBuffer()));
+    // Conservatively return false if the subspan is not found.
+    if (!subspanOp)
+      return false;
+    std::optional<IREE::HAL::DescriptorFlags> descriptorFlags =
+        subspanOp->getDescriptorFlags();
+    return !descriptorFlags.has_value() ||
+           !bitEnumContainsAll(*descriptorFlags,
+                               IREE::HAL::DescriptorFlags::ReadOnly);
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1141,7 +1141,7 @@ int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp) {
 //===---------------------------------------------------------------------===//
 
 std::optional<IREE::HAL::InterfaceBindingSubspanOp>
-getSourceSubspanMemref(MemrefValue buffer) {
+getSourceSubspanMemref(TypedValue<MemRefType> buffer) {
   Operation *currentOp = buffer.getDefiningOp();
   while (currentOp) {
     if (auto subspanOp =

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1140,6 +1140,33 @@ int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp) {
 // Bufferization utility functions
 //===---------------------------------------------------------------------===//
 
+std::optional<IREE::HAL::InterfaceBindingSubspanOp>
+getSourceSubspanMemref(MemrefValue buffer) {
+  Operation *currentOp = buffer.getDefiningOp();
+  while (currentOp) {
+    if (auto subspanOp =
+            dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(currentOp)) {
+      return subspanOp;
+    }
+    // There is expected to be only a single memref source for a given memref
+    // OpResult, because producers of memref Values are expected to be
+    // view-like or cast-like operations. Bail if there are multiple memref
+    // operands, since we don't know which one to use as the source.
+    if (llvm::count_if(currentOp->getOperandTypes(),
+                       llvm::IsaPred<MemRefType>) != 1) {
+      return std::nullopt;
+    }
+    // Otherwise, follow the memref operand to find the source buffer.
+    for (Value operand : currentOp->getOperands()) {
+      if (isa<MemRefType>(operand.getType())) {
+        currentOp = operand.getDefiningOp();
+        break;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 /// Get strides for row-major oredering of a tensor with the given `shape`.
 static SmallVector<int64_t> getStridesFromShape(ArrayRef<int64_t> shape) {
   if (shape.empty()) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -15,7 +15,6 @@
 #include "llvm/TargetParser/Triple.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
-#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.h"
@@ -221,7 +220,7 @@ int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp);
 /// Walks the memref producers and returns the source subspan memref for the
 /// given buffer, or std::nullopt if no subspan is found.
 std::optional<IREE::HAL::InterfaceBindingSubspanOp>
-getSourceSubspanMemref(MemrefValue buffer);
+getSourceSubspanMemref(TypedValue<MemRefType> buffer);
 
 /// Find the memref version of the given InterfaceBindingSubspanOp. If no such
 /// op exists in the same block (before the given op), create a new op.

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -15,6 +15,7 @@
 #include "llvm/TargetParser/Triple.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.h"
@@ -216,6 +217,11 @@ int64_t getMinElementBitwidth(linalg::LinalgOp linalgOp);
 //===---------------------------------------------------------------------===//
 // Bufferization utility functions
 //===---------------------------------------------------------------------===//
+
+/// Walks the memref producers and returns the source subspan memref for the
+/// given buffer, or std::nullopt if no subspan is found.
+std::optional<IREE::HAL::InterfaceBindingSubspanOp>
+getSourceSubspanMemref(MemrefValue buffer);
 
 /// Find the memref version of the given InterfaceBindingSubspanOp. If no such
 /// op exists in the same block (before the given op), create a new op.


### PR DESCRIPTION
`iree_gpu.buffer_resource_cast` ops were being dropped because early bufferization emits a fat_raw_buffer subspan early in the pipeline. The GPUBubbleResourceCasts pass is supposed to remove compiler hints to use fat_raw_buffer on non-bufferized subspans, but we need to support the case for bufferized subspans too.