### PR TITLE
[DT][ROCM] Fix inner_tiled bitcode ukernel lowering with instrinsicsM(N) = 1

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
@@ -101,6 +101,12 @@ getCInnermostStaticCrossIntrinsicDim(IREE::Codegen::InnerTiledOp op) {
     }
     return outputIdx;
   }
+  // Handle the case where there are no `CrossIntrinsic` dims present in
+  // `accSwizzle`, as `intrinsicsM` and `intrinsicsN` are both set as 1. In this
+  // case, we can assume `swizzleIdx` = 0 and just return the rank difference.
+  if (swizzleDims.size() > 0) {
+    return rankDiff;
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
When instrinsicsM(N) !=1, `accSwizzle` looks like: ["CrossThread", "CrossIntrinsic", "CrossIntrinsic", "CrossThread", "CrossThread", "Internal"].

When instrinsicsM(N) ==1, `accSwizzle` looks like: ["CrossThread", "CrossThread", "CrossThread", "Internal"].
 
`getCInnermostStaticCrossIntrinsicDim` was returning `std::nullopt` in the second case, which causes the lowering to fail.