### PR TITLE
Update CODEOWNERS to include new tests and dialect owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,7 @@
 /compiler/src/iree/compiler/ @benvanik
 /compiler/src/iree/compiler/Codegen/ @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/Common @hanhanW
-/compiler/src/iree/compiler/Codegen/Common/GPU @antiagainst @qedawkins @Groverkss
+/compiler/src/iree/compiler/Codegen/Common/GPU @antiagainst @qedawkins @Groverkss @kuhar
 /compiler/src/iree/compiler/Codegen/Dialect/CPU @hanhanW
 /compiler/src/iree/compiler/Codegen/Dialect/GPU @antiagainst @qedawkins
 /compiler/src/iree/compiler/Codegen/Dialect/VectorExt @Groverkss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,19 +45,22 @@
 # llvm-external-projects
 /llvm-external-projects/ @stellaraccident
 /llvm-external-projects/iree-dialects/ @MaheshRavishankar
-/llvm-external-projects/iree-dialects/**/VectorExt/* @Groverkss
 
 # Other Top-Level Directories
 /docs/ @ScottTodd
 /tools/ @benvanik
 
+# Tests
+/tests/external/iree-test-suites @Groverkss @MaheshRavishankar @kuhar
+
 # Compiler
 /compiler/src/iree/compiler/ @benvanik
 /compiler/src/iree/compiler/Codegen/ @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/Common @hanhanW
-/compiler/src/iree/compiler/Codegen/Common/GPU @antiagainst @qedawkins
+/compiler/src/iree/compiler/Codegen/Common/GPU @antiagainst @qedawkins @Groverkss
 /compiler/src/iree/compiler/Codegen/Dialect/CPU @hanhanW
 /compiler/src/iree/compiler/Codegen/Dialect/GPU @antiagainst @qedawkins
+/compiler/src/iree/compiler/Codegen/Dialect/VectorExt @Groverkss
 /compiler/src/iree/compiler/Codegen/ExternalInterfaces @hanhanW
 /compiler/src/iree/compiler/Codegen/LLVMCPU/ @hanhanW @MaheshRavishankar @pashu123
 /compiler/src/iree/compiler/Codegen/LLVMGPU/ @MaheshRavishankar @qedawkins @kuhar @Groverkss
@@ -65,7 +68,7 @@
 /compiler/src/iree/compiler/ConstEval/ @hanhanW @stellaraccident
 /compiler/src/iree/compiler/Dialect/Encoding/ @bjacob @hanhanW
 /compiler/src/iree/compiler/Dialect/Flow/ @hanhanW @MaheshRavishankar @IanWood1
-/compiler/src/iree/compiler/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar
+/compiler/src/iree/compiler/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar @Groverkss
 /compiler/src/iree/compiler/Dialect/TensorExt/ @hanhanW
 /compiler/src/iree/compiler/Dialect/Vulkan/ @antiagainst @kuhar
 /compiler/src/iree/compiler/DispatchCreation/ @hanhanW @MaheshRavishankar @IanWood1


### PR DESCRIPTION
- Update CODEOWNERS for myself, adding myself to GPU/LinalgExt/VectorExt dialect owners.
- Add CODEOWNERS for iree-tests-suites to be me, @MaheshRavishankar and @kuhar 
- Add @kuhar to Common/GPU owners