### PR TITLE
[Codegen] add transform op for matching attention op

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/BUILD.bazel
@@ -56,6 +56,8 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PreprocessingExtensionsOpGen",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/CMakeLists.txt
@@ -42,6 +42,8 @@ iree_cc_library(
     MLIRTransformDialectInterfaces
     MLIRTransformUtils
     MLIRValueBoundsOpInterface
+    iree::compiler::Dialect::LinalgExt::IR
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.h"
 
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Utils/EquivalenceUtils.h"
 #include "iree/compiler/Utils/ShapeUtils.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
@@ -298,6 +300,90 @@ IREE::transform_dialect::MatchContractionOp::matchOperation(
                     iterationSizes(contractionDims.n));
   results.setParams(cast<OpResult>(getKDims()),
                     iterationSizes(contractionDims.k));
+
+  return DiagnosedSilenceableFailure::success();
+}
+
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchAttentionOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  Location loc = current->getLoc();
+  auto attentionOp = dyn_cast<IREE::LinalgExt::AttentionOp>(current);
+  if (!attentionOp) {
+    return emitSilenceableFailure(loc)
+           << "Operation is not an attention operation.";
+  }
+
+  Type targetQueryType = getQueryType();
+  Type currentQueryType =
+      getElementTypeOrSelf(attentionOp.getQuery().getType());
+  if (currentQueryType != targetQueryType) {
+    return emitSilenceableFailure(loc)
+           << "Query type doesn't match: expected " << targetQueryType
+           << ", got " << currentQueryType;
+  }
+
+  Type targetKeyType = getKeyType();
+  Type currentKeyType = getElementTypeOrSelf(attentionOp.getKey().getType());
+  if (currentKeyType != targetKeyType) {
+    return emitSilenceableFailure(loc)
+           << "Key type doesn't match: expected " << targetKeyType << ", got "
+           << currentKeyType;
+  }
+
+  Type targetValueType = getValueType();
+  Type currentValueType =
+      getElementTypeOrSelf(attentionOp.getValue().getType());
+  if (currentValueType != targetValueType) {
+    return emitSilenceableFailure(loc)
+           << "Value type doesn't match: expected " << targetValueType
+           << ", got " << currentValueType;
+  }
+
+  Type targetOutputType = getOutputType();
+  Type currentOutputType =
+      getElementTypeOrSelf(attentionOp.getOutput().getType());
+  if (currentOutputType != targetOutputType) {
+    return emitSilenceableFailure(loc)
+           << "Output type doesn't match: expected " << targetOutputType
+           << ", got " << currentOutputType;
+  }
+
+  ArrayAttr currentIndexingMaps = attentionOp.getIndexingMaps();
+  ArrayAttr targetIndexingMaps = getIndexingMaps();
+  if (currentIndexingMaps != targetIndexingMaps) {
+    return emitSilenceableFailure(loc) << "indexing maps don't match";
+  }
+
+  FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
+      IREE::LinalgExt::AttentionOpDetail::get(
+          attentionOp.getQueryMap(), attentionOp.getKeyMap(),
+          attentionOp.getValueMap(), attentionOp.getOutputMap());
+  if (failed(maybeOpInfo)) {
+    return emitSilenceableFailure(loc)
+           << "Failed to infer attention dimensions";
+  }
+  IREE::LinalgExt::AttentionOpDetail opInfo = *maybeOpInfo;
+  SmallVector<int64_t> iterationDomain = attentionOp.getStaticLoopRanges();
+
+  Builder builder(getContext());
+  auto iterationSizes = [&](ArrayRef<int64_t> dimIndices) {
+    return llvm::map_to_vector(dimIndices, [&](int64_t dimIdx) -> Attribute {
+      return builder.getI64IntegerAttr(iterationDomain[dimIdx]);
+    });
+  };
+
+  results.setParams(cast<OpResult>(getBatchDims()),
+                    iterationSizes(opInfo.getBatchDims()));
+  results.setParams(cast<OpResult>(getMDims()),
+                    iterationSizes(opInfo.getMDims()));
+  results.setParams(cast<OpResult>(getNDims()),
+                    iterationSizes(opInfo.getNDims()));
+  results.setParams(cast<OpResult>(getK1Dims()),
+                    iterationSizes(opInfo.getK1Dims()));
+  results.setParams(cast<OpResult>(getK2Dims()),
+                    iterationSizes(opInfo.getK2Dims()));
 
   return DiagnosedSilenceableFailure::success();
 }

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -185,6 +185,23 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
 
     Optionally matches specific indexing maps patterns.
 
+    ### Example
+
+    ```mlir
+    #map_lhs = affine_map<(d0, d1, d2) -> (d0, d2)>
+    #map_rhs = affine_map<(d0, d1, d2) -> (d1, d2)>
+    #map_output = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+    %batch_dims, %m_dims, %n_dims, %k_dims =
+      transform.iree.match.contraction %matmul_op,
+        lhs_type = f32, rhs_type = f32, output_type = f32
+        {indexing_maps = [#map_lhs, #map_rhs, #map_output]} :
+        !transform.any_op -> !transform.param<i64>
+    ```
+
+    This succeeds when `%matmul_op` is a contraction operation with f32 input
+    types and f32 output type, and matches the specified indexing maps pattern.
+
     #### Return modes
 
     Succeeds if the operation is a contraction operation, and
@@ -304,6 +321,86 @@ def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
     `,` `rhs_type` `=` $rhs_type
     `,` `output_type` `=` $output_type
     (`indexing_maps` $indexing_maps^)?
+    attr-dict `:` type($operand_handle) `->` type($batch_dims)
+  }];
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def MatchAttentionOp : Op<Transform_Dialect, "iree.match.attention",
+    [MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface,
+     AllTypesMatch<["batch_dims", "m_dims", "n_dims",
+                    "k1_dims", "k2_dims"]>
+     ]> {
+  let summary = [{Check whether the op is an attention operation.}];
+  let description = [{
+    Matches operations from the IREELinalgExt dialect that implement
+    attention: iree_linalg_ext.attention.
+
+    ### Example
+
+    ```mlir
+    #map_query = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+    #map_key = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+    #map_value = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+    #map_scale = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+    #map_output = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+
+    %batch_dims, %m_dims, %n_dims, %k1_dims, %k2_dims =
+      transform.iree.match.attention %attn_op,
+        query_type = f32, key_type = f32, value_type = f32, output_type = f32,
+        indexing_maps = [#map_query, #map_key, #map_value, #map_scale, #map_output] :
+        !transform.any_op -> !transform.param<i64>
+    ```
+
+    This succeeds when `%attn_op` is an attention operation with f32 element
+    types for query, key, value, and output tensors, and matches the specified
+    indexing maps pattern.
+
+    #### Return modes
+
+    Succeeds if the operation is an attention operation, and
+    produces a silenceable failure otherwise.
+
+    #### Results
+
+    Returns arrays of dimension sizes extracted from the iteration domain:
+    - batch_dims: Array of batch dimension sizes.
+    - m_dims: Array of query sequence length dimension sizes.
+    - n_dims: Array of number of heads dimension sizes.
+    - k1_dims: Array of key/value sequence length dimension sizes.
+    - k2_dims: Array of key embedding dimension sizes.
+
+    The exact interpretation depends on the indexing maps of the attention op.
+  }];
+
+  let arguments = (ins
+    TransformHandleTypeInterface:$operand_handle,
+    TypeAttr:$query_type,
+    TypeAttr:$key_type,
+    TypeAttr:$value_type,
+    TypeAttr:$output_type,
+    AffineMapArrayAttr:$indexing_maps
+  );
+
+  let results = (outs
+    TransformParamTypeInterface:$batch_dims,
+    TransformParamTypeInterface:$m_dims,
+    TransformParamTypeInterface:$n_dims,
+    TransformParamTypeInterface:$k1_dims,
+    TransformParamTypeInterface:$k2_dims
+  );
+
+  let assemblyFormat = [{
+    $operand_handle
+    `,` `query_type` `=` $query_type
+    `,` `key_type` `=` $key_type
+    `,` `value_type` `=` $value_type
+    `,` `output_type` `=` $output_type
+    `,` `indexing_maps` `=` $indexing_maps
     attr-dict `:` type($operand_handle) `->` type($batch_dims)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;


### PR DESCRIPTION
The key difference is that the indexing map is required for attention operations, so `MatchAttentionOp `does not treat it as optional.