### PR TITLE
[Codegen][GPU] Disable MMA Intrinsics Sorting

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -636,11 +636,9 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     int64_t subgroupSize, std::optional<int64_t> wgpCount, bool transposedLhs,
     bool transposedRhs, bool canUpcastAcc, bool mustBeAligned,
     bool doCPromotion) {
-
-  SmallVector<GPUIntrinsicType> sortedIntrinsics =
-      sortMMAIntrinsics(problem, intrinsics);
-
-  for (const GPUIntrinsicType &intrinsic : sortedIntrinsics) {
+  // TODO(#22160): sortMMAIntrinsics call is disabled for now since it causes
+  // performance regression. Re-enable once the issue is addressed.
+  for (const GPUIntrinsicType &intrinsic : intrinsics) {
     if (failed(canTargetIntrinsic(problem, intrinsic, subgroupSize,
                                   canUpcastAcc, mustBeAligned))) {
       continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -571,17 +571,6 @@ static bool compareIntrinsics(const GPUMatmulShapeType &problem,
          ShapedType::getNumElements(rhs.kSizes);
 }
 
-static SmallVector<GPUIntrinsicType>
-sortMMAIntrinsics(GPUMatmulShapeType problem,
-                  ArrayRef<GPUIntrinsicType> intrinsics) {
-  SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
-  llvm::stable_sort(sortedIntrinsics, [&](const GPUMatmulShapeType &lhs,
-                                          const GPUMatmulShapeType &rhs) {
-    return compareIntrinsics(problem, lhs, rhs);
-  });
-  return sortedIntrinsics;
-}
-
 static int64_t adjustSeedsForWgpCount(const GPUMatmulShapeType &problem,
                                       const GPUIntrinsicType &intrinsic,
                                       std::optional<int64_t> wgpCount,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -78,14 +78,14 @@ func.func @group_conv_hwgc_gfhwc_unaligned(%arg0: tensor<61x93x16x56xbf16>, %arg
 }
 
 // CHECK-LABEL: func.func @group_conv_hwgc_gfhwc_unaligned
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = false
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_BF16>
-//  CHECK-SAME:     padding_conv = [1, 32, 1, 64, 0, 0, 8]
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
+//  CHECK-SAME:     padding_conv = [1, 32, 1, 64, 0, 0, 64]
 //  CHECK-SAME:     promote_operands = [0, 1]
-//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 4]
 //  CHECK-SAME:     subgroup = [0, 1, 0, 1, 0, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 32, 1, 64, 0, 0, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -39,8 +39,8 @@ func.func @expanded_matmul_transpose_b() {
 
 // CHECK-LABEL: func.func @expanded_matmul_transpose_b()
 // CHECK: linalg.generic {{.*}}lowering_config =  #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 256]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 128]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 64, 0]
 
@@ -70,8 +70,8 @@ func.func @conv_nhwc() {
 
 // CHECK-LABEL: func.func @conv_nhwc()
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 64]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 32]
 // CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 128, 0, 0, 0]
 
@@ -134,8 +134,8 @@ func.func @mfma_matmul_1024x1024x1024() {
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 128]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 64]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
@@ -184,8 +184,8 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 32]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
@@ -74,7 +74,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:      mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
+// GFX942-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]
@@ -276,7 +276,7 @@ func.func @fused_contraction_4(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:       mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
+// GFX942-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 // GFX950-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]


### PR DESCRIPTION
This PR removes `sortMMAIntrinsics` function as shown below and its call inside the function `deduceMMASchedule`,  which disables MMA intrinsics sorting. The current sorting method has been identified as causing performance regressions( see issue #22160), so we are disabling it for now. We can re-enable sorting in the future once we ensure it works correctly without regressions.

```C++
static SmallVector<GPUIntrinsicType>
sortMMAIntrinsics(GPUMatmulShapeType problem,
                  ArrayRef<GPUIntrinsicType> intrinsics) {
  SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
  llvm::stable_sort(sortedIntrinsics, [&](const GPUMatmulShapeType &lhs,
                                          const GPUMatmulShapeType &rhs) {
    return compareIntrinsics(problem, lhs, rhs);
  });
  return sortedIntrinsics;
}
```

Issue: #22160