### PR TITLE
Increase acceptable error in punet

### DIFF
--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp16_rocm.json
@@ -47,6 +47,9 @@
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
         "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics)"
     ],
+    "threshold_args": [
+        "--expected_f16_threshold=0.2f"
+    ],
     "run_function": "main",
     "compile_chip_expecting_to_fail": ["gfx90a"],
     "tuner_file": {

--- a/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/quality_tests/sdxl/punet_int8_fp8_rocm.json
@@ -47,6 +47,9 @@
         "--iree-scheduling-dump-statistics-file=compilation_info.json",
         "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics)"
     ],
+    "threshold_args": [
+        "--expected_f16_threshold=0.2f"
+    ],
     "run_function": "main",
     "compile_chip_expecting_to_fail": ["gfx90a"],
     "tuner_file": {


### PR DESCRIPTION
The current check on the punet outputs is too strict. In a PR that changes reduction strategy, I observed

np.max(np.abs(observed - golden)) = 0.1641
np.mean(np.abs(observed - golden)) = 0.02776
that still passed the 'true' (docker) e2e MLPERF test.

To avoid needing to update golden values when the reduction strategy changes but remains valid, this PR increases the allowed threshold.  
