### PR TITLE
Add device specification to `--input` flags for inputs

### DIFF
--- a/runtime/src/iree/tooling/comparison_test.cc
+++ b/runtime/src/iree/tooling/comparison_test.cc
@@ -20,7 +20,7 @@ namespace {
 
 using ::testing::HasSubstr;
 
-static void ParseToVariantList(iree_hal_device_t* device,
+static void ParseToVariantList(iree_hal_device_list_t* device_list,
                                iree_hal_allocator_t* device_allocator,
                                iree_string_view_t cconv,
                                iree::span<const std::string> input_strings,
@@ -35,7 +35,7 @@ static void ParseToVariantList(iree_hal_device_t* device,
       cconv,
       iree_string_view_list_t{input_string_views.size(),
                               input_string_views.data()},
-      device, device_allocator, host_allocator, out_list));
+      device_list, device_allocator, host_allocator, out_list));
 }
 
 class ComparisonTest : public ::testing::Test {
@@ -57,11 +57,11 @@ class ComparisonTest : public ::testing::Test {
       iree_string_view_t cconv, iree::span<const std::string> expected_strings,
       iree::span<const std::string> actual_strings, std::string* out_string) {
     vm::ref<iree_vm_list_t> expected_list;
-    ParseToVariantList(/*device=*/NULL, device_allocator_, cconv,
+    ParseToVariantList(/*device_list=*/NULL, device_allocator_, cconv,
                        expected_strings, host_allocator_, &expected_list);
 
     vm::ref<iree_vm_list_t> actual_list;
-    ParseToVariantList(/*device=*/NULL, device_allocator_, cconv,
+    ParseToVariantList(/*device_list=*/NULL, device_allocator_, cconv,
                        actual_strings, host_allocator_, &actual_list);
 
     iree_string_builder_t builder;

--- a/runtime/src/iree/tooling/context_util.c
+++ b/runtime/src/iree/tooling/context_util.c
@@ -207,20 +207,17 @@ static iree_hal_module_device_policy_t iree_hal_module_device_policy_from_flags(
 static iree_status_t iree_tooling_load_hal_async_module(
     iree_vm_instance_t* instance, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_module_t** out_module,
-    iree_hal_device_t** out_device,
-    iree_hal_allocator_t** out_device_allocator) {
+    iree_hal_device_list_t** out_device_list) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(out_module);
-  IREE_ASSERT_ARGUMENT(out_device);
-  IREE_ASSERT_ARGUMENT(out_device_allocator);
-  if (*out_device || *out_device_allocator) {
+  IREE_ASSERT_ARGUMENT(out_device_list);
+  if (*out_device_list) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "async HAL module can not be used with other primary HAL module types");
   }
   *out_module = NULL;
-  *out_device = NULL;
-  *out_device_allocator = NULL;
+  *out_device_list = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Register required types before creating the module.
@@ -240,11 +237,6 @@ static iree_status_t iree_tooling_load_hal_async_module(
   // Pick a lead device we'll use for bookkeeping.
   iree_hal_device_t* device = iree_hal_device_list_at(device_list, 0);
   IREE_ASSERT(device, "require at least one device");
-  iree_hal_device_retain(device);
-
-  // Fetch the allocator from the device to pass back to the caller.
-  iree_hal_allocator_t* device_allocator = iree_hal_device_allocator(device);
-  iree_hal_allocator_retain(device_allocator);
 
   // Create HAL module wrapping the device created above.
   iree_hal_module_flags_t flags = IREE_HAL_MODULE_FLAG_NONE;
@@ -254,15 +246,11 @@ static iree_status_t iree_tooling_load_hal_async_module(
       device_list->count, device_list->devices, flags,
       iree_hal_module_debug_sink_stdio(stderr), host_allocator, &module);
 
-  iree_hal_device_list_free(device_list);
-
   if (iree_status_is_ok(status)) {
     *out_module = module;
-    *out_device = device;
-    *out_device_allocator = device_allocator;
+    *out_device_list = device_list;
   } else {
-    iree_hal_allocator_release(device_allocator);
-    iree_hal_device_release(device);
+    iree_hal_device_list_free(device_list);
     iree_vm_module_release(module);
   }
   IREE_TRACE_ZONE_END(z0);
@@ -438,7 +426,7 @@ typedef struct {
   iree_allocator_t host_allocator;
   iree_tooling_module_list_t* resolved_list;
   iree_string_view_t default_device_uri;
-  iree_hal_device_t* device;
+  iree_hal_device_list_t* device_list;
   iree_hal_allocator_t* device_allocator;
 } iree_tooling_resolve_state_t;
 static iree_status_t iree_tooling_resolve_module_dependency_callback(
@@ -457,7 +445,7 @@ static iree_status_t iree_tooling_resolve_module_dependency_callback(
   if (iree_string_view_equal(dependency->name, IREE_SV("hal"))) {
     IREE_RETURN_IF_ERROR(iree_tooling_load_hal_async_module(
         state->instance, state->default_device_uri, state->host_allocator,
-        &module, &state->device, &state->device_allocator));
+        &module, &state->device_list));
   } else if (iree_string_view_equal(dependency->name, IREE_SV("hal_inline"))) {
     IREE_RETURN_IF_ERROR(iree_tooling_load_hal_inline_module(
         state->instance, state->host_allocator, &module,
@@ -495,12 +483,12 @@ iree_status_t iree_tooling_resolve_modules(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_tooling_module_list_t* resolved_list,
-    iree_hal_device_t** out_device,
+    iree_hal_device_list_t** out_device_list,
     iree_hal_allocator_t** out_device_allocator) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(!user_module_count || user_modules);
   IREE_ASSERT_ARGUMENT(resolved_list);
-  if (out_device) *out_device = NULL;
+  if (out_device_list) *out_device_list = NULL;
   if (out_device_allocator) *out_device_allocator = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -509,7 +497,7 @@ iree_status_t iree_tooling_resolve_modules(
       .host_allocator = host_allocator,
       .resolved_list = resolved_list,
       .default_device_uri = default_device_uri,
-      .device = NULL,
+      .device_list = NULL,
       .device_allocator = NULL,
   };
   iree_status_t status = iree_ok_status();
@@ -534,16 +522,18 @@ iree_status_t iree_tooling_resolve_modules(
     if (out_device_allocator) {
       *out_device_allocator = resolve_state.device_allocator;
     } else {
-      iree_hal_allocator_release(resolve_state.device_allocator);
+      if (resolve_state.device_allocator) {
+        iree_hal_allocator_release(resolve_state.device_allocator);
+      }
     }
-    if (out_device) {
-      *out_device = resolve_state.device;
+    if (out_device_list) {
+      *out_device_list = resolve_state.device_list;
     } else {
-      iree_hal_device_release(resolve_state.device);
+      iree_hal_device_list_free(resolve_state.device_list);
     }
   } else {
     iree_hal_allocator_release(resolve_state.device_allocator);
-    iree_hal_device_release(resolve_state.device);
+    iree_hal_device_list_free(resolve_state.device_list);
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -624,13 +614,13 @@ iree_status_t iree_tooling_create_context_from_flags(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_context_t** out_context,
-    iree_hal_device_t** out_device,
+    iree_hal_device_list_t** out_device_list,
     iree_hal_allocator_t** out_device_allocator) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(!user_module_count || user_modules);
   IREE_ASSERT_ARGUMENT(out_context);
   *out_context = NULL;
-  if (out_device) *out_device = NULL;
+  if (out_device_list) *out_device_list = NULL;
   if (out_device_allocator) *out_device_allocator = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -638,12 +628,12 @@ iree_status_t iree_tooling_create_context_from_flags(
   // All modules are retained in the list.
   iree_tooling_module_list_t resolved_list;
   iree_tooling_module_list_initialize(&resolved_list);
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_allocator_t* device_allocator = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_tooling_resolve_modules(
               instance, user_module_count, user_modules, default_device_uri,
-              host_allocator, &resolved_list, &device, &device_allocator));
+              host_allocator, &resolved_list, &device_list, &device_allocator));
 
   iree_vm_context_flags_t flags = IREE_VM_CONTEXT_FLAG_NONE;
   if (FLAG_trace_execution) {
@@ -676,14 +666,14 @@ iree_status_t iree_tooling_create_context_from_flags(
     } else {
       iree_hal_allocator_release(device_allocator);
     }
-    if (out_device) {
-      *out_device = device;
+    if (out_device_list) {
+      *out_device_list = device_list;
     } else {
-      iree_hal_device_release(device);
+      iree_hal_device_list_free(device_list);
     }
   } else {
     iree_hal_allocator_release(device_allocator);
-    iree_hal_device_release(device);
+    iree_hal_device_list_free(device_list);
     iree_vm_context_release(context);
   }
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/tooling/context_util.h
+++ b/runtime/src/iree/tooling/context_util.h
@@ -61,7 +61,7 @@ iree_status_t iree_tooling_resolve_modules(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_tooling_module_list_t* resolved_list,
-    iree_hal_device_t** out_device,
+    iree_hal_device_list_t** out_device_list,
     iree_hal_allocator_t** out_device_allocator);
 
 // Loads modules in the order specified by the --module= flag.
@@ -99,7 +99,7 @@ iree_status_t iree_tooling_create_context_from_flags(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_context_t** out_context,
-    iree_hal_device_t** out_device,
+    iree_hal_device_list_t** out_device_list,
     iree_hal_allocator_t** out_device_allocator);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/tooling/function_io.c
+++ b/runtime/src/iree/tooling/function_io.c
@@ -633,8 +633,33 @@ static iree_status_t iree_tooling_parse_file_into(
 
 static iree_status_t iree_tooling_parse_variant_into(
     iree_string_view_t* cconv, iree_string_view_t string, iree_vm_list_t* list,
-    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
+    iree_hal_device_list_t* device_list, iree_hal_allocator_t* device_allocator,
     iree_io_stream_list_t* stream_list, iree_allocator_t host_allocator) {
+  iree_hal_device_t* device = NULL;
+
+  int32_t device_id = 0;
+  size_t found = iree_string_view_find_first_of(string, IREE_SV(":"), 0);
+  if (found != IREE_STRING_VIEW_NPOS) {
+    iree_string_view_t device_id_str =
+        iree_string_view_substr(string, 0, found);
+    string = iree_string_view_remove_prefix(string, found + 1);
+
+    bool valid = iree_string_view_atoi_int32(device_id_str, &device_id);
+    if (!valid) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "device id is not a valid integer");
+    }
+  }
+
+  if (device_list) {
+    if (device_id >= device_list->count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "device id is not in valid range");
+    }
+    device = iree_hal_device_list_at(device_list, device_id);
+    device_allocator = iree_hal_device_allocator(device);
+  }
+
   if (iree_string_view_is_empty(string)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "no value specified for input");
@@ -665,7 +690,7 @@ static iree_status_t iree_tooling_parse_variant_into(
 
 static iree_status_t iree_tooling_parse_variants_into(
     iree_string_view_t cconv, iree_string_view_list_t specs,
-    iree_vm_list_t* list, iree_hal_device_t* device,
+    iree_vm_list_t* list, iree_hal_device_list_t* device_list,
     iree_hal_allocator_t* device_allocator, iree_allocator_t host_allocator) {
   IREE_ASSERT_ARGUMENT(list);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -683,7 +708,7 @@ static iree_status_t iree_tooling_parse_variants_into(
   for (iree_host_size_t i = 0; i < specs.count; ++i) {
     iree_string_view_t string = iree_string_view_trim(specs.values[i]);
     status = iree_status_annotate_f(
-        iree_tooling_parse_variant_into(&cconv, string, list, device,
+        iree_tooling_parse_variant_into(&cconv, string, list, device_list,
                                         device_allocator, stream_list,
                                         host_allocator),
         "parsing input `%.*s`", (int)string.size, string.data);
@@ -697,7 +722,7 @@ static iree_status_t iree_tooling_parse_variants_into(
 
 iree_status_t iree_tooling_parse_variants(
     iree_string_view_t cconv, iree_string_view_list_t specs,
-    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
+    iree_hal_device_list_t* device_list, iree_hal_allocator_t* device_allocator,
     iree_allocator_t host_allocator, iree_vm_list_t** out_list) {
   IREE_ASSERT_ARGUMENT(out_list);
   *out_list = NULL;
@@ -711,7 +736,7 @@ iree_status_t iree_tooling_parse_variants(
 
   // Parse into the argument list.
   iree_status_t status = iree_tooling_parse_variants_into(
-      cconv, specs, list, device, device_allocator, host_allocator);
+      cconv, specs, list, device_list, device_allocator, host_allocator);
 
   if (iree_status_is_ok(status)) {
     *out_list = list;

--- a/runtime/src/iree/tooling/function_io.h
+++ b/runtime/src/iree/tooling/function_io.h
@@ -46,7 +46,7 @@ extern "C" {
 //    `&4xf32=1,2,3,4` (tensor<4xf32> storage with an initial value)
 iree_status_t iree_tooling_parse_variants(
     iree_string_view_t cconv, iree_string_view_list_t specs,
-    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
+    iree_hal_device_list_t* device_list, iree_hal_allocator_t* device_allocator,
     iree_allocator_t host_allocator, iree_vm_list_t** out_list);
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/tooling/function_util.c
+++ b/runtime/src/iree/tooling/function_util.c
@@ -141,13 +141,19 @@ static iree_status_t iree_tooling_submit_transfer(
 
 iree_status_t iree_tooling_transfer_variants(
     iree_vm_list_t* list, iree_hal_device_t* target_device,
-    iree_hal_allocator_t* target_allocator,
+    iree_hal_allocator_t* default_allocator,
     iree_hal_buffer_params_t target_params, iree_hal_fence_t* wait_fence,
     iree_hal_fence_t* signal_fence) {
   IREE_ASSERT_ARGUMENT(list);
   IREE_ASSERT_ARGUMENT(target_device);
-  IREE_ASSERT_ARGUMENT(target_allocator);
+  IREE_ASSERT_ARGUMENT(default_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Grab the device specific allocator if available:
+  iree_hal_allocator_t* target_allocator = default_allocator;
+  if (target_device) {
+    target_allocator = iree_hal_device_allocator(target_device);
+  }
 
   // If all buffers are already host-accessible we can skip the transfer.
   bool requires_transfer = false;

--- a/tools/iree-benchmark-executable-main.c
+++ b/tools/iree-benchmark-executable-main.c
@@ -328,10 +328,12 @@ static iree_status_t iree_benchmark_executable_from_flags(
   // Create the HAL device we'll be using during execution.
   // Devices can be very expensive to create and we want to avoid doing it
   // multiple times throughout the benchmark execution.
-  iree_hal_device_t* device = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_create_device_from_flags(
+  iree_hal_device_list_t* device_list = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_create_devices_from_flags(
       iree_hal_available_driver_registry(), iree_hal_default_device_uri(),
-      host_allocator, &device));
+      host_allocator, &device_list));
+
+  iree_hal_device_t* device = iree_hal_device_list_at(device_list, 0);
 
   // We'll reuse the same executable cache so that once we load the executable
   // we'll be able to reuse any driver-side optimizations.
@@ -354,7 +356,7 @@ static iree_status_t iree_benchmark_executable_from_flags(
                             parsed_params.binding_count),
       (iree_string_view_list_t){parsed_params.binding_count,
                                 parsed_params.binding_specs},
-      device, device_allocator, host_allocator, &binding_list));
+      device_list, device_allocator, host_allocator, &binding_list));
   iree_hal_buffer_ref_t bindings[IREE_HAL_MAX_BINDING_COUNT];
   for (iree_host_size_t i = 0; i < parsed_params.binding_count; ++i) {
     iree_vm_ref_t value = iree_vm_ref_null();

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -483,9 +483,11 @@ class IREEBenchmark {
     IREE_RETURN_IF_ERROR(iree_tooling_create_context_from_flags(
         instance_.get(), module_list_.count, module_list_.values,
         /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-        &context_, &device_, &device_allocator_));
+        &context_, &device_list_, &device_allocator_));
 
-    IREE_TRACE_FRAME_MARK_END_NAMED("init");
+    device_ = iree_hal_device_list_at(device_list_, 0)
+
+        IREE_TRACE_FRAME_MARK_END_NAMED("init");
     return iree_ok_status();
   }
 
@@ -507,7 +509,7 @@ class IREEBenchmark {
         &signature, &arguments_cconv, &results_cconv));
 
     IREE_CHECK_OK(iree_tooling_parse_variants(
-        arguments_cconv, FLAG_input_list(), device_.get(),
+        arguments_cconv, FLAG_input_list(), device_list_,
         device_allocator_.get(), iree_vm_instance_allocator(instance_.get()),
         &inputs_));
 
@@ -599,6 +601,7 @@ class IREEBenchmark {
   iree::vm::ref<iree_vm_instance_t> instance_;
   iree::vm::ref<iree_vm_context_t> context_;
   iree::vm::ref<iree_hal_device_t> device_;
+  iree_hal_device_list_t* device_list_;
   iree::vm::ref<iree_hal_allocator_t> device_allocator_;
   iree_tooling_module_list_t module_list_;
   iree::vm::ref<iree_vm_list_t> inputs_;

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -46,8 +46,10 @@ class CheckModuleTest : public ::testing::Test {
     IREE_CHECK_OK(iree_tooling_create_context_from_flags(
         instance_, module_list_.count, module_list_.values,
         /*default_device_uri=*/iree_string_view_empty(),
-        iree_vm_instance_allocator(instance_), &context_, &device_,
+        iree_vm_instance_allocator(instance_), &context_, &device_list_,
         /*out_device_allocator=*/NULL));
+
+    device_ = iree_hal_device_list_at(device_list_, 0);
   }
 
   void TearDown() override {
@@ -72,6 +74,7 @@ class CheckModuleTest : public ::testing::Test {
 
   iree_vm_context_t* context_ = nullptr;
   iree_hal_device_t* device_ = nullptr;
+  iree_hal_device_list_t* device_list_ = nullptr;
 };
 
 iree_status_t Run(iree_allocator_t host_allocator, int* out_exit_code) {

--- a/tools/test/BUILD.bazel
+++ b/tools/test/BUILD.bazel
@@ -35,6 +35,7 @@ iree_lit_test_suite(
             "iree-run-mlir.mlir",
             "iree-run-module-expected.mlir",
             "iree-run-module-inputs.mlir",
+            "iree-run-module-inputs-device.mlir",
             "iree-run-module-multi.mlir",
             "iree-run-module-outputs.mlir",
             "iree-run-module.mlir",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "iree-run-mlir.mlir"
     "iree-run-module-expected.mlir"
     "iree-run-module-inputs.mlir"
+    "iree-run-module-inputs-device.mlir"
     "iree-run-module-multi.mlir"
     "iree-run-module-outputs.mlir"
     "iree-run-module.mlir"

--- a/tools/test/iree-run-module-inputs-device.mlir
+++ b/tools/test/iree-run-module-inputs-device.mlir
@@ -1,0 +1,24 @@
+
+// Verify parsing of signless small integer types passes either signed or
+// unsigned range checks.
+
+// RUN: (iree-compile --iree-hal-target-device=local \
+// RUN:               --iree-hal-local-target-device-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync \
+// RUN:                  --module=- \
+// RUN:                  --function=device_assignment \
+// RUN:                  --input="2xi16=65535 -32767" \
+// RUN:                  --input="3xi8=-6 250 0xFF") | \
+// RUN: FileCheck --check-prefix=DEVICE-ASSIGNMENT %s
+// DEVICE-ASSIGNMENT-LABEL: EXEC @device_assignment
+func.func @device_assignment(%arg0: tensor<2xi16>, %arg1: tensor<3xi8>) -> (tensor<2xi16>, tensor<3xi8>) {
+  // Signedness of printing signless values is unspecified.
+  // DEVICE-ASSIGNMENT: result[0]: hal.buffer_view
+  // DEVICE-ASSIGNMENT-NEXT: 2xi16=-2 2
+  // DEVICE-ASSIGNMENT: result[1]: hal.buffer_view
+  // DEVICE-ASSIGNMENT-NEXT: 3xi8=-12 -12 -2
+  %0 = arith.addi %arg0, %arg0 : tensor<2xi16>
+  %1 = arith.addi %arg1, %arg1 : tensor<3xi8>
+  return %0, %1 : tensor<2xi16>, tensor<3xi8>
+}
+

--- a/tools/testing/e2e/test_utils.c
+++ b/tools/testing/e2e/test_utils.c
@@ -564,12 +564,17 @@ iree_status_t iree_test_utils_load_and_run_e2e_tests(
 
   // Create the context with our support module and all --module= flags.
   iree_vm_context_t* context = NULL;
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_tooling_create_context_from_flags(
         instance, module_list.count, module_list.values,
         /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-        &context, &device, /*out_device_allocator=*/NULL);
+        &context, &device_list, /*out_device_allocator=*/NULL);
+  }
+
+  iree_hal_device_t* device = NULL;
+  if (iree_status_is_ok(status)) {
+    device = iree_hal_device_list_at(device_list, 0);
   }
 
   // Ensure the test module is possible to run.


### PR DESCRIPTION
For multi device execution specifying the device to allocate on can avoid incorrect performance monitoring. This avoids reading data across devices and obtaining incorrect performance metrics. An example of this would have `--device=1:4xi32` such that the array `4xi32` is placed on device 1. This implementation assuming 0-start indexing.