### PR TITLE
[Codegen] Implement the mechanism to lower bufferized CoalescedDMA op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -77,6 +77,7 @@ iree_compiler_cc_library(
         "GPUGeneralizeNamedOps.cpp",
         "GPUGreedilyDistributeToThreads.cpp",
         "GPUInferMemorySpace.cpp",
+        "GPULowerCoalescedDMAToGlobalLoads.cpp",
         "GPULowerToGlobalLoads.cpp",
         "GPUMultiBuffering.cpp",
         "GPUNestedLayoutDistributionPatterns.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_cc_library(
     "GPUGeneralizeNamedOps.cpp"
     "GPUGreedilyDistributeToThreads.cpp"
     "GPUInferMemorySpace.cpp"
+    "GPULowerCoalescedDMAToGlobalLoads.cpp"
     "GPULowerToGlobalLoads.cpp"
     "GPUMultiBuffering.cpp"
     "GPUNestedLayoutDistributionPatterns.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerCoalescedDMAToGlobalLoads.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerCoalescedDMAToGlobalLoads.cpp
@@ -1,0 +1,304 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdint>
+#include <numeric>
+#include <optional>
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-lower-coalesced-dma-to-global-loads"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPULOWERCOALESCEDDMATOGLOBALLOADSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+static LogicalResult verifyThreadMapping(scf::ForallOp forallOp) {
+  std::optional<ArrayAttr> mappingAttr = forallOp.getMapping();
+  if (!mappingAttr) {
+    return failure();
+  }
+
+  // Verify that all mappings are thread mappings
+  for (Attribute attr : *mappingAttr) {
+    if (!isa<gpu::GPUThreadMappingAttr>(attr)) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult verifyMemoryLayout(IREE::GPU::CoalescedGatherDMAOp dmaOp,
+                                        PatternRewriter &rewriter) {
+  // Check that destination memref is contiguous.
+  auto destMemRefType = cast<MemRefType>(dmaOp.getInit().getType());
+
+  if (!destMemRefType.areTrailingDimsContiguous(1)) {
+    return rewriter.notifyMatchFailure(
+        dmaOp,
+        "destination memref does not have contiguous trailing dimension");
+  }
+
+  /*
+  auto sourceType = cast<MemRefType>(dmaOp.getSource().getType());
+  auto targetType = cast<MemRefType>(dmaOp.getInit().getType());
+
+  bool hasGlobalSource = hasGlobalMemoryAddressSpace(sourceType);
+  bool hasSharedTarget = hasSharedMemoryAddressSpace(targetType);
+
+  if (!hasGlobalSource || !hasSharedTarget) {
+    return rewriter.notifyMatchFailure(
+        dmaOp, "incompatible source or target memory address space");
+  }
+  */
+
+  return success();
+}
+
+static LogicalResult
+isEligibleForGlobalDMA(IREE::GPU::CoalescedGatherDMAOp dmaOp,
+                       PatternRewriter &rewriter) {
+  scf::ForallOp forallOp = dmaOp->getParentOfType<scf::ForallOp>();
+
+  // Verify that the forall has the required GPU thread mapping.
+  if (failed(verifyThreadMapping(forallOp))) {
+    return failure();
+  }
+
+  if (failed(verifyMemoryLayout(dmaOp, rewriter))) {
+    return failure();
+  }
+
+  return success();
+}
+
+static bool matchesTargetDmaSize(int64_t transferSizeBytes,
+                                 ArrayRef<int64_t> targetDmaSizes) {
+  for (int64_t dmaSize : targetDmaSizes) {
+    if (transferSizeBytes == dmaSize) {
+      return true;
+    }
+  }
+  return false;
+}
+
+struct LowerCoalescedGatherDMAPattern
+    : public OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LowerCoalescedGatherDMAPattern(MLIRContext *context,
+                                 ArrayRef<int64_t> targetDmaSizes)
+      : OpRewritePattern<IREE::GPU::CoalescedGatherDMAOp>(context),
+        targetDmaSizes(targetDmaSizes) {}
+
+  LogicalResult matchAndRewrite(IREE::GPU::CoalescedGatherDMAOp dmaOp,
+                                PatternRewriter &rewriter) const override {
+    LDBG() << "Processing CoalescedGatherDMAOp: " << dmaOp;
+
+    // Verify the DMA op is inside a scf.forall
+    auto forallOp = dmaOp->getParentOfType<scf::ForallOp>();
+    if (!forallOp) {
+      return rewriter.notifyMatchFailure(
+          dmaOp, "coalesced_gather_dma not inside scf.forall");
+    }
+
+    // Verify thread mapping
+    if (failed(verifyThreadMapping(forallOp))) {
+      return rewriter.notifyMatchFailure(
+          dmaOp, "forall does not have proper thread mapping");
+    }
+
+    // Verify memory layout
+    if (failed(verifyMemoryLayout(dmaOp, rewriter))) {
+      return failure();
+    }
+
+    [[maybe_unused]] Location loc = dmaOp.getLoc();
+    Value source = dmaOp.getSource();
+    Value dest = dmaOp.getInit();
+
+    LDBG() << "  Source: " << source;
+    LDBG() << "  Dest: " << dest;
+
+    // Get all operands
+    auto indicesRange = dmaOp.getIndices();
+
+    auto sourceType = cast<MemRefType>(source.getType());
+    auto destType = cast<MemRefType>(dest.getType());
+
+    // Check if indices operand exists
+    if (!indicesRange.empty()) {
+      Value indices = indicesRange.front();
+      LDBG() << "  Indices: " << indices;
+      auto indicesType = cast<MemRefType>(indices.getType());
+      ArrayRef<int64_t> indicesShape = indicesType.getShape();
+      ArrayRef<int64_t> destShape = destType.getShape();
+
+      // Verify that indices dimensions are a prefix of dest dimensions
+      if (indicesShape.size() > destShape.size()) {
+        return rewriter.notifyMatchFailure(dmaOp,
+                                           "indices rank exceeds dest rank");
+      }
+
+      for (size_t i = 0; i < indicesShape.size(); ++i) {
+        if (indicesShape[i] != destShape[i]) {
+          return rewriter.notifyMatchFailure(
+              dmaOp, "indices shape is not a prefix of dest shape");
+        }
+      }
+
+      // Get the trailing missing dimension size (innermost dimension only)
+      [[maybe_unused]] int64_t trailingDims =
+          destShape.size() - indicesShape.size();
+      LDBG() << "  Trailing dimensions: " << trailingDims;
+
+      // Get only the innermost dimension size
+      [[maybe_unused]] int64_t trailingSize = destShape.back();
+      LDBG() << "  Trailing size (innermost): " << trailingSize;
+    }
+
+    // Get element size
+    Type elementType = sourceType.getElementType();
+    int64_t elementBits = sourceType.getElementTypeBitWidth();
+    LDBG() << "  Element type: " << elementType;
+    LDBG() << "  Element bits: " << elementBits;
+
+    // Get innermost dimension size of SOURCE and check against target DMA sizes
+    int64_t innermostDimSize = sourceType.getShape().back();
+    int64_t transferSizeBits = innermostDimSize * elementBits;
+    LDBG() << "  Source innermost dimension size: " << innermostDimSize;
+    LDBG() << "  Transfer size in bits: " << transferSizeBits;
+
+    // Check that transfer size matches one of the target DMA sizes (if
+    // specified) Note: dma_sizes are in bits
+    if (!targetDmaSizes.empty() &&
+        !matchesTargetDmaSize(transferSizeBits, targetDmaSizes)) {
+      return rewriter.notifyMatchFailure(
+          dmaOp, "transfer size does not match any target DMA size");
+    }
+
+    // TODO: Handle indices properly - for now we skip the explicit indices
+    // check The lane parameter is always present but we handle it differently
+
+    // Get the second innermost dimension size from SOURCE
+    ArrayRef<int64_t> sourceShape = sourceType.getShape();
+    if (sourceShape.size() < 2) {
+      return rewriter.notifyMatchFailure(
+          dmaOp, "source must have at least 2 dimensions");
+    }
+
+    int64_t secondInnermostDimSize = sourceShape[sourceShape.size() - 2];
+    LDBG() << "  Source second innermost dimension size: "
+           << secondInnermostDimSize;
+
+    // TODO: Continue implementation
+
+    auto transferType = VectorType::get({innermostDimSize}, elementType);
+
+    rewriter.setInsertionPoint(dmaOp);
+
+    for (int64_t i = 0; i < secondInnermostDimSize; ++i) {
+      // assume we have a memref<Yx4xf32>, we want to generate
+      // amdgpu.gather_to_lds: amdgpu.gather_to_lds %source[i, 0], %dest[i, 0],
+      // transfer_type
+
+      Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+      // Build source indices [i, 0]
+      SmallVector<Value> srcIndices;
+      for (int64_t dim = 0; dim < sourceType.getRank() - 2; ++dim) {
+        srcIndices.push_back(zero);
+      }
+      srcIndices.push_back(iVal);
+      srcIndices.push_back(zero);
+
+      // Build dest indices [i, 0]
+      SmallVector<Value> dstIndices;
+      for (int64_t dim = 0; dim < destType.getRank() - 2; ++dim) {
+        dstIndices.push_back(zero);
+      }
+      dstIndices.push_back(iVal);
+      dstIndices.push_back(zero);
+
+      rewriter.create<amdgpu::GatherToLDSOp>(loc, source, srcIndices, dest,
+                                             dstIndices,
+                                             TypeAttr::get(transferType));
+    }
+
+    rewriter.eraseOp(dmaOp);
+    return success();
+  }
+
+private:
+  ArrayRef<int64_t> targetDmaSizes;
+};
+
+namespace {
+struct GPULowerCoalescedDMAToGlobalLoadsPass final
+    : impl::GPULowerCoalescedDMAToGlobalLoadsPassBase<
+          GPULowerCoalescedDMAToGlobalLoadsPass> {
+  void runOnOperation() override {
+    mlir::FunctionOpInterface funcOp = getOperation();
+
+    int count = 0;
+    funcOp.walk([&count](IREE::GPU::CoalescedGatherDMAOp op) {
+      LDBG() << "Found CoalescedGatherDMAOp: " << op;
+      ++count;
+    });
+    LDBG() << "Total CoalescedGatherDMAOps found: " << count;
+    if (count == 0) {
+      LDBG() << "No CoalescedGatherDMAOps found, exiting early";
+      return;
+    }
+
+    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+    LDBG() << "GPU Target attribute: " << target;
+    if (!target) {
+      LDBG() << "Missing GPU target attribute, pass will fail";
+      // Don't fail if no target attribute - just skip the pass
+      return;
+    }
+
+    ArrayRef<int64_t> dmaSizes;
+    if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+      dmaSizes = dmaSizesAttr.asArrayRef();
+    }
+    // dma_sizes is optional - if not specified, skip the size validation
+
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<LowerCoalescedGatherDMAPattern>(context, dmaSizes);
+
+    walkAndApplyPatterns(funcOp, std::move(patterns));
+  }
+};
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerCopyToCoalescedGather.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerCopyToCoalescedGather.cpp
@@ -1,0 +1,115 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "llvm/Support/DebugLog.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-lower-copy-to-coalesced-gather"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPULOWERCOPYTOCOALESCEDGATHERPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+struct LowerCopyToGatherPattern : public OpRewritePattern<linalg::CopyOp> {
+  LowerCopyToGatherPattern(MLIRContext *context, FunctionOpInterface funcOp)
+      : OpRewritePattern<linalg::CopyOp>(context), funcOp(funcOp) {}
+
+  LogicalResult matchAndRewrite(linalg::CopyOp copy,
+                                PatternRewriter &rewriter) const override {
+    auto loweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttrInterface>(copy);
+    // Check for lowering_config attribute (e.g., use_global_load_dma)
+    if (!loweringConfig) {
+      return failure();
+    }
+
+    // Get the source and destination tensors
+    Value source = copy.getOperand(0);
+    Value dest = copy.getOutputs().front();
+
+    auto sourceType = dyn_cast<RankedTensorType>(source.getType());
+    if (!sourceType) {
+      return rewriter.notifyMatchFailure(copy,
+                                         "source must be a ranked tensor");
+    }
+
+    if (sourceType.getRank() == 0) {
+      return rewriter.notifyMatchFailure(
+          copy, "Cannot convert scalar copy to gather");
+    }
+
+    // Create dimension_map attribute - for a copy, we gather along dimension 0
+    SmallVector<int64_t> dimensionMap = {0};
+    auto dimensionMapAttr = rewriter.getDenseI64ArrayAttr(dimensionMap);
+
+    // Create the gather operation with only source (copy mode)
+    auto gatherOp = rewriter.create<IREE::LinalgExt::GatherOp>(
+        copy.getLoc(), dest.getType(), /*inputs=*/ValueRange{source},
+        /*outputs=*/ValueRange{dest}, dimensionMapAttr);
+
+    // Create a proper lowering config with tile sizes from translation info
+    // Get subgroup size from translation info
+    std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+    if (!subgroupSize) {
+      // Fall back to just transferring the existing config
+      setLoweringConfig(gatherOp, loweringConfig);
+    } else {
+      // Build tile sizes based on the tensor rank and subgroup size
+      int64_t rank = sourceType.getRank();
+
+      // Subgroup level: tile innermost dimension with subgroup size
+      SmallVector<int64_t> subgroupTiles(rank, 1);
+      subgroupTiles[rank - 1] = *subgroupSize;
+
+      // Thread level: tile innermost dimension with 1 (each thread handles 1
+      // element)
+      SmallVector<int64_t> threadTiles(rank, 1);
+
+      // Create the lowering config with subgroup and thread tile sizes
+      SmallVector<NamedAttribute> fields;
+      fields.push_back(rewriter.getNamedAttr(
+          "subgroup", rewriter.getI64ArrayAttr(subgroupTiles)));
+      fields.push_back(rewriter.getNamedAttr(
+          "thread", rewriter.getI64ArrayAttr(threadTiles)));
+
+      auto dictAttr = rewriter.getDictionaryAttr(fields);
+      auto newConfig =
+          IREE::GPU::LoweringConfigAttr::get(rewriter.getContext(), dictAttr);
+      setLoweringConfig(gatherOp, newConfig);
+    }
+
+    rewriter.replaceOp(copy, gatherOp.getResults());
+    return success();
+  }
+
+private:
+  FunctionOpInterface funcOp;
+};
+
+namespace {
+struct GPULowerCopyToCoalescedGatherPass final
+    : impl::GPULowerCopyToCoalescedGatherPassBase<
+          GPULowerCopyToCoalescedGatherPass> {
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    mlir::FunctionOpInterface funcOp = getOperation();
+
+    RewritePatternSet patterns(context);
+    patterns.add<LowerCopyToGatherPattern>(context, funcOp);
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
+  }
+};
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -86,7 +86,8 @@ def GPUConvertToCoalescedDMAPass :
     "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect",
     "::mlir::gpu::GPUDialect",
     "::mlir::scf::SCFDialect",
-    "::mlir::tensor::TensorDialect"
+    "::mlir::tensor::TensorDialect",
+    "::mlir::vector::VectorDialect"
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -91,6 +91,15 @@ def GPUConvertToCoalescedDMAPass :
   ];
 }
 
+def GPULowerCoalescedDMAToGlobalLoadsPass :
+    InterfacePass<"iree-codegen-gpu-lower-coalesced-dma-to-global-loads", "mlir::FunctionOpInterface"> {
+  let summary = "Lower coalesced DMA operations to global loads instructions.";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect", "::mlir::scf::SCFDialect",
+    "::mlir::amdgpu::AMDGPUDialect", "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUDistributeForallPass :
     InterfacePass<"iree-codegen-gpu-distribute-forall", "mlir::FunctionOpInterface"> {
   let summary = "Pass to distribute scf.forall ops.";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "gpu_greedily_distribute_to_threads.mlir",
             "gpu_infer_memory_space.mlir",
             "gpu_combine_value_barriers.mlir",
+            "gpu_lower_coalesced_dma_to_global_loads.mlir",
             "gpu_lower_to_global_loads.mlir",
             "gpu_nested_layout_contract_amdgpu.mlir",
             "gpu_nested_layout_vector_distribution.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "gpu_generalize_named_ops.mlir"
     "gpu_greedily_distribute_to_threads.mlir"
     "gpu_infer_memory_space.mlir"
+    "gpu_lower_coalesced_dma_to_global_loads.mlir"
     "gpu_lower_to_global_loads.mlir"
     "gpu_nested_layout_contract_amdgpu.mlir"
     "gpu_nested_layout_vector_distribution.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -18,12 +18,14 @@ func.func @gather_tile_to_subgroup(%source: tensor<1024xf32>, %indices: tensor<3
   // CHECK: %[[DEST_WG_SLICE:.*]] = tensor.extract_slice %[[WG_OUT]][%[[WG_I]], %[[WG_J]]] [1, 32] [1, 1]
   // CHECK-SAME: tensor<32x32xf32> to tensor<1x32xf32>
 
+  // CHECK: %[[VECTOR_INDICES:.*]] = vector.transfer_read %[[INDICES_WG_SLICE]]
+
   // CHECK: %[[INNER:.*]] = scf.forall (%[[TH_I:.*]], %[[TH_J:.*]]) in (1, 32)
   // CHECK-SAME: shared_outs(%[[TH_OUT:.*]] = %[[DEST_WG_SLICE]]) -> (tensor<1x32xf32>)
 
   // CHECK: scf.forall.in_parallel {
-  // CHECK:   iree_gpu.coalesced_gather_dma %[[INDICES_WG_SLICE]], %{{.*}} into %[[TH_OUT]]
-  // CHECK-SAME: tensor<1x32xindex>, tensor<1024xf32>, tensor<1x32xf32> -> tensor<1x32xf32>
+  // CHECK:   iree_gpu.coalesced_gather_dma %{{.*}}[%[[VECTOR_INDICES]]] into %[[TH_OUT]] lane
+  // CHECK-SAME: tensor<1024xf32>, vector<32xindex>, tensor<1x32xf32>, index -> tensor<1x32xf32>
   // CHECK: }
   // CHECK: } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_coalesced_dma_to_global_loads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_coalesced_dma_to_global_loads.mlir
@@ -1,0 +1,106 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-lower-coalesced-dma-to-global-loads))" \
+// RUN:   %s | FileCheck %s
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx1250", features = "", wgp = <
+    compute = fp64|fp32|fp16|int64|int32|int16|int8,
+    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
+    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192>>}>
+
+// CHECK-LABEL: func.func @lower_coalesced_gather_dma_multiple
+func.func @lower_coalesced_gather_dma_multiple(
+    %source: memref<512xf32, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<512xf32, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  // CHECK: scf.forall
+  scf.forall (%arg5, %arg6) in (32, 1) {
+    // CHECK: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) :
+      memref<512xf32, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<512xf32, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return
+}
+
+// -----
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx1250", features = "", wgp = <
+    compute = fp64|fp32|fp16|int64|int32|int16|int8,
+    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
+    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192>>}>
+
+// CHECK-LABEL: func.func @lower_loop_nest
+func.func @lower_loop_nest(%arg0: memref<1x4xf32, #amdgpu.address_space<fat_raw_buffer>>,
+                           %arg2: memref<32x32xf32, #gpu.address_space<workgroup>>) -> memref<32x32xf32, #gpu.address_space<workgroup>>
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  // CHECK: scf.forall (%{{.*}}, %{{.*}}) = (0, 0) to (32, 32) step (1, 32)
+  scf.forall (%arg3, %arg4) = (0, 0) to (32, 32) step (1, 32) {
+    // CHECK: %[[SUBVIEW:.+]] = memref.subview
+    %subview_0 = memref.subview %arg2[%arg3, %arg4] [1, 4] [1, 1] : memref<32x32xf32, #gpu.address_space<workgroup>> to memref<1x4xf32, strided<[32, 1], offset: ?>, #gpu.address_space<workgroup>>
+    // CHECK: scf.forall
+    scf.forall (%arg5, %arg6) in (1, 32) {
+      // CHECK-NOT: iree_gpu.coalesced_gather_dma
+      // CHECK: %[[C0:.*]] = arith.constant 0 : index
+      // CHECK: %[[C0_0:.*]] = arith.constant 0 : index
+      // CHECK: amdgpu.gather_to_lds %{{.*}}[%[[C0]], %[[C0_0]]], %[[SUBVIEW]][%[[C0]], %[[C0_0]]] : vector<4xf32>
+      iree_gpu.coalesced_gather_dma %arg0 into %subview_0 lane(%arg6) :
+        memref<1x4xf32, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<1x4xf32, strided<[32, 1], offset: ?>, #gpu.address_space<workgroup>>, index
+    } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
+  return %arg2 : memref<32x32xf32, #gpu.address_space<workgroup>>
+}
+
+// -----
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx1250", features = "", wgp = <
+    compute = fp64|fp32|fp16|int64|int32|int16|int8,
+    storage = b64|b32|b16|b8, subgroup = shuffle|arithmetic,
+    dot = dp4xi8toi32, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192>>}>
+
+// Test case for coalesced DMA without explicit indices (copy operation)
+// CHECK-LABEL: func.func @lower_coalesced_copy_dma_basic
+func.func @lower_coalesced_copy_dma_basic(
+    %source: memref<2x8xf16>,
+    %dest: memref<2x8xf16, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  // CHECK: scf.forall
+  scf.forall (%arg5, %arg6) in (1, 64) {
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    // CHECK: %[[C0:.*]] = arith.constant 0 : index
+    // CHECK: %[[C0_0:.*]] = arith.constant 0 : index
+    // CHECK: amdgpu.gather_to_lds %{{.*}}[%[[C0]], %[[C0_0]]], %{{.*}}[%[[C0]], %[[C0_0]]] : vector<8xf16>
+    // CHECK: %[[C1:.*]] = arith.constant 1 : index
+    // CHECK: %[[C0_1:.*]] = arith.constant 0 : index
+    // CHECK: amdgpu.gather_to_lds %{{.*}}[%[[C1]], %[[C0_1]]], %{{.*}}[%[[C1]], %[[C0_1]]] : vector<8xf16>
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%arg6) : memref<2x8xf16>, memref<2x8xf16, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -252,15 +252,6 @@ LogicalResult CoalescedGatherDMAOp::verify() {
     // Gather mode:
     auto indicesValues = getIndices();
 
-    for (auto [idx, indicesValue] : llvm::enumerate(indicesValues)) {
-      auto shapedType = dyn_cast<ShapedType>(indicesValue.getType());
-      if (!shapedType || !shapedType.getElementType().isIndex() ||
-          shapedType.getRank() != 1) {
-        return emitOpError("indices[")
-               << idx << "] must be a 1D vector or tensor of index type";
-      }
-    }
-
     if (failed(checkSourceType()))
       return failure();
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -275,9 +275,7 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     * When the source is a memref, the operation writes the gathered data into
       a destination out memref operand.
 
-    The `indices` operand is optional. When `indices` is not present (copy mode),
-    each thread in the subgroup loads a contiguous slice of data from `source` and
-    writes it to its lane-offset in `result`/`init`. The `source` represents the
+    The `indices` operand is optional. The `source` represents the
     data loaded by this thread, while `result`/`init` is the collective output for
     all threads in the subgroup. Therefore, `source` and `result`/`init` may have
     different shapes (typically source is smaller, representing one thread's portion).

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -269,11 +269,18 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
     This operation can exist in two forms: a tensor-based (value-semantic) form
     and a buffer-based (memref-semantic) form.
 
-    In both forms, it reads elements from a source operand based on indices.
+    In both forms, it reads elements from a source operand based on the optional `indices` operand.
     * When the source is a tensor, the operation produces a new result tensor
       containing the gathered data.
     * When the source is a memref, the operation writes the gathered data into
       a destination out memref operand.
+
+    The `indices` operand is optional. When `indices` is not present (copy mode),
+    each thread in the subgroup loads a contiguous slice of data from `source` and
+    writes it to its lane-offset in `result`/`init`. The `source` represents the
+    data loaded by this thread, while `result`/`init` is the collective output for
+    all threads in the subgroup. Therefore, `source` and `result`/`init` may have
+    different shapes (typically source is smaller, representing one thread's portion).
 
     The operation is specifically designed for subgroup-level parallelism, where
     threads within a subgroup cooperatively gather data with coalesced memory
@@ -289,65 +296,84 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
 
     ## Operands and Results
 
-    * `$indices`: Tensor/memref of index type specifying gather locations in
-      the source tensor
-    * `$source`: Source tensor/memref containing the data to be gathered
+    * `$indices`: The variadic `indices` operand is an optional tensor or vector of indices
+      to gather from `source`. If the indices are present, their shape must be a prefix of
+      the `init`/`result` type. Each `index` must be a 1D tensor or vector whose length matches
+      the length of the corresponding dimension of `source`.
+
+      The values in `indices` form indices into the memref starting at
+      `source` from which a given thread will gather data, and each tensor/vector component in `indices`
+      corresponds to one index dimension in `source`.
+      Any component that is not specified is implicitly assumed to be `[0, 1, ..., len - 1]`
+      where `len` is the length of the corresponding dimension of source. That is, gather all the
+      elements along that dimension.
+
+      This operation will gather data into its result as by setting:
+      ```
+      forall (i0, i1, ... iN) in (dim(source, 0), dim(source, 1), ... dim(source, N)):
+        result[i0, i1, ... iN-1, iN + lane_id * dim(source, N)] =
+            source[indices[0][i0], indices[1][i1], ..., indices[N][iN]]
+      ```
+      where `lane_id` is the ID of the thread within its subgroup.
+
+      Note that, in order to enable efficient gathers, the trailing dimension of `source`
+      must have unspecified indices and the dim's size must be a supported
+      DMA width for your target.
+
+    * `$source`: Source tensor/memref containing the data to be gathered.
     * `$init`: Destination tensor/memref receiving the gathered data
-      (destination-passing style)
-    * `$result`: Output tensor/memref with gathered data (same type as `$init`)
+      (destination-passing style).
+    * `$result`: Output tensor with gathered data (same type as `$init`). Only
+      present for tensor semantics; memref form does not have a result.
+    * `lane`: The lane that specifies the coalescing store's offset within the
+      workgroup/shared memory.
 
-    ## Example
-
-    The following example shows how this op is designed to be used in a tiled
-    scenario, which sets up lowering path for efficient gathering.
-
-    1. Outer `scf.forall` represents workgroup-level parallelism.
-    2. Inner `scf.forall` represents subgroup-level parallelism.
-    3. Each thread in the subgroup coalesces its memory accesses when
-       gathering data and writes to its lane-offset in the destination tensor.
-
+    ## Example of a single subgroup using coalesced_gather_dma in copy mode
+       for transferring tensor<4x128xf32>, with an intended DMA width of 128 bits
+       (4 x f32):
     ```mlir
-    %result = scf.forall (%wg_i, %wg_j) in (16, 1) shared_outs(%wg_out = %dest) -> (tensor<128x16xf32>) {
-      %indices_wg_slice = tensor.extract_slice ...
-      %dest_wg_slice = tensor.extract_slice ...
-
-      %inner_result = scf.forall (%sg_i, %sg_j) in (32, 1) shared_outs(%sg_out = %dest_wg_slice) -> (tensor<8x16xf32>) {
+    %result = scf.forall (%arg5, %arg6) in (1, 32) ... -> (tensor<4x128xf32>) {
+        %2 = %arg6 * 4
+        %thread_slice = tensor.extract_slice %source_slice[0, %2] [4, 4] [1, 1] : tensor<4x128xf32> to tensor<4x4xf32>
         scf.forall.in_parallel {
-          iree_gpu.coalesced_gather_dma %indices_wg_slice, %source into %sg_out : ...
+          %3 = iree_gpu.coalesced_gather_dma %thread_slice into %dest_slice lane(%arg6)
+            : tensor<4x4xf32>, tensor<4x128xf32>, index -> tensor<4x128xf32>
         }
       } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
-
-      scf.forall.in_parallel {
-        tensor.parallel_insert_slice %inner_result into %wg_out[...] : ...
-      }
-    } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
     ```
   }];
 
   let arguments = (ins
-    AnyTypeOf<[RankedTensorOf<[Index]>, MemRefOf<[Index]>]>:$indices,
     AnyRankedTensorOrMemRef:$source,
-    AnyRankedTensorOrMemRef:$init
+    Variadic<AnyTypeOf<[RankedTensorOf<[Index]>, VectorOfAnyRankOf<[Index]>]>>:$indices,
+    AnyRankedTensorOrMemRef:$init,
+    Index:$lane
   );
 
-  let results = (outs AnyRankedTensorOrMemRef:$result);
+  let results = (outs Optional<AnyRankedTensor>:$result);
 
   let assemblyFormat = [{
-    $indices `,` $source `into` $init attr-dict
-    `:` type($indices) `,` type($source) `,` type($init) `->` type($result)
+    $source (`[` $indices^ `]`)? `into` $init `lane` `(` $lane `)` attr-dict
+    `:` type(operands) (`->` type($result)^)?
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    // Get the rank of the result tensor/memref
+    // Get the rank of the init/result tensor/memref
     unsigned getResultRank() {
-      if (auto tensorType = ::llvm::dyn_cast<RankedTensorType>(getResult().getType()))
+      // For tensor semantics, use result; for memref semantics, use init
+      Type type = getResult() ? getResult().getType() : getInit().getType();
+      if (auto tensorType = ::llvm::dyn_cast<RankedTensorType>(type))
         return tensorType.getRank();
-      if (auto memrefType = ::llvm::dyn_cast<MemRefType>(getResult().getType()))
+      if (auto memrefType = ::llvm::dyn_cast<MemRefType>(type))
         return memrefType.getRank();
       assert(false && "expected ranked tensor or memref type");
       return 0;
+    }
+
+    bool hasTensorSemantics() {
+      return getResult() != nullptr;
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/bufferize_coalesced_gather_dma.mlir
@@ -1,73 +1,57 @@
 // RUN: iree-opt %s --one-shot-bufferize="bufferize-function-boundaries" --split-input-file | FileCheck %s
 
 // Test bufferization of coalesced_gather_dma with static shapes
-func.func @bufferize_coalesced_gather_dma_static(%indices: tensor<64x32xindex>,
-                                                  %source: tensor<1024x64xf32>,
-                                                  %dest: tensor<64x32xf32> {bufferization.writable = true}) -> tensor<64x32xf32> {
+func.func @bufferize_coalesced_gather_dma_static(%idx0: vector<64xindex>,
+                                                  %source: tensor<2048xf32>,
+                                                  %dest: tensor<64xf32> {bufferization.writable = true},
+                                                  %lane: index) -> tensor<64xf32> {
   %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64x32xf32>) {
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64xf32>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<64x32xindex>, tensor<1024x64xf32>, tensor<64x32xf32> -> tensor<64x32xf32>
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+        : tensor<2048xf32>, vector<64xindex>, tensor<64xf32>, index -> tensor<64xf32>
     }
   }
-  return %result : tensor<64x32xf32>
+  return %result : tensor<64xf32>
 }
 
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_static
 //       CHECK:   scf.forall
-//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<64x32xindex, strided<[?, ?], offset: ?>>, memref<1024x64xf32, strided<[?, ?], offset: ?>>, memref<64x32xf32, strided<[?, ?], offset: ?>>
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : memref<2048xf32, strided<[?], offset: ?>>, vector<64xindex>, memref<64xf32, strided<[?], offset: ?>>, index
 
-// -----
-
-// Test bufferization of coalesced_gather_dma with dynamic shapes
-func.func @bufferize_coalesced_gather_dma_dynamic(%indices: tensor<?x?xindex>,
-                                                   %source: tensor<?x?xf32>,
-                                                   %dest: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<?x?xf32>) {
-    scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<?x?xindex>, tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
-    }
-  }
-  return %result : tensor<?x?xf32>
-}
-
-// CHECK-LABEL: func @bufferize_coalesced_gather_dma_dynamic
-//       CHECK:   scf.forall
-//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<?x?xindex, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>, memref<?x?xf32, strided<[?, ?], offset: ?>>
 // -----
 
 // Test bufferization with different element types
-func.func @bufferize_coalesced_gather_dma_f16(%indices: tensor<128x64xindex>,
-                                               %source: tensor<2048x64xf16>,
-                                               %dest: tensor<128x64xf16>) -> tensor<128x64xf16> {
+func.func @bufferize_coalesced_gather_dma_f16(%idx0: vector<128xindex>,
+                                               %source: tensor<8192xf16>,
+                                               %dest: tensor<128xf16>,
+                                               %lane: index) -> tensor<128xf16> {
   %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<128x64xf16>) {
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<128xf16>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<128x64xindex>, tensor<2048x64xf16>, tensor<128x64xf16> -> tensor<128x64xf16>
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+        : tensor<8192xf16>, vector<128xindex>, tensor<128xf16>, index -> tensor<128xf16>
     }
   }
-  return %result : tensor<128x64xf16>
+  return %result : tensor<128xf16>
 }
 
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_f16
 //       CHECK:   scf.forall
-//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<128x64xindex, strided<[?, ?], offset: ?>>, memref<2048x64xf16, strided<[?, ?], offset: ?>>, memref<128x64xf16, strided<[?, ?], offset: ?>>
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : memref<8192xf16, strided<[?], offset: ?>>, vector<128xindex>, memref<128xf16, strided<[?], offset: ?>>, index
 
 // -----
 
 // Test bufferization with 1D tensors
-func.func @bufferize_coalesced_gather_dma_1d(%indices: tensor<32xindex>,
-                                              %source: tensor<1024xf32>,
-                                              %dest: tensor<1024xf32> {bufferization.writable = true}) -> tensor<1024xf32> {
+func.func @bufferize_coalesced_gather_dma_1d(%indices: vector<1024xindex>,
+                                              %source: tensor<2048xf32>,
+                                              %dest: tensor<1024xf32> {bufferization.writable = true},
+                                              %lane: index) -> tensor<1024xf32> {
   %c32 = arith.constant 32 : index
   %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<1024xf32>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<32xindex>, tensor<1024xf32>, tensor<1024xf32> -> tensor<1024xf32>
+      iree_gpu.coalesced_gather_dma %source[%indices] into %out lane(%lane)
+        : tensor<2048xf32>, vector<1024xindex>, tensor<1024xf32>, index -> tensor<1024xf32>
     }
   }
   return %result : tensor<1024xf32>
@@ -76,40 +60,52 @@ func.func @bufferize_coalesced_gather_dma_1d(%indices: tensor<32xindex>,
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_1d
 //       CHECK:   %[[C32:.+]] = arith.constant 32 : index
 //       CHECK:   scf.forall (%{{.+}}) in (%[[C32]])
-//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<32xindex, strided<[?], offset: ?>>, memref<1024xf32, strided<[?], offset: ?>>, memref<1024xf32, strided<[?], offset: ?>>
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : memref<2048xf32, strided<[?], offset: ?>>, vector<1024xindex>, memref<1024xf32, strided<[?], offset: ?>>, index
 
 // -----
 
 // Test bufferization in nested forall loops (workgroup and subgroup levels)
-func.func @bufferize_coalesced_gather_dma_nested(%indices: tensor<16x32xindex>,
-                                                  %source: tensor<2048x64xf32>,
-                                                  %dest: tensor<128x16xf32> {bufferization.writable = true}) -> tensor<128x16xf32> {
-  %result = scf.forall (%wg_i, %wg_j) in (16, 1) shared_outs(%wg_out = %dest) -> (tensor<128x16xf32>) {
-    %c8 = arith.constant 8 : index
-    %wg_offset = arith.muli %wg_i, %c8 : index
-    %indices_wg_slice = tensor.extract_slice %indices[%wg_offset, 0] [1, 32] [1, 1]
-      : tensor<16x32xindex> to tensor<1x32xindex>
-    %dest_wg_slice = tensor.extract_slice %wg_out[%wg_offset, 0] [8, 16] [1, 1]
-      : tensor<128x16xf32> to tensor<8x16xf32>
-
-    %inner_result = scf.forall (%sg_i, %sg_j) in (32, 1) shared_outs(%sg_out = %dest_wg_slice) -> (tensor<8x16xf32>) {
+func.func @bufferize_coalesced_gather_dma_nested(%idx0: vector<8xindex>,
+                                                  %source: tensor<2048xf32>,
+                                                  %dest: tensor<8xf32> {bufferization.writable = true},
+                                                  %lane: index) -> tensor<8xf32> {
+  %result = scf.forall (%wg_i, %wg_j) in (16, 1) shared_outs(%wg_out = %dest) -> (tensor<8xf32>) {
+    %inner_result = scf.forall (%sg_i, %sg_j) in (32, 1) shared_outs(%sg_out = %wg_out) -> (tensor<8xf32>) {
       scf.forall.in_parallel {
-        iree_gpu.coalesced_gather_dma %indices_wg_slice, %source into %sg_out
-          : tensor<1x32xindex>, tensor<2048x64xf32>, tensor<8x16xf32> -> tensor<8x16xf32>
+        iree_gpu.coalesced_gather_dma %source[%idx0] into %sg_out lane(%lane)
+          : tensor<2048xf32>, vector<8xindex>, tensor<8xf32>, index -> tensor<8xf32>
       }
     } {mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]}
 
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %inner_result into %wg_out[%wg_offset, 0] [8, 16] [1, 1]
-        : tensor<8x16xf32> into tensor<128x16xf32>
+      tensor.parallel_insert_slice %inner_result into %wg_out[0] [8] [1]
+        : tensor<8xf32> into tensor<8xf32>
     }
   } {mapping = [#gpu.warp<linear_dim_1>, #gpu.warp<linear_dim_0>]}
-  return %result : tensor<128x16xf32>
+  return %result : tensor<8xf32>
 }
 
 // CHECK-LABEL: func @bufferize_coalesced_gather_dma_nested
 //       CHECK:   scf.forall (%{{.+}}, %{{.+}}) in (16, 1)
-//       CHECK:     %{{.+}} = memref.subview
-//       CHECK:     %{{.+}} = memref.subview
 //       CHECK:     scf.forall (%{{.+}}, %{{.+}}) in (32, 1)
-//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}, %{{.+}} into %{{.+}} : memref<1x32xindex, strided<[?, ?], offset: ?>>, memref<2048x64xf32, strided<[?, ?], offset: ?>>, memref<8x16xf32, strided<[?, ?], offset: ?>>
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : memref<2048xf32, strided<[?], offset: ?>>, vector<8xindex>, memref<8xf32, strided<[?], offset: ?>>, index
+
+// -----
+
+// Test bufferization without indices (contiguous gather)
+func.func @bufferize_coalesced_gather_dma_no_indices(%source: tensor<1x32xf32>,
+                                                      %dest: tensor<1x32xf32>,
+                                                      %lane: index) -> tensor<1x32xf32> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<1x32xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %source into %out lane(%lane)
+        : tensor<1x32xf32>, tensor<1x32xf32>, index -> tensor<1x32xf32>
+    }
+  }
+  return %result : tensor<1x32xf32>
+}
+
+// CHECK-LABEL: func @bufferize_coalesced_gather_dma_no_indices
+//       CHECK:   scf.forall
+//       CHECK:     iree_gpu.coalesced_gather_dma %{{.+}} into %{{.+}} lane(%{{.+}}) : memref<1x32xf32, strided<[?, ?], offset: ?>>, memref<1x32xf32, strided<[?, ?], offset: ?>>, index

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -136,13 +136,13 @@ func.func @coalesced_gather_dma_f16(%idx0: vector<128xindex>, %source: tensor<81
 
 func.func @coalesced_gather_dma_1d(%indices: vector<1024xindex>, %source: tensor<2048xf32>, %dest: tensor<1024xf32>, %lane: index) -> tensor<1024xf32> {
   %c32 = arith.constant 32 : index
-  %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<1024xf32>) {
+  %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<128xf32>) {
     scf.forall.in_parallel {
       iree_gpu.coalesced_gather_dma %source[%indices] into %out lane(%lane)
         : tensor<2048xf32>, vector<1024xindex>, tensor<1024xf32>, index -> tensor<1024xf32>
     }
   }
-  return %result : tensor<1024xf32>
+  return %result : tensor<128xf32>
 }
 
 // CHECK-LABEL: func @coalesced_gather_dma_1d

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -136,13 +136,13 @@ func.func @coalesced_gather_dma_f16(%idx0: vector<128xindex>, %source: tensor<81
 
 func.func @coalesced_gather_dma_1d(%indices: vector<1024xindex>, %source: tensor<2048xf32>, %dest: tensor<1024xf32>, %lane: index) -> tensor<1024xf32> {
   %c32 = arith.constant 32 : index
-  %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<128xf32>) {
+  %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<1024xf32>) {
     scf.forall.in_parallel {
       iree_gpu.coalesced_gather_dma %source[%indices] into %out lane(%lane)
         : tensor<2048xf32>, vector<1024xindex>, tensor<1024xf32>, index -> tensor<1024xf32>
     }
   }
-  return %result : tensor<128xf32>
+  return %result : tensor<1024xf32>
 }
 
 // CHECK-LABEL: func @coalesced_gather_dma_1d

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -96,87 +96,104 @@ func.func @tensor_barrier_multiple_inputs(%input: tensor<?xf16>) -> (tensor<?xf1
 // -----
 
 // Test basic coalesced_gather_dma with static shapes
-// indices: 64x32 = 2048 elements, dest: 64x32xf32 = 2048 * 4 bytes = 8192 bytes, ratio = 8192/2048 = 4
-func.func @coalesced_gather_dma_static(%indices: tensor<64x32xindex>, %source: tensor<1024x64xf32>, %dest: tensor<64x32xf32>) -> tensor<64x32xf32> {
+// One 1D index for a 1D source gathering into a 1D result
+func.func @coalesced_gather_dma_static(%idx0: vector<64xindex>, %source: tensor<4096xf32>, %dest: tensor<64xf32>, %lane: index) -> tensor<64xf32> {
   %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64x32xf32>) {
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64xf32>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<64x32xindex>, tensor<1024x64xf32>, tensor<64x32xf32> -> tensor<64x32xf32>
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+        : tensor<4096xf32>, vector<64xindex>, tensor<64xf32>, index -> tensor<64xf32>
     }
   }
-  return %result : tensor<64x32xf32>
+  return %result : tensor<64xf32>
 }
 
 // CHECK-LABEL: func @coalesced_gather_dma_static
-//  CHECK-SAME:   %[[INDICES:[A-Za-z0-9]+]]: tensor<64x32xindex>
-//  CHECK-SAME:   %[[SOURCE:[A-Za-z0-9]+]]: tensor<1024x64xf32>
-//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<64x32xf32>
 //       CHECK:   scf.forall
 //       CHECK:     scf.forall.in_parallel
-//       CHECK:       iree_gpu.coalesced_gather_dma %[[INDICES]], %[[SOURCE]] into %{{.+}} : tensor<64x32xindex>, tensor<1024x64xf32>, tensor<64x32xf32> -> tensor<64x32xf32>
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<4096xf32>, vector<64xindex>, tensor<64xf32>, index -> tensor<64xf32>
 
 // -----
 
-// Test coalesced_gather_dma with dynamic shapes
-func.func @coalesced_gather_dma_dynamic(%indices: tensor<?x?xindex>, %source: tensor<?x?xf32>, %dest: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// Test coalesced_gather_dma with different element types
+func.func @coalesced_gather_dma_f16(%idx0: vector<128xindex>, %source: tensor<8192xf16>, %dest: tensor<128xf16>, %lane: index) -> tensor<128xf16> {
   %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<?x?xf32>) {
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<128xf16>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<?x?xindex>, tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+        : tensor<8192xf16>, vector<128xindex>, tensor<128xf16>, index -> tensor<128xf16>
     }
   }
-  return %result : tensor<?x?xf32>
-}
-
-// CHECK-LABEL: func @coalesced_gather_dma_dynamic
-//  CHECK-SAME:   %[[INDICES:[A-Za-z0-9]+]]: tensor<?x?xindex>
-//  CHECK-SAME:   %[[SOURCE:[A-Za-z0-9]+]]: tensor<?x?xf32>
-//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<?x?xf32>
-//       CHECK:   scf.forall
-//       CHECK:     scf.forall.in_parallel
-//       CHECK:       iree_gpu.coalesced_gather_dma %[[INDICES]], %[[SOURCE]] into %{{.+}} : tensor<?x?xindex>, tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
-
-// -----
-
-func.func @coalesced_gather_dma_f16(%indices: tensor<128x64xindex>, %source: tensor<2048x64xf16>, %dest: tensor<128x64xf16>) -> tensor<128x64xf16> {
-  %c1 = arith.constant 1 : index
-  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<128x64xf16>) {
-    scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<128x64xindex>, tensor<2048x64xf16>, tensor<128x64xf16> -> tensor<128x64xf16>
-    }
-  }
-  return %result : tensor<128x64xf16>
+  return %result : tensor<128xf16>
 }
 
 // CHECK-LABEL: func @coalesced_gather_dma_f16
-//  CHECK-SAME:   %[[INDICES:[A-Za-z0-9]+]]: tensor<128x64xindex>
-//  CHECK-SAME:   %[[SOURCE:[A-Za-z0-9]+]]: tensor<2048x64xf16>
-//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<128x64xf16>
 //       CHECK:   scf.forall
 //       CHECK:     scf.forall.in_parallel
-//       CHECK:       iree_gpu.coalesced_gather_dma %[[INDICES]], %[[SOURCE]] into %{{.+}} : tensor<128x64xindex>, tensor<2048x64xf16>, tensor<128x64xf16> -> tensor<128x64xf16>
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<8192xf16>, vector<128xindex>, tensor<128xf16>, index -> tensor<128xf16>
 
 // -----
 
-func.func @coalesced_gather_dma_1d(%indices: tensor<32xindex>, %source: tensor<1024xf32>, %dest: tensor<1024xf32>) -> tensor<1024xf32> {
+func.func @coalesced_gather_dma_1d(%indices: vector<1024xindex>, %source: tensor<2048xf32>, %dest: tensor<1024xf32>, %lane: index) -> tensor<1024xf32> {
   %c32 = arith.constant 32 : index
   %result = scf.forall (%i) in (%c32) shared_outs(%out = %dest) -> (tensor<1024xf32>) {
     scf.forall.in_parallel {
-      iree_gpu.coalesced_gather_dma %indices, %source into %out
-        : tensor<32xindex>, tensor<1024xf32>, tensor<1024xf32> -> tensor<1024xf32>
+      iree_gpu.coalesced_gather_dma %source[%indices] into %out lane(%lane)
+        : tensor<2048xf32>, vector<1024xindex>, tensor<1024xf32>, index -> tensor<1024xf32>
     }
   }
   return %result : tensor<1024xf32>
 }
 
 // CHECK-LABEL: func @coalesced_gather_dma_1d
-//  CHECK-SAME:   %[[INDICES:[A-Za-z0-9]+]]: tensor<32xindex>
-//  CHECK-SAME:   %[[SOURCE:[A-Za-z0-9]+]]: tensor<1024xf32>
-//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: tensor<1024xf32>
 //       CHECK:   %[[C32:.+]] = arith.constant 32 : index
 //       CHECK:   scf.forall (%{{.+}}) in (%[[C32]])
 //       CHECK:     scf.forall.in_parallel
-//       CHECK:       iree_gpu.coalesced_gather_dma %[[INDICES]], %[[SOURCE]] into %{{.+}} : tensor<32xindex>, tensor<1024xf32>, tensor<1024xf32> -> tensor<1024xf32>
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<2048xf32>, vector<1024xindex>, tensor<1024xf32>, index -> tensor<1024xf32>
+
+// -----
+
+func.func @coalesced_gather_dma_copy(%source: tensor<32x128xf32>, %dest: tensor<32x128xf32>, %lane: index) -> tensor<32x128xf32> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<32x128xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %source into %out lane(%lane)
+        : tensor<32x128xf32>, tensor<32x128xf32>, index -> tensor<32x128xf32>
+    }
+  }
+  return %result : tensor<32x128xf32>
+}
+
+// CHECK-LABEL: func @coalesced_gather_dma_copy
+//       CHECK:   scf.forall
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}} into %{{.+}} lane(%{{.+}}) : tensor<32x128xf32>, tensor<32x128xf32>, index -> tensor<32x128xf32>
+
+// -----
+
+func.func @coalesced_gather_dma_copy_memref(%source: memref<1x32xf32, strided<[128, 1], offset: ?>>, %dest: memref<1x32xf32, strided<[128, 1], offset: ?>, #gpu.address_space<workgroup>>, %lane: index) {
+  iree_gpu.coalesced_gather_dma %source into %dest lane(%lane)
+    : memref<1x32xf32, strided<[128, 1], offset: ?>>, memref<1x32xf32, strided<[128, 1], offset: ?>, #gpu.address_space<workgroup>>, index
+  return
+}
+
+// CHECK-LABEL: func @coalesced_gather_dma_copy_memref
+//       CHECK:   iree_gpu.coalesced_gather_dma %{{.+}} into %{{.+}} lane(%{{.+}}) : memref<1x32xf32, strided<[128, 1], offset: ?>>, memref<1x32xf32, strided<[128, 1], offset: ?>, #gpu.address_space<workgroup>>, index
+
+// -----
+
+func.func @coalesced_gather_dma_tensor_indices(%idx0: tensor<64xindex>, %source: tensor<4096xf32>, %dest: tensor<64xf32>, %lane: index) -> tensor<64xf32> {
+  %c1 = arith.constant 1 : index
+  %result = scf.forall (%i) in (%c1) shared_outs(%out = %dest) -> (tensor<64xf32>) {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+        : tensor<4096xf32>, tensor<64xindex>, tensor<64xf32>, index -> tensor<64xf32>
+    }
+  }
+  return %result : tensor<64xf32>
+}
+
+// CHECK-LABEL: func @coalesced_gather_dma_tensor_indices
+//       CHECK:   scf.forall
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       iree_gpu.coalesced_gather_dma %{{.+}}[%{{.+}}] into %{{.+}} lane(%{{.+}}) : tensor<4096xf32>, tensor<64xindex>, tensor<64xf32>, index -> tensor<64xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -302,15 +302,15 @@ struct CoalescedGatherDMAOpBufferizationInterface
           IREE::GPU::CoalescedGatherDMAOp> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {
-    // This op reads from the source and indices tensors.
     auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
-    return opOperand.get() == gatherOp.getIndices() ||
-           opOperand.get() == gatherOp.getSource();
+    if (opOperand.get() == gatherOp.getSource()) {
+      return true;
+    }
+    return false;
   }
 
   bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
                                const AnalysisState &state) const {
-    // This op writes to the init/destination tensor.
     auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
     return opOperand.get() == gatherOp.getInit();
   }
@@ -320,8 +320,7 @@ struct CoalescedGatherDMAOpBufferizationInterface
                     const AnalysisState &state) const {
     auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
     SmallVector<bufferization::AliasingValue> alist;
-    // The result aliases with the init operand.
-    if (opOperand.get() == gatherOp.getInit()) {
+    if (opOperand.get() == gatherOp.getInit() && gatherOp.getResult()) {
       alist.push_back({gatherOp.getResult(), BufferRelation::Equivalent});
     }
     return alist;
@@ -332,15 +331,12 @@ struct CoalescedGatherDMAOpBufferizationInterface
                           bufferization::BufferizationState &state) const {
     auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
 
-    // Get the bufferized operands.
-    FailureOr<Value> indicesBuffer =
-        getBuffer(rewriter, gatherOp.getIndices(), options, state);
     FailureOr<Value> sourceBuffer =
         getBuffer(rewriter, gatherOp.getSource(), options, state);
     FailureOr<Value> initBuffer =
         getBuffer(rewriter, gatherOp.getInit(), options, state);
 
-    if (failed(indicesBuffer) || failed(sourceBuffer) || failed(initBuffer)) {
+    if (failed(sourceBuffer) || failed(initBuffer)) {
       return failure();
     }
 
@@ -351,12 +347,10 @@ struct CoalescedGatherDMAOpBufferizationInterface
       // Get the forall op containing the in_parallel.
       auto forallOp = parentOp->getParentOfType<scf::ForallOp>();
       if (forallOp) {
-        // Insert the memref version before the in_parallel block.
         rewriter.setInsertionPoint(parentOp);
         rewriter.create<IREE::GPU::CoalescedGatherDMAOp>(
-            gatherOp.getLoc(), initBuffer->getType(), *indicesBuffer,
-            *sourceBuffer, *initBuffer);
-        // The result is the same as the init buffer.
+            gatherOp.getLoc(), TypeRange{}, *sourceBuffer,
+            gatherOp.getIndices(), *initBuffer, gatherOp.getLane());
         bufferization::replaceOpWithBufferizedValues(rewriter, op, *initBuffer);
         return success();
       }


### PR DESCRIPTION
This patch implements the lowering mechanism of coalesced dma op to `amdgpu.gather_to_lds`. 
* First iteration: only implemented the fast path.
* supports gather and copy semantics.