### PR TITLE
Promote iree-opt-data-tiling to pipeline options.

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -29,6 +29,18 @@ void GlobalPipelineOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::cat(category));
 
   binder.opt<bool>(
+      "iree-opt-data-tiling", dataTiling,
+      llvm::cl::desc(
+          "Enables data tiling optimization. There are two data-tiling "
+          "paths; it is the global flag that enables data-tiling with the"
+          "suggested path. You can choose one of them to enable explicitly, if "
+          "you have a preference. See `iree-global-opt-data-tiling` and "
+          "`iree-dispatch-creation-data-tiling` for details. Note that this "
+          "flag will override the other two flags, because it has a higher "
+          "priority."),
+      llvm::cl::cat(category));
+
+  binder.opt<bool>(
       "iree-opt-const-expr-hoisting", constExprHoisting,
       llvm::cl::desc(
           "Hoists the results of latent constant expressions into immutable "
@@ -172,7 +184,7 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
                                   "along the outer most dimension."),
                    llvm::cl::cat(category));
   binder.opt<bool>(
-      "iree-opt-data-tiling", dataTiling,
+      "iree-global-opt-data-tiling", dataTiling,
       llvm::cl::desc(
           "Enables data tiling path starting from GlobalOptimization phase."),
       llvm::cl::cat(category));

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -21,6 +21,16 @@ struct GlobalPipelineOptions {
   // Enables const-expr hoisting into globals.
   bool constExprHoisting = true;
 
+  // Enables data tiling.
+  // There are two data-tiling paths. One starts from GlobalOptimization phase
+  // and the other starts from DispatchCreation phase. They are mutually
+  // exclusive. Only one of them can be enabled at a time. The default is using
+  // the GlobalOptimization data-tiling path, since the other path is still
+  // being developed. The main differnce is that the DispatchCreation
+  // data-tiling path enables more fusion opportunities. Any feature built on
+  // top of GlobalOptimization path will be deprecated eventually.
+  bool dataTiling = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GlobalPipelineOptions>;
 };
@@ -125,9 +135,7 @@ struct GlobalOptimizationOptions {
   // Enables transposing all concatenations to the outer most dimension.
   bool outerDimConcat = false;
 
-  // Enables data tiling in global optimization phase. There are two data-tiling
-  // flags during the transition state. The other has to be off if this one is
-  // enabled. Any feature built on top of this path will be deprecated.
+  // Enables data tiling in global optimization phase.
   bool dataTiling = false;
 
   // Enables recursive evaluation of immutable globals using the compiler
@@ -224,10 +232,7 @@ struct DispatchCreationOptions {
   bool enableFuseMultiUse = true;
   bool enableSplitReduction = false;
 
-  // Enables data tiling in dispatch creation phase. There are two data-tiling
-  // flags during the transition state. The other has to be off if this one is
-  // enabled. The main difference is that this path enables the fusion for
-  // data-tiled ops.
+  // Enables data tiling in dispatch creation phase.
   bool dataTiling = false;
 
   void bindOptions(OptionsBinder &binder);

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -317,9 +317,14 @@ void buildIREEVMTransformPassPipeline(
     if (pipelineOptions.dataTiling) {
       dispatchTransformOptions.dataTiling = false;
     }
-    if (dispatchTransformOptions.dataTiling) {
-      assert(!globalOptimizationOptions.dataTiling &&
-             "expect only one data-tiling option to be enabled");
+    if (dispatchTransformOptions.dataTiling &&
+        globalOptimizationOptions.dataTiling) {
+#ifndef NDEBUG
+      llvm::reportFatalUsageError(
+          "Invalid configuration: data-tiling cannot be enabled in both "
+          "global optimization phase and dispatch creation phase.");
+#endif
+      dispatchTransformOptions.dataTiling = false;
     }
     dispatchTransformOptions.enableSplitReduction =
         dispatchCreationOptions.enableSplitReduction;

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -191,7 +191,11 @@ void buildIREEPrecompileTransformPassPipeline(
       globalOptimizationOptions.aggressiveTransposePropagation;
   globalTransformOptions.outerDimConcat =
       globalOptimizationOptions.outerDimConcat;
+  // The pipeline option has higher priority.
   globalTransformOptions.dataTiling = globalOptimizationOptions.dataTiling;
+  if (pipelineOptions.dataTiling) {
+    globalTransformOptions.dataTiling = true;
+  }
   globalTransformOptions.constEval = globalOptimizationOptions.constEval;
   globalTransformOptions.numericPrecisionReduction =
       globalOptimizationOptions.numericPrecisionReduction;
@@ -308,7 +312,15 @@ void buildIREEVMTransformPassPipeline(
         dispatchCreationOptions.enableAggressiveFusion;
     dispatchTransformOptions.enableFuseMultiUse =
         dispatchCreationOptions.enableFuseMultiUse;
+    // The pipeline option has higher priority.
     dispatchTransformOptions.dataTiling = dispatchCreationOptions.dataTiling;
+    if (pipelineOptions.dataTiling) {
+      dispatchTransformOptions.dataTiling = false;
+    }
+    if (dispatchTransformOptions.dataTiling) {
+      assert(!globalOptimizationOptions.dataTiling &&
+             "expect only one data-tiling option to be enabled");
+    }
     dispatchTransformOptions.enableSplitReduction =
         dispatchCreationOptions.enableSplitReduction;
     dispatchTransformOptions.constExprMaxSizeIncreaseThreshold =

--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -102,6 +102,8 @@ The layout changes can be propagated as far as possible across the workload, so
 the entire workload can use the updated layouts, as opposed to having to perform
 layout transformations at runtime. This may involve fusions or
 constant-evaluation that can amortize or remove layout-transformation overheads.
+See the [blog post](https://iree.dev/community/blog/2025-08-25-data-tiling-walkthrough/)
+to learn more about details.
 
 Data-tiling is an optional optimization technique, and it is not supported by
 all backends. Any backend does not develop data-tiling may result in worse
@@ -113,13 +115,34 @@ performance if it is enabled. The targets that support data-tiling are:
 * GPU (ROCm)
 * VMVX
 
-See the [blog post](https://iree.dev/community/blog/2025-08-25-data-tiling-walkthrough/)
-to learn more about details.
+There are two paths in data-tiling:
+
+* `--iree-global-opt-data-tiling` (off): Starts data-tiling from global
+  optimization phase. This is the current default path, if the flag is on. The
+  path will be deprecated in the future, because the other one has better
+  support for multi-device cases.
+* `--iree-dispatch-creation-data-tiling` (off): Starts data-tiling from dispatch
+  creation phase. This is still under development and some features are missing.
+  The main difference is that it enables more fusion opportunities.
+
+Note that the flag will override the other two flags if it is explicitly set,
+because it has higher priority. You have to disable the flag to use a specific
+path.
+
+| Feature             | GlobalOptimization path | DispatchCreation path |
+|---------------------|-------------------------|-----------------------|
+| ConstExpr Hoisting  | ✔️                      | ✔️                    |
+| Constant Evaluation | ✔️                      | ❌                    |
+| Matmul Fusion       | ❌                      | ✔️                    |
+| Multi-device        | ❌                      | ✔️                    |
+
+Note: Constant Evaluation is not yet implemented in the dispatch creation path.
+It is a planned feature.
 
 !!! question - "Something missing or broken?"
 
-    Don't see the target here that you think should be? Reach out to [our
-    data-tiling Discord channel](https://discord.com/channels/689900678990135345/1254843174111678555);
+    Don't see the target or the feature here that you think should be? Reach out
+    to [our data-tiling Discord channel](https://discord.com/channels/689900678990135345/1254843174111678555);
     we welcome contributions on
     [our GitHub page](https://github.com/iree-org/iree)!
 


### PR DESCRIPTION
There are two paths for data-tiling. One starts from global optimization phase and the other starts from dispatch creation phase. The former one is the suggested path, since the latter one is just getting used recently.

The revision adds a new `iree-global-opt-data-tiling` flag that allows users to explicitly start the data-tiling from global optimization phase; it promotes the existing flag to an umbrella flag for data-tiling, so users can start data-tiling with the suggested path. It is intended to be NFC for most users in terms of command line flags. The `iree-opt-data-tiling` used to be identical to the new `iree-global-opt-data-tiling`, and it selects the global optimization path when it is set.

Note that the pipeline flag has higher priority. I.e., it overrides the other two flags if it is set as true.

Doc preview: https://hanhanw.github.io/iree/reference/optimization-options/#data-tiling-iree-opt-data-tiling-off