### PR TITLE
[GPU][DT] Refactor tile size selection for narrow matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
@@ -476,23 +476,23 @@ func.func @matmul_lowering_f32f32f32_gfx942() attributes {
 //   CHECK-DAG:   %[[TILED_M:.+]] = affine.apply #[[$MAP0]]()[%[[M]]]
 //   CHECK-DAG:   %[[TILED_K:.+]] = affine.apply #[[$MAP1]]()[%[[K]]]
 //       CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x4x16x4xf32>>{%[[TILED_M]], %[[TILED_K]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x2x4x4x16x4xf32>>{%[[TILED_M]], %[[TILED_K]]}
 //       CHECK:   %[[TILED_N:.+]] = affine.apply #[[$MAP0]]()[%[[N]]]
 //       CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x4x2x4x16x4xf32>>{%[[TILED_N]], %[[TILED_K]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x2x4x4x16x4xf32>>{%[[TILED_N]], %[[TILED_K]]}
 //       CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x4x8x2x4x16x4xf32>>{%[[TILED_M]], %[[TILED_N]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x2x2x4x4x4x16x4xf32>>{%[[TILED_M]], %[[TILED_N]]}
 //       CHECK:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 8, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 2, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 4, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 2, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[OUTS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 4, 8, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 2, 2, 4, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[GEMM:.+]] = iree_codegen.inner_tiled
 //  CHECK-SAME:       ins(%[[LHS]], %[[RHS]])
 //  CHECK-SAME:       outs(%[[OUTS]])
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[GEMM]], %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 4, 8, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 2, 2, 4, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1, 1]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
@@ -23,11 +23,11 @@ func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
-// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x1x16x16xf16>, %[[RHS:.+]]: tensor<?x?x4x1x16x16xf16>
-// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x8x2x16xf32>
-// CHECK-SAME: ) -> tensor<?x?x4x4x8x2x16xf32>
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x2x2x1x16x16xf16>, %[[RHS:.+]]: tensor<?x?x2x2x1x16x16xf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x2x2x2x2x8x2x16xf32>
+// CHECK-SAME: ) -> tensor<?x?x2x2x2x2x8x2x16xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR3_F32_16x16x16_F16, intrinsics_m = 4, subgroups_n = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR3_F32_16x16x16_F16, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2>
 // CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
@@ -57,11 +57,11 @@ func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x4x4x16x2xf64>, %[[RHS:.+]]: tensor<?x?x4x4x16x2xf64>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x4x4x4x16xf64>
-// CHECK-SAME:   ) -> tensor<?x?x4x4x4x4x16xf64>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x2x4x16x2xf64>, %[[RHS:.+]]: tensor<?x?x2x2x4x16x2xf64>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x2x2x4x4x16xf64>
+// CHECK-SAME:   ) -> tensor<?x?x2x2x2x2x4x4x16xf64>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F64_16x16x4_F64, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 2>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F64_16x16x4_F64, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 2>
 // CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -17,7 +17,7 @@ func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32() -> tensor<255x
 }
 
 // CHECK-LABEL: func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x33x8x4x16x4xf32>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x33x2x4x4x16x4xf32>
 // CHECK:         %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[EMPTY]]
 // CHECK:         return %[[FILL]]
 
@@ -41,11 +41,11 @@ func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 16]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x33x128x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x4x8x4x4x4xf32>
+// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x2x4x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x8x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x33x8x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x2x4x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x33x2x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -68,11 +68,11 @@ func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 16]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x33x128x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x4x8x4x4x4xf32>
+// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x2x4x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x8x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x33x8x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x2x4x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x33x2x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -95,11 +95,11 @@ func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 16]
 // CHECK-SAME:      : tensor<?x?xf32> -> tensor<?x?x128x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<?x?x128x16xf32> into tensor<?x?x4x8x4x4x4xf32>
+// CHECK-SAME       : tensor<?x?x128x16xf32> into tensor<?x?x2x4x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x?x8x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x?x8x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x?x2x4x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x?x2x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -122,10 +122,10 @@ func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 16]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<5x16x128x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x4x16x2x4x4xf32>
+// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x2x4x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x4x2x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x16x4x2x4x16x4xf32>)
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x2x4x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<5x16x2x4x4x16x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -149,10 +149,10 @@ func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 16]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<5x16x128x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x4x16x2x4x4xf32>
+// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x2x4x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x4x2x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x16x4x2x4x16x4xf32>)
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x2x4x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<5x16x2x4x4x16x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -176,11 +176,11 @@ func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x5x128x128xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x5x128x128xf32> into tensor<2x5x4x8x4x4x16x2xf32>
+// CHECK-SAME       : tensor<2x5x128x128xf32> into tensor<2x5x2x4x4x4x2x4x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x8x4x4x4x2x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x2x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -199,11 +199,11 @@ func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513x
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<?x513xf32> -> tensor<?x5x128x128xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<?x5x128x128xf32> into tensor<?x5x4x4x2x4x16x8xf32>
+// CHECK-SAME       : tensor<?x5x128x128xf32> into tensor<?x5x2x4x4x4x2x4x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x5x4x2x4x4x8x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x5x4x2x8x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 7, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x5x2x4x4x4x2x4x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x5x2x2x4x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -223,11 +223,11 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<255x?xf32> -> tensor<2x?x128x128xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x?x128x128xf32> into tensor<2x?x4x8x4x4x16x2xf32>
+// CHECK-SAME       : tensor<2x?x128x128xf32> into tensor<2x?x2x4x4x4x2x4x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x?x8x4x4x4x2x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x?x4x8x2x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x?x2x4x4x4x2x4x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x?x2x2x4x4x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -245,11 +245,11 @@ func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x8x4x4x4x2x16xf32>)
-// CHECK-SAME:       permutation = [0, 1, 3, 5, 7, 2, 4, 6]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x8x4x4x4x2x16xf32> into tensor<2x5x128x128xf32>
+// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xf32> into tensor<2x5x128x128xf32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
@@ -272,11 +272,11 @@ func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-LABEL: func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<?x?x4x8x2x4x16x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x?x8x4x4x4x2x16xf32>)
-// CHECK-SAME:       permutation = [0, 1, 3, 5, 7, 2, 4, 6]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<?x?x2x2x4x4x4x16x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x?x2x4x4x4x2x4x16xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<?x?x8x4x4x4x2x16xf32> into tensor<?x?x128x128xf32>
+// CHECK-SAME:      : tensor<?x?x2x4x4x4x2x4x16xf32> into tensor<?x?x128x128xf32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
@@ -309,13 +309,13 @@ func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x4x2x4x16x4xf32>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x4x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x2x4x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -343,14 +343,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x8x4x16x4xf32>
-// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x?x4x2x4x16x4xf32>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x2x4x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x?x2x4x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -377,11 +376,11 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK-SAME:      inner_tiles = [128, 64]
 // CHECK-SAME:      : tensor<255x513xi8> -> tensor<2x9x128x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x4x8x4x2x4x8xi8>
+// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x2x4x16x2x4x8xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x8x16x2x4x8xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x9x8x4x16x2x8xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4, 6]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x2x4x16x2x4x8xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x9x2x4x4x16x2x8xi8>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5, 7]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -406,8 +405,8 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
 // CHECK-SAME       : tensor<5x4x128x64xi8> into tensor<5x4x4x16x2x2x4x8xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x4x4x2x16x2x4x8xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x4x4x2x4x16x2x8xi8>)
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x4x2x4x16x2x4x8xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<5x4x2x4x4x16x2x8xi8>)
 // CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5, 7]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -431,11 +430,11 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<255x513xi32> -> tensor<2x5x128x128xi32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x5x128x128xi32> into tensor<2x5x4x8x4x4x16x2xi32>
+// CHECK-SAME       : tensor<2x5x128x128xi32> into tensor<2x5x2x4x4x4x2x4x16xi32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x8x4x4x4x2x16xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x2x4x16x4xi32>)
-// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -453,11 +452,11 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x8x4x4x4x2x16xi32>)
-// CHECK-SAME:       permutation = [0, 1, 3, 5, 7, 2, 4, 6]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x8x4x4x4x2x16xi32> into tensor<2x5x128x128xi32>
+// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xi32> into tensor<2x5x128x128xi32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
@@ -505,14 +504,13 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x16x2x8xi8>
-// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x2x4x16x2x8xi8>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x2x4x16x4xi32>
-// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x4x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x2x4x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x4x4x4x16x4xi32>
+// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -570,7 +568,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 // CHECK-SAME:    %[[ACC:[a-zA-Z0-9]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2>
 
 // -----
 
@@ -623,7 +621,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 // CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4>
 
 // -----
 
@@ -777,11 +775,11 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096(
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x4x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x4x4x16x2x8xi8>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x4x4x16x4xi32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x2x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x2x2x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x2x2x4x16x4xi32>
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 2>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 2>
 
 // -----
 
@@ -865,14 +863,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x8x4x16x2x8xf8E4M3FNUZ>
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x4x2x4x16x2x8xf8E4M3FNUZ>
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x4x4x16x2x8xf8E4M3FNUZ>, %[[RHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x4x4x16x2x8xf8E4M3FNUZ>
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -900,14 +897,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x8x4x16x2x4xbf16>
-// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x?x4x2x4x16x2x4xbf16>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x2x4x4x16x2x4xbf16>, %[[RHS:.+]]: tensor<?x?x?x2x4x4x16x2x4xbf16>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_BF16, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -935,16 +931,16 @@ func.func @dequantization(
   return %14 : tensor<2x128x64xf32, #encoding>
 }
 
-// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
-// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d5, d7)>
 // CHECK-LABEL: func.func @dequantization
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x16x4xi8>
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xi8>
 // CHECK-SAME:     %[[SCALES:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
 // CHECK-SAME:     %[[ZPS:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x8x4x16x4xf32>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x2x4x4x16x4xf32>
 // CHECK:         %[[DEQUANT:.+]] = linalg.generic
 // CHECK-SAME:        indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP1]], #[[$MAP]]]
-// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 // CHECK-SAME:        ins(%[[LHS]], %[[SCALES]], %[[ZPS]]
 // CHECK-SAME:        outs(%[[EMPTY]]
 // CHECK:           arith.extui
@@ -970,16 +966,16 @@ func.func @multi_result_generic(%3: tensor<2x128x64xf32, #encoding>) -> (tensor<
   } -> (tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>)
   return %15#0, %15#1 : tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
 // CHECK-LABEL: func.func @multi_result_generic(
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x16x4xf32>
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]]
-//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 //  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
 //       CHECK:     arith.truncf
-//       CHECK:     -> (tensor<2x1x4x8x4x16x4xf32>, tensor<2x1x4x8x4x16x4xf16>)
+//       CHECK:     -> (tensor<2x1x4x2x4x4x16x4xf32>, tensor<2x1x4x2x4x4x16x4xf16>)
 
 // -----
 
@@ -998,15 +994,15 @@ func.func @interchange_generic(%3: tensor<2x128x64xf32, #encoding>) -> tensor<64
   } -> tensor<64x2x128xf32, #output_encoding>
   return %15 : tensor<64x2x128xf32, #output_encoding>
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
 // CHECK-LABEL: func.func @interchange_generic(
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x16x4xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]]]
-//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 //  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
-//       CHECK:     -> tensor<2x1x4x8x4x16x4xf32>
+//       CHECK:     -> tensor<2x1x4x2x4x4x16x4xf32>
 // -----
 
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -17,7 +17,7 @@ func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32() -> tensor<255x
 }
 
 // CHECK-LABEL: func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x33x2x4x4x16x4xf32>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x33x4x16x4xf32>
 // CHECK:         %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[EMPTY]]
 // CHECK:         return %[[FILL]]
 
@@ -38,14 +38,14 @@ func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x33x128x16xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x33x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x2x4x16x4x4xf32>
+// CHECK-SAME       : tensor<16x33x16x16xf32> into tensor<16x33x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x2x4x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x33x2x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x33x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -65,14 +65,14 @@ func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x33x128x16xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x33x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x33x128x16xf32> into tensor<2x33x2x4x16x4x4xf32>
+// CHECK-SAME       : tensor<16x33x16x16xf32> into tensor<16x33x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x2x4x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x33x2x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x33x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -119,14 +119,14 @@ func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<5x16x128x16xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<33x16x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x2x4x16x4x4xf32>
+// CHECK-SAME       : tensor<33x16x16x16xf32> into tensor<33x16x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x2x4x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x16x2x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<33x16x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<33x16x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -146,14 +146,14 @@ func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<5x16x128x16xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<33x16x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x16x128x16xf32> into tensor<5x16x2x4x16x4x4xf32>
+// CHECK-SAME       : tensor<33x16x16x16xf32> into tensor<33x16x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x2x4x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x16x2x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<33x16x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<33x16x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -173,14 +173,14 @@ func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<2x5x128x128xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x33x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x5x128x128xf32> into tensor<2x5x2x4x4x4x2x4x16xf32>
+// CHECK-SAME       : tensor<16x33x16x16xf32> into tensor<16x33x4x4x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x33x4x4x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -235,10 +235,10 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-                                    iteration_sizes = [32, 513, ?]>
-func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x513xf32>) -> tensor<32x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<32x513xf32> -> tensor<32x513xf32, #encoding>
-  return %0 : tensor<32x513xf32, #encoding>
+                                    iteration_sizes = [32, 524288, ?]>
+func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x524288xf32>) -> tensor<32x524288xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<32x524288xf32> -> tensor<32x524288xf32, #encoding>
+  return %0 : tensor<32x524288xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32
@@ -249,43 +249,15 @@ func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x513x
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-                                    iteration_sizes = [513, 32, ?]>
-func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<513x32xf32>) -> tensor<513x32xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<513x32xf32> -> tensor<513x32xf32, #encoding>
-  return %0 : tensor<513x32xf32, #encoding>
+                                    iteration_sizes = [524288, 32, ?]>
+func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<524288x32xf32>) -> tensor<524288x32xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<524288x32xf32> -> tensor<524288x32xf32, #encoding>
+  return %0 : tensor<524288x32xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32
 // CHECK:         %[[PACK:.*]] = linalg.pack
 // CHECK-SAME:      inner_tiles = [512, 32]
-
-// -----
-
-#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
-                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-                                    iteration_sizes = [4, 513, ?]>
-func.func @set_encoding_ACC_extreme_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<4x513xf32>) -> tensor<4x513xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<4x513xf32> -> tensor<4x513xf32, #encoding>
-  return %0 : tensor<4x513xf32, #encoding>
-}
-
-// CHECK-LABEL: func.func @set_encoding_ACC_extreme_narrow_M_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack
-// CHECK-SAME:      inner_tiles = [16, 16]
-
-// -----
-
-#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
-                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-                                    iteration_sizes = [513, 4, ?]>
-func.func @set_encoding_ACC_extreme_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<513x4xf32>) -> tensor<513x4xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<513x4xf32> -> tensor<513x4xf32, #encoding>
-  return %0 : tensor<513x4xf32, #encoding>
-}
-
-// CHECK-LABEL: func.func @set_encoding_ACC_extreme_narrow_N_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack
-// CHECK-SAME:      inner_tiles = [16, 16]
 
 // -----
 
@@ -302,16 +274,16 @@ func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x4x16xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xf32> into tensor<2x5x128x128xf32>
+// CHECK-SAME:      : tensor<16x33x4x4x16xf32> into tensor<16x33x16x16xf32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<2x5x128x128xf32> -> tensor<255x513xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<16x33x16x16xf32> -> tensor<255x513xf32>
 // CHECK:         return %[[UNPACK]]
 
 // -----
@@ -430,14 +402,14 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 64]
-// CHECK-SAME:      : tensor<255x513xi8> -> tensor<2x9x128x64xi8>
+// CHECK-SAME:      inner_tiles = [16, 64]
+// CHECK-SAME:      : tensor<255x513xi8> -> tensor<16x9x16x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x2x4x16x2x4x8xi8>
+// CHECK-SAME       : tensor<16x9x16x64xi8> into tensor<16x9x16x2x4x8xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x2x4x16x2x4x8xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x9x2x4x4x16x2x8xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5, 7]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x9x16x2x4x8xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x9x4x16x2x8xi8>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -457,14 +429,14 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
-// CHECK-SAME:      inner_tiles = [128, 64]
-// CHECK-SAME:      : tensor<255x513xi8> -> tensor<5x4x128x64xi8>
+// CHECK-SAME:      inner_tiles = [16, 64]
+// CHECK-SAME:      : tensor<255x513xi8> -> tensor<33x4x16x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x4x128x64xi8> into tensor<5x4x4x16x2x2x4x8xi8>
+// CHECK-SAME       : tensor<33x4x16x64xi8> into tensor<33x4x16x2x4x8xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x4x2x4x16x2x4x8xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x4x2x4x4x16x2x8xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5, 7]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<33x4x16x2x4x8xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<33x4x4x16x2x8xi8>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -484,14 +456,14 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<255x513xi32> -> tensor<2x5x128x128xi32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xi32> -> tensor<16x33x16x16xi32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x5x128x128xi32> into tensor<2x5x2x4x4x4x2x4x16xi32>
+// CHECK-SAME       : tensor<16x33x16x16xi32> into tensor<16x33x4x4x16xi32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xi32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x33x4x4x16xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x16x4xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -509,16 +481,16 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xi32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<16x33x4x16x4xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x4x16xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xi32> into tensor<2x5x128x128xi32>
+// CHECK-SAME:      : tensor<16x33x4x4x16xi32> into tensor<16x33x16x16xi32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<2x5x128x128xi32> -> tensor<255x513xi32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<16x33x16x16xi32> -> tensor<255x513xi32>
 // CHECK:         return %[[UNPACK]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -230,6 +230,63 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 // CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
+
+// -----
+
+#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
+                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+                                    iteration_sizes = [32, 513, ?]>
+func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x513xf32>) -> tensor<32x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<32x513xf32> -> tensor<32x513xf32, #encoding>
+  return %0 : tensor<32x513xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK-SAME:      inner_tiles = [32, 512]
+
+// -----
+
+#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
+                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+                                    iteration_sizes = [513, 32, ?]>
+func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<513x32xf32>) -> tensor<513x32xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x32xf32> -> tensor<513x32xf32, #encoding>
+  return %0 : tensor<513x32xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK-SAME:      inner_tiles = [512, 32]
+
+// -----
+
+#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
+                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+                                    iteration_sizes = [4, 513, ?]>
+func.func @set_encoding_ACC_extreme_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<4x513xf32>) -> tensor<4x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<4x513xf32> -> tensor<4x513xf32, #encoding>
+  return %0 : tensor<4x513xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_extreme_narrow_M_MFMA_F32_16x16x4_F32
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK-SAME:      inner_tiles = [16, 16]
+
+// -----
+
+#encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
+                                    user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+                                    iteration_sizes = [513, 4, ?]>
+func.func @set_encoding_ACC_extreme_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<513x4xf32>) -> tensor<513x4xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x4xf32> -> tensor<513x4xf32, #encoding>
+  return %0 : tensor<513x4xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_extreme_narrow_N_MFMA_F32_16x16x4_F32
+// CHECK:         %[[PACK:.*]] = linalg.pack
+// CHECK-SAME:      inner_tiles = [16, 16]
+
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -26,11 +26,11 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK-SAME:      inner_tiles = [128, 64]
 // CHECK-SAME:      : tensor<255x513xi8> -> tensor<2x9x128x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x4x8x4x4x16xi8>
+// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x2x4x16x4x16xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x8x16x4x16xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x9x8x4x16x16xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 3, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x2x4x16x4x16xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x9x2x4x4x16x16xi8>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 5, 4, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -53,10 +53,10 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK-SAME:      inner_tiles = [128, 64]
 // CHECK-SAME:      : tensor<255x513xi8> -> tensor<5x4x128x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<5x4x128x64xi8> into tensor<5x4x4x2x16x4x16xi8>
+// CHECK-SAME:      : tensor<5x4x128x64xi8> into tensor<5x4x2x4x16x4x16xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]] : tensor<5x4x4x2x16x4x16xi8>)
-// CHECK-SAME:      outs({{.*}} : tensor<5x4x4x2x4x16x16xi8>)
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<5x4x2x4x16x4x16xi8>)
+// CHECK-SAME:      outs({{.*}} : tensor<5x4x2x4x4x16x16xi8>)
 // CHECK-SAME:      permutation = [0, 1, 2, 3, 5, 4, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -80,11 +80,11 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<255x513xi32> -> tensor<2x5x128x128xi32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<2x5x128x128xi32> into tensor<2x5x8x4x4x4x2x16xi32>
+// CHECK-SAME:      : tensor<2x5x128x128xi32> into tensor<2x5x2x4x4x4x2x4x16xi32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]] : tensor<2x5x8x4x4x4x2x16xi32>)
-// CHECK-SAME:      outs({{.*}} : tensor<2x5x4x8x2x4x16x4xi32>)
-// CHECK-SAME:      permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xi32>)
+// CHECK-SAME:      outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xi32>)
+// CHECK-SAME:      permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -102,11 +102,11 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x8x4x4x4x2x16xi32>)
-// CHECK-SAME:       permutation = [0, 1, 3, 5, 7, 2, 4, 6]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x8x4x4x4x2x16xi32> into tensor<2x5x128x128xi32>
+// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xi32> into tensor<2x5x128x128xi32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
@@ -139,14 +139,14 @@ func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x8x4x16x16xi8>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x4x2x4x16x16xi8>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x4x8x2x4x16x4xi32>
-// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x2x4x4x16x16xi8>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x2x4x4x16x16xi8>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x2x2x4x4x4x16x4xi32>
+// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x64_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x64_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -178,14 +178,14 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x8x4x16x32xf8E4M3FN>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x4x2x4x16x32xf8E4M3FN>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x128_F8E4M3FN, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x128_F8E4M3FN,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -213,14 +213,14 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x8x4x16x8xbf16>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x4x2x4x16x8xbf16>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x8xbf16>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x8xbf16>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -495,15 +495,15 @@ func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x4x16x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x2x2x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x2x2x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x2x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x2x2x4x16x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x2x2x2x2x4x16x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 4>
 
 // -----
 
@@ -568,12 +568,12 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x2x32x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x2x32x32xf4E2M1FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x2x32x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x32x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x4x2x32x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x2x2x4x2x32x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x2x2x4x2x32x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x2x2x32x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x2x2x2x32x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x2x2x2x2x4x2x32x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 4>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -250,15 +250,15 @@ func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [0, 1, 2]
-// CHECK-SAME:      inner_tiles = [64, 16, 32]
-// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<4x8x1x64x16x32xf4E2M1FN>
+// CHECK-SAME:      inner_tiles = [16, 16, 32]
+// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<16x8x1x16x16x32xf4E2M1FN>
 // CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<4x8x1x64x16x32xf4E2M1FN> into tensor<4x8x1x4x16x4x4x32xf4E2M1FN>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<4x8x1x4x4x4x16x32xf4E2M1FN>
+// CHECK-SAME:       : tensor<16x8x1x16x16x32xf4E2M1FN> into tensor<16x8x1x16x4x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x8x1x4x4x16x32xf4E2M1FN>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<4x8x1x4x16x4x4x32xf4E2M1FN>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x8x1x4x4x4x16x32xf4E2M1FN>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 5, 6, 4, 7]
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x8x1x16x4x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x8x1x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -284,15 +284,15 @@ func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [0, 1, 2]
-// CHECK-SAME:      inner_tiles = [128, 16, 32]
-// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<5x8x1x128x16x32xf4E2M1FN>
+// CHECK-SAME:      inner_tiles = [16, 16, 32]
+// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<33x8x1x16x16x32xf4E2M1FN>
 // CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<5x8x1x128x16x32xf4E2M1FN> into tensor<5x8x1x4x2x16x4x4x32xf4E2M1FN>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<5x8x1x4x2x4x4x16x32xf4E2M1FN>
+// CHECK-SAME:       : tensor<33x8x1x16x16x32xf4E2M1FN> into tensor<33x8x1x16x4x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x8x1x4x4x16x32xf4E2M1FN>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<5x8x1x4x2x16x4x4x32xf4E2M1FN>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<5x8x1x4x2x4x4x16x32xf4E2M1FN>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 4, 6, 7, 5, 8]
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x8x1x16x4x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x8x1x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -318,15 +318,15 @@ func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<2
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [64, 16]
-// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<4x8x64x16xf8E8M0FNU>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<16x8x16x16xf8E8M0FNU>
 // CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<4x8x64x16xf8E8M0FNU> into tensor<4x8x4x16x4x4xf8E8M0FNU>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<4x8x4x4x16x4xf8E8M0FNU>
+// CHECK-SAME:       : tensor<16x8x16x16xf8E8M0FNU> into tensor<16x8x16x4x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x8x4x16x4xf8E8M0FNU>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<4x8x4x16x4x4xf8E8M0FNU>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x8x4x4x16x4xf8E8M0FNU>)
-// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x8x16x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x8x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -352,15 +352,15 @@ func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<5
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<5x8x128x16xf8E8M0FNU>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<33x8x16x16xf8E8M0FNU>
 // CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<5x8x128x16xf8E8M0FNU> into tensor<5x8x4x2x16x4x4xf8E8M0FNU>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<5x8x4x2x4x16x4xf8E8M0FNU>
+// CHECK-SAME:       : tensor<33x8x16x16xf8E8M0FNU> into tensor<33x8x16x4x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x8x4x16x4xf8E8M0FNU>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<5x8x4x2x16x4x4xf8E8M0FNU>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<5x8x4x2x4x16x4xf8E8M0FNU>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x8x16x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x8x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -386,15 +386,15 @@ func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x513x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [64, 128]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<4x5x64x128xf32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x33x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<4x5x64x128xf32> into tensor<4x5x4x4x4x4x2x16xf32>
-// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<4x5x4x4x2x4x16x4xf32>
+// CHECK-SAME:       : tensor<16x33x16x16xf32> into tensor<16x33x4x4x16xf32>
+// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<16x33x4x16x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<4x5x4x4x4x4x2x16xf32>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x5x4x4x2x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x33x4x4x16xf32>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -495,15 +495,15 @@ func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x4x2x4x4x16x32xf8E4M3FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x4x16x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x4x16x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 4>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -23,14 +23,14 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 64]
-// CHECK-SAME:      : tensor<255x513xi8> -> tensor<2x9x128x64xi8>
+// CHECK-SAME:      inner_tiles = [16, 64]
+// CHECK-SAME:      : tensor<255x513xi8> -> tensor<16x9x16x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x9x128x64xi8> into tensor<2x9x2x4x16x4x16xi8>
+// CHECK-SAME       : tensor<16x9x16x64xi8> into tensor<16x9x16x4x16xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x2x4x16x4x16xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x9x2x4x4x16x16xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 5, 4, 6]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<16x9x16x4x16xi8>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x9x4x16x16xi8>)
+// CHECK-SAME:       permutation = [0, 1, 3, 2, 4]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -50,14 +50,14 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
-// CHECK-SAME:      inner_tiles = [128, 64]
-// CHECK-SAME:      : tensor<255x513xi8> -> tensor<5x4x128x64xi8>
+// CHECK-SAME:      inner_tiles = [16, 64]
+// CHECK-SAME:      : tensor<255x513xi8> -> tensor<33x4x16x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<5x4x128x64xi8> into tensor<5x4x2x4x16x4x16xi8>
+// CHECK-SAME:      : tensor<33x4x16x64xi8> into tensor<33x4x16x4x16xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]] : tensor<5x4x2x4x16x4x16xi8>)
-// CHECK-SAME:      outs({{.*}} : tensor<5x4x2x4x4x16x16xi8>)
-// CHECK-SAME:      permutation = [0, 1, 2, 3, 5, 4, 6]
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<33x4x16x4x16xi8>)
+// CHECK-SAME:      outs({{.*}} : tensor<33x4x4x16x16xi8>)
+// CHECK-SAME:      permutation = [0, 1, 3, 2, 4]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -77,14 +77,14 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<255x513xi32> -> tensor<2x5x128x128xi32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<255x513xi32> -> tensor<16x33x16x16xi32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<2x5x128x128xi32> into tensor<2x5x2x4x4x4x2x4x16xi32>
+// CHECK-SAME:      : tensor<16x33x16x16xi32> into tensor<16x33x4x4x16xi32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]] : tensor<2x5x2x4x4x4x2x4x16xi32>)
-// CHECK-SAME:      outs({{.*}} : tensor<2x5x2x2x4x4x4x16x4xi32>)
-// CHECK-SAME:      permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<16x33x4x4x16xi32>)
+// CHECK-SAME:      outs({{.*}} : tensor<16x33x4x16x4xi32>)
+// CHECK-SAME:      permutation = [0, 1, 2, 4, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -102,16 +102,16 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
 // CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x2x2x4x4x4x16x4xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x2x4x4x4x2x4x16xi32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<16x33x4x16x4xi32>)
+// CHECK-SAME:       outs({{.*}} : tensor<16x33x4x4x16xi32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 4, 3]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<2x5x2x4x4x4x2x4x16xi32> into tensor<2x5x128x128xi32>
+// CHECK-SAME:      : tensor<16x33x4x4x16xi32> into tensor<16x33x16x16xi32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<2x5x128x128xi32> -> tensor<255x513xi32>
+// CHECK-SAME:      inner_tiles = [16, 16]
+// CHECK-SAME:      : tensor<16x33x16x16xi32> -> tensor<255x513xi32>
 // CHECK:         return %[[UNPACK]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -245,7 +245,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   // Upper bound of tm * tn are decided by the workgroup count of the chip and
   // the intrinsic sizes.
   int64_t maxTotalUnrollMN = INT64_MAX;
-  FailureOr<IREE::Encoding::BxMxNxK> matmulSizes = getMatmulSizes(encoding);
+  FailureOr<IREE::Encoding::BxMxNxKxKb> matmulSizes =
+      getEncodingContractionLikeSizes(encoding);
   if (succeeded(matmulSizes)) {
     if (!ShapedType::isDynamic(matmulSizes->M)) {
       // Cap maxTotalUnrollM to avoid excessive padding.

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -251,13 +251,14 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       // Cap maxTotalUnrollN to avoid excessive padding.
       maxTotalUnrollN = llvm::divideCeil(matmulSizes->N, intrinsicNSize);
     }
-    IREE::GPU::TargetChipAttr chip = target.getChip();
-    if (chip && !ShapedType::isDynamic(matmulSizes->M) &&
+    if (!ShapedType::isDynamic(matmulSizes->M) &&
         !ShapedType::isDynamic(matmulSizes->N)) {
       // Cap maxTotalUnrollMN to avoid underutilizing the workgroups available.
-      maxTotalUnrollMN = llvm::divideCeil(matmulSizes->M * matmulSizes->N,
-                                          chip.getWgpCount() * intrinsicMSize *
-                                              intrinsicNSize);
+      IREE::GPU::TargetChipAttr chip = target.getChip();
+      int64_t numWGPs = chip ? chip.getWgpCount() : 512;
+      maxTotalUnrollMN =
+          llvm::divideCeil(matmulSizes->M * matmulSizes->N,
+                           numWGPs * intrinsicMSize * intrinsicNSize);
     }
   }
   // Iterate over possible tm.

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -267,14 +267,14 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     int64_t tn =
         (*wgp.getVgprSpaceBits() - tm * intrinsicsK * intrinsicSizeBitsLHS) /
         (intrinsicsK * intrinsicSizeBitsRHS + tm * intrinsicSizeBitsACC);
-    // No feasible tn for this tm. Stop the enumeration.
-    if (tn <= 0) {
-      break;
-    }
     // Clamp tn to maxTotalUnrollN.
     tn = std::min(tn, maxTotalUnrollN);
     // Clamp tn to maxTotalUnrollMN / tm.
     tn = std::min(tn, maxTotalUnrollMN / tm);
+    // No feasible tn for this tm. Stop the enumeration.
+    if (tn <= 0) {
+      break;
+    }
     // Round tn down to nearest power of two.
     tn = 1 << (int64_t)std::floor(std::log2(tn));
     // Maximize arithmetic intensity (tm * tn) / (tm + tn).

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
@@ -53,38 +53,53 @@ getEncodingScaledContractionDims(EncodingAttr encoding) {
       ArrayRef<AffineMap>(indexingMaps));
 }
 
-FailureOr<BxMxNxK> getMatmulSizes(EncodingAttr encoding) {
-  if (encoding.getOpType().getValue() != EncodingOpType::matmul) {
-    return failure();
-  }
+FailureOr<BxMxNxKxKb> getEncodingContractionLikeSizes(EncodingAttr encoding) {
   SmallVector<int64_t> iterationSizes = encoding.getIterationSizesArray();
   if (iterationSizes.empty()) {
     return failure();
   }
-  std::optional<linalg::ContractionDimensions> maybeCDims =
-      getEncodingContractionDims(encoding);
-  if (!maybeCDims) {
-    return failure();
+  // Try to get scaled contraction dimensions first (which includes kB),
+  // otherwise fall back to regular contraction dimensions.
+  FailureOr<IREE::LinalgExt::ScaledContractionDimensions> maybeScaledCDims =
+      getEncodingScaledContractionDims(encoding);
+  IREE::LinalgExt::ScaledContractionDimensions cDims;
+  if (succeeded(maybeScaledCDims)) {
+    cDims = *maybeScaledCDims;
+  } else {
+    // Fall back to regular contraction dimensions and convert to scaled format
+    // with an empty kB dimension.
+    FailureOr<linalg::ContractionDimensions> maybeCDims =
+        getEncodingContractionDims(encoding);
+    if (failed(maybeCDims)) {
+      return failure();
+    }
+    // Convert ContractionDimensions to ScaledContractionDimensions.
+    cDims.m = maybeCDims->m;
+    cDims.n = maybeCDims->n;
+    cDims.k = maybeCDims->k;
+    cDims.kB = {}; // Empty for non-scaled matmuls
+    cDims.batch = maybeCDims->batch;
   }
-  linalg::ContractionDimensions cDims = maybeCDims.value();
-  // The following expects M, N, K, and Batch sizes of at most 1 for now.
-  // TODO: Extend this to multiple M/N/K/Batch dims.
+  // The following expects M, N, K, KB, and Batch sizes of at most 1 for now.
+  // TODO: Extend this to multiple M/N/K/KB/Batch dims.
   assert(cDims.m.size() <= 1 && cDims.n.size() <= 1 && cDims.k.size() == 1 &&
-         cDims.batch.size() <= 1 &&
-         "Expected at most one M, N, K, and Batch dimension");
+         cDims.kB.size() <= 1 && cDims.batch.size() <= 1 &&
+         "Expected at most one M, N, K, KB, and Batch dimension");
   const int64_t k = iterationSizes[cDims.k[0]];
-  // M, N or Batch can be empty instead of having an explicit dim size of 1 for
-  // matvec and vecmat, so set to 1 if empty.
+  // M, N, or Batch can be empty instead of having an explicit dim size of 1
+  // for matvec and vecmat, so set to 1 if empty.
   const int64_t m = cDims.m.empty() ? 1 : iterationSizes[cDims.m[0]];
   const int64_t n = cDims.n.empty() ? 1 : iterationSizes[cDims.n[0]];
   const int64_t batch =
       cDims.batch.empty() ? 1 : iterationSizes[cDims.batch[0]];
-  return BxMxNxK{batch, m, n, k};
+  // KB can be empty if the encoding is not a scaled matmul.
+  const int64_t kb = cDims.kB.empty() ? 1 : iterationSizes[cDims.kB[0]];
+  return BxMxNxKxKb{batch, m, n, k, kb};
 }
 
 MatmulNarrowDim getPo2MatmulNarrowDim(EncodingAttr encoding) {
   // Get the matmul sizes for the given encoding.
-  FailureOr<BxMxNxK> matmulSizes = getMatmulSizes(encoding);
+  FailureOr<BxMxNxKxKb> matmulSizes = getEncodingContractionLikeSizes(encoding);
   if (failed(matmulSizes)) {
     return {};
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -52,6 +52,17 @@ getEncodingContractionDims(EncodingAttr encoding);
 FailureOr<IREE::LinalgExt::ScaledContractionDimensions>
 getEncodingScaledContractionDims(EncodingAttr encoding);
 
+struct BxMxNxK {
+  int64_t batch = 1;
+  int64_t M = 1;
+  int64_t N = 1;
+  int64_t K = 1;
+};
+
+/// Returns the matmul size (batch, m, n, k) in a given encoding. Returns
+/// empty if failed.
+FailureOr<BxMxNxK> getMatmulSizes(EncodingAttr encoding);
+
 /// Returns the narrow dim in a given `encoding`, ceiled to a power of two. This
 /// works by inspecting the `iteration_sizes` array attribute in the `encoding`.
 /// If the `iteration_sizes` of one dimension (M or N) is smaller than the

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -52,6 +52,7 @@ getEncodingContractionDims(EncodingAttr encoding);
 FailureOr<IREE::LinalgExt::ScaledContractionDimensions>
 getEncodingScaledContractionDims(EncodingAttr encoding);
 
+/// The sizes for contraction ops with only one each of Batch, M, N, K dims.
 struct BxMxNxK {
   int64_t batch = 1;
   int64_t M = 1;

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -52,17 +52,19 @@ getEncodingContractionDims(EncodingAttr encoding);
 FailureOr<IREE::LinalgExt::ScaledContractionDimensions>
 getEncodingScaledContractionDims(EncodingAttr encoding);
 
-/// The sizes for contraction ops with only one each of Batch, M, N, K dims.
-struct BxMxNxK {
+/// The sizes for contraction-like ops with one each of Batch, M, N, K, Kb dims.
+struct BxMxNxKxKb {
   int64_t batch = 1;
   int64_t M = 1;
   int64_t N = 1;
   int64_t K = 1;
+  int64_t Kb = 1;
 };
 
-/// Returns the matmul size (batch, m, n, k) in a given encoding. Returns
-/// empty if failed.
-FailureOr<BxMxNxK> getMatmulSizes(EncodingAttr encoding);
+/// Returns the contraction-like sizes (batch, M, N, K, Kb) for a given
+/// encoding. Supports both regular contractions and scaled contractions. For
+/// regular contractions, Kb is set to 1.
+FailureOr<BxMxNxKxKb> getEncodingContractionLikeSizes(EncodingAttr encoding);
 
 /// Returns the narrow dim in a given `encoding`, ceiled to a power of two. This
 /// works by inspecting the `iteration_sizes` array attribute in the `encoding`.


### PR DESCRIPTION
Previously, the choice of unroll factor (both subgroup unroll and intrinsic unroll) was done in two steps:

1. A square unrolling shape was first enforced to satisfy register size constraints, regardless of the actual matmul shape.
2. For narrow matmuls, the parameters from step 1 were rounded down as a fix-up.

This approach could produce suboptimal results, since the available unroll factor was not optimally distributed between the M and N dimensions.

This PR resolves unroll factor selection in a single step, by considering the matmul shape directly when searching for optimal parameters. 

Additionally, subgroup unroll can now appear on both M and N dimensions, making 2×2 possible. This change affects many lit tests, which have been updated accordingly.

Closes: #18850, #18851