### PR TITLE
[GPU] Add thread tile size inference for map_scatter op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
@@ -238,3 +238,24 @@ func.func @scatter(%arg0: tensor<3x32x16xf32>, %arg1: tensor<3x1xi32>) -> tensor
 //       CHECK:   scf.forall ({{.*}}) = (0, 0, 0) to (3, 32, 16) step (1, 1, 4)
 //       CHECK:     linalg_ext.scatter
 //       CHECK:     scf.forall.in_parallel
+
+// -----
+
+#config = #iree_gpu.derived_thread_config
+func.func @map_scatter(%arg0: tensor<2x32xf32>, %arg1: tensor<64x256xf32>) -> tensor<64x256xf32>
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [16, 32] subgroup_size = 64, {}>
+    } {
+  %true = arith.constant true
+  %1 = iree_linalg_ext.map_scatter {lowering_config = #config} %arg0 into %arg1 {
+  ^bb0(%arg2: index, %arg3: index):
+    iree_linalg_ext.yield %arg2, %arg3, %true : index, index, i1
+  } : tensor<2x32xf32> into tensor<64x256xf32> -> tensor<64x256xf32>
+  return %1 : tensor<64x256xf32>
+}
+
+// CHECK-LABEL: @map_scatter
+//       CHECK: scf.forall ({{.*}}) = (0, 0) to (2, 32) step (1, 4)
+//       CHECK:   iree_linalg_ext.map_scatter
+//       CHECK:     tensor<1x4xf32> into tensor<64x256xf32>
+//       CHECK:   scf.forall.in_parallel


### PR DESCRIPTION
-- This commit adds thread tile size inference for map_scatter op.
-- Corresponding tracking issue : https://github.com/iree-org/iree/issues/22121

Signed-off-by: Abhishek Varma <abhvarma@amd.com>