### PR TITLE
[ROCm] Enable e2e stablehlo tests

### DIFF
--- a/tests/e2e/stablehlo_models/CMakeLists.txt
+++ b/tests/e2e/stablehlo_models/CMakeLists.txt
@@ -47,8 +47,6 @@ iree_static_linker_test(
     "predict"
   FUNCTION_INPUTS
     "1x28x28x1xf32"
-  COMPILER_FLAGS
-    "--iree-input-type=stablehlo"
 )
 
 iree_static_linker_test(
@@ -63,7 +61,6 @@ iree_static_linker_test(
   FUNCTION_INPUTS
     "1x28x28x1xf32"
   COMPILER_FLAGS
-    "--iree-input-type=stablehlo"
     "--iree-vm-target-index-bits=32"
   EMITC
 )

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -765,9 +765,8 @@ iree_check_single_backend_test_suite(
     "while.mlir"
   TARGET_BACKEND
     "rocm"
-  # Only test compilation for now, the ROCm driver is experimental.
-  # DRIVER
-  #   "rocm"
+  DRIVER
+    "hip"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
 )


### PR DESCRIPTION
We probably forgot to enable these. Also clean up some other stablehlo tests and drop unnecessary flags.