### PR TITLE
[python] Set up python binding for matcher convolution and attention op

### DIFF
--- a/compiler/bindings/python/iree/compiler/dialects/preprocessing_transform.py
+++ b/compiler/bindings/python/iree/compiler/dialects/preprocessing_transform.py
@@ -45,10 +45,10 @@ class MatchContractionOp(MatchContractionOp):
 
         # Call auto-generated base constructor.
         super().__init__(
-            param_type,
-            param_type,
-            param_type,
-            param_type,
+            param_type,  # batch_dims.
+            param_type,  # m_dims.
+            param_type,  # n_dims.
+            param_type,  # k_dims.
             operand_handle,
             lhs_type_attr,
             rhs_type_attr,
@@ -62,6 +62,123 @@ class MatchContractionOp(MatchContractionOp):
         return iter([self.batch_dims, self.m_dims, self.n_dims, self.k_dims])
 
 
+@_ods_cext.register_operation(_Dialect, replace=True)
+class MatchConvolutionOp(MatchConvolutionOp):
+    def __init__(
+        self,
+        operand_handle,
+        lhs_type: ir.Type,
+        rhs_type: ir.Type,
+        output_type: ir.Type,
+        indexing_maps: Optional[Sequence] = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        if loc is None:
+            loc = ir.Location.unknown()
+
+        param_type = transform.ParamType.get(ir.IntegerType.get_signless(64))
+        lhs_type_attr = ir.TypeAttr.get(lhs_type)
+        rhs_type_attr = ir.TypeAttr.get(rhs_type)
+        output_type_attr = ir.TypeAttr.get(output_type)
+
+        indexing_maps_attr = None
+        if indexing_maps is not None:
+            indexing_maps_attr = ir.ArrayAttr.get(
+                [ir.AffineMapAttr.get(m) for m in indexing_maps]
+            )
+
+        # Call auto-generated base constructor.
+        super().__init__(
+            param_type,  # batch_dims.
+            param_type,  # output_image_dims.
+            param_type,  # output_channel_dims.
+            param_type,  # filter_dims.
+            param_type,  # input_channel_dims.
+            param_type,  # depth_dims.
+            param_type,  # strides.
+            param_type,  # dilations.
+            operand_handle,
+            lhs_type_attr,
+            rhs_type_attr,
+            output_type_attr,
+            indexing_maps=indexing_maps_attr,
+            loc=loc,
+            ip=ip,
+        )
+
+    def __iter__(self):
+        return iter(
+            [
+                self.batch_dims,
+                self.output_image_dims,
+                self.output_channel_dims,
+                self.filter_dims,
+                self.input_channel_dims,
+                self.depth_dims,
+                self.strides,
+                self.dilations,
+            ]
+        )
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class MatchAttentionOp(MatchAttentionOp):
+    def __init__(
+        self,
+        operand_handle,
+        query_type: ir.Type,
+        key_type: ir.Type,
+        value_type: ir.Type,
+        output_type: ir.Type,
+        indexing_maps: Sequence,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        if loc is None:
+            loc = ir.Location.unknown()
+
+        param_type = transform.ParamType.get(ir.IntegerType.get_signless(64))
+        query_type_attr = ir.TypeAttr.get(query_type)
+        key_type_attr = ir.TypeAttr.get(key_type)
+        value_type_attr = ir.TypeAttr.get(value_type)
+        output_type_attr = ir.TypeAttr.get(output_type)
+        indexing_maps_attr = ir.ArrayAttr.get(
+            [ir.AffineMapAttr.get(m) for m in indexing_maps]
+        )
+
+        super().__init__(
+            param_type,  # batch_dims.
+            param_type,  # m_dims.
+            param_type,  # n_dims.
+            param_type,  # k1_dims.
+            param_type,  # k2_dims.
+            operand_handle,
+            query_type_attr,
+            key_type_attr,
+            value_type_attr,
+            output_type_attr,
+            indexing_maps_attr,
+            loc=loc,
+            ip=ip,
+        )
+
+    def __iter__(self):
+        return iter(
+            [
+                self.batch_dims,
+                self.m_dims,
+                self.n_dims,
+                self.k1_dims,
+                self.k2_dims,
+            ]
+        )
+
+
 __all__ = [
     "MatchContractionOp",
+    "MatchConvolutionOp",
+    "MatchAttentionOp",
 ]

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/preprocessing_match_ops.mlir
@@ -964,7 +964,7 @@ func.func @attention_ops(
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_attention(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %k1, %k2, %n =
+    %batch, %m, %n, %k1, %k2 =
       transform.iree.match.attention %op,
         query_type = f16, key_type = f16, value_type = f16, output_type = f16,
         indexing_maps = [#map_query, #map_key, #map_value, #map_scale, #map_output] :
@@ -1087,7 +1087,7 @@ func.func @indexing_maps_test(
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @match_with_wrong_maps(%op: !transform.any_op {transform.readonly}) -> !transform.any_op {
-    %batch, %m, %k1, %k2, %n =
+    %batch, %m, %n, %k1, %k2 =
       transform.iree.match.attention %op,
         query_type = f16, key_type = f16, value_type = f16, output_type = f16,
         indexing_maps = [#map_query, #map_wrong_key, #map_value, #map_scale, #map_output] :


### PR DESCRIPTION
This PR extends the preprocessing transform dialect Python bindings by adding `MatchConvolutionOp `and `MatchAttentionOp`, completing the matcher operation API suite started in #22227.

**Motivation** 
Completes the Python binding API for all preprocessing transform matcher operations, enabling SHARK Tuner to programmatically generate Transform Dialect specs for convolutions and attention operations in addition to contractions. This removes the need for string-based spec generation and improves type safety and maintainability.