### PR TITLE
[Codegen][ROCm] Attempt to fix MMA sorting CI failures

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -575,10 +575,10 @@ static SmallVector<GPUIntrinsicType>
 sortMMAIntrinsics(GPUMatmulShapeType problem,
                   ArrayRef<GPUIntrinsicType> intrinsics) {
   SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
-  llvm::stable_sort(sortedIntrinsics,
-             [&](const GPUMatmulShapeType &lhs, const GPUMatmulShapeType &rhs) {
-               return compareIntrinsics(problem, lhs, rhs);
-             });
+  llvm::stable_sort(sortedIntrinsics, [&](const GPUMatmulShapeType &lhs,
+                                          const GPUMatmulShapeType &rhs) {
+    return compareIntrinsics(problem, lhs, rhs);
+  });
   return sortedIntrinsics;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -532,9 +532,9 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
 ///
 /// This function acts as a comparison function object for std::sort, which
 /// returns true if the lhs is ordered before rhs.
-bool compareIntrinsics(const GPUMatmulShapeType &problem,
-                       const GPUMatmulShapeType &lhs,
-                       const GPUMatmulShapeType &rhs) {
+static bool compareIntrinsics(const GPUMatmulShapeType &problem,
+                              const GPUMatmulShapeType &lhs,
+                              const GPUMatmulShapeType &rhs) {
   // Prefer K-aligned intrinsics.
   int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
   int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
@@ -575,7 +575,7 @@ static SmallVector<GPUIntrinsicType>
 sortMMAIntrinsics(GPUMatmulShapeType problem,
                   ArrayRef<GPUIntrinsicType> intrinsics) {
   SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
-  llvm::sort(sortedIntrinsics,
+  llvm::stable_sort(sortedIntrinsics,
              [&](const GPUMatmulShapeType &lhs, const GPUMatmulShapeType &rhs) {
                return compareIntrinsics(problem, lhs, rhs);
              });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx950.mlir
@@ -151,7 +151,7 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
 // CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]


### PR DESCRIPTION
Use stable sorting to guarantee the same order across platforms. This is a follow up fix for https://github.com/iree-org/iree/pull/22090.

ci-extra: windows_x64_msvc