### PR TITLE
[debugging][gpu] Add --iree-hip-emit-debug-info flag

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -451,7 +451,8 @@ public:
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,
                                     OpPassManager &passManager) override {
-    buildLLVMGPUCodegenPassPipeline(passManager, false);
+    buildLLVMGPUCodegenPassPipeline(passManager, false,
+                                    /*preserveDebugInfo=*/false);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/plugins/target/ROCM/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/test/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "emit_debug_info.mlir"
     "external_function_validation.mlir"
     "smoketest.mlir"
     "smoketest_hsaco.mlir"

--- a/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
+++ b/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
@@ -1,7 +1,7 @@
-// RUN: iree-opt --iree-hip-emit-debug-info --mlir-print-debuginfo %s | FileCheck %s
+// RUN: iree-opt --mlir-print-debuginfo %s --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline{preserve-debug-info})))" | FileCheck %s
 
 // Test that LLVM debug info attributes pass through without being stripped when
-// the `--iree-hip-emit-debug-info` flag is used
+// the pipeline `preserve-debug-info` option is used
 
 #di_file = #llvm.di_file<"test.mlir" in "/work">
 #di_compile_unit = #llvm.di_compile_unit<

--- a/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
+++ b/compiler/plugins/target/ROCM/test/emit_debug_info.mlir
@@ -1,0 +1,52 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: iree-compile --iree-hal-target-backends=rocm --iree-hip-target=gfx942 \
+// RUN:   --iree-hip-emit-debug-info \
+// RUN:   --iree-hal-dump-executable-binaries-to=%t \
+// RUN:   %s -o %t/module.vmfb
+// RUN: llvm-dwarfdump --debug-line %t/*.hsaco | FileCheck %s
+
+// Test that the `--iree-hip-emit-debug-info` flag preserves debug information
+// in the generated ELF binary by checking for specific source locations in DWARF.
+
+#di_file = #llvm.di_file<"test.mlir" in "/work">
+#di_compile_unit = #llvm.di_compile_unit<
+  id = distinct[0]<>,
+  sourceLanguage = DW_LANG_C,
+  file = #di_file,
+  producer = "test",
+  isOptimized = false,
+  emissionKind = LineTablesOnly
+>
+#di_subprogram = #llvm.di_subprogram<
+  id = distinct[1]<>,
+  compileUnit = #di_compile_unit,
+  scope = #di_file,
+  name = "simple_mul",
+  file = #di_file,
+  line = 5,
+  scopeLine = 5,
+  subprogramFlags = Definition
+>
+
+module attributes {
+  llvm.di_compile_unit = #di_compile_unit
+} {
+  func.func @simple_mul(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    %0 = tensor.empty() : tensor<16xf32>
+    %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]
+    } ins(%arg0 : tensor<16xf32>) outs(%0 : tensor<16xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %2 = arith.mulf %in, %in : f32
+      linalg.yield %2 : f32
+    } -> tensor<16xf32>
+    return %1 : tensor<16xf32>
+  } loc(fused<#di_subprogram>["test.mlir":5:1])
+}
+
+// CHECK: .debug_line contents:
+// CHECK: file_names[{{.*}}]:
+// CHECK-NEXT: name: "test.mlir"
+// ------ address         line column file ... flags
+// CHECK: {{0x[0-9a-f]+}} 5    1      1 {{.*}} is_stmt

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1251,7 +1251,7 @@ void registerCodegenLLVMGPUPasses() {
   common::registerPasses();
 
   struct LLVMGPUPipelineOptions final
-      :  PassPipelineOptions<LLVMGPUPipelineOptions> {
+      : PassPipelineOptions<LLVMGPUPipelineOptions> {
     Option<bool> preserveDebugInfo{
         *this, "preserve-debug-info",
         llvm::cl::desc("Preserve debug information (do not strip)")};

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1250,8 +1250,8 @@ void registerCodegenLLVMGPUPasses() {
   // Generated.
   common::registerPasses();
 
-  struct LLVMGPUPipelineOptions
-      : public PassPipelineOptions<LLVMGPUPipelineOptions> {
+  struct LLVMGPUPipelineOptions final
+      :  PassPipelineOptions<LLVMGPUPipelineOptions> {
     Option<bool> preserveDebugInfo{
         *this, "preserve-debug-info",
         llvm::cl::desc("Preserve debug information (do not strip)")};
@@ -1302,8 +1302,8 @@ void registerCodegenROCDLPasses() {
   // Generated.
   rocdl::registerPasses();
 
-  struct ROCDLPipelineOptions
-      : public PassPipelineOptions<ROCDLPipelineOptions> {
+  struct ROCDLPipelineOptions final
+      : PassPipelineOptions<ROCDLPipelineOptions> {
     Option<bool> preserveDebugInfo{
         *this, "preserve-debug-info",
         llvm::cl::desc("Preserve debug information (do not strip)")};

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1250,6 +1250,13 @@ void registerCodegenLLVMGPUPasses() {
   // Generated.
   common::registerPasses();
 
+  struct LLVMGPUPipelineOptions
+      : public PassPipelineOptions<LLVMGPUPipelineOptions> {
+    Option<bool> preserveDebugInfo{
+        *this, "preserve-debug-info",
+        llvm::cl::desc("Preserve debug information (do not strip)")};
+  };
+
   static PassPipelineRegistration<> LLVMGPUConfigPipeline(
       "iree-codegen-llvmgpu-configuration-pipeline",
       "Runs the translation strategy configuration pipeline on Linalg for GPU "
@@ -1258,20 +1265,20 @@ void registerCodegenLLVMGPUPasses() {
         buildLLVMGPUCodegenConfigurationPassPipelineImpl(modulePassManager);
       });
 
-  static PassPipelineRegistration<> LinalgNVVMPipeline(
+  static PassPipelineRegistration<LLVMGPUPipelineOptions> LinalgNVVMPipeline(
       "iree-codegen-linalg-to-nvvm-pipeline",
       "Runs the progressive lowering pipeline from Linalg to NVVM",
-      [](OpPassManager &passManager) {
+      [](OpPassManager &passManager, const LLVMGPUPipelineOptions &options) {
         buildLLVMGPUCodegenPassPipeline(passManager, false,
-                                        /*preserveDebugInfo=*/false);
+                                        options.preserveDebugInfo);
       });
 
-  static PassPipelineRegistration<> LinalgROCDLPipeline(
+  static PassPipelineRegistration<LLVMGPUPipelineOptions> LinalgROCDLPipeline(
       "iree-codegen-linalg-to-rocdl-pipeline",
       "Runs the progressive lowering pipeline from Linalg to ROCDL",
-      [](OpPassManager &passManager) {
+      [](OpPassManager &passManager, const LLVMGPUPipelineOptions &options) {
         buildLLVMGPUCodegenPassPipeline(passManager, true,
-                                        /*preserveDebugInfo=*/false);
+                                        options.preserveDebugInfo);
       });
 
   static PassPipelineRegistration<> LLVMGPULinkingPipeline(
@@ -1295,11 +1302,18 @@ void registerCodegenROCDLPasses() {
   // Generated.
   rocdl::registerPasses();
 
-  static PassPipelineRegistration<> LinalgROCDLPipeline(
+  struct ROCDLPipelineOptions
+      : public PassPipelineOptions<ROCDLPipelineOptions> {
+    Option<bool> preserveDebugInfo{
+        *this, "preserve-debug-info",
+        llvm::cl::desc("Preserve debug information (do not strip)")};
+  };
+
+  static PassPipelineRegistration<ROCDLPipelineOptions> LinalgROCDLPipeline(
       "iree-codegen-linalg-to-rocdl-pipeline2",
       "Runs pass pipeline to progressively lower Linalg to ROCDL",
-      [](OpPassManager &passManager) {
-        buildROCDLCodegenPassPipeline(passManager, /*preserveDebugInfo=*/false);
+      [](OpPassManager &passManager, const ROCDLPipelineOptions &options) {
+        buildROCDLCodegenPassPipeline(passManager, options.preserveDebugInfo);
       });
 
   static PassPipelineRegistration<> LLVMGPUBufferizePipeline(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -80,7 +80,7 @@ void buildLLVMGPUCodegenConfigurationPassPipeline(
 /// the structured ops path. The pass manager `pm` in here should operate on
 /// the module within the IREE::HAL::ExecutableOp.
 void buildLLVMGPUCodegenPassPipeline(OpPassManager &variantPassManagery,
-                                     bool useROCM);
+                                     bool useROCM, bool preserveDebugInfo);
 
 /// Verify configuration set for the LLVMGPUVectorDistribute pass pipeline.
 LogicalResult verifyLLVMGPUVectorDistributePipeline(


### PR DESCRIPTION
When this flag is provided it prevents stripping debug info for LLVMGPU.  In particular this will allow the Wave language to emit locations in DWARF for use in profiling.