### PR TITLE
[Input] Add RecomposeComplexOps pass in Torch/InputConversion/Passes

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -44,7 +44,7 @@ void createTorchToIREEPipeline(
     // now be simplified.
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
-  pm.addNestedPass<func::FuncOp>(createRecomposeComplexOpsPass());
+  pm.addNestedPass<func::FuncOp>(torch::Torch::createRecomposeComplexOpsPass());
   pm.addNestedPass<func::FuncOp>(createBitCastTensorPass());
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createReduceOpVariantsPass(llvm::StringRef()));

--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -44,6 +44,7 @@ void createTorchToIREEPipeline(
     // now be simplified.
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
+  pm.addNestedPass<func::FuncOp>(createRecomposeComplexOpsPass());
   pm.addNestedPass<func::FuncOp>(createBitCastTensorPass());
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createReduceOpVariantsPass(llvm::StringRef()));


### PR DESCRIPTION
See https://github.com/llvm/torch-mlir/issues/4339 for more details.

Adding the `RecomposeComplexOps` pass from torch-mlir will decompose `torch.chunk` into `torch.slice` instead of `as_strided`, which is much simpler and better. `as_strided` has issues as described in the issue above. The pass itself is very short and only does a few things, mostly around dealing with `split`. This needs to be added in tandem with other PRs linked in the issue in order to ensure we don't decompose `split` to `as_strided` instead.

I am looking for feedback as to when to add this pass, before or after the bit cast pass?