### PR TITLE
Carry encoding in the preferred storage type of a hoistable type

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "llvm/Support/Casting.h"
@@ -113,6 +114,70 @@ static Value computePackedIndex(OpBuilder &builder, Location loc,
       arith::MulIOp::create(builder, loc, outerIdx, tileSizeVal).getResult();
   return arith::AddIOp::create(builder, loc, outerScaled, innerIdxVal)
       .getResult();
+}
+
+void adjustTileSizesForBitcast(RankedTensorType type,
+                               MaterializeEncodingInfo &info) {
+  auto encoding =
+      dyn_cast_if_present<Encoding::EncodingAttr>(type.getEncoding());
+  if (!encoding) {
+    return;
+  }
+
+  // Only adjust if the encoding has an original_element_type, indicating a
+  // bitcast occurred.
+  auto originalElementTypeAttr = encoding.getOriginalElementType();
+  if (!originalElementTypeAttr) {
+    return;
+  }
+
+  Type originalType = originalElementTypeAttr.getValue();
+  Type storageType = type.getElementType();
+
+  // No adjustment needed if types are the same.
+  if (originalType == storageType) {
+    return;
+  }
+
+  unsigned originalBits = originalType.getIntOrFloatBitWidth();
+  unsigned storageBits = storageType.getIntOrFloatBitWidth();
+
+  // One bit width must be a multiple of the other.
+  assert((storageBits >= originalBits ? storageBits % originalBits
+                                      : originalBits % storageBits) == 0 &&
+         "bit widths must be multiples of each other");
+
+  // Adjust the innermost tile size based on the bit width ratio between
+  // original and storage types. The innermost dimension is where packing
+  // occurs.
+  if (info.innerTileSizes.empty()) {
+    return;
+  }
+  int64_t &innermostTileSize = info.innerTileSizes.back();
+  if (ShapedType::isDynamic(innermostTileSize)) {
+    return;
+  }
+
+  // Scale the tile size: multiply by originalBits and divide by storageBits.
+  // This scales down when storage > original (e.g., i4→i8 packing).
+  int64_t scaledSize = innermostTileSize * originalBits;
+  assert(scaledSize % storageBits == 0 &&
+         "scaled tile size must be divisible by storage bits");
+  innermostTileSize = scaledSize / storageBits;
+
+  // Also adjust the swizzle's expandShape innermost dimension if present.
+  // The expandShape describes how each inner tile dimension is further split,
+  // and the innermost dimension's size must be scaled by the same ratio.
+  if (info.swizzle && !info.swizzle->expandShape.empty()) {
+    Codegen::TileSwizzle::ExpandShapeDimVectorType &innermostExpandDims =
+        info.swizzle->expandShape.back();
+    assert(!innermostExpandDims.empty() && "expand shape must be non-empty");
+    Codegen::TileSwizzle::Dim &innermostDim = innermostExpandDims.back();
+    int64_t scaledExpandSize = innermostDim.size * originalBits;
+    assert(scaledExpandSize % storageBits == 0 &&
+           "scaled expand size must be divisible by storage bits");
+    innermostDim.size = scaledExpandSize / storageBits;
+  }
 }
 
 Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -114,6 +114,7 @@ def EncodingAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "cloneWithLayouts",
+        "convertForBitcast",
       ]>,
       DeclareAttrInterfaceMethods<IREEEncoding_ContractionEncodingAttrInterface, [
         "getReductionDims",
@@ -131,6 +132,12 @@ def EncodingAttr :
     can be used to explicitly manifest the layout change
     through operations like pack/unpack.
 
+    The optional `original_element_type` field indicates that the tensor was
+    bitcast from a different element type. This is used when sub-byte types
+    (e.g., i4) are packed into larger storage types (e.g., i8). When present,
+    tile size calculations use this type instead of the tensor's actual element
+    type to correctly account for the packing ratio.
+
     This attribute has a verifier that will ensure that:
     - The `operand_index` shouldn't exceed the size of
       `user_indexing_maps`, if the latter is provided.
@@ -139,8 +146,8 @@ def EncodingAttr :
 
   let assemblyFormat = [{
     `<`
-    struct($operand_index, $op_type, $element_types, $user_indexing_maps,
-           custom<DynamicI64ArrayAttr>($iteration_sizes))
+    struct($operand_index, $op_type, $element_types, $original_element_type,
+           $user_indexing_maps, custom<DynamicI64ArrayAttr>($iteration_sizes))
     `>`
   }];
 
@@ -148,6 +155,7 @@ def EncodingAttr :
     AttrParameter<"IntegerAttr", "this tensor operand's index in the parameter list">:$operand_index,
     AttrParameter<"EncodingOpTypeAttr", "operand type">:$op_type,
     AttrParameter<"ArrayAttr", "element types of the user's operands">:$element_types,
+    OptionalParameter<"TypeAttr", "original element type before bitcast packing">:$original_element_type,
     OptionalParameter<"ArrayAttr", "Indexing maps of the operation using this tensor">:$user_indexing_maps,
     OptionalParameter<"ArrayAttr", "The original operation's iteration sizes. "
     "This is useful for handling skinny dimension sizes">:$iteration_sizes
@@ -157,6 +165,7 @@ def EncodingAttr :
     AttrBuilder<(ins "int64_t":$operandIndex,
         "EncodingOpType":$opType,
         "ArrayRef<Type>":$elemTypes,
+        CArg<"Type", "{}">:$originalElementType,
         CArg<"ArrayRef<AffineMap>", "{}">:$maps,
         CArg<"ArrayRef<int64_t>", "{}">:$iterationSizes)>
   ];
@@ -186,7 +195,7 @@ def EncodingAttr :
     SmallVector<int64_t> getIterationSizesArray() const;
 
     /// Returns a vector with values in `element_types`.
-    SmallVector<Type> getElementTypesArray();
+    SmallVector<Type> getElementTypesArray() const;
 
     /// Clones an encoding with a new indexing map being appended to the
     /// `operand_index` entry of `user_indexing_map`.
@@ -328,6 +337,7 @@ def TestingAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
         "isSerialized",
         "cloneWithLayouts",
+        "convertForBitcast",
       ]>
     ]> {
   let mnemonic = "testing";
@@ -340,7 +350,11 @@ def TestingAttr :
 
   let parameters = (ins
     OptionalParameter<"ArrayAttr", "An array of attributes that describes the "
-    "layouts.">:$layouts
+    "layouts.">:$layouts,
+    OptionalParameter<"Type", "Original element type before bitcast packing. "
+    "This can differ from the actual storage type. E.g., in case of a bitcast "
+    "from i4 to i8, the tensor's element type becomes the storage type while "
+    "this field preserves the original element type.">:$original_element_type
   );
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -237,6 +237,27 @@ def IREEEncoding_SerializableAttr :
       /*defaultImplementation=*/[{
         return nullptr;
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Converts the encoding for a bitcast operation. Given the shape and
+        element types, returns the new shape and encoding to maintain the same
+        total bit count.
+        Returns failure if the conversion is not possible (e.g., bits don't
+        divide evenly).
+      }],
+      /*retTy=*/"::llvm::FailureOr<::mlir::iree_compiler::IREE::Encoding::BitcastEncodingInfo>",
+      /*methodName=*/"convertForBitcast",
+      /*args=*/(ins
+        "::llvm::ArrayRef<int64_t>":$shape,
+        "::mlir::Type":$original_element_type,
+        "::mlir::Type":$new_element_type
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return failure();
+      }]
     >
   ];
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -89,10 +89,10 @@ SerializableAttr::getEncodingProperties(Operation *op) {
   SmallVector<Value> dynamicDims = getDynamicLoopDims(builder, linalgOp);
 
   auto addEncoding = [&](int64_t operandIndex) {
-    return EncodingProperties{EncodingAttr::get(ctx, operandIndex, opType,
-                                                elemTypes, maps,
-                                                iterationSizes),
-                              dynamicDims};
+    return EncodingProperties{
+        EncodingAttr::get(ctx, operandIndex, opType, elemTypes,
+                          /*originalElementType=*/{}, maps, iterationSizes),
+        dynamicDims};
   };
 
   // Return encoding properties for contraction operations.

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -117,6 +117,15 @@ struct PropagationResult {
   SmallVector<Value> replacements;
 };
 
+/// Information returned by convertForBitcast interface method.
+/// Contains the new shape and encoding after bitcasting to a new element type.
+struct BitcastEncodingInfo {
+  /// The new shape after bitcasting.
+  SmallVector<int64_t> newShape;
+  /// The new encoding attribute after bitcasting.
+  Attribute encoding;
+};
+
 } // namespace mlir::iree_compiler::IREE::Encoding
 
 // clang-format off

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/BUILD.bazel
@@ -35,6 +35,8 @@ iree_compiler_cc_library(
         "HoistableTypeInterface.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
+        "//compiler/src/iree/compiler/Dialect/Encoding/Utils",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/CMakeLists.txt
@@ -34,6 +34,8 @@ iree_cc_library(
     LLVMSupport
     MLIRArithDialect
     MLIRIR
+    iree::compiler::Dialect::Encoding::IR
+    iree::compiler::Dialect::Encoding::Utils
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.h"
 
+#include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "llvm/Support/MathExtras.h"
@@ -51,22 +52,46 @@ struct HoistableTensorTypeInterface
     if (!tensorType.hasStaticShape()) {
       return type;
     }
+
     unsigned elementBitWidth =
         IREE::Util::getTypeBitWidth(tensorType.getElementType());
-    // Bit cast sub-byte and non-byte aligned tensor types as MLIR cannot store
-    // them packed at the moment. Also bools continue getting special treatment.
-    if (elementBitWidth == 1 ||
-        (llvm::isPowerOf2_32(elementBitWidth) && elementBitWidth >= 8)) {
+    // Bools get special treatment - don't pack them.
+    if (elementBitWidth == 1) {
       return type;
     }
+    // Byte-aligned types (8, 16, 32, 64 bits) don't need conversion.
+    if (llvm::isPowerOf2_32(elementBitWidth) && elementBitWidth >= 8) {
+      return type;
+    }
+
+    // Sub-byte types need to be packed into bytes for storage - use i8 storage.
+    Type i8Type = Builder(type.getContext()).getIntegerType(8);
+
+    // If the tensor has an encoding, let it handle the conversion.
+    if (auto serializableAttr =
+            dyn_cast_if_present<IREE::Encoding::SerializableAttr>(
+                tensorType.getEncoding())) {
+      FailureOr<IREE::Encoding::BitcastEncodingInfo> result =
+          serializableAttr.convertForBitcast(
+              tensorType.getShape(), tensorType.getElementType(), i8Type);
+      if (succeeded(result)) {
+        return RankedTensorType::get(result->newShape, i8Type,
+                                     result->encoding);
+      }
+      // Encoding couldn't handle conversion, so return the original type.
+      return type;
+    }
+
+    // In case of no encoding, convert to flat i8 storage.
     int64_t numElements = ShapedType::getNumElements(tensorType.getShape());
+    int64_t totalBits = numElements * elementBitWidth;
     // Bail out if the data can't be aligned on bytes.
-    if (numElements * elementBitWidth % 8 != 0) {
+    if (totalBits % 8 != 0) {
       return type;
     }
-    return RankedTensorType::get({numElements * elementBitWidth / 8},
-                                 Builder(type.getContext()).getIntegerType(8));
+    return RankedTensorType::get({totalBits / 8}, i8Type);
   }
+
   static Value encodeStorageType(OpBuilder &builder, Location loc,
                                  Type storageType, Value init) {
     auto storageTensorType = dyn_cast<RankedTensorType>(storageType);


### PR DESCRIPTION
This PR makes sure that the encoding attribute is included in the preferred storage type of a `HoistableTensorType`. Without this we can get a `tensor.bitcast` on an encoded type returning a non-encoded type, which will result in a compilation failure when converting into stream. 

This PR adds a `convertForBitcast` interface method to the SerializableAttr interface for encodings to specify how the types should be converted on a bitcast operation. This adds generality as different encodings can provide different implementations, allows them to perform correctness checks and would even allow propagating encodings further on the bitcasted type if needed in the future.