### PR TITLE
[Codegen] Rework `GPUConvertToCoalescedDMAPass`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -338,6 +338,7 @@ def IREEGPU_CoalescedGatherDMAOp : Op<IREEGPU_Dialect, "coalesced_gather_dma", [
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 
   let extraClassDeclaration = [{
     // Get the rank of the result tensor/memref

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -327,6 +327,22 @@ struct CoalescedGatherDMAOpBufferizationInterface
     return alist;
   }
 
+  FailureOr<BaseMemRefType>
+  getBufferType(Operation *op, Value value, const BufferizationOptions &options,
+                const bufferization::BufferizationState &state,
+                SmallVector<Value> &invocationStack) const {
+    auto gatherOp = cast<IREE::GPU::CoalescedGatherDMAOp>(op);
+    assert(value == gatherOp.getResult() && "invalid value");
+
+    // Get the buffer type for the init operand
+    auto initMemrefType = bufferization::getBufferType(
+        gatherOp.getInit(), options, state, invocationStack);
+    if (failed(initMemrefType))
+      return failure();
+
+    return cast<BaseMemRefType>(*initMemrefType);
+  }
+
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options,
                           bufferization::BufferizationState &state) const {


### PR DESCRIPTION
Previously, this pass manually tiles the gather op. With the recent update on the SCF tiling interface, we can now opt to use the interface for tiling.

Also added canonicalizer patterns.