### PR TITLE
[DataTiling][GPU] Introduce DataTiledScaledMMAAttr

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
@@ -33,8 +33,8 @@ namespace mlir::iree_compiler {
 
 static bool accGemmToGemmPrecondition(Operation *op) {
   if (auto innerTiledOp = dyn_cast<IREE::Codegen::InnerTiledOp>(op)) {
-    return isa<IREE::GPU::MmaInterfaceAttr, IREE::GPU::ScaledMMAAttr>(
-        innerTiledOp.getKind());
+    return isa<IREE::GPU::MmaInterfaceAttr, IREE::GPU::ScaledMMAAttr,
+               IREE::GPU::DataTiledMMAInterfaceAttr>(innerTiledOp.getKind());
   }
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -68,6 +68,13 @@ bool isIdentityLayout(const MaterializeEncodingInfo &info);
 SmallVector<int64_t>
 getExpandedTileShape(const TileSwizzle::ExpandShapeType &expandShape);
 
+struct TileMxNxKxKb {
+  int64_t M = 1;
+  int64_t N = 1;
+  int64_t K = 1;
+  int64_t KB = 1;
+};
+
 struct TileMxNxK {
   int64_t M = 1;
   int64_t N = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -91,6 +91,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::Encoding::Utils
     iree::compiler::Dialect::LinalgExt::IR
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Utils
     iree::compiler::bindings::c::headers

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -100,30 +100,75 @@ static void interleave(TileSwizzle &swizzle, int srcIdx, int expandedIdx) {
   swizzle.permutation = outPermutation;
 }
 
-static TileSwizzle getIntrinsicSwizzleBeforeMovingCrossThreadOutermost(
-    IREE::GPU::MMAIntrinsic intrinsic, IREE::GPU::MMAFragment fragment) {
-  auto layout = IREE::GPU::getSingleSubgroupLayout(intrinsic, fragment);
+template <typename MMAIntrinsicTy>
+static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
+                                       unsigned operandIdx) {
+  IREE::GPU::MMASingleSubgroupLayout layout;
+  const bool isScaled =
+      std::is_same<MMAIntrinsicTy, IREE::GPU::ScaledMMAIntrinsic>::value;
+  const unsigned lhsIdx = 0;
+  const unsigned rhsIdx = 1;
+  const unsigned lhsScalesIdx = 2;
+  const unsigned rhsScalesIdx = 3;
+  const bool isLHSorRHS = operandIdx == lhsIdx || operandIdx == rhsIdx;
+  if (isScaled) {
+    // The operand mapping for `getSingleSubgroupLayout` follows a different
+    // operand order than is used for TileSwizzle, so we need to remap the
+    // operandIdx to get the right layout. The layouts for TileSwizzle vs.
+    // `getSingleSubgroupLayout` are shown below:
+    //             | TileSwizzle | getSingleSubgroupLayout
+    //         LHS | 0           | 0
+    //         RHS | 1           | 2
+    //  LHS Scales | 2           | 1
+    //  RHS Scales | 3           | 3
+    //         ACC | 4           | 4
+    // TODO(Max191): Decide on a consistent operand order for both.
+    int64_t layoutOperandIdx = operandIdx;
+    if (operandIdx == rhsIdx) {
+      layoutOperandIdx = 2;
+    } else if (operandIdx == lhsScalesIdx) {
+      layoutOperandIdx = 1;
+    }
+    layout = IREE::GPU::getSingleSubgroupLayout(
+        static_cast<ScaledMMAIntrinsic>(intrinsic), layoutOperandIdx);
+  } else {
+    layout = IREE::GPU::getSingleSubgroupLayout(
+        static_cast<MMAIntrinsic>(intrinsic),
+        static_cast<IREE::GPU::MMAFragment>(operandIdx));
+  }
 
-  // MMASingleSubgroupLayout has non-transposed RHS.
-  // TileSwizzle has transposed RHS.
-  if (fragment == IREE::GPU::MMAFragment::Rhs) {
-    std::swap(layout.outer[0], layout.outer[1]);
-    std::swap(layout.thread[0], layout.thread[1]);
-    std::swap(layout.tstrides[0], layout.tstrides[1]);
-    std::swap(layout.element[0], layout.element[1]);
+  // MMASingleSubgroupLayout has non-transposed RHS and RHS scales, but
+  // TileSwizzle has transposed RHS and RHS scales, so reorder the `layout`
+  // to match the TileSwizzle.
+  auto swapRHSKAndN = [](SmallVectorImpl<int64_t> &v) {
+    // The RHS layout is [K, N], and the RHS scales layout is [K, Kb, N], so
+    // rotate right by 1 element to swap [K, Kb] and N.
+    std::rotate(v.begin(), v.end() - 1, v.end());
+  };
+  if (operandIdx == rhsIdx || (isScaled && operandIdx == rhsScalesIdx)) {
+    swapRHSKAndN(layout.outer);
+    swapRHSKAndN(layout.thread);
+    swapRHSKAndN(layout.tstrides);
+    swapRHSKAndN(layout.element);
   }
 
   TileSwizzle swizzle;
-  // There are two source dimensions, corresponding to the arrays in `layout`
-  // all having size 2. Let's just guard that assumption with one assert here.
-  assert(layout.thread.size() == 2);
-  swizzle.expandShape.resize(2);
+  // There are 3 source dimensions for LHS and RHS if the matmul is scaled.
+  // All other operands (and LHS/RHS for non-scaled matmuls) have 2 source
+  // dimensions. These correspond to the arrays in `layout` all having a
+  // matching size. Let's just guard that assumption with one assert here.
+  const unsigned numSrcDims = isScaled && isLHSorRHS ? 3 : 2;
+  assert(layout.thread.size() == numSrcDims);
+  swizzle.expandShape.resize(numSrcDims);
   // Expand the shape from inner-most to outer-most dimension, so that we can
   // simply use the `expand` helper function, which creates new outer dims.
   // `layout.element` dims are inner-most, so we add them first.
-  for (auto [i, e] : llvm::enumerate(layout.element)) {
+  // Iterate layout.element in reverse, because we always want the `Kb`
+  // dimension to be innermost.
+  for (auto [i, e] : llvm::enumerate(llvm::reverse(layout.element))) {
     if (e != 1) {
-      expand(swizzle, i, {Kind::Internal, e});
+      int srcIdx = layout.element.size() - 1 - i;
+      expand(swizzle, srcIdx, {Kind::Internal, e});
     }
   }
   // Next come `layout.thread` dims.
@@ -157,6 +202,12 @@ static TileSwizzle getIntrinsicSwizzleBeforeMovingCrossThreadOutermost(
   // skip them above. Note that this condition also implies that we don't need
   // to worry about `layout.tstrides == 0` which only happens with
   // `layout.thread == 1`.
+  // The `thread` size for the `Kb` dimension is always 1 with a tstride of 1,
+  // so there can only be 2 layout.thread dims to check here, and we can do a
+  // simple swap instead of a rotate.
+  assert(layout.thread.size() == 2 ||
+         (layout.thread.size() == 3 && layout.thread[2] == 1) &&
+             "expected inner thread dim to be 1 for blocked LHS or RHS");
   if (layout.thread[0] != 1 && layout.thread[1] != 1 &&
       layout.tstrides[0] > layout.tstrides[1]) {
     std::swap(swizzle.permutation[0], swizzle.permutation[1]);
@@ -358,20 +409,36 @@ static TileSwizzle moveCrossThreadOutermost(TileSwizzle swizzle,
 /// Return the full swizzle without any reordering of CrossThread dims. The
 /// result of this function should be passed to moveCrossThreadOutermost to
 /// get the final swizzle.
+template <typename MMAAttrTy>
 static TileSwizzle
-getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
-                                           IREE::GPU::MMAFragment fragment) {
-  auto swizzle = getIntrinsicSwizzleBeforeMovingCrossThreadOutermost(
-      mma.getIntrinsic(), fragment);
-  switch (fragment) {
-  case IREE::GPU::MMAFragment::Lhs:
+getSwizzleBeforeMovingCrossThreadOutermost(MMAAttrTy mma, unsigned operandIdx) {
+  auto swizzle = getIntrinsicSwizzle(mma.getIntrinsic(), operandIdx);
+  const bool isScaled =
+      std::is_same<MMAAttrTy, IREE::GPU::DataTiledScaledMMAAttr>::value;
+  const unsigned lhsIdx = 0;
+  const unsigned rhsIdx = 1;
+  const unsigned lhsScalesIdx = 2;
+  const unsigned rhsScalesIdx = 3;
+  const unsigned accIdx = isScaled ? 4 : 2;
+  const bool isRhsScales = isScaled && operandIdx == rhsScalesIdx;
+  const bool isLhsScales = isScaled && operandIdx == lhsScalesIdx;
+  if (operandIdx == lhsIdx || isLhsScales) {
     // A-matrix (LHS). Source dimensions are M (index 0) and K (index 1).
     // Unroll on K with interleaving, then on M.
     if (mma.getIntrinsicsK() > 1) {
       expand(swizzle, 1, {Kind::CrossIntrinsic, mma.getIntrinsicsK()});
       int interleavingIdx =
           getInnermostNonInternalDimIdx(swizzle.expandShape[1]);
-      interleave(swizzle, 1, interleavingIdx);
+      // For scaled matmuls, interleaving happens because we want to load all
+      // the unrolled scales with each vector load, so we need to interleave at
+      // the very last dimension for the scales. For the LHS, we load in blocks,
+      // so we don't need to interleave.
+      if (isLhsScales) {
+        interleavingIdx = swizzle.expandShape[1].size() - 1;
+      }
+      if (!isScaled || isLhsScales) {
+        interleave(swizzle, 1, interleavingIdx);
+      }
     }
     if (mma.getIntrinsicsM() > 1) {
       expand(swizzle, 0, {Kind::CrossIntrinsic, mma.getIntrinsicsM()});
@@ -385,8 +452,7 @@ getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
                            mma.getSubgroupsM() * mma.getSubgroupsN());
       expand(swizzle, 0, dim);
     }
-    break;
-  case IREE::GPU::MMAFragment::Rhs:
+  } else if (operandIdx == rhsIdx || isRhsScales) {
     // B-matrix (RHS). Since the pack ops already took care of transposing B,
     // source dimensions are N (index 0) and K (index 1).
     // Unroll on K with interleaving, then on N.
@@ -394,7 +460,14 @@ getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
       expand(swizzle, 1, {Kind::CrossIntrinsic, mma.getIntrinsicsK()});
       int interleavingIdx =
           getInnermostNonInternalDimIdx(swizzle.expandShape[1]);
-      interleave(swizzle, 1, interleavingIdx);
+      // Like with the LHS above, we want to interleave such that we load all
+      // the unrolled scales with each vector load.
+      if (isRhsScales) {
+        interleavingIdx = swizzle.expandShape[1].size() - 1;
+      }
+      if (!isScaled || isRhsScales) {
+        interleave(swizzle, 1, interleavingIdx);
+      }
     }
     if (mma.getIntrinsicsN() > 1) {
       expand(swizzle, 0, {Kind::CrossIntrinsic, mma.getIntrinsicsN()});
@@ -402,8 +475,7 @@ getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
     if (mma.getSubgroupsN() > 1) {
       expand(swizzle, 0, {Kind::CrossThread, mma.getSubgroupsN()});
     }
-    break;
-  case IREE::GPU::MMAFragment::Acc:
+  } else if (operandIdx == accIdx) {
     // C-matrix (accumulator). Source dimensions are M (index 0) and N (index
     // 1). Unroll on N, then on M.
     if (mma.getIntrinsicsN() > 1) {
@@ -418,33 +490,52 @@ getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
     if (mma.getSubgroupsM() > 1) {
       expand(swizzle, 0, {Kind::CrossThread, mma.getSubgroupsM()});
     }
-    break;
   }
   return swizzle;
 }
 
-TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
-                       IREE::GPU::MMAFragment fragment) {
+/// Implementation of `getSwizzle` for both scaled and non-scaled matmuls.
+template <typename MMAAttrTy>
+static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
   TileSwizzle swizzle =
-      getSwizzleBeforeMovingCrossThreadOutermost(mma, fragment);
+      getSwizzleBeforeMovingCrossThreadOutermost(mma, operandIdx);
   // We want to move the CrossThread dims to be outermost in the source layout
   // for the result. We need the transformations for the Lhs and Rhs to match
   // with the Acc transformation, so we need to know what the acc swizzle is
   // when moving CrossThread dims, even when the fragment is Lhs or Rhs.
-  TileSwizzle accSwizzle = swizzle;
-  if (fragment != IREE::GPU::MMAFragment::Acc) {
-    accSwizzle = getSwizzleBeforeMovingCrossThreadOutermost(
-        mma, IREE::GPU::MMAFragment::Acc);
+  const bool isScaled =
+      std::is_same<MMAAttrTy, IREE::GPU::DataTiledScaledMMAAttr>::value;
+  // There is not a hard requirement to move cross thread dims outermost,
+  // since we use map_scatter now. For scaled matmul, skip this step to reduce
+  // complexity.
+  // TODO(#22144): Consider removing this step for non-scaled matmul too.
+  if (isScaled) {
+    return swizzle;
   }
-  LLVM_DEBUG(llvm::dbgs() << fragment
+  const unsigned accIdx = 2;
+  TileSwizzle accSwizzle = swizzle;
+  if (operandIdx != accIdx) {
+    accSwizzle = getSwizzleBeforeMovingCrossThreadOutermost(mma, accIdx);
+  }
+  LLVM_DEBUG(llvm::dbgs() << "operand " << operandIdx
                           << " swizzle before moving CrossThread dims: "
                           << swizzle << "\n");
-  TileSwizzle crossThreadOuterSwizzle =
-      moveCrossThreadOutermost(swizzle, accSwizzle, fragment);
-  LLVM_DEBUG(llvm::dbgs() << fragment
+  TileSwizzle crossThreadOuterSwizzle = moveCrossThreadOutermost(
+      swizzle, accSwizzle, static_cast<IREE::GPU::MMAFragment>(operandIdx));
+  LLVM_DEBUG(llvm::dbgs() << "operand " << operandIdx
                           << " swizzle after moving CrossThread dims: "
                           << crossThreadOuterSwizzle << "\n\n");
   return crossThreadOuterSwizzle;
+}
+
+TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
+                       unsigned operandIdx) {
+  return getSwizzleImpl(scaledMma, operandIdx);
+}
+
+TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
+                       IREE::GPU::MMAFragment fragment) {
+  return getSwizzleImpl(mma, static_cast<unsigned>(fragment));
 }
 
 /// Remove the expanded dimensions for this index and update the permutation by

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -24,6 +24,11 @@ SmallVector<int64_t> sliceSwizzledShape(
 Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
                                 IREE::GPU::MMAFragment fragment);
 
+/// Returns the swizzle for the full data-tiled-scaled-mma tile, including all
+/// the relevant unrolling and expansion factors.
+Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
+                                unsigned operandIdx);
+
 /// Returns the swizzle for the data-tiled-mma tile, based on the `fragment`
 /// and contraction dimensions required from the `encoding`.
 FailureOr<Codegen::TileSwizzle>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1667,9 +1667,9 @@ LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
   auto intrinCType = cast<VectorType>(intrinsicsAcc.front().getType());
 
   // Loop over the 3 unroll_{m,n,k} dimensions to create the intrinsics.
-  for (int mu = 0; mu < getIntrinsicsM(); ++mu) {
-    for (int nu = 0; nu < getIntrinsicsN(); ++nu) {
-      for (int ku = 0; ku < getIntrinsicsK(); ++ku) {
+  for (int64_t mu = 0; mu < getIntrinsicsM(); ++mu) {
+    for (int64_t nu = 0; nu < getIntrinsicsN(); ++nu) {
+      for (int64_t ku = 0; ku < getIntrinsicsK(); ++ku) {
         Value lhs = intrinsicsLhs[mu * getIntrinsicsK() + ku];
         Value rhs = intrinsicsRhs[nu * getIntrinsicsK() + ku];
         Value lhsScales = intrinsicsLhsScales[mu * getIntrinsicsK() + ku];
@@ -1694,7 +1694,7 @@ LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
   LDBG() << "accCrossIntrinsicShape: "
          << llvm::interleaved(accCrossIntrinsicShape);
   LDBG() << "accInternalShape: " << llvm::interleaved(accInternalShape);
-  int dstRank = accCrossIntrinsicShape.size();
+  size_t dstRank = accCrossIntrinsicShape.size();
   SmallVector<int64_t> strides(dstRank, 1);
   SmallVector<int64_t> indices(dstRank, 0);
   Value acc = outputs[0];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Utils/Indexing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -69,6 +70,17 @@ static bool is_AMD_WMMA(MMAIntrinsic intrinsic) {
 
 static bool is_AMD(MMAIntrinsic intrinsic) {
   return is_AMD_MFMA(intrinsic) || is_AMD_WMMA(intrinsic);
+}
+
+int64_t getIntrinsicSubgroupSize(ScaledMMAIntrinsic intrinsic) {
+  switch (intrinsic) {
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
+  case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
+    return 64;
+  }
+  assert(false &&
+         "all cases should've been handled in ScaledMMA::getBlockSize()");
+  return 0;
 }
 
 int64_t getIntrinsicSubgroupSize(MMAIntrinsic intrinsic) {
@@ -941,8 +953,8 @@ TileSwizzle DataTiledMMAAttr::getTileSwizzle(unsigned operandIndex) const {
   return getSwizzle(*this, fragment);
 }
 
-IREE::Codegen::TileMxNxK DataTiledMMAAttr::getTileMNK() const {
-  IREE::Codegen::TileMxNxK innerTile;
+IREE::Codegen::TileMxNxKxKb DataTiledMMAAttr::getTileMNKKb() const {
+  IREE::Codegen::TileMxNxKxKb innerTile;
   std::tie(innerTile.M, innerTile.N, innerTile.K) =
       getMNKShapeFromIntrinsic(getIntrinsic());
   innerTile.M *= getIntrinsicsM() * getSubgroupsM();
@@ -1317,14 +1329,7 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
 }
 
 int64_t ScaledMMAAttr::getSubgroupSize() const {
-  switch (getIntrinsic()) {
-  case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
-  case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
-    return 64;
-  }
-  assert(false &&
-         "all cases should'vee been handled in ScaledMMA::getBlockSize()");
-  return 0;
+  return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
 SmallVector<Type> ScaledMMAAttr::getSupportedInputTypes(MLIRContext *ctx) {
@@ -1483,7 +1488,7 @@ LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
   Value zeroScales = arith::ConstantOp::create(
       builder, loc,
       SplatElementsAttr::get(
-          VectorType::get({4}, f8E8M0),
+          VectorType::get({getScalesVectorSize()}, f8E8M0),
           llvm::APFloat::getSmallest(f8E8M0.getFloatSemantics())));
   auto padScales = [&](Value scales) {
     Value scale = vector::ExtractOp::create(builder, loc, scales, 0);
@@ -1519,6 +1524,210 @@ LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
                                    /*scalesIdxB=*/0);
   results.push_back(result);
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DataTiledScaledMMA Attributes
+//===----------------------------------------------------------------------===//
+
+TileSwizzle
+DataTiledScaledMMAAttr::getTileSwizzle(unsigned operandIndex) const {
+  return getSwizzle(*this, operandIndex);
+}
+
+static std::tuple<int64_t, int64_t, int64_t, int64_t>
+getMNKKbShapeFromScaledIntrinsic(ScaledMMAIntrinsic intrinsic) {
+  MMASingleSubgroupLayout lhs = getSingleSubgroupLayout(intrinsic, 0);
+  MMASingleSubgroupLayout rhs = getSingleSubgroupLayout(intrinsic, 2);
+  int64_t m = lhs.outer[0] * lhs.thread[0] * lhs.element[0];
+  int64_t n = rhs.outer[2] * rhs.thread[2] * rhs.element[2];
+  int64_t k = lhs.outer[1] * lhs.thread[1] * lhs.element[1];
+  int64_t kB = lhs.outer[2] * lhs.thread[2] * lhs.element[2];
+  return {m, n, k, kB};
+}
+
+int64_t getMSize(ScaledMMAIntrinsic intrinsic) {
+  return std::get<0>(getMNKKbShapeFromScaledIntrinsic(intrinsic));
+}
+int64_t getNSize(ScaledMMAIntrinsic intrinsic) {
+  return std::get<1>(getMNKKbShapeFromScaledIntrinsic(intrinsic));
+}
+int64_t getKSize(ScaledMMAIntrinsic intrinsic) {
+  return std::get<2>(getMNKKbShapeFromScaledIntrinsic(intrinsic));
+}
+int64_t getKbSize(ScaledMMAIntrinsic intrinsic) {
+  return std::get<3>(getMNKKbShapeFromScaledIntrinsic(intrinsic));
+}
+
+IREE::Codegen::TileMxNxKxKb DataTiledScaledMMAAttr::getTileMNKKb() const {
+  IREE::Codegen::TileMxNxKxKb innerTile;
+  std::tie(innerTile.M, innerTile.N, innerTile.K, innerTile.KB) =
+      getMNKKbShapeFromScaledIntrinsic(getIntrinsic());
+  innerTile.M *= getIntrinsicsM() * getSubgroupsM();
+  innerTile.N *= getIntrinsicsN() * getSubgroupsN();
+  innerTile.K *= getIntrinsicsK();
+  return innerTile;
+}
+
+void DataTiledScaledMMAAttr::getElementTypes(
+    SmallVectorImpl<Type> &result) const {
+  result.push_back(getLhsElemType());
+  result.push_back(getRhsElemType());
+  result.push_back(Float8E8M0FNUType::get(getContext()));
+  result.push_back(Float8E8M0FNUType::get(getContext()));
+  result.push_back(getAccElemType());
+  return;
+}
+
+static Value createScaledMmaOp(OpBuilder &builder, Location loc,
+                               ScaledMMAIntrinsic intrinsic, Type resultType,
+                               Value lhs, Value rhs, Value lhsScales,
+                               Value rhsScales, Value acc) {
+  FloatType f8E8M0 = builder.getF8E8M0Type();
+  Value zeroScales = arith::ConstantOp::create(
+      builder, loc,
+      SplatElementsAttr::get(
+          VectorType::get({4}, f8E8M0),
+          llvm::APFloat::getSmallest(f8E8M0.getFloatSemantics())));
+  auto padScales = [&](Value scales) {
+    Value scale = vector::ExtractOp::create(builder, loc, scales, 0);
+    Value padded = vector::InsertOp::create(builder, loc, scale, zeroScales, 0);
+    return padded;
+  };
+
+  lhsScales = padScales(lhsScales);
+  rhsScales = padScales(rhsScales);
+
+  int64_t m = getMSize(intrinsic);
+  // We use m x [k / kPerBlock] x blockSize as the LHS pre-distribution shape
+  // since this makes the higher-level tiling clearer.
+  int64_t k = getKSize(intrinsic) * getKbSize(intrinsic);
+  int64_t n = getNSize(intrinsic);
+
+  return amdgpu::ScaledMFMAOp::create(builder, loc, m, n, k, lhs, rhs, acc,
+                                      lhsScales, rhsScales, /*scalesIdxA=*/0,
+                                      /*scalesIdxB=*/0);
+}
+
+LogicalResult DataTiledScaledMMAAttr::buildUnderlyingOperations(
+    OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
+    SmallVectorImpl<Value> &results) const {
+  // Validation. Similar to MMAAttr::buildMmaOperation.
+  if (inputs.size() != 4) {
+    return failure();
+  }
+  if (outputs.size() != 1) {
+    return failure();
+  }
+  SmallVector<VectorType> regTypes;
+  getDistributedTileTypes(regTypes);
+  if (!llvm::equal(regTypes,
+                   llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
+    return failure();
+  }
+
+  // Prepare Lhs/Rhs/Acc operand slices to feed the intrinsic.
+  const unsigned lhsIdx = 0;
+  const unsigned rhsIdx = 1;
+  const unsigned lhsScalesIdx = 2;
+  const unsigned rhsScalesIdx = 3;
+  const unsigned accIdx = 4;
+  TileSwizzle lhsSwizzle = getSwizzle(*this, lhsIdx);
+  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
+  LDBG() << "    lhsSwizzle: " << lhsSwizzle;
+  SmallVector<Value> intrinsicsLhs =
+      distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
+
+  TileSwizzle rhsSwizzle = getSwizzle(*this, rhsIdx);
+  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
+  LDBG() << "    rhsSwizzle: " << rhsSwizzle;
+  SmallVector<Value> intrinsicsRhs =
+      distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
+
+  TileSwizzle lhsScalesSwizzle = getSwizzle(*this, lhsScalesIdx);
+  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
+  LDBG() << "    lhsScalesSwizzle: " << lhsScalesSwizzle;
+  SmallVector<Value> intrinsicsLhsScales = distributeMmaFragmentToIntrinsics(
+      builder, loc, inputs[2], lhsScalesSwizzle);
+
+  TileSwizzle rhsScalesSwizzle = getSwizzle(*this, rhsScalesIdx);
+  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
+  LDBG() << "    rhsScalesSwizzle: " << rhsScalesSwizzle;
+  SmallVector<Value> intrinsicsRhsScales = distributeMmaFragmentToIntrinsics(
+      builder, loc, inputs[3], rhsScalesSwizzle);
+
+  TileSwizzle accSwizzle = getSwizzle(*this, accIdx);
+  LDBG() << "DataTiledScaledMMAAttr::buildMmaOperation";
+  LDBG() << "    accSwizzle: " << accSwizzle;
+
+  SmallVector<Value> intrinsicsAcc =
+      distributeMmaFragmentToIntrinsics(builder, loc, outputs[0], accSwizzle);
+
+  ScaledMMAIntrinsic intrinsic = getIntrinsic();
+  auto intrinCType = cast<VectorType>(intrinsicsAcc.front().getType());
+
+  // Loop over the 3 unroll_{m,n,k} dimensions to create the intrinsics.
+  for (int mu = 0; mu < getIntrinsicsM(); ++mu) {
+    for (int nu = 0; nu < getIntrinsicsN(); ++nu) {
+      for (int ku = 0; ku < getIntrinsicsK(); ++ku) {
+        Value lhs = intrinsicsLhs[mu * getIntrinsicsK() + ku];
+        Value rhs = intrinsicsRhs[nu * getIntrinsicsK() + ku];
+        Value lhsScales = intrinsicsLhsScales[mu * getIntrinsicsK() + ku];
+        Value rhsScales = intrinsicsRhsScales[nu * getIntrinsicsK() + ku];
+        Value &acc = intrinsicsAcc[mu * getIntrinsicsN() + nu];
+        acc = createScaledMmaOp(builder, loc, intrinsic, intrinCType, lhs, rhs,
+                                lhsScales, rhsScales, acc);
+      }
+    }
+  }
+
+  // Insert the results into the destination accumulator.
+  SmallVector<int64_t> accCrossIntrinsicShape =
+      sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
+        return dim.kind == TileSwizzle::Dim::Kind::CrossIntrinsic;
+      });
+  SmallVector<int64_t> accInternalShape =
+      sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
+        return dim.kind == TileSwizzle::Dim::Kind::Internal;
+      });
+
+  LDBG() << "accCrossIntrinsicShape: "
+         << llvm::interleaved(accCrossIntrinsicShape);
+  LDBG() << "accInternalShape: " << llvm::interleaved(accInternalShape);
+  int dstRank = accCrossIntrinsicShape.size();
+  SmallVector<int64_t> strides(dstRank, 1);
+  SmallVector<int64_t> indices(dstRank, 0);
+  Value acc = outputs[0];
+  for (Value intrAcc : intrinsicsAcc) {
+    auto expandedAcc = vector::ShapeCastOp::create(
+        builder, loc,
+        VectorType::get(
+            accInternalShape,
+            cast<VectorType>(outputs[0].getType()).getElementType()),
+        intrAcc);
+    acc = vector::InsertStridedSliceOp::create(builder, loc, expandedAcc, acc,
+                                               indices, strides);
+    incrementIndices(indices, accCrossIntrinsicShape);
+  }
+  results.push_back(acc);
+  return success();
+}
+
+int64_t DataTiledScaledMMAAttr::getExpectedNumInputs() const { return 4; }
+
+int64_t DataTiledScaledMMAAttr::getExpectedNumOutputs() const { return 1; }
+
+int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
+  return getIntrinsicSubgroupSize(getIntrinsic());
+}
+
+int64_t DataTiledScaledMMAAttr::getFlatWorkgroupSize() const {
+  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN();
+}
+
+LogicalResult
+DataTiledScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
+  return IREE::LinalgExt::inferScaledContractionDims(maps);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -63,9 +63,24 @@ struct MMASingleSubgroupLayout {
   SmallVector<int64_t, 2> element;
 };
 
+/// Helpers to return the M, N, K, and Kb sizes for the given scaled MMA
+/// intrinsic. These sizes correspond to computation performed by a single
+/// subgroup.
+int64_t getMSize(ScaledMMAIntrinsic intrinsic);
+int64_t getNSize(ScaledMMAIntrinsic intrinsic);
+int64_t getKSize(ScaledMMAIntrinsic intrinsic);
+int64_t getKbSize(ScaledMMAIntrinsic intrinsic);
+
+/// Returns the subgroup size used by the given scaled MMA intrinsic.
+int64_t getIntrinsicSubgroupSize(ScaledMMAIntrinsic intrinsic);
+
+/// Helpers to return the M, N, and K sizes for the given MMA intrinsic.
+/// These sizes correspond to computation performed by a single subgroup.
 int64_t getMSize(MMAIntrinsic intrinsic);
 int64_t getNSize(MMAIntrinsic intrinsic);
 int64_t getKSize(MMAIntrinsic intrinsic);
+
+/// Returns the subgroup size used by the given MMA intrinsic.
 int64_t getIntrinsicSubgroupSize(MMAIntrinsic intrinsic);
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
@@ -85,6 +100,9 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
 MMASingleSubgroupLayout
 getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
                         MMAFragment fragment);
+
+MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
+                                                int64_t operandIndex);
 
 /// Returns the name of the tilling `level`, as used in the `lowering_config`
 /// attribute.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -345,6 +345,50 @@ def IREEGPU_DataTiledMMAAttr :
   );
 }
 
+def IREEGPU_DataTiledScaledMMAAttr :
+    IREEGPU_DataTiledMMAInnerTileDescAttr<"DataTiledScaledMMA", [
+  DeclareAttrInterfaceMethods<IREECodegen_InnerTileDescAttrInterface, [
+    "getExpectedNumInputs",
+    "getExpectedNumOutputs",
+    "verifyIndexingMaps",
+    "buildUnderlyingOperations"
+  ]>
+]> {
+  let mnemonic = "data_tiled_scaled_mma_layout";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let description = [{
+    This mma variant represents scaled MMA ops with data-tiling details. The
+    |intrinsic| field specifies which particular scaled MMA intrinsic is
+    targeted by the data-tiling.
+
+    The |lhs_elem_type|, |rhs_elem_type|, and |acc_elem_type| fields specify the
+    element types of the LHS, RHS, and ACC operands respectively. The element
+    types for the scales operands are always Float8E8M0FNUType, so they are not
+    specified on the attribute.
+
+    The other fields default to one, and that default results in a single
+    intrinsic, while values greater than one result in wider "kernels"
+    consisting of multiple intrinsic instructions, with the data layout already
+    swizzled into a tile layout that allows each intrinsic to access data at an
+    offset that's as simple as possible a mapping from the thread ID.
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let parameters = (ins
+    EnumParameter<IREEGPU_ScaledMMAIntrinsic>:$intrinsic,
+    "::mlir::Type":$lhs_elem_type,
+    "::mlir::Type":$rhs_elem_type,
+    "::mlir::Type":$acc_elem_type,
+    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the M dimension.">:$intrinsics_m,
+    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the M dimension.">:$subgroups_m,
+    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the N dimension.">:$intrinsics_n,
+    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the N dimension.">:$subgroups_n,
+    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the K dimension, with interleaved layout.">:$intrinsics_k
+  );
+}
+
 def IREEGPU_VirtualMMAIntrinsicAttr
   : IREEGPU_MmaEnumAttr<IREEGPU_VirtualMMAIntrinsic, "virtual_mma_intrinsic">;
 
@@ -460,6 +504,13 @@ def IREEGPU_ScaledMMAAttr :
     // Return all supported element types for inputs
     static SmallVector<Type> getSupportedInputTypes(MLIRContext *ctx);
     static SmallVector<Type> getSupportedOutputTypes(MLIRContext *ctx);
+
+    /// For scaled MFMA intrinsics, the scales are packed into a 32 bit register.
+    /// Since scales are 8 bits, the intrinsic takes a vector of 4 scales, along
+    /// with a selector to indicate which scale is used.
+    int64_t getScalesVectorSize() const {
+      return 4;
+    }
 
     // Return the number of elements per shared scale.
     int64_t getBlockSize() const;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -331,6 +331,11 @@ def IREEGPU_DataTiledMMAAttr :
     wider "kernels" consisting of multiple intrinsics, with the data layout
     already swizzled into a tile layout that allows each intrinsic to access
     data at an offset that's as simple as possible a mapping from the thread ID.
+
+    For intrinsics_k, the extra unrolling dimension is interleaved along the
+    innermost non-internal dimension of the swizzled shape. This means the
+    unrolled K dimension will be the innermost non-internal dimension of the
+    swizzled shape.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
@@ -372,6 +377,11 @@ def IREEGPU_DataTiledScaledMMAAttr :
     consisting of multiple intrinsic instructions, with the data layout already
     swizzled into a tile layout that allows each intrinsic to access data at an
     offset that's as simple as possible a mapping from the thread ID.
+
+    For intrinsics_k, the extra unrolling dimension is interleaved along the
+    innermost dimension for the scales operands, meaning this dimension will
+    become the innermost dimension of the swizzled shape. For non-scales
+    operands, the intrinsics_k dimension is not interleaved at all.
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -144,8 +144,8 @@ def IREEGPU_DataTiledMMAInterfaceAttr
         tiling materialization, these correspond to the innerTileSizes in the
         MaterializeEncodingInfo.
       }],
-      /*retType=*/"::mlir::iree_compiler::IREE::Codegen::TileMxNxK",
-      /*methodName=*/"getTileMNK",
+      /*retType=*/"::mlir::iree_compiler::IREE::Codegen::TileMxNxKxKb",
+      /*methodName=*/"getTileMNKKb",
       /*args=*/(ins)
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -91,6 +91,24 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8>
 
 module {
+  func.func @test_data_tiled_scaled_mfma_F32_32x32x64_B32() attributes {
+      mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_scaled_mfma_F32_32x32x64_B32
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
+
+module {
+  func.func @test_data_tiled_scaled_mfma_F32_16x16x128_B32() attributes {
+      mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_scaled_mfma_F32_16x16x128_B32
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+
+module {
   func.func @test_any_lowering_config() attributes {
       lowering_config = #iree_gpu.lowering_config<{workgroup = [16, 16], thread = [0, 4]}>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -571,6 +571,148 @@ func.func @data_tiled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(%lhs: tensor<
 
 // -----
 
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled_to_subgroups(
+    %lhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>, %rhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>,
+    %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, subgroups_m = 2, subgroups_n = 2, intrinsics_k = 4>} : tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, tensor<1x1x2x4x16x4xf8E8M0FNU>, tensor<1x1x2x4x16x4xf8E8M0FNU> into tensor<1x1x2x2x4x16x4xf32>
+    return %0 : tensor<1x1x2x2x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled_to_subgroups
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]
+//       CHECK:   %[[C2:.+]] = arith.constant 2 : index
+//       CHECK:   scf.forall (%[[THREAD_ID:.+]]) in (256) shared_outs(%[[ACC_ARG:.+]] = %[[ACC]]) -> (tensor<1x1x2x2x4x16x4xf32>)
+//   CHECK-DAG:     %[[LHS_IDS:.+]]:4 = affine.delinearize_index %[[THREAD_ID]] into (4, 4, 16)
+//   CHECK-DAG:     %[[LHS_IDX0_CLAMPED:.+]] = arith.divui %[[LHS_IDS]]#1, %[[C2]] : index
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[LHS_IDX0_CLAMPED]], 0, %[[LHS_IDS]]#2, %[[LHS_IDS]]#3, 0] [1, 1, 1, 1, 4, 1, 1, 32] [1, 1, 1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_IDS:.+]]:4 = affine.delinearize_index %[[THREAD_ID]] into (2, 4, 16)
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[RHS_IDS]]#1, 0, %[[RHS_IDS]]#2, %[[RHS_IDS]]#3, 0] [1, 1, 1, 1, 4, 1, 1, 32] [1, 1, 1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[LHS_IDX0_CLAMPED]], %[[LHS_IDS]]#2, %[[LHS_IDS]]#3, 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[RHS_IDS]]#1, %[[RHS_IDS]]#2, %[[RHS_IDS]]#3, 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_IDS:.+]]:5 = affine.delinearize_index %[[THREAD_ID]] into (2, 2, 4, 16)
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[ACC_IDS]]#1, %[[ACC_IDS]]#2, %[[ACC_IDS]]#3, %[[ACC_IDS]]#4, 0] [1, 1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, subgroups_m = 2, subgroups_n = 2, intrinsics_k = 4>}
+//  CHECK-SAME:       : tensor<1x1x1x1x4x1x1x32xf4E2M1FN>, tensor<1x1x1x1x4x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x4xf8E8M0FNU>, tensor<1x1x1x1x1x4xf8E8M0FNU> into tensor<1x1x1x1x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[ACC_IDS]]#1, %[[ACC_IDS]]#2, %[[ACC_IDS]]#3, %[[ACC_IDS]]#4, 0] [1, 1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled(
+    %lhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x2x4x4x16x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>, %rhs_scales: tensor<1x1x2x4x16x4xf8E8M0FNU>,
+    %acc: tensor<1x1x2x2x4x16x4xf32>) -> tensor<1x1x2x2x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 4>} : tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, tensor<1x1x1x2x4x4x16x32xf4E2M1FN>, tensor<1x1x2x4x16x4xf8E8M0FNU>, tensor<1x1x2x4x16x4xf8E8M0FNU> into tensor<1x1x2x2x4x16x4xf32>
+    return %0 : tensor<1x1x2x2x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @data_tiled_scaled_2x2x4_tensor_multi_mma_unrolled
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9_]+]]
+//       CHECK:   scf.forall (%[[THREAD_ID:[A-Za-z0-9_]+]]) in (256) shared_outs(%[[ACC_ARG:[A-Za-z0-9_]+]] = %[[ACC]]) -> (tensor<1x1x2x2x4x16x4xf32>)
+//   CHECK-DAG:     %[[IDS:.+]]:3 = affine.delinearize_index %[[THREAD_ID]] into (4, 16)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 2, 4, 1, 1, 32] [1, 1, 1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 2, 4, 1, 1, 32] [1, 1, 1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 2, 1, 1, 4] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 2, 1, 1, 4] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 2, 2, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 4>
+//  CHECK-SAME:       : tensor<1x1x1x2x4x1x1x32xf4E2M1FN>, tensor<1x1x1x2x4x1x1x32xf4E2M1FN>, tensor<1x1x2x1x1x4xf8E8M0FNU>, tensor<1x1x2x1x1x4xf8E8M0FNU> into tensor<1x1x2x2x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 2, 2, 1, 1, 4] [1, 1, 1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
+#scaled_contraction_accesses = [
+  affine_map<(m, n, k, kb) -> (m, k, kb)>,
+  affine_map<(m, n, k, kb) -> (n, k, kb)>,
+  affine_map<(m, n, k, kb) -> (m, k)>,
+  affine_map<(m, n, k, kb) -> (n, k)>,
+  affine_map<(m, n, k, kb) -> (m, n)>
+]
+func.func @data_tiled_scaled_1x1x1_tensor_multi_mma(
+    %lhs: tensor<1x1x1x4x16x32xf4E2M1FN>, %rhs: tensor<1x1x1x4x16x32xf4E2M1FN>,
+    %lhs_scales: tensor<1x1x4x16xf8E8M0FNU>, %rhs_scales: tensor<1x1x4x16xf8E8M0FNU>,
+    %acc: tensor<1x1x4x16x4xf32>) -> tensor<1x1x4x16x4xf32>
+    attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhs_scales, %rhs_scales) outs(%acc) {
+    indexing_maps = #scaled_contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>} : tensor<1x1x1x4x16x32xf4E2M1FN>, tensor<1x1x1x4x16x32xf4E2M1FN>, tensor<1x1x4x16xf8E8M0FNU>, tensor<1x1x4x16xf8E8M0FNU> into tensor<1x1x4x16x4xf32>
+    return %0 : tensor<1x1x4x16x4xf32>
+}
+
+// CHECK-LABEL: func @data_tiled_scaled_1x1x1_tensor_multi_mma
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[LHS_SCALES:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[RHS_SCALES:[A-Za-z0-9_]+]]
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9_]+]]
+//       CHECK:   scf.forall (%[[THREAD_ID:[A-Za-z0-9_]+]]) in (64) shared_outs(%[[ACC_ARG:[A-Za-z0-9_]+]] = %[[ACC]]) -> (tensor<1x1x4x16x4xf32>)
+//   CHECK-DAG:     %[[IDS:.+]]:3 = affine.delinearize_index %[[THREAD_ID]] into (4, 16)
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]]
+//  CHECK-SAME:       [0, 0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 1, 32] [1, 1, 1, 1, 1, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALES]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2] [1, 1, 1, 1] [1, 1, 1, 1]
+//   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:     %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
+//  CHECK-SAME:       : tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1x1x32xf4E2M1FN>, tensor<1x1x1x1xf8E8M0FNU>, tensor<1x1x1x1xf8E8M0FNU> into tensor<1x1x1x1x4xf32>
+//       CHECK:     tensor.parallel_insert_slice %[[INNER]] into %[[ACC_ARG]]
+//  CHECK-SAME:       [0, 0, %[[IDS]]#1, %[[IDS]]#2, 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+//       CHECK:   mapping = [#gpu.thread<linear_dim_0>]
+
+// -----
+
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
  affine_map<(i, j, k, b) -> (i, k)>,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -363,7 +363,11 @@ struct GPUEncodingPackedLayoutMaterializerAttr
 
     // Map the matmul TileMxNxK to an actual tile shape for the tensor at hand,
     // based on its operand index in the matmul.
-    TileMxNxK innerTile = mma.getTileMNK();
+    Codegen::TileMxNxKxKb innerTileScaled = mma.getTileMNKKb();
+    TileMxNxK innerTile;
+    innerTile.M = innerTileScaled.M;
+    innerTile.N = innerTileScaled.N;
+    innerTile.K = innerTileScaled.K;
     FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
         getEncodingInfoForMatmul(encoding, innerTile);
     if (failed(maybeEncodingInfo)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "pipeline_igemm_tile_and_fuse.mlir",
             "pipeline_scaled_truncation_gfx950.mlir",
             "pipeline_tile_and_fuse.mlir",
+            "pipeline_tile_and_fuse_gfx950.mlir",
             "pipeline_vector_distribute_dynamic_shapes_gfx942.mlir",
             "pipeline_vector_distribute_gfx942.mlir",
             "pipeline_vector_distribute_reduction_gfx942.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "pipeline_igemm_tile_and_fuse.mlir"
     "pipeline_scaled_truncation_gfx950.mlir"
     "pipeline_tile_and_fuse.mlir"
+    "pipeline_tile_and_fuse_gfx950.mlir"
     "pipeline_vector_distribute_dynamic_shapes_gfx942.mlir"
     "pipeline_vector_distribute_gfx1100.mlir"
     "pipeline_vector_distribute_gfx942.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse_gfx950.mlir
@@ -1,0 +1,151 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>],
+  flags = Indirect
+>
+#translation_info = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [256, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_shared_memory = false,
+      no_reduce_shared_memory_bank_conflicts = true>
+  }
+>
+#config = #iree_gpu.lowering_config<{
+  workgroup = [1, 1, 0, 0],
+  reduction = [0, 0, 1, 1],
+  promote_operands = [0, 1]
+}>
+hal.executable public @main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @data_tiled_scaled_mma_inner_tiled ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @data_tiled_scaled_mma_inner_tiled()
+        attributes {translation_info = #translation_info} {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x8x4x4x16x32xf4E2M1FN>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x4x2x4x4x16x32xf4E2M1FN>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x8x4x16x4xf8E8M0FNU>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x2x4x16x4xf8E8M0FNU>>
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x8x2x4x16x4xf32>>
+        %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 8, 4, 4, 16, 32], strides = [1, 1, 1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x8x4x4x16x32xf4E2M1FN>> -> tensor<9x9x1x8x4x4x16x32xf4E2M1FN>
+        %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0, 0, 0, 0, 0, 0], sizes = [9, 9, 1, 4, 2, 4, 4, 16, 32], strides = [1, 1, 1, 1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x1x4x2x4x4x16x32xf4E2M1FN>> -> tensor<9x9x1x4x2x4x4x16x32xf4E2M1FN>
+        %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0, 0, 0], sizes = [9, 9, 8, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x8x4x16x4xf8E8M0FNU>> -> tensor<9x9x8x4x16x4xf8E8M0FNU>
+        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [9, 9, 4, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9x9x4x2x4x16x4xf8E8M0FNU>> -> tensor<9x9x4x2x4x16x4xf8E8M0FNU>
+        %9 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [9, 9, 4, 8, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x8x2x4x16x4xf32>> -> tensor<9x9x4x8x2x4x16x4xf32>
+        %10 = iree_codegen.inner_tiled ins(%5, %6, %7, %8) outs(%9) {
+          lowering_config = #config,
+          indexing_maps = [
+            affine_map<(m, n, k, kb) -> (m, k, kb)>,
+            affine_map<(m, n, k, kb) -> (n, k, kb)>,
+            affine_map<(m, n, k, kb) -> (m, k)>,
+            affine_map<(m, n, k, kb) -> (n, k)>,
+            affine_map<(m, n, k, kb) -> (m, n)>],
+          iterator_types = [
+            #linalg.iterator_type<parallel>,
+            #linalg.iterator_type<parallel>,
+            #linalg.iterator_type<reduction>,
+            #linalg.iterator_type<reduction>],
+          kind = #iree_gpu.data_tiled_scaled_mma_layout<
+            intrinsic = MFMA_SCALE_F32_16x16x128_B32,
+            lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32,
+            intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>}
+          : tensor<9x9x1x8x4x4x16x32xf4E2M1FN>, tensor<9x9x1x4x2x4x4x16x32xf4E2M1FN>, tensor<9x9x8x4x16x4xf8E8M0FNU>, tensor<9x9x4x2x4x16x4xf8E8M0FNU> into tensor<9x9x4x8x2x4x16x4xf32>
+        iree_tensor_ext.dispatch.tensor.store %10, %4, offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [9, 9, 4, 8, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1] : tensor<9x9x4x8x2x4x16x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<9x9x4x8x2x4x16x4xf32>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @data_tiled_scaled_mma_inner_tiled()
+// CHECK-DAG:  %[[C_INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x8x2x1x1x4xf32>
+// CHECK-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:  %[[C9:.+]] = arith.constant 9 : index
+// CHECK-DAG:  %[[BINDING_A:.+]] = hal.interface.binding.subspan {{.*}} binding(0)
+// CHECK-DAG:  %[[ASSUMED_BINDING_A:.+]] = memref.assume_alignment %[[BINDING_A]]
+// CHECK-DAG:  %[[BUFFER_A:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_A]]
+// CHECK-DAG:  %[[BINDING_A_SCALE:.+]] = hal.interface.binding.subspan {{.*}} binding(2)
+// CHECK-DAG:  %[[ASSUMED_BINDING_A_SCALE:.+]] = memref.assume_alignment %[[BINDING_A_SCALE]]
+// CHECK-DAG:  %[[BUFFER_A_SCALE:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_A_SCALE]]
+// CHECK-DAG:  %[[BINDING_B:.+]] = hal.interface.binding.subspan {{.*}} binding(1)
+// CHECK-DAG:  %[[ASSUMED_BINDING_B:.+]] = memref.assume_alignment %[[BINDING_B]]
+// CHECK-DAG:  %[[BUFFER_B:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_B]]
+// CHECK-DAG:  %[[BINDING_B_SCALE:.+]] = hal.interface.binding.subspan {{.*}} binding(3)
+// CHECK-DAG:  %[[ASSUMED_BINDING_B_SCALE:.+]] = memref.assume_alignment %[[BINDING_B_SCALE]]
+// CHECK-DAG:  %[[BUFFER_B_SCALE:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_B_SCALE]]
+// CHECK-DAG:  %[[BINDING_C:.+]] = hal.interface.binding.subspan {{.*}} binding(4)
+// CHECK-DAG:  %[[ASSUMED_BINDING_C:.+]] = memref.assume_alignment %[[BINDING_C]]
+// CHECK-DAG:  %[[BUFFER_C:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_BINDING_C]]
+// CHECK-DAG:  %[[A_ALLOC:.+]] = memref.alloc() : memref<1x1x1x8x4x4x16x32xf4E2M1FN, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[B_ALLOC:.+]] = memref.alloc() : memref<1x1x1x4x2x4x4x16x32xf4E2M1FN, #gpu.address_space<workgroup>>
+// CHECK:      gpu.barrier
+// CHECK-DAG:  scf.for {{.*}} %[[C0]] to %[[C9]] step %[[C1]] iter_args(%[[C_LOOP_INIT:.+]] = %[[C_INIT]]) -> (vector<1x1x1x8x2x1x1x4xf32>)
+// CHECK-DAG:    %[[A_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BUFFER_A]]{{.*}} vector<32xf4E2M1FN>
+// CHECK-DAG:    %[[B_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BUFFER_B]]{{.*}} vector<32xf4E2M1FN>
+// CHECK-DAG:    vector.transfer_write %[[A_GLOBAL_LOAD]], %[[A_ALLOC]]
+// CHECK-DAG:    vector.transfer_write %[[B_GLOBAL_LOAD]], %[[B_ALLOC]]
+// CHECK:        gpu.barrier
+// CHECK-DAG:    %[[A_READ:.+]] = vector.transfer_read %[[A_ALLOC]]{{.*}} vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_READ:.+]] = vector.transfer_read %[[B_ALLOC]]{{.*}} vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_SCALE_READ:.+]] = vector.transfer_read %[[BUFFER_A_SCALE]]{{.*}} vector<8x1x1x4xf8E8M0FNU>
+// CHECK-DAG:    %[[B_SCALE_READ:.+]] = vector.transfer_read %[[BUFFER_B_SCALE]]{{.*}} vector<2x1x1x4xf8E8M0FNU>
+// CHECK-DAG:    %[[A_EXTRACT00:.+]] = vector.extract %[[A_READ]][0, 0, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT01:.+]] = vector.extract %[[A_READ]][0, 1, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT02:.+]] = vector.extract %[[A_READ]][0, 2, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT03:.+]] = vector.extract %[[A_READ]][0, 3, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT70:.+]] = vector.extract %[[A_READ]][7, 0, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT71:.+]] = vector.extract %[[A_READ]][7, 1, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT72:.+]] = vector.extract %[[A_READ]][7, 2, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_EXTRACT73:.+]] = vector.extract %[[A_READ]][7, 3, 0, 0] : vector<32xf4E2M1FN> from vector<8x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT00:.+]] = vector.extract %[[B_READ]][0, 0, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT01:.+]] = vector.extract %[[B_READ]][0, 1, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT02:.+]] = vector.extract %[[B_READ]][0, 2, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT03:.+]] = vector.extract %[[B_READ]][0, 3, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT10:.+]] = vector.extract %[[B_READ]][1, 0, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT11:.+]] = vector.extract %[[B_READ]][1, 1, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT12:.+]] = vector.extract %[[B_READ]][1, 2, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[B_EXTRACT13:.+]] = vector.extract %[[B_READ]][1, 3, 0, 0] : vector<32xf4E2M1FN> from vector<2x4x1x1x32xf4E2M1FN>
+// CHECK-DAG:    %[[A_SCALE_VECTOR0:.+]] = vector.extract_strided_slice {{.*}} {offsets = [0], sizes = [4], strides = [1]} : vector<32xf8E8M0FNU> to vector<4xf8E8M0FNU>
+// CHECK-DAG:    %[[A_SCALE_VECTOR7:.+]] = vector.extract_strided_slice {{.*}} {offsets = [28], sizes = [4], strides = [1]} : vector<32xf8E8M0FNU> to vector<4xf8E8M0FNU>
+// CHECK-DAG:    %[[B_SCALE_VECTOR0:.+]] = vector.extract_strided_slice {{.*}} {offsets = [0], sizes = [4], strides = [1]} : vector<8xf8E8M0FNU> to vector<4xf8E8M0FNU>
+// CHECK-DAG:    %[[B_SCALE_VECTOR1:.+]] = vector.extract_strided_slice {{.*}} {offsets = [4], sizes = [4], strides = [1]} : vector<8xf8E8M0FNU> to vector<4xf8E8M0FNU>
+// CHECK-DAG:    %[[C_INIT00:.+]] = vector.extract %[[C_LOOP_INIT]][0, 0, 0, 0, 0, 0, 0] : vector<4xf32> from vector<1x1x1x8x2x1x1x4xf32>
+// CHECK-DAG:    %[[C_INIT01:.+]] = vector.extract %[[C_LOOP_INIT]][0, 0, 0, 0, 1, 0, 0] : vector<4xf32> from vector<1x1x1x8x2x1x1x4xf32>
+// CHECK-DAG:    %[[C_INIT70:.+]] = vector.extract %[[C_LOOP_INIT]][0, 0, 0, 7, 0, 0, 0] : vector<4xf32> from vector<1x1x1x8x2x1x1x4xf32>
+// CHECK-DAG:    %[[C_INIT71:.+]] = vector.extract %[[C_LOOP_INIT]][0, 0, 0, 7, 1, 0, 0] : vector<4xf32> from vector<1x1x1x8x2x1x1x4xf32>
+// CHECK-DAG:    %[[C_00_1:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][0] * %[[A_EXTRACT00]]) * (%[[B_SCALE_VECTOR0]][0] * %[[B_EXTRACT00]]) + %[[C_INIT00]]
+// CHECK-DAG:    %[[C_00_2:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][1] * %[[A_EXTRACT01]]) * (%[[B_SCALE_VECTOR0]][1] * %[[B_EXTRACT01]]) + %[[C_00_1]]
+// CHECK-DAG:    %[[C_00_3:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][2] * %[[A_EXTRACT02]]) * (%[[B_SCALE_VECTOR0]][2] * %[[B_EXTRACT02]]) + %[[C_00_2]]
+// CHECK-DAG:    %[[C_00_4:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][3] * %[[A_EXTRACT03]]) * (%[[B_SCALE_VECTOR0]][3] * %[[B_EXTRACT03]]) + %[[C_00_3]]
+// CHECK-DAG:    %[[C_01_1:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][0] * %[[A_EXTRACT00]]) * (%[[B_SCALE_VECTOR1]][0] * %[[B_EXTRACT10]]) + %[[C_INIT01]]
+// CHECK-DAG:    %[[C_01_2:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][1] * %[[A_EXTRACT01]]) * (%[[B_SCALE_VECTOR1]][1] * %[[B_EXTRACT11]]) + %[[C_01_1]]
+// CHECK-DAG:    %[[C_01_3:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][2] * %[[A_EXTRACT02]]) * (%[[B_SCALE_VECTOR1]][2] * %[[B_EXTRACT12]]) + %[[C_01_2]]
+// CHECK-DAG:    %[[C_01_4:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR0]][3] * %[[A_EXTRACT03]]) * (%[[B_SCALE_VECTOR1]][3] * %[[B_EXTRACT13]]) + %[[C_01_3]]
+// CHECK-DAG:    %[[C_70_1:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][0] * %[[A_EXTRACT70]]) * (%[[B_SCALE_VECTOR0]][0] * %[[B_EXTRACT00]]) + %[[C_INIT70]]
+// CHECK-DAG:    %[[C_70_2:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][1] * %[[A_EXTRACT71]]) * (%[[B_SCALE_VECTOR0]][1] * %[[B_EXTRACT01]]) + %[[C_70_1]]
+// CHECK-DAG:    %[[C_70_3:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][2] * %[[A_EXTRACT72]]) * (%[[B_SCALE_VECTOR0]][2] * %[[B_EXTRACT02]]) + %[[C_70_2]]
+// CHECK-DAG:    %[[C_70_4:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][3] * %[[A_EXTRACT73]]) * (%[[B_SCALE_VECTOR0]][3] * %[[B_EXTRACT03]]) + %[[C_70_3]]
+// CHECK-DAG:    %[[C_71_1:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][0] * %[[A_EXTRACT70]]) * (%[[B_SCALE_VECTOR1]][0] * %[[B_EXTRACT10]]) + %[[C_INIT71]]
+// CHECK-DAG:    %[[C_71_2:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][1] * %[[A_EXTRACT71]]) * (%[[B_SCALE_VECTOR1]][1] * %[[B_EXTRACT11]]) + %[[C_71_1]]
+// CHECK-DAG:    %[[C_71_3:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][2] * %[[A_EXTRACT72]]) * (%[[B_SCALE_VECTOR1]][2] * %[[B_EXTRACT12]]) + %[[C_71_2]]
+// CHECK-DAG:    %[[C_71_4:.+]] = amdgpu.scaled_mfma(%[[A_SCALE_VECTOR7]][3] * %[[A_EXTRACT73]]) * (%[[B_SCALE_VECTOR1]][3] * %[[B_EXTRACT13]]) + %[[C_71_3]]
+// CHECK:        vector.insert_strided_slice %[[C_00_4]], {{.*}}offsets = [0, 0, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
+// CHECK:        vector.insert_strided_slice %[[C_01_4]], {{.*}}offsets = [0, 1, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
+// CHECK:        vector.insert_strided_slice %[[C_70_4]], {{.*}}offsets = [7, 0, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
+// CHECK:        vector.insert_strided_slice %[[C_71_4]], {{.*}}offsets = [7, 1, 0, 0, 0]{{.*}} : vector<4xf32> into vector<8x2x1x1x4xf32>
+// CHECK:      vector.transfer_read %[[BUFFER_C]]
+// CHECK:      arith.addf
+// CHECK:      vector.transfer_write


### PR DESCRIPTION
Introduces a new `DataTiledMMAInnerTileDescAttr` implementation for scaled mfma intrinsics, which will be used for materialization of scaled matmul encodings. The new attribute, `DataTiledScaledMMAAttr`, mimics the existing `DataTiledMMAAttr`, except that it carries a scaled intrinsic, and the LHS, RHS, and ACC element types for the intrinsic. The implementation for the core interface functions of `DataTiledMMAInterfaceAttr` are similar to those of the non scaled counterpart, with a couple of notable differences:

1. The `getTileMNK` function does not fit scaled matmuls, so it is updated to `getTileMNKKb`, which returns a struct containing all the dimensions needed in a scaled matmul. This is a superset of the matmul dimensions, so the same interface method can be used for both.
2. The interleaving semantics for `intrinsics_k` are different for the scaled mma attribute. With the scaled version, interleaving happens at the innermost dimension for the scales operands, and does not happen for the LHS and RHS operands. This is because we want to load scales for multiple intrinsics into a single 32 bit register that can be reused for each instruction.

This PR completes the implementation and basic code generation requirements for data tiled scaled matmuls. The actual data tiling materialization will come as a followup, which will make use of this attribute.