### PR TITLE
Removing virtual MMAs from vector distribute matmul/conv pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -533,8 +533,8 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
 /// This function acts as a comparison function object for std::sort, which
 /// returns true if the lhs is ordered before rhs.
 static bool compareIntrinsics(const GPUMatmulShapeType &problem,
-                              const GPUMatmulShapeType &lhs,
-                              const GPUMatmulShapeType &rhs) {
+                              const GPUIntrinsicType &lhs,
+                              const GPUIntrinsicType &rhs) {
   // Prefer K-aligned intrinsics.
   int lhsKAligned = problem.kSizes.back() % lhs.kSizes.back() == 0 ? 1 : 0;
   int rhsKAligned = problem.kSizes.back() % rhs.kSizes.back() == 0 ? 1 : 0;
@@ -555,7 +555,7 @@ static bool compareIntrinsics(const GPUMatmulShapeType &problem,
     return lhsMNAligned > rhsMNAligned;
   }
 
-  auto intrinsicArea = [&](const GPUMatmulShapeType &intrinsic) {
+  auto intrinsicArea = [&](const GPUIntrinsicType &intrinsic) {
     return (ShapedType::getNumElements(intrinsic.mSizes) +
             ShapedType::getNumElements(intrinsic.nSizes)) *
            ShapedType::getNumElements(intrinsic.kSizes);
@@ -575,8 +575,8 @@ static SmallVector<GPUIntrinsicType>
 sortMMAIntrinsics(GPUMatmulShapeType problem,
                   ArrayRef<GPUIntrinsicType> intrinsics) {
   SmallVector<GPUIntrinsicType> sortedIntrinsics(intrinsics);
-  llvm::stable_sort(sortedIntrinsics, [&](const GPUMatmulShapeType &lhs,
-                                          const GPUMatmulShapeType &rhs) {
+  llvm::stable_sort(sortedIntrinsics, [&](const GPUIntrinsicType &lhs,
+                                          const GPUIntrinsicType &rhs) {
     return compareIntrinsics(problem, lhs, rhs);
   });
   return sortedIntrinsics;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -978,13 +978,8 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
     if (mma.getSubgroupSize() != targetSubgroupSize)
       continue;
     storeMmaInfo(mma, intrinsics);
-    // Store info on virtual intrinsics based on current mma if any
-    for (IREE::GPU::VirtualMMAIntrinsic virtualIntrinsic :
-         mma.getVirtualIntrinsics()) {
-      auto virtualMma =
-          IREE::GPU::VirtualMMAAttr::get(context, virtualIntrinsic);
-      storeMmaInfo(virtualMma, intrinsics);
-    }
+    // Skip adding any virtual intrinsics since they are not tested for
+    // convolutions.
   }
 
   if (intrinsics.empty())
@@ -1209,13 +1204,7 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
     if (mma.getSubgroupSize() != targetSubgroupSize)
       continue;
     storeMmaInfo(mma, intrinsics);
-    // Store info on virtual intrinsics based on current mma if any
-    for (IREE::GPU::VirtualMMAIntrinsic virtualIntrinsic :
-         mma.getVirtualIntrinsics()) {
-      auto virtualMma =
-          IREE::GPU::VirtualMMAAttr::get(context, virtualIntrinsic);
-      storeMmaInfo(virtualMma, intrinsics);
-    }
+    // Skip adding any virtual intrinsics since they are not tested for matmuls.
   }
 
   if (intrinsics.empty())

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_gfx942.mlir
@@ -39,8 +39,8 @@ func.func @expanded_matmul_transpose_b() {
 
 // CHECK-LABEL: func.func @expanded_matmul_transpose_b()
 // CHECK: linalg.generic {{.*}}lowering_config =  #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 256]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 128]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 4, 1], [0, 1, 2, 3, 4]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 64, 0]
 
@@ -70,8 +70,8 @@ func.func @conv_nhwc() {
 
 // CHECK-LABEL: func.func @conv_nhwc()
 // CHECK: linalg.conv_2d_nhwc_hwcf {{.*}} lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 64]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 1, 1, 32]
 // CHECK-SAME{LITERAL}:                  subgroup_basis = [[1, 1, 2, 2, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]
 // CHECK-SAME:                           workgroup =  [1, 1, 64, 128, 0, 0, 0]
 
@@ -134,8 +134,8 @@ func.func @mfma_matmul_1024x1024x1024() {
 
 // CHECK-LABEL: func.func @mfma_matmul_1024x1024x1024()
 // CHECK: linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 128]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 64]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[2, 2, 1], [0, 1, 2]]
 // CHECK-SAME:                           workgroup =  [64, 128, 0]
 
@@ -184,8 +184,8 @@ func.func @conv_nchwc() {
 
 // CHECK-LABEL: func.func @conv_nchwc()
 // CHECK: linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:                           mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16>
-// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 64]
+// CHECK-SAME:                           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+// CHECK-SAME:                           reduction =  [0, 0, 0, 0, 0, 1, 1, 1, 32]
 // CHECK-SAME{LITERAL}:                   subgroup_basis = [[1, 1, 1, 2, 2, 1, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6, 7, 8]]
 // CHECK-SAME:                           workgroup =  [1, 1, 1, 32, 32, 0, 0, 0, 0]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_horizontally_fused_ops.mlir
@@ -74,7 +74,7 @@ func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:      mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
+// GFX942-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 // GFX950-SAME:      mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]
@@ -276,7 +276,7 @@ func.func @fused_contraction_4(%arg0: tensor<2x4096x640xf16>,
 //  CHECK-SAME:         subgroup_size = 64
 //       CHECK:   %[[GENERIC:.+]]:3 = linalg.generic
 //  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config
-// GFX942-SAME:       mma_kind = #iree_gpu.virtual_mma_layout<VMFMA_F32_16x16x32_F16
+// GFX942-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
 // GFX950-SAME:       mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F16
 //  CHECK-SAME:       promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:       reduction = [0, 0, 0, 0, 128]

--- a/tests/external/iree-test-suites/sharktank_models/benchmarks/sdxl/unet_fp16_rocm.json
+++ b/tests/external/iree-test-suites/sharktank_models/benchmarks/sdxl/unet_fp16_rocm.json
@@ -21,7 +21,7 @@
     },
     "golden_time_ms": {
         "mi250": 233,
-        "mi300": 63.2,
+        "mi300": 59.0,
         "mi308": 64.7
     },
     "golden_dispatch": {


### PR DESCRIPTION
This should resolve https://github.com/iree-org/iree/issues/22160.

The timeline of the entire events that has caused various kind of regression is:
 1. Virtual MMAs are added to vector distribute matmul and conv pipeline untested. But they didn't cause a problem because they are appended at the back of the intrinsic vector
 2. Intrinsic sorting comes to place that use "sort()" function which happen to continue to prioritize non-virtual MMA when there's a tie. Intrinsic sorting is only applied to tile and fuse.
 3. Intrinsic sorting get introduced to attention, whereas a bug was introduced.
 4. The introduced bug get fixed.  <----------- This is when the perf slowdown is observed first.
 5. "sort()" function is unstable and caused a different result on windows -> we switched to "stable_sort()", but "stable_sort()" favors virtual MMAs instead, this caused a performance regression
 6. This PR, remove virtual MMAs since they are not useful to matmul/conv and we've never used them before. Removing the virtual MMAs will push codegen behavior back to its original state.

Locally this will make punet perf reclaim its perf lost. I'd like to see CI results and then amend the golden perf numbers back to original.