### PR TITLE
Assert affinity attribute present

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -37,10 +37,10 @@ static std::tuple<Value, Value> lookupDeviceAndQueueAffinityFor(
 static std::tuple<SmallVector<Value>, SmallVector<Value>>
 lookupDevicesAndQueueAffintiesFor(Operation *op, OpBuilder &builder) {
   auto affinityAttr = IREE::Stream::AffinityAttr::lookupOrDefault(op);
+  assert(affinityAttr && "expected an affinitly attribute at this point");
   SmallVector<Value> devices;
   SmallVector<Value> queueAffinities;
-  if (auto optimalAttr =
-          dyn_cast_if_present<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
+  if (auto optimalAttr = dyn_cast<IREE::HAL::DeviceOptimalAttr>(affinityAttr)) {
     for (auto affinity : optimalAttr.getAffinities()) {
       auto [device, queueAffinity] =
           lookupDeviceAndQueueAffinityFor(op->getLoc(), affinity, builder);


### PR DESCRIPTION
The function `IREE::Stream::AffinityAttr::lookupOrDefault` might return null. Discussion in https://github.com/iree-org/iree/pull/22241 suggests that, at the point it is called in this PR, it should really never be null. Assert that this is the case. 