### PR TITLE
[python] Set up binding for preprocessing transform ops

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -118,6 +118,14 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME iree_gpu
 )
 
+declare_mlir_dialect_extension_python_bindings(
+  ADD_TO_PARENT IREEPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
+  TD_FILE dialects/PreprocessingTransformExtensionsBinding.td
+  SOURCES dialects/preprocessing_transform.py
+  DIALECT_NAME transform
+  EXTENSION_NAME preprocessing_transform)
+
 declare_mlir_python_sources(IREECompilerAPIPythonCore
   ADD_TO_PARENT IREEPythonSources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"

--- a/compiler/bindings/python/iree/compiler/dialects/PreprocessingTransformExtensionsBinding.td
+++ b/compiler/bindings/python/iree/compiler/dialects/PreprocessingTransformExtensionsBinding.td
@@ -1,0 +1,12 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_PREPROCESSING_TRANSFORM_EXTENSIONS_PYTHON_BINDING
+#define IREE_PREPROCESSING_TRANSFORM_EXTENSIONS_PYTHON_BINDING
+
+include "iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td"
+
+#endif // IREE_PREPROCESSING_TRANSFORM_EXTENSIONS_PYTHON_BINDING

--- a/compiler/bindings/python/iree/compiler/dialects/preprocessing_transform.py
+++ b/compiler/bindings/python/iree/compiler/dialects/preprocessing_transform.py
@@ -1,0 +1,67 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional, Sequence
+from iree.compiler import ir
+from iree.compiler.dialects import transform
+from ._preprocessing_transform_ops_gen import *
+from ._preprocessing_transform_ops_gen import _Dialect
+
+try:
+    from ._ods_common import _cext as _ods_cext
+except ImportError as e:
+    raise RuntimeError("Error loading imports from extension module") from e
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class MatchContractionOp(MatchContractionOp):
+    def __init__(
+        self,
+        operand_handle,
+        lhs_type: ir.Type,
+        rhs_type: ir.Type,
+        output_type: ir.Type,
+        indexing_maps: Optional[Sequence] = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        if loc is None:
+            loc = ir.Location.unknown()
+
+        param_type = transform.ParamType.get(ir.IntegerType.get_signless(64))
+        lhs_type_attr = ir.TypeAttr.get(lhs_type)
+        rhs_type_attr = ir.TypeAttr.get(rhs_type)
+        output_type_attr = ir.TypeAttr.get(output_type)
+
+        indexing_maps_attr = None
+        if indexing_maps is not None:
+            indexing_maps_attr = ir.ArrayAttr.get(
+                [ir.AffineMapAttr.get(m) for m in indexing_maps]
+            )
+
+        # Call auto-generated base constructor.
+        super().__init__(
+            param_type,
+            param_type,
+            param_type,
+            param_type,
+            operand_handle,
+            lhs_type_attr,
+            rhs_type_attr,
+            output_type_attr,
+            indexing_maps=indexing_maps_attr,
+            loc=loc,
+            ip=ip,
+        )
+
+    def __iter__(self):
+        return iter([self.batch_dims, self.m_dims, self.n_dims, self.k_dims])
+
+
+__all__ = [
+    "MatchContractionOp",
+]

--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -145,7 +145,6 @@ def test_isa_attention_op():
     """
     input_module = ir.Module.parse(module_str)
     assert input_module is not None, "Failed to parse input MLIR module"
-    print(input_module)
     root_op_list = iree_codegen.get_tuner_root_ops(input_module)
     assert len(root_op_list) == 1
     assert root_op_list[0].name == "iree_linalg_ext.attention"


### PR DESCRIPTION
This PR adds Python bindings for the Preprocessing Transform Extension ops.
It exposes the transform ops defined in that extension, such as `transform.iree.match.contraction`, as well as other commonly used ops like `transform.iree.match.cast_compatible_dag_from_root `and `transform.iree.match.dim_is_multiple_of`, etc.

The bindings are exposed using `declare_mlir_dialect_extension_python_bindings`. The logic mainly follows this llvm upstream PR: https://github.com/llvm/llvm-project/pull/159450. 