### PR TITLE
Simplify op conversion pattern inheriting constructor definitions. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
@@ -437,7 +437,7 @@ struct PartitionIdOpConversion
 /// Converts stablehlo.replica_id to floor_div(flow.channel.rank, numPartitions)
 struct ReplicaIdOpConversion
     : public OpConversionPattern<mlir::stablehlo::ReplicaIdOp> {
-  using OpConversionPattern<mlir::stablehlo::ReplicaIdOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ReplicaIdOp op, OpAdaptor adaptor,
@@ -471,7 +471,7 @@ struct ReplicaIdOpConversion
 
 struct AllGatherOpConversion final
     : OpConversionPattern<mlir::stablehlo::AllGatherOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::AllGatherOp op, OpAdaptor adaptor,
@@ -530,7 +530,7 @@ struct AllGatherOpConversion final
 
 struct AllReduceOpConversion final
     : OpConversionPattern<mlir::stablehlo::AllReduceOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::AllReduceOp op, OpAdaptor adaptor,
@@ -662,7 +662,7 @@ Value splitAndConcatForAllToAll(ConversionPatternRewriter &rewriter,
 
 struct AllToAllOpConversion final
     : OpConversionPattern<mlir::stablehlo::AllToAllOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::AllToAllOp op, OpAdaptor adaptor,
@@ -727,7 +727,7 @@ struct AllToAllOpConversion final
 
 struct ReduceScatterOpConversion final
     : OpConversionPattern<mlir::stablehlo::ReduceScatterOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ReduceScatterOp op, OpAdaptor adaptor,

--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
@@ -107,7 +107,7 @@ std::optional<ScfForBounds> extractForBounds(mlir::stablehlo::WhileOp op) {
 
 // Rewrites `stablehlo.while` to `scf.while` or `scf.for`.
 struct WhileOpPattern final : OpConversionPattern<mlir::stablehlo::WhileOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::WhileOp op, OpAdaptor adaptor,
@@ -164,7 +164,7 @@ struct WhileOpPattern final : OpConversionPattern<mlir::stablehlo::WhileOp> {
 
 // Rewrites `stablehlo.if` to `scf.if`.
 struct IfOpPattern final : OpConversionPattern<mlir::stablehlo::IfOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::IfOp op, OpAdaptor adaptor,
@@ -184,7 +184,7 @@ struct IfOpPattern final : OpConversionPattern<mlir::stablehlo::IfOp> {
 
 // Rewrites `stablehlo.case` to a nested `scf.if`.
 struct CaseOpPattern : public OpConversionPattern<mlir::stablehlo::CaseOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   // Recursively create if/else ops to handle each possible value in a case op.
   scf::IfOp createNestedCases(int currentIdx, mlir::stablehlo::CaseOp op,

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
@@ -52,7 +52,7 @@ namespace {
 /// so we use this lowering instead with a higher pattern benefit.
 struct ConcatenateOpConversion final
     : OpConversionPattern<mlir::stablehlo::ConcatenateOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ConcatenateOp op, OpAdaptor adaptor,
@@ -166,7 +166,7 @@ Value createLinalgMatmulOnTensors(OpBuilder b, Location loc,
 
 /// Converts stablehlo.fft operation to Linalg ops.
 struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::FftOp op, OpAdaptor adaptor,
@@ -211,7 +211,7 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
 
 struct OptimizationBarrierOpConversion final
     : OpConversionPattern<mlir::stablehlo::OptimizationBarrierOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::OptimizationBarrierOp op, OpAdaptor adaptor,
@@ -291,7 +291,7 @@ static void rewriteFuncAttrs(func::FuncOp funcOp) {
 
 // We need to convert func ops in order to convert types.
 struct BuiltinFuncOpPattern final : OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(func::FuncOp srcOp, OpAdaptor adaptor,
@@ -340,7 +340,7 @@ struct BuiltinFuncOpPattern final : OpConversionPattern<func::FuncOp> {
 };
 
 struct TensorEmptyPattern final : OpConversionPattern<tensor::EmptyOp> {
-  using OpConversionPattern<tensor::EmptyOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
@@ -362,7 +362,7 @@ struct TensorEmptyPattern final : OpConversionPattern<tensor::EmptyOp> {
 };
 
 struct GlobalOpPattern final : OpConversionPattern<ml_program::GlobalOp> {
-  using OpConversionPattern<ml_program::GlobalOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(ml_program::GlobalOp globalOp, OpAdaptor adaptor,

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -148,7 +148,7 @@ struct LinalgExtRegionHLOOpConversion final : OpConversionPattern<OpTy> {
 
 struct LinalgExtRegionReturnOpConversion final
     : OpConversionPattern<mlir::stablehlo::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -165,7 +165,7 @@ struct LinalgExtRegionReturnOpConversion final
 //===----------------------------------------------------------------------===//
 
 struct SortOpConversion final : OpConversionPattern<mlir::stablehlo::SortOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::SortOp op, OpAdaptor adaptor,
@@ -204,7 +204,7 @@ struct SortOpConversion final : OpConversionPattern<mlir::stablehlo::SortOp> {
 
 struct ScatterOpConversion final
     : OpConversionPattern<mlir::stablehlo::ScatterOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   /// Returns true if the `dimensionNumbers` from the stablehlo.scatter op
   /// follows a canonical form:
@@ -295,7 +295,7 @@ struct ScatterOpConversion final
 //===----------------------------------------------------------------------===//
 
 struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(mlir::stablehlo::FftOp op, OpAdaptor adaptor,
@@ -330,7 +330,7 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
 
 struct ReverseOpConversion final
     : OpConversionPattern<mlir::stablehlo::ReverseOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ReverseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -397,7 +397,7 @@ static bool checkUnary(const ArrayRef<int64_t> &values) {
 
 struct ScanOpConversion final
     : OpConversionPattern<mlir::stablehlo::ReduceWindowOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::stablehlo::ReduceWindowOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -546,7 +546,7 @@ struct ScanOpConversion final
 //===----------------------------------------------------------------------===//
 
 struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(chlo::TopKOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -76,7 +76,7 @@ public:
 //===----------------------------------------------------------------------===//
 struct ConvertHalInterfaceBindingSubspan final
     : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
@@ -99,7 +99,7 @@ struct ConvertHalInterfaceBindingSubspan final
 };
 
 struct ConvertMemRefAlloc final : OpConversionPattern<memref::AllocOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::AllocOp op, OpAdaptor adaptor,
@@ -185,7 +185,7 @@ struct GenericTypeConversionPattern : public ConversionPattern {
 };
 
 struct ConvertMemRefLoad final : OpConversionPattern<memref::LoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::LoadOp op, OpAdaptor adaptor,
@@ -204,7 +204,7 @@ struct ConvertMemRefLoad final : OpConversionPattern<memref::LoadOp> {
 };
 
 struct ConvertMemRefStore final : OpConversionPattern<memref::StoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::StoreOp op, OpAdaptor adaptor,
@@ -224,7 +224,7 @@ struct ConvertMemRefStore final : OpConversionPattern<memref::StoreOp> {
 
 struct ConvertAmdgpuFatRawBufferCast final
     : OpConversionPattern<amdgpu::FatRawBufferCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(amdgpu::FatRawBufferCastOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -36,7 +36,7 @@ namespace {
 
 struct ConvertHalInterfaceBindingSubspan final
     : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
@@ -331,7 +331,7 @@ static void nonAtomicRMW(OpBuilder &builder, Location loc,
 // NOTE: By default, all RMW sequences are atomic. Set `disableAtomicRMW` to
 // `false` to generate non-atomic RMW sequences.
 struct IREEConvertVectorStore final : OpConversionPattern<vector::StoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   IREEConvertVectorStore(MLIRContext *context, bool disableAtomicRMW,
                          PatternBenefit benefit)

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -173,7 +173,7 @@ struct FlattenAlloc final : public OpConversionPattern<AllocOpTy> {
 
 /// Flattens memref global ops with more than 1 dimensions to 1 dimension.
 struct FlattenGlobal final : public OpConversionPattern<memref::GlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   static Attribute flattenAttribute(Attribute value, ShapedType newType) {
     if (!value)
@@ -215,7 +215,7 @@ struct FlattenGlobal final : public OpConversionPattern<memref::GlobalOp> {
 /// Flattens memref global load ops with more than 1 dimensions to 1 dimension.
 struct FlattenGetGlobal final
     : public OpConversionPattern<memref::GetGlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::GetGlobalOp getOp, OpAdaptor adaptor,
@@ -242,7 +242,7 @@ struct FlattenGetGlobal final
 /// Flattens memref subspan ops with more than 1 dimensions to 1 dimension.
 struct FlattenBindingSubspan final
     : public OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp subspanOp,
@@ -320,7 +320,7 @@ struct FlattenBindingSubspan final
 // necessary.
 struct FlattenReinterpretCast
     : public OpConversionPattern<memref::ReinterpretCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::ReinterpretCastOp op, OpAdaptor adaptor,
@@ -432,7 +432,7 @@ static Value linearizeIndices(Value sourceValue, ValueRange indices,
 
 /// Flattens memref subspan ops with more than 1 dimensions to 1 dimension.
 struct FlattenSubView final : public OpConversionPattern<memref::SubViewOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::SubViewOp op, OpAdaptor adaptor,
@@ -463,7 +463,7 @@ struct FlattenSubView final : public OpConversionPattern<memref::SubViewOp> {
 
 /// Linearizes indices in memref.load ops.
 struct LinearizeLoadIndices final : public OpConversionPattern<memref::LoadOp> {
-  using OpConversionPattern<memref::LoadOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
@@ -488,7 +488,7 @@ struct LinearizeLoadIndices final : public OpConversionPattern<memref::LoadOp> {
 /// Linearizes indices in gpu.subgroup_mma_load_matrix ops.
 struct LinearizeMMALoadIndices final
     : public OpConversionPattern<gpu::SubgroupMmaLoadMatrixOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(gpu::SubgroupMmaLoadMatrixOp loadOp, OpAdaptor adaptor,
@@ -514,7 +514,7 @@ struct LinearizeMMALoadIndices final
 /// Linearizes indices in memref.store ops.
 struct LinearizeStoreIndices final
     : public OpConversionPattern<memref::StoreOp> {
-  using OpConversionPattern<memref::StoreOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::StoreOp storeOp, OpAdaptor adaptor,
@@ -539,7 +539,7 @@ struct LinearizeStoreIndices final
 /// Linearizes indices in gpu.subgroup_mma_store_matrix ops.
 struct LinearizeMMAStoreIndices final
     : public OpConversionPattern<gpu::SubgroupMmaStoreMatrixOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(gpu::SubgroupMmaStoreMatrixOp storeOp, OpAdaptor adaptor,
@@ -566,7 +566,7 @@ struct LinearizeMMAStoreIndices final
 /// Linearizes indices in vector.transfer_read ops.
 struct LinearizeTransferReadIndices final
     : public OpConversionPattern<vector::TransferReadOp> {
-  using OpConversionPattern<vector::TransferReadOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(vector::TransferReadOp transferReadOp, OpAdaptor adaptor,
@@ -599,7 +599,7 @@ struct LinearizeTransferReadIndices final
 /// Linearizes indices in vector.transfer_write ops.
 struct LinearizeTransferWriteIndices final
     : public OpConversionPattern<vector::TransferWriteOp> {
-  using OpConversionPattern<vector::TransferWriteOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(vector::TransferWriteOp transferWriteOp, OpAdaptor adaptor,
@@ -630,7 +630,7 @@ struct LinearizeTransferWriteIndices final
 
 /// Updates deallocations to the flattened allocation.
 struct FlattenDealloc final : public OpConversionPattern<memref::DeallocOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::DeallocOp deallocOp, OpAdaptor adaptor,
@@ -648,7 +648,7 @@ struct FlattenDealloc final : public OpConversionPattern<memref::DeallocOp> {
 /// Adjusts unrealized_conversion_cast ops' inputs to flattened memref values.
 struct AdjustConversionCast final
     : public OpConversionPattern<UnrealizedConversionCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(UnrealizedConversionCastOp castOp, OpAdaptor adaptor,
@@ -717,7 +717,7 @@ struct FoldMemRefReshape final : public OpConversionPattern<ReshapeOpTy> {
 /// Fold alignment hints.
 struct FoldAssumeAlignOp
     : public OpConversionPattern<memref::AssumeAlignmentOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::AssumeAlignmentOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -120,7 +120,7 @@ struct MaterializePadEncodingTypeConverter final
 /// materializing the encoding.
 struct MaterializeFlowDispatchTensorLoadOp final
     : OpConversionPattern<IREE::TensorExt::DispatchTensorLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::TensorExt::DispatchTensorLoadOp loadOp,
@@ -165,7 +165,7 @@ struct MaterializeFlowDispatchTensorLoadOp final
 /// materializing the encoding.
 struct MaterializeFlowDispatchTensorStoreOp final
     : OpConversionPattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
@@ -213,7 +213,7 @@ struct MaterializeFlowDispatchTensorStoreOp final
 /// TODO(#20160): Abstract new interface methods and collapse two patterns.
 struct MaterializeInterfaceBindingEncoding final
     : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp subspanOp,

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -712,7 +712,7 @@ getReassociationIndices(int outerDims,
 /// expand_shape + linalg.transpose to represent a tile swizzling op.
 struct SetEncodingOpLoweringConversion
     : public OpConversionPattern<IREE::Encoding::SetEncodingOp> {
-  using OpConversionPattern<IREE::Encoding::SetEncodingOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp, OpAdaptor adaptor,
@@ -888,7 +888,7 @@ static bool isRankedTensorTypeWithEncoding(Type type) {
 
 struct MaterializeFuncReturnOp final
     : public OpConversionPattern<func::ReturnOp> {
-  using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUEmulateNarrowType.cpp
@@ -24,7 +24,7 @@ namespace {
 
 struct ConvertRawBufferCast final
     : OpConversionPattern<amdgpu::FatRawBufferCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(amdgpu::FatRawBufferCastOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -352,7 +352,7 @@ struct HALInterfaceLoadConstantConverter final
 /// to annotate push constants.
 struct UtilAssumeIntConverter final
     : OpConversionPattern<IREE::Util::AssumeIntOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::Util::AssumeIntOp assumeOp, OpAdaptor adaptor,
@@ -506,7 +506,7 @@ struct RemoveStaticDynamicCast final : OpRewritePattern<memref::CastOp> {
 /// lowering when possible.
 struct RemoveIdentityConversionCast final
     : OpConversionPattern<UnrealizedConversionCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -49,7 +49,7 @@ namespace {
 
 struct ConvertHalInterfaceBindingSubspan final
     : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
@@ -78,7 +78,7 @@ struct ConvertHalInterfaceBindingSubspan final
 /// there's a type conversion, we drop the assumptions.
 struct ConvertUtilAssumeIntOp final
     : OpConversionPattern<IREE::Util::AssumeIntOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::Util::AssumeIntOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/Patterns.cpp
@@ -17,7 +17,7 @@ namespace {
 
 struct ConvertDeviceResolveAnyOp
     : public OpConversionPattern<IREE::HAL::DeviceResolveOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::DeviceResolveOp resolveOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -57,7 +57,7 @@ struct ConvertDeviceResolveAnyOp
 
 struct ConvertDeviceResolveAffinityOp
     : public OpConversionPattern<IREE::HAL::DeviceResolveOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::DeviceResolveOp resolveOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -103,7 +103,7 @@ struct ConvertDeviceResolveAffinityOp
 
 struct ConvertExecutableCalculateWorkgroupsOp
     : public OpConversionPattern<IREE::HAL::ExecutableCalculateWorkgroupsOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::ExecutableCalculateWorkgroupsOp calculateOp,
                   OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
@@ -180,7 +180,7 @@ private:
 
 struct MemoryTypeOpConversion
     : public OpConversionPattern<IREE::HAL::MemoryTypeOp> {
-  using OpConversionPattern<IREE::HAL::MemoryTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::MemoryTypeOp op,
                   IREE::HAL::MemoryTypeOp::Adaptor adaptor,
@@ -193,7 +193,7 @@ struct MemoryTypeOpConversion
 
 struct BufferUsageOpConversion
     : public OpConversionPattern<IREE::HAL::BufferUsageOp> {
-  using OpConversionPattern<IREE::HAL::BufferUsageOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferUsageOp op,
                   IREE::HAL::BufferUsageOp::Adaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
@@ -12,7 +12,7 @@ namespace mlir::iree_compiler {
 
 struct ElementTypeOpConversion
     : public OpConversionPattern<IREE::HAL::ElementTypeOp> {
-  using OpConversionPattern<IREE::HAL::ElementTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::ElementTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -28,7 +28,7 @@ struct ElementTypeOpConversion
 
 struct EncodingTypeOpConversion
     : public OpConversionPattern<IREE::HAL::EncodingTypeOp> {
-  using OpConversionPattern<IREE::HAL::EncodingTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::EncodingTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
@@ -74,7 +74,7 @@ namespace {
 class RemoveExecutableOpConversion
     : public OpConversionPattern<IREE::HAL::ExecutableOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::HAL::ExecutableOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
@@ -17,7 +17,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct BufferViewDimPattern : public OpConversionPattern<tensor::DimOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(tensor::DimOp dimOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -34,7 +34,7 @@ struct BufferViewDimPattern : public OpConversionPattern<tensor::DimOp> {
 };
 
 struct BufferViewRankPattern : public OpConversionPattern<tensor::RankOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(tensor::RankOp rankOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -1706,7 +1706,7 @@ struct ElideYieldOpPattern
 // equivalent we have access to so that we could do it in a generic way.
 struct GlobalTimepointConversionPattern
     : public OpConversionPattern<IREE::Util::GlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::GlobalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL/Patterns.cpp
@@ -19,7 +19,7 @@ namespace {
 
 struct GlobalConversionPattern
     : public OpConversionPattern<IREE::Util::GlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::GlobalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -538,7 +538,7 @@ struct ConvertChannelDefaultOp
 
 struct ConvertChannelSplitOp
     : public OpConversionPattern<IREE::Flow::ChannelSplitOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::ChannelSplitOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -550,7 +550,7 @@ struct ConvertChannelSplitOp
 
 struct ConvertChannelRankOp
     : public OpConversionPattern<IREE::Flow::ChannelRankOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::ChannelRankOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -562,7 +562,7 @@ struct ConvertChannelRankOp
 
 struct ConvertChannelCountOp
     : public OpConversionPattern<IREE::Flow::ChannelCountOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::ChannelCountOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -885,7 +885,7 @@ struct ConvertDispatchOp
 };
 
 struct ConvertFuncOp : public OpConversionPattern<IREE::Flow::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -1089,7 +1089,7 @@ struct ConvertDispatchWorkgroupInfoOp : public OpConversionPattern<FlowOpT> {
 
 struct ConvertExecutableOp
     : public OpConversionPattern<IREE::Flow::ExecutableOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::ExecutableOp flowOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -1194,7 +1194,7 @@ struct ConvertExecutableOp
 };
 
 struct ConvertReturnOp : public OpConversionPattern<IREE::Flow::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Flow::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -33,7 +33,7 @@ static SmallVector<Value> flattenValues(ArrayRef<ValueRange> values) {
 
 struct FuncOpSignatureConversion
     : public OpConversionPattern<IREE::Util::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
@@ -79,7 +79,7 @@ namespace {
 
 struct ConvertInitializerOp
     : public OpConversionPattern<IREE::Util::InitializerOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::InitializerOp initializerOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -97,7 +97,7 @@ struct ConvertInitializerOp
 };
 
 struct ConvertFuncOp : public OpConversionPattern<IREE::Util::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -140,7 +140,7 @@ struct ConvertFuncOp : public OpConversionPattern<IREE::Util::FuncOp> {
 };
 
 struct ConvertCallOp : public OpConversionPattern<IREE::Util::CallOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::CallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -159,7 +159,7 @@ struct ConvertCallOp : public OpConversionPattern<IREE::Util::CallOp> {
 };
 
 struct ConvertReturnOp : public OpConversionPattern<IREE::Util::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ReturnOp returnOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -170,7 +170,7 @@ struct ConvertReturnOp : public OpConversionPattern<IREE::Util::ReturnOp> {
 };
 
 struct ConvertFuncFuncOp : public OpConversionPattern<mlir::func::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::func::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -213,7 +213,7 @@ struct ConvertFuncFuncOp : public OpConversionPattern<mlir::func::FuncOp> {
 };
 
 struct ConvertFuncCallOp : public OpConversionPattern<mlir::func::CallOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::func::CallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -229,7 +229,7 @@ struct ConvertFuncCallOp : public OpConversionPattern<mlir::func::CallOp> {
 };
 
 struct ConvertFuncReturnOp : public OpConversionPattern<mlir::func::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::func::ReturnOp returnOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -240,7 +240,7 @@ struct ConvertFuncReturnOp : public OpConversionPattern<mlir::func::ReturnOp> {
 };
 
 struct ConvertBranchOp : public OpConversionPattern<mlir::cf::BranchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::cf::BranchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -252,7 +252,7 @@ struct ConvertBranchOp : public OpConversionPattern<mlir::cf::BranchOp> {
 
 struct ConvertCondBranchOp
     : public OpConversionPattern<mlir::cf::CondBranchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::cf::CondBranchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -265,7 +265,7 @@ struct ConvertCondBranchOp
 };
 
 struct ConvertSwitchOp : public OpConversionPattern<mlir::cf::SwitchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::cf::SwitchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -278,7 +278,7 @@ struct ConvertSwitchOp : public OpConversionPattern<mlir::cf::SwitchOp> {
 };
 
 struct ConvertSelectOp : public OpConversionPattern<mlir::arith::SelectOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::arith::SelectOp selectOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -290,7 +290,7 @@ struct ConvertSelectOp : public OpConversionPattern<mlir::arith::SelectOp> {
 };
 
 struct ConvertIfOp : public OpConversionPattern<scf::IfOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(scf::IfOp ifOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -315,7 +315,7 @@ struct ConvertIfOp : public OpConversionPattern<scf::IfOp> {
 };
 
 struct ConvertYieldOp : public OpConversionPattern<scf::YieldOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(scf::YieldOp yieldOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/FuncToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/FuncToUtil/Patterns.cpp
@@ -21,7 +21,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::FuncOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -124,7 +124,7 @@ struct FuncFuncOpPattern : public OpConversionPattern<func::FuncOp> {
 };
 
 struct FuncCallOpPattern : public OpConversionPattern<func::CallOp> {
-  using OpConversionPattern<func::CallOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::CallOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -143,7 +143,7 @@ struct FuncCallOpPattern : public OpConversionPattern<func::CallOp> {
 };
 
 struct FuncReturnOpPattern : public OpConversionPattern<func::ReturnOp> {
-  using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::ReturnOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -112,7 +112,7 @@ struct ElideNoOp final : public OpConversionPattern<OpTy> {
 };
 
 struct ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::GlobalOp globalOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -155,7 +155,7 @@ struct ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
 
 struct ConvertMemRefGetGlobalOp
     : public OpConversionPattern<memref::GetGlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::GetGlobalOp getOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -170,7 +170,7 @@ struct ConvertMemRefGetGlobalOp
 };
 
 struct ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::AllocaOp allocaOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -185,7 +185,7 @@ struct ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
 };
 
 struct ConvertMemRefDimOp : public OpConversionPattern<memref::DimOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::DimOp dimOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -206,7 +206,7 @@ struct ConvertMemRefDimOp : public OpConversionPattern<memref::DimOp> {
 };
 
 struct ConvertMemRefLoadOp : public OpConversionPattern<memref::LoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -245,7 +245,7 @@ struct ConvertMemRefLoadOp : public OpConversionPattern<memref::LoadOp> {
 };
 
 struct ConvertMemRefStoreOp : public OpConversionPattern<memref::StoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(memref::StoreOp storeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -284,7 +284,7 @@ struct ConvertMemRefStoreOp : public OpConversionPattern<memref::StoreOp> {
 // Make `reinterpret_cast` a no-op.
 struct ConvertMemRefReinterpretCastOp
     : public OpConversionPattern<memref::ReinterpretCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(memref::ReinterpretCastOp castOp, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
@@ -96,7 +96,7 @@ struct ConstantOpConversion : public OpConversionPattern<arith::ConstantOp> {
 };
 
 struct CmpI32OpConversion : public OpConversionPattern<arith::CmpIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::CmpIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -151,7 +151,7 @@ struct CmpI32OpConversion : public OpConversionPattern<arith::CmpIOp> {
 };
 
 struct CmpI64OpConversion : public OpConversionPattern<arith::CmpIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::CmpIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -206,7 +206,7 @@ struct CmpI64OpConversion : public OpConversionPattern<arith::CmpIOp> {
 };
 
 struct CmpF32OpConversion : public OpConversionPattern<arith::CmpFOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::CmpFOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -296,7 +296,7 @@ struct CmpF32OpConversion : public OpConversionPattern<arith::CmpFOp> {
 };
 
 struct CmpF64OpConversion : public OpConversionPattern<arith::CmpFOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::CmpFOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -483,7 +483,7 @@ struct IndexCastOpConversion : public OpConversionPattern<OpTy> {
 };
 
 struct ZeroExtendIOpConversion : public OpConversionPattern<arith::ExtUIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::ExtUIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -527,7 +527,7 @@ struct ZeroExtendIOpConversion : public OpConversionPattern<arith::ExtUIOp> {
 };
 
 struct SignExtendIOpConversion : public OpConversionPattern<arith::ExtSIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::ExtSIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -572,7 +572,7 @@ struct SignExtendIOpConversion : public OpConversionPattern<arith::ExtSIOp> {
 };
 
 struct TruncateIOpConversion : public OpConversionPattern<arith::TruncIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::TruncIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -617,7 +617,7 @@ struct TruncateIOpConversion : public OpConversionPattern<arith::TruncIOp> {
 };
 
 struct ExtendFOpConversion : public OpConversionPattern<arith::ExtFOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::ExtFOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -637,7 +637,7 @@ struct ExtendFOpConversion : public OpConversionPattern<arith::ExtFOp> {
 };
 
 struct SIToFPOpConversion : public OpConversionPattern<arith::SIToFPOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::SIToFPOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -684,7 +684,7 @@ struct SIToFPOpConversion : public OpConversionPattern<arith::SIToFPOp> {
 };
 
 struct UIToFPOpConversion : public OpConversionPattern<arith::UIToFPOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::UIToFPOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -732,7 +732,7 @@ struct UIToFPOpConversion : public OpConversionPattern<arith::UIToFPOp> {
 };
 
 struct FPToSIOpConversion : public OpConversionPattern<arith::FPToSIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::FPToSIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -758,7 +758,7 @@ struct FPToSIOpConversion : public OpConversionPattern<arith::FPToSIOp> {
 };
 
 struct FPToUIOpConversion : public OpConversionPattern<arith::FPToUIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::FPToUIOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -782,7 +782,7 @@ struct FPToUIOpConversion : public OpConversionPattern<arith::FPToUIOp> {
 };
 
 struct BitcastOpConversion : public OpConversionPattern<arith::BitcastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::BitcastOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -810,7 +810,7 @@ struct BitcastOpConversion : public OpConversionPattern<arith::BitcastOp> {
 };
 
 struct SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(arith::SelectOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
@@ -26,7 +26,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct ModuleOpConversion : public OpConversionPattern<ModuleOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(ModuleOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -110,7 +110,7 @@ static void copyFuncAttrs(func::FuncOp srcOp, Operation *dstOp) {
 }
 
 struct FuncOpConversion : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::FuncOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -184,7 +184,7 @@ static void copyImportAttrs(func::FuncOp srcOp, IREE::VM::ImportOp dstOp) {
 }
 
 struct ExternalFuncOpConversion : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(func::FuncOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -392,7 +392,7 @@ struct CallOpConversion : public OpConversionPattern<func::CallOp> {
 };
 
 struct ReturnOpConversion : public OpConversionPattern<mlir::func::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(mlir::func::ReturnOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -403,7 +403,7 @@ struct ReturnOpConversion : public OpConversionPattern<mlir::func::ReturnOp> {
 };
 
 template <typename StdOp>
-struct CastingOpConversion : public OpConversionPattern<StdOp> {
+struct CastingOpConversion final : public OpConversionPattern<StdOp> {
   using OpConversionPattern<StdOp>::OpConversionPattern;
   LogicalResult
   matchAndRewrite(StdOp srcOp, typename StdOp::Adaptor adaptor,
@@ -414,7 +414,7 @@ struct CastingOpConversion : public OpConversionPattern<StdOp> {
 };
 
 struct AssertOpConversion : public OpConversionPattern<cf::AssertOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(cf::AssertOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -434,7 +434,7 @@ struct AssertOpConversion : public OpConversionPattern<cf::AssertOp> {
 };
 
 struct BranchOpConversion : public OpConversionPattern<cf::BranchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(cf::BranchOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -445,7 +445,7 @@ struct BranchOpConversion : public OpConversionPattern<cf::BranchOp> {
 };
 
 struct CondBranchOpConversion : public OpConversionPattern<cf::CondBranchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(cf::CondBranchOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -458,7 +458,7 @@ struct CondBranchOpConversion : public OpConversionPattern<cf::CondBranchOp> {
 };
 
 struct SwitchOpConversion : public OpConversionPattern<cf::SwitchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(cf::SwitchOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
@@ -48,7 +48,7 @@ void insertAlignOps(IREE::Util::AlignOp srcOp,
 }
 
 struct AlignOpConversion : public OpConversionPattern<IREE::Util::AlignOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::AlignOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -81,7 +81,7 @@ struct AlignOpConversion : public OpConversionPattern<IREE::Util::AlignOp> {
 /// where it is known.
 struct FixateIndexSizeofConversion
     : public OpConversionPattern<IREE::Util::SizeOfOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::SizeOfOp sizeofOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAssignmentOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAssignmentOps.cpp
@@ -23,7 +23,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct SwitchOpConversion : public OpConversionPattern<IREE::Util::SwitchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::SwitchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
@@ -35,7 +35,7 @@ static Value castToIndex(Value value, OpBuilder &builder) {
 
 struct BufferConstantOpConversion
     : public OpConversionPattern<IREE::Util::BufferConstantOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -63,7 +63,7 @@ static Value getAlignment(Location loc, std::optional<APInt> alignment,
 
 struct BufferAllocOpConversion
     : public OpConversionPattern<IREE::Util::BufferAllocOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferAllocOp allocOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -78,7 +78,7 @@ struct BufferAllocOpConversion
 
 struct BufferDeallocOpConversion
     : public OpConversionPattern<IREE::Util::BufferDeallocOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferDeallocOp deallocOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -94,7 +94,7 @@ struct BufferDeallocOpConversion
 // do in the runtime besides this.
 struct BufferSliceOpConversion
     : public OpConversionPattern<IREE::Util::BufferSliceOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferSliceOp sliceOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -116,7 +116,7 @@ struct BufferSliceOpConversion
 
 struct BufferSizeOpConversion
     : public OpConversionPattern<IREE::Util::BufferSizeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferSizeOp sizeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -129,7 +129,7 @@ struct BufferSizeOpConversion
 
 struct BufferCopyOpConversion
     : public OpConversionPattern<IREE::Util::BufferCopyOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferCopyOp copyOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -144,7 +144,7 @@ struct BufferCopyOpConversion
 
 struct BufferCompareOpConversion
     : public OpConversionPattern<IREE::Util::BufferCompareOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferCompareOp compareOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -170,7 +170,7 @@ static Value unscaleOffset(Location loc, Value offset, int64_t scale,
 
 struct BufferFillOpConversion
     : public OpConversionPattern<IREE::Util::BufferFillOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferFillOp fillOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -221,7 +221,7 @@ struct BufferFillOpConversion
 
 struct BufferLoadOpConversion
     : public OpConversionPattern<IREE::Util::BufferLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferLoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -277,7 +277,7 @@ struct BufferLoadOpConversion
 
 struct BufferStoreOpConversion
     : public OpConversionPattern<IREE::Util::BufferStoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferStoreOp storeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -318,7 +318,7 @@ struct BufferStoreOpConversion
 
 struct BufferHashOpConversion
     : public OpConversionPattern<IREE::Util::BufferHashOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::BufferHashOp hashOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -16,7 +16,7 @@ namespace {
 
 struct InitializerOpConversion
     : public OpConversionPattern<IREE::Util::InitializerOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::InitializerOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -38,7 +38,7 @@ struct InitializerOpConversion
 };
 
 struct ReturnOpConversion : public OpConversionPattern<IREE::Util::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ReturnOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
@@ -35,7 +35,7 @@ static Value castToIndex(Value value, OpBuilder &builder) {
 
 class ListCreateOpConversion
     : public OpConversionPattern<IREE::Util::ListCreateOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListCreateOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -55,7 +55,7 @@ class ListCreateOpConversion
 
 class ListConstructOpConversion
     : public OpConversionPattern<IREE::Util::ListConstructOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListConstructOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -104,7 +104,7 @@ class ListConstructOpConversion
 
 class ListSizeOpConversion
     : public OpConversionPattern<IREE::Util::ListSizeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListSizeOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -117,7 +117,7 @@ class ListSizeOpConversion
 
 class ListResizeOpConversion
     : public OpConversionPattern<IREE::Util::ListResizeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListResizeOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -128,7 +128,7 @@ class ListResizeOpConversion
 };
 
 class ListGetOpConversion : public OpConversionPattern<IREE::Util::ListGetOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListGetOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -157,7 +157,7 @@ class ListGetOpConversion : public OpConversionPattern<IREE::Util::ListGetOp> {
 };
 
 class ListSetOpConversion : public OpConversionPattern<IREE::Util::ListSetOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::ListSetOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
@@ -17,7 +17,7 @@ namespace {
 
 struct InitializerOpConversion
     : public OpConversionPattern<IREE::Util::InitializerOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::Util::InitializerOp op, OpAdaptor adaptor,
@@ -85,7 +85,7 @@ static void copyFuncAttrs(IREE::Util::FuncOp srcOp, Operation *dstOp) {
 }
 
 class FuncOpConversion : public OpConversionPattern<IREE::Util::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::FuncOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -161,7 +161,7 @@ static void copyImportAttrs(IREE::Util::FuncOp srcOp,
 
 class ExternalFuncOpConversion
     : public OpConversionPattern<IREE::Util::FuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::FuncOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -367,7 +367,7 @@ struct CallOpConversion : public OpConversionPattern<IREE::Util::CallOp> {
 };
 
 struct ReturnOpConversion : public OpConversionPattern<IREE::Util::ReturnOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(IREE::Util::ReturnOp op, OpAdaptor adaptor,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
@@ -55,7 +55,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct NullOpConversion : public OpConversionPattern<IREE::Util::NullOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::NullOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -70,7 +70,7 @@ struct NullOpConversion : public OpConversionPattern<IREE::Util::NullOp> {
 //===----------------------------------------------------------------------===//
 
 struct CmpEQOpConversion : public OpConversionPattern<IREE::Util::CmpEQOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::CmpEQOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -89,7 +89,7 @@ struct CmpEQOpConversion : public OpConversionPattern<IREE::Util::CmpEQOp> {
 //===----------------------------------------------------------------------===//
 
 struct CmpNEOpConversion : public OpConversionPattern<IREE::Util::CmpNEOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::CmpNEOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -109,7 +109,7 @@ struct CmpNEOpConversion : public OpConversionPattern<IREE::Util::CmpNEOp> {
 
 struct UnreachableOpConversion
     : public OpConversionPattern<IREE::Util::UnreachableOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::UnreachableOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -104,7 +104,7 @@ namespace {
 /// function.
 struct ConvertHALInterfaceWorkgroupIDOp
     : public OpConversionPattern<IREE::HAL::InterfaceWorkgroupIDOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceWorkgroupIDOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -128,7 +128,7 @@ struct ConvertHALInterfaceWorkgroupIDOp
 /// function.
 struct ConvertHALInterfaceWorkgroupSizeOp
     : public OpConversionPattern<IREE::HAL::InterfaceWorkgroupSizeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceWorkgroupSizeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -152,7 +152,7 @@ struct ConvertHALInterfaceWorkgroupSizeOp
 /// the function.
 struct ConvertHALInterfaceWorkgroupCountOp
     : public OpConversionPattern<IREE::HAL::InterfaceWorkgroupCountOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceWorkgroupCountOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -175,7 +175,7 @@ struct ConvertHALInterfaceWorkgroupCountOp
 /// Rewrites hal.interface.constant.load to ops loading from the ABI structs.
 struct ConvertHALInterfaceConstantLoadOp
     : public OpConversionPattern<IREE::HAL::InterfaceConstantLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceConstantLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -205,7 +205,7 @@ struct ConvertHALInterfaceConstantLoadOp
 
 struct ConvertGetRawInterfaceBindingBufferOp
     : public OpConversionPattern<IREE::VMVX::GetRawInterfaceBindingBufferOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::VMVX::GetRawInterfaceBindingBufferOp op,
                   OpAdaptor adaptor,
@@ -233,7 +233,7 @@ struct ConvertGetRawInterfaceBindingBufferOp
 /// Rewrites hal.interface.binding.subspan to ops loading from the ABI structs.
 struct ConvertHALInterfaceBindingSubspanOp
     : public OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/StandardToVMVX/ConvertStandardToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/StandardToVMVX/ConvertStandardToVMVX.cpp
@@ -43,7 +43,7 @@ struct FoldAsNoOp final : public OpConversionPattern<OpTy> {
 /// lowering when possible.
 struct RemoveIdentityConversionCast final
     : public OpConversionPattern<UnrealizedConversionCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
@@ -21,7 +21,7 @@ namespace {
 
 struct ElementTypeOpConversion
     : public OpConversionPattern<IREE::HAL::ElementTypeOp> {
-  using OpConversionPattern<IREE::HAL::ElementTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::ElementTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -37,7 +37,7 @@ struct ElementTypeOpConversion
 
 struct EncodingTypeOpConversion
     : public OpConversionPattern<IREE::HAL::EncodingTypeOp> {
-  using OpConversionPattern<IREE::HAL::EncodingTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::EncodingTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -52,7 +52,7 @@ struct EncodingTypeOpConversion
 
 struct MemoryTypeOpConversion
     : public OpConversionPattern<IREE::HAL::MemoryTypeOp> {
-  using OpConversionPattern<IREE::HAL::MemoryTypeOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::MemoryTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -64,7 +64,7 @@ struct MemoryTypeOpConversion
 
 struct BufferUsageOpConversion
     : public OpConversionPattern<IREE::HAL::BufferUsageOp> {
-  using OpConversionPattern<IREE::HAL::BufferUsageOp>::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferUsageOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -76,7 +76,7 @@ struct BufferUsageOpConversion
 
 struct BufferSubspanOpPattern
     : public OpConversionPattern<IREE::HAL::BufferSubspanOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferSubspanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -90,7 +90,7 @@ struct BufferSubspanOpPattern
 
 struct BufferLengthOpPattern
     : public OpConversionPattern<IREE::HAL::BufferLengthOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferLengthOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -103,7 +103,7 @@ struct BufferLengthOpPattern
 
 struct BufferLoadOpPattern
     : public OpConversionPattern<IREE::HAL::BufferLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -124,7 +124,7 @@ struct BufferLoadOpPattern
 
 struct BufferStoreOpPattern
     : public OpConversionPattern<IREE::HAL::BufferStoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferStoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -144,7 +144,7 @@ struct BufferStoreOpPattern
 
 struct BufferViewCreateOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewCreateOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewCreateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -158,7 +158,7 @@ struct BufferViewCreateOpPattern
 
 struct BufferViewBufferOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewBufferOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewBufferOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -170,7 +170,7 @@ struct BufferViewBufferOpPattern
 
 struct BufferViewAssertOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewAssertOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewAssertOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -184,7 +184,7 @@ struct BufferViewAssertOpPattern
 
 struct BufferViewElementTypeOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewElementTypeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewElementTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -196,7 +196,7 @@ struct BufferViewElementTypeOpPattern
 
 struct BufferViewEncodingTypeOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewEncodingTypeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewEncodingTypeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -208,7 +208,7 @@ struct BufferViewEncodingTypeOpPattern
 
 struct BufferViewRankOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewRankOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewRankOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -220,7 +220,7 @@ struct BufferViewRankOpPattern
 
 struct BufferViewDimOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewDimOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewDimOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -233,7 +233,7 @@ struct BufferViewDimOpPattern
 
 struct BufferViewTraceOpPattern
     : public OpConversionPattern<IREE::HAL::BufferViewTraceOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::HAL::BufferViewTraceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -57,7 +57,7 @@ static Storage getResourceStorage(Location loc, Value resource,
 
 struct ResourceAllocOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceAllocOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceAllocOp allocOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -79,7 +79,7 @@ struct ResourceAllocOpPattern
 
 struct ResourceAllocaOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceAllocaOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceAllocaOp allocaOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -104,7 +104,7 @@ struct ResourceAllocaOpPattern
 
 struct ResourceDeallocaOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceDeallocaOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceDeallocaOp deallocaOp,
                   OpAdaptor adaptor,
@@ -120,7 +120,7 @@ struct ResourceDeallocaOpPattern
 
 struct ResourceRetainOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceRetainOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceRetainOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -132,7 +132,7 @@ struct ResourceRetainOpPattern
 
 struct ResourceReleaseOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceReleaseOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceReleaseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -145,7 +145,7 @@ struct ResourceReleaseOpPattern
 
 struct ResourceIsTerminalOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceIsTerminalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceIsTerminalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -158,7 +158,7 @@ struct ResourceIsTerminalOpPattern
 
 struct ResourceSizeOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceSizeOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceSizeOp sizeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -173,7 +173,7 @@ struct ResourceSizeOpPattern
 // (after taking a subspan for the defined range).
 struct ResourceTryMapOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceTryMapOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceTryMapOp tryMapOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -190,7 +190,7 @@ struct ResourceTryMapOpPattern
 
 struct ResourceLoadOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceLoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -210,7 +210,7 @@ struct ResourceLoadOpPattern
 
 struct ResourceStoreOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceStoreOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceStoreOp storeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -228,7 +228,7 @@ struct ResourceStoreOpPattern
 
 struct ResourceSubviewOpPattern
     : public OpConversionPattern<IREE::Stream::ResourceSubviewOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceSubviewOp subviewOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -250,7 +250,7 @@ struct ResourceSubviewOpPattern
 
 struct FileConstantOpPattern
     : public OpConversionPattern<IREE::Stream::FileConstantOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileConstantOp constantOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -263,7 +263,7 @@ struct FileConstantOpPattern
 
 struct FileReadOpPattern
     : public OpConversionPattern<IREE::Stream::FileReadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileReadOp readOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -286,7 +286,7 @@ struct FileReadOpPattern
 
 struct FileWriteOpPattern
     : public OpConversionPattern<IREE::Stream::FileWriteOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::FileWriteOp writeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -310,7 +310,7 @@ struct FileWriteOpPattern
 
 struct TensorImportBufferOpPattern
     : public OpConversionPattern<IREE::Stream::TensorImportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -327,7 +327,7 @@ struct TensorImportBufferOpPattern
 
 struct TensorImportBufferViewOpPattern
     : public OpConversionPattern<IREE::Stream::TensorImportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -347,7 +347,7 @@ struct TensorImportBufferViewOpPattern
 
 struct TensorExportBufferOpPattern
     : public OpConversionPattern<IREE::Stream::TensorExportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -361,7 +361,7 @@ struct TensorExportBufferOpPattern
 
 struct TensorExportBufferViewOpPattern
     : public OpConversionPattern<IREE::Stream::TensorExportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -404,7 +404,7 @@ struct TensorExportBufferViewOpPattern
 
 struct TensorTraceOpPattern
     : public OpConversionPattern<IREE::Stream::TensorTraceOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorTraceOp traceOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -438,7 +438,7 @@ struct TensorTraceOpPattern
 
 struct CmdFlushOpPattern
     : public OpConversionPattern<IREE::Stream::CmdFlushOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFlushOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -449,7 +449,7 @@ struct CmdFlushOpPattern
 
 struct CmdInvalidateOpPattern
     : public OpConversionPattern<IREE::Stream::CmdInvalidateOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdInvalidateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -460,7 +460,7 @@ struct CmdInvalidateOpPattern
 
 struct CmdDiscardOpPattern
     : public OpConversionPattern<IREE::Stream::CmdDiscardOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdDiscardOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -470,7 +470,7 @@ struct CmdDiscardOpPattern
 };
 
 struct CmdFillOpPattern : public OpConversionPattern<IREE::Stream::CmdFillOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFillOp fillOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -485,7 +485,7 @@ struct CmdFillOpPattern : public OpConversionPattern<IREE::Stream::CmdFillOp> {
 };
 
 struct CmdCopyOpPattern : public OpConversionPattern<IREE::Stream::CmdCopyOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdCopyOp copyOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -505,7 +505,7 @@ struct CmdCopyOpPattern : public OpConversionPattern<IREE::Stream::CmdCopyOp> {
 
 struct CmdDispatchOpPattern
     : public OpConversionPattern<IREE::Stream::CmdDispatchOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdDispatchOp dispatchOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -545,7 +545,7 @@ struct CmdDispatchOpPattern
 };
 
 struct CmdFuncOpPattern : public OpConversionPattern<IREE::Stream::CmdFuncOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdFuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -569,7 +569,7 @@ struct CmdFuncOpPattern : public OpConversionPattern<IREE::Stream::CmdFuncOp> {
 };
 
 struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdCallOp callOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -613,7 +613,7 @@ struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
 
 struct CmdExecuteOpPattern
     : public OpConversionPattern<IREE::Stream::CmdExecuteOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdExecuteOp executeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -631,7 +631,7 @@ struct CmdExecuteOpPattern
 
 struct CmdSerialOpPattern
     : public OpConversionPattern<IREE::Stream::CmdSerialOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdSerialOp serialOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -644,7 +644,7 @@ struct CmdSerialOpPattern
 
 struct CmdConcurrentOpPattern
     : public OpConversionPattern<IREE::Stream::CmdConcurrentOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::CmdConcurrentOp concurrentOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -659,7 +659,7 @@ struct CmdConcurrentOpPattern
 // equivalent we have access to so that we could do it in a generic way.
 struct GlobalTimepointConversionPattern
     : public OpConversionPattern<IREE::Util::GlobalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Util::GlobalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -676,7 +676,7 @@ struct GlobalTimepointConversionPattern
 
 struct TimepointImmediateOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointImmediateOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointImmediateOp immediateOp,
                   OpAdaptor adaptor,
@@ -688,7 +688,7 @@ struct TimepointImmediateOpPattern
 
 struct TimepointImportOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointImportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointImportOp importOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -700,7 +700,7 @@ struct TimepointImportOpPattern
 
 struct TimepointExportOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointExportOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointExportOp exportOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -712,7 +712,7 @@ struct TimepointExportOpPattern
 
 struct TimepointChainExternalOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointChainExternalOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointChainExternalOp exportOp,
                   OpAdaptor adaptor,
@@ -725,7 +725,7 @@ struct TimepointChainExternalOpPattern
 
 struct TimepointJoinOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointJoinOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointJoinOp joinOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -736,7 +736,7 @@ struct TimepointJoinOpPattern
 
 struct TimepointBarrierOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointBarrierOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointBarrierOp barrierOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -751,7 +751,7 @@ struct TimepointBarrierOpPattern
 
 struct TimepointAwaitOpPattern
     : public OpConversionPattern<IREE::Stream::TimepointAwaitOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::TimepointAwaitOp awaitOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -761,7 +761,7 @@ struct TimepointAwaitOpPattern
 };
 
 struct ElideYieldOpPattern : public OpConversionPattern<IREE::Stream::YieldOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::YieldOp yieldOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.cpp
@@ -24,7 +24,7 @@ namespace {
 
 struct ParameterLoadOpPattern
     : public OpConversionPattern<IREE::Stream::ParameterLoadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ParameterLoadOp loadOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -68,7 +68,7 @@ struct ParameterLoadOpPattern
 
 struct ParameterReadOpPattern
     : public OpConversionPattern<IREE::Stream::ParameterReadOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ParameterReadOp readOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -98,7 +98,7 @@ struct ParameterReadOpPattern
 
 struct ParameterWriteOpPattern
     : public OpConversionPattern<IREE::Stream::ParameterWriteOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ParameterWriteOp writeOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -127,7 +127,7 @@ struct ParameterWriteOpPattern
 
 struct ParameterGatherOpPattern
     : public OpConversionPattern<IREE::Stream::ParameterGatherOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ParameterGatherOp gatherOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -155,7 +155,7 @@ struct ParameterGatherOpPattern
 
 struct ParameterScatterOpPattern
     : public OpConversionPattern<IREE::Stream::ParameterScatterOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
   LogicalResult
   matchAndRewrite(IREE::Stream::ParameterScatterOp scatterOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {


### PR DESCRIPTION
Use the `Base` type alias added in https://github.com/llvm/llvm-project/pull/158433.