### PR TITLE
[Codegen] Adding an optional `dma_sizes` field in GPU attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -641,6 +641,8 @@ def IREEGPU_TargetWgpAttr : AttrDef<IREEGPU_Dialect, "TargetWgp"> {
     OptionalParameter<"std::optional<int32_t>">:$simds_per_wgp,
     // VGPR register space size in bits. TODO(#18849): populate on all GPUs.
     OptionalParameter<"std::optional<int32_t>">:$vgpr_space_bits,
+    // Available bit-widths for direct load from global to LDS memory.
+    OptionalParameter<"DenseI64ArrayAttr">:$dma_sizes,
 
     // An optional extra dict
     // This field allows to inject more features/limits not supported in the

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
@@ -12,7 +12,8 @@ func.func @test_target_wgp() attributes {
   // CHECK-SAME: max_workgroup_sizes = [1024, 1024, 1024],
   // CHECK-SAME: max_thread_count_per_workgroup = 1024,
   // CHECK-SAME: max_workgroup_memory_bytes = 65536,
-  // CHECK-SAME: max_workgroup_counts = [2147483647, 2147483647, 2147483647]>
+  // CHECK-SAME: max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  // CHECK-SAME: dma_sizes = [32, 128]>
   wgp = #iree_gpu.target_wgp<
     compute = fp16|fp32|int8, storage = b16|b32,
     subgroup = shuffle|arithmetic, dot = dp4xi8toi32,
@@ -21,7 +22,8 @@ func.func @test_target_wgp() attributes {
     max_workgroup_sizes = [1024, 1024, 1024],
     max_thread_count_per_workgroup = 1024,
     max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647]
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    dma_sizes = [32, 128]
   >
 } { return }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -56,7 +56,7 @@ struct WgpDetails {
   std::optional<int32_t> maxLoadInstructionBits;
   std::optional<int32_t> simdsPerWgp;
   std::optional<int32_t> vgprSpaceBits;
-  std::optional<SmallVector<int64_t>> dmaSizes;
+  std::optional<ArrayRef<int64_t>> dmaSizes;
 };
 
 // Chip level feature/limit details
@@ -232,6 +232,7 @@ const WgpDetails *getCDNA4WgpDetails() {
       ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32,
       ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32,
   };
+  static const int64_t cdna4DMASizes[] = {32, 128};
   static const WgpDetails cdna4Wgp = {
       allComputeBits,
       allStorageBits,
@@ -250,7 +251,7 @@ const WgpDetails *getCDNA4WgpDetails() {
       /*maxLoadInstructionBits=*/128,
       /*simdsPerWgp=*/4,
       /*vgprSpaceBits=*/512 * 32,
-      /*dmaSizes=*/SmallVector<int64_t>{32, 128}};
+      /*dmaSizes=*/ArrayRef<int64_t>(cdna4DMASizes)};
   return &cdna4Wgp;
 }
 
@@ -277,23 +278,25 @@ const WgpDetails *getCDNA3WgpDetails() {
       MMAIntrinsic::MFMA_F32_16x16x16_F16,
       MMAIntrinsic::MFMA_F32_32x32x8_F16,
   };
-  static const WgpDetails cdna3Wgp = {allComputeBits,
-                                      allStorageBits,
-                                      allSubgroupOps,
-                                      allDotProductOps,
-                                      std::size(cdna3MMAOps),
-                                      cdna3MMAOps,
-                                      0,
-                                      nullptr,
-                                      {64, 64},
-                                      {1024, 1024, 1024},
-                                      1024,
-                                      64 * 1024,
-                                      {0x7fffffff, 0x7fffffff, 0x7fffffff},
-                                      /*maxLoadInstructionBits=*/128,
-                                      /*simdsPerWgp=*/4,
-                                      /*vgprSpaceBits=*/512 * 32,
-                                      /*dmaSizes=*/SmallVector<int64_t>{32}};
+  static const int64_t cdna3DMASizes[] = {32};
+  static const WgpDetails cdna3Wgp = {
+      allComputeBits,
+      allStorageBits,
+      allSubgroupOps,
+      allDotProductOps,
+      std::size(cdna3MMAOps),
+      cdna3MMAOps,
+      0,
+      nullptr,
+      {64, 64},
+      {1024, 1024, 1024},
+      1024,
+      64 * 1024,
+      {0x7fffffff, 0x7fffffff, 0x7fffffff},
+      /*maxLoadInstructionBits=*/128,
+      /*simdsPerWgp=*/4,
+      /*vgprSpaceBits=*/512 * 32,
+      /*dmaSizes=*/ArrayRef<int64_t>(cdna3DMASizes)};
   return &cdna3Wgp;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -56,6 +56,7 @@ struct WgpDetails {
   std::optional<int32_t> maxLoadInstructionBits;
   std::optional<int32_t> simdsPerWgp;
   std::optional<int32_t> vgprSpaceBits;
+  std::optional<SmallVector<int64_t>> dmaSizes;
 };
 
 // Chip level feature/limit details
@@ -131,6 +132,11 @@ TargetAttr createTargetAttr(const TargetDetails &details, StringRef arch,
     subgroupSizes.push_back(wgp->subgroupSizeChoices.back());
   }
 
+  DenseI64ArrayAttr dmaSizesAttr;
+  if (wgp->dmaSizes.has_value()) {
+    dmaSizesAttr = DenseI64ArrayAttr::get(context, *wgp->dmaSizes);
+  }
+
   auto targetWgp = TargetWgpAttr::get(
       context, ComputeBitwidthsAttr::get(context, details.wgp->compute),
       StorageBitwidthsAttr::get(context, wgp->storage),
@@ -143,7 +149,7 @@ TargetAttr createTargetAttr(const TargetDetails &details, StringRef arch,
       wgp->maxThreadSize, wgp->maxWorkgroupMemoryBytes,
       DenseI32ArrayAttr::get(context, wgp->maxWorkgroupCounts),
       wgp->maxLoadInstructionBits, wgp->simdsPerWgp, wgp->vgprSpaceBits,
-      DictionaryAttr{});
+      dmaSizesAttr, DictionaryAttr{});
 
   TargetChipAttr targetChip;
   if (details.chip) {
@@ -226,23 +232,25 @@ const WgpDetails *getCDNA4WgpDetails() {
       ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32,
       ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32,
   };
-  static const WgpDetails cdna4Wgp = {allComputeBits,
-                                      allStorageBits,
-                                      allSubgroupOps,
-                                      allDotProductOps,
-                                      std::size(cdna4MMAOps),
-                                      cdna4MMAOps,
-                                      std::size(cdna4ScaledMMAOps),
-                                      cdna4ScaledMMAOps,
-                                      {64, 64},
-                                      {1024, 1024, 1024},
-                                      1024,
-                                      // Note: upgraded from CDNA3
-                                      160 * 1024,
-                                      {0x7fffffff, 0x7fffffff, 0x7fffffff},
-                                      /*maxLoadInstructionBits=*/128,
-                                      /*simdsPerWgp=*/4,
-                                      /*vgprSpaceBits=*/512 * 32};
+  static const WgpDetails cdna4Wgp = {
+      allComputeBits,
+      allStorageBits,
+      allSubgroupOps,
+      allDotProductOps,
+      std::size(cdna4MMAOps),
+      cdna4MMAOps,
+      std::size(cdna4ScaledMMAOps),
+      cdna4ScaledMMAOps,
+      {64, 64},
+      {1024, 1024, 1024},
+      1024,
+      // Note: upgraded from CDNA3
+      160 * 1024,
+      {0x7fffffff, 0x7fffffff, 0x7fffffff},
+      /*maxLoadInstructionBits=*/128,
+      /*simdsPerWgp=*/4,
+      /*vgprSpaceBits=*/512 * 32,
+      /*dmaSizes=*/SmallVector<int64_t>{32, 128}};
   return &cdna4Wgp;
 }
 
@@ -284,7 +292,8 @@ const WgpDetails *getCDNA3WgpDetails() {
                                       {0x7fffffff, 0x7fffffff, 0x7fffffff},
                                       /*maxLoadInstructionBits=*/128,
                                       /*simdsPerWgp=*/4,
-                                      /*vgprSpaceBits=*/512 * 32};
+                                      /*vgprSpaceBits=*/512 * 32,
+                                      /*dmaSizes=*/SmallVector<int64_t>{32}};
   return &cdna3Wgp;
 }
 


### PR DESCRIPTION
Need to have a way to query the supported global to lds DMA on a specific architecture. 

Only populated CDNA3 and CDNA4.