### PR TITLE
Fix typo ConditionalTranspose attribute description

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -819,7 +819,7 @@ def IREEGPU_ConditionalTransposeAttr  :
       - numTileLoadsTransposed = 32 + ceildiv(304, 32) = 42
       => numTileLoadsTransposed < numTileLoadsDefault => enable transpose
 
-     - (M=8192, N=128256, K=4096)
+     - (M=16384, N=8192, K=4096) (tileM=256, tileN=256)
       - numTileLoadsDefault = 32 + ceildiv(304, 32) = 42
       - numTileLoadsTransposed = 64 + ceildiv(304, 64) = 69
       numTileLoadsTransposed > numTileLoadsDefault => disable transpose


### PR DESCRIPTION
This PR fixes a typo in the description of ConditionalTranspose  after 3a29873980a929da61070926359727efffb399fc