### PR TITLE
Revert "[LLVMGPU] Unroll elementwise operations (#21665)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -184,52 +183,6 @@ struct SetMulAddFMF final : OpRewritePattern<vector::MultiDimReductionOp> {
   }
 };
 
-struct UnrollElementwiseOps final : public RewritePattern {
-  UnrollElementwiseOps(MLIRContext *context, PatternBenefit benefit = 1)
-      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    if (!OpTrait::hasElementwiseMappableTraits(op) || op->getNumResults() != 1)
-      return failure();
-
-    Location loc = op->getLoc();
-    VectorType dstVecTy = dyn_cast<VectorType>(op->getResult(0).getType());
-    if (!dstVecTy || dstVecTy.getRank() <= 1) {
-      return failure();
-    }
-    ArrayRef<int64_t> originalSize = dstVecTy.getShape();
-
-    Value result = ub::PoisonOp::create(rewriter, loc, dstVecTy);
-    auto subVecTy =
-        VectorType::get({originalSize.back()}, dstVecTy.getElementType());
-
-    SmallVector<int64_t> tileShape(dstVecTy.getRank() - 1, 1);
-    for (SmallVector<int64_t> offsets :
-         StaticTileOffsetRange(originalSize.drop_back(), tileShape)) {
-      // Extract from each operand.
-      SmallVector<Value> operands;
-      for (Value val : op->getOperands()) {
-        // Extract subvector if the operand is a vector. This is to handle
-        // things like arith.select which take a scalar conditional but are
-        // otherwise elementwise.
-        if (isa<VectorType>(val.getType())) {
-          val = vector::ExtractOp::create(rewriter, loc, val, offsets);
-        }
-        operands.push_back(val);
-      }
-
-      Operation *clonedOp = clone(rewriter, op, subVecTy, operands);
-      Value subResult = clonedOp->getResult(0);
-      result =
-          vector::InsertOp::create(rewriter, loc, subResult, result, offsets);
-    }
-
-    rewriter.replaceOp(op, result);
-    return success();
-  }
-};
-
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -275,7 +228,6 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorMultiReductionLoweringPatterns(
           contractLoweringPatterns,
           vector::VectorMultiReductionLowering::InnerReduction);
-      contractLoweringPatterns.add<UnrollElementwiseOps>(funcOp->getContext());
       if (failed(applyPatternsGreedily(funcOp,
                                        std::move(contractLoweringPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -108,18 +108,13 @@ func.func @multi_reduction_f32(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> 
 }
 
 // CHECK-LABEL: func.func @multi_reduction_f32
-// CHECK-SAME: %[[ARG0:.+]]: vector<2x1x8xf32>, %[[ARG1:.+]]: vector<2x1x8xf32>)
-// CHECK-DAG: %[[LHS0:.+]] = vector.extract %[[ARG0]][0, 0]
-// CHECK-DAG: %[[RHS0:.+]] = vector.extract %[[ARG1]][0, 0]
-// CHECK-DAG: %[[LHS1:.+]] = vector.extract %[[ARG0]][1, 0]
-// CHECK-DAG: %[[RHS1:.+]] = vector.extract %[[ARG1]][1, 0]
-// CHECK-DAG: %[[FMA1:.+]] = math.fma %[[LHS0]], %[[RHS0]], %{{.*}} fastmath<contract> : vector<8xf32>
-// CHECK-DAG: %[[FMA2:.+]] = math.fma %[[LHS1]], %[[RHS1]], %{{.*}} fastmath<contract> : vector<8xf32>
-// CHECK-DAG: %[[RED1:.+]] = vector.reduction <add>, %[[FMA1]], %{{.*}} : vector<8xf32> into f32
-// CHECK-DAG: %[[RED2:.+]] = vector.reduction <add>, %[[FMA2]], %{{.*}} : vector<8xf32> into f32
-// CHECK: vector.from_elements %[[RED1]], %[[RED2]] : vector<2x1xf32>
-
-// -----
+// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+// CHECK:      %[[FMA:.+]] = math.fma %{{.*}}, %{{.*}}, %[[V0]] fastmath<contract> : vector<2x1x8xf32>
+// CHECK:      %[[E0:.+]]  = vector.extract %[[FMA]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
+// CHECK:      %[[E1:.+]]  = vector.extract %[[FMA]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32
 
 func.func @multi_reduction_no_uplift(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32>) -> vector<2x1xf32> {
   %cst_4 = arith.constant dense<0.000000e+00> : vector<2x1xf32>
@@ -131,11 +126,11 @@ func.func @multi_reduction_no_uplift(%a: vector<2x1x8xf32>, %b: vector<2x1x8xf32
 }
 
 // CHECK-LABEL: func.func @multi_reduction_no_uplift
-// CHECK-SAME: %[[ARG0:.+]]: vector<2x1x8xf32>, %[[ARG1:.+]]: vector<2x1x8xf32>)
-// CHECK-DAG: %[[LHS0:.+]] = vector.extract %[[ARG0]][0, 0]
-// CHECK-DAG: %[[RHS0:.+]] = vector.extract %[[ARG1]][0, 0]
-// CHECK-DAG: %[[LHS1:.+]] = vector.extract %[[ARG0]][1, 0]
-// CHECK-DAG: %[[RHS1:.+]] = vector.extract %[[ARG1]][1, 0]
-// CHECK-DAG: arith.mulf %[[LHS0]], %[[RHS0]] fastmath<fast> : vector<8xf32>
-// CHECK-DAG: arith.mulf %[[LHS1]], %[[RHS1]] fastmath<fast> : vector<8xf32>
-// CHECK-NOT: math.fma
+// CHECK-DAG:  %[[C0:.+]]  = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:  %[[V0:.+]]  = arith.constant dense<0.000000e+00> : vector<2x1x8xf32>
+// CHECK:      %[[MUL:.+]] = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : vector<2x1x8xf32>
+// CHECK:      %[[ADD:.+]] = arith.addf %[[MUL]], %[[V0]] : vector<2x1x8xf32>
+// CHECK:      %[[E0:.+]]  = vector.extract %[[ADD]][0, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E0]], %[[C0]] : vector<8xf32> into f32
+// CHECK:      %[[E1:.+]]  = vector.extract %[[ADD]][1, 0] : vector<8xf32> from vector<2x1x8xf32>
+// CHECK:                    vector.reduction <add>, %[[E1]], %[[C0]] : vector<8xf32> into f32


### PR DESCRIPTION
This reverts commit 6538d9a8a782b8706e7e7634de96743089f4c97b.

Seems like while the IREE generated code is "better", requires more work at LLVM level to fix this. So reverting for now