### PR TITLE
[CI][TorchModels] Update flags used for LLaMa 8b f8/fp16.

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp16/modules/llama_gfx942",
-  "golden_dispatch_count": 1005,
+  "golden_dispatch_count": 877,
   "golden_binary_size": 2300000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/compstat_gfx942.json
@@ -6,5 +6,5 @@
   ],
   "module": "llama_8b_fp16/modules/llama_gfx942",
   "golden_dispatch_count": 1005,
-  "golden_binary_size": 2200000
+  "golden_binary_size": 2300000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/llama_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/modules/llama_gfx942.json
@@ -3,6 +3,12 @@
   "compiler_flags": [
       "--iree-hal-target-device=hip",
       "--iree-hip-target=gfx942",
-      "--iree-opt-level=O3"
+      "--iree-opt-level=O3",
+      "--iree-dispatch-creation-propagate-collapse-across-expands=true",
+      "--iree-hip-enable-tensor-ukernels",
+      "--iree-hip-specialize-dispatches",
+      "--iree-stream-resource-memory-model=discrete",
+      "--iree-hal-indirect-command-buffers=true",
+      "--iree-hal-memoization=true"
   ]
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 30.0
+    "golden_time_ms": 42.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 450.0
+    "golden_time_ms": 260.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
@@ -6,5 +6,5 @@
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942",
   "golden_dispatch_count": 1586,
-  "golden_binary_size": 2800000
+  "golden_binary_size": 3000000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942",
-  "golden_dispatch_count": 1586,
+  "golden_dispatch_count": 1517,
   "golden_binary_size": 3000000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/modules/llama_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/modules/llama_gfx942.json
@@ -3,6 +3,12 @@
   "compiler_flags": [
       "--iree-hal-target-device=hip",
       "--iree-hip-target=gfx942",
-      "--iree-opt-level=O3"
+      "--iree-opt-level=O3",
+      "--iree-dispatch-creation-propagate-collapse-across-expands=true",
+      "--iree-hip-enable-tensor-ukernels",
+      "--iree-hip-specialize-dispatches",
+      "--iree-stream-resource-memory-model=discrete",
+      "--iree-hal-indirect-command-buffers=true",
+      "--iree-hal-memoization=true"
   ]
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 20.0
+    "golden_time_ms": 26.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 270.0
+    "golden_time_ms": 180.0
 }


### PR DESCRIPTION
The flags are updated based on what is used here
https://github.com/nod-ai/iree-model-benchmark/blob/main/llama3/compile-8b-base.sh.

The changes here do not change the number of dispatches, but binary size does increase by a bit. Adjusting the golden binary size accordingly. The number of dispatches remains the same though.

TODO: Before submit adjust the golden times as well.

ci-extra: test_torch