### PR TITLE
[build flags] enable more warnings in compile flags (#21996)

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -106,30 +106,11 @@ build:generic_clang --copt=-Wall
 # Disable warnings we don't care about or that generally have a low signal/noise
 # ratio.
 build:generic_clang --copt=-Wno-ambiguous-member-template
-build:generic_clang --copt=-Wno-char-subscripts
 build:generic_clang --copt=-Wno-extern-c-compat # Matches upstream. Cannot impact due to extern C inclusion method.
-build:generic_clang --copt=-Wno-gnu-alignof-expression
-build:generic_clang --copt=-Wno-gnu-variable-sized-type-not-at-end
-build:generic_clang --copt=-Wno-ignored-optimization-argument
 build:generic_clang --copt=-Wno-invalid-offsetof # Technically UB but needed for intrusive ptrs
-build:generic_clang --copt=-Wno-invalid-source-encoding
-build:generic_clang --copt=-Wno-mismatched-tags
-build:generic_clang --copt=-Wno-pointer-sign
-build:generic_clang --copt=-Wno-reserved-user-defined-literal
-build:generic_clang --copt=-Wno-return-type-c-linkage
-build:generic_clang --copt=-Wno-self-assign-overloaded
-build:generic_clang --copt=-Wno-sign-compare
-build:generic_clang --copt=-Wno-signed-unsigned-wchar
-build:generic_clang --copt=-Wno-strict-overflow
-build:generic_clang --copt=-Wno-trigraphs
-build:generic_clang --copt=-Wno-unknown-pragmas
-build:generic_clang --copt=-Wno-unknown-warning-option
-build:generic_clang --copt=-Wno-unused-command-line-argument
 build:generic_clang --copt=-Wno-unused-const-variable
 build:generic_clang --copt=-Wno-unused-function
-build:generic_clang --copt=-Wno-unused-local-typedef
 build:generic_clang --copt=-Wno-unused-private-field
-build:generic_clang --copt=-Wno-user-defined-warnings
 
 # Explicitly enable some additional warnings.
 # Some of these aren't on by default, or under -Wall, or are subsets of warnings

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -169,32 +169,11 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
 
     # Disable warnings we don't care about or that generally have a low
     # signal/noise ratio.
-    "-Wno-ambiguous-member-template"
-    "-Wno-char-subscripts"
     "-Wno-extern-c-compat" # Matches upstream. Cannot impact due to extern C inclusion method.
-    "-Wno-gnu-alignof-expression"
-    "-Wno-gnu-variable-sized-type-not-at-end"
-    "-Wno-ignored-optimization-argument"
     "-Wno-invalid-offsetof" # Technically UB but needed for intrusive ptrs
-    "-Wno-invalid-source-encoding"
-    "-Wno-mismatched-tags"
-    "-Wno-pointer-sign"
-    "-Wno-reserved-user-defined-literal"
-    "-Wno-return-type-c-linkage"
-    "-Wno-self-assign-overloaded"
-    "-Wno-sign-compare"
-    "-Wno-signed-unsigned-wchar"
-    "-Wno-strict-overflow"
-    "-Wno-trigraphs"
-    "-Wno-unknown-pragmas"
-    "-Wno-unknown-warning-option"
-    "-Wno-unused-command-line-argument"
     "-Wno-unused-const-variable"
     "-Wno-unused-function"
-    "-Wno-unused-local-typedef"
     "-Wno-unused-private-field"
-    "-Wno-user-defined-warnings"
-    "-Wno-missing-braces"  # Inconsistently triggers between C++/C headers.
 
     # Explicitly enable some additional warnings.
     # Some of these aren't on by default, or under -Wall, or are subsets of


### PR DESCRIPTION
Enable more warnings during compilation by removing some of of the -Wno-* compile flags:
```
-Wno-ambiguous-member-template
-Wno-char-subscripts
-Wno-gnu-alignof-expression
-Wno-gnu-variable-sized-type-not-at-end
-Wno-ignored-optimization-argument
-Wno-invalid-source-encoding
-Wno-mismatched-tags
-Wno-missing-braces
-Wno-pointer-sign
-Wno-reserved-user-defined-literal
-Wno-return-type-c-linkage
-Wno-self-assign-overloaded
-Wno-sign-compare
-Wno-signed-unsigned-wchar
-Wno-strict-overflow
-Wno-trigraphs
-Wno-unknown-pragmas
-Wno-unknown-warning-option
-Wno-unused-command-line-argument
-Wno-unused-local-typedef
-Wno-user-defined-warnings
```
The -Wno-* flags used by bazel had been slightly different from the ones used by cmake. This change re-aligns this.

A few code locations have been adapted to compile with the additional warnings enabled.