### PR TITLE
[Codegen] Update the assembly formats and corresponding tests for matcher ops

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -382,7 +382,7 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %inpu
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_correct_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
    %batch, %m, %n, %k = transform.iree.match.contraction %op,
-    lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2]} :
+    lhs_type = i8, rhs_type = i8, output_type = i32, indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2] :
     !transform.any_op -> !transform.param<i64>
     transform.yield %op : !transform.any_op
   }
@@ -423,7 +423,7 @@ func.func @op_matmul(%input0: tensor<32x64xi8>, %input1: tensor<32x64xi8>, %dest
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_different_count(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %m, %n, %k = transform.iree.match.contraction %op,
-      lhs_type = i8, rhs_type = i8, output_type = i32 {indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0]} :
+      lhs_type = i8, rhs_type = i8, output_type = i32, indexing_maps = [#map_matmul0, #map_matmul1, #map_matmul2, #map_matmul0] :
       !transform.any_op -> !transform.param<i64>
     transform.yield %op : !transform.any_op
   }
@@ -691,12 +691,12 @@ func.func @broadcast_mmt_cases(
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_broadcast_rhs(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %m, %n, %k = transform.iree.match.contraction %op,
-      lhs_type = i8, rhs_type = i8, output_type = i32
-      { indexing_maps = [
+      lhs_type = i8, rhs_type = i8, output_type = i32,
+      indexing_maps = [
           affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
           affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
           affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-        ] } : !transform.any_op -> !transform.param<i64>
+      ] : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [-1, 8] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [1024] : !transform.param<i64>
@@ -706,12 +706,12 @@ module attributes {transform.with_named_sequence} {
 
   transform.named_sequence @match_broadcast_lhs(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %m, %n, %k = transform.iree.match.contraction %op,
-      lhs_type = i8, rhs_type = i8, output_type = i32
-      { indexing_maps = [
+      lhs_type = i8, rhs_type = i8, output_type = i32,
+      indexing_maps = [
           affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
           affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
           affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-        ] } : !transform.any_op -> !transform.param<i64>
+      ] : !transform.any_op -> !transform.param<i64>
     transform.iree.match.dims_equal %batch, [] : !transform.param<i64>
     transform.iree.match.dims_equal %m, [1024] : !transform.param<i64>
     transform.iree.match.dims_equal %n, [-1, 8] : !transform.param<i64>
@@ -783,8 +783,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_conv_nhwc_hwcf(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
       transform.iree.match.convolution %op,
-        lhs_type = f32, rhs_type = f32, output_type = f32
-        {indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output]} :
+        lhs_type = f32, rhs_type = f32, output_type = f32,
+        indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output] :
         !transform.any_op -> !transform.param<i64>
     transform.yield %op : !transform.any_op
   }
@@ -792,8 +792,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_conv_nchw_fchw(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
       transform.iree.match.convolution %op,
-        lhs_type = f16, rhs_type = f16, output_type = f16
-        {indexing_maps = [#map_nchw_fchw_input, #map_nchw_fchw_filter, #map_nchw_fchw_output]} :
+        lhs_type = f16, rhs_type = f16, output_type = f16,
+        indexing_maps = [#map_nchw_fchw_input, #map_nchw_fchw_filter, #map_nchw_fchw_output] :
         !transform.any_op -> !transform.param<i64>
     %c4 = transform.param.constant 4 : i64 -> !transform.param<i64>
     transform.match.param.cmpi eq %batch, %c4 : !transform.param<i64>
@@ -845,8 +845,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_conv_all_dims(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
       transform.iree.match.convolution %op,
-        lhs_type = f16, rhs_type = f16, output_type = f32
-        {indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output]} :
+        lhs_type = f16, rhs_type = f16, output_type = f32,
+        indexing_maps = [#map_nhwc_hwcf_input, #map_nhwc_hwcf_filter, #map_nhwc_hwcf_output] :
         !transform.any_op -> !transform.param<i64>
 
     transform.iree.match.dims_equal %batch, [1] : !transform.param<i64>
@@ -903,8 +903,8 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_with_wrong_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
     %batch, %out_img, %out_ch, %filt, %in_ch, %depth, %strides, %dilations =
       transform.iree.match.convolution %op,
-        lhs_type = f32, rhs_type = f32, output_type = f32
-        {indexing_maps = [#map_nhwc_hwcf_input, #map_wrong_filter, #map_nhwc_hwcf_output]} :
+        lhs_type = f32, rhs_type = f32, output_type = f32,
+        indexing_maps = [#map_nhwc_hwcf_input, #map_wrong_filter, #map_nhwc_hwcf_output] :
         !transform.any_op -> !transform.param<i64>
     transform.yield %op : !transform.any_op
   }

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -194,8 +194,8 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
 
     %batch_dims, %m_dims, %n_dims, %k_dims =
       transform.iree.match.contraction %matmul_op,
-        lhs_type = f32, rhs_type = f32, output_type = f32
-        {indexing_maps = [#map_lhs, #map_rhs, #map_output]} :
+        lhs_type = f32, rhs_type = f32, output_type = f32,
+        indexing_maps = [#map_lhs, #map_rhs, #map_output] :
         !transform.any_op -> !transform.param<i64>
     ```
 
@@ -236,7 +236,7 @@ def MatchContractionOp : Op<Transform_Dialect, "iree.match.contraction",
     `,` `lhs_type` `=` $lhs_type
     `,` `rhs_type` `=` $rhs_type
     `,` `output_type` `=` $output_type
-    (`indexing_maps` $indexing_maps^)?
+    (`,` `indexing_maps` `=` $indexing_maps^)?
     attr-dict `:` type($operand_handle) `->` type($batch_dims)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
@@ -270,8 +270,8 @@ def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
     %batch_dims, %output_image_dims, %output_channel_dims, %filter_dims,
     %input_channel_dims, %depth_dims, %strides, %dilations =
       transform.iree.match.convolution %conv_op,
-        lhs_type = f32, rhs_type = f32, output_type = f32
-        {indexing_maps = [#map_input, #map_filter, #map_output]} :
+        lhs_type = f32, rhs_type = f32, output_type = f32,
+        indexing_maps = [#map_input, #map_filter, #map_output] :
         !transform.any_op -> !transform.param<i64>
     ```
 
@@ -320,7 +320,7 @@ def MatchConvolutionOp : Op<Transform_Dialect, "iree.match.convolution",
     `,` `lhs_type` `=` $lhs_type
     `,` `rhs_type` `=` $rhs_type
     `,` `output_type` `=` $output_type
-    (`indexing_maps` $indexing_maps^)?
+    (`,` `indexing_maps` `=` $indexing_maps^)?
     attr-dict `:` type($operand_handle) `->` type($batch_dims)
   }];
   let extraClassDeclaration = SingleOpMatcher.extraDeclaration;


### PR DESCRIPTION
According to this comment: https://github.com/iree-org/iree/pull/22227#issuecomment-3381214702, this PR updates the assembly format for contraction and convolution matcher ops.  The attention matcher op's indexing map is not optional and also consistent with what is suggested in the comment, so no need to update.