### PR TITLE
[DataTiling][GPU] Implement scaled matmul data tiling materialization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -4,7 +4,7 @@
 
 // Contains tests that differ from gfx942/MI-300
 
-//----------------------------------------------//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // 1. MFMA_I32_16x16x64_I8
 //-----------------------------------------------------------------------------
 
@@ -322,3 +322,358 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16() {
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
 // CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+
+// -----
+
+//-----------------------------------------------------------------------------
+// 1. Scaled MFMA
+//-----------------------------------------------------------------------------
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 0 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127x32xf4E2M1FN>) -> tensor<255x127x32xf4E2M1FN, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x127x32xf4E2M1FN> -> tensor<255x127x32xf4E2M1FN, #encoding>
+  return %0 : tensor<255x127x32xf4E2M1FN, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [0, 1, 2]
+// CHECK-SAME:      inner_tiles = [64, 16, 32]
+// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<4x8x1x64x16x32xf4E2M1FN>
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<4x8x1x64x16x32xf4E2M1FN> into tensor<4x8x1x4x16x4x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<4x8x1x4x4x4x16x32xf4E2M1FN>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<4x8x1x4x16x4x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x8x1x4x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 5, 6, 4, 7]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 1 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127x32xf4E2M1FN>) -> tensor<513x127x32xf4E2M1FN, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x127x32xf4E2M1FN> -> tensor<513x127x32xf4E2M1FN, #encoding>
+  return %0 : tensor<513x127x32xf4E2M1FN, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
+// CHECK-SAME:      outer_dims_perm = [0, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [0, 1, 2]
+// CHECK-SAME:      inner_tiles = [128, 16, 32]
+// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<5x8x1x128x16x32xf4E2M1FN>
+// CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<5x8x1x128x16x32xf4E2M1FN> into tensor<5x8x1x4x2x16x4x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<5x8x1x4x2x4x4x16x32xf4E2M1FN>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<5x8x1x4x2x16x4x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<5x8x1x4x2x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 4, 6, 7, 5, 8]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 2 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127xf8E8M0FNU>) -> tensor<255x127xf8E8M0FNU, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x127xf8E8M0FNU> -> tensor<255x127xf8E8M0FNU, #encoding>
+  return %0 : tensor<255x127xf8E8M0FNU, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
+// CHECK-SAME:      outer_dims_perm = [0, 1]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [64, 16]
+// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<4x8x64x16xf8E8M0FNU>
+// CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<4x8x64x16xf8E8M0FNU> into tensor<4x8x4x16x4x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<4x8x4x4x16x4xf8E8M0FNU>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<4x8x4x16x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x8x4x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 3 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127xf8E8M0FNU>) -> tensor<513x127xf8E8M0FNU, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<513x127xf8E8M0FNU> -> tensor<513x127xf8E8M0FNU, #encoding>
+  return %0 : tensor<513x127xf8E8M0FNU, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
+// CHECK-SAME:      outer_dims_perm = [0, 1]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [128, 16]
+// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<5x8x128x16xf8E8M0FNU>
+// CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<5x8x128x16xf8E8M0FNU> into tensor<5x8x4x2x16x4x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<5x8x4x2x4x16x4xf8E8M0FNU>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<5x8x4x2x16x4x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<5x8x4x2x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding = #iree_encoding.encoding<
+  operand_index = 4 : index, op_type = scaled_matmul,
+  element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32],
+  user_indexing_maps = [#map, #map1, #map2, #map3, #map4],
+  iteration_sizes = [255, 513, 127, 32]>
+
+func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x513xf32>) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
+}
+
+// CHECK-LABEL: func.func @set_encoding_ACC_scaled_matmul_f4_f4_f8_f8_f32(
+// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:      outer_dims_perm = [0, 1]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [64, 128]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<4x5x64x128xf32>
+// CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
+// CHECK-SAME:       : tensor<4x5x64x128xf32> into tensor<4x5x4x4x4x4x2x16xf32>
+// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<4x5x4x4x2x4x16x4xf32>
+// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<4x5x4x4x4x4x2x16xf32>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<4x5x4x4x2x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
+// CHECK:         return %[[TRANSPOSE]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
+    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x2x4x4x16x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x4x16x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
+// CHECK-SAME:    outs(%[[RESULT]])
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f8E4M3FN, f8E4M3FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
+    %arg0: tensor<?x?x32xf8E4M3FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf8E4M3FN, #encoding_lhs>, tensor<?x?x32xf8E4M3FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f8E4M3FN, %in_0: f8E4M3FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f8E4M3FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f8E4M3FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x4x2x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x4x16x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
+// CHECK-SAME:    outs(%[[RESULT]])
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_lhs_scales = #iree_encoding.encoding<operand_index = 2 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_rhs_scales = #iree_encoding.encoding<operand_index = 3 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+#encoding_result = #iree_encoding.encoding<operand_index = 4 : index, op_type = scaled_matmul, element_types = [f4E2M1FN, f4E2M1FN, f8E8M0FNU, f8E8M0FNU, f32], user_indexing_maps = [#map, #map1, #map2, #map3, #map4], iteration_sizes = [?, ?, ?, 32]>
+
+#executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree_codegen.target_info = #iree_gpu.target<
+    arch = "gfx950", features = "",
+    wgp = <compute = fp16, storage =  b16,
+           scaled_mma = [
+             <intrinsic = MFMA_SCALE_F32_32x32x64_B32,
+              lhs_elem_type = f4E2M1FN,
+              rhs_elem_type = f4E2M1FN,
+              acc_elem_type = f32>],
+           subgroup =  none, subgroup_size_choices = [64],
+           max_workgroup_sizes = [1024, 1024, 1024],
+           max_thread_count_per_workgroup = 1024,
+           max_workgroup_memory_bytes = 163840,
+           max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+           max_load_instruction_bits = 128,
+           simds_per_wgp = 4,
+           vgpr_space_bits = 16384>>,
+   iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>}>
+func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
+    %arg0: tensor<?x?x32xf4E2M1FN, #encoding_lhs>,
+    %arg1: tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+    %arg2: tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>,
+    %arg3: tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>,
+    %arg4: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result>
+    attributes { hal.executable.target = #executable_target } {
+  %0 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map3, #map4],
+      iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+      ins(%arg0, %arg1, %arg2, %arg3
+           : tensor<?x?x32xf4E2M1FN, #encoding_lhs>, tensor<?x?x32xf4E2M1FN, #encoding_rhs>,
+             tensor<?x?xf8E8M0FNU, #encoding_lhs_scales>, tensor<?x?xf8E8M0FNU, #encoding_rhs_scales>)
+      outs(%arg4 : tensor<?x?xf32, #encoding_result>) {
+  ^bb0(%in: f4E2M1FN, %in_0: f4E2M1FN, %in_1: f8E8M0FNU, %in_2: f8E8M0FNU, %out: f32):
+    %11 = arith.scaling_extf %in, %in_1 : f4E2M1FN, f8E8M0FNU to f32
+    %12 = arith.scaling_extf %in_0, %in_2 : f4E2M1FN, f8E8M0FNU to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<?x?xf32, #encoding_result>
+  return %0 : tensor<?x?xf32, #encoding_result>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+// CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x2x32x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x2x32x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x2x32x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x32x4xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x4x2x32x4xf32>
+// CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
+// CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
+// CHECK-SAME:    outs(%[[RESULT]])
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
+// CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 4>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
@@ -24,6 +24,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Encoding::Utils
+    iree::compiler::Dialect::LinalgExt::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -306,45 +308,137 @@ getExpandedTileShape(const TileSwizzle::ExpandShapeType &expandShape) {
   return result;
 }
 
-FailureOr<MaterializeEncodingInfo>
-getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK) {
-  MaterializeEncodingInfo encodingInfo;
-  FailureOr<linalg::ContractionDimensions> cDims =
-      Encoding::getEncodingContractionDims(encoding);
-  if (failed(cDims)) {
+/// Returns the EncodingContractionLikeDimInfo for an encoding with scaled
+/// contraction user_indexing_maps, or failure if the scaled contraction
+/// dimensions can not be inferred.
+static FailureOr<EncodingContractionLikeDimInfo>
+getScaledContractionLikeDimInfo(Encoding::EncodingAttr encoding) {
+  FailureOr<IREE::LinalgExt::ScaledContractionDimensions> maybeScaledCDims =
+      Encoding::getEncodingScaledContractionDims(encoding);
+  if (failed(maybeScaledCDims)) {
     return failure();
   }
-  // The following expects M, N, K, and Batch sizes of at most 1 for now
-  assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() == 1 &&
-         cDims->batch.size() <= 1 &&
+  IREE::LinalgExt::ScaledContractionDimensions scaledCDims =
+      maybeScaledCDims.value();
+  EncodingContractionLikeDimInfo dimInfo;
+  assert(scaledCDims.m.size() <= 1 && scaledCDims.n.size() <= 1 &&
+         scaledCDims.k.size() == 1 && scaledCDims.batch.size() <= 1 &&
+         scaledCDims.kB.size() == 1 &&
+         "Expected at most one M, N, K, Kb, and Batch dimension");
+  int64_t operandIdx = encoding.getOperandIndex().getInt();
+  bool isLhs = operandIdx == IREE::Encoding::SCALED_MATMUL_LHS;
+  bool isRhs = operandIdx == IREE::Encoding::SCALED_MATMUL_RHS;
+  bool isLhsScales = operandIdx == IREE::Encoding::SCALED_MATMUL_LHS_SCALES;
+  bool isRhsScales = operandIdx == IREE::Encoding::SCALED_MATMUL_RHS_SCALES;
+  bool isResult = operandIdx == IREE::Encoding::SCALED_MATMUL_RESULT;
+  if (!scaledCDims.batch.empty()) {
+    dimInfo.batchDim = {/*shouldHaveDim=*/true,
+                        encoding.mapDimToOperandIndex(scaledCDims.batch[0])};
+  }
+  if (!scaledCDims.m.empty()) {
+    dimInfo.mDim = {/*shouldHaveDim=*/isLhs || isResult,
+                    encoding.mapDimToOperandIndex(scaledCDims.m[0])};
+  }
+  if (!scaledCDims.n.empty()) {
+    dimInfo.nDim = {/*shouldHaveDim=*/isRhs || isResult,
+                    encoding.mapDimToOperandIndex(scaledCDims.n[0])};
+  }
+  dimInfo.kDim = {/*shouldHaveDim=*/isLhs || isRhs || isLhsScales ||
+                      isRhsScales,
+                  encoding.mapDimToOperandIndex(scaledCDims.k[0])};
+  dimInfo.kBDim = {/*shouldHaveDim=*/isLhs || isRhs,
+                   encoding.mapDimToOperandIndex(scaledCDims.kB[0])};
+  return dimInfo;
+}
+
+/// Returns the EncodingContractionLikeDimInfo for an encoding with contraction
+/// user_indexing_maps, or failure if the contraction dimensions can not be
+/// inferred.
+static FailureOr<EncodingContractionLikeDimInfo>
+getContractionLikeDimInfo(Encoding::EncodingAttr encoding) {
+  FailureOr<linalg::ContractionDimensions> maybeCDims =
+      Encoding::getEncodingContractionDims(encoding);
+  if (failed(maybeCDims)) {
+    return failure();
+  }
+  linalg::ContractionDimensions cDims = maybeCDims.value();
+  EncodingContractionLikeDimInfo dimInfo;
+  assert(cDims.m.size() <= 1 && cDims.n.size() <= 1 && cDims.k.size() == 1 &&
+         cDims.batch.size() <= 1 &&
          "Expected at most one M, N, K, and Batch dimension");
-  std::optional<unsigned> batchDim =
-      cDims->batch.empty() ? std::nullopt
-                           : encoding.mapDimToOperandIndex(cDims->batch[0]);
-  std::optional<unsigned> mDim =
-      cDims->m.empty() ? std::nullopt
-                       : encoding.mapDimToOperandIndex(cDims->m[0]);
-  std::optional<unsigned> nDim =
-      cDims->n.empty() ? std::nullopt
-                       : encoding.mapDimToOperandIndex(cDims->n[0]);
-  std::optional<unsigned> kDim = encoding.mapDimToOperandIndex(cDims->k[0]);
+  int64_t operandIdx = encoding.getOperandIndex().getInt();
+  bool isLhs = operandIdx == IREE::Encoding::MATMUL_LHS;
+  bool isRhs = operandIdx == IREE::Encoding::MATMUL_RHS;
+  bool isResult = operandIdx == IREE::Encoding::MATMUL_RESULT;
+  if (!cDims.batch.empty()) {
+    dimInfo.batchDim = {/*shouldHaveDim=*/true,
+                        encoding.mapDimToOperandIndex(cDims.batch[0])};
+  }
+  if (!cDims.m.empty()) {
+    dimInfo.mDim = {/*shouldHaveDim=*/isLhs || isResult,
+                    encoding.mapDimToOperandIndex(cDims.m[0])};
+  }
+  if (!cDims.n.empty()) {
+    dimInfo.nDim = {/*shouldHaveDim=*/isRhs || isResult,
+                    encoding.mapDimToOperandIndex(cDims.n[0])};
+  }
+  dimInfo.kDim = {/*shouldHaveDim=*/isLhs || isRhs,
+                  encoding.mapDimToOperandIndex(cDims.k[0])};
+  return dimInfo;
+}
+
+FailureOr<EncodingContractionLikeDimInfo>
+getEncodingContractionLikeDims(Encoding::EncodingAttr encoding) {
+  FailureOr<EncodingContractionLikeDimInfo> maybeDimInfo =
+      getContractionLikeDimInfo(encoding);
+  if (succeeded(maybeDimInfo)) {
+    return maybeDimInfo.value();
+  }
+  return getScaledContractionLikeDimInfo(encoding);
+}
+
+FailureOr<MaterializeEncodingInfo>
+getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK) {
+  return getEncodingInfoForMatmul(
+      encoding, TileMxNxKxKb{tileMxNxK.M, tileMxNxK.N, tileMxNxK.K});
+}
+
+FailureOr<MaterializeEncodingInfo>
+getEncodingInfoForMatmul(Encoding::EncodingAttr encoding,
+                         TileMxNxKxKb tileMxNxKxKb) {
+  FailureOr<EncodingContractionLikeDimInfo> maybeDimInfo =
+      getEncodingContractionLikeDims(encoding);
+  if (failed(maybeDimInfo)) {
+    return failure();
+  }
+  std::optional<unsigned> batchDim = maybeDimInfo->batchDim.operandIdx;
+  std::optional<unsigned> mDim = maybeDimInfo->mDim.operandIdx;
+  std::optional<unsigned> nDim = maybeDimInfo->nDim.operandIdx;
+  std::optional<unsigned> kDim = maybeDimInfo->kDim.operandIdx;
+  std::optional<unsigned> kBDim = maybeDimInfo->kBDim.operandIdx;
+  MaterializeEncodingInfo encodingInfo;
   if (batchDim.has_value()) {
     encodingInfo.outerDimsPerm.push_back(batchDim.value());
   }
   if (mDim.has_value()) {
     encodingInfo.outerDimsPerm.push_back(mDim.value());
     encodingInfo.innerDimsPos.push_back(mDim.value());
-    encodingInfo.innerTileSizes.push_back(tileMxNxK.M);
+    encodingInfo.innerTileSizes.push_back(tileMxNxKxKb.M);
   }
   if (nDim.has_value()) {
     encodingInfo.outerDimsPerm.push_back(nDim.value());
     encodingInfo.innerDimsPos.push_back(nDim.value());
-    encodingInfo.innerTileSizes.push_back(tileMxNxK.N);
+    encodingInfo.innerTileSizes.push_back(tileMxNxKxKb.N);
   }
   if (kDim.has_value()) {
     encodingInfo.outerDimsPerm.push_back(kDim.value());
     encodingInfo.innerDimsPos.push_back(kDim.value());
-    encodingInfo.innerTileSizes.push_back(tileMxNxK.K);
+    encodingInfo.innerTileSizes.push_back(tileMxNxKxKb.K);
+  }
+  if (kBDim.has_value()) {
+    encodingInfo.outerDimsPerm.push_back(kBDim.value());
+    encodingInfo.innerDimsPos.push_back(kBDim.value());
+    encodingInfo.innerTileSizes.push_back(tileMxNxKxKb.KB);
   }
   return encodingInfo;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -68,12 +68,46 @@ bool isIdentityLayout(const MaterializeEncodingInfo &info);
 SmallVector<int64_t>
 getExpandedTileShape(const TileSwizzle::ExpandShapeType &expandShape);
 
+/// The dimensions needed for materializing an encoding for either a contraction
+/// or a scaled contraction.
+struct EncodingContractionLikeDimInfo {
+  /// Info for each dimension. `shouldHaveDim` indicates whether or not the dim
+  /// is present on the root operation's operand, and `operandIdx` is the index
+  /// of the encoded tensor that belongs to the Dim. For example, the LHS
+  /// operand's encoding would have `mDim = {true, 0}` for a plain matmul, while
+  /// the RHS operand's encoding would have `mDim = {false, std::nullopt}`.
+  /// If `shouldHaveDim` is true, and `operandIdx` is std::nullopt, this
+  /// indicates that the encoded Value may be the source of a broadcast, and the
+  /// Dim is not present on the Value, but it is present on the corresponding
+  /// operand of the encoding root operation.
+  struct DimInfo {
+    bool shouldHaveDim = false;
+    std::optional<unsigned> operandIdx;
+  };
+  DimInfo batchDim;
+  DimInfo mDim;
+  DimInfo nDim;
+  DimInfo kDim;
+  DimInfo kBDim;
+};
+
+/// Returns the dimension info needed for materializing an encoding for either a
+/// contraction or a scaled contraction. This function expects at most one each
+/// of M, N, K, Kb, and Batch dimensions, since multiple contraction dimensions
+/// are currently not supported in data tiling.
+FailureOr<EncodingContractionLikeDimInfo>
+getEncodingContractionLikeDims(Encoding::EncodingAttr encoding);
+
 struct TileMxNxKxKb {
   int64_t M = 1;
   int64_t N = 1;
   int64_t K = 1;
   int64_t KB = 1;
 };
+
+FailureOr<MaterializeEncodingInfo>
+getEncodingInfoForMatmul(Encoding::EncodingAttr encoding,
+                         TileMxNxKxKb tileMxNxKxKb);
 
 struct TileMxNxK {
   int64_t M = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -34,7 +34,7 @@ Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
 FailureOr<Codegen::TileSwizzle>
 getEncodingSwizzle(IREE::Encoding::EncodingAttr encoding,
                    IREE::GPU::DataTiledMMAInterfaceAttr mma,
-                   IREE::GPU::MMAFragment fragment);
+                   unsigned operandIndex);
 
 } // namespace mlir::iree_compiler::IREE::GPU
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Encoding::Utils
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -40,6 +40,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
@@ -54,9 +55,30 @@
 namespace mlir::iree_compiler::IREE::GPU {
 
 using IREE::Codegen::MaterializeEncodingInfo;
-using IREE::Codegen::TileMxNxK;
+using IREE::Codegen::TileMxNxKxKb;
 
 namespace {
+
+/// Chooses a ScaledMMAAttr that supports the given element types. Currently
+/// just selects the first ScaledMMAAttr that is compatible with the given
+/// element types.
+/// TODO(#21923): This is a placeholder for now. We want a better heuristic
+/// in the future.
+static ScaledMMAAttr chooseScaledIntrinsicMMAAttr(TypeRange eTypes,
+                                                  TargetWgpAttr wgp) {
+  ScaledMMAAttr candidateMma;
+  for (ScaledMMAAttr mma : wgp.getScaledMma()) {
+    // Filter out intrinsics that don't match the element types of this matmul.
+    if (mma.getLhsElemType() != eTypes[0] ||
+        mma.getRhsElemType() != eTypes[1] ||
+        mma.getAccElemType() != eTypes[4]) {
+      continue;
+    }
+    candidateMma = mma;
+    break;
+  }
+  return candidateMma;
+}
 
 static MMAAttr chooseIntrinsicMMAAttr(TypeRange eTypes, TargetWgpAttr wgp) {
   MMAAttr candidateMma;
@@ -111,10 +133,56 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   }
 
   //
-  // Step 1: select a MMAIntrinsic.
+  // Step 1: select a MMAIntrinsic and compute the LHS and RHS vector sizes.
   //
-  MMAAttr intrinsicMma = chooseIntrinsicMMAAttr(eTypes, wgp);
-  if (!intrinsicMma) {
+  auto sizeInBits = [](VectorType type) -> int {
+    return type.getElementTypeBitWidth() * type.getNumElements();
+  };
+  int64_t intrinsicSizeBitsLHS = 0;
+  int64_t intrinsicSizeBitsRHS = 0;
+  int64_t intrinsicSizeBitsACC = 0;
+  int64_t intrinsicMSize = 0;
+  int64_t intrinsicNSize = 0;
+  Attribute intrinsicAttr;
+  switch (encoding.getOpType().getValue()) {
+  case IREE::Encoding::EncodingOpType::matmul: {
+    MMAAttr intrinsicMma = chooseIntrinsicMMAAttr(eTypes, wgp);
+    if (!intrinsicMma) {
+      return {};
+    }
+    auto [intrinsicA, intrinsicB, intrinsicC] =
+        intrinsicMma.getABCVectorTypes();
+    intrinsicSizeBitsLHS = sizeInBits(intrinsicA);
+    intrinsicSizeBitsRHS = sizeInBits(intrinsicB);
+    intrinsicSizeBitsACC = sizeInBits(intrinsicC);
+    intrinsicMSize = getMSize(intrinsicMma.getIntrinsic());
+    intrinsicNSize = getNSize(intrinsicMma.getIntrinsic());
+    intrinsicAttr = intrinsicMma;
+    break;
+  }
+  case IREE::Encoding::EncodingOpType::scaled_matmul: {
+    ScaledMMAAttr intrinsicScaledMma =
+        chooseScaledIntrinsicMMAAttr(eTypes, wgp);
+    if (!intrinsicScaledMma) {
+      return {};
+    }
+    SmallVector<VectorType> vectorTypes;
+    intrinsicScaledMma.getDistributedTileTypes(vectorTypes);
+    // For scaled_matmul, the size of the LHS scales and RHS scales are added
+    // to the total LHS and RHS sizes, because we use these sizes to select the
+    // unrolling factors for M, N, and K, which affect both the input and the
+    // scale operands.
+    intrinsicSizeBitsLHS =
+        sizeInBits(vectorTypes[0]) + sizeInBits(vectorTypes[1]);
+    intrinsicSizeBitsRHS =
+        sizeInBits(vectorTypes[2]) + sizeInBits(vectorTypes[3]);
+    intrinsicSizeBitsACC = sizeInBits(vectorTypes[4]);
+    intrinsicMSize = getMSize(intrinsicScaledMma.getIntrinsic());
+    intrinsicNSize = getNSize(intrinsicScaledMma.getIntrinsic());
+    intrinsicAttr = intrinsicScaledMma;
+    break;
+  }
+  default:
     return {};
   }
 
@@ -122,20 +190,25 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   // Step 2: Select the unrolling factors for the generic case where there is no
   //         narrow dimension.
   //
-
-  auto sizeInBits = [](VectorType type) -> int {
-    return type.getElementTypeBitWidth() * type.getNumElements();
-  };
-
-  auto [intrinsicA, intrinsicB, intrinsicC] = intrinsicMma.getABCVectorTypes();
   // The intrinsicsK factor serves to allow loads from the A and B matrices to
   // use the target ISA's vector loads. For instance, if the ISA has 128-bit
   // loads and each intrinsic consumes only 32 bits from A and B, then we want
   // to set intrinsicsK=4 to turn 4 separate 32-bit loads into one 128-bit load.
-  int intrinsicLoadBits =
-      std::min(sizeInBits(intrinsicA), sizeInBits(intrinsicB));
-  const int intrinsicsK =
+  int intrinsicLoadBits = std::min(intrinsicSizeBitsLHS, intrinsicSizeBitsRHS);
+  int intrinsicsK =
       std::max(1, *wgp.getMaxLoadInstructionBits() / intrinsicLoadBits);
+
+  // For scaled intrinsics, there is another reason to unroll K. Scales are held
+  // in a vector of multiple scales, but only a single scale is used for each
+  // instruction. We want to be able to load a contiguous vector of scales into
+  // registers, and use the same vector for consecutive instructions. Choose the
+  // LCM of the scales vector size unrolling factor, and the load bitwidth
+  // unrolling factor, so both are satisfied.
+  // * Note that typically, the load bitwidth unrolling factor will be 1, so the
+  // total K unrolling factor will just be the scales vector size.
+  if (auto scaledMmaAttr = dyn_cast<ScaledMMAAttr>(intrinsicAttr)) {
+    intrinsicsK = std::lcm(intrinsicsK, scaledMmaAttr.getScalesVectorSize());
+  }
 
   // The total amount of unrolling along the M and N dimensions is normally
   // limited only by the number of available registers, since larger M and N
@@ -162,8 +235,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   //       x^2 * sizeInBits(intrinsicC)
   //     + x   * intrinsicsK * (sizeInBits(intrinsicA) + sizeInBits(intrinsicB))
   //    == wgp.getVgprSpaceBits()
-  float c2 = sizeInBits(intrinsicC);
-  float c1 = intrinsicsK * (sizeInBits(intrinsicA) + sizeInBits(intrinsicB));
+  float c2 = intrinsicSizeBitsACC;
+  float c1 = intrinsicsK * (intrinsicSizeBitsLHS + intrinsicSizeBitsRHS);
   float c0 = -*wgp.getVgprSpaceBits(); // negative by construction.
   // Now the equation to solve is: c2 * x^2 + c1 * x + c0 == 0.
   float discriminant = c1 * c1 - 4 * c0 * c2; // positive, because c0 < 0.
@@ -227,30 +300,33 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   IREE::Encoding::MatmulNarrowDim narrowDim =
       IREE::Encoding::getPo2MatmulNarrowDim(encoding);
   if (narrowDim.isM()) {
-    intrinsicsM =
-        std::min(intrinsicsM,
-                 static_cast<int>(llvm::divideCeil(
-                     narrowDim.size, getMSize(intrinsicMma.getIntrinsic()))));
+    intrinsicsM = std::min(intrinsicsM, static_cast<int>(llvm::divideCeil(
+                                            narrowDim.size, intrinsicMSize)));
   }
   if (narrowDim.isN()) {
     std::swap(intrinsicsM, intrinsicsN);
     std::swap(subgroupsM, subgroupsN);
     assert(subgroupsN == 1);
-    intrinsicsN =
-        std::min(intrinsicsN,
-                 static_cast<int>(llvm::divideCeil(
-                     narrowDim.size, getNSize(intrinsicMma.getIntrinsic()))));
+    intrinsicsN = std::min(intrinsicsN, static_cast<int>(llvm::divideCeil(
+                                            narrowDim.size, intrinsicNSize)));
   }
 
-  return DataTiledMMAAttr::get(ctx, intrinsicMma.getIntrinsic(), intrinsicsM,
-                               subgroupsM, intrinsicsN, subgroupsN,
-                               intrinsicsK);
+  if (auto intrinsicMma = dyn_cast<MMAAttr>(intrinsicAttr)) {
+    return DataTiledMMAAttr::get(ctx, intrinsicMma.getIntrinsic(), intrinsicsM,
+                                 subgroupsM, intrinsicsN, subgroupsN,
+                                 intrinsicsK);
+  }
+  auto intrinsicScaledMma = cast<ScaledMMAAttr>(intrinsicAttr);
+  return DataTiledScaledMMAAttr::get(
+      ctx, intrinsicScaledMma.getIntrinsic(),
+      intrinsicScaledMma.getLhsElemType(), intrinsicScaledMma.getRhsElemType(),
+      intrinsicScaledMma.getAccElemType(), intrinsicsM, subgroupsM, intrinsicsN,
+      subgroupsN, intrinsicsK);
 }
 
-static Operation *
-lowerContractionOpToMultiMmaOp(OpBuilder &builder, linalg::LinalgOp linalgOp,
-                               ValueRange operands,
-                               GPUEncodingResolverAttr resolver) {
+static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(
+    OpBuilder &builder, linalg::LinalgOp linalgOp, ValueRange operands,
+    GPUEncodingResolverAttr resolver) {
   IREE::GPU::TargetAttr targetAttr =
       getGPUTargetAttr(resolver.getConfiguration());
   if (!targetAttr) {
@@ -259,35 +335,57 @@ lowerContractionOpToMultiMmaOp(OpBuilder &builder, linalg::LinalgOp linalgOp,
   if (!linalgOp.hasPureTensorSemantics()) {
     return nullptr;
   }
-  if (!linalg::isaContractionOpInterface(linalgOp)) {
-    return nullptr;
-  }
-  FailureOr<linalg::ContractionDimensions> contractionDims =
-      linalg::inferContractionDims(linalgOp);
-  if (failed(contractionDims)) {
+  if (!linalg::isaContractionOpInterface(linalgOp) &&
+      !IREE::LinalgExt::isaScaledContractionOpInterface(linalgOp)) {
     return nullptr;
   }
 
-  auto inputs = linalgOp.getDpsInputOperands();
-  auto outputs = linalgOp.getDpsInits();
+  SmallVector<Value> inputs = linalgOp.getDpsInputs();
+  SmallVector<Value> outputs = linalgOp.getDpsInits();
 
-  auto lhsType = cast<RankedTensorType>(inputs[0]->get().getType());
-  auto rhsType = cast<RankedTensorType>(inputs[1]->get().getType());
-  auto resultType = cast<RankedTensorType>(outputs[0].getType());
-  auto lhsEncoding = IREE::Encoding::getEncodingAttr(lhsType);
-  auto rhsEncoding = IREE::Encoding::getEncodingAttr(rhsType);
-  auto resultEncoding = IREE::Encoding::getEncodingAttr(resultType);
-  if (!lhsEncoding || !rhsEncoding || !resultEncoding) {
+  SmallVector<IREE::Encoding::EncodingAttr> operandEncodings;
+  // Return false if the operand has no encoding.
+  auto appendEncodingIfPresent = [&](Value operand) -> bool {
+    auto type = cast<RankedTensorType>(operand.getType());
+    auto encoding = IREE::Encoding::getEncodingAttr(type);
+    if (!encoding) {
+      return false;
+    }
+    operandEncodings.push_back(encoding);
+    return true;
+  };
+  if (!llvm::all_of(llvm::concat<Value>(inputs, outputs),
+                    appendEncodingIfPresent)) {
     return nullptr;
   }
 
-  if (lhsEncoding.getOperandIndex().getValue() != IREE::Encoding::MATMUL_LHS ||
-      rhsEncoding.getOperandIndex().getValue() != IREE::Encoding::MATMUL_RHS ||
-      resultEncoding.getOperandIndex().getValue() !=
-          IREE::Encoding::MATMUL_RESULT) {
+  auto checkEncodingIndex = [&](int64_t idx, int64_t expectedIdx) -> bool {
+    return operandEncodings[idx].getOperandIndex().getInt() == expectedIdx;
+  };
+  switch (operandEncodings[0].getOpType().getValue()) {
+  case IREE::Encoding::EncodingOpType::matmul: {
+    if (!checkEncodingIndex(0, IREE::Encoding::MATMUL_LHS) ||
+        !checkEncodingIndex(1, IREE::Encoding::MATMUL_RHS) ||
+        !checkEncodingIndex(2, IREE::Encoding::MATMUL_RESULT)) {
+      return nullptr;
+    }
+    break;
+  }
+  case IREE::Encoding::EncodingOpType::scaled_matmul: {
+    if (!checkEncodingIndex(0, IREE::Encoding::SCALED_MATMUL_LHS) ||
+        !checkEncodingIndex(1, IREE::Encoding::SCALED_MATMUL_RHS) ||
+        !checkEncodingIndex(2, IREE::Encoding::SCALED_MATMUL_LHS_SCALES) ||
+        !checkEncodingIndex(3, IREE::Encoding::SCALED_MATMUL_RHS_SCALES) ||
+        !checkEncodingIndex(4, IREE::Encoding::SCALED_MATMUL_RESULT)) {
+      return nullptr;
+    }
+    break;
+  }
+  default:
     return nullptr;
   }
 
+  IREE::Encoding::EncodingAttr resultEncoding = operandEncodings.back();
   IREE::GPU::DataTiledMMAInterfaceAttr dataTiledAttr =
       chooseDataTiledMMAAttr(resultEncoding.getElementTypesArray(), targetAttr,
                              resultEncoding, resolver);
@@ -297,37 +395,65 @@ lowerContractionOpToMultiMmaOp(OpBuilder &builder, linalg::LinalgOp linalgOp,
   }
 
   SmallVector<AffineExpr> lhsExprs, rhsExprs, accExprs;
-  int baseIdx = contractionDims->batch.empty() ? 0 : 1;
-  if (baseIdx) {
-    AffineExpr bExpr = builder.getAffineDimExpr(0);
+  Codegen::EncodingContractionLikeDimInfo cDimInfo =
+      Codegen::getEncodingContractionLikeDims(resultEncoding).value();
+  int numDims = 0;
+  AffineExpr bExpr = builder.getAffineDimExpr(numDims);
+  if (cDimInfo.batchDim.operandIdx.has_value()) {
     lhsExprs.push_back(bExpr);
     rhsExprs.push_back(bExpr);
     accExprs.push_back(bExpr);
+    ++numDims;
   }
-  AffineExpr mExpr = builder.getAffineDimExpr(baseIdx + 0);
-  AffineExpr nExpr = builder.getAffineDimExpr(baseIdx + 1);
-  AffineExpr kExpr = builder.getAffineDimExpr(baseIdx + 2);
+  AffineExpr mExpr = builder.getAffineDimExpr(numDims++);
+  AffineExpr nExpr = builder.getAffineDimExpr(numDims++);
+  AffineExpr kExpr = builder.getAffineDimExpr(numDims++);
 
   // The outer dims are all in row-major order after relayout.
   lhsExprs.append({mExpr, kExpr});
   rhsExprs.append({nExpr, kExpr});
   accExprs.append({mExpr, nExpr});
-  int64_t numDims = baseIdx + 3;
+  SmallVector<AffineMap> indexingMaps;
   MLIRContext *ctx = builder.getContext();
-  auto lhsMap = AffineMap::get(numDims, 0, lhsExprs, ctx);
-  auto rhsMap = AffineMap::get(numDims, 0, rhsExprs, ctx);
-  auto accMap = AffineMap::get(numDims, 0, accExprs, ctx);
-
+  Location loc = linalgOp.getLoc();
   SmallVector<utils::IteratorType> iteratorTypes =
       linalgOp.getIteratorTypesArray();
-
-  Location loc = linalgOp.getLoc();
-  Operation *mmaOp = Codegen::InnerTiledOp::create(
-      builder, loc, operands.take_front(inputs.size()),
-      operands.take_back(outputs.size()),
-      ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes,
-      cast<IREE::GPU::DataTiledMMAAttr>(dataTiledAttr));
-  return mmaOp;
+  switch (resultEncoding.getOpType().getValue()) {
+  case IREE::Encoding::EncodingOpType::matmul: {
+    indexingMaps.push_back(AffineMap::get(numDims, 0, lhsExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, rhsExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, accExprs, ctx));
+    return Codegen::InnerTiledOp::create(
+        builder, loc, operands.take_front(inputs.size()),
+        operands.take_back(outputs.size()), indexingMaps, iteratorTypes,
+        cast<IREE::GPU::DataTiledMMAAttr>(dataTiledAttr));
+  }
+  case IREE::Encoding::EncodingOpType::scaled_matmul: {
+    SmallVector<AffineExpr> lhsScalesExprs, rhsScalesExprs;
+    if (cDimInfo.batchDim.operandIdx.has_value()) {
+      lhsScalesExprs.push_back(bExpr);
+      rhsScalesExprs.push_back(bExpr);
+    }
+    AffineExpr kbExpr = builder.getAffineDimExpr(numDims++);
+    lhsExprs.append({kbExpr});
+    rhsExprs.append({kbExpr});
+    lhsScalesExprs.append({mExpr, kExpr});
+    rhsScalesExprs.append({nExpr, kExpr});
+    indexingMaps.push_back(AffineMap::get(numDims, 0, lhsExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, rhsExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, lhsScalesExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, rhsScalesExprs, ctx));
+    indexingMaps.push_back(AffineMap::get(numDims, 0, accExprs, ctx));
+    return Codegen::InnerTiledOp::create(
+        builder, loc, operands.take_front(inputs.size()),
+        operands.take_back(outputs.size()), indexingMaps, iteratorTypes,
+        cast<IREE::GPU::DataTiledScaledMMAAttr>(dataTiledAttr));
+  }
+  default: {
+    assert(false && "unexpected encoding op type");
+    return nullptr;
+  }
+  }
 }
 
 struct GPUEncodingPackedLayoutMaterializerAttr
@@ -361,23 +487,17 @@ struct GPUEncodingPackedLayoutMaterializerAttr
       return info;
     }
 
-    // Map the matmul TileMxNxK to an actual tile shape for the tensor at hand,
-    // based on its operand index in the matmul.
-    Codegen::TileMxNxKxKb innerTileScaled = mma.getTileMNKKb();
-    TileMxNxK innerTile;
-    innerTile.M = innerTileScaled.M;
-    innerTile.N = innerTileScaled.N;
-    innerTile.K = innerTileScaled.K;
+    // Map the matmul TileMxNxKxKb to an actual tile shape for the tensor at
+    // hand, based on its operand index in the matmul.
+    TileMxNxKxKb innerTile = mma.getTileMNKKb();
     FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
         getEncodingInfoForMatmul(encoding, innerTile);
     if (failed(maybeEncodingInfo)) {
       return info;
     }
     info = std::move(maybeEncodingInfo.value());
-    auto fragment = static_cast<IREE::GPU::MMAFragment>(
-        encoding.getOperandIndex().getInt());
     FailureOr<IREE::Codegen::TileSwizzle> maybeSwizzle =
-        getEncodingSwizzle(encoding, mma, fragment);
+        getEncodingSwizzle(encoding, mma, encoding.getOperandIndex().getInt());
     if (failed(maybeSwizzle)) {
       return info;
     }
@@ -397,8 +517,8 @@ struct GPUEncodingResolverMaterializerAttr
     if (!linalgOp) {
       return nullptr;
     }
-    return lowerContractionOpToMultiMmaOp(b, linalgOp, convertedOperands,
-                                          resolverAttr);
+    return lowerContractionOrScaledContractionOpToInnerTiledOp(
+        b, linalgOp, convertedOperands, resolverAttr);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -135,7 +135,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   //
   // Step 1: select a MMAIntrinsic and compute the LHS and RHS vector sizes.
   //
-  auto sizeInBits = [](VectorType type) -> int {
+  auto sizeInBits = [](VectorType type) -> int64_t {
     return type.getElementTypeBitWidth() * type.getNumElements();
   };
   int64_t intrinsicSizeBitsLHS = 0;

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/BUILD.bazel
@@ -24,6 +24,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgUtils
     iree::compiler::Dialect::Encoding::IR
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Util::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/IR/AffineMap.h"
@@ -37,6 +38,20 @@ getEncodingContractionDims(EncodingAttr encoding) {
   // originally encoded operation.
   SmallVector<AffineMap> indexingMaps = encoding.getRootMaps();
   return linalg::inferContractionDims(indexingMaps);
+}
+
+FailureOr<IREE::LinalgExt::ScaledContractionDimensions>
+getEncodingScaledContractionDims(EncodingAttr encoding) {
+  ArrayAttr indexingMapsAttr = encoding.getUserIndexingMaps();
+  if (!indexingMapsAttr) {
+    return failure();
+  }
+  // Derive the contraction dims from the first maps in every entry of the
+  // `user_indexing_maps` as these contain the layout information about the
+  // originally encoded operation.
+  SmallVector<AffineMap> indexingMaps = encoding.getRootMaps();
+  return IREE::LinalgExt::inferScaledContractionDims(
+      ArrayRef<AffineMap>(indexingMaps));
 }
 
 MatmulNarrowDim getPo2MatmulNarrowDim(EncodingAttr encoding) {

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -12,6 +12,10 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
+namespace mlir::iree_compiler::IREE::LinalgExt {
+class ScaledContractionDimensions;
+} // namespace mlir::iree_compiler::IREE::LinalgExt
+
 namespace mlir::iree_compiler::IREE::Encoding {
 
 constexpr char kDataTilingHint[] = "iree.opt.data_tiling";
@@ -46,6 +50,10 @@ bool hasPackedStorageAttr(RankedTensorType type);
 /// Returns the ContractionDimensions for the encoding user_indexing_maps.
 FailureOr<linalg::ContractionDimensions>
 getEncodingContractionDims(EncodingAttr encoding);
+
+/// Returns the ScaledContractionDimensions for the encoding user_indexing_maps.
+FailureOr<IREE::LinalgExt::ScaledContractionDimensions>
+getEncodingScaledContractionDims(EncodingAttr encoding);
 
 /// Returns the narrow dim in a given `encoding`, ceiled to a power of two. This
 /// works by inspecting the `iteration_sizes` array attribute in the `encoding`.


### PR DESCRIPTION
Implements materialization for scaled matmuls with data tiling encodings into an iree_codegen.inner_tiled op and/or pack + tile swizzle layout transformations. The logic for selecting the data tiling layout follows the existing logic for non-scaled matmul, with some small differences to account for the scaled operands and using the new `iree_gpu.data_tiled_scaled_mma_layout` attribute.

This PR does not yet enable the `iree-dispatch-creation-test-set-scaled-matmul-encodings` flag, because there are codegen issues with layout transformations that need to be resolved.