### PR TITLE
[Codegen] Fix premature return in iree_codegen.inner_tiled verifier

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pack_to_instrinsics.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pack_to_instrinsics.mlir
@@ -145,17 +145,17 @@ module {
 #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 module {
-  func.func @scaled_mfma_32x32x64(%a: tensor<?x?x?xf8E8M0FNU>, %b: tensor<?x?x?xf8E8M0FNU>, %a_scales: tensor<?x?xf32>, %b_scales: tensor<?x?xf32>, %c: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  func.func @scaled_mfma_32x32x64(%a: tensor<?x?x?xf8E8M0FNU>, %b: tensor<?x?x?xf8E8M0FNU>, %a_scales: tensor<?x?xf8E8M0FNU>, %b_scales: tensor<?x?xf8E8M0FNU>, %c: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %mm = linalg.generic {
       indexing_maps = [#map, #map1, #map2, #map3, #map4],
       iterator_types = ["parallel", "parallel", "reduction", "reduction"]
-    } ins(%a, %b, %a_scales, %b_scales : tensor<?x?x?xf8E8M0FNU>, tensor<?x?x?xf8E8M0FNU>, tensor<?x?xf32>, tensor<?x?xf32>)
+    } ins(%a, %b, %a_scales, %b_scales : tensor<?x?x?xf8E8M0FNU>, tensor<?x?x?xf8E8M0FNU>, tensor<?x?xf8E8M0FNU>, tensor<?x?xf8E8M0FNU>)
     outs(%c : tensor<?x?xf32>) attrs =  {
       lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f8E8M0FNU, rhs_elem_type = f8E8M0FNU, acc_elem_type = f32>}>
     } {
-    ^bb0(%in: f8E8M0FNU, %in_4: f8E8M0FNU, %in_5: f32, %in_6: f32, %out: f32):
-      %17 = arith.scaling_extf %in, %in_5 : f8E8M0FNU, f32 to f32
-      %18 = arith.scaling_extf %in_4, %in_6 : f8E8M0FNU, f32 to f32
+    ^bb0(%in: f8E8M0FNU, %in_4: f8E8M0FNU, %in_5: f8E8M0FNU, %in_6: f8E8M0FNU, %out: f32):
+      %17 = arith.scaling_extf %in, %in_5 : f8E8M0FNU, f8E8M0FNU to f32
+      %18 = arith.scaling_extf %in_4, %in_6 : f8E8M0FNU, f8E8M0FNU to f32
       %19 = arith.mulf %17, %18 : f32
       %20 = arith.addf %out, %19 : f32
       linalg.yield %20 : f32
@@ -174,7 +174,7 @@ module {
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 //  CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f8E8M0FNU, rhs_elem_type = f8E8M0FNU, acc_elem_type = f32>}>
 // CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf32>, tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf32> into tensor<?x?x32x32xf32>
+//  CHECK-SAME:     : tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -228,20 +228,8 @@ LogicalResult InnerTiledOp::verify() {
   int64_t expectedNumOuts = getKind().getExpectedNumOutputs();
   if (expectedNumOuts != getNumOutputs()) {
     return emitOpError("number of outputs (" + Twine(getNumOutputs()) +
-                       ")doesn't match expected number from kind (" +
+                       ") doesn't match expected number from kind (" +
                        Twine(expectedNumOuts) + ")");
-  }
-
-  if (getNumResults() != expectedNumOuts) {
-    return emitOpError("number of results (" + Twine(getNumResults()) +
-                       ") does't match expected number from kind (" +
-                       Twine(expectedNumOuts) + ")");
-  }
-
-  if (!llvm::equal(getResultTypes(), getOutputs().getTypes())) {
-    return emitOpError("output types '")
-           << getOutputs().getTypes() << "' do not match result type '"
-           << getResultTypes() << "'";
   }
 
   SmallVector<ShapedType> opTypes = llvm::map_to_vector(
@@ -268,15 +256,15 @@ LogicalResult InnerTiledOp::verify() {
     // This also correctly accounts for (..) -> () for rank-0 results.
     if (map.getNumDims() != numIterators) {
       return emitOpError("expected indexing map ")
-             << index << " to have " << numIterators << " number of inputs";
+             << index << " to have " << numIterators << " input dims";
     }
     if (map.getNumResults() >= rank) {
       return emitOpError("expected indexing map ")
-             << index << " to have fewer than " << rank << " number of outputs";
+             << index << " to have fewer than " << rank << " results";
     }
     if (!map.isProjectedPermutation()) {
       return emitOpError("expected indexing map ")
-             << index << " to be a projected permutation of its inputs";
+             << index << " to be a projected permutation";
     }
 
     for (int64_t size :
@@ -303,8 +291,7 @@ LogicalResult InnerTiledOp::verify() {
         return emitOpError("shape does not match iteration bounds");
       }
     }
-    return success();
-  };
+  }
 
   SmallVector<VectorType> preThreadTypes;
   getKind().getUndistributedTileTypes(preThreadTypes);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "bufferize_coalesced_gather_dma.mlir",
             "canonicalize.mlir",
+            "invalid.mlir",
             "iree_gpu_attrs.mlir",
             "iree_gpu_inner_tiled_ops.mlir",
             "iree_gpu_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "bufferize_coalesced_gather_dma.mlir"
     "canonicalize.mlir"
+    "invalid.mlir"
     "iree_gpu_attrs.mlir"
     "iree_gpu_inner_tiled_ops.mlir"
     "iree_gpu_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -1,15 +1,5 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
-
-// func.func @mma_inner_tiled_valid(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-//   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
-//     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
-//     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
-//     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//   } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
-//   return %0 : tensor<?x?x4xf32>
-// }
-
 func.func @mma_inner_tiled_invalid_num_inputs(%lhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
   // expected-error @+1 {{number of inputs (1) doesn't match expected number from kind (2)}}
   %0 = iree_codegen.inner_tiled ins(%lhs) outs(%acc) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -1,0 +1,129 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics %s
+
+
+// func.func @mma_inner_tiled_valid(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+//   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+//     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+//     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+//     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+//   } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+//   return %0 : tensor<?x?x4xf32>
+// }
+
+func.func @mma_inner_tiled_invalid_num_inputs(%lhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{number of inputs (1) doesn't match expected number from kind (2)}}
+  %0 = iree_codegen.inner_tiled ins(%lhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_num_outputs(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> (tensor<?x?x4xf32>, tensor<?x?x4xf32>) {
+  // expected-error @+1 {{number of outputs (2) doesn't match expected number from kind (1)}}
+  %0:2 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc, %acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>, tensor<?x?x4xf32>
+  return %0#0, %0#1 : tensor<?x?x4xf32>, tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_num_indexing_maps(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{expected an indexing map for each operand}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_indexing_map_num_dims(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{expected indexing map 0 to have 3 input dims}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k, x) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_indexing_map_num_results(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{expected indexing map 0 to have fewer than 3 results}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, j, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_indexing_map_non_permutation(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{expected indexing map 0 to be a projected permutation}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, j + k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_outer_shape(%lhs: tensor<2x2x4xf16>, %rhs: tensor<2x3x4xf16>, %acc: tensor<2x2x4xf32>) -> tensor<2x2x4xf32> {
+  // expected-error @+1 {{shape does not match iteration bounds}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<2x2x4xf16>, tensor<2x3x4xf16> into tensor<2x2x4xf32>
+  return %0 : tensor<2x2x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_dynamic_inner_dim(%lhs: tensor<?x?x?xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{Unexpected dynamic inner dim for operand 0 of type 'tensor<?x?x?xf16>'}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x?xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_element_type(%lhs: tensor<?x?x4xf32>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{iree_codegen.inner_tiled' op operand 0 element type 'f32' does not match expected tile type 'vector<16x16xf16>' for operator}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x4xf32>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}
+
+// -----
+
+func.func @mma_inner_tiled_invalid_inner_types(%lhs: tensor<?x?x3xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  // expected-error @+1 {{operation parallel semantics can't be inferred as either distributed or undistributed}}
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+  } : tensor<?x?x3xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+  return %0 : tensor<?x?x4xf32>
+}


### PR DESCRIPTION
There was a bug in the iree_codegen.inner_tiled verifier that caused the function to return success before making all the necessary checks. This PR removes the early return, and adds some `invalid` lit tests to properly test the verifier. The PR also removes 2 redundant checks that are already present in the verifier for the DestinationStyleOpInterface.

This also updates an invalid pack_to_intrinsics test, which is now caught by the verifier.