### PR TITLE
[TensorExt] Add Operations/Attributes/Interfaces for specifying ragged tensors.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
@@ -77,6 +77,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
     ],

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
@@ -17,7 +17,9 @@ iree_td_library(
     name = "td_files",
     srcs = enforce_glob(
         [
+            "TensorExtAttrs.td",
             "TensorExtBase.td",
+            "TensorExtInterfaces.td",
             "TensorExtOps.td",
         ],
         include = ["*.td"],
@@ -34,21 +36,36 @@ iree_td_library(
 iree_compiler_cc_library(
     name = "IR",
     srcs = [
+        "TensorExtAttrInterfaces.cpp",
+        "TensorExtAttrInterfaces.cpp.inc",
+        "TensorExtAttrs.cpp",
+        "TensorExtAttrs.cpp.inc",
         "TensorExtDialect.cpp",
         "TensorExtDialect.cpp.inc",
         "TensorExtOpFolders.cpp",
+        "TensorExtOpInterfaces.cpp",
+        "TensorExtOpInterfaces.cpp.inc",
         "TensorExtOps.cpp",
         "TensorExtOps.cpp.inc",
         "TensorExtTypes.cpp",
     ],
     hdrs = [
+        "TensorExtAttrInterfaces.h",
+        "TensorExtAttrInterfaces.h.inc",
+        "TensorExtAttrs.h",
+        "TensorExtAttrs.h.inc",
         "TensorExtDialect.h",
         "TensorExtDialect.h.inc",
+        "TensorExtOpInterfaces.h",
+        "TensorExtOpInterfaces.h.inc",
         "TensorExtOps.h",
         "TensorExtOps.h.inc",
         "TensorExtTypes.h",
     ],
     deps = [
+        ":TensorExtAttrInterfacesGen",
+        ":TensorExtAttrsGen",
+        ":TensorExtOpInterfacesGen",
         ":TensorExtOpsGen",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
@@ -59,9 +76,67 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
+        "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
     ],
+)
+
+iree_gentbl_cc_library(
+    name = "TensorExtAttrsGen",
+    tbl_outs = [
+        (
+            [
+                "--dialect=iree_tensor_ext",
+                "--gen-attrdef-decls",
+            ],
+            "TensorExtAttrs.h.inc",
+        ),
+        (
+            [
+                "--dialect=iree_tensor_ext",
+                "--gen-attrdef-defs",
+            ],
+            "TensorExtAttrs.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TensorExtAttrs.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "TensorExtAttrInterfacesGen",
+    tbl_outs = [
+        (
+            ["--gen-attr-interface-decls"],
+            "TensorExtAttrInterfaces.h.inc",
+        ),
+        (
+            ["--gen-attr-interface-defs"],
+            "TensorExtAttrInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TensorExtInterfaces.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "TensorExtOpInterfacesGen",
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "TensorExtOpInterfaces.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "TensorExtOpInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TensorExtInterfaces.td",
+    deps = [":td_files"],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
@@ -76,7 +76,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
-        "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     MLIRIR
     MLIRInferTypeOpInterface
     MLIRMemRefDialect
+    MLIRSCFDialect
     MLIRSupport
     MLIRTensorDialect
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
@@ -48,7 +48,6 @@ iree_cc_library(
     MLIRArithUtils
     MLIRIR
     MLIRInferTypeOpInterface
-    MLIRMemRefDialect
     MLIRSCFDialect
     MLIRSupport
     MLIRTensorDialect

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
@@ -14,30 +14,76 @@ iree_cc_library(
   NAME
     IR
   HDRS
+    "TensorExtAttrInterfaces.h"
+    "TensorExtAttrInterfaces.h.inc"
+    "TensorExtAttrs.h"
+    "TensorExtAttrs.h.inc"
     "TensorExtDialect.h"
     "TensorExtDialect.h.inc"
+    "TensorExtOpInterfaces.h"
+    "TensorExtOpInterfaces.h.inc"
     "TensorExtOps.h"
     "TensorExtOps.h.inc"
     "TensorExtTypes.h"
   SRCS
+    "TensorExtAttrInterfaces.cpp"
+    "TensorExtAttrInterfaces.cpp.inc"
+    "TensorExtAttrs.cpp"
+    "TensorExtAttrs.cpp.inc"
     "TensorExtDialect.cpp"
     "TensorExtDialect.cpp.inc"
     "TensorExtOpFolders.cpp"
+    "TensorExtOpInterfaces.cpp"
+    "TensorExtOpInterfaces.cpp.inc"
     "TensorExtOps.cpp"
     "TensorExtOps.cpp.inc"
     "TensorExtTypes.cpp"
   DEPS
+    ::TensorExtAttrInterfacesGen
+    ::TensorExtAttrsGen
+    ::TensorExtOpInterfacesGen
     ::TensorExtOpsGen
     LLVMSupport
     MLIRArithDialect
     MLIRArithUtils
     MLIRIR
     MLIRInferTypeOpInterface
+    MLIRMemRefDialect
     MLIRSupport
     MLIRTensorDialect
     iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
   PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    TensorExtAttrsGen
+  TD_FILE
+    "TensorExtAttrs.td"
+  OUTS
+    --dialect=iree_tensor_ext --gen-attrdef-decls TensorExtAttrs.h.inc
+    --dialect=iree_tensor_ext --gen-attrdef-defs TensorExtAttrs.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    TensorExtAttrInterfacesGen
+  TD_FILE
+    "TensorExtInterfaces.td"
+  OUTS
+    --gen-attr-interface-decls TensorExtAttrInterfaces.h.inc
+    --gen-attr-interface-defs TensorExtAttrInterfaces.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    TensorExtOpInterfacesGen
+  TD_FILE
+    "TensorExtInterfaces.td"
+  OUTS
+    --gen-op-interface-decls TensorExtOpInterfaces.h.inc
+    --gen-op-interface-defs TensorExtOpInterfaces.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.cpp
@@ -1,0 +1,13 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h"
+
+#include "mlir/Support/LLVM.h"
+
+// clang-format off: must be included after all LLVM/MLIR headers
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.cpp.inc" // IWYU pragma: keep
+// clang-format on: must be included after all LLVM/MLIR headers

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h
@@ -1,0 +1,17 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTATTRINTERFACES_H_
+#define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTATTRINTERFACES_H_
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+
+// clang-format off: must be included after all LLVM/MLIR headers
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h.inc" // IWYU pragma: keep
+// clang-format on: must be included after all LLVM/MLIR headers
+
+#endif

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
@@ -78,10 +78,9 @@ LogicalResult
 RaggedShapeAttr::getStridesAndOffset(ArrayRef<int64_t> shape,
                                      SmallVectorImpl<int64_t> &strides,
                                      int64_t &offset) const {
-  // This should only be required on the first "subview" of the
-  // ragged tensor. So we can assume that there are no strides to begin with
-  // and set all strides starting from the least significant sparse dimension
-  // to dynamic.
+  // This should only be required on the first "subview" of the ragged tensor.
+  // So we can assume that there are no strides to begin with and set all
+  // strides starting from the least significant sparse dimension to dynamic.
   strides.clear();
   SmallVector<int64_t> sparseDims = getSparseDimensions();
   std::optional<int64_t> forceDynamicFrom = std::nullopt;

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
@@ -49,7 +49,7 @@ LogicalResult RaggedShapeAttr::verifyLayout(
   if (llvm::any_of(sparseDimensions,
                    [&](int64_t dim) { return dim >= shape.size(); })) {
     return emitError() << "sparse dimensions specified are greater than the "
-                          "rank of the tensor";
+                          "rank of the shaped type";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
@@ -1,0 +1,100 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+
+// clang-format off
+#define GET_ATTRDEF_CLASSES
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp.inc" // IWYU pragma: keep
+// clang-format on
+
+namespace mlir::iree_compiler::IREE::TensorExt {
+
+void IREETensorExtDialect::initializeAttrs() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp.inc" // IWYU pragma: keep
+      >();
+}
+
+//===---------------------------------------------------------------------===//
+// iree_tensor_ext.ragged_shape
+//===---------------------------------------------------------------------===//
+
+SmallVector<int64_t> RaggedShapeAttr::getSparseDimensions() const {
+  int64_t raggedRow = getRaggedRow();
+  return {raggedRow, raggedRow + 1};
+}
+
+/// MemRefLayoutAttrInterface methods.
+
+AffineMap RaggedShapeAttr::getAffineMap() const { return AffineMap(); }
+
+bool RaggedShapeAttr::isIdentity() const { return false; }
+
+LogicalResult RaggedShapeAttr::verifyLayout(
+    ArrayRef<int64_t> shape,
+    function_ref<InFlightDiagnostic()> emitError) const {
+  SmallVector<int64_t> sparseDimensions = getSparseDimensions();
+  if (llvm::any_of(sparseDimensions,
+                   [&](int64_t dim) { return dim >= shape.size(); })) {
+    return emitError() << "sparse dimensions specified are greater than the "
+                          "rank of the tensor";
+  }
+  return success();
+}
+
+static SmallVector<int64_t>
+getDefaultStrides(ArrayRef<int64_t> shape,
+                  std::optional<int64_t> forceDynamicFrom = std::nullopt) {
+  SmallVector<int64_t> strides;
+  strides.resize(shape.size(), 1);
+  if (shape.size() <= 1) {
+    return strides;
+  }
+  for (int index = shape.size() - 2; index >= 0; --index) {
+    if ((forceDynamicFrom && index < forceDynamicFrom.value()) ||
+        ShapedType::isDynamic(shape[index + 1]) ||
+        ShapedType::isDynamic(strides[index + 1])) {
+      strides[index] = ShapedType::kDynamic;
+      continue;
+    }
+    strides[index] = shape[index + 1] * strides[index + 1];
+  }
+  return strides;
+}
+
+LogicalResult
+RaggedShapeAttr::getStridesAndOffset(ArrayRef<int64_t> shape,
+                                     SmallVectorImpl<int64_t> &strides,
+                                     int64_t &offset) const {
+  // This should only be required on the first "subview" of the
+  // ragged tensor. So we can assume that there are no strides to begin with
+  // and set all strides starting from the least significant sparse dimension
+  // to dynamic.
+  strides.clear();
+  SmallVector<int64_t> sparseDims = getSparseDimensions();
+  std::optional<int64_t> forceDynamicFrom = std::nullopt;
+  for (auto dim : sparseDims) {
+    if (!forceDynamicFrom) {
+      forceDynamicFrom = dim;
+      continue;
+    }
+    forceDynamicFrom = std::max(forceDynamicFrom.value(), dim);
+  }
+  strides = getDefaultStrides(shape, forceDynamicFrom);
+  offset = 0;
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
@@ -1,0 +1,18 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTATTRS_H_
+#define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTATTRS_H_
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h"
+#include "mlir/IR/Attributes.h"
+
+// clang-format off
+#define GET_ATTRDEF_CLASSES
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h.inc" // IWYU pragma: keep
+// clang-format on
+
+#endif // IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTATTRS_H_

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
@@ -1,0 +1,49 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECT_TENSOR_EXT_ATTRS
+#define IREE_DIALECT_TENSOR_EXT_ATTRS
+
+include "iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td"
+include "iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td"
+
+def RaggedShapeAttr :
+  AttrDef<IREETensorExt_Dialect, "RaggedShape", [
+    DeclareAttrInterfaceMethods<IREETensorExt_SparseShapeAttrInterface>,
+    DeclareAttrInterfaceMethods<MemRefLayoutAttrInterface, [
+      "getAffineMap",
+      "isIdentity",
+      "verifyLayout",
+      "getStridesAndOffset"
+    ]>]> {
+  let mnemonic = "ragged_shape";
+
+  let parameters = (ins "int64_t":$raggedRow);
+
+  let assemblyFormat = "`<` $raggedRow `>`";
+
+  let description = [{
+    Attribute to encode that a shaped type is ragged shaped.
+
+    if `raggedRow` is `n`, then the dimension `n` and `n+1` of the shaped type are
+    "ragged" dimensions, i.e. the size of the `n+1` dimension of the shaped type
+    varies. So a 2D ragged shaped type would have `raggedRow` as `0` where the size
+    of dimension 1 is different as shown below.
+
+    ```
+    OOOO
+    OOOOOO
+    OOO
+    OOOOO
+    ```
+
+    The shape is "logical" view of the ragged dimensions,
+    i.e. the `n+1`-th dimension should always be dynamic. So the 2D shaped type
+    above has a logical shape of `4x?`.
+  }];
+}
+
+#endif // IREE_DIALECT_TENSOR_EXT_ATTRS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
@@ -28,7 +28,7 @@ def RaggedShapeAttr :
   let description = [{
     Attribute to encode that a shaped type is ragged shaped.
 
-    if `raggedRow` is `n`, then the dimension `n` and `n+1` of the shaped type are
+    If `raggedRow` is `n`, then the dimension `n` and `n+1` of the shaped type are
     "ragged" dimensions, i.e. the size of the `n+1` dimension of the shaped type
     varies. So a 2D ragged shaped type would have `raggedRow` as `0` where the size
     of dimension 1 is different as shown below.

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td
@@ -30,7 +30,11 @@ def IREETensorExt_Dialect : Dialect {
   let dependentDialects = [
     "arith::ArithDialect" // For materializeConstant()
   ];
+  let extraClassDeclaration = [{
+    void initializeAttrs();
+  }];
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
   let hasConstantMaterializer = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -40,12 +40,13 @@ struct IREETensorExtInlinerInterface : public DialectInlinerInterface {
 } // namespace
 
 void IREETensorExtDialect::initialize() {
+  initializeAttrs();
   addInterfaces<IREETensorExtInlinerInterface>();
   addTypes<DispatchTensorType>();
 
-#define GET_OP_LIST
   addOperations<
-#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp.inc"
+#define GET_OP_LIST
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp.inc" // IWYU pragma: keep
       >();
 
   getContext()->getOrLoadDialect<tensor::TensorDialect>();

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
@@ -26,7 +26,7 @@ def IREETensorExt_SparseShapeAttrInterface :
 
   let methods = [
     InterfaceMethod<
-      /*description =*/"Return the dimensions that are sparse",
+      /*description =*/"Returns the dimensions that are sparse",
       /*retTy=*/"::llvm::SmallVector<int64_t>",
       /*methodName=*/"getSparseDimensions"
     >

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td
@@ -1,0 +1,57 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECT_TENSOR_EXT_INTERFACES
+#define IREE_DIALECT_TENSOR_EXT_INTERFACES
+
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/OpBase.td"
+
+def IREETensorExt_SparseShapeAttrInterface :
+  AttrInterface<"SparseShapeAttrInterface"> {
+
+  let cppNamespace = "::mlir::iree_compiler::IREE::TensorExt";
+
+  let description = [{
+    Attribute interface to annotate sparse layouts.
+
+    For operations that cast a source tensor/memref type to a sparse layout, these
+    attributes are used to represent that the created shaped type has a logical shape
+    + sparse layout. The interface here is to allow for different sparse
+    representations that are opaque to the transformations.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*description =*/"Return the dimensions that are sparse",
+      /*retTy=*/"::llvm::SmallVector<int64_t>",
+      /*methodName=*/"getSparseDimensions"
+    >
+  ];
+}
+
+def IREETensorExt_SparseCastOpInterface :
+  OpInterface<"SparseCastOpInterface"> {
+
+  let cppNamespace = "::mlir::iree_compiler::IREE::TensorExt";
+
+  let description = [{
+    Interface for operations that create shaped types with sparse layout.
+
+    Operations that implement this interface cast a source operand of tensor/memref type
+    to a shaped type with a logical shape with an sparse layout. The sparsity information
+    is represented using a `SparseShapeAttrInterface` on the type. For `tensor` type this
+    is recorded as an `EncodingAttr`. For `memref` type this is represented using the
+    `MemrefLayoutAttrInterface`.
+  }];
+
+  let verify = [{
+   return ::mlir::iree_compiler::IREE::TensorExt::verifySparseCastOpInterface(
+     ::mlir::cast<::mlir::iree_compiler::IREE::TensorExt::SparseCastOpInterface>($_op));
+  }];
+}
+
+#endif // IREE_DIALECT_TENSOR_EXT_INTERFACES

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
@@ -26,7 +26,7 @@ LogicalResult verifySparseCastOpInterface(SparseCastOpInterface sparseOp) {
   SparseShapeAttrInterface sparseAttr;
   if (auto tensorType = dyn_cast<RankedTensorType>(resultType)) {
     sparseAttr =
-        dyn_cast_or_null<SparseShapeAttrInterface>(tensorType.getEncoding());
+        dyn_cast_if_present<SparseShapeAttrInterface>(tensorType.getEncoding());
     if (!sparseAttr) {
       return sparseOp.emitOpError(
           "expected result type to have an encoding attribute that implements "
@@ -34,7 +34,7 @@ LogicalResult verifySparseCastOpInterface(SparseCastOpInterface sparseOp) {
     }
   } else if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
     sparseAttr =
-        dyn_cast_or_null<SparseShapeAttrInterface>(memrefType.getLayout());
+        dyn_cast_if_present<SparseShapeAttrInterface>(memrefType.getLayout());
     if (!sparseAttr) {
       return sparseOp.emitOpError(
           "expected result type to have a layout attribute that implements "

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp
@@ -1,0 +1,63 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h"
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h"
+
+// clang-format off: must be included after all LLVM/MLIR headers
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.cpp.inc" // IWYU pragma: keep
+// clang-format on: must be included after all LLVM/MLIR headers
+
+namespace mlir::iree_compiler::IREE::TensorExt {
+
+LogicalResult verifySparseCastOpInterface(SparseCastOpInterface sparseOp) {
+  // Check that the operation has only one result.
+  if (sparseOp->getNumResults() != 1) {
+    return sparseOp.emitOpError("sparse operations can only have one result");
+  }
+
+  // The sparse operation needs to return a shaped type that has an attribute
+  // specifying the sparsity.
+  Type resultType = sparseOp->getResult(0).getType();
+  SparseShapeAttrInterface sparseAttr;
+  if (auto tensorType = dyn_cast<RankedTensorType>(resultType)) {
+    sparseAttr =
+        dyn_cast_or_null<SparseShapeAttrInterface>(tensorType.getEncoding());
+    if (!sparseAttr) {
+      return sparseOp.emitOpError(
+          "expected result type to have an encoding attribute that implements "
+          "the `SparseShapeAttrInterface`");
+    }
+  } else if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
+    sparseAttr =
+        dyn_cast_or_null<SparseShapeAttrInterface>(memrefType.getLayout());
+    if (!sparseAttr) {
+      return sparseOp.emitOpError(
+          "expected result type to have a layout attribute that implements "
+          "the `SparseShapeAttrInterface`");
+    }
+  } else {
+    return sparseOp->emitOpError("unhandled return type for sparse operation");
+  }
+
+  assert(sparseAttr);
+  SmallVector<int64_t> sparseDimensions = sparseAttr.getSparseDimensions();
+  if (sparseDimensions.size() < 2) {
+    return sparseOp.emitOpError(
+        "need at least two sparse dimensions for the result of a sparse op");
+  }
+  // Assert that the sparse dimensions are contiguous.
+  for (int i = 1; i < sparseDimensions.size(); ++i) {
+    if (sparseDimensions[i] != sparseDimensions[i - 1] + 1) {
+      return sparseOp.emitOpError(
+          "expected sparse dimensions to be contiguous");
+    }
+  }
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h
@@ -1,0 +1,27 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTOPINTERFACES_H_
+#define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTOPINTERFACES_H_
+
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler::IREE::TensorExt {
+
+class SparseCastOpInterface;
+// Interface verification method to verify the sparse op satisfies
+// interface constraints.
+LogicalResult verifySparseCastOpInterface(SparseCastOpInterface sparseOp);
+
+} // namespace mlir::iree_compiler::IREE::TensorExt
+
+// clang-format off: must be included after all LLVM/MLIR headers
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h.inc" // IWYU pragma: keep
+// clang-format on: must be included after all LLVM/MLIR headers
+
+#endif

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -7,8 +7,8 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::TensorExt {
 
@@ -512,7 +512,7 @@ LogicalResult CastToRaggedShapeOp::verify() {
     int resultIndex = index + foundRaggedDim;
     int64_t resultShape = resultType.getDimSize(resultIndex);
     if (ShapedType::isDynamic(sourceShape)) {
-      if (!ShapedType::isDynamic(resultShape)) {
+      if (ShapedType::isStatic(resultShape)) {
         return emitOpError("expected dimension ")
                << resultIndex
                << " of result to be dynamic since the corresponding dimension "

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -419,7 +419,7 @@ LogicalResult ComputeBarrierEndOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult CastToRaggedShapeOp::verify() {
-  // Check that the ragged row dimensions `raggedRowDim` < rank(`result`) - 1
+  // Check that the ragged row dimensions `raggedRowDim` < rank(`result`) - 1.
   int64_t raggedDim = getRaggedDim().getSExtValue();
   ShapedType sourceType = getSourceType();
   if (raggedDim >= sourceType.getRank()) {
@@ -549,7 +549,7 @@ OpFoldResult CastToRaggedShapeOp::getNumRaggedRowsAsOfr() {
   }
   ArrayRef<int64_t> resultShape = getResultType().getShape();
   int64_t raggedDim = getRaggedDimAttr().getInt();
-  assert(!ShapedType::isDynamic(resultShape[raggedDim]) &&
+  assert(ShapedType::isStatic(resultShape[raggedDim]) &&
          "expected number of ragged rows to be static");
   return IntegerAttr::get(IndexType::get(getContext()), resultShape[raggedDim]);
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -6,6 +6,10 @@
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
 namespace mlir::iree_compiler::IREE::TensorExt {
 
 //===----------------------------------------------------------------------===//
@@ -408,6 +412,146 @@ LogicalResult ComputeBarrierEndOp::verify() {
     return op.emitOpError("value and result types must match");
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.cast_to_ragged_shape
+//===----------------------------------------------------------------------===//
+
+LogicalResult CastToRaggedShapeOp::verify() {
+  // Check that the ragged row dimensions `raggedRowDim` < rank(`result`) - 1
+  int64_t raggedDim = getRaggedDim().getSExtValue();
+  ShapedType sourceType = getSourceType();
+  if (raggedDim >= sourceType.getRank()) {
+    return emitOpError("expected `ragged_dim` to be less than ")
+           << sourceType.getRank() << ", i.e the rank of source";
+  }
+
+  auto columnLengthsType = cast<ShapedType>(getColumnLengths().getType());
+  if (columnLengthsType.getRank() != 1) {
+    return emitOpError("expected `column_lengths` to be of rank 1");
+  }
+
+  ShapedType resultType = getResultType();
+  if (resultType.getRank() != sourceType.getRank() + 1) {
+    return emitOpError("expected result rank to be ")
+           << sourceType.getRank() + 1
+           << ", i.e. one more than the source rank, but got "
+           << resultType.getRank();
+  }
+  RaggedShapeAttr raggedTensorAttr = getResultSparseEncoding();
+  if (!raggedTensorAttr) {
+    return emitOpError("expected result type to have an encoding of type "
+                       "`RaggedShapeAttr`");
+  }
+  if (raggedTensorAttr.getRaggedRow() != raggedDim) {
+    return emitOpError("mismatch in specified `ragged_dim` value of ")
+           << raggedDim << " and `raggedRow` value in the sparse encoding "
+           << raggedTensorAttr.getRaggedRow();
+  }
+
+  if (Value numRaggedRows = getNumRaggedRows()) {
+    // If `num_ragged_rows` is dynamic, check that columnLengths shape is
+    // dynamic as well.
+    if (!columnLengthsType.isDynamicDim(0)) {
+      return emitOpError("invalid to have static dimensions for "
+                         "`column_lengths` when `num_ragged_rows` is dynamic");
+    }
+
+    // Check that the result has the number of rows dynamic as well.
+    if (!resultType.isDynamicDim(raggedDim)) {
+      return emitOpError("invalid to have static value for dimension ")
+             << raggedDim
+             << " of result when `num_ragged_rows` is specified as dynamic "
+                "value";
+    }
+  } else {
+    // if `num_ragged_rows` is static, check that the `column_lengths` shape is
+    // static as well. This effectively where the number of rows is statically
+    // recorded.
+    if (columnLengthsType.isDynamicDim(0) ||
+        columnLengthsType.getDimSize(0) <= 1) {
+      return emitOpError(
+          "expected shape of `column_lengths` to be static and "
+          "greater than 1 when `num_ragged_rows` is unspecified, i.e. "
+          "number of ragged rows is statically known");
+    }
+
+    // Check that the size of `ragged_dim` dimension in result type is
+    // consistent with the shape of column_lengths`.
+    if (resultType.isDynamicDim(raggedDim) ||
+        resultType.getDimSize(raggedDim) !=
+            columnLengthsType.getDimSize(0) - 1) {
+      return emitOpError("expected shape of dimension ")
+             << raggedDim
+             << " of result, i.e. the `ragged_dim`, to be static and equal to "
+             << columnLengthsType.getDimSize(0) - 1
+             << " when `num_ragged_rows` is unspecified, i.e number of ragged "
+                "rows is "
+                "statically known";
+    }
+  }
+
+  // The dimension for the "ragged columns" should be dynamic.
+  if (!resultType.isDynamicDim(raggedDim + 1)) {
+    return emitOpError("expected dimension ")
+           << (raggedDim + 1)
+           << " of result, i.e. `ragged_dim` + 1, to be dynamic";
+  }
+
+  bool foundRaggedDim = false;
+  int expectedNumSourceDynamicDims = 0;
+  for (auto [index, sourceShape] : llvm::enumerate(sourceType.getShape())) {
+    if (index == raggedDim) {
+      foundRaggedDim = true;
+      if (ShapedType::isDynamic(sourceShape)) {
+        expectedNumSourceDynamicDims++;
+      }
+      continue;
+    }
+    int resultIndex = index + foundRaggedDim;
+    int64_t resultShape = resultType.getDimSize(resultIndex);
+    if (ShapedType::isDynamic(sourceShape)) {
+      if (!ShapedType::isDynamic(resultShape)) {
+        return emitOpError("expected dimension ")
+               << resultIndex
+               << " of result to be dynamic since the corresponding dimension "
+               << index << " in the source is dynamic";
+      }
+      expectedNumSourceDynamicDims++;
+      continue;
+    }
+
+    if (ShapedType::isDynamic(resultShape) || resultShape != sourceShape) {
+      return emitOpError("expected shape of dimension ")
+             << resultIndex << " of result to match the shape of dimension "
+             << index << " of source, but got "
+             << (ShapedType::isDynamic(resultShape)
+                     ? std::string("?")
+                     : std::to_string(resultShape))
+             << " and " << sourceShape << " respectively";
+    }
+  }
+
+  if (expectedNumSourceDynamicDims != getSourceDynamicDims().size()) {
+    return emitOpError("mismatch in number of dynamic dimensions specified for "
+                       "source, expected ")
+           << expectedNumSourceDynamicDims << " values, got "
+           << getSourceDynamicDims().size();
+  }
+
+  return success();
+}
+
+OpFoldResult CastToRaggedShapeOp::getNumRaggedRowsAsOfr() {
+  if (Value v = getNumRaggedRows()) {
+    return v;
+  }
+  ArrayRef<int64_t> resultShape = getResultType().getShape();
+  int64_t raggedDim = getRaggedDimAttr().getInt();
+  assert(!ShapedType::isDynamic(resultShape[raggedDim]) &&
+         "expected number of ragged rows to be static");
+  return IntegerAttr::get(IndexType::get(getContext()), resultShape[raggedDim]);
 }
 
 } // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h
@@ -7,6 +7,8 @@
 #ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTOPS_H_
 #define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTOPS_H_
 
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOpInterfaces.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "mlir/IR/Attributes.h"

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -564,6 +564,21 @@ def IREETensorExt_CastToRaggedShapeOp :
     upper bound for the number of columns (for static upper bounds the shape of the
     dimension in the result shaped type encodes this value)
 
+    For example, if the `n` and `n+1` dimensions of the result represent this ragged structure
+
+    ```
+    OOOO
+    OOOOOO
+    OOO
+    OOOOO
+    ```
+
+    then,
+    - `ragged_dim` is `n`
+    - `num_ragged_rows` is 4
+    - `column_lengths` is [0, 4, 10, 13, 18]
+    - result has an encoding attribute of `#iree_tensor_ext.ragged_shape<n>`.
+
     Contraints are
     1. `ragged_dim` < rank(`source`)
     2. rank(`columnLengths`) == 1.
@@ -602,9 +617,9 @@ def IREETensorExt_CastToRaggedShapeOp :
     }
     RaggedShapeAttr getResultSparseEncoding() {
       if (auto tensorType = dyn_cast<RankedTensorType>(getResultType())) {
-        return dyn_cast_or_null<RaggedShapeAttr>(tensorType.getEncoding());
+        return dyn_cast_if_present<RaggedShapeAttr>(tensorType.getEncoding());
       } else if (auto memrefType = dyn_cast<MemRefType>(getResultType())) {
-        return dyn_cast_or_null<RaggedShapeAttr>(memrefType.getLayout());
+        return dyn_cast_if_present<RaggedShapeAttr>(memrefType.getLayout());
       }
       return RaggedShapeAttr();
     }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -8,6 +8,7 @@
 #define IREE_DIALECT_TENSOR_EXT_OPS
 
 include "iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td"
+include "iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -524,6 +525,92 @@ def IREETensorExt_ComputeBarrierEndOp : IREETensorExt_PureOp<"compute_barrier.en
   }];
 
   let hasFolder = 1;
+  let hasVerifier = 1;
+}
+
+//===---------------------------------------------------------------------===//
+// Sparse Tensor Operations
+//===---------------------------------------------------------------------===//
+
+def IREETensorExt_CastToRaggedShapeOp :
+    IREETensorExt_PureOp<"cast_to_ragged_shape", [
+      AttrSizedOperandSegments,
+      DeclareOpInterfaceMethods<IREETensorExt_SparseCastOpInterface>
+    ]> {
+  let summary = [{
+    Create a shaped type with ragged rows.
+  }];
+
+  let description = [{
+    The op takes a shaped type and reinterprets its contents as a ragged shaped type. The
+    dimensions specified by `ragged_dim` in the source is interpreted as two
+    dimensions at `ragged_dim` and `ragged_dim + 1` in the result shaped type. The
+    result shaped type has a rank of one more than that of the `source`. The result
+    type also has the encoding set to an attribute of type `RaggedShapeAttr`
+    with the specified `ragged_dim` used to specify the `raggedRow` in the
+    encoding attribute. (See description of `RaggedShapeAttr`). The number of
+    ragged rows is specified using `num_ragged_rows` argument. The size of each
+    row is specified using `column_lengths` argument, which is a single rank
+    shaped type of size `num_rows + 1` and where size of the `i`-th row of the result
+    is computed using
+
+    ```
+    column_lengths[i+1] - column_lengths[i]
+    ```
+
+    In other words, `column_lengths` is same as the `ROW_INDEX` in CSR
+    representation (https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)).
+    An optional argument `max_ragged_column_length` allows specifying the dynamic
+    upper bound for the number of columns (for static upper bounds the shape of the
+    dimension in the result shaped type encodes this value)
+
+    Contraints are
+    1. `ragged_dim` < rank(`source`)
+    2. rank(`columnLengths`) == 1.
+    3. dim(`columnLengths`, 0) == `num_rows` + 1.
+    4. dim(`result`, `raggedRowDim` + 1) >=
+        (`columnLengths`[k+1] - `columnLengths`[k])
+        for all 0 <= k < dim(`result`, `raggedRowDim`)
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$source,
+    IndexAttr:$raggedDim,
+    AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$columnLengths,
+    Optional<Index>:$numRaggedRows,
+    Optional<Index>:$avgRaggedColumnLength,
+    Variadic<Index>:$sourceDynamicDims
+  );
+  let results = (outs AnyTypeOf<[AnyRankedTensor, AnyMemRef]>:$result);
+
+  let assemblyFormat = [{
+    $source `ragged_dim` `(` $raggedDim `)`
+    `column_lengths` `(` $columnLengths `)`
+    (`num_ragged_rows` `(` $numRaggedRows^ `)`)?
+    (`avg_ragged_column_length` `(` $avgRaggedColumnLength^ `)`)?
+    attr-dict `:`
+    `(` type($source) (`{` $sourceDynamicDims^ `}`)? `,` type($columnLengths) `)`
+    `->` type($result)
+  }];
+
+  let extraClassDeclaration = [{
+    ShapedType getSourceType() {
+      return cast<ShapedType>(getSource().getType());
+    }
+    ShapedType getResultType() {
+      return cast<ShapedType>(getResult().getType());
+    }
+    RaggedShapeAttr getResultSparseEncoding() {
+      if (auto tensorType = dyn_cast<RankedTensorType>(getResultType())) {
+        return dyn_cast_or_null<RaggedShapeAttr>(tensorType.getEncoding());
+      } else if (auto memrefType = dyn_cast<MemRefType>(getResultType())) {
+        return dyn_cast_or_null<RaggedShapeAttr>(memrefType.getLayout());
+      }
+      return RaggedShapeAttr();
+    }
+    OpFoldResult getNumRaggedRowsAsOfr();
+  }];
+
   let hasVerifier = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -53,7 +53,7 @@ util.func public @barrier_end_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: in
 //===----------------------------------------------------------------------===//
 
 // Check that the sparse dimensions are in-bounds of the rank.
-// expected-error @+1{{sparse dimensions specified are greater than the rank of the tensor}}
+// expected-error @+1{{sparse dimensions specified are greater than the rank of the shaped type}}
 util.func public @test(memref<?xf32, #iree_tensor_ext.ragged_shape<0>>) {
   return
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -45,3 +45,322 @@ util.func public @barrier_end_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: in
   %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.ragged_shape
+//===----------------------------------------------------------------------===//
+
+// Check that the sparse dimensions are in-bounds of the rank.
+// expected-error @+1{{sparse dimensions specified are greater than the rank of the tensor}}
+util.func public @test(memref<?xf32, #iree_tensor_ext.ragged_shape<0>>) {
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.cast_to_ragged_shape
+//===----------------------------------------------------------------------===//
+
+// Error if the ragged_dim value is greater than the rank of the source.
+util.func public @raggedDimError(%source : tensor<10x20x30xf32>,
+    %columnLengths : tensor<4xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected `ragged_dim` to be less than 3, i.e the rank of source}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(3) column_lengths(%columnLengths)
+      : (tensor<10x20x30xf32>, tensor<4xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error if the rank of the `column_lengths` is not 1.
+util.func public @zeroDColumnLengths(%source : tensor<10x20x30xf32>,
+    %columnLengths : tensor<index>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected `column_lengths` to be of rank 1}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<10x20x30xf32>, tensor<index>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error if the rank of the `column_lengths` is greater than 1.
+util.func public @twoDcolumnLengths(%source : tensor<10x20x30xf32>,
+    %columnLengths : tensor<4x2xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected `column_lengths` to be of rank 1}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<10x20x30xf32>, tensor<4x2xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error if the result rank is not one more than the source rank.
+util.func public @resultRankSameAsSourceRank(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected result rank to be 4, i.e. one more than the source rank, but got 3}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error if the result rank is not one more than the source rank.
+util.func public @resultRankTwoMoreThanSourceRank(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected result rank to be 4, i.e. one more than the source rank, but got 5}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error if the result does not have a `iree_tensor_ext.ragged_shape` attribute.
+util.func public @missingRaggedShapeAttr(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32> {
+  // expected-error @+1 {{expected result type to have an encoding attribute that implements the `SparseShapeAttrInterface`}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?x?xf32>
+  util.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+// Error if the result does not have a `iree_tensor_ext.ragged_shape` attribute.
+util.func public @wrongEncodingAttr(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32, "foo"> {
+  // expected-error @+1 {{expected result type to have an encoding attribute that implements the `SparseShapeAttrInterface`}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?x?xf32, "foo">
+  util.return %0 : tensor<?x?x?x?xf32, "foo">
+}
+
+// -----
+
+// Error if the result does not have a `iree_tensor_ext.ragged_shape` attribute.
+util.func public @wrongEncodingAttr(%source : memref<?x?x?xf32>,
+    %columnLengths : memref<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> memref<?x?x?x?xf32> {
+  // expected-error @+1 {{expected result type to have a layout attribute that implements the `SparseShapeAttrInterface`}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (memref<?x?x?xf32>{%d0, %d1, %d2}, memref<?xindex>)
+      -> memref<?x?x?x?xf32>
+  util.return %0 : memref<?x?x?x?xf32>
+}
+
+// -----
+
+// Mismatched between `ragged_shape` attr used and `ragged_dim` specified.
+util.func public @mismatchedRaggedShapeAttr(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<0>> {
+  // expected-error @+1 {{mismatch in specified `ragged_dim` value of 1 and `raggedRow` value in the sparse encoding 0}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+  util.return %0 : tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<0>>
+}
+
+// -----
+
+// Error when `column_lengths` is static shaped when `num_ragged_rows` is dynamic.
+util.func public @staticColumnLenghtsWithDynamicNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{invalid to have static dimensions for `column_lengths` when `num_ragged_rows` is dynamic}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>)
+      -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `result` has static shape for `ragged_dim` when `num_ragged_rows` is dynamic.
+util.func public @staticResultDimWithDynamicNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{invalid to have static value for dimension 1 of result when `num_ragged_rows` is specified as dynamic value}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `num_ragged_rows` is unspecified (i.e. it is static) but `column_lengths` is
+// static. When `num_ragged_rows` is not specified, the size of `column_lengths` gives
+// the number of rows.
+util.func public @dynamicColumnLengthWithStaticNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of `column_lengths` to be static and greater than 1 when `num_ragged_rows` is unspecified, i.e. number of ragged rows is statically known}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>) -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `num_ragged_rows` is unspecified (i.e. it is static), the size of
+// `column_lengths` is less then or equal to 1.
+util.func public @unitColumnLengthWithStaticNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<1xindex>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of `column_lengths` to be static and greater than 1 when `num_ragged_rows` is unspecified, i.e. number of ragged rows is statically known}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<1xindex>) -> tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x2x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `ragged_dim` dimension of result is dynamic with static `column_lengths`.
+util.func public @dynamicResultDimWithStaticNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of dimension 1 of result, i.e. the `ragged_dim`, to be static and equal to 3 when `num_ragged_rows` is unspecified, i.e number of ragged rows is statically known}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `ragged_dim` dimension of result is mismatched with static `column_lengths` shape.
+util.func public @dynamicResultDimWithStaticNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x4x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of dimension 1 of result, i.e. the `ragged_dim`, to be static and equal to 3 when `num_ragged_rows` is unspecified, i.e number of ragged rows is statically known}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x4x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x4x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when `ragged_dim` + 1 dimension is static.
+util.func public @staticRaggedColumnLengths(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %avgColumnLength : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected dimension 2 of result, i.e. `ragged_dim` + 1, to be dynamic}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      avg_ragged_column_length(%avgColumnLength)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x4x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result.
+util.func public @mismatchSourceAndResultDims0(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index, %d2 : index) -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected dimension 0 of result to be dynamic since the corresponding dimension 0 in the source is dynamic}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result
+
+util.func public @mismatchSourceAndResultDims1(%source : tensor<4x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index)
+    -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of dimension 0 of result to match the shape of dimension 0 of source, but got 2 and 4 respectively}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<4x?x?xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result
+
+util.func public @mismatchSourceAndResultDims2(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index, %d2 : index)
+    -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected dimension 0 of result to be dynamic since the corresponding dimension 0 in the source is dynamic}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<2x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result
+
+util.func public @mismatchSourceAndResultDims3(%source : tensor<?x?x4xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index)
+    -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of dimension 3 of result to match the shape of dimension 2 of source, but got ? and 4 respectively}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x4xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result
+
+util.func public @mismatchSourceAndResultDims4(%source : tensor<?x?x4xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index)
+    -> tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected shape of dimension 3 of result to match the shape of dimension 2 of source, but got 5 and 4 respectively}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x4xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Error when mismatch between dimensions of source and result
+
+util.func public @mismatchSourceAndResultDims4(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index, %d2 : index)
+    -> tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected dimension 3 of result to be dynamic since the corresponding dimension 2 in the source is dynamic}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Unspecified dynamic dimensions of source
+
+util.func public @insufficientSourceDynamicDims(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index)
+    -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{mismatch in number of dynamic dimensions specified for source, expected 3 values, got 2}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
+// Overspecified dynamic dimensions of source
+
+util.func public @extraSourceDynamicDims(%source : tensor<2x?x5xf32>,
+    %columnLengths : tensor<4xindex>, %d0 : index, %d1 : index, %d2 : index)
+    -> tensor<2x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{mismatch in number of dynamic dimensions specified for source, expected 1 values, got 2}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<2x?x5xf32>{%d0, %d1}, tensor<4xindex>) -> tensor<2x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<2x3x?x5xf32, #iree_tensor_ext.ragged_shape<1>>
+}

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -86,3 +86,103 @@ util.func public @barrier_end_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim
   %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
+
+// -----
+
+// Check RaggedTensorAttr
+
+util.func public @raggedTensorAttrTest(%arg0 : tensor<?x?xf32, #iree_tensor_ext.ragged_shape<0>>) {
+  util.return
+}
+// CHECK-LABEL: @raggedTensorAttrTest
+
+// -----
+
+// Check static iree_tensor_ext.cast_to_ragged
+
+util.func public @castToRaggedStatic(%source : tensor<10x20x30xf32>,
+    %columnLengths : tensor<4xindex>) -> tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<10x20x30xf32>, tensor<4xindex>) -> tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @castToRaggedStatic
+
+// -----
+
+// Check dynamic iree_tensor_ext.cast_to_ragged
+
+util.func public @castToRaggedDynamic(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<?xindex>, %numRaggedRows : index)
+    -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %source, %c0 : tensor<?x?x?xf32>
+  %d1 = tensor.dim %source, %c1 : tensor<?x?x?xf32>
+  %d2 = tensor.dim %source, %c2 : tensor<?x?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<?xindex>)
+      -> tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @castToRaggedDynamic
+
+// -----
+
+// Check memref-type iree_tensor_ext.cast_to_ragged
+
+util.func public @castToRaggedDynamicMemRef(%source : memref<?x?x?xf32>,
+    %columnLengths : memref<?xindex>, %numRaggedRows : index)
+    -> memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = memref.dim %source, %c0 : memref<?x?x?xf32>
+  %d1 = memref.dim %source, %c1 : memref<?x?x?xf32>
+  %d2 = memref.dim %source, %c2 : memref<?x?x?xf32>
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      num_ragged_rows(%numRaggedRows) : (memref<?x?x?xf32>{%d0, %d1, %d2}, memref<?xindex>)
+      -> memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @castToRaggedDynamic
+
+
+// -----
+
+// Check for static number of ragged rows
+
+util.func public @staticNumRaggedRows(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %maxColumnLength : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @staticNumRaggedRows
+
+// -----
+
+util.func public @staticAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @staticAvgRaggedColumnLengths
+
+// -----
+
+// Check for dynamically specified `avg_ragged_column_length`
+
+util.func public @dynamicAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
+    %columnLengths : tensor<4xindex>, %avgColumnLength : index,
+    %d0 : index, %d1 : index, %d2 : index) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>> {
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(1) column_lengths(%columnLengths)
+      avg_ragged_column_length(%avgColumnLength)
+      : (tensor<?x?x?xf32>{%d0, %d1, %d2}, tensor<4xindex>) -> tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+// CHECK-LABEL: @dynamicAvgRaggedColumnLengths

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -89,16 +89,17 @@ util.func public @barrier_end_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim
 
 // -----
 
-// Check RaggedTensorAttr
+// Check RaggedTensorAttr.
 
 util.func public @raggedTensorAttrTest(%arg0 : tensor<?x?xf32, #iree_tensor_ext.ragged_shape<0>>) {
   util.return
 }
 // CHECK-LABEL: @raggedTensorAttrTest
+//  CHECK-SAME:     #iree_tensor_ext.ragged_shape<0>
 
 // -----
 
-// Check static iree_tensor_ext.cast_to_ragged
+// Check static iree_tensor_ext.cast_to_ragged.
 
 util.func public @castToRaggedStatic(%source : tensor<10x20x30xf32>,
     %columnLengths : tensor<4xindex>) -> tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>> {
@@ -107,10 +108,11 @@ util.func public @castToRaggedStatic(%source : tensor<10x20x30xf32>,
   util.return %0 : tensor<10x3x?x30xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @castToRaggedStatic
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
 
 // -----
 
-// Check dynamic iree_tensor_ext.cast_to_ragged
+// Check dynamic iree_tensor_ext.cast_to_ragged.
 
 util.func public @castToRaggedDynamic(%source : tensor<?x?x?xf32>,
     %columnLengths : tensor<?xindex>, %numRaggedRows : index)
@@ -127,10 +129,11 @@ util.func public @castToRaggedDynamic(%source : tensor<?x?x?xf32>,
   util.return %0 : tensor<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @castToRaggedDynamic
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
 
 // -----
 
-// Check memref-type iree_tensor_ext.cast_to_ragged
+// Check memref-type iree_tensor_ext.cast_to_ragged.
 
 util.func public @castToRaggedDynamicMemRef(%source : memref<?x?x?xf32>,
     %columnLengths : memref<?xindex>, %numRaggedRows : index)
@@ -147,11 +150,11 @@ util.func public @castToRaggedDynamicMemRef(%source : memref<?x?x?xf32>,
   util.return %0 : memref<?x?x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @castToRaggedDynamic
-
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
 
 // -----
 
-// Check for static number of ragged rows
+// Check for static number of ragged rows.
 
 util.func public @staticNumRaggedRows(%source : tensor<?x?x?xf32>,
     %columnLengths : tensor<4xindex>, %maxColumnLength : index,
@@ -161,6 +164,7 @@ util.func public @staticNumRaggedRows(%source : tensor<?x?x?xf32>,
   util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @staticNumRaggedRows
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
 
 // -----
 
@@ -172,10 +176,11 @@ util.func public @staticAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
   util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @staticAvgRaggedColumnLengths
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape
 
 // -----
 
-// Check for dynamically specified `avg_ragged_column_length`
+// Check for dynamically specified `avg_ragged_column_length`.
 
 util.func public @dynamicAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
     %columnLengths : tensor<4xindex>, %avgColumnLength : index,
@@ -186,3 +191,4 @@ util.func public @dynamicAvgRaggedColumnLengths(%source : tensor<?x?x?xf32>,
   util.return %0 : tensor<?x3x?x?xf32, #iree_tensor_ext.ragged_shape<1>>
 }
 // CHECK-LABEL: @dynamicAvgRaggedColumnLengths
+//       CHECK:     iree_tensor_ext.cast_to_ragged_shape


### PR DESCRIPTION
This commit adds an operation that can be used to specify ragged
dimensions of a tensor. This is done through use of a new attribute
`RaggedTensorAttr` which can be used as an encoding attribute for a
`RankedTensorType`. The attribute specifies which dimension of the
result represents the "rows" of ragged tensors, i.e. if the n-th
dimensions of a tensor is specified as ragged than the n+1-th
dimension of the tensor has dimensions that are not equal, and n-th
dimension represents the number of such "columns". The n-th dimension
is refered to as the `raggedRow` and the n+1-th dimension is refered to
as a `raggedColumn`.

The commit also adds an operation `cast_to_ragged_shape` that takes a
source and allows specifying any dimension of the source
`tensor/memref` as the linearized `raggedRow` and `raggedColumn`
dimensions of the result tensor.

See documentation of `RaggedTensorAttr` and `CastToRaggedShape` for
more details.

The commit also adds a `SparseTensorAttrInterface` and
`SparseOpInterface`. Currently this is just a stub with
`RaggedTensorAttr` implementing the `SparseTensorAttrInterface` and
the `CastToRaggedTensor` implementing the
`SparseOpInterface`. Since sparsity could be expressed in any
form, it is expected that the transformations used these interfaces to
interpret the nature of sparsity as needed while the actual details of
the sparsity implemented by operations/attributes are behind the
interface. For now these attributes dont have any methods, but will be
populated as the operations/attributes implemented here are lowered
through the compilation pipeline.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>