### PR TITLE
[Stream] Deduplicate the dispatch workloads

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/Support/Debug.h"
@@ -35,6 +36,55 @@ namespace {
 // Per-dispatchable export optimization
 //===----------------------------------------------------------------------===//
 
+// Returns the uniformly duplicated values across all indexing map entries of
+// duplicated values and a bit vector indicating the 'dead' values.
+//
+// Example:
+// Map of duplicated values per entry: [[0, 1, 0, 1], [0, 1, 0, 2]]
+// Returns:
+// - A map of uniformly duplicated values: [0, 1, 0, 3]
+// - A bit vector with dead values: b0010
+static std::pair<SmallVector<unsigned>, llvm::BitVector>
+getUniformDupeIndexingAndDeadValues(
+    const SmallVector<SmallVector<unsigned>> &dupeIndexMaps) {
+  if (dupeIndexMaps.size() == 0) {
+    return {};
+  }
+  unsigned numValues = dupeIndexMaps[0].size();
+  llvm::BitVector sameValues(numValues);
+  llvm::BitVector deadOperandsMap(numValues);
+  SmallVector<unsigned> uniformDupeIndexMap =
+      llvm::to_vector(llvm::seq(0u, numValues)); // old -> new
+  for (unsigned idx = 0; idx < numValues; ++idx) {
+    if (deadOperandsMap.test(idx)) {
+      continue;
+    }
+    // Each bit represents a value that duplicates the value at idx.
+    // We walk all the sites and AND their masks together to get the safe
+    // set of duplicate operands.
+    // Example for idx=0 and list=[(%a, %b, %a)] -> b001
+    // Example for idx=1 and list=[(%a, %b, %a)] -> b000
+    sameValues.set(); // note reused
+    for (ArrayRef<unsigned> dupeIndexMap : dupeIndexMaps) {
+      for (unsigned i = 0; i < numValues; ++i) {
+        if (i == idx || dupeIndexMap[i] != idx) {
+          sameValues.reset(i);
+        }
+      }
+    }
+    if (sameValues.none()) {
+      uniformDupeIndexMap[idx] = idx;
+      continue;
+    }
+    deadOperandsMap |= sameValues;
+    uniformDupeIndexMap[idx] = idx;
+    for (auto dupeIdx : sameValues.set_bits()) {
+      uniformDupeIndexMap[dupeIdx] = idx;
+    }
+  }
+  return std::make_pair(uniformDupeIndexMap, deadOperandsMap);
+}
+
 // Deduplicates operands that have the same value at all dispatch sites.
 // This will deduplicate dynamic values as well.
 //
@@ -52,12 +102,11 @@ deduplicateOperands(mlir::FunctionOpInterface funcOp,
 
   // Build a map of operand indices to its base duplicate for each dispatch
   // site. Base/non-duplicated values will be identity.
-  // Example: (%a, %b, %a, %b) -> (0, 1, 0, 1)
-  static const int kUnassigned = -1;
+  // Example: (%a, %b, %a, %b, %c) -> (0, 1, 0, 1, 4)
   SmallVector<SmallVector<unsigned>> dupeIndexMaps(dispatchOps.size());
   for (auto dispatchOp : llvm::enumerate(dispatchOps)) {
     auto &dupeIndexMap = dupeIndexMaps[dispatchOp.index()];
-    dupeIndexMap.resize(operandCount, kUnassigned);
+    dupeIndexMap = llvm::to_vector(llvm::seq(0u, operandCount));
     auto operands = dispatchOp.value().getUniformOperands();
     for (unsigned i = 0; i < operands.size(); ++i) {
       for (unsigned j = 0; j < i; ++j) {
@@ -70,36 +119,8 @@ deduplicateOperands(mlir::FunctionOpInterface funcOp,
   }
 
   // Per-operand now find which are consistently duplicated.
-  llvm::BitVector sameValues(operandCount);
-  llvm::BitVector deadOperandsMap(operandCount);
-  auto uniformDupeIndexMap =
-      llvm::to_vector(llvm::seq(0u, operandCount)); // old -> new
-  for (unsigned idx = 0; idx < operandCount; ++idx) {
-    if (deadOperandsMap.test(idx))
-      continue;
-    // Each bit represents an operand that duplicates the operand at idx.
-    // We walk all the sites and AND their masks together to get the safe
-    // set of duplicate operands.
-    // Example for %0: (%a, %b, %a) -> b001
-    // Example for %1: (%a, %b, %a) -> b000
-    sameValues.set(); // note reused
-    for (auto &dupeIndexMap : dupeIndexMaps) {
-      for (unsigned i = 0; i < operandCount; ++i) {
-        if (i == idx || dupeIndexMap[i] != idx) {
-          sameValues.reset(i);
-        }
-      }
-    }
-    if (sameValues.none()) {
-      uniformDupeIndexMap[idx] = idx;
-      continue;
-    }
-    deadOperandsMap |= sameValues;
-    uniformDupeIndexMap[idx] = idx;
-    for (auto dupeIdx : sameValues.set_bits()) {
-      uniformDupeIndexMap[dupeIdx] = idx;
-    }
-  }
+  auto [uniformDupeIndexMap, deadOperandsMap] =
+      getUniformDupeIndexingAndDeadValues(dupeIndexMaps);
   if (deadOperandsMap.none()) {
     // No-op.
     return;
@@ -154,8 +175,7 @@ deduplicateOperands(mlir::FunctionOpInterface funcOp,
   // Update the function signature.
   // Lame we need two data structures to do this.
   funcOp.setType(funcOp.getTypeWithoutArgsAndResults(deadArgMap, {}));
-  entryBlock.eraseArguments(
-      [&](BlockArgument arg) { return deadArgMap.test(arg.getArgNumber()); });
+  entryBlock.eraseArguments(deadArgMap);
 }
 
 // Inlines constant values passed in at dispatch sites that are uniform across
@@ -248,8 +268,116 @@ inlineUniformConstants(mlir::FunctionOpInterface funcOp,
 
   // Fixup function signature.
   funcOp.setType(funcOp.getTypeWithoutArgsAndResults(deadArgMap, {}));
-  entryBlock.eraseArguments(
-      [&](BlockArgument arg) { return deadArgMap.test(arg.getArgNumber()); });
+  entryBlock.eraseArguments(deadArgMap);
+}
+
+// Deduplicates workloads that have the same value at all dispatch sites.
+//
+// Example:
+//   stream.cmd.dispatch @foo[%0, %0](...)
+//  ->
+//   stream.cmd.dispatch @foo[%0](...)
+// + deduped arguments in `stream.executable.export`
+// + deduped ordinals in `dispatch.workload.ordinal`
+static void
+deduplicateWorkloads(IREE::Stream::ExecutableExportOp exportOp,
+                     SmallVector<IREE::Stream::CmdDispatchOp> &dispatchOps) {
+  if (exportOp.getWorkgroupCount().empty()) {
+    return;
+  }
+  mlir::FunctionOpInterface funcOp = exportOp.lookupFunctionRef();
+  if (!funcOp) {
+    return;
+  }
+  IREE::Stream::CmdDispatchOp anyDispatchOp = dispatchOps.front();
+  unsigned workloadCount = anyDispatchOp.getWorkload().size();
+
+  // Build a map of workload indices to its base duplicate for each dispatch
+  // site. Base/non-duplicated values will be identity.
+  // Example: (%a, %b, %a, %b, %c) -> (0, 1, 0, 1, 4)
+  SmallVector<SmallVector<unsigned>> dupeIndexMaps(dispatchOps.size());
+  for (auto [i, dispatchOp] : llvm::enumerate(dispatchOps)) {
+    SmallVector<unsigned> &dupeIndexMap = dupeIndexMaps[i];
+    dupeIndexMap = llvm::to_vector(llvm::seq(0u, workloadCount));
+    SmallVector<Value> workloads = dispatchOp.getWorkload();
+    for (unsigned i = 0; i < workloads.size(); ++i) {
+      for (unsigned j = 0; j < i; ++j) {
+        if (workloads[j] == workloads[i]) {
+          dupeIndexMap[i] = j;
+          break;
+        }
+      }
+    }
+  }
+
+  // Per-workload now find which are consistently duplicated.
+  auto [uniformDupeIndexMap, deadOperandsMap] =
+      getUniformDupeIndexingAndDeadValues(dupeIndexMaps);
+  if (deadOperandsMap.none()) {
+    // No-op.
+    return;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "deduplicateWorkloads for " << exportOp.getName() << "\n";
+    llvm::dbgs() << "  dead workloads: ";
+    llvm::interleaveComma(deadOperandsMap.set_bits(), llvm::dbgs());
+    llvm::dbgs() << "\n";
+    for (auto [deadIdx, liveIdx] : llvm::enumerate(uniformDupeIndexMap)) {
+      if (deadIdx == liveIdx) {
+        continue;
+      }
+      llvm::dbgs() << "  %arg" << deadIdx << " -> %arg" << liveIdx << "\n";
+    }
+  });
+
+  // Update the ordinals in the workload ordinal ops.
+  unsigned ordinalCount = 0;
+  SmallVector<unsigned> newOrdinals(uniformDupeIndexMap.size());
+  for (auto [deadIdx, liveIdx] : llvm::enumerate(uniformDupeIndexMap)) {
+    if (deadIdx != liveIdx) {
+      continue;
+    }
+    newOrdinals[deadIdx] = ordinalCount++;
+  }
+  funcOp->walk([&](IREE::TensorExt::DispatchWorkloadOrdinalOp ordinalOp) {
+    uint64_t ordinal = ordinalOp.getOrdinal().getZExtValue();
+    uint64_t newOrdinal = newOrdinals[ordinal];
+    if (newOrdinal == ordinal) {
+      return WalkResult::advance();
+    }
+    ordinalOp.setOrdinalAttr(
+        IntegerAttr::get(IndexType::get(ordinalOp.getContext()), newOrdinal));
+    return WalkResult::advance();
+  });
+
+  // Update the workgroup region arguments.
+  Block &entryBlock = exportOp.getWorkgroupCount().front();
+  auto argReplacementMap = llvm::to_vector(
+      llvm::seq(0u, entryBlock.getNumArguments())); // old -> new
+  llvm::BitVector deadArgMap(entryBlock.getNumArguments());
+  for (auto [deadIdx, liveIdx] : llvm::enumerate(uniformDupeIndexMap)) {
+    if (deadIdx == liveIdx) {
+      continue;
+    }
+    deadArgMap.set(deadIdx);
+    entryBlock.getArgument(deadIdx).replaceAllUsesWith(
+        entryBlock.getArgument(liveIdx));
+  }
+
+  // Update each dispatch site to remove duplicates.
+  SmallVector<unsigned> deadOperands;
+  for (auto idx : deadOperandsMap.set_bits()) {
+    deadOperands.push_back(idx);
+  }
+  for (auto dispatchOp : dispatchOps) {
+    for (auto idx : llvm::reverse(deadOperands)) {
+      dispatchOp.getWorkloadMutable().erase(idx);
+    }
+  }
+
+  // Update the block arguments.
+  entryBlock.eraseArguments(deadArgMap);
 }
 
 //===----------------------------------------------------------------------===//
@@ -276,8 +404,9 @@ struct FoldUniformOperandsPass
     // Optimize each dispatch op.
     for (auto executableOp :
          getOperation().getBodyRegion().getOps<IREE::Stream::ExecutableOp>()) {
-      if (!executableOp.getInnerModule())
+      if (!executableOp.getInnerModule()) {
         continue;
+      }
       for (auto exportOp :
            executableOp.getOps<IREE::Stream::ExecutableExportOp>()) {
         auto &dispatchOps = entryDispatchMap[exportOp];
@@ -290,6 +419,9 @@ struct FoldUniformOperandsPass
         // We do this first so that we know all constants passed in are unique
         // per dispatch site.
         deduplicateOperands(funcOp, dispatchOps);
+
+        // Deduplicate workloads that are correlated at all dispatch sites.
+        deduplicateWorkloads(exportOp, dispatchOps);
 
         // Inline constants that have the same value at all sites.
         inlineUniformConstants(funcOp, dispatchOps);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fold_uniform_operands.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fold_uniform_operands.mlir
@@ -1,5 +1,35 @@
 // RUN: iree-opt --split-input-file --iree-stream-fold-uniform-operands %s | FileCheck %s
 
+// Tests that the pass doesn't crash if there is no inner module.
+
+// CHECK-LABEL: @noInnerModuleEx
+stream.executable private @noInnerModuleEx {
+  // CHECK: stream.executable.export public @dispatch workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index)
+  stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: index) -> (index, index, index) {
+    // CHECK: iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[ARG0]], %[[ARG1]])
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+    stream.return %x, %y, %z : index, index, index
+  }
+}
+// CHECK: util.func public @no_inner_module(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+util.func public @no_inner_module(%arg0: !hal.buffer_view, %arg1: index, %arg2: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %alloc = stream.resource.alloc uninitialized : !stream.resource<transient>{%c20}
+  %result_timepoint = stream.cmd.execute with(%alloc as %capture: !stream.resource<transient>{%c20}) {
+    // CHECK: stream.cmd.dispatch @noInnerModuleEx::@dispatch
+    // CHECK-SAME: [%[[ARG1]], %[[ARG1]]]
+    // CHECK-SAME: (%[[ARG1]], %[[ARG2]], %[[ARG2]] : index, index, index)
+    stream.cmd.dispatch @noInnerModuleEx::@dispatch[%arg1, %arg1](%arg1, %arg2, %arg2 : index, index, index) {
+      rw %capture[%c0 for %c20] : !stream.resource<transient>{%c20}
+    }
+  } => !stream.timepoint
+  util.return
+}
+
+// -----
+
 // Tests that duplicate primitive operands are folded if they are uniform at all
 // dispatch sites.
 //
@@ -90,6 +120,78 @@ util.func public @inlineConstantOperands(%a: i32) {
     }
     // CHECK: stream.cmd.dispatch {{.+}}(%[[A]], %true : i32, i1)
     stream.cmd.dispatch @inlineConstantOperandsEx::@dispatch[%c1, %c1, %c1](%a, %c20, %true : i32, index, i1) {
+      rw %capture[%c0 for %c20] : !stream.resource<transient>{%c20}
+    }
+  } => !stream.timepoint
+  util.return
+}
+
+// -----
+
+// Tests that duplicate workloads are folded if they are uniform at all dispatch sites.
+
+// CHECK-LABEL: @deduplicateWorkloadsEx
+stream.executable private @deduplicateWorkloadsEx {
+  // CHECK: stream.executable.export public @dispatch workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+  stream.executable.export public @dispatch workgroups(%arg0: index, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
+    // CHECK: iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[ARG0]], %[[ARG0]], %[[ARG1]], %[[ARG0]], %[[ARG2]])
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1, %arg2, %arg3, %arg4)
+    stream.return %x, %y, %z : index, index, index
+  }
+  builtin.module  {
+    // CHECK: util.func public @dispatch(%[[ARG0:.+]]: !stream.binding, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
+    util.func public @dispatch(%arg0: !stream.binding, %arg1: index, %arg2: index, %arg3: index) {
+      // CHECK-NEXT: util.optimization_barrier %[[ARG0]] : !stream.binding
+      util.optimization_barrier %arg0 : !stream.binding
+      // CHECK-NEXT: %[[ASSUME:.+]]:5 = util.assume.int
+      %0:5 = util.assume.int
+          %arg1<umin = 4, umax = 524160, udiv = 4>,
+          %arg1<umin = 4, umax = 524160, udiv = 4>,
+          %arg2<umin = 4, umax = 524160, udiv = 4>,
+          %arg1<umin = 4, umax = 524160, udiv = 4>,
+          %arg3<umin = 4, umax = 524160, udiv = 4>
+        : index, index, index, index, index
+      // CHECK: %[[ORDINAL0:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ASSUME]]#0, 0 : index
+      %1 = iree_tensor_ext.dispatch.workload.ordinal %0#0, 0 : index
+      // CHECK-NEXT: util.optimization_barrier %[[ORDINAL0]] : index
+      util.optimization_barrier %1 : index
+      // CHECK-NEXT: %[[ORDINAL1:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ASSUME]]#1, 0 : index
+      %2 = iree_tensor_ext.dispatch.workload.ordinal %0#1, 1 : index
+      // CHECK-NEXT: util.optimization_barrier %[[ORDINAL1]] : index
+      util.optimization_barrier %2 : index
+      // CHECK-NEXT: %[[ORDINAL2:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ASSUME]]#2, 1 : index
+      %3 = iree_tensor_ext.dispatch.workload.ordinal %0#2, 2 : index
+      // CHECK-NEXT: util.optimization_barrier %[[ORDINAL2]] : index
+      util.optimization_barrier %3 : index
+      // CHECK-NEXT: %[[ORDINAL3:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ASSUME]]#3, 0 : index
+      %4 = iree_tensor_ext.dispatch.workload.ordinal %0#3, 3 : index
+      // CHECK-NEXT: util.optimization_barrier %[[ORDINAL3]] : index
+      util.optimization_barrier %4 : index
+      // CHECK-NEXT: %[[ORDINAL4:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ASSUME]]#4, 2 : index
+      %5 = iree_tensor_ext.dispatch.workload.ordinal %0#4, 4 : index
+      // CHECK-NEXT: util.optimization_barrier %[[ORDINAL4]] : index
+      util.optimization_barrier %5 : index
+      util.return
+    }
+  }
+}
+// CHECK: util.func public @deduplicateWorkloads(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
+util.func public @deduplicateWorkloads(%arg0: !hal.buffer_view, %arg1: index, %arg2: index, %arg3: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %alloc = stream.resource.alloc uninitialized : !stream.resource<transient>{%c20}
+  %result_timepoint = stream.cmd.execute with(%alloc as %capture: !stream.resource<transient>{%c20}) {
+    // CHECK: stream.cmd.dispatch @deduplicateWorkloadsEx::@dispatch
+    // CHECK-SAME: [%[[ARG1]], %[[ARG1]], %[[ARG3]]]
+    // CHECK-SAME: (%[[ARG1]], %[[ARG2]], %[[ARG3]] : index, index, index)
+    stream.cmd.dispatch @deduplicateWorkloadsEx::@dispatch[%arg1, %arg1, %arg1, %arg1, %arg3](%arg1, %arg2, %arg3 : index, index, index) {
+      rw %capture[%c0 for %c20] : !stream.resource<transient>{%c20}
+    }
+    // CHECK: stream.cmd.dispatch @deduplicateWorkloadsEx::@dispatch
+    // CHECK-SAME: [%[[ARG1]], %[[ARG2]], %[[ARG3]]]
+    // CHECK-SAME: (%[[ARG1]], %[[ARG2]], %[[ARG3]] : index, index, index)
+    stream.cmd.dispatch @deduplicateWorkloadsEx::@dispatch[%arg1, %arg1, %arg2, %arg1, %arg3](%arg1, %arg2, %arg3 : index, index, index) {
       rw %capture[%c0 for %c20] : !stream.resource<transient>{%c20}
     }
   } => !stream.timepoint


### PR DESCRIPTION
Adds logic to deduplicate the dispatch workloads in the same way as the operands are already deduplicated. This allows codegen to use the information that two workloads are the same. This is for example useful in case of dynamic dimensions.