### PR TITLE
Let MLIR ukernels provide their matching and data-tiled-layout info.

### DIFF
--- a/compiler/plugins/target/ROCM/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/BUILD.bazel
@@ -42,6 +42,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/HAL/Utils:ExecutableDebugInfoUtils",
         "//compiler/src/iree/compiler/Dialect/HAL/Utils:LLVMLinkerUtils",
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/PluginAPI",
         "//compiler/src/iree/compiler/Utils",
         "//runtime/src/iree/schemas:amdgpu_executable_def_c_fbs",

--- a/compiler/plugins/target/ROCM/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/CMakeLists.txt
@@ -65,6 +65,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::HAL::Utils::ExecutableDebugInfoUtils
     iree::compiler::Dialect::HAL::Utils::LLVMLinkerUtils
+    iree::compiler::Dialect::Util::IR
     iree::compiler::PluginAPI
     iree::compiler::Utils
     iree::compiler::plugins::target::ROCM::Dialect::ROCM::IR::ROCMDialect

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/BUILD.bazel
@@ -83,6 +83,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgInterfaces",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:ROCDLDialect",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgInterfacesIncGenLib
     MLIRParser
+    MLIRROCDLDialect
     MLIRSupport
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -64,6 +64,45 @@ TensorUKernelProviderAttr::getMLIRUKernel(StringRef name, DictionaryAttr,
   return symbolTable.lookup(name);
 }
 
+// Helper for getDataLayoutForUKernel: returns true if the actual
+// `iterationSizes` satisfy any `iterationSizeConstraints`.
+static bool checkIterationSizeConstraints(ArrayRef<int64_t> iterationSizes,
+                                          ArrayAttr iterationSizeConstraints) {
+  for (Attribute c : iterationSizeConstraints) {
+    auto constraint = dyn_cast<UKernelIterationSizeConstraintAttr>(c);
+    if (!constraint) {
+      return false;
+    }
+    IntegerAttr index = constraint.getIndex();
+    if (!index) {
+      return false;
+    }
+    int64_t indexVal = index.getInt();
+    if (indexVal < 0 || indexVal >= iterationSizes.size()) {
+      return false;
+    }
+    if (IntegerAttr sizeMin = constraint.getSizeMin()) {
+      if (iterationSizes[indexVal] < sizeMin.getInt()) {
+        return false;
+      }
+    }
+    if (IntegerAttr sizeMax = constraint.getSizeMax()) {
+      if (iterationSizes[indexVal] > sizeMax.getInt()) {
+        return false;
+      }
+    }
+    if (IntegerAttr sizeDiv = constraint.getSizeDiv()) {
+      if (sizeDiv.getInt() <= 0) {
+        return false;
+      }
+      if (iterationSizes[indexVal] % sizeDiv.getInt()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
     Attribute encoding, DictionaryAttr targetConfiguration) const {
   auto encodingAttr =
@@ -72,9 +111,6 @@ Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
     return {};
   }
   IREE::GPU::TargetAttr targetAttr = getGPUTargetAttr(targetConfiguration);
-  if (!targetAttr || targetAttr.getArch() != "gfx942") {
-    return {};
-  }
   ArrayAttr indexingMapsAttr = encodingAttr.getUserIndexingMaps();
   if (!indexingMapsAttr) {
     return {};
@@ -87,33 +123,77 @@ Attribute TensorUKernelProviderAttr::getDataLayoutForUKernel(
   if (types.size() != 3 || iterationSizes.size() != 3) {
     return {};
   }
-  // Match the layouts based on UKernels implementation:
-  // https://github.com/iree-org/iree/tree/main/compiler/plugins/target/ROCM/builtins/mlir_ukernel
-  Type f16 = Float16Type::get(encoding.getContext());
-  Type f32 = Float32Type::get(encoding.getContext());
-  Type f8E4M3FNUZ = Float8E4M3FNUZType::get(encoding.getContext());
-  if (types[0] == f16 && types[1] == f16 && types[2] == f32) {
-    // UKernel: pingpong_dt_large_f16.
-    return IREE::GPU::DataTiledMMAAttr::get(
-        encoding.getContext(), IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x16_F16,
-        8, 2, 4, 4, 1);
-  }
-  if (types[0] == f8E4M3FNUZ && types[1] == f8E4M3FNUZ && types[2] == f32) {
-    /// TODO(#21865): Remove the upper bound (8192) once the scratch memory
-    /// issue is resolved.
-    if (iterationSizes[1] >= 2048 && iterationSizes[1] <= 8192) {
-      // UKernel: pingpong_dt_large_f8E4M3FNUZ.
-      return IREE::GPU::DataTiledMMAAttr::get(
-          encoding.getContext(),
-          IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ, 8, 2, 4, 4, 1);
-    } else {
-      // UKernel: pingpong_dt_medium_f8E4M3FNUZ.
-      return IREE::GPU::DataTiledMMAAttr::get(
-          encoding.getContext(),
-          IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ, 8, 1, 2, 8, 2);
+  auto &rocmDialect = cast<ROCMDialect>(getDialect());
+  // Iterate over all MLIR ukernels and select the one with highest benefit.
+  Attribute selectedMma;          // Initial value means no match.
+  int64_t selectedMmaBenefit = 0; // Initial value not actually used.
+
+  for (Util::FuncOp funcOp : rocmDialect.getMlirUKernels()) {
+    // Require MLIR ukernels to have a ukernel_info attribute, otherwise we
+    // won't be able to know how to data-tile for them.
+    auto info =
+        dyn_cast_if_present<UKernelInfoAttr>(funcOp->getAttr(ukernelInfoName));
+    if (!info) {
+      continue;
     }
+    // Match the element types.
+    auto matchTypes =
+        dyn_cast_if_present<ArrayAttr>(info.getMatch().get(typesName));
+    auto actualTypes =
+        ArrayAttr::get(matchTypes.getContext(),
+                       llvm::map_to_vector(types, [](Type v) -> Attribute {
+                         return TypeAttr::get(v);
+                       }));
+    if (matchTypes != actualTypes) {
+      continue;
+    }
+    // Match any constraints on iteration sizes.
+    if (auto iterationSizeConstraints = dyn_cast_if_present<ArrayAttr>(
+            info.getMatch().get(iterationSizesConstraintsName))) {
+      if (!checkIterationSizeConstraints(iterationSizes,
+                                         iterationSizeConstraints)) {
+        continue;
+      }
+    }
+    // Read the data-tiled-layout attribute
+    Attribute mma = info.getMma();
+    if (!mma) {
+      continue;
+    }
+    // Depending on the type of data-tiled layout attribute, read the
+    // appropriate kind of MMA-like intrinsic and check that it's supported by
+    // the target.
+    if (auto dtMma = dyn_cast<GPU::DataTiledMMAAttr>(mma)) {
+      // Regular MMA intrinsic.
+      auto intrinsicAttr =
+          GPU::MMAAttr::get(matchTypes.getContext(), dtMma.getIntrinsic());
+      if (!llvm::is_contained(targetAttr.getWgp().getMma(), intrinsicAttr)) {
+        continue;
+      }
+    } else if (auto dtScaledMma = dyn_cast<GPU::DataTiledScaledMMAAttr>(mma)) {
+      // Scaled MMA intrinsic.
+      auto intrinsicAttr = GPU::ScaledMMAAttr::get(
+          matchTypes.getContext(), dtScaledMma.getIntrinsic(),
+          /*lhs_elem_type=*/types[0], /*rhs_elem_type=*/types[1],
+          /*acc_elem_type=*/types[2], /*col_major=*/false);
+      if (!llvm::is_contained(targetAttr.getWgp().getScaledMma(),
+                              intrinsicAttr)) {
+        continue;
+      }
+    } else {
+      // Unhandled type of data-tiled-layout attr.
+      continue;
+    }
+    // If a previously selected mma has a larger or equal benefit, skip.
+    if (selectedMma && selectedMmaBenefit >= info.getBenefit()) {
+      continue;
+    }
+    // Selected!
+    selectedMma = mma;
+    selectedMmaBenefit = info.getBenefit();
   }
-  return {};
+
+  return selectedMma;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
@@ -20,10 +20,14 @@
 #undef GET_ATTRDEF_CLASSES
 // clang-format on
 
+namespace mlir::iree_compiler::IREE::ROCM {
+
 // Some keys used in the DictionaryAttr rocm.ukernel_info.match
-static constexpr char ukernelInfoName[] = "ukernel_info";
-static constexpr char typesName[] = "types";
-static constexpr char iterationSizesConstraintsName[] =
+constexpr char kUKernelInfoName[] = "ukernel_info";
+constexpr char kUKernelInfoTypesName[] = "types";
+constexpr char kUKernelInfoIterationSizesConstraintsName[] =
     "iteration_sizes_constraints";
+
+} // namespace mlir::iree_compiler::IREE::ROCM
 
 #endif // IREE_PLUGINS_TARGET_ROCM_DIALECT_ROCM_ROCMATTRS_H_

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.h
@@ -20,4 +20,10 @@
 #undef GET_ATTRDEF_CLASSES
 // clang-format on
 
+// Some keys used in the DictionaryAttr rocm.ukernel_info.match
+static constexpr char ukernelInfoName[] = "ukernel_info";
+static constexpr char typesName[] = "types";
+static constexpr char iterationSizesConstraintsName[] =
+    "iteration_sizes_constraints";
+
 #endif // IREE_PLUGINS_TARGET_ROCM_DIALECT_ROCM_ROCMATTRS_H_

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.td
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.td
@@ -72,4 +72,49 @@ def ROCM_TensorUKernelProviderAttr  :
   let assemblyFormat = [{}];
 }
 
+//===---------------------------------------------------------------------===//
+// rocm.ukernel_info
+//===---------------------------------------------------------------------===//
+
+def ROCM_UKernelInfoAttr : AttrDef<ROCM_Dialect, "UKernelInfo", []> {
+  let mnemonic = "ukernel_info";
+  let summary = [{
+    An attribute that provides metadata around a ukernel, e.g. for matching.
+  }];
+  let parameters =
+      (ins AttrParameter<
+           "DictionaryAttr",
+           "Parameters controlling matching this ukernel, in addition to ISA "
+           "requirements from the mma attribute.">:$match,
+          DefaultValuedParameter<"int64_t", "0",
+                                 "Determines which ukernel is selected when "
+                                 "multiple ones are applicable.">:$benefit,
+          OptionalParameter<"Attribute",
+                            "MMAAttr-like attribute if applicable, dictates "
+                            "layout and/or ISA requirements">:$mma);
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+//===---------------------------------------------------------------------===//
+// rocm.ukernel_interation_size_constraint
+//===---------------------------------------------------------------------===//
+
+def ROCM_UKernelIterationSizeConstraint
+    : AttrDef<ROCM_Dialect, "UKernelIterationSizeConstraint", []> {
+  let mnemonic = "ukernel_interation_size_constraint";
+  let summary = [{
+    An attribute that provides a matching constraint on an iteration size.
+  }];
+  let parameters = (ins OptionalParameter<
+                        "IntegerAttr",
+                        "Index of iteration dimension to match">:$index,
+      OptionalParameter<"IntegerAttr",
+                        "Minimum iteration dimension size to match">:$size_min,
+      OptionalParameter<"IntegerAttr",
+                        "Maximum iteration dimension size to match">:$size_max,
+      OptionalParameter<"IntegerAttr", "Divisor of iteration dimension size to "
+                                       "match">:$size_div);
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
 #endif // IREE_PLUGINS_TARGET_ROCM_DIALECT_ROCMATTRS

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.cpp
@@ -5,12 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.h"
-
-#include "compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.cpp.inc"
 #include "compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_mlir_ukernel_patterns_amdgpu.h"
 #include "compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_mlir_ukernels_amdgpu.h"
 #include "compiler/plugins/target/ROCM/builtins/specialization/iree_specialization_patterns_amdgpu.h"
 #include "compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_specs_amdgpu.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+
+#include "compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.cpp.inc"
 
 namespace mlir::iree_compiler::IREE::ROCM {
 
@@ -60,6 +64,26 @@ std::optional<StringRef> ROCMDialect::getBuiltin(llvm::StringRef name) {
 
 SmallVector<StringRef> ROCMDialect::getBuiltinNames() {
   return llvm::to_vector(builtins.getMap().keys());
+}
+
+const ArrayRef<Util::FuncOp> ROCMDialect::getMlirUKernels() {
+  std::lock_guard<std::mutex> guard(mlirUkernelsMutex);
+  if (mlirUkernels.empty()) {
+    const iree_file_toc_t *toc = iree_mlir_ukernels_amdgpu_create();
+    llvm::SmallVector<ModuleOp> result;
+    for (size_t i = 0, e = iree_mlir_ukernels_amdgpu_size(); i != e; ++i) {
+      auto moduleOp = this->getOrLoadBuiltinModule(toc[i].name);
+      if (failed(moduleOp)) {
+        // parseSourceString should have reported an error already.
+        continue;
+      }
+      moduleOp->walk(
+          [&](Util::FuncOp funcOp) { mlirUkernels.push_back(funcOp); });
+    }
+  }
+  assert(!mlirUkernels.empty() &&
+         "Zero MLIR ukernels found after parsing builtins?!");
+  return mlirUkernels;
 }
 
 } // namespace mlir::iree_compiler::IREE::ROCM

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.h
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.h
@@ -9,6 +9,7 @@
 
 #include <mutex>
 
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Utils/EmbeddedDataDirectory.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.td
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMDialect.td
@@ -23,6 +23,9 @@ def ROCM_Dialect : Dialect {
     for AMD targets that lower to LLVM.
   }];
   let useDefaultAttributePrinterParser = 1;
+  let dependentDialects = ["::mlir::iree_compiler::IREE::Util::UtilDialect",
+                           "::mlir::gpu::GPUDialect",
+                           "mlir::ROCDL::ROCDLDialect"];
 
   let extraClassDeclaration = [{
     void registerAttributes();
@@ -40,6 +43,8 @@ def ROCM_Dialect : Dialect {
     FailureOr<::mlir::ModuleOp>
     getOrLoadBuiltinModule(StringRef path);
 
+    const ArrayRef<Util::FuncOp> getMlirUKernels();
+
     private:
 
     /// Pseudo-directory for storing references to builtins.
@@ -52,6 +57,11 @@ def ROCM_Dialect : Dialect {
     /// Lock to control the updating of the builtin modules such that we only
     /// load the module once and can reuse it across all invocations.
     std::mutex builtinMutex;
+
+    // List of MLIR ukernel functions. These belong in the ModuleOp's cached in
+    // `builtinModules`.
+    ::llvm::SmallVector<Util::FuncOp> mlirUkernels;
+    std::mutex mlirUkernelsMutex;
   }];
 }
 

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -26,6 +26,7 @@
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/HAL/Utils/ExecutableDebugInfoUtils.h"
 #include "iree/compiler/Dialect/HAL/Utils/LLVMLinkerUtils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/PluginAPI/Client.h"
 #include "iree/compiler/Utils/EmbeddedDataDirectory.h"
 #include "iree/compiler/Utils/FlatbufferUtils.h"
@@ -395,6 +396,8 @@ public:
     registry.insert<IREE::VectorExt::IREEVectorExtDialect>();
     registry.insert<IREE::GPU::IREEGPUDialect>();
     registry.insert<IREE::ROCM::ROCMDialect>();
+    registry.insert<IREE::Util::UtilDialect>();
+    registry.insert<mlir::gpu::GPUDialect>();
     // Configuration may load and manipulate transform dialect libraries.
     registerTransformDialectTranslationDependentDialects(registry);
   }

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
@@ -14,7 +14,20 @@
  affine_map<(i, j, k) -> (i, j)>
 ]
 
-util.func @pingpong_dt_large_f16(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty {
+util.func @pingpong_dt_large_f16(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      types = [f16, f16, f32]
+    },
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = MFMA_F32_16x16x16_F16,
+      intrinsics_m = 8,
+      subgroups_m = 2,
+      intrinsics_n = 4,
+      subgroups_n = 4
+    >
+  >
+} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
@@ -24,7 +24,30 @@
  affine_map<(i, j, k) -> (i, j)>
 ]
 
-util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty {
+util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      types = [f8E4M3FNUZ, f8E4M3FNUZ, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<
+          index = 1,
+          size_min = 2048,
+          size_max = 8192
+        >
+      ]
+    },
+    // Benefit larger than the default 0 means we prefer this "large" kernel when it matches.
+    benefit = 1,
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ,
+      intrinsics_m = 8,
+      subgroups_m = 2,
+      intrinsics_n = 4,
+      subgroups_n = 4,
+      intrinsics_k = 1
+    >
+  >
+} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -264,7 +287,21 @@ util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs
   util.return %1 : !acc_base_ty
 }
 
-util.func private @pingpong_dt_medium_f8E4M3FNUZ(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty {
+util.func private @pingpong_dt_medium_f8E4M3FNUZ(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty attributes {
+  ukernel_info = #rocm.ukernel_info<
+    match = {
+      types = [f8E4M3FNUZ, f8E4M3FNUZ, f32]
+    },
+    mma = #iree_gpu.data_tiled_mma_layout<
+      intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ,
+      intrinsics_m = 8,
+      subgroups_m = 1,
+      intrinsics_n = 2,
+      subgroups_n = 8,
+      intrinsics_k = 2
+    >
+  >
+} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index


### PR DESCRIPTION
Fixes #22068.