### PR TITLE
[build flags] prepare to enable more warnings in compile flags (#21996)

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -376,7 +376,7 @@ static void optimizeModule(llvm::Module &module,
 
 class CUDATargetDevice final : public TargetDevice {
 public:
-  CUDATargetDevice(const CUDAOptions &options) : options(options) {}
+  CUDATargetDevice(const CUDAOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -395,9 +395,6 @@ public:
                                             deviceConfigAttr,
                                             executableTargetAttrs);
   }
-
-private:
-  const CUDAOptions &options;
 };
 
 class CUDATargetBackend final : public TargetBackend {

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -56,7 +56,7 @@ struct MetalSPIRVOptions {
 // TODO: MetalOptions for choosing the Metal version.
 class MetalTargetDevice : public TargetDevice {
 public:
-  MetalTargetDevice(const MetalSPIRVOptions &options) : options(options) {}
+  MetalTargetDevice(const MetalSPIRVOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -74,9 +74,6 @@ public:
     return IREE::HAL::DeviceTargetAttr::get(context, b.getStringAttr("metal"),
                                             configAttr, executableTargetAttrs);
   }
-
-private:
-  const MetalSPIRVOptions &options;
 };
 
 class MetalSPIRVTargetBackend : public TargetBackend {

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -1050,7 +1050,7 @@ private:
 
 class AMDGPUTargetDevice final : public TargetDevice {
 public:
-  AMDGPUTargetDevice(const ROCMOptions &options) : options(options) {}
+  AMDGPUTargetDevice(const ROCMOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -1069,14 +1069,11 @@ public:
                                             deviceConfigAttr,
                                             executableTargetAttrs);
   }
-
-private:
-  const ROCMOptions &options;
 };
 
 class HIPTargetDevice final : public TargetDevice {
 public:
-  HIPTargetDevice(const ROCMOptions &options) : options(options) {}
+  HIPTargetDevice(const ROCMOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -1095,9 +1092,6 @@ public:
                                             deviceConfigAttr,
                                             executableTargetAttrs);
   }
-
-private:
-  const ROCMOptions &options;
 };
 
 namespace {

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -154,8 +154,7 @@ createPipelineLayoutDefs(ArrayRef<IREE::HAL::ExecutableExportOp> exportOps,
 // TODO: VulkanOptions for choosing the Vulkan version and extensions/features.
 class VulkanTargetDevice : public TargetDevice {
 public:
-  VulkanTargetDevice(const VulkanSPIRVTargetOptions &options)
-      : options_(options) {}
+  VulkanTargetDevice(const VulkanSPIRVTargetOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -173,9 +172,6 @@ public:
                                             deviceConfigAttr,
                                             executableTargetAttrs);
   }
-
-private:
-  const VulkanSPIRVTargetOptions &options_;
 };
 
 class VulkanSPIRVTargetBackend : public TargetBackend {

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -46,7 +46,7 @@ struct WebGPUSPIRVOptions {
 // TODO: WebGPUOptions for choosing the version/extensions/etc.
 class WebGPUTargetDevice : public TargetDevice {
 public:
-  WebGPUTargetDevice(const WebGPUSPIRVOptions &options) : options(options) {}
+  WebGPUTargetDevice(const WebGPUSPIRVOptions & /*options*/) {}
 
   IREE::HAL::DeviceTargetAttr
   getDefaultDeviceTarget(MLIRContext *context,
@@ -64,9 +64,6 @@ public:
     return IREE::HAL::DeviceTargetAttr::get(context, b.getStringAttr("webgpu"),
                                             configAttr, executableTargetAttrs);
   }
-
-private:
-  const WebGPUSPIRVOptions &options;
 };
 
 class WebGPUSPIRVTargetBackend : public TargetBackend {

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -1062,10 +1062,10 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id,
       param_strings.push_back(std::make_pair(py::cast<std::string>(it.first),
                                              py::cast<std::string>(it.second)));
       passed_params.push_back(
-          iree_string_pair_t{{param_strings.back().first.c_str(),
-                              param_strings.back().first.size()},
-                             {param_strings.back().second.c_str(),
-                              param_strings.back().second.size()}});
+          iree_string_pair_t{{{param_strings.back().first.c_str(),
+                               param_strings.back().first.size()}},
+                             {{param_strings.back().second.c_str(),
+                               param_strings.back().second.size()}}});
     }
   }
 

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -480,7 +480,7 @@ typedef struct iree_hal_dispatch_config_t {
 static inline iree_hal_dispatch_config_t iree_hal_make_static_dispatch_config(
     uint32_t workgroup_count_x, uint32_t workgroup_count_y,
     uint32_t workgroup_count_z) {
-  iree_hal_dispatch_config_t config = {0};
+  iree_hal_dispatch_config_t config = {};
   config.workgroup_count[0] = workgroup_count_x;
   config.workgroup_count[1] = workgroup_count_y;
   config.workgroup_count[2] = workgroup_count_z;

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -57,24 +57,24 @@ static iree_status_t iree_hal_cuda_query_limits(
 
   IREE_CUDA_RETURN_IF_ERROR(
       symbols,
-      cuDeviceGetAttribute(&out_limits->max_block_dims[0],
+      cuDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[0],
                            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, device),
       "cuDeviceGetAttribute");
   IREE_CUDA_RETURN_IF_ERROR(
       symbols,
-      cuDeviceGetAttribute(&out_limits->max_block_dims[1],
+      cuDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[1],
                            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, device),
       "cuDeviceGetAttribute");
   IREE_CUDA_RETURN_IF_ERROR(
       symbols,
-      cuDeviceGetAttribute(&out_limits->max_block_dims[2],
+      cuDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[2],
                            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, device),
       "cuDeviceGetAttribute");
 
   IREE_CUDA_RETURN_IF_ERROR(
       symbols,
       cuDeviceGetAttribute(
-          &out_limits->max_block_shared_memory_size,
+          (int32_t*)&out_limits->max_block_shared_memory_size,
           CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, device),
       "cuDeviceGetAttribute");
 

--- a/runtime/src/iree/hal/drivers/metal/direct_command_buffer.m
+++ b/runtime/src/iree/hal/drivers/metal/direct_command_buffer.m
@@ -915,9 +915,9 @@ static iree_status_t iree_hal_metal_command_buffer_prepare_dispatch(
   }
 
   // Copy push constants to the end of the current segment for later access.
-  segment->dispatch.constant_count = constants.data_length / sizeof(uint32_t);
+  segment->dispatch.constant_count = constants.data_length / sizeof(int32_t);
   uint8_t* constant_ptr = storage_base + sizeof(*segment) + descriptor_length;
-  segment->dispatch.constants = (uint32_t*)constant_ptr;
+  segment->dispatch.constants = (int32_t*)constant_ptr;
   memcpy(constant_ptr, constants.data, constants.data_length);
 
   if (iree_hal_dispatch_uses_indirect_parameters(flags)) {

--- a/runtime/src/iree/vm/native_module_test.h
+++ b/runtime/src/iree/vm/native_module_test.h
@@ -266,7 +266,7 @@ static_assert(IREE_ARRAYSIZE(((module_b_state_t*)NULL)->imports) ==
                   IREE_ARRAYSIZE(module_b_imports_),
               "import storage must be able to hold all imports");
 static const iree_string_pair_t module_b_entry_attrs_[] = {
-    {IREE_SV("key1"), IREE_SV("value1")},
+    {{IREE_SV("key1")}, {IREE_SV("value1")}},
 };
 static const iree_vm_native_export_descriptor_t module_b_exports_[] = {
     {IREE_SV("entry"), IREE_SV("0i_i"), IREE_ARRAYSIZE(module_b_entry_attrs_),


### PR DESCRIPTION
Prepare the code to enable more warnings during compilation:
```
-Wambiguous-member-template
-Wchar-subscripts
-Wgnu-alignof-expression
-Wgnu-variable-sized-type-not-at-end
-Wignored-optimization-argument
-Winvalid-source-encoding
-Wmismatched-tags
-Wmissing-braces
-Wpointer-sign
-Wreserved-user-defined-literal
-Wreturn-type-c-linkage
-Wself-assign-overloaded
-Wsign-compare
-Wsigned-unsigned-wchar
-Wstrict-overflow
-Wtrigraphs
-Wunknown-pragmas
-Wunknown-warning-option
-Wunused-command-line-argument
-Wunused-local-typedef
-Wuser-defined-warnings
```

This change contains only the code changes to avoid the warnings mentioned above, but does not turn on the warnings yet.