### PR TITLE
Correct dynamic_cast when value might be null

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -39,7 +39,8 @@ lookupDevicesAndQueueAffintiesFor(Operation *op, OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
   SmallVector<Value> devices;
   SmallVector<Value> queueAffinities;
-  if (auto optimalAttr = dyn_cast<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
+  if (auto optimalAttr =
+          dyn_cast_if_present<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
     for (auto affinity : optimalAttr.getAffinities()) {
       auto [device, queueAffinity] =
           lookupDeviceAndQueueAffinityFor(op->getLoc(), affinity, builder);


### PR DESCRIPTION
Compilation:
```
iree-compile --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false e2e/regression/scalar_computation.mlir
```

Assertion failure:
```
llvm::dyn_cast(From &) [To = mlir::iree_compiler::IREE::HAL::DeviceOptimalAttr, From = mlir::iree_compiler::IREE::Stream::AffinityAttr]: Assertion `detail::isPresent(Val) && "dyn_cast on a non-existent value"' failed
```

For some reason this is only after an LLVM bump + 2 other fixes (see https://github.com/iree-org/iree/pull/22234). 