### PR TITLE
[codegen][gpu] GPUApplyPaddingLevel: fold case where no padding

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -219,6 +219,7 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
   }
 
   TilingInterface paddedOp = *maybePaddedOp;
+  Location loc = paddedOp.getLoc();
 
   if (auto paddedLinalgOp =
           dyn_cast<linalg::LinalgOp>(paddedOp.getOperation())) {
@@ -250,7 +251,7 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
              "obtained with confirmation earlier");
       for (auto &&dimInfo : reductionDimInfo.value()) {
         Value redDimSize = rewriter.createOrFold<tensor::DimOp>(
-            paddedOp.getLoc(), dimInfo.operand, dimInfo.operandDim);
+            loc, dimInfo.operand, dimInfo.operandDim);
         reductionDimSizes.push_back({dimInfo.loopIndex, redDimSize});
       }
 
@@ -265,25 +266,22 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
         // and directly optimize for this case.
         int64_t lhs = paddedLoopRanges[dimension];
         std::optional<int64_t> rhs = getConstantIntValue(unpaddedSize);
-        if (lhs != ShapedType::kDynamic && rhs.has_value() && lhs <= rhs) {
-          cond = arith::ConstantOp::create(rewriter, paddedOp.getLoc(),
+        if (lhs != ShapedType::kDynamic && lhs <= rhs) {
+          cond = arith::ConstantOp::create(rewriter, loc,
                                            rewriter.getBoolAttr(true));
         } else {
-          Value redDimIndex =
-              linalg::IndexOp::create(rewriter, paddedOp.getLoc(), dimension);
-          cond = arith::CmpIOp::create(rewriter, paddedOp.getLoc(),
-                                       arith::CmpIPredicate::ult, redDimIndex,
-                                       unpaddedSize);
+          Value redDimIndex = linalg::IndexOp::create(rewriter, loc, dimension);
+          cond = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult,
+                                       redDimIndex, unpaddedSize);
         }
         conds.push_back(cond);
       }
-      Value reductionIdentityValue = arith::ConstantOp::create(
-          rewriter, paddedOp.getLoc(), reductionIdentity.value());
+      Value reductionIdentityValue =
+          arith::ConstantOp::create(rewriter, loc, reductionIdentity.value());
       assert(conds.size() > 0);
       Value cond = conds[0];
       for (Value nxtCond : llvm::drop_begin(conds, 1)) {
-        cond =
-            arith::AndIOp::create(rewriter, paddedOp.getLoc(), cond, nxtCond);
+        cond = arith::AndIOp::create(rewriter, loc, cond, nxtCond);
       }
 
       // Find the reduction op operand that is reduced with the carried output.
@@ -296,8 +294,8 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
       Value uncarried = reduction->getOperand(uncarryIndex);
 
       // Select the reduction identity value if in the padding region.
-      Value selected = arith::SelectOp::create(
-          rewriter, paddedOp.getLoc(), cond, uncarried, reductionIdentityValue);
+      Value selected = arith::SelectOp::create(rewriter, loc, cond, uncarried,
+                                               reductionIdentityValue);
       IRMapping mapping;
       mapping.map(reduction->getOperand(uncarryIndex), selected);
       Operation *redClone = rewriter.clone(*reduction, mapping);
@@ -318,16 +316,15 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
     int64_t rank = tensorTy.getRank();
     SmallVector<OpFoldResult> sizes(rank, OpFoldResult());
     for (int64_t i = 0; i < rank; ++i) {
-      sizes[i] = rewriter.createOrFold<tensor::DimOp>(paddedOp->getLoc(),
-                                                      padOp.getResult(), i);
+      sizes[i] =
+          rewriter.createOrFold<tensor::DimOp>(loc, padOp.getResult(), i);
       if (auto v = dyn_cast<Value>(sizes[i]))
         sizes[i] = getAsOpFoldResult(v);
     }
 
-    Value out = tensor::EmptyOp::create(rewriter, paddedOp.getLoc(), sizes,
+    Value out = tensor::EmptyOp::create(rewriter, loc, sizes,
                                         getElementTypeOrSelf(tensorTy));
-    auto copied = linalg::CopyOp::create(rewriter, paddedOp.getLoc(),
-                                         padOp.getResult(), out);
+    auto copied = linalg::CopyOp::create(rewriter, loc, padOp.getResult(), out);
     rewriter.replaceUsesWithIf(padOp.getResult(), copied.getResult(0),
                                [&](OpOperand &opOperand) {
                                  return users.contains(opOperand.getOwner());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -41,12 +41,10 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 //    CHECK-SAME:      translation_info = #[[TRANSLATION_INFO]]
 //     CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x4xf32>
 //     CHECK-DAG:    %[[TID:.+]] = gpu.thread_id  x
-//     CHECK-DAG:    arith.constant dense<[0, 1, 2, 3]> : vector<4xindex>
 //         CHECK:    %[[R0:.+]] = scf.for %{{.*}} = %c0 to %c10240 step %c1024 iter_args(%[[A0:.+]] = %[[CST]]) -> (vector<1x1x4xf32>) {
 //         CHECK:      %[[V:.+]] = vector.transfer_read {{.*}} : memref<512x10240xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //         CHECK:      %[[STRIDED:.+]] = vector.insert_strided_slice %[[V]], {{.*}} : vector<4xf32> into vector<1x1x4xf32>
-//         CHECK:      %[[PADSELECTION:.+]] = arith.select %{{.*}}, %[[STRIDED]], %[[CST]] : vector<1x1x4xi1>, vector<1x1x4xf32>
-//         CHECK:      %[[ADD:.+]] = arith.addf %[[PADSELECTION]], %[[A0]] : vector<1x1x4xf32>
+//         CHECK:      %[[ADD:.+]] = arith.addf %[[STRIDED]], %[[A0]] : vector<1x1x4xf32>
 //         CHECK:      scf.yield %[[ADD]] : vector<1x1x4xf32>
 //         CHECK:    }
 //         CHECK:    gpu.subgroup_reduce  add {{.*}} cluster(size = 32) : (f32) -> f32


### PR DESCRIPTION
This is a 'direct' approach alternative to the upstream PR https://github.com/llvm/llvm-project/pull/161615. 

It directly folds the case where the linalg.index is known to always be less than the unpadded dimension size. This happens when `partial_reduction` perfectly divides the reduction dimension. 

The upstream approach (see link above) folds at a later stage, where after vectorization there is a vector.step compared to a constant. 