### PR TITLE
Simplify op rewrite pattern inheriting constructor definitions. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
@@ -82,7 +82,7 @@ struct HloElementwiseConverter : OpRewritePattern<OpTy> {
 
 struct ConcatenateConverter final
     : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConcatenateOp op,
                                 PatternRewriter &rewriter) const override {
@@ -117,7 +117,7 @@ struct ConcatenateConverter final
 
 struct GetDimSizeConverter final
     : OpRewritePattern<mlir::stablehlo::GetDimensionSizeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp op,
                                 PatternRewriter &rewriter) const override {
@@ -138,7 +138,7 @@ struct GetDimSizeConverter final
 };
 
 struct ReshapeConverter : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -113,7 +113,7 @@ static TypedAttr foldBinaryOpIntOrFloat(TypedAttr lhs, TypedAttr rhs,
 }
 
 struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::AddOp op,
                                 PatternRewriter &rewriter) const override {
@@ -160,7 +160,7 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
 };
 
 struct SubtractOpCanon final : OpRewritePattern<mlir::stablehlo::SubtractOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::SubtractOp op,
                                 PatternRewriter &rewriter) const override {
@@ -202,7 +202,7 @@ struct SubtractOpCanon final : OpRewritePattern<mlir::stablehlo::SubtractOp> {
 };
 
 struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::MulOp op,
                                 PatternRewriter &rewriter) const override {
@@ -328,7 +328,7 @@ static APInt calculateComp(mlir::stablehlo::ComparisonType kind,
 }
 
 struct CompareOpCanon final : OpRewritePattern<mlir::stablehlo::CompareOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::CompareOp op,
                                 PatternRewriter &rewriter) const override {
@@ -404,7 +404,7 @@ struct CompareOpCanon final : OpRewritePattern<mlir::stablehlo::CompareOp> {
 };
 
 struct SelectOpCanon final : OpRewritePattern<mlir::stablehlo::SelectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::SelectOp op,
                                 PatternRewriter &rewriter) const override {
@@ -463,7 +463,7 @@ struct SelectOpCanon final : OpRewritePattern<mlir::stablehlo::SelectOp> {
 
 struct BroadcastInDimOpCanon final
     : OpRewritePattern<mlir::stablehlo::BroadcastInDimOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::BroadcastInDimOp op,
                                 PatternRewriter &rewriter) const override {
@@ -528,7 +528,7 @@ struct BroadcastInDimOpCanon final
 
 struct ConcatenateOpCanon final
     : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConcatenateOp op,
                                 PatternRewriter &rewriter) const override {
@@ -573,7 +573,7 @@ struct ConcatenateOpCanon final
 };
 
 struct ConvertOpCanon final : OpRewritePattern<mlir::stablehlo::ConvertOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvertOp op,
                                 PatternRewriter &rewriter) const override {
@@ -625,7 +625,7 @@ static OpTy refineOpWithNewOp(PatternRewriter &rewriter, Operation *op,
 /// BroadcastInDimOp.
 struct DynamicBroadcastInDimOpNotActuallyDynamic final
     : OpRewritePattern<mlir::stablehlo::DynamicBroadcastInDimOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DynamicBroadcastInDimOp op,
                                 PatternRewriter &rewriter) const override {
@@ -666,7 +666,7 @@ struct DynamicBroadcastInDimOpNotActuallyDynamic final
 
 struct ChainedDynamicBroadcastInDimCanonicalization final
     : OpRewritePattern<mlir::stablehlo::DynamicBroadcastInDimOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DynamicBroadcastInDimOp bcast,
                                 PatternRewriter &rewriter) const override {
@@ -694,7 +694,7 @@ struct ChainedDynamicBroadcastInDimCanonicalization final
 // the dynamic broadcast with a cast.
 struct DynamicBroadcastInDimAllDimsNonExpanding final
     : OpRewritePattern<mlir::stablehlo::DynamicBroadcastInDimOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DynamicBroadcastInDimOp op,
                                 PatternRewriter &rewriter) const override {
@@ -717,7 +717,7 @@ struct DynamicBroadcastInDimAllDimsNonExpanding final
 };
 
 struct NoopReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ReduceOp op,
                                 PatternRewriter &rewriter) const override {
@@ -747,7 +747,7 @@ struct NoopReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
 };
 
 struct EmptyReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ReduceOp op,
                                 PatternRewriter &rewriter) const override {
@@ -793,7 +793,7 @@ struct EmptyReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
 
 struct DynamicReshapeOpCanon final
     : OpRewritePattern<mlir::stablehlo::DynamicReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DynamicReshapeOp op,
                                 PatternRewriter &rewriter) const override {
@@ -810,7 +810,7 @@ struct DynamicReshapeOpCanon final
 
 struct GetTupleElementOpCanon final
     : OpRewritePattern<mlir::stablehlo::GetTupleElementOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::GetTupleElementOp op,
                                 PatternRewriter &rewriter) const override {
@@ -826,7 +826,7 @@ struct GetTupleElementOpCanon final
 };
 
 struct RealOpCanon final : OpRewritePattern<mlir::stablehlo::RealOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::RealOp op,
                                 PatternRewriter &rewriter) const override {
@@ -840,7 +840,7 @@ struct RealOpCanon final : OpRewritePattern<mlir::stablehlo::RealOp> {
 };
 
 struct ImagOpCanon final : OpRewritePattern<mlir::stablehlo::ImagOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ImagOp op,
                                 PatternRewriter &rewriter) const override {
@@ -855,7 +855,7 @@ struct ImagOpCanon final : OpRewritePattern<mlir::stablehlo::ImagOp> {
 
 struct GetDimensionSizeOpCanon final
     : OpRewritePattern<mlir::stablehlo::GetDimensionSizeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp op,
                                 PatternRewriter &rewriter) const override {
@@ -879,7 +879,7 @@ struct GetDimensionSizeOpCanon final
 /// Converts gather ops to slice ops in case we have a single set of constant
 /// indices.
 struct GatherOpCanon final : OpRewritePattern<mlir::stablehlo::GatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::GatherOp gather,
                                 PatternRewriter &rewriter) const override {
@@ -953,7 +953,7 @@ struct GatherOpCanon final : OpRewritePattern<mlir::stablehlo::GatherOp> {
 };
 
 struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {
@@ -986,7 +986,7 @@ struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
 
 struct MergeConsecutiveReshapes final
     : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1011,7 +1011,7 @@ struct MergeConsecutiveReshapes final
 
 struct TransposeIsReshape final
     : OpRewritePattern<mlir::stablehlo::TransposeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::TransposeOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
@@ -147,7 +147,7 @@ Value processDotArg(Value arg, Location loc, ArrayRef<int64_t> contractDimsAttr,
 
 struct GeneralDotRemoveBatch final
     : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
                                 PatternRewriter &rewriter) const override {
@@ -211,7 +211,7 @@ struct GeneralDotRemoveBatch final
 
 struct GeneralDotConvert final
     : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   // Attempts to lower a General Dot operator to a standard Dot operator.
   // General dots include batching dimensions and can have collapsing
   // dimensions along any axis. Inserting correctly arrange transpose and
@@ -382,7 +382,7 @@ struct GeneralDotConvert final
 };
 
 struct DotVectorOptimization final : OpRewritePattern<mlir::stablehlo::DotOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::stablehlo::DotOp op,
                                 PatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/EinsumToDotGeneral.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/EinsumToDotGeneral.cpp
@@ -21,7 +21,7 @@ namespace {
 
 struct EinsumToDotGeneralPattern final
     : OpRewritePattern<mlir::stablehlo::EinsumOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::EinsumOp einsum,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
@@ -123,7 +123,7 @@ LogicalResult untupleAndLookupValues(T values,
 }
 
 class DetupleReturnOp : public OpRewritePattern<func::ReturnOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(func::ReturnOp op,
                                 PatternRewriter &builder) const override {
@@ -143,7 +143,7 @@ class DetupleReturnOp : public OpRewritePattern<func::ReturnOp> {
 };
 
 class DetupleCallOp : public OpRewritePattern<func::CallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(func::CallOp oldOp,
                                 PatternRewriter &builder) const override {
@@ -176,7 +176,7 @@ class DetupleCallOp : public OpRewritePattern<func::CallOp> {
 };
 
 class DetupleIndirectCallOp : public OpRewritePattern<func::CallIndirectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(func::CallIndirectOp oldOp,
                                 PatternRewriter &builder) const override {
@@ -198,7 +198,7 @@ class DetupleIndirectCallOp : public OpRewritePattern<func::CallIndirectOp> {
 };
 
 class DetupleBranchOp : public OpRewritePattern<cf::BranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(cf::BranchOp oldOp,
                                 PatternRewriter &builder) const override {
@@ -221,7 +221,7 @@ class DetupleBranchOp : public OpRewritePattern<cf::BranchOp> {
 };
 
 class DetupleConditionOp : public OpRewritePattern<cf::CondBranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(cf::CondBranchOp oldOp,
                                 PatternRewriter &builder) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
@@ -100,7 +100,7 @@ void DetupleRegion(Region &srcRegion, Region &destRegion, ArrayRef<Type> types,
 }
 
 class DetupleYieldOp : public OpRewritePattern<scf::YieldOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::scf::YieldOp op,
                                 PatternRewriter &rewriter) const override {
@@ -123,7 +123,7 @@ class DetupleYieldOp : public OpRewritePattern<scf::YieldOp> {
 };
 
 class DetupleConditionOp : public OpRewritePattern<scf::ConditionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::scf::ConditionOp op,
                                 PatternRewriter &rewriter) const override {
@@ -147,7 +147,7 @@ class DetupleConditionOp : public OpRewritePattern<scf::ConditionOp> {
 };
 
 class DetupleIfOp : public OpRewritePattern<scf::IfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::scf::IfOp op,
                                 PatternRewriter &rewriter) const override {
@@ -190,7 +190,7 @@ class DetupleIfOp : public OpRewritePattern<scf::IfOp> {
 };
 
 class DetupleWhileOp : public OpRewritePattern<scf::WhileOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::scf::WhileOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
@@ -21,7 +21,7 @@ namespace mlir::iree_compiler::stablehlo {
 namespace {
 struct GatherIsTorchIndexSelectPattern final
     : OpRewritePattern<mlir::stablehlo::GatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::GatherOp gather,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/LowerComplex.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/LowerComplex.cpp
@@ -22,7 +22,7 @@ namespace mlir::iree_compiler::stablehlo {
 namespace {
 
 struct ConvertComplexDot final : OpRewritePattern<mlir::stablehlo::DotOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   // Will decompose stablehlo::DotOp with complex parameters down to
   // four Dot operations in the following fashion:

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -56,7 +56,7 @@ Value getF32Const(ImplicitLocOpBuilder b, ArrayRef<int64_t> shapes,
 // dim.
 struct ReorderConvOpInputDimensions final
     : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
                                 PatternRewriter &rewriter) const override {
@@ -117,7 +117,7 @@ struct ReorderConvOpInputDimensions final
 
 struct ReorderConvOpKernelDimensions final
     : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
                                 PatternRewriter &rewriter) const override {
     auto kernel = op.getRhs();
@@ -185,7 +185,7 @@ struct ReorderConvOpKernelDimensions final
 // dim.
 struct ReorderConvOpOutputDimensions final
     : OpRewritePattern<mlir::stablehlo::ConvolutionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
                                 PatternRewriter &rewriter) const override {
@@ -270,7 +270,7 @@ bool isConsecutive(ArrayRef<int64_t> array) {
 /// generate a rank-3 dot_general op.
 struct TransposeReshapeGenericDotGeneral final
     : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   Value TransposeIfNonConsecutive(OpBuilder &b, Location loc, Value src,
                                   ArrayRef<int64_t> targetOrder) const {
@@ -449,7 +449,7 @@ struct TransposeReshapeGenericDotGeneral final
 
 struct ScatterInt64Indices final
     : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
@@ -493,7 +493,7 @@ struct ScatterInt64Indices final
 // an explicit dim.
 struct ScatterImplicitIndex final
     : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
@@ -537,7 +537,7 @@ struct ScatterImplicitIndex final
 
 struct ScatterImplicitBatch final
     : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   static Value addUnitBatchDim(Location loc, Value value,
                                PatternRewriter &rewriter) {
@@ -620,7 +620,7 @@ struct ScatterImplicitBatch final
 
 struct ScatterCollapseBatch final
     : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   static Value collapseBatchDims(Location loc, Value value, int64_t batchCount,
                                  PatternRewriter &rewriter) {
@@ -722,7 +722,7 @@ struct ScatterCollapseBatch final
 // Ensure the batch dimensions of both the indices and updates are the first
 // dimensions. If they are not, transpose them to the start.
 struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
@@ -852,7 +852,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
 //  return %0 : tensor<5x4x1xi32>
 struct ScatterMaterializeInsertedDim final
     : OpRewritePattern<mlir::stablehlo::ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
@@ -993,7 +993,7 @@ bool isFromBool(Value val) {
 // Mul of non-finite values (e.g. NaN, inf) and 0.0 produce 0.0 in StableHLO.
 // For linalg we need to convert these to select operations.
 struct MulCastOfBool final : OpRewritePattern<mlir::stablehlo::MulOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::MulOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1048,7 +1048,7 @@ struct MulCastOfBool final : OpRewritePattern<mlir::stablehlo::MulOp> {
 // Generates Gaussian noise with uniform random generator based on Box-Muller
 // transform.
 struct ExpandRngNormal final : OpRewritePattern<mlir::stablehlo::RngOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::RngOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1253,7 +1253,7 @@ struct FuseWidenOperands final : OpRewritePattern<Op> {
 };
 
 struct DotToMul final : OpRewritePattern<mlir::stablehlo::DotOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DotOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1327,7 +1327,7 @@ struct DotToMul final : OpRewritePattern<mlir::stablehlo::DotOp> {
 // number of i32 outputs, then BitcastConvert to return f32.
 struct RngBitcastFloat final
     : OpRewritePattern<mlir::stablehlo::RngBitGeneratorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::RngBitGeneratorOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1362,7 +1362,7 @@ struct RngBitcastFloat final
 };
 
 struct ZeroConcat final : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConcatenateOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1396,7 +1396,7 @@ struct ZeroConcat final : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
 // can be represented using a mul operation. This includes possibly making
 // an implicit cast explicit prior the mul.
 struct DotGeneralIsMul final : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1555,7 +1555,7 @@ struct DotGeneralIsMul final : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
 // TODO(suderman): Move this to solve code.
 struct CustomCallIsTopK final
     : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::CustomCallOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1691,7 +1691,7 @@ bool isIotaOrIotaBroadcast(PatternRewriter &rewriter, Value input) {
 }
 
 struct IotaSortSliceIsTopK final : OpRewritePattern<mlir::stablehlo::SortOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::SortOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1775,7 +1775,7 @@ struct IotaSortSliceIsTopK final : OpRewritePattern<mlir::stablehlo::SortOp> {
 
 // TODO(suderman): Move this to solve code.
 struct ApproxTopK final : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::CustomCallOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
@@ -233,7 +233,7 @@ Value calculateReduceSize(Operation *op, Value operand,
 //    ((X - E[X]) / Sqrt(Var[X] + epsilon)) * scale + offset.
 struct UnfuseBatchNormTrainingPattern final
     : OpRewritePattern<mlir::stablehlo::BatchNormTrainingOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::BatchNormTrainingOp bnOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
@@ -150,7 +150,7 @@ static Value computeHouseholderSlice(Value matrix, Value tau, Value k,
 
 struct HouseholderReflectorRewriter final
     : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
-  using OpRewritePattern<mlir::stablehlo::CustomCallOp>::OpRewritePattern;
+  using Base::Base;
   using OpAdaptor = mlir::stablehlo::CustomCallOp::Adaptor;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::CustomCallOp op,
@@ -225,7 +225,7 @@ struct HouseholderReflectorRewriter final
 
 struct ShapeAssertionDrop final
     : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
-  using OpRewritePattern<mlir::stablehlo::CustomCallOp>::OpRewritePattern;
+  using Base::Base;
   using OpAdaptor = mlir::stablehlo::CustomCallOp::Adaptor;
 
   LogicalResult matchAndRewrite(mlir::stablehlo::CustomCallOp op,

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -30,7 +30,7 @@ namespace {
 // for each update.
 class ScatterConversion : public OpRewritePattern<tosa::ScatterOp> {
 public:
-  using OpRewritePattern<tosa::ScatterOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tosa::ScatterOp op,
                                 PatternRewriter &rewriter) const final {

--- a/compiler/plugins/input/Torch/InputConversion/BitCastTensor.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BitCastTensor.cpp
@@ -25,7 +25,7 @@ namespace {
 class BitCastViewDtype
     : public OpRewritePattern<torch::Torch::AtenViewDtypeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(torch::Torch::AtenViewDtypeOp op,
                                 PatternRewriter &rewriter) const override {
 
@@ -119,7 +119,7 @@ public:
 
 class BitCastMatmul : public OpRewritePattern<torch::Torch::OperatorOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(torch::Torch::OperatorOp op,
                                 PatternRewriter &rewriter) const override {
     // Check for group quantized matrix multiplications.

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -47,7 +47,7 @@ struct TMTensorOpConversion : public OpRewritePattern<SrcOpTy> {
 
 struct ScatterOpConversion
     : public OpRewritePattern<mlir::torch::TMTensor::ScatterOp> {
-  using OpRewritePattern<mlir::torch::TMTensor::ScatterOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::torch::TMTensor::ScatterOp op,
                                 PatternRewriter &rewriter) const override {
     auto indicesTy = op.getIndicesType();
@@ -119,7 +119,7 @@ static SmallVector<AffineMap> getStandardAttentionIndexingMaps(MLIRContext *ctx,
 
 struct AttentionOpConversion
     : public OpRewritePattern<mlir::torch::TMTensor::AttentionOp> {
-  using OpRewritePattern<mlir::torch::TMTensor::AttentionOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::torch::TMTensor::AttentionOp op,
                                 PatternRewriter &rewriter) const override {
     MLIRContext *ctx = getContext();

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTorchUnstructuredToLinalgExt.cpp
@@ -23,7 +23,7 @@ namespace {
 
 struct FftRfftOpConversion
     : public OpRewritePattern<torch::Torch::AtenFftRfftOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(torch::Torch::AtenFftRfftOp op,
                                 PatternRewriter &rewriter) const override {
 

--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -38,7 +38,7 @@ namespace {
 
 struct RemoveOptimizationBarrier final
     : public OpRewritePattern<IREE::Util::OptimizationBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Util::OptimizationBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename CastOpTy>
 struct BubbleUpAcrossCastOp
     : public OpRewritePattern<IREE::TensorExt::DispatchWorkloadOrdinalOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::TensorExt::DispatchWorkloadOrdinalOp ordinalOp,
                   PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -171,7 +171,7 @@ dropBatchTileSize(IREE::CPU::LoweringConfigAttr config) {
 /// Pattern to convert linalg.batch_mmt4d with batch dim = 1 into mmt4d.
 struct ConvertBatchMmt4DtoMmt4DPattern
     : public OpRewritePattern<linalg::BatchMmt4DOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::BatchMmt4DOp op,
                                 PatternRewriter &rewriter) const override {
@@ -250,7 +250,7 @@ struct ConvertBatchMmt4DtoMmt4DPattern
 };
 
 struct Convert3DPackto2DPackPattern : public OpRewritePattern<linalg::PackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::PackOp packOp,
                                 PatternRewriter &rewriter) const override {
@@ -320,7 +320,7 @@ struct Convert3DPackto2DPackPattern : public OpRewritePattern<linalg::PackOp> {
 
 struct Convert5DUnPackto4DUnPackPattern
     : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::UnPackOp unpackOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
@@ -34,7 +34,7 @@ namespace {
 /// not common in practice, so it is not supported now.
 struct SinkDownCollapsingUnitDimsAcrossUnpack final
     : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::UnPackOp op,
                                 PatternRewriter &rewriter) const override {
     if (!isIdentityPermutation(op.getOuterDimsPerm())) {

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -47,7 +47,7 @@ namespace {
 /// Concretizes tensor.pad op's result shape if its source op implements
 /// OffsetSizeAndStrideOpInterface. For example, pad(extract_slice).
 struct ConcretizePadResultShape final : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -564,7 +564,7 @@ struct RemoveCstOutsDependency
 /// This is a workaround for #11273 while a proper fix lands.
 struct SwitchStoreOfIfResultValue
     : public OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
@@ -29,7 +29,7 @@ using iree_compiler::IREE::LinalgExt::IREELinalgExtDialect;
 /// to set the configuration.
 /// TODO(Max191): Use a funcOp walk instead of a pattern for this.
 struct SetIGEMMConfiguration final : OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   SetIGEMMConfiguration(MLIRContext *context, IGEMMConfigFn configFn)
       : OpRewritePattern(context), configFn(configFn) {}

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -46,7 +46,7 @@ namespace {
 /// A wrapper pattern that calls linalg::lowerPack on linalg::PackOp. It lowers
 /// a linalg.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
 struct LowerPackPattern : public OpRewritePattern<linalg::PackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   explicit LowerPackPattern(MLIRContext *context,
                             std::optional<PackUnPackControlFn> controlFn)
@@ -79,7 +79,7 @@ private:
 /// lowers a linalg.unpack op to tensor.empty + linalg.transpose +
 /// tensor.collapse_shape + tensor.extract_slice ops.
 struct LowerUnPackPattern : public OpRewritePattern<linalg::UnPackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   explicit LowerUnPackPattern(MLIRContext *context,
                               std::optional<PackUnPackControlFn> controlFn)

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
@@ -28,7 +28,7 @@ static bool isScalarOrTensorOfSizeOne(Type t) {
 }
 
 struct FuseElementWiseGenericOps : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
@@ -31,7 +31,7 @@ static Value evalErfPolynomial(Value x, Value t, ArrayRef<Value> coeffs,
 // (from
 // https://github.com/ROCm/llvm-project/blob/amd-staging/amd/device-libs/ocml/src/erfF.cl#L11)
 struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(math::ErfOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -728,7 +728,7 @@ struct FoldAssumeAlignOp
 
 /// Removes memref.cast that turns static shapes into dynamic shapes.
 struct RemoveDynamicCastOp final : public OpRewritePattern<memref::CastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::CastOp castOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefs.cpp
@@ -296,7 +296,7 @@ struct FlattenVectorTransferWrite
 };
 
 struct FlattenSubview : public OpRewritePattern<memref::SubViewOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::SubViewOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
@@ -82,7 +82,7 @@ namespace {
 /// bound so that we can replace them with the tight bound.
 struct FoldAffineMinOverDistributedLoopInductionVariable final
     : public OpRewritePattern<affine::AffineMinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(affine::AffineMinOp minOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
@@ -53,7 +53,7 @@ namespace {
 class FoldExtractSliceIntoTransferRead final
     : public OpRewritePattern<vector::TransferReadOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransferReadOp xferOp,
                                 PatternRewriter &rewriter) const override {
@@ -195,7 +195,7 @@ static bool isDestinationFullyOverwritten(vector::TransferWriteOp writeOp) {
 class FoldInsertSliceIntoTransferWrite final
     : public OpRewritePattern<tensor::InsertSliceOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
                                 PatternRewriter &rewriter) const override {
@@ -280,7 +280,7 @@ public:
 class FoldExtractSliceIntoTransferWrite final
     : public OpRewritePattern<tensor::ExtractSliceOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -23,7 +23,7 @@ namespace {
 
 struct CanonicalizeForOpInductionVarShape final
     : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   // Return true if it might be possible to yield the operand of `op` instead of
   // its result.
@@ -200,7 +200,7 @@ struct CanonicalizeForOpInductionVarShape final
 /// pattern allows packing i4/i8/f16 values into i32 variables tightly so that
 /// we can generate shader conformant SPIR-V.
 struct PackForOpInductionVarVector final : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -51,7 +51,7 @@ static Operation *isTriviallyProducedByReadOnlyViewLike(Value input) {
 namespace {
 struct BubbleResourceCastPattern
     : public OpRewritePattern<IREE::GPU::BufferResourceCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::GPU::BufferResourceCastOp castOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
@@ -30,7 +30,7 @@ namespace mlir::iree_compiler {
 
 namespace {
 struct DistributeLoop final : OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   DistributeLoop(MLIRContext *context, bool useBD, PatternBenefit benefit = 1)
       : OpRewritePattern(context, benefit), useBlockDims(useBD) {}

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -91,7 +91,7 @@ static bool forallTripCountMatchesWorkgroupSize(scf::ForallOp forallOp,
   return *maybeTripCount == flatWorkgroupSize;
 }
 struct FuseForalls final : OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   FuseForalls(MLIRContext *ctx, int64_t flatWorkgroupSize, PatternBenefit b = 1)
       : OpRewritePattern<scf::ForallOp>(ctx, b),
         flatWorkgroupSize(flatWorkgroupSize) {}
@@ -136,7 +136,7 @@ private:
 };
 
 struct FuseNestedLaneAndWarpForalls final : OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(scf::ForallOp warpForallOp,
                                 PatternRewriter &rewriter) const override {
@@ -157,7 +157,7 @@ struct FuseNestedLaneAndWarpForalls final : OpRewritePattern<scf::ForallOp> {
 };
 
 struct FuseTilableDestinationProducers final : OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::ForallOp forallOp,
                                 PatternRewriter &rewriter) const override {
     TilingInterface tileableProducer;
@@ -196,7 +196,7 @@ struct FuseTilableDestinationProducers final : OpRewritePattern<scf::ForallOp> {
 };
 
 struct FuseUnitLoopDestination final : OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::ForallOp forallOp,
                                 PatternRewriter &rewriter) const override {
     std::optional<int64_t> maybeTripCount = getStaticForallTripCount(forallOp);
@@ -259,7 +259,7 @@ struct FuseUnitLoopDestination final : OpRewritePattern<scf::ForallOp> {
 
 struct FuseTilableSliceProducers final
     : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     if (sliceOp->use_empty()) {
@@ -292,7 +292,7 @@ struct FuseTilableSliceProducers final
 
 struct FuseCollapseShapeConsumers final
     : OpRewritePattern<tensor::CollapseShapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::CollapseShapeOp collapseOp,
                                 PatternRewriter &rewriter) const override {
     auto forallOp = collapseOp.getSrc().getDefiningOp<scf::ForallOp>();
@@ -310,7 +310,7 @@ struct FuseCollapseShapeConsumers final
 
 struct FuseExtractSliceConsumers final
     : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
                                 PatternRewriter &rewriter) const override {
     // Find the scf::ForallOp producer, and get the corresponding

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -123,7 +123,7 @@ struct ConvertToMultiMma final : OpInterfaceRewritePattern<linalg::LinalgOp> {
 
 // This pattern hoists pack & unpack ops out of scf.for op.
 struct PackDestinationForOp final : OpRewritePattern<scf::YieldOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::YieldOp yieldOp,
                                 PatternRewriter &rewriter) const override {
     Location loc = yieldOp.getLoc();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -44,7 +44,7 @@ namespace {
 ///      : vector<1x16x8xf32> to vector<16x1x8xf32>
 /// ```
 struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransferReadOp transferReadOp,
                                 PatternRewriter &rewriter) const override {
@@ -153,7 +153,7 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
 // MMA types but MMA load can transpose the matrix when loading.
 struct CombineTransferReadOpBroadcast final
     : public OpRewritePattern<vector::BroadcastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::BroadcastOp op,
                                 PatternRewriter &rewriter) const override {
@@ -201,7 +201,7 @@ static LogicalResult contractOpFilter(Operation *op) {
 // The memref descriptor being an SSA value, there is no need to clean it up
 // in any way.
 struct DropSharedMemoryDeallocOp : public OpRewritePattern<memref::DeallocOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::DeallocOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -97,7 +97,7 @@ static bool transposeOpFilter(Operation *op) {
 /// ```
 struct SwapAllocTensorPattern final
     : OpRewritePattern<bufferization::AllocTensorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(bufferization::AllocTensorOp allocOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -151,7 +151,7 @@ static void moveScalarAndBindingUniformCode(gpu::WarpExecuteOnLane0Op warpOp) {
 /// Pattern to convert single element vector.insert to broadcast, this is a
 /// workaround until MultiDimReduction distribution is supported.
 struct InsertToBroadcast final : OpRewritePattern<vector::InsertOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::InsertOp insertOp,
                                 PatternRewriter &rewriter) const override {
@@ -165,7 +165,7 @@ struct InsertToBroadcast final : OpRewritePattern<vector::InsertOp> {
 
 /// Pattern to sink `gpu.barrier` ops out of a `warp_execute_on_lane_0` op.
 struct WarpOpBarrier final : OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(gpu::WarpExecuteOnLane0Op warpOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREECodegenCanonicalizer.cpp
@@ -77,7 +77,7 @@ static bool isTrivialSubViewOp(memref::SubViewOp subviewOp) {
 class DynamicTrivialSubViewOpFolder final
     : public OpRewritePattern<memref::SubViewOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::SubViewOp subViewOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -130,7 +130,7 @@ namespace {
 
 struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     : public OpRewritePattern<memref::ExtractStridedMetadataOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(memref::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
     auto binding =

--- a/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
@@ -18,7 +18,7 @@ namespace mlir::iree_compiler {
 
 namespace {
 struct MemrefCopyOpToLinalg : public OpRewritePattern<memref::CopyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -242,7 +242,7 @@ void moveLoopInvariantCodeFromGenericOps(Operation *op) {
 namespace {
 struct CastLikeExtractSliceOpFolder final
     : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -257,7 +257,7 @@ struct CastLikeExtractSliceOpFolder final
 
 struct CastLikeInsertSliceOpFolder final
     : OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -282,7 +282,7 @@ struct CastLikeInsertSliceOpFolder final
 /// write to memory.
 // TODO: Consider upstreaming
 struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransferReadOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -37,7 +37,7 @@ namespace {
 class TransposeUnitDimToShapeCast
     : public OpRewritePattern<vector::TransposeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransposeOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateConstantOffsets.cpp
@@ -56,7 +56,7 @@ static std::optional<int64_t> getValueConstantRhs(Value v, bool nsw) {
 ///   %x = arith.addi %apply, C overflow<nsw>
 struct ExtractConstantApplyOffset final
     : OpRewritePattern<affine::AffineApplyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(affine::AffineApplyOp apply,
                                 PatternRewriter &rewriter) const override {
@@ -97,7 +97,7 @@ struct ExtractConstantApplyOffset final
 /// to
 ///   %x = affine.apply affine_map<expr(d0 + C)>(%in)
 struct FoldApplySymbolOrDimSum final : OpRewritePattern<affine::AffineApplyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(affine::AffineApplyOp apply,
                                 PatternRewriter &rewriter) const override {
     AffineMap map = apply.getMap();
@@ -148,7 +148,7 @@ struct FoldApplySymbolOrDimSum final : OpRewritePattern<affine::AffineApplyOp> {
 /// if the linearization basis is static.
 struct PropagateConstantAddsThroughLinearize final
     : OpRewritePattern<affine::AffineLinearizeIndexOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(affine::AffineLinearizeIndexOp op,
                                 PatternRewriter &rewriter) const override {
@@ -240,7 +240,7 @@ struct PropagateConstantAddsThroughLinearize final
 ///   %linearize = affine.linearize_index [..., %x, %c0, ...] (..., 4, 4, ...)
 struct FoldDivisibleConstantMulsIntoLinearize final
     : OpRewritePattern<affine::AffineLinearizeIndexOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(affine::AffineLinearizeIndexOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateReshapesByExpansion.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateReshapesByExpansion.cpp
@@ -177,7 +177,7 @@ expandVerifiedUsers(PatternRewriter &rewriter, Location loc, MLIRContext *ctx,
 /// hoisting out collapse_shape op consumed by its parallel.insert_slice op.
 struct ExpandDestinationForallOp final
     : OpRewritePattern<tensor::ParallelInsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ParallelInsertSliceOp parallelInsertOp,
                                 PatternRewriter &rewriter) const override {
     Location loc = parallelInsertOp.getLoc();
@@ -312,7 +312,7 @@ struct ExpandDestinationForallOp final
 /// should be applied later.
 struct SwapInnerBitcastWithExtractSlice
     : OpRewritePattern<IREE::TensorExt::BitCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -36,7 +36,7 @@ static bool hasDirectWriteResult(Operation *op) {
 /// `flow.dispatch.region`.
 struct RematerializeParallelOpsPattern
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -89,7 +89,7 @@ inferCollapsedShape(RewriterBase &rewriter, Location loc,
 ///       tensor<864xf32>
 struct FoldCollapseShapeIntoInterfaceTensorLoad
     : OpRewritePattern<tensor::CollapseShapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::CollapseShapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
@@ -165,7 +165,7 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
 ///       tensor<864xf32>
 struct FoldExpandShapeIntoInterfaceTensorLoad
     : OpRewritePattern<tensor::ExpandShapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
@@ -819,7 +819,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
 /// the source hal.interface.binding.subspan
 struct FoldInnerBitcastIntoInterfaceTensorLoad
     : OpRewritePattern<IREE::TensorExt::BitCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::TensorExt::BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const override {
@@ -1031,7 +1031,7 @@ expandMemrefOperand(RewriterBase &rewriter, OpTy tensorToMemrefOp,
 /// tensor operand with the source of the expand_shape.
 struct FoldExpandShapeIntoStoreToBuffer
     : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1055,7 +1055,7 @@ struct FoldExpandShapeIntoStoreToBuffer
 /// tensor operand with the source of the collapse_shape.
 struct FoldCollapseShapeIntoStoreToBuffer
     : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1083,7 +1083,7 @@ struct FoldCollapseShapeIntoStoreToBuffer
 /// the collapse_shape with the collapsed load_from_buffer op.
 struct FoldCollapseShapeIntoLoadFromBuffer
     : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
@@ -1112,7 +1112,7 @@ struct FoldCollapseShapeIntoLoadFromBuffer
 /// expand_shape with the expanded load_from_buffer op.
 struct FoldExpandShapeIntoLoadFromBuffer
     : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -58,7 +58,7 @@ struct StripLinalgOpCompilationInfo final
 
 struct StripAttentionOpCompilationInfo final
     : OpRewritePattern<IREE::LinalgExt::AttentionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::AttentionOp attentionOp,
                                 PatternRewriter &rewriter) const override {
     if (getCompilationInfo(attentionOp)) {

--- a/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
@@ -78,7 +78,7 @@ namespace {
 /// ```
 struct VectorizePadWithConditions final
     : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -566,7 +566,7 @@ namespace {
 /// slice.
 struct SwapExtractSliceWithDispatchTensorLoad
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -597,7 +597,7 @@ struct SwapExtractSliceWithDispatchTensorLoad
 /// `empty` of the slice.
 struct SwapExtractSliceWithTensorEmpty
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -851,7 +851,7 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
 namespace {
 /// Pattern to rewrite tensor.empty to tensor.alloc.
 struct EmptyTensorLoweringPattern : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::EmptyOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -139,7 +139,7 @@ namespace {
 
 struct FoldRelayoutOpIntoMapScatterPattern
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
@@ -160,7 +160,7 @@ struct FoldRelayoutOpIntoMapScatterPattern
 
 struct FoldPadOpIntoMapScatterPattern
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   FoldPadOpIntoMapScatterPattern(MLIRContext *context,
                                  PadDistributionConfigFn configFn,
                                  PatternBenefit benefit = 1)
@@ -353,7 +353,7 @@ namespace {
 
 struct SwapExpandShapeWithSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -698,7 +698,7 @@ namespace {
 
 struct SwapCollapseShapeWithSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
@@ -18,7 +18,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct ConvertLinalgCopyToMemrefCopy final : OpRewritePattern<linalg::CopyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
     if (copyOp.hasPureTensorSemantics()) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -144,7 +144,7 @@ static RankedTensorType getMaximumStaticType(tensor::CastOp castOp) {
 
 struct FoldBufferCastOfTensorCast final
     : OpRewritePattern<BufferResourceCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(BufferResourceCastOp castOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -98,7 +98,7 @@ combineBarrierRegionPair(RewriterBase &rewriter,
 
 struct CombineAdjacentBarrierRegions final
     : OpRewritePattern<IREE::GPU::BarrierRegionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::GPU::BarrierRegionOp barrierOp,
                                 PatternRewriter &rewriter) const override {
     auto prevBarrier = llvm::dyn_cast_if_present<IREE::GPU::BarrierRegionOp>(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ExpandUndistributedInnerTiles.cpp
@@ -101,7 +101,7 @@ static LogicalResult materializeOperandExpandedShape(
 
 namespace {
 struct ExpandInnerTileShapes final : OpRewritePattern<Codegen::InnerTiledOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   ExpandInnerTileShapes(MLIRContext *context, bool expandInputs,
                         bool expandOutputs)

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -950,7 +950,7 @@ fuseExtractSliceIntoProducerForall(RewriterBase &rewriter,
 namespace {
 struct LowerInnerTiledPattern
     : public OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     if (tiledOp.hasTensorSemantics()) {
@@ -1425,7 +1425,7 @@ distributeInnerTiledOp(RewriterBase &rewriter,
 namespace {
 struct DropInnerTiledUnitDimsPattern
     : public OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     if (tiledOp.hasTensorSemantics()) {
@@ -1785,7 +1785,7 @@ void mapLaneForalls(RewriterBase &rewriter, Operation *funcOp,
 namespace {
 struct LowerBarrierRegion
     : public OpRewritePattern<IREE::GPU::BarrierRegionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::GPU::BarrierRegionOp barrierRegionOp,
                                 PatternRewriter &rewriter) const final {
     Location loc = barrierRegionOp.getLoc();
@@ -1876,7 +1876,7 @@ vectorizeStaticInnerTiledOp(RewriterBase &rewriter,
 namespace {
 struct VectorizeStaticInnerTiledOpPattern final
     : OpRewritePattern<IREE::Codegen::InnerTiledOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
                                 PatternRewriter &rewriter) const override {
     return vectorizeStaticInnerTiledOp(rewriter, tiledOp);
@@ -1895,7 +1895,7 @@ void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns) {
 namespace {
 struct LowerValueBarrierPattern
     : public OpRewritePattern<IREE::GPU::ValueBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::GPU::ValueBarrierOp barrier,
                                 PatternRewriter &rewriter) const override {
     if (barrier.hasTensorSemantics()) {
@@ -1912,7 +1912,7 @@ struct LowerValueBarrierPattern
 
 struct LowerGlobalLoadDMAPattern
     : public OpRewritePattern<IREE::GPU::GlobalLoadDMAOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::GPU::GlobalLoadDMAOp dmaOp,
                                 PatternRewriter &rewriter) const override {
     Type transferType = rewriter.getI32Type();

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -591,7 +591,7 @@ OpFoldResult TransferGatherOp::fold(FoldAdaptor adaptor) {
 }
 
 struct FoldSingleElementIndexVec final : OpRewritePattern<TransferGatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(TransferGatherOp xferOp,
                                 PatternRewriter &rewriter) const override {
@@ -632,7 +632,7 @@ struct FoldSingleElementIndexVec final : OpRewritePattern<TransferGatherOp> {
 
 struct FoldContigousGatherToTransferRead final
     : OpRewritePattern<TransferGatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(TransferGatherOp xferOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
@@ -19,7 +19,7 @@ namespace {
 
 struct DropToLayoutUnitDims final
     : OpRewritePattern<IREE::VectorExt::ToLayoutOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::VectorExt::ToLayoutOp toLayoutOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -27,7 +27,7 @@ namespace {
 
 struct VectorizeToLayoutOpPattern final
     : OpRewritePattern<IREE::VectorExt::ToLayoutOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   vector::TransferReadOp
   createReadOp(PatternRewriter &rewriter,
@@ -593,7 +593,7 @@ vectorizeLinalgExtGatherToTransferGather(RewriterBase &rewriter,
 /// but this is done this way to match upstream vector.transfer_read masking.
 struct MaskedTransferGatherOpPattern : public OpRewritePattern<vector::MaskOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::MaskOp maskOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -887,7 +887,7 @@ struct RewriteExternCallOpToDynamicImportCallOp
 /// vectorized.
 class ExpandMulSIExtended : public OpRewritePattern<arith::MulSIExtendedOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::MulSIExtendedOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -21,7 +21,7 @@ namespace {
 // TODO(ataei): Upstream this pattern if needed ?
 class UnfusedFMAOpsPassConversion : public OpRewritePattern<LLVM::FMAOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(LLVM::FMAOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -1020,7 +1020,7 @@ public:
 struct MMT_8x4x8_i8i8i32_Aarch64Dotprod_Intrinsics
     : public OpRewritePattern<vector::ContractionOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::ContractionOp contractionOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -147,7 +147,7 @@ struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
 };
 
 struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::AllocOp allocOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -59,7 +59,7 @@ namespace {
 // operations as well.
 struct ReplaceGPUBarrierWithLDSBarrier
     : public OpRewritePattern<gpu::BarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(gpu::BarrierOp op,
                                 PatternRewriter &rewriter) const override {
@@ -101,7 +101,7 @@ static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns,
 /// effort.
 constexpr StringLiteral kSwapName = "iree_gpu.swap_mfma";
 struct SwapSetPrioWithMFMA : public OpRewritePattern<ROCDL::SetPrioOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ROCDL::SetPrioOp setPrio,
                                 PatternRewriter &rewriter) const override {
     if (!setPrio->hasAttr(kSwapName)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -28,7 +28,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct UpcastContractOutput final : OpRewritePattern<vector::ContractionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -97,7 +97,7 @@ struct PromoteContractOperands final
 /// upstream does not have a mechanism of registering canonicalization without
 /// adding dependencies like this, we manually add it where it is needed.
 struct FoldI1SelectToBroadcast final : OpRewritePattern<arith::SelectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::SelectOp selectOp,
                                 PatternRewriter &rewriter) const override {
@@ -147,7 +147,7 @@ struct FoldI1SelectToBroadcast final : OpRewritePattern<arith::SelectOp> {
 // Set FMF to fold arith.mulf + arith.addf -> math.fma and thus enable
 // optimizations w.r.t vector.multi_reduction(fma).
 struct SetMulAddFMF final : OpRewritePattern<vector::MultiDimReductionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::MultiDimReductionOp redOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -410,7 +410,7 @@ namespace {
 /// gpu.synchronize
 /// %0 = memref.load %src[%c0] : memref<1024xf32>
 struct WarpOpLoad : public OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(gpu::WarpExecuteOnLane0Op warpOp,
                                 PatternRewriter &rewriter) const override {
     OpOperand *operand = getWarpResult(warpOp, llvm::IsaPred<memref::LoadOp>);
@@ -455,7 +455,7 @@ struct WarpOpLoad : public OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
 /// really have the semantic of global variables. Therefore hoisting them is
 /// always correct for static allocations.
 struct HoistSharedMemoryAlloc : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(memref::AllocOp alloc,
                                 PatternRewriter &rewriter) const override {
     if (!iree_compiler::hasSharedMemoryAddressSpace(alloc.getType()))
@@ -1347,7 +1347,7 @@ namespace {
 /// Polygeist.
 class BarrierElimination final : public OpRewritePattern<gpu::BarrierOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(gpu::BarrierOp barrier,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -487,7 +487,7 @@ struct FoldAsNoOp final : OpConversionPattern<OpTy> {
 
 /// Removes memref.cast that converts static and dynamic shapes.
 struct RemoveStaticDynamicCast final : OpRewritePattern<memref::CastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(memref::CastOp castOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
@@ -62,7 +62,7 @@ namespace {
 // stored in memory as [BA, DC, FE, HG], and read as an i32 HGFEDCBA. Therefore
 // the first i4 element is the lest significant 4 bits.
 struct BreakDownCastExtractExtend final : OpRewritePattern<arith::ExtUIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ExtUIOp extOp,
                                 PatternRewriter &rewriter) const override {
     auto extractOp =

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -279,7 +279,7 @@ void populateVectorUnrollPatterns(ArrayRef<int64_t> cooperativeOpSize,
 class CombineContractTranspose final
     : public OpRewritePattern<vector::ContractionOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::ContractionOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -798,7 +798,7 @@ static Value predicateMaybeMaskedScalarTransfer(
 /// if any of the memory access is not vector.
 struct ScalarizeVectorTransferRead final
     : public OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
                                 PatternRewriter &rewriter) const override {
@@ -878,7 +878,7 @@ struct ScalarizeVectorTransferRead final
 };
 
 struct ScalarizeVectorLoad final : public OpRewritePattern<vector::LoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::LoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
@@ -923,7 +923,7 @@ struct ScalarizeVectorLoad final : public OpRewritePattern<vector::LoadOp> {
 
 struct ScalarizeVectorTransferWrite final
     : public OpRewritePattern<vector::TransferWriteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
                                 PatternRewriter &rewriter) const override {
@@ -1007,7 +1007,7 @@ struct ScalarizeVectorTransferWrite final
 /// operations.
 struct ReifyExtractOfCreateMask final
     : public OpRewritePattern<vector::ExtractOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(vector::ExtractOp extractOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -161,7 +161,7 @@ static std::optional<int64_t> foldAffineMin(affine::AffineMinOp minOp) {
 namespace {
 struct AffineMinDistributedSCFCanonicalizationPattern
     : public mlir::OpRewritePattern<mlir::affine::AffineMinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   mlir::LogicalResult
   matchAndRewrite(mlir::affine::AffineMinOp minOp,

--- a/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
@@ -60,7 +60,7 @@ static void replaceForWithIf(PatternRewriter &rewriter, scf::ForOp op,
 namespace {
 /// Rewriting pattern that replaces single-iteration loops with their bodies.
 struct SimplifyTrivialLoops : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(scf::ForOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -573,7 +573,7 @@ static SmallVector<Attribute> appendSplitReductionMappingToWorkgroupMapping(
 // loop also has workgroup mapping.
 struct FoldSplitReductionForallWithWorkgroupForall
     : public OpRewritePattern<scf::ForallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(scf::ForallOp forallOp,
                                 PatternRewriter &rewriter) const override {
@@ -940,7 +940,7 @@ distributeLinalgOpsWithFilter(mlir::FunctionOpInterface funcOp,
 
 namespace {
 struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::ForOp loop,
                                 PatternRewriter &rewriter) const final {
     if (loop.getBody()->getOperations().size() == 1) {
@@ -1253,7 +1253,7 @@ namespace {
 // TODO: atm hardcoded on linalg.fill but we could take any result of any
 // generic that yields a constant in that result.
 struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const final {
     Operation *currentOp = padOp.getSource().getDefiningOp();

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
@@ -524,7 +524,7 @@ struct CopyEmitter {
 /// as a vmvx op.
 struct LinalgBinaryGenericConversion
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     auto &children = op.getBlock()->getOperations();
@@ -704,7 +704,7 @@ struct LinalgBinaryGenericConversion
 /// as a vmvx op.
 struct LinalgUnaryGenericConversion
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     auto &children = op.getBlock()->getOperations();
@@ -827,7 +827,7 @@ struct LinalgUnaryGenericConversion
 /// operation(s).
 struct LinalgTrivialGenericConversion
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     auto &children = op.getBlock()->getOperations();
@@ -866,7 +866,7 @@ struct LinalgTrivialGenericConversion
 };
 
 struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   struct OpInfo {
     linalg::FillOp op;
     Value scalar;

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -30,7 +30,7 @@ namespace {
 /// functionalities for the fill, instead of dispatching kernels.
 struct ConvertLinalgFillPattern final
     : public OpRewritePattern<linalg::FillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::FillOp fillOp,
                                 PatternRewriter &rewriter) const override {
@@ -50,7 +50,7 @@ struct ConvertLinalgFillPattern final
 /// Convert tensor.insert_slice ops into flow.tensor.update ops where possible.
 struct ConvertTensorInsertSlicePattern
     : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
                                 PatternRewriter &rewriter) const override {
     return convertInsertSliceOpToFlowUpdateOp(rewriter, insertOp);
@@ -59,7 +59,7 @@ struct ConvertTensorInsertSlicePattern
 
 /// Convert tensor.insert ops into flow.tensor.store ops where possible.
 struct ConvertTensorInsertPattern : public OpRewritePattern<tensor::InsertOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::InsertOp insertOp,
                                 PatternRewriter &rewriter) const override {
     if (insertOp->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -75,7 +75,7 @@ struct ConvertTensorInsertPattern : public OpRewritePattern<tensor::InsertOp> {
 /// Convert tensor.extract_slice ops into flow.tensor.slice ops where possible.
 struct ConvertTensorExtractSlicePattern
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     return convertExtractSliceOpToFlowSliceOp(rewriter, sliceOp);
@@ -84,7 +84,7 @@ struct ConvertTensorExtractSlicePattern
 
 struct ConvertTensorExtractPattern
     : public OpRewritePattern<tensor::ExtractOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractOp op,
                                 PatternRewriter &rewriter) const override {
@@ -99,7 +99,7 @@ struct ConvertTensorExtractPattern
 
 struct ConvertTensorExtBitcastPattern
     : public OpRewritePattern<TensorExt::BitCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorExt::BitCastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -114,7 +114,7 @@ struct ConvertTensorExtBitcastPattern
 
 struct ConvertTensorBitcastPattern
     : public OpRewritePattern<tensor::BitcastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::BitcastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -130,7 +130,7 @@ struct ConvertTensorBitcastPattern
 };
 
 struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::CastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
@@ -194,7 +194,7 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
 };
 
 struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {
@@ -277,7 +277,7 @@ struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
 
 struct ConvertTensorFromElementsPattern
     : public OpRewritePattern<tensor::FromElementsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::FromElementsOp op,
                                 PatternRewriter &rewriter) const override {
     // TODO: This pattern was mainly added to iron out some kinks specific to
@@ -338,7 +338,7 @@ static SmallVector<Value> getDynamicTensorSizes(OpBuilder &builder,
 /// Convert tensor.reshape ops into flow.tensor.reshape ops where possible.
 struct ConvertTensorDialectReshapeOpPattern
     : public OpRewritePattern<tensor::ReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -205,7 +205,7 @@ dedupAndGetOldToNewPosMapping(ValueRange values) {
 
 struct ReplaceDispatchResultIfZeroElements
     : public OpRewritePattern<DispatchWorkgroupsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
                                 PatternRewriter &rewriter) const override {
     // NOTE: we only look at used results; if unused then closure optimization
@@ -230,7 +230,7 @@ struct ReplaceDispatchResultIfZeroElements
 /// requires modifying the `count` region of the op to match the new workloads.
 struct ElideRedundantWorkloadValues
     : public OpRewritePattern<DispatchWorkgroupsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
                                 PatternRewriter &rewriter) const override {
     ValueRange workload = op.getWorkload();
@@ -293,7 +293,7 @@ struct ElideRedundantWorkloadValues
 /// the operands in the `dispatch.workgroup_count_from_slice`.
 struct ElideRedundantOperandsOfWorkgroupCountFromSliceOp
     : OpRewritePattern<DispatchWorkgroupsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
                                 PatternRewriter &rewriter) const override {
     Region &count = op.getWorkgroupCount();
@@ -387,7 +387,7 @@ namespace {
 
 struct DeduplicateDispatchEntryRefs final
     : public OpRewritePattern<DispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchOp dispatchOp,
                                 PatternRewriter &rewriter) const override {
     auto originalAttr = dispatchOp.getEntryPointsAttr();
@@ -449,7 +449,7 @@ namespace {
 
 struct ExpandDynamicShapeConstant
     : public OpRewritePattern<TensorDynamicConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorDynamicConstantOp op,
                                 PatternRewriter &rewriter) const override {
     auto constantOp = IREE::Flow::TensorConstantOp::create(
@@ -564,7 +564,7 @@ struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
 };
 
 struct ResolveShapedRank : public OpRewritePattern<tensor::RankOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::RankOp op,
                                 PatternRewriter &rewriter) const override {
     auto shapedType = llvm::cast<ShapedType>(op.getTensor().getType());
@@ -575,7 +575,7 @@ struct ResolveShapedRank : public OpRewritePattern<tensor::RankOp> {
 };
 
 struct ResolveShapedDim : public OpRewritePattern<tensor::DimOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::DimOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getConstantIndex().has_value()) {
@@ -675,7 +675,7 @@ namespace {
 // Replace `flow.tensor.splat`-`flow.tensor.load` op-pairs by the input
 // primitive value for the splat op.
 struct FoldSplatLoadIntoPrimitive : public OpRewritePattern<TensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceOp =
@@ -748,7 +748,7 @@ void TensorEmptyOp::getCanonicalizationPatterns(RewritePatternSet &results,
 namespace {
 
 struct FoldSplatReshapeIntoSplat : public OpRewritePattern<TensorReshapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorReshapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
     auto splatOp = dyn_cast_if_present<TensorSplatOp>(
@@ -872,7 +872,7 @@ namespace {
 // control flow edges or globals and is mostly for simplifying IR that may come
 // in with a transfer on every single tensor.
 struct ElideRedundantTransfer : public OpRewritePattern<TensorTransferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorTransferOp op,
                                 PatternRewriter &rewriter) const override {
     auto baseValue =
@@ -892,7 +892,7 @@ struct ElideRedundantTransfer : public OpRewritePattern<TensorTransferOp> {
 // rewrite it as (A -> C). Writes it as A -> B and A -> C relying on dead code
 // elimination to remove the unused A -> B transfer.
 struct ElideIntermediateTransfer final : OpRewritePattern<TensorTransferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorTransferOp targetTransferOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceTransferOp = dyn_cast_if_present<IREE::Flow::TensorTransferOp>(
@@ -1066,7 +1066,7 @@ namespace {
 // When the target tensor is a result of a tensor.cast operation, the op needs
 // to be updated to use the source of the cast as the target tensor.
 struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     auto targetCastOp = updateOp.getTarget().getDefiningOp<tensor::CastOp>();
@@ -1094,7 +1094,7 @@ struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
 
 struct ReplaceOpIfTensorUpdateOperandZeroElements
     : public OpRewritePattern<TensorUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorUpdateOp op,
                                 PatternRewriter &rewriter) const override {
     auto operand = op.getUpdate();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -629,7 +629,7 @@ bool dropUnusedAndRedundantDispatchRegionResults(
 
 struct DispatchRegionDropUnusedResults
     : public OpRewritePattern<DispatchRegionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(DispatchRegionOp regionOp,
                                 PatternRewriter &rewriter) const final {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalize.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalize.cpp
@@ -35,7 +35,7 @@ static std::optional<SmallVector<OpFoldResult>> getDefiningMixedSizes(Value v) {
 }
 
 struct FoldFullInsertSlice : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertSliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -87,7 +87,7 @@ struct FoldFullInsertSlice : public OpRewritePattern<tensor::InsertSliceOp> {
 /// Convert an "affine.apply" operation into a sequence of arith ops.
 class AffineApplyLowering : public OpRewritePattern<affine::AffineApplyOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(affine::AffineApplyOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -43,7 +43,7 @@ namespace {
 
 /// Converts an tensor.empty() op to `flow.tensor.splat` op.
 struct RewriteTensorEmptyToSplat : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::EmptyOp emptyTensorOp,
                                 PatternRewriter &rewriter) const override {
     if (!shouldBeConvertedToFlowTensorOp(emptyTensorOp)) {
@@ -67,7 +67,7 @@ struct RewriteTensorEmptyToSplat : public OpRewritePattern<tensor::EmptyOp> {
 
 /// Converts an tensor.empty() op to `flow.tensor.empty` op.
 struct RewriteTensorEmptyToEmpty : public OpRewritePattern<tensor::EmptyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::EmptyOp emptyTensorOp,
                                 PatternRewriter &rewriter) const override {
     if (!shouldBeConvertedToFlowTensorOp(emptyTensorOp)) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -76,7 +76,7 @@ namespace {
 /// Deduplicates hal.tensor.barrier operands.
 struct DeduplicateTensorBarrierSources
     : public OpRewritePattern<TensorBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorBarrierOp op,
                                 PatternRewriter &rewriter) const override {
     DenseMap<Value, unsigned> uniqueSources; // source -> unique index
@@ -121,7 +121,7 @@ namespace {
 /// Tries to fold either the device or queue affinity of a select when all
 /// potential values of either match.
 struct FoldAllocatorSelect : public OpRewritePattern<AllocatorSelectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AllocatorSelectOp op,
                                 PatternRewriter &rewriter) const override {
     // Calculate the unique set of devices and unique set of queue affinities.
@@ -174,7 +174,7 @@ namespace {
 /// Folds hal.buffer.subspans into buffer view creation subspans.
 struct FoldBufferViewCreateSubspan
     : public OpRewritePattern<BufferViewCreateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferViewCreateOp op,
                                 PatternRewriter &rewriter) const override {
     auto ip = rewriter.saveInsertionPoint();
@@ -236,7 +236,7 @@ namespace {
 /// the same scope.
 struct SkipCommandBufferDeviceOp
     : public OpRewritePattern<CommandBufferDeviceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(CommandBufferDeviceOp op,
                                 PatternRewriter &rewriter) const override {
@@ -261,7 +261,7 @@ namespace {
 /// Folds hal.buffer.subspans into buffer fill offsets.
 struct FoldCommandBufferFillBufferSubspans
     : public OpRewritePattern<CommandBufferFillBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(CommandBufferFillBufferOp op,
                                 PatternRewriter &rewriter) const override {
@@ -301,7 +301,7 @@ namespace {
 /// Folds hal.buffer.subspans into buffer update offsets.
 struct FoldCommandBufferUpdateBufferSubspans
     : public OpRewritePattern<CommandBufferUpdateBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(CommandBufferUpdateBufferOp op,
                                 PatternRewriter &rewriter) const override {
@@ -341,7 +341,7 @@ namespace {
 /// Folds hal.buffer.subspans into buffer copy offsets.
 struct FoldCommandBufferCopyBufferSubspans
     : public OpRewritePattern<CommandBufferCopyBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(CommandBufferCopyBufferOp op,
                                 PatternRewriter &rewriter) const override {
@@ -444,7 +444,7 @@ namespace {
 /// The binding range is always equal to or a subset of the subspan.
 struct FoldCommandBufferDispatchIndirectBufferSubspan
     : public OpRewritePattern<CommandBufferDispatchIndirectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(CommandBufferDispatchIndirectOp op,
                                 PatternRewriter &rewriter) const override {
@@ -531,7 +531,7 @@ namespace {
 /// wait fence is immediately resolved (null).
 struct ImmediatelyResolveDeviceQueueBarrier
     : public OpRewritePattern<DeviceQueueBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DeviceQueueBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {
     // Check for whether we know the wait fence is immediately resolved in the
@@ -560,7 +560,7 @@ struct ImmediatelyResolveDeviceQueueBarrier
 ///  hal.device.queue.barrier signal(%fence1)
 struct HoistDeviceQueueBarrierChain
     : public OpRewritePattern<DeviceQueueBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DeviceQueueBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {
     // See if we can observe the original fence creation in the local scope.
@@ -617,7 +617,7 @@ struct HoistDeviceQueueBarrierChain
 ///  hal.device.queue.execute wait(%a) signal(%c) commands(...)
 struct ElideDeviceQueueBarrierOp
     : public OpRewritePattern<DeviceQueueBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DeviceQueueBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {
 
@@ -713,7 +713,7 @@ namespace {
 /// selected. This happens if the condition region is folded using a specialized
 /// target environment that allows for compile-time query evaluation.
 struct DropTrueConditionRegion : public OpRewritePattern<ExecutableExportOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExecutableExportOp exportOp,
                                 PatternRewriter &rewriter) const override {
     auto *block = exportOp.getConditionBody();
@@ -801,7 +801,7 @@ static void rewriteToOneReturn(int numResults, Region &region,
 /// DeduplicateExecutableConstantBlockKeys.
 struct MergeExecutableConstantBlocks
     : public OpRewritePattern<ExecutableVariantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExecutableVariantOp variantOp,
                                 PatternRewriter &rewriter) const override {
     auto blockOps = llvm::to_vector(variantOp.getConstantBlockOps());
@@ -935,7 +935,7 @@ static void filterReturnOperands(ExecutableConstantBlockOp blockOp,
 /// Drops the %device argument of a constant block region if unused.
 struct DropUnusedExecutableConstantBlockDeviceArg
     : public OpRewritePattern<ExecutableConstantBlockOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExecutableConstantBlockOp blockOp,
                                 PatternRewriter &rewriter) const override {
     if (blockOp.getNumArguments() == 0)
@@ -958,7 +958,7 @@ struct DropUnusedExecutableConstantBlockDeviceArg
 /// as users are expected to uniquely name their keys.
 struct DeduplicateExecutableConstantBlockKeys
     : public OpRewritePattern<ExecutableConstantBlockOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExecutableConstantBlockOp blockOp,
                                 PatternRewriter &rewriter) const override {
     // Build a set of preserved result indices (those with unique keys).
@@ -1024,7 +1024,7 @@ namespace {
 
 /// Replaces a fence join with no operands with a null value.
 struct ElideEmptyFenceJoin : public OpRewritePattern<FenceJoinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(FenceJoinOp op,
                                 PatternRewriter &rewriter) const override {
     if (op.getNumOperands() != 0)
@@ -1056,7 +1056,7 @@ deduplicateFenceOperands(ValueRange operands) {
 
 /// Deduplicates fence join operands and drops nulls.
 struct DeduplicateFenceJoinFences : public OpRewritePattern<FenceJoinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(FenceJoinOp op,
                                 PatternRewriter &rewriter) const override {
     auto newOperands = deduplicateFenceOperands(op.getFences());
@@ -1095,7 +1095,7 @@ namespace {
 /// ->
 ///  %fence = util.null : !hal.fence
 struct ElideSignaledFence : public OpRewritePattern<FenceSignalOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(FenceSignalOp signalOp,
                                 PatternRewriter &rewriter) const override {
     auto fence = signalOp.getFence();
@@ -1149,7 +1149,7 @@ namespace {
 
 /// Elides a fence await with no fences.
 struct ElideEmptyFenceAwait : public OpRewritePattern<FenceAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(FenceAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getFences().empty())
@@ -1161,7 +1161,7 @@ struct ElideEmptyFenceAwait : public OpRewritePattern<FenceAwaitOp> {
 
 /// Deduplicates fence await operands and drops nulls.
 struct DeduplicateFenceAwaitFences : public OpRewritePattern<FenceAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(FenceAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     auto newOperands = deduplicateFenceOperands(op.getFences());

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -500,7 +500,7 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
 namespace {
 
 struct ConvertReturnPattern : public OpRewritePattern<IREE::Stream::ReturnOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::ReturnOp op,
                                 PatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<IREE::HAL::ReturnOp>(op, op.getOperands());
@@ -523,7 +523,7 @@ struct ConvertDispatchWorkgroupInfoPattern final
 
 struct InlineConstantWorkgroupSizePattern
     : public OpRewritePattern<IREE::HAL::InterfaceWorkgroupSizeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::HAL::InterfaceWorkgroupSizeOp sizeOp,
                                 PatternRewriter &rewriter) const override {
     // Lookup the entry point matching the parent.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -498,7 +498,7 @@ SmallVector<AffineMap> GatherOp::getIndexingMapsForResults() {
 namespace {
 struct ConvertGatherToExtract
     : public OpRewritePattern<IREE::LinalgExt::GatherOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::GatherOp gatherOp,
                                 PatternRewriter &rewriter) const override {
     // TODO: support memref case.
@@ -740,7 +740,7 @@ bool MapScatterOp::isIdentity() {
 namespace {
 struct ConvertIdentityMapScatterToCopy
     : public OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
     if (!mapScatterOp.isIdentity()) {
@@ -862,7 +862,7 @@ namespace {
 /// functionality.
 struct RemoveUnusedSortOpResults
     : public OpRewritePattern<IREE::LinalgExt::SortOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::SortOp sortOp,
                                 PatternRewriter &rewriter) const override {
     // To avoid problems in dispatches associated with unused results, prune

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -28,7 +28,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 /// be collapsible, because the decomposition will work for collapsable memrefs,
 /// and there is no need to fold the subview.
 struct FoldSubViewIntoMapScatter final : OpRewritePattern<MapScatterOp> {
-  using OpRewritePattern<MapScatterOp>::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
     if (!mapScatterOp.isVectorized()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -112,7 +112,7 @@ struct FoldWinogradOpUnitDims : public OpRewritePattern<TransformOp> {
 /// ````
 struct DecomposeWinogradFilterTransform
     : public OpRewritePattern<WinogradFilterTransformOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(WinogradFilterTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {
@@ -194,7 +194,7 @@ struct DecomposeWinogradFilterTransform
 /// ````
 struct DecomposeWinogradInputTransform
     : public OpRewritePattern<WinogradInputTransformOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(WinogradInputTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {
@@ -277,7 +277,7 @@ struct DecomposeWinogradInputTransform
 /// ````
 struct DecomposeWinogradOutputTransform
     : public OpRewritePattern<WinogradOutputTransformOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(WinogradOutputTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -528,7 +528,7 @@ fuseWithReshapeByExpansion(OpTy op, Operation *reshapeOp,
 namespace {
 
 struct DropScatterUnitIndexDepth final : public OpRewritePattern<ScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ScatterOp scatterOp,
                                 PatternRewriter &rewriter) const override {
     llvm::ArrayRef<int64_t> indicesShape =
@@ -640,7 +640,7 @@ Value rankExpandValue(RewriterBase &rewriter, Location loc, Value destVal,
 }
 
 struct DropMapScatterUnitDims final : public OpRewritePattern<MapScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   DropMapScatterUnitDims(MLIRContext *context,
                          linalg::ControlDropUnitDims options,
                          PatternBenefit benefit = 1)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/VectorizeIREELinalgExtOps.cpp
@@ -20,7 +20,7 @@ namespace {
 
 struct VectorizeStaticMapScatterOpPattern final
     : OpRewritePattern<IREE::LinalgExt::MapScatterOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::LinalgExt::MapScatterOp mapScatterOp,
                                 PatternRewriter &rewriter) const override {
     if (mapScatterOp.isVectorized()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -65,7 +65,7 @@ struct StreamFolderInterface : public DialectFoldInterface {
 //        !stream.resource<transient>, index to !stream.resource<transient>
 struct StripResourceConversionCastPattern
     : public OpRewritePattern<UnrealizedConversionCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(UnrealizedConversionCastOp castOp,
                                 PatternRewriter &rewriter) const override {
     auto result = castOp.getResult(0);

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -515,7 +515,7 @@ namespace {
 // used after deallocations have been inserted but prior to that point this
 // pattern allows for more eager removal of unused allocations.
 struct ElideUnusedAllocaOp : public OpRewritePattern<ResourceAllocaOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceAllocaOp allocaOp,
                                 PatternRewriter &rewriter) const override {
     if (!allocaOp.getResult().use_empty()) {
@@ -540,7 +540,7 @@ struct ElideUnusedAllocaOp : public OpRewritePattern<ResourceAllocaOp> {
 //   %resource, %alloca_t = stream.resource.alloca
 //   %dealloca_t = stream.resource.dealloca await(%alloca_t) %resource
 struct ElideAllocaDeallocaOp : public OpRewritePattern<ResourceAllocaOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceAllocaOp allocaOp,
                                 PatternRewriter &rewriter) const override {
     if (!allocaOp.getResult().hasOneUse()) {
@@ -699,7 +699,7 @@ namespace {
 //  %c = select %cond, %a, %b : !stream.resource<*>
 //  %c_sz = select %cond, %a_sz, %b_sz : index
 struct SelectResourceSizeOp : public OpRewritePattern<ResourceSizeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceSizeOp op,
                                 PatternRewriter &rewriter) const override {
     auto selectOp = op.getOperand().getDefiningOp<mlir::arith::SelectOp>();
@@ -748,7 +748,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  %1 = stream.resource.load %src[%new_offset]
 struct FoldSubviewIntoLoadOp : public OpRewritePattern<ResourceLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getSource());
@@ -793,7 +793,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  stream.resource.store %c123_i32, %dst[%new_offset]
 struct FoldSubviewIntoStoreOp : public OpRewritePattern<ResourceStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceStoreOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getTarget());
@@ -859,7 +859,7 @@ namespace {
 // no impact on the actual packing operation.
 struct PropagateResourcePackBaseOffset
     : public OpRewritePattern<ResourcePackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourcePackOp op,
                                 PatternRewriter &rewriter) const override {
     // Offset is optional.
@@ -907,7 +907,7 @@ struct PropagateResourcePackBaseOffset
 //  }) : index
 struct CanonicalizeResourcePackIntervals
     : public OpRewritePattern<ResourcePackOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourcePackOp op,
                                 PatternRewriter &rewriter) const override {
     // Get the slices in a possibly unsorted order and sort.
@@ -980,7 +980,7 @@ namespace {
 // Folds subview -> subview to point at the original source resource with an
 // updated range.
 struct FoldResourceSubviewOps : public OpRewritePattern<ResourceSubviewOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ResourceSubviewOp op,
                                 PatternRewriter &rewriter) const override {
     auto parentOp = ResourceSubviewOp::findSubviewOp(op.getSource());
@@ -1009,7 +1009,7 @@ struct FoldResourceSubviewOps : public OpRewritePattern<ResourceSubviewOp> {
 //  %subview = stream.resource.subview %src[%offset]
 struct SinkSubviewAcrossSelectOps
     : public OpRewritePattern<mlir::arith::SelectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {
     if (!llvm::isa<IREE::Stream::ResourceType>(op.getType()))
@@ -1051,7 +1051,7 @@ namespace {
 
 struct FoldParameterLoadTargetSubviews
     : public OpRewritePattern<ParameterLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ParameterLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto ip = rewriter.saveInsertionPoint();
@@ -1116,7 +1116,7 @@ namespace {
 
 struct FoldParameterReadTargetSubview
     : public OpRewritePattern<ParameterReadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ParameterReadOp op,
                                 PatternRewriter &rewriter) const override {
     auto ip = rewriter.saveInsertionPoint();
@@ -1169,7 +1169,7 @@ namespace {
 
 struct FoldParameterWriteSourceSubview
     : public OpRewritePattern<ParameterWriteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ParameterWriteOp op,
                                 PatternRewriter &rewriter) const override {
     auto ip = rewriter.saveInsertionPoint();
@@ -1312,7 +1312,7 @@ void TensorExportOp::getCanonicalizationPatterns(RewritePatternSet &results,
 namespace {
 
 struct TensorConstantToEmpty : public OpRewritePattern<TensorConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
     auto shapedType =
@@ -1355,7 +1355,7 @@ struct TensorConstantToEmpty : public OpRewritePattern<TensorConstantOp> {
 };
 
 struct TensorConstantToSplat : public OpRewritePattern<TensorConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
     auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(constantOp.getValue());
@@ -1431,7 +1431,7 @@ namespace {
 
 // Elides clones that don't do anything meaningful (like setting up a tie).
 struct ElideUnneededTensorClones : public OpRewritePattern<TensorCloneOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorCloneOp cloneOp,
                                 PatternRewriter &rewriter) const override {
     if (cloneOp.getType() == cloneOp.getSource().getType() &&
@@ -1561,7 +1561,7 @@ namespace {
 
 struct DeduplicateTensorDispatchEntryRefs final
     : public OpRewritePattern<TensorDispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TensorDispatchOp dispatchOp,
                                 PatternRewriter &rewriter) const override {
     auto originalAttr = dispatchOp.getEntryPointsAttr();
@@ -1670,7 +1670,7 @@ namespace {
 // Converts constants with splat values into splats.
 struct ConvertSplatConstantsIntoSplats
     : public OpRewritePattern<AsyncConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
     auto value = dyn_cast<ElementsAttr>(constantOp.getValue());
@@ -1753,7 +1753,7 @@ namespace {
 // ->
 //  %1 = stream.async.splat %c123_i32 : i32 -> !stream.resource<*>{%c128}
 struct PropagateSplatsThroughSlices : public OpRewritePattern<AsyncSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     auto splatOp =
@@ -1793,7 +1793,7 @@ namespace {
 // ->
 //  %0 = stream.async.splat %cst : f32 -> !stream.resource<*>{%dstsz}
 struct FlattenFullFillToSplat : public OpRewritePattern<AsyncFillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncFillOp fillOp,
                                 PatternRewriter &rewriter) const override {
     if (fillOp.getTargetLength() != fillOp.getTargetSize())
@@ -1823,7 +1823,7 @@ struct FlattenFullFillToSplat : public OpRewritePattern<AsyncFillOp> {
 //  %0 = stream.async.splat %c123
 //  %1 = stream.async.fill %c123, %0[...]
 struct ElideRedundantFill : public OpRewritePattern<AsyncFillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncFillOp fillOp,
                                 PatternRewriter &rewriter) const override {
     auto splatOp = dyn_cast_or_null<IREE::Stream::AsyncSplatOp>(
@@ -1854,7 +1854,7 @@ struct ElideRedundantFill : public OpRewritePattern<AsyncFillOp> {
 // ->
 //  %0 = stream.async.fill %c123, %...[%a to %c for %l0plus1]
 struct CoalesceAdjacentFills : public OpRewritePattern<AsyncFillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncFillOp fillOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceOp = dyn_cast_or_null<IREE::Stream::AsyncFillOp>(
@@ -1982,7 +1982,7 @@ namespace {
 // ->
 //  %2 = stream.async.dispatch .... %0 -> %0
 struct ElideInPlaceUpdate : public OpRewritePattern<AsyncUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     // Look for entire tensor replacement.
@@ -2070,7 +2070,7 @@ struct ElideInPlaceUpdate : public OpRewritePattern<AsyncUpdateOp> {
 // ->
 //  %1 = stream.async.fill %c123_i32, %dst[%c0 to %c128 for %c128]
 struct CombineSplatUpdateFromToFill : public OpRewritePattern<AsyncUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     auto splatOp =
@@ -2104,7 +2104,7 @@ struct CombineSplatUpdateFromToFill : public OpRewritePattern<AsyncUpdateOp> {
 // want if it there are users of the source after this op such that we wouldn't
 // be the op keeping the entire unsliced source resource live.
 struct CombineSliceUpdateFromToCopy : public OpRewritePattern<AsyncUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     auto sliceOp =
@@ -2154,7 +2154,7 @@ namespace {
 // ->
 //  %2 = stream.async.update %0, %1[%c0 to %sz1]
 struct AsyncCopyFullSourceToUpdate : public OpRewritePattern<AsyncCopyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncCopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
     if (copyOp.getSourceEnd() == copyOp.getSourceSize() &&
@@ -2213,7 +2213,7 @@ namespace {
 // Elides transfer operations that are a no-op (from/to the same affinity and
 // same resource type).
 struct RedundantTransferElision : public OpRewritePattern<AsyncTransferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncTransferOp transferOp,
                                 PatternRewriter &rewriter) const override {
     if (transferOp.getSourceAffinityAttr() ==
@@ -2229,7 +2229,7 @@ struct RedundantTransferElision : public OpRewritePattern<AsyncTransferOp> {
 
 // Collapses chains of transfers that have no use.
 struct IntermediateTransferElision : public OpRewritePattern<AsyncTransferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncTransferOp transferOp,
                                 PatternRewriter &rewriter) const override {
     // Walk up the transfer chain to the first non-transfer op.
@@ -2272,7 +2272,7 @@ namespace {
 // Folds subsequent bitcasts into the load op. The bit width will be the same
 // and it avoids additional conversion.
 struct FoldAsyncLoadBitcast : public OpRewritePattern<AsyncLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     auto loadedValue = loadOp.getResult();
@@ -2310,7 +2310,7 @@ namespace {
 // Folds preceding bitcasts into the store op. The bit width will be the same
 // and it avoids additional conversion.
 struct FoldAsyncStoreBitcast : public OpRewritePattern<AsyncStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
     auto storedValue = storeOp.getValue();
@@ -2342,7 +2342,7 @@ namespace {
 
 struct DeduplicateAsyncDispatchEntryRefs final
     : public OpRewritePattern<AsyncDispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncDispatchOp dispatchOp,
                                 PatternRewriter &rewriter) const override {
     auto originalAttr = dispatchOp.getEntryPointsAttr();
@@ -2385,7 +2385,7 @@ namespace {
 // allows us to progressively fold the subviews into the ops consuming them.
 struct CloneCapturedAsyncExecuteSubviewOps
     : public OpRewritePattern<AsyncExecuteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncExecuteOp op,
                                 PatternRewriter &rewriter) const override {
     struct SubviewCapture {
@@ -2442,7 +2442,7 @@ struct CloneCapturedAsyncExecuteSubviewOps
 //  %result = %capture
 //  %timepoint = stream.timepoint.immediate
 struct ElideNoOpAsyncExecuteOp : public OpRewritePattern<AsyncExecuteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AsyncExecuteOp op,
                                 PatternRewriter &rewriter) const override {
     auto &entryBlock = op.getBody().front();
@@ -2508,7 +2508,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  stream.cmd.flush %dst[%new_offset for %subview_length]
 struct FoldSubviewsIntoCmdFlushOp : public OpRewritePattern<CmdFlushOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdFlushOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getTarget());
@@ -2550,7 +2550,7 @@ namespace {
 //  stream.cmd.invalidate %dst[%new_offset for %subview_length]
 struct FoldSubviewsIntoCmdInvalidateOp
     : public OpRewritePattern<CmdInvalidateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdInvalidateOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getTarget());
@@ -2591,7 +2591,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  stream.cmd.discard %dst[%new_offset for %subview_length]
 struct FoldSubviewsIntoCmdDiscardOp : public OpRewritePattern<CmdDiscardOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdDiscardOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getTarget());
@@ -2632,7 +2632,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  stream.cmd.fill %cst, %dst[%new_offset for %subview_length]
 struct FoldSubviewsIntoCmdFillOp : public OpRewritePattern<CmdFillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdFillOp op,
                                 PatternRewriter &rewriter) const override {
     auto subviewOp = ResourceSubviewOp::findSubviewOp(op.getTarget());
@@ -2674,7 +2674,7 @@ namespace {
 //  %new_offset = arith.addi %offset, %subview_offset
 //  stream.cmd.copy %src[%new_offset], %dst[%new_offset], %subview_length
 struct FoldSubviewsIntoCmdCopyOp : public OpRewritePattern<CmdCopyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdCopyOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceSubviewOp = ResourceSubviewOp::findSubviewOp(op.getSource());
@@ -2791,7 +2791,7 @@ namespace {
 
 struct DeduplicateCmdDispatchEntryRefs final
     : public OpRewritePattern<CmdDispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdDispatchOp dispatchOp,
                                 PatternRewriter &rewriter) const override {
     auto originalAttr = dispatchOp.getEntryPointsAttr();
@@ -2822,7 +2822,7 @@ namespace {
 // This duplicates FoldSubviewsIntoDispatchOp to handle the call op until the
 // interface can be written.
 struct FoldSubviewsIntoCmdCallOp : public OpRewritePattern<CmdCallOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdCallOp op,
                                 PatternRewriter &rewriter) const override {
     // Original operand index + the subview.
@@ -2893,7 +2893,7 @@ namespace {
 //  }
 struct CloneCapturedCmdExecuteSubviewOps
     : public OpRewritePattern<CmdExecuteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdExecuteOp op,
                                 PatternRewriter &rewriter) const override {
     struct SubviewCapture {
@@ -2942,7 +2942,7 @@ struct CloneCapturedCmdExecuteSubviewOps
 // Elides stream.cmd.execute ops when they have no meaningful work.
 // The returned timepoint is replaced with an immediately resolved timepoint.
 struct ElideNoOpCmdExecuteOp : public OpRewritePattern<CmdExecuteOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmdExecuteOp op,
                                 PatternRewriter &rewriter) const override {
     auto &entryBlock = op.getBody().front();
@@ -3060,7 +3060,7 @@ namespace {
 //  %chained_fence = %arg_fence
 struct PassThroughChainExternal
     : public OpRewritePattern<TimepointChainExternalOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointChainExternalOp op,
                                 PatternRewriter &rewriter) const override {
     // Try to get the original external values that we want to chain.
@@ -3136,7 +3136,7 @@ namespace {
 
 struct ElideImmediateTimepointJoinOperands
     : public OpRewritePattern<TimepointJoinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointJoinOp op,
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value> newTimepoints;
@@ -3162,7 +3162,7 @@ struct ElideImmediateTimepointJoinOperands
 
 struct FoldDuplicateTimepointJoinOperands
     : public OpRewritePattern<TimepointJoinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointJoinOp op,
                                 PatternRewriter &rewriter) const override {
     SetVector<Value> newTimepoints;
@@ -3184,7 +3184,7 @@ struct FoldDuplicateTimepointJoinOperands
 // Which we want to fold and expand:
 //   %j1 = stream.timepoint.join max(%tp2, %tp0, %tp1, %tp3)
 struct ExpandTimepointJoinOperands : public OpRewritePattern<TimepointJoinOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointJoinOp op,
                                 PatternRewriter &rewriter) const override {
     SetVector<Value> newTimepoints;
@@ -3250,7 +3250,7 @@ static bool isSourceImmediatelyResolved(Value resource) {
 //  %r0b = %r0a
 //  %r0ready = stream.timepoint.immediate
 struct ElideImmediateBarrier : public OpRewritePattern<TimepointBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {
     if (!isSourceImmediatelyResolved(barrierOp.getResource())) {
@@ -3297,7 +3297,7 @@ findSourceAwaitOp(Value resource) {
 //  %r0b = %source
 //  %t1 = %t0
 struct ChainTimepoints : public OpRewritePattern<TimepointBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointBarrierOp barrierOp,
                                 PatternRewriter &rewriter) const override {
     // Try to find an await op. This may traverse through any number of tied ops
@@ -3350,7 +3350,7 @@ LogicalResult TimepointAwaitOp::fold(FoldAdaptor operands,
 namespace {
 
 struct ElideImmediateHostAwaits : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     if (isa_and_nonnull<TimepointImmediateOp>(
@@ -3365,7 +3365,7 @@ struct ElideImmediateHostAwaits : public OpRewritePattern<TimepointAwaitOp> {
 // Sinks an await down to the first consumer of any resource. Note that there
 // may be multiple resources guarded by the await.
 struct SinkAwaitToFirstConsumer : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     // Don't move sync points as they may be implicitly guarding execution.
@@ -3426,7 +3426,7 @@ struct SinkAwaitToFirstConsumer : public OpRewritePattern<TimepointAwaitOp> {
 // This allows us to pass-through the subviews to consumers that can hopefully
 // fold the range.
 struct SinkSubviewsAcrossAwaits : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     rewriter.setInsertionPointAfter(op);
@@ -3493,7 +3493,7 @@ static bool areAllOperandsDefinedBy(Operation *op, Operation *insertionPoint,
 //  %7 = stream.tensor.export %6#0 ...
 //  %9 = stream.tensor.export %6#1 ...
 struct GroupAwaitsByTimepoint : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     DominanceInfo dominanceInfo(op->getParentOp());
@@ -3558,7 +3558,7 @@ struct GroupAwaitsByTimepoint : public OpRewritePattern<TimepointAwaitOp> {
 // ->
 //  %1:2 = stream.timepoint.await %tp => %1, %2
 struct FoldDuplicateAwaitResources : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     DenseMap<Value, unsigned> baseMap;
@@ -3600,7 +3600,7 @@ struct FoldDuplicateAwaitResources : public OpRewritePattern<TimepointAwaitOp> {
 };
 
 struct ElideUnusedTimepointAwait : public OpRewritePattern<TimepointAwaitOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TimepointAwaitOp op,
                                 PatternRewriter &rewriter) const override {
     // If there are any uses the await is required to associate the timepoint.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -202,7 +202,7 @@ static Value canonicalizeFillPattern(Value pattern, OpBuilder &builder) {
 
 struct EncodeTensorImportOp
     : public OpRewritePattern<IREE::Stream::TensorImportOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorImportOp op,
                                 PatternRewriter &rewriter) const override {
     auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
@@ -225,7 +225,7 @@ struct EncodeTensorImportOp
 
 struct EncodeTensorExportOp
     : public OpRewritePattern<IREE::Stream::TensorExportOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorExportOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
@@ -248,7 +248,7 @@ struct EncodeTensorExportOp
 
 struct EncodeTensorSizeOfOp
     : public OpRewritePattern<IREE::Stream::TensorSizeOfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSizeOfOp op,
                                 PatternRewriter &rewriter) const override {
     auto encodingType = llvm::cast<RankedTensorType>(op.getEncoding());
@@ -276,7 +276,7 @@ struct EncodeTensorSizeOfOp
 
 struct EncodeTensorEmptyOp
     : public OpRewritePattern<IREE::Stream::TensorEmptyOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorEmptyOp op,
                                 PatternRewriter &rewriter) const override {
     auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
@@ -299,7 +299,7 @@ struct EncodeTensorEmptyOp
 
 struct EncodeTensorConstantOp
     : public OpRewritePattern<IREE::Stream::TensorConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorConstantOp op,
                                 PatternRewriter &rewriter) const override {
     auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
@@ -360,7 +360,7 @@ struct EncodeTensorConstantOp
 
 struct EncodeTensorSplatOp
     : public OpRewritePattern<IREE::Stream::TensorSplatOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSplatOp op,
                                 PatternRewriter &rewriter) const override {
     auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
@@ -393,7 +393,7 @@ struct EncodeTensorSplatOp
 
 struct EncodeTensorCloneOp
     : public OpRewritePattern<IREE::Stream::TensorCloneOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorCloneOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
@@ -422,7 +422,7 @@ struct EncodeTensorCloneOp
 
 struct EncodeTensorSliceOp
     : public OpRewritePattern<IREE::Stream::TensorSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSliceOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
@@ -455,7 +455,7 @@ struct EncodeTensorSliceOp
 
 struct EncodeTensorFillOp
     : public OpRewritePattern<IREE::Stream::TensorFillOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorFillOp op,
                                 PatternRewriter &rewriter) const override {
     auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
@@ -494,7 +494,7 @@ struct EncodeTensorFillOp
 
 struct EncodeTensorUpdateOp
     : public OpRewritePattern<IREE::Stream::TensorUpdateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorUpdateOp op,
                                 PatternRewriter &rewriter) const override {
     auto updateType = llvm::cast<RankedTensorType>(op.getUpdateEncoding());
@@ -528,7 +528,7 @@ struct EncodeTensorUpdateOp
 
 struct EncodeTensorLoadOp
     : public OpRewritePattern<IREE::Stream::TensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
@@ -571,7 +571,7 @@ struct EncodeTensorLoadOp
 
 struct EncodeTensorStoreOp
     : public OpRewritePattern<IREE::Stream::TensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
     auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
@@ -601,7 +601,7 @@ struct EncodeTensorStoreOp
 
 struct EncodeTensorDispatchOp
     : public OpRewritePattern<IREE::Stream::TensorDispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorDispatchOp op,
                                 PatternRewriter &rewriter) const override {
     // Strip off the tensor encoding information - it's not used at all here. If
@@ -677,7 +677,7 @@ alignDispatchTensorType(IREE::TensorExt::DispatchTensorType originalType) {
 // a resource.
 struct EncodeBindingSubspanOp
     : public OpRewritePattern<IREE::Stream::BindingSubspanOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::BindingSubspanOp op,
                                 PatternRewriter &rewriter) const override {
     auto originalType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
@@ -707,7 +707,7 @@ struct EncodeBindingSubspanOp
 
 struct EncodeDispatchTensorLoadOp
     : public OpRewritePattern<IREE::TensorExt::DispatchTensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto targetType = llvm::cast<RankedTensorType>(op.getResult().getType());
@@ -741,7 +741,7 @@ struct EncodeDispatchTensorLoadOp
 
 struct EncodeDispatchTensorStoreOp
     : public OpRewritePattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
     auto sourceType = llvm::cast<RankedTensorType>(op.getValue().getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -323,7 +323,7 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
 //===----------------------------------------------------------------------===//
 
 struct RemoveBarriers : public OpRewritePattern<IREE::Stream::AsyncBarrierOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::AsyncBarrierOp op,
                                 PatternRewriter &rewriter) const override {
     rewriter.replaceOp(op, op.getOperand(0));

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -17,7 +17,7 @@ namespace mlir::iree_compiler::IREE::TensorExt {
 
 namespace {
 struct ReplaceBitCastIfTensorOperandEmpty final : OpRewritePattern<BitCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BitCastOp op,
                                 PatternRewriter &rewriter) const override {
     auto emptyOp =
@@ -31,7 +31,7 @@ struct ReplaceBitCastIfTensorOperandEmpty final : OpRewritePattern<BitCastOp> {
 };
 
 struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(BitCastOp bitcastOp,
                                 PatternRewriter &rewriter) const final {
@@ -153,7 +153,7 @@ static bool updateTensorOpDims(RewriterBase &rewriter, Operation *op,
 
 struct ReuseDispatchTensorLoadShapeDims
     : public OpRewritePattern<DispatchTensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     return success(updateTensorOpDims(rewriter, loadOp, loadOp.getSource(),
@@ -174,7 +174,7 @@ struct ReuseDispatchTensorLoadShapeDims
 // subtensor %v[..] [..] [..]
 struct ConvertDispatchInputLoadOfTensorToSubTensor
     : public OpRewritePattern<DispatchTensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     if (!llvm::isa<RankedTensorType>(loadOp.getSource().getType())) {
@@ -249,7 +249,7 @@ canonicalizeSubViewParts(OpTy op, RankedTensorType sliceType,
 /// Pattern to rewrite a subview op with constant arguments.
 struct DispatchTensorLoadOpWithOffsetSizesAndStridesConstantArgumentFolder final
     : public OpRewritePattern<DispatchTensorLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     SmallVector<OpFoldResult> mixedOffsets, mixedSizes, mixedStrides;
@@ -306,7 +306,7 @@ namespace {
 
 struct ReuseDispatchTensorStoreShapeDims
     : public OpRewritePattern<DispatchTensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
     return success(updateTensorOpDims(rewriter, storeOp, storeOp.getTarget(),
@@ -316,7 +316,7 @@ struct ReuseDispatchTensorStoreShapeDims
 
 struct FoldCastOpIntoDispatchStoreOp
     : public OpRewritePattern<DispatchTensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
     auto parentOp = storeOp.getValue().getDefiningOp<tensor::CastOp>();
@@ -349,7 +349,7 @@ struct FoldCastOpIntoDispatchStoreOp
 
 struct DispatchTensorStoreOpWithOffsetSizesAndStridesConstantArgumentFolder
     final : public OpRewritePattern<DispatchTensorStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
     SmallVector<OpFoldResult> mixedOffsets, mixedSizes, mixedStrides;
@@ -390,7 +390,7 @@ namespace {
 
 // Bubble up the ordinal ops so that all uses go through this operation.
 struct BubbleUpOrdinalOp : public OpRewritePattern<DispatchWorkloadOrdinalOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(DispatchWorkloadOrdinalOp ordinalOp,
                                 PatternRewriter &rewriter) const override {
     auto blockArg = dyn_cast<BlockArgument>(ordinalOp.getOperand());

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/Folders.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::IREE::TensorExt {
 /// `tensor.extract_slice`.
 struct FoldTensorLoadWithExtractSlice
     : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractSliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -207,7 +207,7 @@ namespace {
 
 /// Deduplicates operands, merging assume ranges along the way.
 struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(AssumeIntOp op,
                                 PatternRewriter &rewriter) const override {
     ArrayAttr assumptions = op.getAssumptions();
@@ -269,7 +269,7 @@ struct DeduplicateOperands : public OpRewritePattern<AssumeIntOp> {
 ///
 /// Where X | Y.
 struct FoldDivMulOfAssume : public OpRewritePattern<arith::MulIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::MulIOp mulOp,
                                 PatternRewriter &rewriter) const override {
     APInt mulConstantInt;
@@ -343,7 +343,7 @@ namespace {
 /// Folds cast ops into the result of other ops.
 /// Only safe to apply to ops that don't care about their types.
 struct FoldCastIntoNullOp : public OpRewritePattern<CastOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CastOp castOp,
                                 PatternRewriter &rewriter) const override {
     auto nullOp = dyn_cast_or_null<NullOp>(castOp.getOperand().getDefiningOp());
@@ -538,7 +538,7 @@ static Value makeRangeEnd(Location loc, Value offset, Value length,
 namespace {
 
 struct FoldConstantRanges : public OpRewritePattern<RangeExtentsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(RangeExtentsOp op,
                                 PatternRewriter &rewriter) const override {
     // Build a constant range for all we find and preserve the dynamic pairs.
@@ -601,7 +601,7 @@ struct FoldConstantRanges : public OpRewritePattern<RangeExtentsOp> {
 };
 
 struct ExpandSimpleRangeExtentsOp : public OpRewritePattern<RangeExtentsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(RangeExtentsOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
@@ -632,7 +632,7 @@ struct ExpandSimpleRangeExtentsOp : public OpRewritePattern<RangeExtentsOp> {
 };
 
 struct DeduplicateRangeExtentsOp : public OpRewritePattern<RangeExtentsOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(RangeExtentsOp op,
                                 PatternRewriter &rewriter) const override {
     // First filter out any pure duplicates. Note SetVector so order is
@@ -826,7 +826,7 @@ namespace {
 
 struct ExpandUnfoldableConstantOp
     : public OpRewritePattern<UnfoldableConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(UnfoldableConstantOp op,
                                 PatternRewriter &rewriter) const override {
     auto stdConst = arith::ConstantOp::create(rewriter, op.getLoc(),
@@ -852,7 +852,7 @@ namespace {
 
 // Deletes empty vm.initializer ops.
 struct DropEmptyInitializerOp : public OpRewritePattern<InitializerOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(InitializerOp op,
                                 PatternRewriter &rewriter) const override {
@@ -911,7 +911,7 @@ namespace {
 /// store back to the same global: we want to be able to elide the entire load
 /// and store.
 struct EraseUnusedGlobalStoreOp : public OpRewritePattern<GlobalStoreOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(GlobalStoreOp op,
                                 PatternRewriter &rewriter) const override {
@@ -938,7 +938,7 @@ namespace {
 /// Turns util.global.address -> util.global.store.indirect into a direct store.
 class PropagateGlobalStoreAddress
     : public OpRewritePattern<GlobalStoreIndirectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
 public:
   LogicalResult matchAndRewrite(GlobalStoreIndirectOp op,
@@ -986,7 +986,7 @@ namespace {
 // Folds subspan -> subspan to point at the original source buffer with an
 // updated range.
 struct FoldBufferSubspanOps : public OpRewritePattern<BufferSubspanOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferSubspanOp op,
                                 PatternRewriter &rewriter) const override {
     auto parentOp = BufferSubspanOp::findSubspanOp(op.getSource());
@@ -1014,7 +1014,7 @@ struct FoldBufferSubspanOps : public OpRewritePattern<BufferSubspanOp> {
 //  util.buffer.copy %src[%new_offset], %dst[%new_offset], %subspan_length
 struct FoldBufferSubspanOpsIntoConsumers
     : public OpRewritePattern<BufferSubspanOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferSubspanOp op,
                                 PatternRewriter &rewriter) const override {
     bool didUpdateAny = false;
@@ -1052,7 +1052,7 @@ struct FoldBufferSubspanOpsIntoConsumers
 //  %subspan = util.buffer.subspan %src[%offset]
 struct SinkSubspanAcrossSelectOps
     : public OpRewritePattern<mlir::arith::SelectOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(mlir::arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {
     if (!llvm::isa<IREE::Util::BufferType>(op.getType()))
@@ -1133,7 +1133,7 @@ namespace {
 //  %c = select %cond, %a, %b : !util.buffer
 //  %c_sz = select %cond, %a_sz, %b_sz : index
 struct SelectBufferSizeOp : public OpRewritePattern<BufferSizeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferSizeOp op,
                                 PatternRewriter &rewriter) const override {
     auto selectOp = op.getOperand().getDefiningOp<mlir::arith::SelectOp>();
@@ -1171,7 +1171,7 @@ namespace {
 //  %storage, %raw_offset = util.buffer.storage %src
 //  %offset = arith.addi %raw_offset, %subspan_offset
 struct FoldSubspansIntoStorageOp : public OpRewritePattern<BufferStorageOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferStorageOp op,
                                 PatternRewriter &rewriter) const override {
     auto subspanOp = BufferSubspanOp::findSubspanOp(op.getOperand());

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -392,7 +392,7 @@ void expandAffineOps(Operation *rootOp) {
 //===----------------------------------------------------------------------===//
 
 struct ElideTruncOfIndexCast : public OpRewritePattern<arith::TruncIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::TruncIOp truncOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -329,7 +329,7 @@ struct ElideBranchOperandsPattern
 //    scf.yield %default : i32
 //  }
 struct IndexSwitchToIfPattern : public OpRewritePattern<scf::IndexSwitchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(scf::IndexSwitchOp switchOp,
                                 PatternRewriter &rewriter) const override {
     if (switchOp.getNumCases() != 1)

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -61,7 +61,7 @@ namespace {
 
 // Deletes empty vm.initializer ops.
 struct DropEmptyInitializerOp : public OpRewritePattern<InitializerOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(InitializerOp op,
                                 PatternRewriter &rewriter) const override {
     if (op.getBody().getBlocks().size() != 1)
@@ -79,7 +79,7 @@ struct DropEmptyInitializerOp : public OpRewritePattern<InitializerOp> {
 // This is not strictly required but can help our initialization code perform
 // more efficient initialization of large numbers of primitive values.
 struct InlineConstGlobalInitializer : public OpRewritePattern<InitializerOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(InitializerOp op,
                                 PatternRewriter &rewriter) const override {
@@ -2896,7 +2896,7 @@ namespace {
 
 /// Changes a cmp.eq.ref check against null to a cmp.nz.ref and inverted cond.
 struct NullCheckCmpEQRefToCmpNZRef : public OpRewritePattern<CmpEQRefOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmpEQRefOp op,
                                 PatternRewriter &rewriter) const override {
     Attribute rhs;
@@ -2931,7 +2931,7 @@ namespace {
 
 /// Changes a cmp.ne.ref check against null to a cmp.nz.ref.
 struct NullCheckCmpNERefToCmpNZRef : public OpRewritePattern<CmpNERefOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CmpNERefOp op,
                                 PatternRewriter &rewriter) const override {
     Attribute rhs;
@@ -3026,7 +3026,7 @@ namespace {
 ///
 /// (same logic as for std.br)
 struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     // Check that the successor block has a single predecessor.
@@ -3052,7 +3052,7 @@ struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
 ///
 /// (same logic as for std.br)
 struct SimplifyPassThroughBr : public OpRewritePattern<BranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     Block *dest = op.getDest();
@@ -3084,7 +3084,7 @@ namespace {
 
 /// Simplifies a cond_br with a constant condition to an unconditional branch.
 struct SimplifyConstCondBranchPred : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     if (matchPattern(op.getCondition(), m_NonZero())) {
@@ -3105,7 +3105,7 @@ struct SimplifyConstCondBranchPred : public OpRewritePattern<CondBranchOp> {
 /// Simplifies a cond_br with both targets (including operands) being equal to
 /// an unconditional branch.
 struct SimplifySameTargetCondBranchOp : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     if (op.getTrueDest() != op.getFalseDest()) {
@@ -3128,7 +3128,7 @@ struct SimplifySameTargetCondBranchOp : public OpRewritePattern<CondBranchOp> {
 
 /// Swaps the cond_br true and false targets if the condition is inverted.
 struct SwapInvertedCondBranchOpTargets : public OpRewritePattern<CondBranchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CondBranchOp op,
                                 PatternRewriter &rewriter) const override {
     // TODO(benvanik): figure out something more reliable when the xor may be
@@ -3165,7 +3165,7 @@ namespace {
 
 /// Converts a vm.call.variadic to a non-variadic function to a normal vm.call.
 struct ConvertNonVariadicToCallOp : public OpRewritePattern<CallVariadicOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CallVariadicOp op,
                                 PatternRewriter &rewriter) const override {
     // If any segment size is != -1 (which indicates variadic) we bail.
@@ -3192,7 +3192,7 @@ namespace {
 
 /// Rewrites a cond_fail op to a cond_branch to a fail op.
 struct RewriteCondFailToBranchFail : public OpRewritePattern<CondFailOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CondFailOp op,
                                 PatternRewriter &rewriter) const override {
     auto *block = rewriter.getInsertionBlock();
@@ -3307,7 +3307,7 @@ namespace {
 
 // Folds vm.import.resolved ops referencing required imports.
 struct RequiredImportResolver : public OpRewritePattern<ImportResolvedOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ImportResolvedOp op,
                                 PatternRewriter &rewriter) const override {
     auto importOp = SymbolTable::lookupNearestSymbolFrom<IREE::VM::ImportOp>(
@@ -3357,7 +3357,7 @@ struct RemoveDisabledDebugAsyncOp : public OpRewritePattern<T> {
 };
 
 struct SimplifyConstCondBreakPred : public OpRewritePattern<CondBreakOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(CondBreakOp op,
                                 PatternRewriter &rewriter) const override {
     IntegerAttr condValue;

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -226,7 +226,7 @@ replaceOffsetSizesAndStridesWith(RewriterBase &rewriter,
 namespace {
 
 struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto subview = op.getSource().template getDefiningOp<memref::SubViewOp>();
@@ -291,7 +291,7 @@ struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
 
 struct FromHalInterfaceBindingSubspan
     : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto binding =
@@ -335,7 +335,7 @@ getBaseBufferReplacementForDescriptor(GetBufferDescriptorOp descriptorOp,
 
 struct FromMemRefAssumeAlignment
     : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto assumeOp = op.getSource().getDefiningOp<memref::AssumeAlignmentOp>();
@@ -375,7 +375,7 @@ struct FromMemRefAssumeAlignment
 // Allocations always return a non-offset memref and are matched by this
 // pattern.
 struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto alloca = op.getSource().template getDefiningOp<memref::AllocaOp>();
@@ -409,7 +409,7 @@ struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
 // MemRef globals are always static shaped and reference a non-offset
 // buffer.
 struct FromGlobal : public OpRewritePattern<GetBufferDescriptorOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GetBufferDescriptorOp op,
                                 PatternRewriter &rewriter) const override {
     auto global = op.getSource().template getDefiningOp<memref::GetGlobalOp>();

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -53,7 +53,7 @@ struct BubbleUpExpandShapesPass final
 // Because `extract_slice` ops and dequantize-like ops get cloned into regions
 // later, it's okay to bubble up through multi-use dequant ops.
 struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const final {
@@ -141,7 +141,7 @@ struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
 /// former can be folded away.
 struct SwapExtractSliceOfFill final
     : public OpRewritePattern<tensor::ExtractSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractOp,
                                 PatternRewriter &rewriter) const override {
@@ -167,7 +167,7 @@ struct SwapExtractSliceOfFill final
 struct BubbleExpandThroughExtract final
     : public OpRewritePattern<tensor::ExpandShapeOp> {
 
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {
@@ -270,7 +270,7 @@ struct BubbleExpandThroughExtract final
 
 struct BubbleExpandThroughConcat final
     : public OpRewritePattern<tensor::ExpandShapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -57,7 +57,7 @@ static SmallVector<T> applyProjectedPermutation(const SmallVectorImpl<T> &input,
 // is not affine (index values come from a tensor).
 namespace {
 struct GatherFusionPattern final : public OpRewritePattern<tensor::ExtractOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ExtractOp extractOp,
                                 PatternRewriter &rewriter) const override {
     // Check if extractOp is inside a generic op

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -60,7 +60,7 @@ namespace {
 /// ```
 struct DropUnitDimsFromCollapseOfExpand
     : OpRewritePattern<tensor::CollapseShapeOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::CollapseShapeOp collapseOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/FusionPreprocessing.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionPreprocessing.cpp
@@ -46,7 +46,7 @@ namespace {
 // If possible, interchange indexing maps to make input maps all identity.
 struct ElementwiseOpInterchangePattern final
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     if (!linalg::isElementwise(genericOp) || genericOp.getNumResults() != 1 ||
@@ -98,7 +98,7 @@ struct ElementwiseOpInterchangePattern final
 /// ```
 struct FoldSuccessiveTensorInsertSliceOps final
     : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceInsertSlice =

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -176,7 +176,7 @@ struct HoistEncodingOpsPass
 /// of a dispatch.
 struct BubbleUpSetEncodingOp
     : public OpRewritePattern<IREE::Encoding::SetEncodingOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {
@@ -202,7 +202,7 @@ struct BubbleUpSetEncodingOp
 /// Pattern to sink UnsetEncoding ops down through consumers.
 struct SinkUnsetEncodingOp
     : public OpRewritePattern<IREE::Encoding::UnsetEncodingOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Encoding::UnsetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/PropagateEncodings.cpp
@@ -75,7 +75,7 @@ namespace {
 /// Pattern to swap `tensor.cast` -> `iree_encoding.set_encoding`.
 struct SwapEncodingOpWithTensorCastOp
     : public OpRewritePattern<IREE::Encoding::SetEncodingOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {
     auto castOp = encodingOp.getSource().getDefiningOp<tensor::CastOp>();

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -207,7 +207,7 @@ namespace {
 /// operation into a `linalg.fill` of the encoded type.
 struct FoldFillWithSetEncoding final
     : OpRewritePattern<IREE::Encoding::SetEncodingOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
@@ -35,7 +35,7 @@ namespace {
 /// tensor.insert_slice. This is needed till tensor.pad op can be fused with its
 /// consumers.
 struct TensorPadOpConversion : public OpRewritePattern<tensor::PadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   TensorPadOpConversion(MLIRContext *context, bool skipSingleLinalgOpUses)
       : OpRewritePattern<tensor::PadOp>(context, skipSingleLinalgOpUses),
         skipSingleLinalgOpUses(skipSingleLinalgOpUses) {}

--- a/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
@@ -31,7 +31,7 @@ namespace {
 /// dimension.
 struct MakeReductionInnermostPattern final
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     SmallVector<unsigned> interchange;
@@ -64,7 +64,7 @@ struct MakeReductionInnermostPattern final
 /// fixes up elementwise operations for which that is not the case.
 struct TransposeGenericOpPattern final
     : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     if (!genericOp.hasPureTensorSemantics()) {

--- a/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ConvertStridedContractionToContraction.cpp
@@ -22,7 +22,7 @@ namespace {
 class ConvertStridedContractionToContraction
     : public OpRewritePattern<linalg::GenericOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     // Check if the generic op satisfies all other conditions for being a

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -41,7 +41,7 @@ static Value createTranspose(OpBuilder &builder, Value source,
 // becoming a sequence of copies. The hope then is that the transposes on the
 // inputs and output is then fusable with surrounding operations.
 struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {
@@ -90,7 +90,7 @@ struct TransposeInnerConcatenation : public OpRewritePattern<tensor::ConcatOp> {
 /// `flow.tensor.update` on conversion to Flow and then they get modified to be
 /// in-place.
 struct DecomposeNonOuterDimConcats : public OpRewritePattern<tensor::ConcatOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -161,7 +161,7 @@ struct LinalgFillCast
 
 // For narrowable inputs, selects
 struct LinalgFpMatmulToLowP : public OpRewritePattern<linalg::MatmulOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -191,7 +191,7 @@ namespace {
 class FuseTransposeWithProducerLinalgOp
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   FuseTransposeWithProducerLinalgOp(MLIRContext *ctx, bool aggressiveProp,
                                     bool convProp, PatternBenefit b = 1)
       : OpRewritePattern<linalg::TransposeOp>(ctx, b),
@@ -307,7 +307,7 @@ private:
 class BubbleTransposeThroughCollapseShape
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {
@@ -376,7 +376,7 @@ namespace {
 // new propagation opportunities and eases the analysis in fusion/later passes.
 class ComposeTransposes : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp consumer,
                                 PatternRewriter &rewriter) const override {
@@ -409,7 +409,7 @@ public:
 class SinkTransposeThroughExtractSlice
     : public OpRewritePattern<tensor::ExtractSliceOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp extractOp,
                                 PatternRewriter &rewriter) const override {
@@ -504,7 +504,7 @@ public:
 class SinkTransposeThroughExpandShape
     : public OpRewritePattern<tensor::ExpandShapeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::ExpandShapeOp expandOp,
                                 PatternRewriter &rewriter) const override {
@@ -724,7 +724,7 @@ getTransposedIndexingMaps(linalg::GenericOp genericOp,
 class SinkTransposeThroughUnaryElementwiseInput
     : public OpRewritePattern<linalg::GenericOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
@@ -816,7 +816,7 @@ public:
 class BubbleTransposeThroughUnaryElementwiseDpsInit
     : public OpRewritePattern<linalg::TransposeOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -125,7 +125,7 @@ Value multiplyDims(ImplicitLocOpBuilder &builder, Value value,
 // https://arxiv.org/abs/1712.05877.
 struct QuantizedConvToConv
     : public OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfQOp op,
                                 PatternRewriter &rewriter) const override {
@@ -244,7 +244,7 @@ struct QuantizedConvToConv
 // https://arxiv.org/abs/1712.05877.
 struct QuantizedDepthwiseConvToDepthwiseConv
     : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcQOp op,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -477,7 +477,7 @@ matchATransposeBBatchMatmul(linalg::LinalgOp bmmOp) {
 
 class FuseMatmulTranspose : public OpRewritePattern<linalg::MatmulOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(matmulOp)) {
@@ -503,7 +503,7 @@ public:
 class FuseBatchMatmulTranspose
     : public OpRewritePattern<linalg::BatchMatmulOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::BatchMatmulOp bmmOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(bmmOp)) {
@@ -559,7 +559,7 @@ static std::optional<Value> matchGenericFill(linalg::LinalgOp linalgOp) {
 
 class RaiseGenericFill : public OpRewritePattern<linalg::GenericOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(genericOp)) {
@@ -588,7 +588,7 @@ public:
 
 class RaiseInsertSliceToPad : public OpRewritePattern<tensor::InsertSliceOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(sliceOp)) {
@@ -962,7 +962,7 @@ static Value rewriteCatNegateAndSlice(RewriterBase &rewriter,
 class InsertSliceNegateAndSlicePattern
     : public OpRewritePattern<tensor::InsertSliceOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(sliceOp)) {
@@ -982,7 +982,7 @@ public:
 class ConcatenateNegateAndSlicePattern
     : public OpRewritePattern<tensor::ConcatOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(tensor::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {
     if (!IREE::Flow::isNonNullAndOutsideDispatch(concatOp)) {

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -64,7 +64,7 @@ struct ReplaceZeroExtentOperands : public RewritePattern {
 /// Forward the destination of a `tensor.insert_slice` to its uses
 /// if the source is zero-extent.
 struct FoldZeroExtentInserts : public OpRewritePattern<tensor::InsertSliceOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.cpp
@@ -16,7 +16,7 @@ namespace mlir::iree_compiler::IREE::Check {
 namespace {
 // Rewrites expect_eq_const -> expect_eq
 struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExpectEqConstOp op,
                                 PatternRewriter &rewriter) const override {
     auto rhs = arith::ConstantOp::create(rewriter, op.getLoc(), op.getValue());
@@ -29,7 +29,7 @@ struct ExpectEqConstOpToExpectEqOp : public OpRewritePattern<ExpectEqConstOp> {
 // Rewrites expect_almost_eq_const -> expect_almost_eq
 struct ExpectAlmostEqConstOpToExpectAlmostEqOp
     : public OpRewritePattern<ExpectAlmostEqConstOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExpectAlmostEqConstOp op,
                                 PatternRewriter &rewriter) const override {
     auto rhs = arith::ConstantOp::create(rewriter, op.getLoc(), op.getValue());

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -151,7 +151,7 @@ namespace {
 /// Folds hal_inline.buffer_view.subspans into buffer view creation subspans.
 struct FoldBufferViewCreateSubspan
     : public OpRewritePattern<BufferViewCreateOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferViewCreateOp op,
                                 PatternRewriter &rewriter) const override {
     auto ip = rewriter.saveInsertionPoint();
@@ -199,7 +199,7 @@ namespace {
 /// Skips a hal.buffer_view.buffer accessor when the buffer view was created in
 /// the same scope and we know the origin buffer.
 struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(BufferViewBufferOp op,
                                 PatternRewriter &rewriter) const override {
     if (auto createOp = dyn_cast_or_null<BufferViewCreateOp>(

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
@@ -162,7 +162,7 @@ namespace {
 // Folds subspan ranges into dispatch resource ranges.
 struct FoldBindingSubspansIntoDispatchOp
     : public OpRewritePattern<ExecutableDispatchOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(ExecutableDispatchOp op,
                                 PatternRewriter &rewriter) const override {
     bool didChangeAny = false;

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -80,7 +80,7 @@ namespace {
 class ConvertConv2DNhwcHwcf final
     : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
                                 PatternRewriter &rewriter) const override {
@@ -239,7 +239,7 @@ public:
 class ConvertDepthwiseConv2DNhwcHwc final
     : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcOp convOp,
                                 PatternRewriter &rewriter) const override {
@@ -403,7 +403,7 @@ public:
 class ConvertConv2DNchwFchw final
     : public OpRewritePattern<linalg::Conv2DNchwFchwOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp convOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -85,7 +85,7 @@ convertConvFilterToTargetLayout(linalg::Conv2DNhwcHwcfOp convOp,
 
 namespace {
 struct ConvertHwcfToHwfc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
                                 PatternRewriter &rewriter) const override {
@@ -95,7 +95,7 @@ struct ConvertHwcfToHwfc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
 };
 
 struct ConvertHwcfToFhwc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -447,7 +447,7 @@ namespace {
 // Named op -> named op conversions if a default inner tile size is specified.
 
 struct ConvertLinalgConvNchwFchw : OpRewritePattern<linalg::Conv2DNchwFchwOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   ConvertLinalgConvNchwFchw(MLIRContext *context, PatternBenefit benefit = 2)
       : OpRewritePattern<linalg::Conv2DNchwFchwOp>(context, benefit) {}
 
@@ -516,7 +516,7 @@ getTilingReassociationMap(const int64_t rank, SetTy innerDims) {
 class GeneralizeOuterUnitDimsPackOp final
     : public OpRewritePattern<linalg::PackOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   GeneralizeOuterUnitDimsPackOp(MLIRContext *context,
                                 PatternBenefit benefit = 2)
       : OpRewritePattern<linalg::PackOp>(context, benefit) {}
@@ -597,7 +597,7 @@ public:
 class GeneralizeOuterUnitDimsUnPackOp final
     : public OpRewritePattern<linalg::UnPackOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   GeneralizeOuterUnitDimsUnPackOp(MLIRContext *context,
                                   PatternBenefit benefit = 2)
       : OpRewritePattern<linalg::UnPackOp>(context, benefit) {}

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -56,7 +56,7 @@ namespace {
 ///
 struct FoldAttentionAndTranspose
     : public OpRewritePattern<IREE::LinalgExt::AttentionOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(IREE::LinalgExt::AttentionOp attentionOp,
                                 PatternRewriter &rewriter) const override {


### PR DESCRIPTION
Use the `Base` type alias added in https://github.com/llvm/llvm-project/pull/158433.