### PR TITLE
[DispatchCreation] infer split-reduction sizes for ArgCompare

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1223,8 +1223,7 @@ LogicalResult ArgCompareOp::reifyResultShapes(
 SmallVector<AffineMap>
 IREE::LinalgExt::ArgCompareOp::getIndexingMapsForOperands() {
   Builder b(getContext());
-  const int64_t rank = getInputRank();
-  return SmallVector<AffineMap>{b.getMultiDimIdentityMap(rank)};
+  return {b.getMultiDimIdentityMap(getInputRank())};
 }
 
 SmallVector<AffineMap>
@@ -1241,7 +1240,7 @@ IREE::LinalgExt::ArgCompareOp::getIndexingMapsForResults() {
   }
 
   AffineMap resultMap = AffineMap::get(rank, 0, proj, ctx);
-  return SmallVector<AffineMap>{resultMap, resultMap};
+  return {resultMap, resultMap};
 }
 
 SmallVector<int64_t> IREE::LinalgExt::ArgCompareOp::getStaticLoopRanges() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -679,6 +679,9 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 
 def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+  DeclareOpInterfaceMethods<LinalgFusionInterface,
+   ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+    "getStaticLoopRanges"]>,
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
   ["generateScalarImplementation",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -798,6 +798,8 @@ def IREELinalgExt_ArgCompareOp : IREELinalgExt_Op<"arg_compare", [
     MutableOperandRange getDpsInitsMutable() {
       return getOutputsMutable();
     }
+
+    SmallVector<AffineMap> getIndexingMapsArray();
   }];
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -41,12 +41,13 @@ static std::optional<SmallVector<int64_t>> getReductionDimSizes(Operation *Op) {
     return std::nullopt;
   }
 
-  SmallVector<utils::IteratorType> iters;
-  iters = tilingInterfaceOp.getLoopIteratorTypes();
+  SmallVector<utils::IteratorType> iters =
+      tilingInterfaceOp.getLoopIteratorTypes();
   SmallVector<int64_t> reductionDimSizes;
   for (auto [range, it] : llvm::zip_equal(loopRanges, iters)) {
-    if (it == utils::IteratorType::reduction)
+    if (it == utils::IteratorType::reduction) {
       reductionDimSizes.push_back(range);
+    }
   }
   return reductionDimSizes;
 }

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -30,10 +30,12 @@ static SmallVector<int64_t> getStaticReductionDimSizes(linalg::LinalgOp op) {
 }
 
 static std::optional<SmallVector<int64_t>> getReductionDimSizes(Operation *Op) {
-  SmallVector<int64_t> loopRanges;
-  if (auto fusionOp = dyn_cast<IREE::LinalgExt::LinalgFusionOpInterface>(Op)) {
-    loopRanges = fusionOp.getStaticLoopRanges();
+  auto fusionOp = dyn_cast<IREE::LinalgExt::LinalgFusionOpInterface>(Op);
+  if (!fusionOp) {
+    LDBG() << "skipping op; not a LinalgFusionOpInterface op";
+    return std::nullopt;
   }
+  SmallVector<int64_t> loopRanges = fusionOp.getStaticLoopRanges();
 
   auto tilingInterfaceOp = dyn_cast<TilingInterface>(Op);
   if (!tilingInterfaceOp) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
@@ -21,3 +21,45 @@ util.func public @basic_reduction(%arg0: tensor<4096xf32>) -> tensor<f32> {
   // CHECK: return %[[RESULT]]
   util.return %2 : tensor<f32>
 }
+
+// -----
+
+// CHECK-LABEL: @basic_arg_compare(
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<4096xf32>
+util.func public @basic_arg_compare(%arg0: tensor<4096xf32>)
+    -> (tensor<f32>, tensor<i32>) {
+  %c0f = arith.constant 0.0 : f32
+  %c0i = arith.constant 0 : i32
+
+  %init_val = tensor.empty() : tensor<f32>
+  %init_idx = tensor.empty() : tensor<i32>
+  %filled_val = linalg.fill ins(%c0f : f32)
+                 outs(%init_val : tensor<f32>) -> tensor<f32>
+  %filled_idx = linalg.fill ins(%c0i : i32)
+                 outs(%init_idx : tensor<i32>) -> tensor<i32>
+
+  %res_val, %res_idx = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%arg0 : tensor<4096xf32>)
+    outs(%filled_val, %filled_idx : tensor<f32>, tensor<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f32>, tensor<i32>
+
+  // First level: tile reduction in 1024-size chunks.
+  // CHECK: %[[SPLIT:.+]]:2 = flow.dispatch.workgroups(%[[ARG0]]) : (tensor<4096xf32>) -> (tensor<4xf32>, tensor<4xi32>)
+  // CHECK:   scf.forall ({{.*}}) = (0) to (4096) step (1024)
+  // CHECK:     iree_linalg_ext.arg_compare
+  // CHECK-SAME: ins({{.*}} : tensor<1024xf32>)
+
+  // Second level: merge 4 partials via linalg.reduce.
+  // CHECK: %[[RESULT:.+]]:2 = flow.dispatch.workgroups(%[[SPLIT]]#0, %[[SPLIT]]#1)
+  // CHECK:   linalg.reduce
+  // CHECK-SAME: ins({{.*}} : tensor<4xf32>, tensor<4xi32>)
+  // CHECK-SAME: outs({{.*}} : tensor<f32>, tensor<i32>)
+
+  // CHECK: util.return %[[RESULT]]#0, %[[RESULT]]#1
+
+  util.return %res_val, %res_idx : tensor<f32>, tensor<i32>
+}

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes.mlir
@@ -116,3 +116,90 @@ util.func public @negative_complex_reduction(%arg0: tensor<256x4096xf32>, %arg1:
   } -> tensor<256x256xf32>
   util.return %2 : tensor<256x256xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @arg_compare_basic
+util.func public @arg_compare_basic(%arg0: tensor<4096xf32>)
+    -> (tensor<f32>, tensor<index>) {
+  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  %c0f = arith.constant 0.0 : f32
+  %c0i = arith.constant 0 : index
+
+  %init_val = tensor.empty() : tensor<f32>
+  %init_idx = tensor.empty() : tensor<index>
+  %filled_val = linalg.fill ins(%c0f : f32)
+                outs(%init_val : tensor<f32>) -> tensor<f32>
+  %filled_idx = linalg.fill ins(%c0i : index)
+                outs(%init_idx : tensor<index>) -> tensor<index>
+
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%arg0 : tensor<4096xf32>)
+    outs(%filled_val, %filled_idx : tensor<f32>, tensor<index>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f32>, tensor<index>
+
+  util.return %res#0, %res#1 : tensor<f32>, tensor<index>
+}
+
+// -----
+
+// CHECK-LABEL: @arg_compare_inner_dynamic_parallel
+util.func public @arg_compare_inner_dynamic_parallel(%arg0: tensor<4096x?xf32>, %d0: index)
+    -> (tensor<?xf32>, tensor<?xindex>) {
+  // Dynamic parallel dimension shouldn't prevent tiling.
+  // CHECK: iree_linalg_ext.split_reduction = [1024 : index]
+  %c0f = arith.constant 0.0 : f32
+  %c0i = arith.constant 0 : index
+
+  %init_val = tensor.empty(%d0) : tensor<?xf32>
+  %init_idx = tensor.empty(%d0) : tensor<?xindex>
+  %filled_val = linalg.fill ins(%c0f : f32)
+                 outs(%init_val : tensor<?xf32>) -> tensor<?xf32>
+  %filled_idx = linalg.fill ins(%c0i : index)
+                 outs(%init_idx : tensor<?xindex>) -> tensor<?xindex>
+
+  %res_val, %res_idx = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%arg0 : tensor<4096x?xf32>)
+    outs(%filled_val, %filled_idx : tensor<?xf32>, tensor<?xindex>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<?xf32>, tensor<?xindex>
+
+  util.return %res_val, %res_idx : tensor<?xf32>, tensor<?xindex>
+}
+
+// -----
+
+// CHECK-LABEL: @arg_compare_negative_outer_dynamic_reduction
+util.func public @arg_compare_negative_outer_dynamic_reduction(
+    %arg0: tensor<?x64xf32>, %d0: index)
+    -> (tensor<64xf32>, tensor<64xindex>) {
+  // We bail out on dynamic reduction dimensions.
+  // CHECK-NOT: iree_linalg_ext.split_reduction
+  %c0f = arith.constant 0.0 : f32
+  %c0i = arith.constant 0 : index
+
+  %init_val = tensor.empty() : tensor<64xf32>
+  %init_idx = tensor.empty() : tensor<64xindex>
+  %filled_val = linalg.fill ins(%c0f : f32)
+                 outs(%init_val : tensor<64xf32>) -> tensor<64xf32>
+  %filled_idx = linalg.fill ins(%c0i : index)
+                 outs(%init_idx : tensor<64xindex>) -> tensor<64xindex>
+
+  %res_val, %res_idx = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%arg0 : tensor<?x64xf32>)
+    outs(%filled_val, %filled_idx : tensor<64xf32>, tensor<64xindex>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<64xf32>, tensor<64xindex>
+
+  util.return %res_val, %res_idx : tensor<64xf32>, tensor<64xindex>
+}


### PR DESCRIPTION
Following PR #21731, this PR also extend the pass SetSplitReductionSizesPass to support ArgCompare op  `iree_linalg_ext.arg_compare`. Corresponding tests are added. 

Note: `iree_linalg_ext.arg_compare` currently reduces over a single dimension.