### PR TITLE
[Codegen][AMDGPU] Enable gpu.printf patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -346,8 +346,10 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
+      // We pass Runtime::HIP in order to enable gpu.printf for debugging.
+      // At time of writing, that flag has no other effect.
       populateGpuToROCDLConversionPatterns(
-          converter, llvmPatterns, gpu::amd::Runtime::Unknown, *maybeChipset);
+          converter, llvmPatterns, gpu::amd::Runtime::HIP, *maybeChipset);
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);


### PR DESCRIPTION
Now that upstream PR https://github.com/llvm-project/llvm/pull/161266 has landed, the gpu.printf lowerings are no longer restricted to a gpu.module. Therefore, we can use them as-is in IREE for debugging purposes, since the declarations will land in the nearest symbol table
- in our case, the module being loaded.

(There's currently no test to keep this functionality working since it's not clear how to add one - we'll rely on the upstream regression tests here, but I have tested it.)