### PR TITLE
[Codegen][GPU] Fix IGEMM pre-padding and fusion patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -149,7 +149,7 @@ func.func @nchw_conv_unaligned_mfma() {
 // MI300X-SAME:     subgroup = [1, 1, 1, 1, 0]
 // MI300X-SAME:     workgroup = [1, 32, 2, 32, 0]
 
-// PAD-CONV-GFX942:     padding_conv = [1, 64, 4, 32, 0, 0, 0]
+// PAD-CONV-GFX942-NOT:     padding_conv
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -143,9 +143,9 @@ hal.executable private @main {
 //      CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
 //      CHECK-DAG:   %[[ASSUMED_B2:.+]] = memref.assume_alignment %[[B2]], 64
 //      CHECK-DAG:   %[[BUF2:.+]] = amdgpu.fat_raw_buffer_cast %[[ASSUMED_B2]]
-//      CHECK-DAG:   memref.alloc() : memref<2x1x32x16xf32, #gpu.address_space<workgroup>>
-//      CHECK-DAG:   memref.alloc() : memref<16x16xf16, #gpu.address_space<workgroup>>
-//      CHECK-DAG:   memref.alloc() : memref<2x1x32x16xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloc() : memref<2x1x32x18xf32, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloc() : memref<16x20xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloc() : memref<2x1x32x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -155,13 +155,11 @@ hal.executable private @main {
 //      CHECK-DAG:       %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4xf16>
 //      CHECK-DAG:       %[[RHS_MM:.+]] = vector.transfer_read {{.*}} vector<4xf16>
 // CHECK-COUNT-1:       amdgpu.mfma {{.*}}blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32
-//          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4x1x1xf32>
+//          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4xf32>
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
 //          CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#amdgpu.address_space<fat_raw_buffer>
 //          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
-
-// TODO(vivian): This test doesn't have reduce bank conflicts taken effect because of collapsing a dynamic allocation. Try to fix it.
 
 // -----
 


### PR DESCRIPTION
This PR includes two fixes for https://github.com/iree-org/iree/issues/22180.

- Fix 1: Don't pad convolution for NCHW layout.
Pre-padding has no performance benefit on NCHW layout and can introduce errors due to `collapse_shape` fusion issues.

- Fix 2: Don't swap `collapse_shape` with `extract_slice` when extracted_slice result is dynamic.
Dynamic shaped `collapse_shape` as the operand of a computational op may cause padding failure in `GPUPadOperandsPass`. In addition, it may also block the intended reduction of bank conflicts.

Fixes : https://github.com/iree-org/iree/issues/22180