### PR TITLE
[Codegen] Add transform op for matching convolution ops

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -742,3 +742,203 @@ module attributes {transform.with_named_sequence} {
     transform.yield
  }
 }
+
+// -----
+
+// Verify that the basic convolution matcher works.
+
+#map_nhwc_hwcf_input = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map_nhwc_hwcf_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map_nhwc_hwcf_output = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#map_nchw_fchw_input = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>
+#map_nchw_fchw_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+#map_nchw_fchw_output = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+// CHECK-LABEL: func.func @conv_ops
+func.func @conv_ops(
+    %input_nhwc: tensor<2x34x34x64xf32>,
+    %filter_nhwc: tensor<3x3x64x128xf32>,
+    %output_nhwc: tensor<2x32x32x128xf32>,
+    %input_nchw: tensor<4x32x112x112xf16>,
+    %filter_nchw: tensor<64x32x7x7xf16>,
+    %output_nchw: tensor<4x64x106x106xf16>,
+    %input_mm: tensor<32x64xf32>,
+    %filter_mm: tensor<64x32xf32>,
+    %output_mm: tensor<32x32xf32>) -> (tensor<2x32x32x128xf32>, tensor<4x64x106x106xf16>, tensor<32x32xf32>) {
+
+  // CHECK: linalg.conv_2d_nhwc_hwcf
+  // CHECK-SAME:   match_status = "matched"
+  %res1 = linalg.conv_2d_nhwc_hwcf
+        ins(%input_nhwc, %filter_nhwc : tensor<2x34x34x64xf32>, tensor<3x3x64x128xf32>)
+        outs(%output_nhwc : tensor<2x32x32x128xf32>) {match_status = "unmatched"} -> tensor<2x32x32x128xf32>
+
+  // CHECK: linalg.conv_2d_nchw_fchw
+  // CHECK-SAME:   match_status = "matched"
+  %res2 = linalg.conv_2d_nchw_fchw
+        ins(%input_nchw, %filter_nchw : tensor<4x32x112x112xf16>, tensor<64x32x7x7xf16>)
+        outs(%output_nchw : tensor<4x64x106x106xf16>) {match_status = "unmatched"} -> tensor<4x64x106x106xf16>
+
+  // Non-convolution operation should not match.
+  // CHECK: linalg.matmul
+  // CHECK-SAME:   match_status = "unmatched"
+  %res3 = linalg.matmul
+        ins(%input_mm, %filter_mm : tensor<32x64xf32>, tensor<64x32xf32>)
+        outs(%output_mm : tensor<32x32xf32>) {match_status = "unmatched"} -> tensor<32x32xf32>
+
+  return %res1, %res2, %res3 : tensor<2x32x32x128xf32>, tensor<4x64x106x106xf16>, tensor<32x32xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_conv_nhwc_hwcf(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
+      transform.iree.match.convolution %op,
+        lhs_type = f32, rhs_type = f32, output_type = f32
+        {indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output]} :
+        (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>)
+    %c2 = transform.param.constant 2 : i64 -> !transform.param<i64>
+    transform.match.param.cmpi eq %batch, %c2 : !transform.param<i64>
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @match_conv_nchw_fchw(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
+      transform.iree.match.convolution %op,
+        lhs_type = f16, rhs_type = f16, output_type = f16
+        {indexing_maps = [#map_nchw_fchw_input, #map_nchw_fchw_filter, #map_nchw_fchw_output]} :
+        (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>)
+    %c4 = transform.param.constant 4 : i64 -> !transform.param<i64>
+    transform.match.param.cmpi eq %batch, %c4 : !transform.param<i64>
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "match_status" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    transform.foreach_match in %module
+        @match_conv_nhwc_hwcf -> @annotate,
+        @match_conv_nchw_fchw -> @annotate
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+// Verify dimension size constraints for the convolution op with lowering config.
+
+#map_nhwc_hwcf_input = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map_nhwc_hwcf_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map_nhwc_hwcf_output = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+#lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1]}>
+
+// CHECK-LABEL: func.func @conv_constraints
+func.func @conv_constraints(
+    %in1: tensor<1x224x224x3xf16>,
+    %filt1: tensor<7x7x3x64xf16>,
+    %out1: tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32> {
+
+  // CHECK: linalg.conv_2d_nhwc_hwcf
+  // CHECK-SAME:   match_status = "matched"
+  %res = linalg.conv_2d_nhwc_hwcf
+        ins(%in1, %filt1 : tensor<1x224x224x3xf16>, tensor<7x7x3x64xf16>)
+        outs(%out1 : tensor<1x112x112x64xf32>) {match_status = "unmatched"} -> tensor<1x112x112x64xf32>
+
+  return %res : tensor<1x112x112x64xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_conv_all_dims(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
+      transform.iree.match.convolution %op,
+        lhs_type = f16, rhs_type = f16, output_type = f32
+        {indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output]} :
+        (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>)
+
+    transform.iree.match.dims_equal %batch, [1] : !transform.param<i64>
+    transform.iree.match.dims_equal %out_img, [112, 112] : !transform.param<i64>
+    transform.iree.match.dims_equal %out_ch, [64] : !transform.param<i64>
+    transform.iree.match.dims_equal %filt, [7, 7] : !transform.param<i64>
+    transform.iree.match.dims_equal %in_ch, [3] : !transform.param<i64>
+    transform.iree.match.dims_equal %depth, [] : !transform.param<i64>
+    transform.iree.match.dims_equal %strides, [1, 1] : !transform.param<i64>
+    transform.iree.match.dims_equal %dilations, [1, 1] : !transform.param<i64>
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "match_status" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    transform.foreach_match in %module
+        @match_conv_all_dims -> @annotate
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// -----
+
+// Verify indexing maps mismatching for the convolution op.
+
+#map_nhwc_hwcf_input = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map_nhwc_hwcf_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map_nhwc_hwcf_output = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+// Wrong filter map with transposed channels: (d4, d5, d3, d6) instead of (d4, d5, d6, d3).
+#map_wrong_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d3, d6)>
+
+// CHECK-LABEL: func.func @indexing_maps_test
+func.func @indexing_maps_test(
+    %input: tensor<1x224x224x3xf32>,
+    %filter: tensor<7x7x3x64xf32>,
+    %output: tensor<1x218x218x64xf32>) -> tensor<1x218x218x64xf32> {
+
+  // CHECK: linalg.conv_2d_nhwc_hwcf
+  // CHECK-SAME:   maps_match = "unmatched"
+  %res = linalg.conv_2d_nhwc_hwcf
+        ins(%input, %filter : tensor<1x224x224x3xf32>, tensor<7x7x3x64xf32>)
+        outs(%output : tensor<1x218x218x64xf32>) {maps_match = "unmatched"} -> tensor<1x218x218x64xf32>
+
+  return %res : tensor<1x218x218x64xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @match_with_wrong_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
+    %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
+      transform.iree.match.convolution %op,
+        lhs_type = f32, rhs_type = f32, output_type = f32
+        {indexing_maps = [#map_nhwc_hwcf_input, #map_wrong_filter, #map_nhwc_hwcf_output]} :
+        (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>, !transform.param<i64>,
+                                 !transform.param<i64>, !transform.param<i64>)
+    transform.yield %op : !transform.any_op
+  }
+
+  transform.named_sequence @annotate(%op: !transform.any_op {transform.readonly}) {
+    %0 = transform.param.constant "matched" -> !transform.any_param
+    transform.annotate %op "maps_match" = %0 : !transform.any_op, !transform.any_param
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    transform.foreach_match in %module
+        @match_with_wrong_maps -> @annotate
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -233,16 +233,15 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
     Operation *current, transform::TransformResults &results,
     transform::TransformState &state) {
   Location loc = current->getLoc();
-  StringRef opName = current->getName().getStringRef();
   auto linalgOp = dyn_cast<linalg::LinalgOp>(current);
   if (!linalgOp) {
     return emitSilenceableFailure(loc)
-           << "Operation " << opName << " is not a LinalgOp.";
+           << "Operation " << *current << " is not a LinalgOp.";
   }
 
   if (!linalg::isaContractionOpInterface(linalgOp)) {
     return emitSilenceableFailure(loc)
-           << "Operation " << opName << " is not a contraction operation.";
+           << "Operation " << *current << " is not a contraction operation.";
   }
 
   Type targetLhsType = getLhsType();
@@ -313,16 +312,14 @@ IREE::transform_dialect::MatchConvolutionOp::matchOperation(
     Operation *current, transform::TransformResults &results,
     transform::TransformState &state) {
   Location loc = current->getLoc();
-  StringRef opName = current->getName().getStringRef();
   auto linalgOp = dyn_cast<linalg::LinalgOp>(current);
   if (!linalgOp) {
-    return emitSilenceableFailure(loc)
-           << "Operation " << opName << " is not a LinalgOp.";
+    return emitSilenceableFailure(loc) << "Operation is not a LinalgOp.";
   }
 
   if (!linalg::isaConvolutionOpInterface(linalgOp)) {
     return emitSilenceableFailure(loc)
-           << "Operation " << opName << " is not a convolution operation.";
+           << "Operation is not a convolution operation.";
   }
 
   Type targetLhsType = getLhsType();
@@ -368,7 +365,7 @@ IREE::transform_dialect::MatchConvolutionOp::matchOperation(
   MLIRContext *ctx = getContext();
   Builder builder(ctx);
 
-  auto buildI64Attrs = [&](auto values, auto transform) {
+  auto buildI64Attrs = [&builder](const auto &values, const auto &transform) {
     return llvm::map_to_vector(values, [&](auto val) -> Attribute {
       return builder.getI64IntegerAttr(transform(val));
     });

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -362,39 +362,27 @@ IREE::transform_dialect::MatchConvolutionOp::matchOperation(
   }
   linalg::ConvolutionDimensions convDims = *maybeConvDims;
   SmallVector<int64_t> iterationDomain = linalgOp.getStaticLoopRanges();
-  MLIRContext *ctx = getContext();
-  Builder builder(ctx);
 
+  Builder builder(getContext());
   auto buildI64Attrs = [&builder](const auto &values, const auto &transform) {
     return llvm::map_to_vector(values, [&](auto val) -> Attribute {
       return builder.getI64IntegerAttr(transform(val));
     });
   };
+  auto getIterationSize = [&](unsigned idx) { return iterationDomain[idx]; };
 
   results.setParams(cast<OpResult>(getBatchDims()),
-                    buildI64Attrs(convDims.batch, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.batch, getIterationSize));
   results.setParams(cast<OpResult>(getOutputImageDims()),
-                    buildI64Attrs(convDims.outputImage, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.outputImage, getIterationSize));
   results.setParams(cast<OpResult>(getOutputChannelDims()),
-                    buildI64Attrs(convDims.outputChannel, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.outputChannel, getIterationSize));
   results.setParams(cast<OpResult>(getFilterDims()),
-                    buildI64Attrs(convDims.filterLoop, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.filterLoop, getIterationSize));
   results.setParams(cast<OpResult>(getInputChannelDims()),
-                    buildI64Attrs(convDims.inputChannel, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.inputChannel, getIterationSize));
   results.setParams(cast<OpResult>(getDepthDims()),
-                    buildI64Attrs(convDims.depth, [&](unsigned idx) {
-                      return iterationDomain[idx];
-                    }));
+                    buildI64Attrs(convDims.depth, getIterationSize));
   results.setParams(
       cast<OpResult>(getStrides()),
       buildI64Attrs(convDims.strides, [](int64_t val) { return val; }));

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -233,15 +233,16 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
     Operation *current, transform::TransformResults &results,
     transform::TransformState &state) {
   Location loc = current->getLoc();
+  StringRef opName = current->getName().getStringRef();
   auto linalgOp = dyn_cast<linalg::LinalgOp>(current);
   if (!linalgOp) {
     return emitSilenceableFailure(loc)
-           << "Operation " << *current << " is not a LinalgOp.";
+           << "Operation " << opName << " is not a LinalgOp.";
   }
 
   if (!linalg::isaContractionOpInterface(linalgOp)) {
     return emitSilenceableFailure(loc)
-           << "Operation " << *current << " is not a contraction operation.";
+           << "Operation " << opName << " is not a contraction operation.";
   }
 
   Type targetLhsType = getLhsType();
@@ -312,15 +313,16 @@ IREE::transform_dialect::MatchConvolutionOp::matchOperation(
     Operation *current, transform::TransformResults &results,
     transform::TransformState &state) {
   Location loc = current->getLoc();
+  StringRef opName = current->getName().getStringRef();
   auto linalgOp = dyn_cast<linalg::LinalgOp>(current);
   if (!linalgOp) {
     return emitSilenceableFailure(loc)
-           << "Operation " << *current << " is not a LinalgOp.";
+           << "Operation " << opName << " is not a LinalgOp.";
   }
 
   if (!linalg::isaConvolutionOpInterface(linalgOp)) {
     return emitSilenceableFailure(loc)
-           << "Operation " << *current << " is not a convolution operation.";
+           << "Operation " << opName << " is not a convolution operation.";
   }
 
   Type targetLhsType = getLhsType();

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -225,6 +225,68 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
+def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
+    [MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
+  let summary = [{Check whether the op is a convolution operation.}];
+  let description = [{
+    Matches operations that implement the ConvolutionOpInterface.
+    This includes operations like linalg.conv_2d_nhwc_hwcf,
+    linalg.conv_2d_nchw_fchw, linalg.depthwise_conv_2d_nhwc_hwc, etc.
+
+    Optionally matches specific indexing maps patterns.
+
+    #### Return modes
+
+    Succeeds if the operation is a convolution operation, and
+    produces a silenceable failure otherwise.
+
+    #### Results
+
+    Returns arrays of dimension sizes for each convolution dimension:
+    - batch_dims: Array of batch dimension sizes.
+    - output_image_dims: Array of output spatial dimension sizes.
+    - output_channel_dims: Array of output channel dimension sizes.
+    - filter_dims: Array of filter spatial dimension sizes.
+    - input_channel_dims: Array of input channel dimension sizes.
+    - depth_dims: Array of depth dimension sizes (for depthwise convolutions).
+    - strides: Array of stride values.
+    - dilations: Array of dilation values.
+  }];
+
+  let arguments = (ins
+    TransformHandleTypeInterface:$operand_handle,
+    TypeAttr:$lhs_type,
+    TypeAttr:$rhs_type,
+    TypeAttr:$output_type,
+    OptionalAttr<AffineMapArrayAttr>:$indexing_maps
+  );
+
+  let results = (outs
+    TransformParamTypeInterface:$batch_dims,
+    TransformParamTypeInterface:$output_image_dims,
+    TransformParamTypeInterface:$output_channel_dims,
+    TransformParamTypeInterface:$filter_dims,
+    TransformParamTypeInterface:$input_channel_dims,
+    TransformParamTypeInterface:$depth_dims,
+    TransformParamTypeInterface:$strides,
+    TransformParamTypeInterface:$dilations
+  );
+
+  let assemblyFormat = [{
+    $operand_handle
+    `,` `lhs_type` `=` $lhs_type
+    `,` `rhs_type` `=` $rhs_type
+    `,` `output_type` `=` $output_type
+    (`indexing_maps` $indexing_maps^)?
+    attr-dict `:` functional-type(operands, results)
+  }];
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
 def MatchDimsEqualOp : Op<Transform_Dialect, "iree.match.dims_equal",
     [DeclareOpInterfaceMethods<TransformOpInterface>,
      MatchOpInterface,

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -241,6 +241,24 @@ def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
 
     Optionally matches specific indexing maps patterns.
 
+    ### Example
+
+    ```mlir
+    #map_input = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+    #map_filter = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+    #map_output = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+
+    %batch_dims, %output_image_dims, %output_channel_dims, %filter_dims,
+    %input_channel_dims, %depth_dims, %strides, %dilations =
+      transform.iree.match.convolution %conv_op,
+        lhs_type = f32, rhs_type = f32, output_type = f32
+        {indexing_maps = [#map_input, #map_filter, #map_output]} :
+        !transform.any_op -> !transform.param<i64>
+    ```
+
+    This succeeds when `%conv_op` is a convolution operation with f32 element
+    types for input, filter, and output tensors.
+
     #### Return modes
 
     Succeeds if the operation is a convolution operation, and
@@ -317,7 +335,7 @@ def MatchDimsEqualOp : Op<Transform_Dialect, "iree.match.dims_equal",
 
   let arguments = (ins
     TransformParamTypeInterface:$dimension_sizes, // Array of dimension parameters.
-    DenseI64ArrayAttr:$expected_values                    // Array of expected i64 values.
+    DenseI64ArrayAttr:$expected_values            // Array of expected i64 values.
   );
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -228,7 +228,11 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
 def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
     [MatchOpInterface,
      SingleOpMatcher,
-     MemoryEffectsOpInterface]> {
+     MemoryEffectsOpInterface,
+     AllTypesMatch<["batch_dims", "output_image_dims", "output_channel_dims",
+                    "filter_dims", "input_channel_dims", "depth_dims",
+                    "strides", "dilations"]>
+     ]> {
   let summary = [{Check whether the op is a convolution operation.}];
   let description = [{
     Matches operations that implement the ConvolutionOpInterface.
@@ -280,7 +284,7 @@ def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
     `,` `rhs_type` `=` $rhs_type
     `,` `output_type` `=` $output_type
     (`indexing_maps` $indexing_maps^)?
-    attr-dict `:` functional-type(operands, results)
+    attr-dict `:` type($operand_handle) `->` type($batch_dims)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
 


### PR DESCRIPTION
This PR adds `transform.iree.match.convolution` that matches convolution operations and extract their dimension information. 
This change replicates the design logic from PR #21981, extending the contraction operation matching infrastructure to support convolution operations.