### PR TITLE
 [LLVMGPU][Codegen] Increase parallel rows read for matvec

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -430,7 +430,7 @@ getVectorDistributeReductionConfig(
     const int64_t maxParallelFactor = workgroupSize / 4;
     for (int64_t parallelFactor = 2; (parallelFactor < maxParallelFactor) &&
                                      (parallelBound % parallelFactor == 0) &&
-                                     (parallelBound > parallelFactor);
+                                     (parallelBound >= parallelFactor);
          parallelFactor *= 2) {
       numParallelReductions = parallelFactor;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -440,4 +440,4 @@ func.func @batch_matvec_f16_f32() {
 //  CHECK-SAME:                 partial_reduction = [0, 0, 512],
 //  CHECK-SAME:                 subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
 //  CHECK-SAME:                 thread = [0, 0, 8],
-//  CHECK-SAME:                 workgroup = [2, 1, 0]
+//  CHECK-SAME:                 workgroup = [4, 1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -357,7 +357,7 @@ func.func @skinny_mmt_lhs_is_vector() {
 // CHECK-SAME:       partial_reduction =       [0, 0, 512],
 // CHECK-SAME:       subgroup_basis =    {{\[}}[1, 1, 1], [0, 1, 2]],
 // CHECK-SAME:       thread =                  [0, 0, 8],
-// CHECK-SAME:       workgroup =               [1, 1, 0]}>}
+// CHECK-SAME:       workgroup =               [2, 1, 0]}>}
 
 // -----
 


### PR DESCRIPTION
Allow parallel factor to increase up to the parallel bound for matvecs (i.e. rows from N dim processed in parallel per workgroup) . This yields a ~20% improvement under `iree-benchmark-module` on gfx942. 

Issue: #21300