### PR TITLE
[GlobalOpt] Use Option<> for TransformOptions

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -9,7 +9,6 @@
 
 #include <functional>
 
-#include "iree/compiler/Pipelines/Options.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -17,12 +16,97 @@
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
-/// We have a layer of indirection around the GlobalOptimizationOptions because
-/// we also need a reference to the const-eval builder, which is injected
-/// in by callers.
 struct TransformOptions : public PassPipelineOptions<TransformOptions> {
-  GlobalOptimizationOptions options;
-
+  ListOption<std::string> parameterImportPaths{
+      *this,
+      "parameter-import-paths",
+      llvm::cl::desc("File paths to archives to import parameters from with an "
+                     "optional `scope=` prefix."),
+  };
+  ListOption<std::string> parameterImportKeys{
+      *this,
+      "parameter-import-keys",
+      llvm::cl::desc("List of parameter keys to import. Any matching keys from "
+                     "any scope will be imported."),
+  };
+  Option<int64_t> parameterImportMaximumSize{
+      *this,
+      "parameter-import-maximum-size",
+      llvm::cl::desc("Maximum size of parameters to import or 0 to disable "
+                     "automatic import."),
+      llvm::cl::init(0),
+  };
+  Option<std::string> parameterExportPath{
+      *this,
+      "parameter-export-path",
+      llvm::cl::desc("File path to an archive to export parameters to with an "
+                     "optional `scope=` prefix."),
+      llvm::cl::init(""),
+  };
+  Option<int64_t> parameterExportMinimumSize{
+      *this,
+      "parameter-export-minimum-size",
+      llvm::cl::desc("Minimum size of constants to export as parameters."),
+      llvm::cl::init(0),
+  };
+  Option<std::string> parameterSplatExportFile{
+      *this,
+      "parameter-splat-export-file",
+      llvm::cl::desc("File path to create a splat parameter archive out of all "
+                     "parameters in the module."),
+      llvm::cl::init(""),
+  };
+  Option<bool> aggressiveTransposePropagation{
+      *this,
+      "aggressive-transpose-propagation",
+      llvm::cl::desc(
+          "Enables aggressive propagation of transposes to the inputs of named "
+          "ops, rewriting named ops as fused generics."),
+      llvm::cl::init(false),
+  };
+  Option<bool> outerDimConcat{
+      *this,
+      "outer-dim-concat",
+      llvm::cl::desc("Enables transposing all concatenations to the outer most "
+                     "dimension."),
+      llvm::cl::init(false),
+  };
+  Option<bool> dataTiling{
+      *this,
+      "data-tiling",
+      llvm::cl::desc("Enables data tiling in global optimization phase. There "
+                     "are two data-tiling flags during the transition state. "
+                     "The other has to be off if this one is enabled. Any "
+                     "feature built on top of this path will be deprecated."),
+      llvm::cl::init(false),
+  };
+  Option<bool> constEval{
+      *this,
+      "const-eval",
+      llvm::cl::desc("Enables recursive evaluation of immutable globals using "
+                     "the compiler and runtime."),
+      llvm::cl::init(true),
+  };
+  Option<bool> numericPrecisionReduction{
+      *this,
+      "numeric-precision-reduction",
+      llvm::cl::desc("Optimizations to reduce numeric precision where it is "
+                     "safe to do so."),
+      llvm::cl::init(false),
+  };
+  Option<bool> stripAssertions{
+      *this,
+      "strip-assertions",
+      llvm::cl::desc("Strips debug assertions after any useful information has "
+                     "been extracted."),
+      llvm::cl::init(false),
+  };
+  Option<bool> generalizeMatmul{
+      *this,
+      "generalize-matmul",
+      llvm::cl::desc("Converts linalg named matmul ops to linalg generic ops."),
+      llvm::cl::init(false),
+  };
   Option<bool> constExprHoisting{
       *this,
       "const-expr-hoisting",

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -175,7 +175,30 @@ void buildIREEPrecompileTransformPassPipeline(
                                                   halAssignmentOptions);
 
   GlobalOptimization::TransformOptions globalTransformOptions;
-  globalTransformOptions.options = globalOptimizationOptions;
+  globalTransformOptions.parameterImportPaths =
+      globalOptimizationOptions.parameterImportPaths;
+  globalTransformOptions.parameterImportKeys =
+      globalOptimizationOptions.parameterImportKeys;
+  globalTransformOptions.parameterImportMaximumSize =
+      globalOptimizationOptions.parameterImportMaximumSize;
+  globalTransformOptions.parameterExportPath =
+      globalOptimizationOptions.parameterExportPath;
+  globalTransformOptions.parameterExportMinimumSize =
+      globalOptimizationOptions.parameterExportMinimumSize;
+  globalTransformOptions.parameterSplatExportFile =
+      globalOptimizationOptions.parameterSplatExportFile;
+  globalTransformOptions.aggressiveTransposePropagation =
+      globalOptimizationOptions.aggressiveTransposePropagation;
+  globalTransformOptions.outerDimConcat =
+      globalOptimizationOptions.outerDimConcat;
+  globalTransformOptions.dataTiling = globalOptimizationOptions.dataTiling;
+  globalTransformOptions.constEval = globalOptimizationOptions.constEval;
+  globalTransformOptions.numericPrecisionReduction =
+      globalOptimizationOptions.numericPrecisionReduction;
+  globalTransformOptions.stripAssertions =
+      globalOptimizationOptions.stripAssertions;
+  globalTransformOptions.generalizeMatmul =
+      globalOptimizationOptions.generalizeMatmul;
   globalTransformOptions.constExprHoisting = pipelineOptions.constExprHoisting;
   globalTransformOptions.constExprMaxSizeIncreaseThreshold =
       pipelineOptions.constExprMaxSizeIncreaseThreshold;


### PR DESCRIPTION
Copies all the members from `GlobalOptimizationOptions` into `TransformOptions` and removes `GlobalOptimizationOptions` member. Since the new members are of type `Option<T>`, `TransformOptions` can now be used to parse pipeline flags into the struct.

Similar to https://github.com/iree-org/iree/pull/21964