### PR TITLE
[PkgCI] Use urllib instead of github cli in pkgci artifact_run

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -53,6 +53,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi325.yml
+++ b/.github/workflows/pkgci_test_amd_mi325.yml
@@ -58,6 +58,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -51,6 +51,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_android.yml
+++ b/.github/workflows/pkgci_test_android.yml
@@ -65,6 +65,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install build dependencies
         run: sudo apt update && sudo apt install -y ninja-build
 

--- a/.github/workflows/pkgci_test_nvidia_t4.yml
+++ b/.github/workflows/pkgci_test_nvidia_t4.yml
@@ -61,6 +61,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install build dependencies
         run: |
           sudo apt update

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -96,6 +96,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout test suites repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -179,6 +181,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout test suites repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/pkgci_test_pjrt.yml
+++ b/.github/workflows/pkgci_test_pjrt.yml
@@ -62,6 +62,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: ccache
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:

--- a/.github/workflows/pkgci_test_riscv64.yml
+++ b/.github/workflows/pkgci_test_riscv64.yml
@@ -69,6 +69,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Bootstrap
         env:
           IREE_ARTIFACT_URL: "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files"

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -99,6 +99,8 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
           source ${VENV_DIR}/bin/activate
           pip install -e ${{ github.workspace }}/iree-test-suites/sharktank_models
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run sharktank model tests
         run: |
@@ -206,6 +208,8 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
           source ${VENV_DIR}/bin/activate
           pip install -e ${{ github.workspace }}/iree-test-suites/sharktank_models
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run sharktank model tests
         run: |

--- a/.github/workflows/pkgci_test_tensorflow.yml
+++ b/.github/workflows/pkgci_test_tensorflow.yml
@@ -45,6 +45,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
           source ${VENV_DIR}/bin/activate

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -74,6 +74,8 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
           source ${VENV_DIR}/bin/activate
           pip install -r ${{ github.workspace }}/iree-test-suites/torch_models/requirements.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Torch Model tests
         run: |

--- a/.github/workflows/pkgci_unit_test.yml
+++ b/.github/workflows/pkgci_unit_test.yml
@@ -46,6 +46,8 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
           source ${VENV_DIR}/bin/activate
           pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate runtime wheel
         run: |
           source ${VENV_DIR}/bin/activate

--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -66,6 +66,9 @@ There are several modes in which to use this script:
   ```
 
   (Note that these two modes are often combined to allow for workflow testing)
+
+You must have a GitHub token with `repo` scope available as the `GH_TOKEN`
+environment variable if you will be fetching artifacts.
 """
 
 from glob import glob

--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -66,9 +66,6 @@ There are several modes in which to use this script:
   ```
 
   (Note that these two modes are often combined to allow for workflow testing)
-
-You must have the `gh` command line tool installed and authenticated if you
-will be fetching artifacts.
 """
 
 from glob import glob
@@ -83,6 +80,8 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+import os
+import urllib.request
 
 THIS_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = THIS_DIR.parent.parent
@@ -125,6 +124,29 @@ def parse_arguments(argv=None):
     return args
 
 
+def query_gh_api(api_path: str):
+    url = f"https://api.github.com{api_path}"
+    print(f"Querying GitHub API: {url}")
+    gh_token = os.environ.get("GH_TOKEN", "")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {gh_token}",
+    }
+    req = urllib.request.Request(url)
+    for k, v in headers.items():
+        # https://github.com/arduino/report-size-deltas/pull/83
+        req.add_unredirected_header(k, v)
+
+    with urllib.request.urlopen(req) as response:
+        if response.status != 200:
+            raise RuntimeError(
+                f"GitHub API request failed: {response.status} {response.reason}"
+            )
+        contents = response.read()
+        return contents
+
+
 def get_latest_workflow_run_id_for_main() -> int:
     print(f"Looking up latest workflow run for main branch")
     # Note: at a high level, we probably want to select one of these:
@@ -133,19 +155,9 @@ def get_latest_workflow_run_id_for_main() -> int:
     # Instead, we just check for the latest completed workflow. This can miss
     # runs that are still pending (especially if jobs are queued waiting for
     # runners) and can include jobs that failed tests (for better or worse).
-    workflow_run_args = [
-        "gh",
-        "api",
-        "-H",
-        "Accept: application/vnd.github+json",
-        "-H",
-        "X-GitHub-Api-Version: 2022-11-28",
-        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?branch=main&event=push&status=completed&per_page=1",
-    ]
-    print(
-        f"Running command to find latest completed workflow run:\n  {' '.join(workflow_run_args)}"
+    workflow_run_output = query_gh_api(
+        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?branch=main&event=push&status=completed&per_page=1"
     )
-    workflow_run_output = subprocess.check_output(workflow_run_args)
     workflow_run_json_output = json.loads(workflow_run_output)
     latest_run = workflow_run_json_output["workflow_runs"][0]
     print(f"\nFound workflow run: {latest_run['html_url']}")
@@ -161,17 +173,9 @@ def get_latest_workflow_run_id_for_ref(ref: str) -> int:
     )
 
     print(f"  Using normalized ref: {normalized_ref}")
-    workflow_run_args = [
-        "gh",
-        "api",
-        "-H",
-        "Accept: application/vnd.github+json",
-        "-H",
-        "X-GitHub-Api-Version: 2022-11-28",
-        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?head_sha={normalized_ref}",
-    ]
-    print(f"\nRunning command to list workflow runs:\n  {' '.join(workflow_run_args)}")
-    workflow_run_output = subprocess.check_output(workflow_run_args)
+    workflow_run_output = query_gh_api(
+        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?head_sha={normalized_ref}"
+    )
     workflow_run_json_output = json.loads(workflow_run_output)
     if workflow_run_json_output["total_count"] == 0:
         raise RuntimeError("Workflow did not run at this commit")
@@ -184,18 +188,7 @@ def get_latest_workflow_run_id_for_ref(ref: str) -> int:
 @functools.lru_cache
 def list_gh_artifacts(run_id: str) -> Dict[str, str]:
     print(f"Fetching artifacts for workflow run: {run_id}")
-
-    output = subprocess.check_output(
-        [
-            "gh",
-            "api",
-            "-H",
-            "Accept: application/vnd.github+json",
-            "-H",
-            "X-GitHub-Api-Version: 2022-11-28",
-            f"{BASE_API_PATH}/actions/runs/{run_id}/artifacts",
-        ]
-    )
+    output = query_gh_api(f"{BASE_API_PATH}/actions/runs/{run_id}/artifacts")
     data = json.loads(output)
     # Uncomment to debug:
     # print(json.dumps(data, indent=2))
@@ -211,17 +204,7 @@ def list_gh_artifacts(run_id: str) -> Dict[str, str]:
 
 def fetch_gh_artifact(api_path: str, file: Path):
     print(f"Downloading artifact {api_path}")
-    contents = subprocess.check_output(
-        [
-            "gh",
-            "api",
-            "-H",
-            "Accept: application/vnd.github+json",
-            "-H",
-            "X-GitHub-Api-Version: 2022-11-28",
-            api_path,
-        ]
-    )
+    contents = query_gh_api(api_path)
     file.write_bytes(contents)
 
 


### PR DESCRIPTION
This removes the requirement of having a gh-cli installed on a runner, and instead directly queries the api using urllib.

It requires passing a GH_TOKEN as an environment variable instead of having a authenticated gh cli (as recommended by https://cli.github.com/manual/gh_auth_login)