### PR TITLE
Integrate llvm/llvm-project@7af31bf

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -555,8 +555,8 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
           return consumerOperand.getDefiningOp<tensor::EmptyOp>();
         });
   };
-  linalg::populateDataLayoutPropagationPatterns(propagationPatterns,
-                                                controlPropagationFn);
+  linalg::populateDataLayoutPropagationPatterns(
+      propagationPatterns, controlPropagationFn, /*PoisonPaddingOk=*/true);
   // TODO(Max191): The propagation patterns could be applied at the same time as
   // relayout ops are folded into the map_scatter, which may enable even more
   // folding. This requires the relayout op folding to be done as pattern

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -314,7 +314,8 @@ void GPUPackToIntrinsicsPass::runOnOperation() {
            consumer->getBlock() == producer->getBlock();
   };
 
-  linalg::populateDataLayoutPropagationPatterns(patterns, control);
+  linalg::populateDataLayoutPropagationPatterns(patterns, control,
+                                                /*PoisonPaddingOk=*/true);
   linalg::populateExtractSliceSinkingPatterns(patterns, controlExtract);
   patterns.add<PackDestinationForOp>(context);
   linalg::UnPackOp::getCanonicalizationPatterns(patterns, context);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -58,14 +58,11 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:     %[[WG_TARGET:.+]] = memref.subview %[[ARG2]]
 //       CHECK:     %[[TID_X:.+]] = gpu.thread_id x
 //       CHECK:     %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK:     %[[TID_Y:.+]] = gpu.thread_id y
-//       CHECK:     %[[DIM_Y:.+]] = gpu.block_dim y
-//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:         %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][%[[IV_Y]], %[[IV_X]]] [1, 1] [1, 1]
-//       CHECK:         %[[T_INDEX:.+]] = memref.subview %[[WG_INDEX]][%[[IV_Y]], 0] [1, 1] [1, 1]
-//       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
-//       CHECK:         iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
-//  CHECK-SAME:           ins(%[[T_UPDATE]], %[[T_INDEX]]
-//  CHECK-SAME:           outs(%[[T_TARGET]]
+//       CHECK:     scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:       %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][0, %[[IV_X]]] [1, 1] [1, 1]
+//       CHECK:       %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
+//       CHECK:       %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
+//       CHECK:       iree_linalg_ext.scatter
+//  CHECK-SAME:         unique_indices(true)
+//  CHECK-SAME:         ins(%[[T_UPDATE]], %[[T_INDEX]]
+//  CHECK-SAME:         outs(%[[T_TARGET]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -58,11 +58,14 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:     %[[WG_TARGET:.+]] = memref.subview %[[ARG2]]
 //       CHECK:     %[[TID_X:.+]] = gpu.thread_id x
 //       CHECK:     %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK:     scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:       %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][0, %[[IV_X]]] [1, 1] [1, 1]
-//       CHECK:       %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
-//       CHECK:       %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
-//       CHECK:       iree_linalg_ext.scatter
-//  CHECK-SAME:         unique_indices(true)
-//  CHECK-SAME:         ins(%[[T_UPDATE]], %[[T_INDEX]]
-//  CHECK-SAME:         outs(%[[T_TARGET]]
+//       CHECK:     %[[TID_Y:.+]] = gpu.thread_id y
+//       CHECK:     %[[DIM_Y:.+]] = gpu.block_dim y
+//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
+//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:         %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][%[[IV_Y]], %[[IV_X]]] [1, 1] [1, 1]
+//       CHECK:         %[[T_INDEX:.+]] = memref.subview %[[WG_INDEX]][%[[IV_Y]], 0] [1, 1] [1, 1]
+//       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
+//       CHECK:         iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
+//  CHECK-SAME:           ins(%[[T_UPDATE]], %[[T_INDEX]]
+//  CHECK-SAME:           outs(%[[T_TARGET]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
@@ -50,11 +50,10 @@ util.func public @layoutDynamic(%size_a: index, %size_b: index) -> (index, index
   // CHECK-DAG: %c0 = arith.constant 0 : index
   // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
-  // CHECK-DAG: %1 = arith.addi %0, %c0 : index
-  // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index
-  // CHECK-DAG: %3 = arith.addi %1, %2 : index
+  // CHECK-DAG: %1 = util.align %[[SIZE_B]], %c16 : index
+  // CHECK-DAG: %2 = arith.addi %0, %1 : index
 
-  // CHECK: util.return %3, %c0, %1, %c0
+  // CHECK: util.return %2, %c0, %0, %c0
   util.return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
@@ -50,10 +50,11 @@ util.func public @layoutDynamic(%size_a: index, %size_b: index) -> (index, index
   // CHECK-DAG: %c0 = arith.constant 0 : index
   // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
-  // CHECK-DAG: %1 = util.align %[[SIZE_B]], %c16 : index
-  // CHECK-DAG: %2 = arith.addi %0, %1 : index
+  // CHECK-DAG: %1 = arith.addi %0, %c0 : index
+  // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index
+  // CHECK-DAG: %3 = arith.addi %1, %2 : index
 
-  // CHECK: util.return %2, %c0, %0, %c0
+  // CHECK: util.return %3, %c0, %1, %c0
   util.return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
 }
 

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -152,6 +152,7 @@ iree_bytecode_module(
     ],
 )
 
+# TODO:Fix https://github.com/iree-org/iree/issues/22161
 #iree_bytecode_module(
 #    name = "simple_embedding_test_bytecode_module_cpu_arm_32",
 #    src = "simple_embedding_test.mlir",

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -152,21 +152,21 @@ iree_bytecode_module(
     ],
 )
 
-iree_bytecode_module(
-    name = "simple_embedding_test_bytecode_module_cpu_arm_32",
-    src = "simple_embedding_test.mlir",
-    c_identifier = "iree_samples_simple_embedding_test_module_cpu_arm_32",
-    flags = [
-        "--iree-hal-target-device=local",
-        "--iree-hal-local-target-device-backends=llvm-cpu",
-        "--iree-llvmcpu-target-triple=armv7a-pc-linux-elf",
-        "--iree-llvmcpu-target-cpu=generic",
-        "--iree-llvmcpu-target-float-abi=hard",
-        "--iree-llvmcpu-debug-symbols=false",
-        "--iree-vm-bytecode-module-strip-source-map=true",
-        "--iree-vm-emit-polyglot-zip=false",
-    ],
-)
+#iree_bytecode_module(
+#    name = "simple_embedding_test_bytecode_module_cpu_arm_32",
+#    src = "simple_embedding_test.mlir",
+#    c_identifier = "iree_samples_simple_embedding_test_module_cpu_arm_32",
+#    flags = [
+#        "--iree-hal-target-device=local",
+#        "--iree-hal-local-target-device-backends=llvm-cpu",
+#        "--iree-llvmcpu-target-triple=armv7a-pc-linux-elf",
+#        "--iree-llvmcpu-target-cpu=generic",
+#        "--iree-llvmcpu-target-float-abi=hard",
+#        "--iree-llvmcpu-debug-symbols=false",
+#        "--iree-vm-bytecode-module-strip-source-map=true",
+#        "--iree-vm-emit-polyglot-zip=false",
+#    ],
+#)
 
 iree_bytecode_module(
     name = "simple_embedding_test_bytecode_module_cpu_arm_64",

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -152,7 +152,7 @@ iree_bytecode_module(
     ],
 )
 
-# TODO:Fix https://github.com/iree-org/iree/issues/22161
+# TODO(#22161): reenable the bytecode module.
 #iree_bytecode_module(
 #    name = "simple_embedding_test_bytecode_module_cpu_arm_32",
 #    src = "simple_embedding_test.mlir",

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -89,7 +89,7 @@ iree_runtime_cc_binary(
         "simple_embedding.c",
     ],
     deps = [
-        ":simple_embedding_test_bytecode_module_cpu_arm_32_c",
+        #":simple_embedding_test_bytecode_module_cpu_arm_32_c",
         ":simple_embedding_test_bytecode_module_cpu_arm_64_c",
         ":simple_embedding_test_bytecode_module_cpu_riscv_32_c",
         ":simple_embedding_test_bytecode_module_cpu_riscv_64_c",

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -147,25 +147,6 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    simple_embedding_test_bytecode_module_cpu_arm_32
-  SRC
-    "simple_embedding_test.mlir"
-  C_IDENTIFIER
-    "iree_samples_simple_embedding_test_module_cpu_arm_32"
-  FLAGS
-    "--iree-hal-target-device=local"
-    "--iree-hal-local-target-device-backends=llvm-cpu"
-    "--iree-llvmcpu-target-triple=armv7a-pc-linux-elf"
-    "--iree-llvmcpu-target-cpu=generic"
-    "--iree-llvmcpu-target-float-abi=hard"
-    "--iree-llvmcpu-debug-symbols=false"
-    "--iree-vm-bytecode-module-strip-source-map=true"
-    "--iree-vm-emit-polyglot-zip=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
     simple_embedding_test_bytecode_module_cpu_arm_64
   SRC
     "simple_embedding_test.mlir"

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -74,7 +74,6 @@ iree_cc_binary(
     "device_embedded_sync.c"
     "simple_embedding.c"
   DEPS
-    ::simple_embedding_test_bytecode_module_cpu_arm_32_c
     ::simple_embedding_test_bytecode_module_cpu_arm_64_c
     ::simple_embedding_test_bytecode_module_cpu_riscv_32_c
     ::simple_embedding_test_bytecode_module_cpu_riscv_64_c


### PR DESCRIPTION
Carrying revert for 9690a718b.
Adds revert for https://github.com/llvm/llvm-project/pull/160615 due to infinite loop error
Skips generating test which segfaults during test generation on msvc.

ci-extra: windows_x64_msvc
