### PR TITLE
Fix linking MSVC error from forward declaration used as templated type

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 
-#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/IR/AffineMap.h"

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.h
@@ -8,13 +8,10 @@
 #define IREE_COMPILER_DIALECT_ENCODING_UTILS_UTILS_H_
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-
-namespace mlir::iree_compiler::IREE::LinalgExt {
-class ScaledContractionDimensions;
-} // namespace mlir::iree_compiler::IREE::LinalgExt
 
 namespace mlir::iree_compiler::IREE::Encoding {
 


### PR DESCRIPTION
Fixes a build error for MSVC: https://discord.com/channels/689900678990135345/689957613152239638/1425159686247809054

The MSVC compiler doesn't support using forward declared classes as template types, so this PR just includes the relevant file instead of forward declaring.

Confirmed that the MSVC CI action passes: https://github.com/iree-org/iree/actions/runs/18320843225/job/52173225710