### PR TITLE
[NFC][Codegen] Vector distribute kernel config test refactor 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -53,7 +53,7 @@ func.func @expanded_matmul_transpose_b() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @conv_nhwc() {
+func.func @conv_nhwc_1() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x258x514x768xf16>>
@@ -68,7 +68,7 @@ func.func @conv_nhwc() {
   return
 }
 
-// CHECK-LABEL: func.func @conv_nhwc()
+// CHECK-LABEL: func.func @conv_nhwc_1()
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 64]
@@ -107,10 +107,9 @@ func.func @matmul_256x256x256() attributes {hal.executable.target = #executable_
 // Check that we do not use the distribute pipeline if there are no supported
 // intrinsics.
 //       CHECK-NOT: iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK-LABEL: func.func @matmul_256x256x256()
 
 // -----
-
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -132,14 +131,16 @@ func.func @mfma_matmul_1024x1024x1024() {
   return
 }
 
+// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 128]
-// CHECK-SAME{LITERAL}:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
+// CHECK-SAME{LITERAL}:                  subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
 // -----
+
 
 // CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 
@@ -154,7 +155,7 @@ func.func @mfma_matmul_1024x1024x1024() {
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d4, d8)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
 #map3 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
-func.func @conv_nchwc() {
+func.func @conv_nchwc_2() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x20x34x34x64xf16>>
@@ -182,7 +183,7 @@ func.func @conv_nchwc() {
   return
 }
 
-// CHECK-LABEL: func.func @conv_nchwc()
+// CHECK-LABEL: func.func @conv_nchwc_2()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
@@ -464,3 +465,54 @@ func.func @attention_multi_m_dynamic(%4 : tensor<20x8x?x16x64xf16>, %5 : tensor<
 // CHECK-SAME:           #iree_gpu.lowering_config
 // CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 64, 0]
 // CHECK-SAME:                           workgroup =  [1, 4, 1, 16, 0, 0, 64]
+
+// -----
+
+// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK-SAME: iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @attention_20x1x64x4096x64() {
+  %cst = arith.constant 1.250000e-01 : f16
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
+  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
+  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+  %7 = tensor.empty() : tensor<20x1x64xf16>
+  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+               affine_map<(d0, d1, d2, d3, d4) -> ()>,
+               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
+                ^bb0(%score: f32):
+                  iree_linalg_ext.yield %score : f32
+               } -> tensor<20x1x64xf16>
+  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
+  return
+}
+
+// CHECK:      decomposition_config =
+// CHECK-SAME:  pv_attrs =
+// CHECK-SAME:    #iree_gpu.lowering_config
+// CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 4, 3]{{\]}}
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 4, 3]{{\]}}
+// CHECK-SAME:      thread = [0, 0, 0, 8]
+// CHECK-SAME:  qk_attrs =
+// CHECK-SAME:    #iree_gpu.lowering_config
+// CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 3, 4]{{\]}}
+// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 2, 4]{{\]}}
+// CHECK-SAME:      thread = [0, 0, 8, 0]
+// CHECK-SAME:  lowering_config =
+// CHECK-SAME:    #iree_gpu.lowering_config
+// CHECK-SAME:      partial_reduction = [0, 0, 0, 512, 0]
+// CHECK-SAME:      workgroup = [1, 1, 0, 0, 16]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -2,58 +2,6 @@
 // RUN:   --iree-codegen-llvmgpu-use-igemm=false \
 // RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
-// CHECK-SAME: iree_codegen.denormal_fp_math_f32 = #iree_codegen.denormal_fp_math<"preserve-sign">
-
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @attention_20x1x64x4096x64() {
-  %cst = arith.constant 1.250000e-01 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
-  %7 = tensor.empty() : tensor<20x1x64xf16>
-  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
-               affine_map<(d0, d1, d2, d3, d4) -> ()>,
-               affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
-               ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
-                ^bb0(%score: f32):
-                  iree_linalg_ext.yield %score : f32
-               } -> tensor<20x1x64xf16>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
-  return
-}
-
-// CHECK:      decomposition_config =
-// CHECK-SAME:  pv_attrs =
-// CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 4, 3]{{\]}}
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 4, 3]{{\]}}
-// CHECK-SAME:      thread = [0, 0, 0, 8]
-// CHECK-SAME:  qk_attrs =
-// CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 1, 64], [1, 0, 3, 4]{{\]}}
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 1, 8], [0, 1, 2, 4]{{\]}}
-// CHECK-SAME:      thread = [0, 0, 8, 0]
-// CHECK-SAME:  lowering_config =
-// CHECK-SAME:    #iree_gpu.lowering_config
-// CHECK-SAME:      partial_reduction = [0, 0, 0, 512, 0]
-// CHECK-SAME:      workgroup = [1, 1, 0, 0, 16]
-
-
-// -----
-
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
@@ -84,15 +32,14 @@ func.func @reduction_with_no_consumer() {
     iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [2, 32], strides = [1, 1] : tensor<2x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32xf32>>
     return
 }
-// CHECK:      #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
-
-// CHECK-LABEL: func.func @reduction_with_no_consumer
-// CHECK:           lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:      lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]
-// CHECK-SAME:      partial_reduction = [0, 0, 1, 4096]
-// CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]
-// CHECK-SAME:      thread = [0, 0, 1, 8],
-// CHECK-SAME:      workgroup = [1, 1, 0, 0]
+//       CHECK:  #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+// CHECK-LABEL:  func.func @reduction_with_no_consumer
+//       CHECK:     lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:          lane_basis = {{\[}}[1, 1, 1, 64], [0, 1, 2, 3]
+//  CHECK-SAME:   partial_reduction = [0, 0, 1, 4096]
+//  CHECK-SAME:      subgroup_basis = {{\[}}[1, 1, 1, 8], [0, 1, 2, 3]
+//  CHECK-SAME:              thread = [0, 0, 1, 8],
+//  CHECK-SAME:           workgroup = [1, 1, 0, 0]
 
 // -----
 
@@ -186,12 +133,12 @@ func.func @test_multiple_reduction() {
 #pipeline_layout = #hal.pipeline.layout<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 func.func @test_dyn_reduction(%arg0: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<128x128xf32>>, %arg1: index) {
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x32xf8E4M3FNUZ>>{%arg1}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x32x128xf8E4M3FNUZ>>{%arg1}
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x64xf8E4M3FNUZ>>{%arg1}
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x64x128xf8E4M3FNUZ>>{%arg1}
   %2 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<128x128xf32>> -> tensor<128x128xf32>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [128, %arg1, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x32xf8E4M3FNUZ>>{%arg1} -> tensor<128x?x32xf8E4M3FNUZ>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [128, %arg1, 32, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x32x128xf8E4M3FNUZ>>{%arg1} -> tensor<128x?x32x128xf8E4M3FNUZ>
-  %5 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<128x?x32xf8E4M3FNUZ>, tensor<128x?x32x128xf8E4M3FNUZ>) outs(%2 : tensor<128x128xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 1, 32], subgroup_basis = [[1, 1, 1, 1], [0, 1, 2, 3]], thread = [0, 0, 1, 16], lane_basis = [[1, 1, 1, 2], [0, 1, 2, 3]], workgroup = [1, 1, 0, 0]}>} {
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [128, %arg1, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x64xf8E4M3FNUZ>>{%arg1} -> tensor<128x?x64xf8E4M3FNUZ>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [128, %arg1, 32, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x?x64x128xf8E4M3FNUZ>>{%arg1} -> tensor<128x?x64x128xf8E4M3FNUZ>
+  %5 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<128x?x64xf8E4M3FNUZ>, tensor<128x?x64x128xf8E4M3FNUZ>) outs(%2 : tensor<128x128xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{partial_reduction = [0, 0, 1, 32], subgroup_basis = [[1, 1, 1, 1], [0, 1, 2, 3]], thread = [0, 0, 1, 16], lane_basis = [[1, 1, 1, 2], [0, 1, 2, 3]], workgroup = [1, 1, 0, 0]}>} {
   ^bb0(%in: f8E4M3FNUZ, %in_0: f8E4M3FNUZ, %out: f32):
     %6 = arith.extf %in : f8E4M3FNUZ to f32
     %7 = arith.extf %in_0 : f8E4M3FNUZ to f32
@@ -202,13 +149,13 @@ func.func @test_dyn_reduction(%arg0: !iree_tensor_ext.dispatch.tensor<readwrite:
   iree_tensor_ext.dispatch.tensor.store %5, %arg0, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<128x128xf32>>
   return
 }
-//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [2, 1, 1] subgroup_size = 64
-//       CHECK: func.func @test_dyn_reduction
+//       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [4, 1, 1] subgroup_size = 64
+// CHECK-LABEL: func.func @test_dyn_reduction
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
-//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 2], [0, 1, 2, 3]],
-//  CHECK-SAME:               partial_reduction = [0, 0, 1, 32],
+//  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 1, 4], [0, 1, 2, 3]],
+//  CHECK-SAME:               partial_reduction = [0, 0, 1, 64],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1, 1], [0, 1, 2, 3]],
 //  CHECK-SAME:               thread = [0, 0, 1, 16],
 //  CHECK-SAME:               workgroup = [1, 1, 0, 0]
@@ -243,7 +190,7 @@ func.func @test_multiple_stores(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
   return
 }
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
-//       CHECK: func.func @test_multiple_stores
+// CHECK-LABEL: func.func @test_multiple_stores
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
@@ -288,7 +235,7 @@ func.func @test_gather_config(%arg0: !iree_tensor_ext.dispatch.tensor<readonly:t
   return
 }
 //      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-//      CHECK: func.func @test_gather_config
+//CHECK-LABEL: func.func @test_gather_config
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.generic
 //  CHECK-NOT:      attrs =  {lowering_config = #iree_gpu.lowering_config<{
@@ -332,9 +279,9 @@ func.func @split_reduction_config(%arg0 : tensor<?x131072xf32>,
       : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%1}
   return
 }
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-//      CHECK: func @split_reduction_config
-//      CHECK:   linalg.generic
+//      CHECK:       #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//      CHECK-LABEL: func @split_reduction_config
+//      CHECK:       linalg.generic
 // CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
 
 // -----
@@ -441,3 +388,235 @@ func.func @batch_matvec_f16_f32() {
 //  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CHECK-SAME:                 thread = [0, 0, 8],
 //  CHECK-SAME:                 workgroup = [2, 1, 0]
+
+
+// -----
+
+!TA = tensor<1024x96xf32>
+!TB = tensor<1024xf32>
+!DTB = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1024xf32>>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+// TODO(newling) this should use vector distribute
+//       CHECK:  LLVMGPUTileAndFuse
+//  CHECK-SAME: workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-LABEL:  @reduction_size_96
+func.func @reduction_size_96(%arg0 : !TA, %arg1 : !TB, %arg2 : !DTB) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]}
+  ins(%arg0 : !TA) outs(%arg1 : !TB) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> !TB
+  iree_tensor_ext.dispatch.tensor.store %0, %arg2, offsets = [0], sizes = [1024], strides = [1] : !TB -> !DTB
+  return
+}
+
+// -----
+
+!TA = tensor<1024x97xf32>
+!TB = tensor<1024xf32>
+!DTB = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1024xf32>>
+// TODO(newling) this should use vector distribute
+//       CHECK:  LLVMGPUTileAndFuse
+//  CHECK-SAME: workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-LABEL:  @reduction_size_97
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+func.func @reduction_size_97(%arg0 : !TA, %arg1 : !TB, %arg2 : !DTB) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]}
+  ins(%arg0 : !TA) outs(%arg1 : !TB) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> !TB
+  iree_tensor_ext.dispatch.tensor.store %0, %arg2, offsets = [0], sizes = [1024], strides = [1] : !TB -> !DTB
+  return
+}
+
+// -----
+
+// TODO(newling) workgroups should process multiple elements in the parallel dimension.
+!TA = tensor<1152x384xf32>
+!TB = tensor<384xf32>
+!DTB = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<384xf32>>
+//       CHECK: LLVMGPUVectorDistribute
+//  CHECK-SAME: workgroup_size = [576, 1, 1] subgroup_size = 64
+// CHECK-LABEL: @non_contiguous_reduction_example
+//       CHECK:       iterator_types = ["parallel", "reduction"]}
+//  CHECK-SAME: attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:           lane_basis = {{\[}}[1, 64], [0, 1]],
+//  CHECK-SAME:    partial_reduction = [0, 1152],
+//  CHECK-SAME:       subgroup_basis = {{\[}}[1, 9], [0, 1]],
+//  CHECK-SAME:               thread = [0, 2],
+//  CHECK-SAME:            workgroup = [1, 0]}>
+#map = affine_map<(d0, d1) -> (d1, d0)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+func.func @non_contiguous_reduction_example(%arg0: !TA, %arg1: !TB, %arg2: !DTB) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]}
+  ins(%arg0 : !TA) outs(%arg1 : !TB) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> !TB
+  iree_tensor_ext.dispatch.tensor.store %0, %arg2, offsets = [0], sizes = [384], strides = [1] : !TB -> !DTB
+  return
+}
+
+// -----
+
+//       CHECK: LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64,
+// CHECK-LABEL: fused_elementwise
+//       CHECK: linalg.generic
+//  CHECK-SAME:    iterator_types = ["parallel", "reduction"]
+//  CHECK-SAME:        lane_basis = {{\[}}[1, 64], [0, 1]],
+//  CHECK-SAME: partial_reduction = [0, 64],
+//  CHECK-SAME:    subgroup_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:            thread = [0, 1],
+//  CHECK-SAME:         workgroup = [1, 0]
+//       CHECK: linalg.generic
+//  CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel"]
+//  CHECK-SAME:        lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:         reduction = [0, 1, 64],
+//  CHECK-SAME:    subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:            thread = [0, 0, 1],
+//  CHECK-SAME:         workgroup = [1, 0, 0]
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+func.func @fused_elementwise(%arg0: tensor<320xf32>, %arg1: tensor<320x64xf32>, %arg2: tensor<320x64x5120xf32>, %arg3: tensor<320x64x5120xf32>, %arg4: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<320x64x5120xf32>>) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg1 : tensor<320x64xf32>) outs(%arg0 : tensor<320xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %2 = arith.addf %in, %out : f32
+    linalg.yield %2 : f32
+  } -> tensor<320xf32>
+  %1 = linalg.generic {indexing_maps = [#map2, #map3, #map4, #map2], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg2, %0, %arg1 : tensor<320x64x5120xf32>, tensor<320xf32>, tensor<320x64xf32>) outs(%arg3 : tensor<320x64x5120xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %in_1: f32, %out: f32):
+    %2 = arith.addf %in, %in_0 : f32
+    %3 = arith.addf %2, %in_1 : f32
+    linalg.yield %3 : f32
+  } -> tensor<320x64x5120xf32>
+  iree_tensor_ext.dispatch.tensor.store %1, %arg4, offsets = [0, 0, 0], sizes = [320, 64, 5120], strides = [1, 1, 1] : tensor<320x64x5120xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<320x64x5120xf32>>
+  return
+}
+
+// -----
+
+!T4567 = tensor<4x5x6x7xf32>
+!DT4567 = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x5x6x7xf32>>
+!T45 = tensor<4x5xf32>
+!T67 = tensor<6x7xf32>
+!T1045 = tensor<10x4x5xf32>
+!T1067 = tensor<10x6x7xf32>
+
+#map44 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map33 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map32 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map42_0 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+#map42_1 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+
+
+// CHECK: LLVMGPUTileAndFuse
+// CHECK-LABEL: currently_not_vector_distribute
+func.func @currently_not_vector_distribute(%arg0 : !T4567, %arg1 : !T45, %arg2 : !T67, %arg3 : !T1045, %arg4 : !T1067, %arg5 : !DT4567) {
+
+  // Step 1: reduce T1045 (arg3) into T45 (arg1)
+  %red0 = linalg.generic {indexing_maps = [#map33, #map32], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg3 : !T1045) outs(%arg1 : !T45) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> !T45
+
+  // Step 2: reduce T1067 (arg4) into T67 (arg2)
+  %red1 = linalg.generic {indexing_maps = [#map33, #map32], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg4 : !T1067) outs(%arg2 : !T67) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    linalg.yield %1 : f32
+  } -> !T67
+
+  // Step 3: elementwise add the results of step 1 and step 2 and T4567 (arg0)
+  %sum = linalg.generic {indexing_maps = [#map44, #map42_0, #map42_1, #map44], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0, %red0, %red1 : !T4567, !T45, !T67) outs(%arg0 : !T4567) {
+  ^bb0(%in: f32, %in_0: f32, %in_1: f32, %out: f32):
+    %1 = arith.addf %in, %in_0 : f32
+    %2 = arith.addf %1, %in_1 : f32
+    linalg.yield %2 : f32
+  } -> !T4567
+
+  iree_tensor_ext.dispatch.tensor.store %sum, %arg5, offsets = [0, 0, 0, 0], sizes = [4, 5, 6, 7], strides = [1, 1, 1, 1] : !T4567 -> !DT4567
+  return
+}
+
+// -----
+
+//       CHECK: LLVMGPUVectorDistribute
+//  CHECK-SAME: workgroup_size = [64, 1, 1] subgroup_size = 64,
+// CHECK-LABEL: matmul_bias
+//       CHECK: linalg.generic
+//  CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction"]
+//  CHECK-SAME:        lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME: partial_reduction = [0, 0, 64],
+//  CHECK-SAME:    subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:            thread = [0, 0, 1],
+//  CHECK-SAME:         workgroup = [1, 1, 0]
+//       CHECK: linalg.generic
+//  CHECK-SAME:    iterator_types = ["parallel", "parallel"]
+//  CHECK-SAME:        lane_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:         reduction = [0, 1],
+//  CHECK-SAME:    subgroup_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:            thread = [0, 1],
+//  CHECK-SAME:         workgroup = [1, 1]
+
+func.func @matmul_bias(%4: tensor<320x2xf16>, %5: tensor<1280x320xf16>, %6: tensor<1280xf16>, %3 : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1280xf16>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 1.000000e+00 : f16
+  %c262208 = arith.constant 262208 : index
+  %c0 = arith.constant 0 : index
+  %c298304 = arith.constant 298304 : index
+  %7 = tensor.empty() : tensor<2x1280xf16>
+  %8 = tensor.empty() : tensor<2x1280xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<2x1280xf32>) -> tensor<2x1280xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%4, %5 : tensor<320x2xf16>, tensor<1280x320xf16>) outs(%9 : tensor<2x1280xf32>) {
+  ^bb0(%in: f16, %in_1: f16, %out: f32):
+    %12 = arith.extf %in : f16 to f32
+    %13 = arith.extf %in_1 : f16 to f32
+    %14 = arith.mulf %12, %13 : f32
+    %15 = arith.addf %out, %14 : f32
+    linalg.yield %15 : f32
+  } -> tensor<2x1280xf32>
+  %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%10, %6 : tensor<2x1280xf32>, tensor<1280xf16>) outs(%7 : tensor<2x1280xf16>) {
+  ^bb0(%in: f32, %in_1: f16, %out: f16):
+    %12 = arith.extf %in_1 : f16 to f32
+    %13 = arith.addf %in, %12 : f32
+    %14 = arith.truncf %13 : f32 to f16
+    %15 = arith.negf %14 : f16
+    %16 = math.exp %15 : f16
+    %17 = arith.addf %16, %cst_0 : f16
+    %18 = arith.divf %cst_0, %17 : f16
+    %19 = arith.mulf %18, %14 : f16
+    linalg.yield %19 : f16
+  } -> tensor<2x1280xf16>
+  iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [2, 1280], strides = [1, 1] : tensor<2x1280xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1280xf16>>
+  return
+}
+
+// -----
+
+// CHECK: LLVMGPUVectorDistribute workgroup_size = [1024, 1, 1] subgroup_size = 64
+// CHECK-LABEL: reduction_small_parallel
+// CHECK: lane_basis = {{\[}}[1, 64], [0, 1]], partial_reduction = [0, 4096], subgroup_basis = {{\[}}[1, 16], [0, 1]], thread = [0, 4], workgroup = [1, 0]
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+module {
+  func.func @reduction_small_parallel(%arg0: tensor<64x61440xf32>, %arg2: tensor<64xf32>, %arg3: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64xf32>>) {
+    %0 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<64x61440xf32>) outs(%arg2 : tensor<64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %1 = arith.addf %in, %out : f32
+      linalg.yield %1 : f32
+    } -> tensor<64xf32>
+    iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0], sizes = [64], strides = [1] : tensor<64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64xf32>>
+    return
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matmul.mlir
@@ -13,8 +13,9 @@
 !TC = tensor<32x32xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32x32xf32>>
 
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
+//       CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CHECK-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64, {
+// CHECK-LABEL:   @matmul_32_32_32
 func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   // Sanity check that generalize/specialize works.
   // GENERALIZED:   linalg.generic
@@ -33,8 +34,9 @@ func.func @matmul_32_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !TB = tensor<4096x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
+//       CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CHECK-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64, {
+// CHECK-LABEL:   @matmul_4096_4096_4096
 func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK: {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
   // CHECK-SAME: promote_operands = [0, 1], reduction = [0, 0, 4], subgroup = [4, 4, 0], workgroup = [128, 128, 0]}>
@@ -49,8 +51,9 @@ func.func @matmul_4096_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC
 !TB = tensor<32x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:    workgroup_size = [256, 1, 1] subgroup_size = 64, {
+//       CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CHECK-SAME:   workgroup_size = [256, 1, 1] subgroup_size = 64, {
+// CHECK-LABEL:   @matmul_4096_32_4096
 func.func @matmul_4096_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK:  #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
   // CHECK-SAME:  promote_operands = [0, 1], reduction = [0, 0, 8], subgroup = [2, 4, 0],
@@ -62,19 +65,71 @@ func.func @matmul_4096_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) 
 
 // -----
 
+
 !TA = tensor<4096x1xf32>
 !TB = tensor<1x4096xf32>
 !TC = tensor<4096x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4096x4096xf32>>
-//      CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
-// CHECK-SAME:   workgroup_size = [128, 1, 1] subgroup_size = 64
-// CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
+//       CHECK:  #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
+//  CHECK-SAME:  workgroup_size = [128, 1, 1] subgroup_size = 64
+//  CHECK-SAME:  {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
+// CHECK-LABEL:  @matmul_4096_1_4096
 func.func @matmul_4096_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
   //      CHECK: #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
   // CHECK-SAME: padding = [32, 32, 4], promote_operands = [0, 1], reduction = [0, 0, 1], subgroup = [1, 2, 0], workgroup = [32, 32, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [4096, 4096], strides = [1, 1] : !TC -> !DTC
   return
+}
+
+// -----
+
+// A matvec-like matmul. Here we specifically check the logic in config selection that makes 2
+// parallel dimensions used per workgroup.
+!TA = tensor<4x4096xf32>
+!TB = tensor<4096x4096xf32>
+!TC = tensor<4x4096xf32>
+!DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x4096xf32>>
+//        CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//   CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-LABEL:    @matmul_4_4096_4096
+func.func @matmul_4_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
+  //      CHECK:  lowering_config = #iree_gpu.lowering_config<{
+  // CHECK-SAME:     lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+  // CHECK-SAME:     partial_reduction = [0, 0, 256],
+  // CHECK-SAME:     subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+  // CHECK-SAME:     thread = [0, 0, 4],
+  // CHECK-SAME:     workgroup = [2, 1, 0]}>
+  %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
+  iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : !TC -> !DTC
+  return
+}
+
+// -----
+
+//       CHECK: LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-LABEL: matmul_m2_k320_n1280
+//       CHECK: lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME: partial_reduction = [0, 0, 64],
+//  CHECK-SAME: subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME: thread = [0, 0, 1],
+//  CHECK-SAME: workgroup = [1, 1, 0]
+#map = affine_map<(d0, d1, d2) -> (d2, d0)>
+#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  func.func @matmul_m2_k320_n1280(%arg0: tensor<320x2xf16>, %arg1: tensor<1280x320xf16>, %arg2: tensor<2x1280xf32>, %arg3: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1280xf32>>) {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<320x2xf16>, tensor<1280x320xf16>) outs(%arg2 : tensor<2x1280xf32>) {
+    ^bb0(%in: f16, %in_0: f16, %out: f32):
+      %1 = arith.extf %in : f16 to f32
+      %2 = arith.extf %in_0 : f16 to f32
+      %3 = arith.mulf %1, %2 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<2x1280xf32>
+    iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [2, 1280], strides = [1, 1] : tensor<2x1280xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1280xf32>>
+    return
+  }
 }
 
 // -----
@@ -89,6 +144,7 @@ func.func @matmul_4096_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x32xf32>>
 //      CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 // CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK-LABEL:   @matmul_DYN_32_32
 func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
   // CHECK:       #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 1, 0], workgroup = [1, 64, 0]}>
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
@@ -101,13 +157,15 @@ func.func @matmul_DYN_32_32(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %ar
 //      CHECK:         #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-SAME:         workgroup_size = [1024, 1, 1] subgroup_size = 64,
 // CHECK-SAME:         {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}>
+// CHECK-LABEL:    @matmul_DYN_4096_4096
 !TA = tensor<?x4096xf32>
 !TB = tensor<4096x4096xf32>
 !TC = tensor<?x4096xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x4096xf32>>
 func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index) {
 //      CHECK:         #iree_gpu.lowering_config<{lane_basis =  {{\[}}[1, 1, 64], [0, 1, 2]],
-// CHECK-SAME:         partial_reduction = [0, 0, 4096], subgroup_basis =  {{\[}}[1, 1, 16], [0, 1, 2]], thread = [0, 0, 4], workgroup = [1, 1, 0]}
+// CHECK-SAME:         partial_reduction = [0, 0, 4096],
+// CHECK-SAME:         subgroup_basis =  {{\[}}[1, 1, 16], [0, 1, 2]], thread = [0, 0, 4], workgroup = [1, 1, 0]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
   iree_tensor_ext.dispatch.tensor.store %0, %arg3, offsets = [0, 0], sizes = [%arg4, 4096], strides = [1, 1] : !TC -> !DTC{%arg4}
   return
@@ -116,6 +174,7 @@ func.func @matmul_DYN_4096_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC,
 // -----
 
 // CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK-LABEL:   @matmul_DYN_32_4096
 // CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 4], thread = [1, 4, 0], workgroup = [1, 256, 0]}
 !TA = tensor<?x32xf32>
 !TB = tensor<32x4096xf32>
@@ -130,6 +189,7 @@ func.func @matmul_DYN_32_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %
 // -----
 
 // CHECK:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
+// CHECK-LABEL:   @matmul_DYN_1_4096
 // CHECK:    #iree_gpu.lowering_config<{promote_operands = [0, 1], reduction = [0, 0, 1], thread = [1, 4, 0], workgroup = [1, 256, 0]}
 !TA = tensor<?x1xf32>
 !TB = tensor<1x4096xf32>
@@ -155,6 +215,7 @@ func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %a
 //      CHECK:    #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 // CHECK-SAME:    workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false,
 // CHECK-SAME:    no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+// CHECK-LABEL:   @matmul_32_32_DYN
 func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
    // CHECK:     #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
@@ -171,6 +232,7 @@ func.func @matmul_32_32_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
 //      CHECK:         #translation = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse
 // CHECK-SAME:         workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false,
 // CHECK-SAME:         no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+// CHECK-LABEL:    @matmul_4096_4096_DYN
 func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC) {
    // CHECK:      #iree_gpu.lowering_config<{reduction = [0, 0, 1], thread = [1, 8, 0], workgroup = [64, 128, 1]}
   %0 = linalg.matmul ins(%arg0, %arg1 : !TA, !TB) outs(%arg2 : !TC) -> !TC
@@ -186,13 +248,12 @@ func.func @matmul_4096_4096_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC)
 
 //     CHECK:      LLVMGPUVectorDistribute
 // CHECK-SAME:     workgroup_size = [1024, 1, 1] subgroup_size = 64,
-
-
+// CHECK-LABEL:  @matmul_DYN_DYN_DYN
 !TA = tensor<?x?xf32>
 !TB = tensor<?x?xf32>
 !TC = tensor<?x?xf32>
 !DTC = !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32>>
-func.func @matmul_DYN_1_4096(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index, %arg5 : index, %arg6 : index) {
+func.func @matmul_DYN_DYN_DYN(%arg0: !TA, %arg1: !TB, %arg2: !TC, %arg3: !DTC, %arg4 : index, %arg5 : index, %arg6 : index) {
 
   //      CHECK:     {lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
   // CHECK-SAME:     partial_reduction = [0, 0, 4096], subgroup_basis = {{\[}}[1, 1, 16], [0, 1, 2]],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -307,7 +307,7 @@ func.func @i4_dequant_matvec() {
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //       CHECK:   linalg.generic
-//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:    attrs = {lowering_config = #iree_gpu.lowering_config<{
 //  CHECK-SAME:               lane_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
 //  CHECK-SAME:               partial_reduction = [0, 1, 128],
 //  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
@@ -439,56 +439,55 @@ func.func @not_vmt() {
 
 // -----
 
-
-  func.func @dynamic_parallel_dims_dispatch_0_reduction_Dx4096_f16xf32() {
-    %c32_i64 = arith.constant 32 : i64
-    %cst = arith.constant 0.000000e+00 : f32
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
-    %1 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
-    %2 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
-    %3 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
-    %4 = arith.extui %0 : i32 to i64
-    %5 = arith.extui %1 : i32 to i64
-    %6 = arith.shli %5, %c32_i64 : i64
-    %7 = arith.ori %4, %6 : i64
-    %8 = arith.index_castui %7 : i64 to index
-    %9 = arith.extui %2 : i32 to i64
-    %10 = arith.extui %3 : i32 to i64
-    %11 = arith.shli %10, %c32_i64 : i64
-    %12 = arith.ori %9, %11 : i64
-    %13 = arith.index_castui %12 : i64 to index
-    %14:2 = util.assume.int
-        %8<udiv = 4>,
-        %13<umin = 0, umax = 36028797018963964, udiv = 4>
-      : index, index
-    %15 = iree_tensor_ext.dispatch.workload.ordinal %14#0, 0 : index
-    %16 = iree_tensor_ext.dispatch.workload.ordinal %14#1, 1 : index
-    %17 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%16}
-    %18 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%15}
-    %19 = iree_tensor_ext.dispatch.tensor.load %17, offsets = [0, 0], sizes = [%16, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%16} -> tensor<?x4096xf16>
-    %20 = tensor.empty(%15) : tensor<?xf32>
-    %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<?xf32>) -> tensor<?xf32>
-    %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%19 : tensor<?x4096xf16>) outs(%21 : tensor<?xf32>) {
-    ^bb0(%in: f16, %out: f32):
-      %23 = arith.extf %in : f16 to f32
-      %24 = arith.addf %23, %out : f32
-      linalg.yield %24 : f32
-    } -> tensor<?xf32>
-    iree_tensor_ext.dispatch.tensor.store %22, %18, offsets = [0], sizes = [%15], strides = [1] : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%15}
-    return
-  }
+func.func @dynamic_parallel_dims_dispatch_0_reduction_Dx4096_f16xf32() {
+  %c32_i64 = arith.constant 32 : i64
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
+  %1 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
+  %2 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
+  %3 = hal.interface.constant.load layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
+  %4 = arith.extui %0 : i32 to i64
+  %5 = arith.extui %1 : i32 to i64
+  %6 = arith.shli %5, %c32_i64 : i64
+  %7 = arith.ori %4, %6 : i64
+  %8 = arith.index_castui %7 : i64 to index
+  %9 = arith.extui %2 : i32 to i64
+  %10 = arith.extui %3 : i32 to i64
+  %11 = arith.shli %10, %c32_i64 : i64
+  %12 = arith.ori %9, %11 : i64
+  %13 = arith.index_castui %12 : i64 to index
+  %14:2 = util.assume.int
+      %8<udiv = 4>,
+      %13<umin = 0, umax = 36028797018963964, udiv = 4>
+    : index, index
+  %15 = iree_tensor_ext.dispatch.workload.ordinal %14#0, 0 : index
+  %16 = iree_tensor_ext.dispatch.workload.ordinal %14#1, 1 : index
+  %17 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%16}
+  %18 = hal.interface.binding.subspan layout(<constants = 4, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%15}
+  %19 = iree_tensor_ext.dispatch.tensor.load %17, offsets = [0, 0], sizes = [%16, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%16} -> tensor<?x4096xf16>
+  %20 = tensor.empty(%15) : tensor<?xf32>
+  %21 = linalg.fill ins(%cst : f32) outs(%20 : tensor<?xf32>) -> tensor<?xf32>
+  %22 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%19 : tensor<?x4096xf16>) outs(%21 : tensor<?xf32>) {
+  ^bb0(%in: f16, %out: f32):
+    %23 = arith.extf %in : f16 to f32
+    %24 = arith.addf %23, %out : f32
+    linalg.yield %24 : f32
+  } -> tensor<?xf32>
+  iree_tensor_ext.dispatch.tensor.store %22, %18, offsets = [0], sizes = [%15], strides = [1] : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?xf32>>{%15}
+  return
+}
 
 //      CHECK:   #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CHECK-SAME:   workgroup_size = [512, 1, 1] subgroup_size = 64
+// CHECK-LABEL:  func.func @dynamic_parallel_dims_dispatch_0_reduction_Dx4096_f16xf32()
 
 //      CDNA:   #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
 // CDNA-SAME:   workgroup_size = [512, 1, 1] subgroup_size = 64
 
-
 // -----
 
-func.func @test_dyn_reduction() {
+func.func @test_dyn_small_reduction() {
   %c32 = arith.constant 32 : index
   %c32_i64 = arith.constant 32 : i64
   %cst = arith.constant 0.000000e+00 : f32
@@ -549,6 +548,8 @@ func.func @test_dyn_reduction() {
   iree_tensor_ext.dispatch.tensor.store %30, %16, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf8E4M3FNUZ> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x128xf8E4M3FNUZ>>
   return
 }
+//       CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//  CHECK-SAME: workgroup_size = [2, 1, 1] subgroup_size = 64
+// CHECK-LABEL: func.func @test_dyn_small_reduction()
 
-//      CHECK: #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
-// CHECK-SAME: workgroup_size = [2, 1, 1] subgroup_size = 64,
+// -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -278,7 +278,6 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 
 // CHECK-LABEL: hal.executable public @reduction_dispatch
 //       CHECK:   hal.executable.variant public @cuda
-//       CHECK:     "llvm.intr.vector.reduce.fadd"({{.*}}) {{.*}} : (f32, vector<4xf32>) -> f32
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -1,84 +1,41 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
-// RUN:  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" \
+// RUN:  --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target))" \
 // RUN:  %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 \
-// RUN:  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" \
+// RUN:  --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target))" \
 // RUN:  %s | FileCheck %s --check-prefix=RDNA3
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable @group_reduction_1d {
-hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @group_reduction_1d() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant -0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
-      %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [64], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>> -> tensor<64xf32>
-      %3 = tensor.empty() : tensor<f32>
-      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<f32>) -> tensor<f32>
-      %5 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%2 : tensor<64xf32>) outs(%4 : tensor<f32>) {
-      ^bb0(%in: f32, %out: f32):
-        %6 = arith.addf %in, %out : f32
-        linalg.yield %6 : f32
-      } -> tensor<f32>
-      iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
-      return
-    }
-  }
-}
+func.func @group_reduction_1d() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [64], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>> -> tensor<64xf32>
+  %3 = tensor.empty() : tensor<f32>
+  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<f32>) -> tensor<f32>
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%2 : tensor<64xf32>) outs(%4 : tensor<f32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<f32>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
+  return
 }
 
-//         RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
-//         RDNA3: func.func @group_reduction_1d()
-//    RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
-//         RDNA3:        gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
+// On CDNA, we require subgroup size of 64. On RDNA we require subgroup size of 32.
 
-// -----
+//        CHECK:   #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-LABEL:   func.func @group_reduction_1d
+//        CHECK:   gpu.subgroup_reduce  add {{.*}} cluster(size = 64) : (f32) -> f32
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-hal.executable @group_reduction_1d {
-hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root(%arg1, %arg2)
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @group_reduction_1d() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant -0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>>
-      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
-      %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [64], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64xf32>> -> tensor<64xf32>
-      %3 = tensor.empty() : tensor<f32>
-      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<f32>) -> tensor<f32>
-      %5 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%2 : tensor<64xf32>) outs(%4 : tensor<f32>) {
-      ^bb0(%in: f32, %out: f32):
-        %6 = arith.addf %in, %out : f32
-        linalg.yield %6 : f32
-      } -> tensor<f32>
-      iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32>>
-      return
-    }
-  }
-}
-}
-
-// On CDNA, we prefer wave64 with subgroup size of 64.
-
-//        CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-//        CHECK: func.func @group_reduction_1d
-//        CHECK:     gpu.subgroup_reduce  add {{.*}} cluster(size = 64) : (f32) -> f32
+//        RDNA3:   #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//  RDNA3-LABEL:   func.func @group_reduction_1d()
+//   RDNA3-SAME:   translation_info = #[[$TRANSLATION]]
+//        RDNA3:   gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32
 
 // -----
 
@@ -89,297 +46,177 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @i4_dequant_matvec {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @i4_dequant_matvec() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>>
-        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 32, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>> -> tensor<4096x32x128xi4>
-        %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
-        %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
-        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [32, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>> -> tensor<32x128xf16>
-        %9 = tensor.empty() : tensor<4096xf16>
-        %10 = tensor.empty() : tensor<4096x32x128xf16>
-        %11 = linalg.fill ins(%cst : f16) outs(%9 : tensor<4096xf16>) -> tensor<4096xf16>
-        %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5, %6, %7 : tensor<4096x32x128xi4>, tensor<4096x32xf16>, tensor<4096x32xf16>) outs(%10 : tensor<4096x32x128xf16>) {
-        ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
-          %14 = arith.extui %in : i4 to i32
-          %15 = arith.uitofp %14 : i32 to f16
-          %16 = arith.subf %15, %in_1 : f16
-          %17 = arith.mulf %16, %in_0 : f16
-          linalg.yield %17 : f16
-        } -> tensor<4096x32x128xf16>
-        %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%8, %12 : tensor<32x128xf16>, tensor<4096x32x128xf16>) outs(%11 : tensor<4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %14 = arith.mulf %in, %in_0 : f16
-          %15 = arith.addf %14, %out : f16
-          linalg.yield %15 : f16
-        } -> tensor<4096xf16>
-        iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        return
-      }
-    }
-  }
+func.func @i4_dequant_matvec() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>>
+  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
+  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 32, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>> -> tensor<4096x32x128xi4>
+  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
+  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
+  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [32, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>> -> tensor<32x128xf16>
+  %9 = tensor.empty() : tensor<4096xf16>
+  %10 = tensor.empty() : tensor<4096x32x128xf16>
+  %11 = linalg.fill ins(%cst : f16) outs(%9 : tensor<4096xf16>) -> tensor<4096xf16>
+  %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5, %6, %7 : tensor<4096x32x128xi4>, tensor<4096x32xf16>, tensor<4096x32xf16>) outs(%10 : tensor<4096x32x128xf16>) {
+  ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
+    %14 = arith.extui %in : i4 to i32
+    %15 = arith.uitofp %14 : i32 to f16
+    %16 = arith.subf %15, %in_1 : f16
+    %17 = arith.mulf %16, %in_0 : f16
+    linalg.yield %17 : f16
+  } -> tensor<4096x32x128xf16>
+  %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%8, %12 : tensor<32x128xf16>, tensor<4096x32x128xf16>) outs(%11 : tensor<4096xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %14 = arith.mulf %in, %in_0 : f16
+    %15 = arith.addf %14, %out : f16
+    linalg.yield %15 : f16
+  } -> tensor<4096xf16>
+  iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
+  return
 }
 
-//        RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
-//        RDNA3: func.func @i4_dequant_matvec()
-//   RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
-//     RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//     RDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
-//     RDNA3-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//     RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x4xf16>
-//         RDNA3:   %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x4xf16>)
-//         RDNA3:   %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x4xi4> to vector<4x1x1x1x1x4xi32>
-//         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x4xi32> to vector<4x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
-//         RDNA3:   %{{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         CHECK:  #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//   CHECK-LABEL:  func.func @i4_dequant_matvec()
+//    CHECK-SAME:  translation_info = #[[$TRANSLATION]]
 
-//         RDNA3:   %{{.*}} = vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x4xf16> to vector<4x1x1xf16>
+//         RDNA3:  #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32,
+//   RDNA3-LABEL:  func.func @i4_dequant_matvec()
+//    RDNA3-SAME:  translation_info = #[[$TRANSLATION]]
+//     RDNA3-DAG:  %[[C0:.+]] = arith.constant 0 : index
+//     RDNA3-DAG:  %[[C32:.+]] = arith.constant 32 : index
+//     RDNA3-DAG:  %[[C1:.+]] = arith.constant 1 : index
+//     RDNA3-DAG:  %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %[[FOR:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%{{.*}} = %[[CST]]) -> (vector<4x1x1x1x1x4xf16>)
+//         RDNA3:  %{{.*}} = arith.extui %{{.*}} : vector<4x1x1x1x1x4xi4> to vector<4x1x1x1x1x4xi32>
+//         RDNA3:  %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x4xi32> to vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %{{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x4xf16>
+//         RDNA3:  %{{.*}} = vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x4xf16> to vector<4x1x1xf16>
 
 // -----
-
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-hal.executable private @i4_dequant_matvec {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @i4_dequant_matvec() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>>
-        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>>
-        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 32, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32x128xi4>> -> tensor<4096x32x128xi4>
-        %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
-        %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [4096, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x32xf16>> -> tensor<4096x32xf16>
-        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [32, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x128xf16>> -> tensor<32x128xf16>
-        %9 = tensor.empty() : tensor<4096xf16>
-        %10 = tensor.empty() : tensor<4096x32x128xf16>
-        %11 = linalg.fill ins(%cst : f16) outs(%9 : tensor<4096xf16>) -> tensor<4096xf16>
-        %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5, %6, %7 : tensor<4096x32x128xi4>, tensor<4096x32xf16>, tensor<4096x32xf16>) outs(%10 : tensor<4096x32x128xf16>) {
-        ^bb0(%in: i4, %in_0: f16, %in_1: f16, %out: f16):
-          %14 = arith.extui %in : i4 to i32
-          %15 = arith.uitofp %14 : i32 to f16
-          %16 = arith.subf %15, %in_1 : f16
-          %17 = arith.mulf %16, %in_0 : f16
-          linalg.yield %17 : f16
-        } -> tensor<4096x32x128xf16>
-        %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%8, %12 : tensor<32x128xf16>, tensor<4096x32x128xf16>) outs(%11 : tensor<4096xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %14 = arith.mulf %in, %in_0 : f16
-          %15 = arith.addf %14, %out : f16
-          linalg.yield %15 : f16
-        } -> tensor<4096xf16>
-        iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0], sizes = [4096], strides = [1] : tensor<4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096xf16>>
-        return
-      }
-    }
-  }
-}
-
-//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-//      CHECK: func.func @i4_dequant_matvec()
-// CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-
-// -----
-
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-hal.executable private @matvec_fp16 {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matvec_fp16() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-        %5 = tensor.empty() : tensor<1x32000xf16>
-        %6 = linalg.fill  ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %8 = arith.mulf %in, %in_0 : f16
-          %9 = arith.addf %out, %8 : f16
-          linalg.yield %9 : f16
-        } -> tensor<1x32000xf16>
-        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-        return
-      }
-    }
-  }
-}
 
 // This matvec is expected to be reduced multiple rows at a time by a single workgroup.
 // Check that we distribute it across subgroup threads properly. Thread 0 is expected to
 // write 8 results at the end.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-//          CHECK: func.func @matvec_fp16()
-//     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
-//      CHECK-DAG:   %[[C4096:.+]] = arith.constant 4096 : index
-//      CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x8xf16>
-//          CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C512]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x8xf16>)
-//          CHECK:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
-//          CHECK:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//          CHECK:  #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+//    CHECK-LABEL:  func.func @matvec_fp16()
+//     CHECK-SAME:  translation_info = #[[$TRANSLATION]]
+//      CHECK-DAG:  %[[C0:.+]] = arith.constant 0 : index
+//      CHECK-DAG:  %[[C512:.+]] = arith.constant 512 : index
+//      CHECK-DAG:  %[[C4096:.+]] = arith.constant 4096 : index
+//      CHECK-DAG:  %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<8x1x1x1x1x8xf16>
+//          CHECK:  scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C512]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<8x1x1x1x1x8xf16>)
+//          CHECK:  {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//          CHECK:  {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<8x1x1x1x1x8xf16>
+//          CHECK:  vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<8x1x1x1x1x8xf16> to vector<8x1x1xf16>
 
-//          CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<8x1x1x1x1x8xf16> to vector<8x1x1xf16>
-
-// -----
+//          RDNA3:  #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
+//          RDNA3:  func.func @matvec_fp16()
+//     RDNA3-SAME:  translation_info = #[[$TRANSLATION]]
+//      RDNA3-DAG:  %[[C0:.+]] = arith.constant 0 : index
+//      RDNA3-DAG:  %[[C256:.+]] = arith.constant 256 : index
+//      RDNA3-DAG:  %[[C4096:.+]] = arith.constant 4096 : index
+//      RDNA3-DAG:  %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x8xf16>
+//          RDNA3:  scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C256]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<4x1x1x1x1x8xf16>)
+//          RDNA3:  {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
+//          RDNA3:  {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
+//          RDNA3:  vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x8xf16> to vector<4x1x1xf16>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable private @matvec_fp16 {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matvec_fp16() {
-        %c0 = arith.constant 0 : index
-        %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-        %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
-        %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
-        %5 = tensor.empty() : tensor<1x32000xf16>
-        %6 = linalg.fill  ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) {
-        ^bb0(%in: f16, %in_0: f16, %out: f16):
-          %8 = arith.mulf %in, %in_0 : f16
-          %9 = arith.addf %out, %8 : f16
-          linalg.yield %9 : f16
-        } -> tensor<1x32000xf16>
-        iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
-        return
-      }
-    }
-  }
+func.func @matvec_fp16() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+  %5 = tensor.empty() : tensor<1x32000xf16>
+  %6 = linalg.fill  ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %8 = arith.mulf %in, %in_0 : f16
+    %9 = arith.addf %out, %8 : f16
+    linalg.yield %9 : f16
+  } -> tensor<1x32000xf16>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+  return
 }
+
 
 // Multi-row matvec with wave32.
 // TODO(kuhar): We should reduce the number of `gpu.shuffles` performed.
 
-//          RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [32, 1, 1] subgroup_size = 32
-//          RDNA3: func.func @matvec_fp16()
-//     RDNA3-SAME:     translation_info = #[[$TRANSLATION]]
-//      RDNA3-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//      RDNA3-DAG:   %[[C256:.+]] = arith.constant 256 : index
-//      RDNA3-DAG:   %[[C4096:.+]] = arith.constant 4096 : index
-//      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4x1x1x1x1x8xf16>
-//          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C4096]] step %[[C256]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<4x1x1x1x1x8xf16>)
-//          RDNA3:     {{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
-//          RDNA3:     {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x8xf16>
-
-//          RDNA3: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<4x1x1x1x1x8xf16> to vector<4x1x1xf16>
-
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-hal.executable public @multi_reduction {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @multi_reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
-      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @multi_reduction() {
-        %cst = arith.constant 0.000000e+00 : f32
-        %cst_0 = arith.constant 2.304000e+05 : f32
-        %cst_1 = arith.constant 9.99999974E-6 : f32
-        %c85483008 = arith.constant 85483008 : index
-        %c165416448 = arith.constant 165416448 : index
-        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c85483008) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x60x3840xf16>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c165416448) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x60x3840xf32>>
-        %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 32, 60, 3840], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x60x3840xf16>> -> tensor<2x32x60x3840xf16>
-        %3 = tensor.empty() : tensor<2x32x60x3840xf32>
-        %4 = tensor.empty() : tensor<2x32xf32>
-        %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<2x32x60x3840xf16>) outs(%3 : tensor<2x32x60x3840xf32>) {
-        ^bb0(%in: f16, %out: f32):
-          %11 = arith.extf %in : f16 to f32
-          linalg.yield %11 : f32
-        } -> tensor<2x32x60x3840xf32>
-        %6 = linalg.fill ins(%cst : f32) outs(%4 : tensor<2x32xf32>) -> tensor<2x32xf32>
-        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%5 : tensor<2x32x60x3840xf32>) outs(%6 : tensor<2x32xf32>) {
-        ^bb0(%in: f32, %out: f32):
-          %11 = arith.addf %in, %out : f32
-          linalg.yield %11 : f32
-        } -> tensor<2x32xf32>
-        %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<2x32xf32>) outs(%4 : tensor<2x32xf32>) {
-        ^bb0(%in: f32, %out: f32):
-          %11 = arith.divf %in, %cst_0 : f32
-          linalg.yield %11 : f32
-        } -> tensor<2x32xf32>
-        %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%5, %8 : tensor<2x32x60x3840xf32>, tensor<2x32xf32>) outs(%6 : tensor<2x32xf32>) {
-        ^bb0(%in: f32, %in_2: f32, %out: f32):
-          %11 = arith.subf %in, %in_2 : f32
-          %12 = arith.mulf %11, %11 : f32
-          %13 = arith.addf %12, %out : f32
-          linalg.yield %13 : f32
-        } -> tensor<2x32xf32>
-        %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %8, %9 : tensor<2x32x60x3840xf16>, tensor<2x32xf32>, tensor<2x32xf32>) outs(%3 : tensor<2x32x60x3840xf32>) {
-        ^bb0(%in: f16, %in_2: f32, %in_3: f32, %out: f32):
-          %11 = arith.divf %in_3, %cst_0 : f32
-          %12 = arith.addf %11, %cst_1 : f32
-          %13 = math.rsqrt %12 : f32
-          %14 = arith.extf %in : f16 to f32
-          %15 = arith.subf %14, %in_2 : f32
-          %16 = arith.mulf %15, %13 : f32
-          linalg.yield %16 : f32
-        } -> tensor<2x32x60x3840xf32>
-        iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0, 0, 0, 0], sizes = [2, 32, 60, 3840], strides = [1, 1, 1, 1] : tensor<2x32x60x3840xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x60x3840xf32>>
-        return
-      }
-    }
-  }
+func.func @multi_reduction() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant 2.304000e+05 : f32
+  %cst_1 = arith.constant 9.99999974E-6 : f32
+  %c85483008 = arith.constant 85483008 : index
+  %c165416448 = arith.constant 165416448 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c85483008) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x60x3840xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c165416448) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x60x3840xf32>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 32, 60, 3840], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x32x60x3840xf16>> -> tensor<2x32x60x3840xf16>
+  %3 = tensor.empty() : tensor<2x32x60x3840xf32>
+  %4 = tensor.empty() : tensor<2x32xf32>
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<2x32x60x3840xf16>) outs(%3 : tensor<2x32x60x3840xf32>) {
+  ^bb0(%in: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    linalg.yield %11 : f32
+  } -> tensor<2x32x60x3840xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%4 : tensor<2x32xf32>) -> tensor<2x32xf32>
+  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%5 : tensor<2x32x60x3840xf32>) outs(%6 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %11 = arith.addf %in, %out : f32
+    linalg.yield %11 : f32
+  } -> tensor<2x32xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<2x32xf32>) outs(%4 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %11 = arith.divf %in, %cst_0 : f32
+    linalg.yield %11 : f32
+  } -> tensor<2x32xf32>
+  %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%5, %8 : tensor<2x32x60x3840xf32>, tensor<2x32xf32>) outs(%6 : tensor<2x32xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %out: f32):
+    %11 = arith.subf %in, %in_2 : f32
+    %12 = arith.mulf %11, %11 : f32
+    %13 = arith.addf %12, %out : f32
+    linalg.yield %13 : f32
+  } -> tensor<2x32xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %8, %9 : tensor<2x32x60x3840xf16>, tensor<2x32xf32>, tensor<2x32xf32>) outs(%3 : tensor<2x32x60x3840xf32>) {
+  ^bb0(%in: f16, %in_2: f32, %in_3: f32, %out: f32):
+    %11 = arith.divf %in_3, %cst_0 : f32
+    %12 = arith.addf %11, %cst_1 : f32
+    %13 = math.rsqrt %12 : f32
+    %14 = arith.extf %in : f16 to f32
+    %15 = arith.subf %14, %in_2 : f32
+    %16 = arith.mulf %15, %13 : f32
+    linalg.yield %16 : f32
+  } -> tensor<2x32x60x3840xf32>
+  iree_tensor_ext.dispatch.tensor.store %10, %1, offsets = [0, 0, 0, 0], sizes = [2, 32, 60, 3840], strides = [1, 1, 1, 1] : tensor<2x32x60x3840xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x32x60x3840xf32>>
+  return
 }
 
 // Check that all loops are singly nested.
 //
-//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [960, 1, 1] subgroup_size = 64
+//          CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+//     CHECK-SAME: workgroup_size = [960, 1, 1] subgroup_size = 64
 //          CHECK: func.func @multi_reduction()
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index

--- a/tests/e2e/regression/layernorm.mlir
+++ b/tests/e2e/regression/layernorm.mlir
@@ -79,7 +79,8 @@ func.func @layernorm_dynamic() {
   %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x384xf32>
   %cst_2 = flow.tensor.dynamic_constant dense<9.99999996E-13> : tensor<128x1xf32> -> tensor<?x1xf32>
   %cst_3 = flow.tensor.dynamic_constant dense<3.840000e+02> : tensor<128x1xf32> -> tensor<?x1xf32>
-  %cst_4 = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<128x384xf32> -> tensor<?x?xf32>
+  %dyn_cst_4 = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<128x384xf32> -> tensor<?x?xf32>
+  %cst_4 = util.optimization_barrier %dyn_cst_4 : tensor<?x?xf32>
   %c_0_index = arith.constant 0 : index
   %c_1_index = arith.constant 1 : index
   %dim_0 = tensor.dim %cst_4, %c_0_index : tensor<?x?xf32>

--- a/tests/e2e/regression/linalg_ops_dynamic.mlir
+++ b/tests/e2e/regression/linalg_ops_dynamic.mlir
@@ -28,6 +28,21 @@ func.func @batch_matmul_dynamic_reduction_size_B32_M1_N128_K3() {
   return
 }
 
+func.func @matmul_dynamic_M_M1_N64_K32() {
+  %lhs = flow.tensor.dynamic_constant dense<1.0> : tensor<1x32xf32> -> tensor<?x32xf32>
+  %rhs = flow.tensor.dynamic_constant dense<0.5> : tensor<32x64xf32> -> tensor<32x64xf32>
+  %cst = arith.constant 0.000000 : f32
+  %c_0_index = arith.constant 0 : index
+  %dim_0 = tensor.dim %lhs, %c_0_index : tensor<?x32xf32>
+  %output = tensor.empty(%dim_0) : tensor<?x64xf32>
+  %filled = linalg.fill ins(%cst : f32) outs(%output : tensor<?x64xf32>) -> tensor<?x64xf32>
+  %observed = linalg.matmul ins(%lhs, %rhs : tensor<?x32xf32>, tensor<32x64xf32>) outs(%filled : tensor<?x64xf32>) -> tensor<?x64xf32>
+  %expected = flow.tensor.dynamic_constant dense<16.0> : tensor<1x64xf32> -> tensor<?x64xf32>
+  check.expect_almost_eq(%observed, %expected, atol 1.0e-04) : tensor<?x64xf32>
+  return
+}
+
+
 // Batched matmul where B=2 M=1 N=3 K=dynamic.
 // Tested with K=5 and operands with varying values.
 func.func @dynamic_matmul_dynamic_reduction_size_B2_M1_N3_K5() {

--- a/tests/e2e/regression/reduction_broadcast_elementwise.mlir
+++ b/tests/e2e/regression/reduction_broadcast_elementwise.mlir
@@ -40,7 +40,8 @@ func.func @max_sub_exp() {
 func.func @max_sub_exp_dynamic() {
   %cst = arith.constant -3.40282347E+38 : f32
   %cst_0 = arith.constant dense<1.000000e+00> : tensor<12x128x128xf32>
-  %cst_1 = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<12x128x128xf32> -> tensor<?x?x?xf32>
+  %dynamic_constant = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<12x128x128xf32> -> tensor<?x?x?xf32>
+  %cst_1 = util.optimization_barrier %dynamic_constant : tensor<?x?x?xf32>
   %c_0_index = arith.constant 0 : index
   %c_1_index = arith.constant 1 : index
   %c_2_index = arith.constant 2 : index

--- a/tests/e2e/regression/softmax.mlir
+++ b/tests/e2e/regression/softmax.mlir
@@ -63,7 +63,8 @@ func.func @softmax_dynamic() {
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant -3.40282347E+38 : f32
   %cst_2 = arith.constant dense<7.812500e-03> : tensor<12x128x128xf32>
-  %cst_3 = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<12x128x128xf32> -> tensor<?x?x?xf32>
+  %dynamic_input = flow.tensor.dynamic_constant dense<5.000000e+00> : tensor<12x128x128xf32> -> tensor<?x?x?xf32>
+  %cst_3 = util.optimization_barrier %dynamic_input : tensor<?x?x?xf32>
   %c_0_index = arith.constant 0 : index
   %c_1_index = arith.constant 1 : index
   %c_2_index = arith.constant 2 : index


### PR DESCRIPTION
In preparation for functional changes. Changes:

- avoid reusing the same name for func.funcs in same file
- move attention_20x1x64x4096x6 to the file containing attention tests
- use CHECK-LABEL
- add tests for configs for dispatches used in e2e tests
- add tests for unchecked logic
- fix indentation issues, and remove redundant module from tests 
 - use util.optimization_barrier to avoid compilation errors in end-to-end numerical tests on constants 