### PR TITLE
Allow the hip driver to be selected & fix a minor bug in hipMalloc.

### DIFF
--- a/experimental/streaming/init.c
+++ b/experimental/streaming/init.c
@@ -9,7 +9,7 @@
 #include <string.h>  // for memset
 
 #include "experimental/streaming/internal.h"
-
+#include "iree/hal/drivers/hip/registration/driver_module.h"
 //===----------------------------------------------------------------------===//
 // Global state
 //===----------------------------------------------------------------------===//
@@ -489,7 +489,10 @@ iree_status_t iree_hal_streaming_init_global(
     // status = iree_hal_register_all_available_drivers(
     //     device_registry->driver_registry);
     const char* driver_name = getenv("IREE_HAL_DRIVER");
-    if (driver_name && strcmp(driver_name, "local-sync") == 0) {
+    if (driver_name && strcmp(driver_name, "hip") == 0) {
+      status =
+          iree_hal_hip_driver_module_register(device_registry->driver_registry);
+    } else if (driver_name && strcmp(driver_name, "local-sync") == 0) {
       status = iree_hal_local_sync_driver_module_register(
           device_registry->driver_registry);
     } else if (!driver_name ||

--- a/experimental/streaming/memory.c
+++ b/experimental/streaming/memory.c
@@ -50,14 +50,16 @@ static iree_status_t iree_hal_streaming_buffer_wrap(
     wrapper->device_ptr =
         (iree_hal_streaming_deviceptr_t)device_ptr.handle.device_allocation.ptr;
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_allocator_export_buffer(
-        context->device_allocator, buffer,
-        IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
-        IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &device_ptr);
-  }
-  if (iree_status_is_ok(status)) {
-    wrapper->host_ptr = (void*)device_ptr.handle.host_allocation.ptr;
+  if (memory_type & IREE_HAL_MEMORY_TYPE_HOST_VISIBLE) {
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_allocator_export_buffer(
+          context->device_allocator, buffer,
+          IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
+          IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &device_ptr);
+    }
+    if (iree_status_is_ok(status)) {
+      wrapper->host_ptr = (void*)device_ptr.handle.host_allocation.ptr;
+    }
   }
 
   if (iree_status_is_ok(status)) {


### PR DESCRIPTION
Add hip to the list of all available drivers, we should probably use iree_hal_register_all_available_drivers and then select the driver based on an env-var eventually (to break the explicit dep).