### PR TITLE
[CI] Add clip and llama torch_models tests

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -103,6 +103,12 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_sharktank')
     uses: ./.github/workflows/pkgci_test_sharktank.yml
 
+  test_torch:
+    name: Test Torch
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_torch')
+    uses: ./.github/workflows/pkgci_test_torch.yml
+
   test_tensorflow:
     name: Test TensorFlow
     needs: [setup, build_packages]

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -35,7 +35,7 @@ jobs:
               - X64
           # MI325
           - name: amdgpu_mi325_gfx942
-            markers: "hip or gfx942 or mi325"
+            markers: "gfx942 or mi325"
             cache-dir: /shark-cache/data/iree-regression-cache
             runs-on: linux-mi325-1gpu-ossci-iree-org
     env:

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -10,6 +10,11 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_run_id:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -120,6 +120,7 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         # None.
         "windows_x64_msvc",
+        "test_torch",
     ]
 )
 

--- a/tests/external/iree-test-suites/torch_models/README.md
+++ b/tests/external/iree-test-suites/torch_models/README.md
@@ -38,4 +38,4 @@ on these markers.
 
 ## Misc
 
-Information on accepted test schema : https://github.com/iree-org/iree-test-suites/blob/main/torch_models/README.md
+Information on accepted test schema: https://github.com/iree-org/iree-test-suites/blob/main/torch_models/README.md

--- a/tests/external/iree-test-suites/torch_models/README.md
+++ b/tests/external/iree-test-suites/torch_models/README.md
@@ -1,0 +1,41 @@
+# Torch Models Test Suite
+
+## Directory Structure
+
+torch_models/
+├── model1/
+│   ├── modules/
+│   │   ├── module1.json
+│   │   ├── module2.json
+│   │   └── ...
+│   ├── test1.json
+│   ├── test2.json
+│   └── ...
+├── model2/
+│   ├── modules/
+│   │   ├── module1.json
+│   │   ├── module2.json
+│   │   └── ...
+│   ├── test1.json
+│   ├── test2.json
+│   └── ...
+
+
+## Markers
+
+We try to add markers to every test. The CI collects tests for a machine based
+on these markers.
+
+- Add a marker for the model class. For example "sdxl".
+- Add a marker for the compilation backend for the test. For example
+  "llvm-cpu", "hip", "spirv".
+- Add a compilation target specific marker if the test is sku independent. For
+  example: "gfx942", "gfx1201", "sm80". This is generally try for quality and
+  compstat tests, unless using sku specific tuning specs.
+- Add a sku specific marker if the test is sku specific. For example: "mi325",
+  "w7900", "rtx4090". This is generally true for all benchmarking tests and
+  when using sku specific tuner files.
+
+## Misc
+
+Information on accepted test schema : https://github.com/iree-org/iree-test-suites/blob/main/torch_models/README.md

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp16/modules/llama_gfx942",
-  "golden_dispatch_count": 12,
-  "golden_binary_size": 12345678
+  "golden_dispatch_count": 937,
+  "golden_binary_size": 1100000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
@@ -1,0 +1,10 @@
+{
+  "type": "compstat",
+  "markers": [
+    "hip",
+    "gfx942"
+  ],
+  "module": "llama_8b_fp16/modules/llama_gfx942",
+  "golden_dispatch_count": 12,
+  "golden_binary_size": 12345678
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -1,0 +1,41 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp16/modules/llama_gfx942"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=decode_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x1xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x4xi64"
+      },
+      {
+        "value": "34x2097152xf16"
+      }
+    ],
+    "golden_time_ms": 7.7
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -37,5 +37,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 7.7
+    "golden_time_ms": 6.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -16,7 +16,7 @@
     "run_args": [
         "--function=decode_bs4",
         "--device=hip",
-        "--benchmark_repetitions=10",
+        "--benchmark_repetitions=3",
         "--benchmark_min_warmup_time=3.0"
     ],
 

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -37,5 +37,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 7.7
+    "golden_time_ms": 10.5
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -1,0 +1,41 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp16/modules/llama_gfx942"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=decode_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x1xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x64xi64"
+      },
+      {
+        "value": "34x2097152xf16"
+      }
+    ],
+    "golden_time_ms": 7.7
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -16,7 +16,7 @@
     "run_args": [
         "--function=decode_bs4",
         "--device=hip",
-        "--benchmark_repetitions=10",
+        "--benchmark_repetitions=3",
         "--benchmark_min_warmup_time=3.0"
     ],
 

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/llama_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/llama_gfx942.json
@@ -1,0 +1,8 @@
+{
+  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/8b_f16_random.mlir",
+  "compiler_flags": [
+      "--iree-hal-target-device=hip",
+      "--iree-hip-target=gfx942",
+      "--iree-opt-level=O3"
+  ]
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -1,0 +1,38 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp16/modules/llama_gfx942"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=prefill_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x128xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x4xi64"
+      },
+      {
+        "value": "34x2097152xf16"
+      }
+    ],
+    "golden_time_ms": 30.0
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -16,7 +16,7 @@
     "run_args": [
         "--function=prefill_bs4",
         "--device=hip",
-        "--benchmark_repetitions=10",
+        "--benchmark_repetitions=3",
         "--benchmark_min_warmup_time=3.0"
     ],
 

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -1,0 +1,38 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp16/modules/llama_gfx942"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/halo-models/llm-dev/llama3_8b_random/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=prefill_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x2048xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x64xi64"
+      },
+      {
+        "value": "34x2097152xf16"
+      }
+    ],
+    "golden_time_ms": 300.0
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -34,5 +34,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 300.0
+    "golden_time_ms": 450.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -16,7 +16,7 @@
     "run_args": [
         "--function=prefill_bs4",
         "--device=hip",
-        "--benchmark_repetitions=10",
+        "--benchmark_repetitions=3",
         "--benchmark_min_warmup_time=3.0"
     ],
 

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
@@ -35,5 +35,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time_ms": 400.0
+    "golden_time_ms": 405.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
@@ -1,0 +1,39 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "cpu",
+        "local-task"
+    ],
+    "modules": [
+        "sdxl/modules/clip_cpu"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=encode_prompts",
+        "--device=local-task",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0",
+        "--device_allocator=caching"
+    ],
+
+    "inputs": [
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      }
+    ],
+    "golden_time": 400.0
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
@@ -35,5 +35,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time": 400.0
+    "golden_time_ms": 400.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_gfx942.json
@@ -1,0 +1,39 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "gfx942"
+    ],
+    "modules": [
+        "sdxl/modules/clip_gfx942"
+    ],
+    "weights": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+            "scope": "model"
+        }
+    ],
+    "run_args": [
+        "--function=encode_prompts",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0",
+        "--device_allocator=caching"
+    ],
+
+    "inputs": [
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      },
+      {
+        "value": "1x64xi64"
+      }
+    ],
+    "golden_time": 7.65
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
@@ -35,5 +35,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time": 7.65
+    "golden_time_ms": 7.65
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
@@ -2,7 +2,7 @@
     "type": "benchmark",
     "markers": [
         "hip",
-        "gfx942"
+        "mi325"
     ],
     "modules": [
         "sdxl/modules/clip_gfx942"

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_cpu.json
@@ -2,6 +2,6 @@
   "type": "compstat",
   "markers": ["cpu"],
   "module": "sdxl/modules/clip_cpu",
-  "golden_dispatch_count": 12,
-  "golden_binary_size": 12345678
+  "golden_dispatch_count": 2089,
+  "golden_binary_size": 650000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_cpu.json
@@ -1,0 +1,7 @@
+{
+  "type": "compstat",
+  "markers": ["cpu"],
+  "module": "sdxl/modules/clip_cpu",
+  "golden_dispatch_count": 12,
+  "golden_binary_size": 12345678
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "sdxl/modules/clip_gfx942",
-  "golden_dispatch_count": 12,
-  "golden_binary_size": 12345678
+  "golden_dispatch_count": 794,
+  "golden_binary_size": 460000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
@@ -1,0 +1,10 @@
+{
+  "type": "compstat",
+  "markers": [
+    "hip",
+    "gfx942"
+  ],
+  "module": "sdxl/modules/clip_gfx942",
+  "golden_dispatch_count": 12,
+  "golden_binary_size": 12345678
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_quality_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_quality_cpu.json
@@ -1,0 +1,49 @@
+{
+    "type": "quality",
+    "markers": [
+      "cpu",
+      "local-task"
+    ],
+    "modules": [
+      "sdxl/modules/clip_cpu"
+    ],
+    "weights": [
+      {
+        "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+        "scope": "model"
+      }
+    ],
+    "run_args": [
+      "--function=encode_prompts",
+      "--device=local-task",
+      "--expected_f16_threshold=1.0f"
+    ],
+    "inputs": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
+            "value": "1x64xi64"
+        }
+    ],
+    "expected_outputs": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
+            "value": "2x64x2048xf16"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
+            "value": "2x1280xf16"
+        }
+    ]
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_quality_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_quality_gfx942.json
@@ -1,0 +1,49 @@
+{
+    "type": "quality",
+    "markers": [
+      "hip",
+      "gfx942"
+    ],
+    "modules": [
+      "sdxl/modules/clip_gfx942"
+    ],
+    "weights": [
+      {
+        "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/real_weights.irpa",
+        "scope": "model"
+      }
+    ],
+    "run_args": [
+      "--function=encode_prompts",
+      "--device=hip",
+      "--expected_f16_threshold=1.0f"
+    ],
+    "inputs": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.0.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.1.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.2.bin",
+            "value": "1x64xi64"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_input.3.bin",
+            "value": "1x64xi64"
+        }
+    ],
+    "expected_outputs": [
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.0.bin",
+            "value": "2x64x2048xf16"
+        },
+        {
+            "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/inference_output.1.bin",
+            "value": "2x1280xf16"
+        }
+    ]
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_cpu.json
@@ -1,0 +1,13 @@
+{
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
+    "compiler_flags": [
+        "--iree-hal-local-target-device-backends=llvm-cpu",
+        "--iree-hal-target-device=local",
+        "--iree-llvmcpu-target-cpu-features=host",
+        "--iree-opt-level=O1",
+        "--iree-opt-data-tiling",
+        "--iree-llvmcpu-distribution-size=32",
+        "--iree-scheduling-dump-statistics-format=json",
+        "--iree-scheduling-dump-statistics-file=compilation_info.json"
+    ]
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
@@ -1,0 +1,15 @@
+{
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
+    "compiler_flags": [
+        "--iree-hal-target-device=hip",
+        "--iree-hip-target=gfx942",
+        "--iree-opt-level=O3",
+        "--iree-opt-generalize-matmul=false",
+        "--iree-opt-const-eval=false",
+        "--iree-hip-waves-per-eu=2",
+        "--iree-llvmgpu-enable-prefetch",
+        "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
+        "--iree-execution-model=async-external",
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
+    ]
+}


### PR DESCRIPTION
This PR adds basic tests for clip and llama to run on post submit. It also enables running the torch_models ci by using a ci-extra label.

ci-extra: test_torch