### PR TITLE
[E2E-Matmul] Remove redundant flag from scaled matmul e2e test

### DIFF
--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1783,7 +1783,6 @@ iree_generated_e2e_runner_test(
     --iree-opt-data-tiling=false
     --iree-dispatch-creation-data-tiling=true
     --iree-hip-encoding-layout-resolver=data-tiling
-    --iree-llvmgpu-test-combine-layout-transformation=true
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1780,7 +1780,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-    --iree-opt-data-tiling=false
     --iree-dispatch-creation-data-tiling=true
     --iree-hip-encoding-layout-resolver=data-tiling
   LABELS


### PR DESCRIPTION
Removes the `--iree-llvmgpu-test-combine-layout-transformation=true` and `--iree-opt-data-tiling=false` flags from the data tiled scaled matmul e2e tests, since they are already set by default.