### PR TITLE
Use llvm wrappers for accumulate. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -551,8 +551,7 @@ struct ConcatenateOpCanon final
 
     uint64_t axis = op.getDimension();
     ArrayRef<int64_t> shape = type.getShape();
-    int64_t topSize = std::accumulate(shape.begin(), shape.begin() + axis,
-                                      int64_t{1}, std::multiplies<>{});
+    int64_t topSize = llvm::product_of(shape.take_front(axis));
 
     SmallVector<Attribute> newElems;
     newElems.reserve(numElems);

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -295,17 +295,13 @@ struct TransposeReshapeGenericDotGeneral final
         shape.size() - dimsBorder1 <= 1)
       return src;
 
-    SmallVector<int64_t> result_shape = {
-        std::accumulate(shape.begin(), shape.begin() + dimsBorder0, 1,
-                        std::multiplies<int64_t>()),
-        std::accumulate(shape.begin() + dimsBorder0,
-                        shape.begin() + dimsBorder1, 1,
-                        std::multiplies<int64_t>()),
-        std::accumulate(shape.begin() + dimsBorder1, shape.end(), 1,
-                        std::multiplies<int64_t>())};
+    int64_t resultShape[] = {
+        llvm::product_of(shape.take_front(dimsBorder0)),
+        llvm::product_of(shape.drop_front(dimsBorder0)
+                             .take_front(dimsBorder1 - dimsBorder0)),
+        llvm::product_of(shape.drop_front(dimsBorder1))};
     return mlir::stablehlo::ReshapeOp::create(
-        b, loc, RankedTensorType::get(result_shape, type.getElementType()),
-        src);
+        b, loc, RankedTensorType::get(resultShape, type.getElementType()), src);
   }
 
   LogicalResult matchAndRewrite(mlir::stablehlo::DotGeneralOp op,

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -297,8 +297,7 @@ struct TransposeReshapeGenericDotGeneral final
 
     int64_t resultShape[] = {
         llvm::product_of(shape.take_front(dimsBorder0)),
-        llvm::product_of(shape.drop_front(dimsBorder0)
-                             .take_front(dimsBorder1 - dimsBorder0)),
+        llvm::product_of(shape.slice(dimsBorder0, dimsBorder1 - dimsBorder0)),
         llvm::product_of(shape.drop_front(dimsBorder1))};
     return mlir::stablehlo::ReshapeOp::create(
         b, loc, RankedTensorType::get(resultShape, type.getElementType()), src);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
@@ -188,9 +188,7 @@ void GPUDistributeForallPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  int64_t flatWorkgroupSize =
-      std::accumulate(workgroupSize.begin(), workgroupSize.end(), 1,
-                      std::multiplies<int64_t>());
+  int64_t flatWorkgroupSize = llvm::product_of(workgroupSize);
   int64_t subgroupSize = *maybeSubgroupSize;
 
   if (flatWorkgroupSize % subgroupSize != 0 &&

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -338,9 +338,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
   std::optional<int64_t> maybeFlatWorkgroupSize = std::nullopt;
   if (std::optional<SmallVector<int64_t>> workgroupSize =
           getWorkgroupSize(funcOp)) {
-    maybeFlatWorkgroupSize =
-        std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
-                        std::multiplies<int64_t>());
+    maybeFlatWorkgroupSize = llvm::product_of(*workgroupSize);
   }
 
   // First run the hoisting and fusion patterns.

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -176,8 +176,7 @@ void GenericVectorizationPass::runOnOperation() {
       // Do not vectorize the op if the vector size is greater than or equal
       // to limit.
       if (enableVectorMasking) {
-        if (std::accumulate(vectorSizes.begin(), vectorSizes.end(), 1LL,
-                            std::multiplies<int64_t>()) >= maxVectorSize)
+        if (llvm::product_of(vectorSizes) >= maxVectorSize)
           continue;
       } else {
         if (failed(isWithinVectorSizeLimit(linalgOp, maxVectorSize)))

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -30,10 +30,9 @@ namespace {
 //===---------------------------------------------------------------------===//
 
 static int64_t getProductExcludingDynamic(ArrayRef<int64_t> sizes) {
-  return std::accumulate(
-      sizes.begin(), sizes.end(), 1, [](int64_t res, int64_t size) {
-        return ShapedType::isDynamic(size) ? res : res * size;
-      });
+  return llvm::accumulate(sizes, int64_t(1), [](int64_t res, int64_t size) {
+    return ShapedType::isDynamic(size) ? res : res * size;
+  });
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -194,11 +194,6 @@ InnerTiledOp::inferReturnTypes(MLIRContext *, std::optional<Location>,
   return success();
 }
 
-static int64_t multiplyAcc(ArrayRef<int64_t> shape) {
-  return std::accumulate(shape.begin(), shape.end(), 1,
-                         std::multiplies<int64_t>());
-}
-
 static bool countsMatchTileTypes(ArrayRef<int64_t> innerElemCounts,
                                  ArrayRef<VectorType> tileTypes) {
   return llvm::all_of_zip(
@@ -213,7 +208,7 @@ static SmallVector<int64_t> getInnerElemCounts(InnerTiledOp tiledOp) {
            tiledOp.getOperandTypes(),
            tiledOp.getIndexingMapsAttr().getAsValueRange<AffineMapAttr>())) {
     ArrayRef<int64_t> shape = cast<ShapedType>(opType).getShape();
-    result.push_back(multiplyAcc(shape.drop_front(map.getNumResults())));
+    result.push_back(llvm::product_of(shape.drop_front(map.getNumResults())));
   }
   return result;
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -62,8 +62,7 @@ static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
   // If the number of loop trips are indivisible by the number of threads then
   // also default to just the vector size (e.g., [1, ..., 1, vector_size] when
   // `targetDim` is the innermost).
-  int64_t flatNumTrips = std::accumulate(loopRanges.begin(), loopRanges.end(),
-                                         1, std::multiplies<int64_t>());
+  int64_t flatNumTrips = llvm::product_of(loopRanges);
   if (flatNumTrips % numThreads != 0) {
     return getVectorSizeTileSizes(rank, targetDim, targetRange, vectorSize);
   }
@@ -158,9 +157,7 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
   if (!workgroupSize) {
     return {};
   }
-  int64_t numThreads =
-      std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
-                      std::multiplies<int64_t>());
+  int64_t numThreads = llvm::product_of(*workgroupSize);
   return TypeSwitch<Operation *, SmallVector<int64_t>>(op)
       .Case([&](linalg::LinalgOp linalgOp) -> SmallVector<int64_t> {
         return deriveLinalgOpThreadTileSizes(linalgOp, numThreads);
@@ -210,9 +207,7 @@ SmallVector<int64_t> globalLoadDMATileSizes(Operation *op) {
       (kDefaultGlobalLoadBitSizePerThread * targetSubgroupSize) /
       getElementTypeOrSelf(linalgOp->getResultTypes()[0])
           .getIntOrFloatBitWidth();
-  int64_t numThreads =
-      std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
-                      std::multiplies<int64_t>());
+  int64_t numThreads = llvm::product_of(*workgroupSize);
   SmallVector<int64_t> tileSizes = getVectorTileSizesFromLoopRanges(
       loopRanges, numThreads, subgroupLoadSize);
   return tileSizes;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -457,9 +457,7 @@ static void reduceDistributionWorkgroups(
   }
 
   int64_t numWorkgroupsLimit = 2 * clNumberOfRuntimeThreads;
-  int64_t numWorkgroups =
-      std::accumulate(numWorkgroupsPerDim.begin(), numWorkgroupsPerDim.end(),
-                      1LL, std::multiplies<int64_t>{});
+  int64_t numWorkgroups = llvm::product_of(numWorkgroupsPerDim);
   unsigned currDim = workload.size();
   while (numWorkgroups > numWorkgroupsLimit && currDim > 0) {
     unsigned index = currDim - 1;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
@@ -41,8 +41,7 @@ static int64_t getTotalSizeInBytes(Type elemType, ArrayRef<int64_t> shape) {
   if (elemType.isIntOrFloat()) {
     elemBitWidth = elemType.getIntOrFloatBitWidth();
   }
-  int64_t size = std::accumulate(shape.begin(), shape.end(), elemBitWidth,
-                                 std::multiplies<int64_t>{});
+  int64_t size = llvm::product_of(shape, elemBitWidth);
   constexpr int64_t kBitsInByte = 8;
   size = llvm::divideCeil(size, kBitsInByte);
   return size;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1390,14 +1390,13 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   };
 
   SmallVector<int64_t> mBounds = getDimBounds(opInfo.getMDims());
-  int64_t mSize = std::accumulate(mBounds.begin(), mBounds.end(), (int64_t)1,
-                                  [](int64_t a, int64_t b) -> int64_t {
-                                    if (ShapedType::isDynamic(a) ||
-                                        ShapedType::isDynamic(b)) {
-                                      return ShapedType::kDynamic;
-                                    }
-                                    return a * b;
-                                  });
+  int64_t mSize = llvm::accumulate(
+      mBounds, int64_t(1), [](int64_t a, int64_t b) -> int64_t {
+        if (ShapedType::isDynamic(a) || ShapedType::isDynamic(b)) {
+          return ShapedType::kDynamic;
+        }
+        return a * b;
+      });
   // Bail out on skinny M dimension. This will be handled by the warp reduction
   // pipeline.
   if (!ShapedType::isDynamic(mSize) && mSize <= kVerySkinnyDimThreshold) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
@@ -7,11 +7,13 @@
 #include "iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.h"
 
 #include <algorithm>
+#include <functional>
 #include <numeric>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Utils/Permutation.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Shard/IR/ShardOps.h"
@@ -132,14 +134,12 @@ static SmallVector<int64_t> collapseAxesN(ArrayRef<int64_t> shape,
                                           size_t firstAxis, size_t n) {
   assert(firstAxis + n <= shape.size());
   assert(n > 1);
-  SmallVector<int64_t> res;
-  std::copy(shape.begin(), shape.begin() + firstAxis, std::back_inserter(res));
+  auto res = llvm::to_vector_of<int64_t>(shape.take_front(firstAxis));
   size_t collapsedAxisSize = std::accumulate(
       shape.begin() + firstAxis + 1, shape.begin() + firstAxis + n,
-      shape[firstAxis], [](size_t a, size_t b) { return a * b; });
+      shape[firstAxis], std::multiplies<>{});
   res.push_back(collapsedAxisSize);
-  std::copy(shape.begin() + firstAxis + n, shape.end(),
-            std::back_inserter(res));
+  llvm::append_range(res, shape.drop_front(firstAxis + n));
   return res;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/Flow/Conversion/ShardToFlow/Patterns.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <numeric>
 
@@ -135,9 +136,7 @@ static SmallVector<int64_t> collapseAxesN(ArrayRef<int64_t> shape,
   assert(firstAxis + n <= shape.size());
   assert(n > 1);
   auto res = llvm::to_vector_of<int64_t>(shape.take_front(firstAxis));
-  size_t collapsedAxisSize = std::accumulate(
-      shape.begin() + firstAxis + 1, shape.begin() + firstAxis + n,
-      shape[firstAxis], std::multiplies<>{});
+  int64_t collapsedAxisSize = llvm::product_of(shape.slice(firstAxis, n));
   res.push_back(collapsedAxisSize);
   llvm::append_range(res, shape.drop_front(firstAxis + n));
   return res;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -945,9 +945,7 @@ static ElementsAttr tensorSlice(ElementsAttr tensor, uint64_t dim,
   llvm::SmallVector<Attribute> newContents;
   newContents.reserve(outputType.getNumElements());
   auto valuesBegin = tensor.getValues<Attribute>().begin();
-  int64_t step =
-      std::accumulate(shape.rbegin(), shape.rbegin() + shape.size() - dim,
-                      /*init=*/1, /*op=*/std::multiplies<int64_t>());
+  int64_t step = llvm::product_of(llvm::drop_begin(shape, dim));
   int64_t num = length * step / shape[dim];
   for (int64_t offset = step / shape[dim] * start,
                numElements = tensorType.getNumElements();

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -192,9 +192,9 @@ struct ConvertGenericChwfToFhwc : public OpRewritePattern<linalg::GenericOp> {
     mPos.append(batchPos.begin(), batchPos.end());
 
     auto getProduct = [](ArrayRef<int64_t> shape, ArrayRef<int64_t> pos) {
-      return std::accumulate(
-          pos.begin(), pos.end(), int64_t{1},
-          [&](int64_t a, int64_t idx) { return a * shape[idx]; });
+      return llvm::accumulate(pos, int64_t{1}, [&](int64_t a, int64_t idx) {
+        return a * shape[idx];
+      });
     };
 
     int64_t mSize = getProduct(outputShape, mPos);


### PR DESCRIPTION
Adopt accumulate wrappers from https://github.com/llvm/llvm-project/pull/162129.

The main benefit is that these operate on ranges instead of iterators, and `product_of` does not require an initial value. Providing initial value is error prone because it determines the accumulator type, and it's easy to accidentally accumulate `int64_t` to a plain `int` by using `1` for the initial value.