### PR TITLE
[build flags] 2nd prep to enable more warnings in compile flags (#21996)

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -500,7 +500,7 @@ static bool iree_hal_hip_driver_is_path_uuid(iree_string_view_t device_path) {
 }
 
 static bool iree_hal_hip_driver_is_path_index(iree_string_view_t device_path) {
-  uint32_t unused_device_index = 0;
+  int32_t unused_device_index = 0;
   return iree_string_view_atoi_int32(device_path, &unused_device_index);
 }
 

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -63,23 +63,23 @@ static iree_status_t iree_hal_hip_query_limits(
 
   IREE_HIP_RETURN_IF_ERROR(
       symbols,
-      hipDeviceGetAttribute(&out_limits->max_block_dims[0],
+      hipDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[0],
                             hipDeviceAttributeMaxBlockDimX, device),
       "hipDeviceGetAttribute");
   IREE_HIP_RETURN_IF_ERROR(
       symbols,
-      hipDeviceGetAttribute(&out_limits->max_block_dims[1],
+      hipDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[1],
                             hipDeviceAttributeMaxBlockDimY, device),
       "hipDeviceGetAttribute");
   IREE_HIP_RETURN_IF_ERROR(
       symbols,
-      hipDeviceGetAttribute(&out_limits->max_block_dims[2],
+      hipDeviceGetAttribute((int32_t*)&out_limits->max_block_dims[2],
                             hipDeviceAttributeMaxBlockDimZ, device),
       "hipDeviceGetAttribute");
 
   IREE_HIP_RETURN_IF_ERROR(
       symbols,
-      hipDeviceGetAttribute(&out_limits->max_block_shared_memory_size,
+      hipDeviceGetAttribute((int32_t*)&out_limits->max_block_shared_memory_size,
                             hipDeviceAttributeMaxSharedMemoryPerBlock, device),
       "hipDeviceGetAttribute");
 


### PR DESCRIPTION
Second step of preparing the code to enable more warnings during compilation:
```
-Wambiguous-member-template
-Wchar-subscripts
-Wgnu-alignof-expression
-Wgnu-variable-sized-type-not-at-end
-Wignored-optimization-argument
-Winvalid-source-encoding
-Wmismatched-tags
-Wmissing-braces
-Wpointer-sign
-Wreserved-user-defined-literal
-Wreturn-type-c-linkage
-Wself-assign-overloaded
-Wsign-compare
-Wsigned-unsigned-wchar
-Wstrict-overflow
-Wtrigraphs
-Wunknown-pragmas
-Wunknown-warning-option
-Wunused-command-line-argument
-Wunused-local-typedef
-Wuser-defined-warnings
```

This change contains a few more code changes to avoid the warnings mentioned above, which were missed in #22252. It does not turn on the warnings yet.