### PR TITLE
[DT][NFC] Trim IRs in encoding materialization tests for GPU and RISCV backends.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
@@ -8,53 +8,27 @@
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf16, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf16, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf16, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xf16, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf16, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xf16, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-      -> tensor<?x?xf32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xf16, #encoding_lhs>,
-                   tensor<?x?xf16, #encoding_rhs>)
-      outs(%5 : tensor<?x?xf32, #encoding_result>)
-      -> tensor<?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  return
+func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
+  %lhs: tensor<?x?xf16, #encoding_lhs>,
+  %rhs: tensor<?x?xf16, #encoding_rhs>,
+  %acc: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %result = linalg.matmul
+    ins(%lhs, %rhs : tensor<?x?xf16, #encoding_lhs>, tensor<?x?xf16, #encoding_rhs>)
+    outs(%acc : tensor<?x?xf32, #encoding_result>)
+    -> tensor<?x?xf32, #encoding_result>
+  return %result : tensor<?x?xf32, #encoding_result>
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x1x8x2x16xf16>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x1x16x16xf16>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x4x8x2x16xf32>
+// CHECK:     func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
+// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
+// CHECK-SAME: ) -> tensor<?x?x4x4x8x2x16xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR3_F32_16x16x16_F16, intrinsics_m = 4, subgroups_n = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
@@ -23,9 +23,9 @@ func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
-// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x1x8x2x16xf16>
+// CHECK-SAME:   %[[RHS:.+]]: tensor<?x?x4x1x16x16xf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x8x2x16xf32>
 // CHECK-SAME: ) -> tensor<?x?x4x4x8x2x16xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
@@ -24,9 +24,9 @@ func.func @matmul_lowering_MFMA_i32_16x16x16_i8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_i32_16x16x16_i8
-// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x4x4x4x4x4xi8>
+// CHECK-SAME:   %[[RHS:.+]]: tensor<?x?x4x2x4x16x4x4xi8>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
@@ -8,53 +8,27 @@
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_lowering_MFMA_i32_16x16x16_i8() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-      -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+func.func @matmul_lowering_MFMA_i32_16x16x16_i8(
+  %lhs: tensor<?x?xi8, #encoding_lhs>,
+  %rhs: tensor<?x?xi8, #encoding_rhs>,
+  %acc: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> {
+  %result = linalg.matmul
+    ins(%lhs, %rhs : tensor<?x?xi8, #encoding_lhs>,
+                     tensor<?x?xi8, #encoding_rhs>)
+    outs(%acc : tensor<?x?xi32, #encoding_result>)
+    -> tensor<?x?xi32, #encoding_result>
+  return %result : tensor<?x?xi32, #encoding_result>
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_i32_16x16x16_i8
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x4x4x4x4x4xi8>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x2x4x16x4x4xi8>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x4x2x4x16x4xi32>
+// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x16_I8, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
@@ -8,56 +8,31 @@
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_lowering_MFMA_f32_16x16x8_bf16() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xbf16, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xbf16, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xbf16, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xbf16, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xbf16, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xbf16, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
+  %lhs: tensor<?x?xbf16, #encoding_lhs>,
+  %rhs: tensor<?x?xbf16, #encoding_rhs>,
+  %acc: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %result = linalg.matmul
+    ins(%lhs, %rhs: tensor<?x?xbf16, #encoding_lhs>,
+                    tensor<?x?xbf16, #encoding_rhs>)
+    outs(%acc: tensor<?x?xf32, #encoding_result>)
       -> tensor<?x?xf32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xbf16, #encoding_lhs>,
-                   tensor<?x?xbf16, #encoding_rhs>)
-      outs(%5 : tensor<?x?xf32, #encoding_result>)
-      -> tensor<?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  return
+  return %result : tensor<?x?xf32, #encoding_result>
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_MFMA_f32_16x16x8_bf16
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x4x4x4x4x2xbf16>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x2x4x16x4x2xbf16>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK:     func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
+// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
+// CHECK-SAME: ) -> tensor<?x?x4x4x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x8_BF16, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -67,53 +42,28 @@ func.func @matmul_lowering_MFMA_f32_16x16x8_bf16() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f64, f64, f64], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f64, f64, f64], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f64, f64, f64], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_lowering_MFMA_f64_16x16x4_f64() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf64, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf64, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf64, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf64, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xf64, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf64, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xf64, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf64, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
+    %lhs: tensor<?x?xf64, #encoding_lhs>,
+    %rhs: tensor<?x?xf64, #encoding_rhs>,
+    %acc: tensor<?x?xf64, #encoding_result>
+) -> tensor<?x?xf64, #encoding_result> {
+  %result = linalg.matmul
+      ins(%lhs, %rhs : tensor<?x?xf64, #encoding_lhs>,
+                       tensor<?x?xf64, #encoding_rhs>)
+      outs(%acc : tensor<?x?xf64, #encoding_result>)
       -> tensor<?x?xf64, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xf64, #encoding_lhs>,
-                   tensor<?x?xf64, #encoding_rhs>)
-      outs(%5 : tensor<?x?xf64, #encoding_result>)
-      -> tensor<?x?xf64, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xf64, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf64, #encoding_result>>{%M, %N}
-  return
+  return %result : tensor<?x?xf64, #encoding_result>
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_MFMA_f64_16x16x4_f64
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x4x4x4x2xf64>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x4x16x2xf64>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x4x4x4x16xf64>
+// CHECK:     func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x4x4x4x4x16xf64>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F64_16x16x4_F64, intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 2>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
@@ -24,9 +24,9 @@ func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
-// CHECK-SAME:   %[[LHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[RHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:   %[[ACC:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x4x4x4x4x2xbf16>
+// CHECK-SAME:   %[[RHS:.+]]: tensor<?x?x4x2x4x16x4x2xbf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
 // CHECK-SAME: ) -> tensor<?x?x4x4x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -58,9 +58,9 @@ func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x4x4x4x4x2xf64>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x4x16x2xf64>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x4x4x4x16xf64>
 // CHECK-SAME:   ) -> tensor<?x?x4x4x4x4x16xf64>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -9,44 +9,33 @@
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %cst = arith.constant 0.0 : f32
+func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32() -> tensor<255x513xf32, #encoding> {
+  %0 = arith.constant 0.0 : f32
   %1 = tensor.empty() : tensor<255x513xf32, #encoding>
-  %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<255x513xf32, #encoding>) -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %2, %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  return
+  %2 = linalg.fill ins(%0 : f32) outs(%1 : tensor<255x513xf32, #encoding>) -> tensor<255x513xf32, #encoding>
+  return %2 : tensor<255x513xf32, #encoding>
 }
+
 // CHECK-LABEL: func.func @empty_fill_encoding_unroll8x8x4_MFMA_F32_16x16x4_F32
 // CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x33x8x4x4x4x4xf32>
-// CHECK:         %{{.+}} = linalg.fill ins({{.+}}) outs(%[[EMPTY]]
+// CHECK:         %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[EMPTY]]
+// CHECK:         return %[[FILL]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 16]
@@ -57,29 +46,23 @@ func.func @set_encoding_LHS_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x4x8x4x4x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x33x8x4x4x4x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 3, 6, 2, 4, 5]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 16]
@@ -90,39 +73,23 @@ func.func @set_encoding_LHS_narrow_unroll1x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x33x4x8x4x4x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x33x8x4x4x4x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 3, 6, 2, 4, 5]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [?, ?, ?]>
-#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding>>{%M, %K}
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
-      -> tensor<?x?xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : tensor<?x?xf32, #encoding>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding>>{%M, %K}
-  return
+func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<?x?xf32>
+) -> tensor<?x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  return %0 : tensor<?x?xf32, #encoding>
 }
+
 // CHECK-LABEL: func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 16]
@@ -133,29 +100,23 @@ func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x?x4x8x4x4x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<?x?x8x4x4x4x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 3, 6, 2, 4, 5]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
 // CHECK-SAME:      inner_tiles = [128, 16]
@@ -166,29 +127,23 @@ func.func @set_encoding_RHS_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x4x16x2x4x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<5x16x4x2x4x16x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 3, 5]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
 // CHECK-SAME:      inner_tiles = [128, 16]
@@ -199,29 +154,23 @@ func.func @set_encoding_RHS_narrow_unroll8x1x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x16x4x16x2x4x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<5x16x4x2x4x16x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 3, 5]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
@@ -232,7 +181,7 @@ func.func @set_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x4x8x4x4x16x2xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x2x4x16x4xf32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
@@ -243,7 +192,6 @@ func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513x
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x513xf32> -> tensor<?x513xf32, #encoding>
   return %0 : tensor<?x513xf32, #encoding>
 }
-
 // CHECK-LABEL: func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
@@ -287,23 +235,17 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32, #encoding>> -> tensor<255x513xf32, #encoding>
-  %3 = iree_encoding.unset_encoding %2 : tensor<255x513xf32, #encoding> -> tensor<255x513xf32>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32>>
-  return
+func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<255x513xf32, #encoding>
+) -> tensor<255x513xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xf32, #encoding> -> tensor<255x513xf32>
+  return %0 : tensor<255x513xf32>
 }
 
-// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32() {
+// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%{{.+}} : tensor<2x5x4x8x2x4x16x4xf32>)
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x4x4x16x2xf32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
@@ -313,40 +255,24 @@ func.func @unset_encoding_ACC_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<2x5x128x128xf32> -> tensor<255x513xf32>
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[UNPACK]]
+// CHECK:         return %[[UNPACK]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-                                    iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32>>{%M, %K}
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%M, %K}
-      -> tensor<?x?xf32, #encoding>
-  %3 = iree_encoding.unset_encoding %2 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%M, %K}
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : tensor<?x?xf32>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32>>{%M, %K}
-  return
+                                    iteration_sizes = [?, ?, ?]>
+func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index
+) -> tensor<?x?xf32> {
+  %2 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  return %2 : tensor<?x?xf32>
 }
+
 // CHECK-LABEL: func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%{{.+}} : tensor<?x?x4x8x2x4x16x4xf32>)
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<?x?x4x8x2x4x16x4xf32>)
 // CHECK-SAME:       outs({{.*}} : tensor<?x?x4x8x4x4x16x2xf32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
@@ -356,7 +282,7 @@ func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<?x?x128x128xf32> -> tensor<?x?xf32>
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[UNPACK]]
+// CHECK:         return %[[UNPACK]]
 
 // -----
 
@@ -366,56 +292,32 @@ func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_lowering_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xf32, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xf32, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<?x?xf32, #encoding_lhs>,
+    %arg1: tensor<?x?xf32, #encoding_rhs>,
+    %arg2: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xf32, #encoding_lhs>,
+                         tensor<?x?xf32, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xf32, #encoding_result>)
       -> tensor<?x?xf32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xf32, #encoding_lhs>,
-                   tensor<?x?xf32, #encoding_rhs>)
-      outs(%5 : tensor<?x?xf32, #encoding_result>)
-      -> tensor<?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_MFMA_F32_16x16x4_F32
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x8x4x4x4x4xf32>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x2x4x16x4xf32>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x8x2x4x16x4xf32>
+// CHECK:     func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -425,57 +327,32 @@ func.func @matmul_lowering_MFMA_F32_16x16x4_F32() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
-#pipeline_layout_4 = #hal.pipeline.layout<constants = 4, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32() {
-  %c0 = arith.constant 0 : index
-  %B = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(0) : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(1) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(2) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(3) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32, #encoding_lhs>>{%B, %M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32, #encoding_rhs>>{%B, %K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [%B, %M, %K], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32, #encoding_lhs>>{%B, %M, %K}
-      -> tensor<?x?x?xf32, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [%B, %K, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32, #encoding_rhs>>{%B, %K, %N}
-      -> tensor<?x?x?xf32, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
+func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
+    %arg0: tensor<?x?x?xf32, #encoding_lhs>,
+    %arg1: tensor<?x?x?xf32, #encoding_rhs>,
+    %arg2: tensor<?x?x?xf32, #encoding_result>
+) -> tensor<?x?x?xf32, #encoding_result> {
+  %0 = linalg.batch_matmul
+      ins(%arg0, %arg1 : tensor<?x?x?xf32, #encoding_lhs>,
+                         tensor<?x?x?xf32, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?x?xf32, #encoding_result>)
       -> tensor<?x?x?xf32, #encoding_result>
-  %6 = linalg.batch_matmul
-      ins(%3, %4 : tensor<?x?x?xf32, #encoding_lhs>,
-                   tensor<?x?x?xf32, #encoding_rhs>)
-      outs(%5 : tensor<?x?x?xf32, #encoding_result>)
-      -> tensor<?x?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : tensor<?x?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  return
+  return %0 : tensor<?x?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x?x8x4x4x4x4xf32>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x?x4x2x4x16x4xf32>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -486,22 +363,16 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32() {
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>> -> tensor<255x513xi8>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi8, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8,  #encoding>>
-  return
+func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
+    %arg0: tensor<255x513xi8>
+) -> tensor<255x513xi8, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  return %0 : tensor<255x513xi8, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i8)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 64]
@@ -512,29 +383,23 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x32_I8() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x4x8x4x2x4x8xi8>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x9x8x4x4x4x2x8xi8>)
 // CHECK-SAME:       permutation = [0, 1, 3, 6, 2, 4, 5, 7]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>> -> tensor<255x513xi8>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi8, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8,  #encoding>>
-  return
+func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8(
+    %arg0: tensor<255x513xi8>
+) -> tensor<255x513xi8, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  return %0 : tensor<255x513xi8, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i8)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
 // CHECK-SAME:      inner_tiles = [128, 64]
@@ -545,29 +410,23 @@ func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x32_I8() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x4x4x16x2x2x4x8xi8>)
 // CHECK-SAME:       outs({{.*}} : tensor<5x4x4x2x4x16x2x8xi8>)
 // CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 3, 5, 7]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32>> -> tensor<255x513xi32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32,  #encoding>>
-  return
+func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
+    %arg0: tensor<255x513xi32>
+) -> tensor<255x513xi32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
+  return %0 : tensor<255x513xi32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i32)
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
@@ -578,30 +437,24 @@ func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x4x8x4x4x16x2xi32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x2x4x16x4xi32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32, #encoding>> -> tensor<255x513xi32, #encoding>
-  %3 = iree_encoding.unset_encoding %2 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32>>
-  return
+func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8(
+    %arg0: tensor<255x513xi32, #encoding>
+) -> tensor<255x513xi32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
+  return %0 : tensor<255x513xi32>
 }
 
-// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
+// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%{{.+}} : tensor<2x5x4x8x2x4x16x4xi32>)
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xi32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x4x4x16x2xi32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
@@ -611,7 +464,7 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<2x5x128x128xi32> -> tensor<255x513xi32>
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[UNPACK]]
+// CHECK:         return %[[UNPACK]]
 
 // -----
 
@@ -621,57 +474,32 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x32_I8() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                       tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x32_I8
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x8x4x4x4x2x8xi8>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x2x4x16x2x8xi8>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x8x2x4x16x4xi32>
+// CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -709,44 +537,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64() attributes {hal.executable.target = #target_gfx942_except_max_load_instruction_bits_64} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_max_load_instruction_bits_64} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64
+// CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ACC:[a-zA-Z0-9]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
@@ -783,44 +590,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64() attributes {hal.executable.target = #target_gfx942_except_max_load_instruction_bits_256} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_max_load_instruction_bits_256} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits_64
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4>
@@ -857,44 +643,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1() attributes {hal.executable.target = #target_gfx942_except_simds_per_wgp_1} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_simds_per_wgp_1} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 8, intrinsics_k = 2>
@@ -931,44 +696,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1() attribu
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192() attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_8192} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_8192} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
@@ -1005,44 +749,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192() at
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096() attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_4096} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_4096} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 2>
@@ -1079,44 +802,23 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096() at
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768() attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_32768} {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {hal.executable.target = #target_gfx942_except_vgpr_space_bits_32768} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                         tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2>
@@ -1133,57 +835,32 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768() a
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
-#pipeline_layout_4 = #hal.pipeline.layout<constants = 4, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ() {
-  %c0 = arith.constant 0 : index
-  %B = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(0) : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(1) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(2) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(3) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>>{%B, %M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>>{%B, %K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [%B, %M, %K], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>>{%B, %M, %K}
-      -> tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [%B, %K, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>>{%B, %K, %N}
-      -> tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
+func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
+    %arg0: tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>,
+    %arg1: tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>,
+    %arg2: tensor<?x?x?xf32, #encoding_result>
+) -> tensor<?x?x?xf32, #encoding_result> {
+  %0 = linalg.batch_matmul
+      ins(%arg0, %arg1 : tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>,
+                         tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?x?xf32, #encoding_result>)
       -> tensor<?x?x?xf32, #encoding_result>
-  %6 = linalg.batch_matmul
-      ins(%3, %4 : tensor<?x?x?xf8E4M3FNUZ, #encoding_lhs>,
-                   tensor<?x?x?xf8E4M3FNUZ, #encoding_rhs>)
-      outs(%5 : tensor<?x?x?xf32, #encoding_result>)
-      -> tensor<?x?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : tensor<?x?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  return
+  return %0 : tensor<?x?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x?x8x4x4x4x2x8xf8E4M3FNUZ>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x?x4x2x4x16x2x8xf8E4M3FNUZ>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -1193,57 +870,32 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
-#pipeline_layout_4 = #hal.pipeline.layout<constants = 4, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16() {
-  %c0 = arith.constant 0 : index
-  %B = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(0) : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(1) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(2) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(3) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_lhs>>{%B, %M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_rhs>>{%B, %K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [%B, %M, %K], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_lhs>>{%B, %M, %K}
-      -> tensor<?x?x?xbf16, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [%B, %K, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_rhs>>{%B, %K, %N}
-      -> tensor<?x?x?xbf16, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
+func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
+    %arg0: tensor<?x?x?xbf16, #encoding_lhs>,
+    %arg1: tensor<?x?x?xbf16, #encoding_rhs>,
+    %arg2: tensor<?x?x?xf32, #encoding_result>
+) -> tensor<?x?x?xf32, #encoding_result> {
+  %0 = linalg.batch_matmul
+      ins(%arg0, %arg1 : tensor<?x?x?xbf16, #encoding_lhs>,
+                         tensor<?x?x?xbf16, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?x?xf32, #encoding_result>)
       -> tensor<?x?x?xf32, #encoding_result>
-  %6 = linalg.batch_matmul
-      ins(%3, %4 : tensor<?x?x?xbf16, #encoding_lhs>,
-                   tensor<?x?x?xbf16, #encoding_rhs>)
-      outs(%5 : tensor<?x?x?xf32, #encoding_result>)
-      -> tensor<?x?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : tensor<?x?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  return
+  return %0 : tensor<?x?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x?x8x4x4x4x2x4xbf16>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x?x4x2x4x16x2x4xbf16>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -1253,31 +905,23 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16() {
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>}>
 #encoding = #iree_encoding.layout<[#iree_gpu.gpu_encoding_resolver<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_with_layout() attributes {
+func.func @set_encoding_with_layout(
+    %arg0: tensor<255x513xf32>
+) -> tensor<255x513xf32, #encoding> attributes {
   hal.executable.target = #executable_target_rocm_hsaco_fb
 } {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>> -> tensor<255x513xf32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xf32,  #encoding>>
-  return
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xf32> -> tensor<255x513xf32, #encoding>
+  return %0 : tensor<255x513xf32, #encoding>
 }
+
 // CHECK-LABEL: func.func @set_encoding_with_layout
-//   CHECK-DAG:   %[[INPUT_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(0) {{.*}} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xf32>>
-//   CHECK-DAG:   %[[RESULT_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(1) {{.*}} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x33x128x16xf32>
-//       CHECK:   %[[INPUT:.+]] = iree_tensor_ext.dispatch.tensor.load %[[INPUT_BINDING]]
-//       CHECK:   %[[PACK:.+]] = linalg.pack %[[INPUT]]
-//  CHECK-SAME:     outer_dims_perm = [0, 1]
-//  CHECK-SAME:     inner_dims_pos = [0, 1]
-//  CHECK-SAME:     inner_tiles = [128, 16]
-//  CHECK-SAME:     tensor<255x513xf32> -> tensor<2x33x128x16xf32>
-//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[PACK]], %[[RESULT_BINDING]]
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]]
+// CHECK-SAME:     outer_dims_perm = [0, 1]
+// CHECK-SAME:     inner_dims_pos = [0, 1]
+// CHECK-SAME:     inner_tiles = [128, 16]
+// CHECK-SAME:     tensor<255x513xf32> -> tensor<2x33x128x16xf32>
+// CHECK:         return %[[PACK]]
 
 // -----
 
@@ -1311,95 +955,63 @@ func.func @missing_user_indexing_maps() {
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
 #encoding_bcast = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2) -> (d0, d2)>], affine_map<(d0, d1, d2, d3) -> (d0, d3, d1)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
-func.func @dequantization() {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xi8, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64xf32, #encoding_bcast>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64xf32, #encoding_bcast>>
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf32, #encoding>>
-  %7 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xi8, #encoding>> -> tensor<2x128x64xi8, #encoding>
-  %8 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64xf32, #encoding_bcast>> -> tensor<2x64xf32, #encoding_bcast>
-  %9 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [2, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64xf32, #encoding_bcast>> -> tensor<2x64xf32, #encoding_bcast>
+func.func @dequantization(
+    %arg0: tensor<2x128x64xi8, #encoding>,
+    %arg1: tensor<2x64xf32, #encoding_bcast>,
+    %arg2: tensor<2x64xf32, #encoding_bcast>
+) -> tensor<2x128x64xf32, #encoding> {
   %13 = tensor.empty() : tensor<2x128x64xf32, #encoding>
-  %14 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%7, %8, %9 : tensor<2x128x64xi8, #encoding>, tensor<2x64xf32, #encoding_bcast>, tensor<2x64xf32, #encoding_bcast>) outs(%13 : tensor<2x128x64xf32, #encoding>) {
-  ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
-    %21 = arith.extui %in : i8 to i32
-    %22 = arith.uitofp %21 : i32 to f32
-    %23 = arith.subf %22, %in_1 : f32
-    %24 = arith.mulf %23, %in_0 : f32
-    linalg.yield %24 : f32
+  %14 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<2x128x64xi8, #encoding>, tensor<2x64xf32, #encoding_bcast>, tensor<2x64xf32, #encoding_bcast>) outs(%13 : tensor<2x128x64xf32, #encoding>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %21 = arith.extui %in : i8 to i32
+      %22 = arith.uitofp %21 : i32 to f32
+      %23 = arith.subf %22, %in_1 : f32
+      %24 = arith.mulf %23, %in_0 : f32
+      linalg.yield %24 : f32
   } -> tensor<2x128x64xf32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %14, %6, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : tensor<2x128x64xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf32, #encoding>>
-  return
+  return %14 : tensor<2x128x64xf32, #encoding>
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d4, d7)>
-// CHECK-LABEL: func.func @dequantization()
-//   CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(0) {{.*}} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1x4x8x4x4x4x4xi8>>
-//   CHECK-DAG:   %[[LHS_SCALES_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(1) {{.*}} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4x4x4xf32>>
-//   CHECK-DAG:   %[[LHS_ZPS_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(2) {{.*}} : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4x4x4xf32>>
-//   CHECK-DAG:   %[[RESULT_BINDING:.+]] = hal.interface.binding.subspan {{.*}} binding(3) {{.*}} : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1x4x8x4x4x4x4xf32>>
-//   CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]], offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [2, 1, 4, 8, 4, 4, 4, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1x4x8x4x4x4x4xi8>> -> tensor<2x1x4x8x4x4x4x4xi8>
-//   CHECK-DAG:   %[[LHS_SCALES:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_SCALES_BINDING]], offsets = [0, 0, 0, 0], sizes = [2, 4, 4, 4], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4x4x4xf32>> -> tensor<2x4x4x4xf32>
-//   CHECK-DAG:   %[[LHS_ZPS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_ZPS_BINDING]], offsets = [0, 0, 0, 0], sizes = [2, 4, 4, 4], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x4x4x4xf32>> -> tensor<2x4x4x4xf32>
-//   CHECK-DAG:   %[[EMPTY_LHS:.+]] = tensor.empty() : tensor<2x1x4x8x4x4x4x4xf32>
-//   CHECK-DAG:   %[[LHS_DEQUANT:.+]] = linalg.generic
-//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP1]], #[[$MAP]]]
-//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
-//  CHECK-SAME:       ins(%[[LHS]], %[[LHS_SCALES]], %[[LHS_ZPS]] : tensor<2x1x4x8x4x4x4x4xi8>, tensor<2x4x4x4xf32>, tensor<2x4x4x4xf32>)
-//  CHECK-SAME:       outs(%[[EMPTY_LHS]] : tensor<2x1x4x8x4x4x4x4xf32>)
-//       CHECK:     arith.extui
-//       CHECK:     arith.uitofp
-//       CHECK:     arith.subf
-//       CHECK:     arith.mulf
-//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[LHS_DEQUANT]], %[[RESULT_BINDING]], offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [2, 1, 4, 8, 4, 4, 4, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1] : tensor<2x1x4x8x4x4x4x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1x4x8x4x4x4x4xf32>>
+
+// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d4, d7)>
+// CHECK-LABEL: func.func @dequantization
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[SCALES:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[ZPS:[a-zA-Z0-9_]+]]
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x8x4x4x4x4xf32>
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic
+// CHECK-SAME:        indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP1]], #[[$MAP]]]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME:        ins(%[[LHS]], %[[SCALES]], %[[ZPS]] : tensor<2x1x4x8x4x4x4x4xi8>, tensor<2x4x4x4xf32>, tensor<2x4x4x4xf32>)
+// CHECK-SAME:        outs(%[[EMPTY]] : tensor<2x1x4x8x4x4x4x4xf32>)
+// CHECK:           arith.extui
+// CHECK:           arith.uitofp
+// CHECK:           arith.subf
+// CHECK:           arith.mulf
+// CHECK:         return %[[DEQUANT]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1) -> ()>]]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_0D_tensor() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<f32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<f32>> -> tensor<f32>
-  %3 = iree_encoding.set_encoding %2 : tensor<f32> -> tensor<f32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [], sizes = [], strides = [] : tensor<f32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f32,  #encoding>>
-  return
+func.func @set_encoding_0D_tensor(
+    %arg0: tensor<f32>
+) -> tensor<f32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<f32> -> tensor<f32, #encoding>
+  return %0 : tensor<f32, #encoding>
 }
-// CHECK-LABEL: func.func @set_encoding_0D_tensor()
-//       CHECK:   %[[INPUT:.+]] = iree_tensor_ext.dispatch.tensor.load
-//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[INPUT]]
+
+// CHECK-LABEL: func.func @set_encoding_0D_tensor
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         return %[[ARG0]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
-func.func @multi_result_generic() {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xf32, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf32, #encoding>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf16, #encoding>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xf32, #encoding>> -> tensor<2x128x64xf32, #encoding>
+func.func @multi_result_generic(%3: tensor<2x128x64xf32, #encoding>) -> (tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>) {
   %4 = tensor.empty() : tensor<2x128x64xf32, #encoding>
   %5 = tensor.empty() : tensor<2x128x64xf16, #encoding>
   %15:2 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]}
@@ -1410,12 +1022,10 @@ func.func @multi_result_generic() {
     %7 = arith.truncf %6 : f32 to f16
     linalg.yield %6, %7 : f32, f16
   } -> (tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>)
-  iree_tensor_ext.dispatch.tensor.store %15#0, %1, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : tensor<2x128x64xf32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf32, #encoding>>
-  iree_tensor_ext.dispatch.tensor.store %15#1, %2, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : tensor<2x128x64xf16, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x128x64xf16, #encoding>>
-  return
+  return %15#0, %15#1 : tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>
 }
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
-// CHECK-LABEL: func.func @multi_result_generic()
+// CHECK-LABEL: func.func @multi_result_generic(
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]]
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
@@ -1433,12 +1043,7 @@ func.func @multi_result_generic() {
 #map1 = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
 #output_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [[affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2) -> (d2, d0, d1)>], affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
-func.func @interchange_generic() {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xf32, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x2x128xf32, #output_encoding>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 128, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x128x64xf32, #encoding>> -> tensor<2x128x64xf32, #encoding>
+func.func @interchange_generic(%3: tensor<2x128x64xf32, #encoding>) -> tensor<64x2x128xf32, #output_encoding> {
   %4 = tensor.empty() : tensor<64x2x128xf32, #output_encoding>
   %15 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]}
       ins(%3 : tensor<2x128x64xf32, #encoding>)
@@ -1447,11 +1052,10 @@ func.func @interchange_generic() {
     %6 = arith.addf %in, %in : f32
     linalg.yield %6 : f32
   } -> tensor<64x2x128xf32, #output_encoding>
-  iree_tensor_ext.dispatch.tensor.store %15, %1, offsets = [0, 0, 0], sizes = [64, 2, 128], strides = [1, 1, 1] : tensor<64x2x128xf32, #output_encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x2x128xf32, #output_encoding>>
-  return
+  return %15 : tensor<64x2x128xf32, #output_encoding>
 }
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
-// CHECK-LABEL: func.func @interchange_generic()
+// CHECK-LABEL: func.func @interchange_generic(
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]]]
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -309,9 +309,9 @@ func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x4x4x4xf32>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x2x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -344,9 +344,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x8x4x4x4x4xf32>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x?x4x2x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -491,9 +491,9 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x4x4x2x8xi8>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x2x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x2x4x16x4xi32>
 // CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -763,9 +763,9 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096(
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x4x4x4x4x2x8xi8>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x4x4x16x4xi32>
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_n = 4, intrinsics_k = 2>
@@ -816,9 +816,9 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768(
 }
 
 // CHECK:      func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x4x4x2x8xi8>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x4x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x4x4x16x4xi32>
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2>
@@ -852,9 +852,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x8x4x4x4x2x8xf8E4M3FNUZ>
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x4x2x4x16x2x8xf8E4M3FNUZ>
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -887,9 +887,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[RHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x8x4x4x4x2x4xbf16>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x?x4x2x4x16x2x4xbf16>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -977,15 +977,15 @@ func.func @dequantization(
 // CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
 // CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d4, d7)>
 // CHECK-LABEL: func.func @dequantization
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[SCALES:[a-zA-Z0-9_]+]]
-// CHECK-SAME:     %[[ZPS:[a-zA-Z0-9_]+]]
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x4x4x4xi8>
+// CHECK-SAME:     %[[SCALES:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
+// CHECK-SAME:     %[[ZPS:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
 // CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x8x4x4x4x4xf32>
 // CHECK:         %[[DEQUANT:.+]] = linalg.generic
 // CHECK-SAME:        indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP1]], #[[$MAP]]]
 // CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
-// CHECK-SAME:        ins(%[[LHS]], %[[SCALES]], %[[ZPS]] : tensor<2x1x4x8x4x4x4x4xi8>, tensor<2x4x4x4xf32>, tensor<2x4x4x4xf32>)
-// CHECK-SAME:        outs(%[[EMPTY]] : tensor<2x1x4x8x4x4x4x4xf32>)
+// CHECK-SAME:        ins(%[[LHS]], %[[SCALES]], %[[ZPS]]
+// CHECK-SAME:        outs(%[[EMPTY]]
 // CHECK:           arith.extui
 // CHECK:           arith.uitofp
 // CHECK:           arith.subf
@@ -1004,7 +1004,7 @@ func.func @set_encoding_0D_tensor(
 }
 
 // CHECK-LABEL: func.func @set_encoding_0D_tensor
-// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: tensor<f32>
 // CHECK:         return %[[ARG0]]
 
 // -----
@@ -1026,19 +1026,17 @@ func.func @multi_result_generic(%3: tensor<2x128x64xf32, #encoding>) -> (tensor<
 }
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
 // CHECK-LABEL: func.func @multi_result_generic(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x4x4x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]]
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
 //       CHECK:     arith.truncf
 //       CHECK:     -> (tensor<2x1x4x8x4x4x4x4xf32>, tensor<2x1x4x8x4x4x4x4xf16>)
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]>
@@ -1056,9 +1054,10 @@ func.func @interchange_generic(%3: tensor<2x128x64xf32, #encoding>) -> tensor<64
 }
 //   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
 // CHECK-LABEL: func.func @interchange_generic(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x8x4x4x4x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]]]
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
-//  CHECK-SAME:       ins(%{{.*}}: tensor<2x1x4x8x4x4x4x4xf32>)
+//  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
 //       CHECK:     -> tensor<2x1x4x8x4x4x4x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -12,18 +12,11 @@
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>> -> tensor<255x513xi8>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi8, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8,  #encoding>>
-  return
+func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
+    %src: tensor<255x513xi8>
+) -> tensor<255x513xi8, #encoding> {
+  %0 = iree_encoding.set_encoding %src : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  return %0 : tensor<255x513xi8, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8
@@ -38,96 +31,78 @@ func.func @set_encoding_LHS_unroll8x8x2_MFMA_I32_16x16x64_I8() {
 // CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x9x4x8x4x4x16xi8>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x9x8x4x4x4x16xi8>)
 // CHECK-SAME:       permutation = [0, 1, 3, 5, 2, 4, 6]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi8>> -> tensor<255x513xi8>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi8, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi8,  #encoding>>
-  return
+func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8(
+    %arg0: tensor<255x513xi8>
+) -> tensor<255x513xi8, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi8> -> tensor<255x513xi8, #encoding>
+  return %0 : tensor<255x513xi8, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_RHS_unroll8x8x2_MFMA_I32_16x16x64_I8
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i8)
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i8)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
 // CHECK-SAME:      inner_dims_pos = [1, 0]
 // CHECK-SAME:      inner_tiles = [128, 64]
 // CHECK-SAME:      : tensor<255x513xi8> -> tensor<5x4x128x64xi8>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<5x4x128x64xi8> into tensor<5x4x4x16x2x4x16xi8>
+// CHECK-SAME:      : tensor<5x4x128x64xi8> into tensor<5x4x4x16x2x4x16xi8>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<5x4x4x16x2x4x16xi8>)
-// CHECK-SAME:       outs({{.*}} : tensor<5x4x4x2x4x16x16xi8>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3, 6]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<5x4x4x16x2x4x16xi8>)
+// CHECK-SAME:      outs({{.*}} : tensor<5x4x4x2x4x16x16xi8>)
+// CHECK-SAME:      permutation = [0, 1, 2, 4, 5, 3, 6]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32, #encoding>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32>> -> tensor<255x513xi32>
-  %3 = iree_encoding.set_encoding %2 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi32, #encoding> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32,  #encoding>>
-  return
+func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
+    %arg0: tensor<255x513xi32>
+) -> tensor<255x513xi32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<255x513xi32> -> tensor<255x513xi32, #encoding>
+  return %0 : tensor<255x513xi32, #encoding>
 }
 
 // CHECK-LABEL: func.func @set_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8
-// CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : i32)
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : i32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<255x513xi32> -> tensor<2x5x128x128xi32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME       : tensor<2x5x128x128xi32> into tensor<2x5x4x8x4x4x16x2xi32>
+// CHECK-SAME:      : tensor<2x5x128x128xi32> into tensor<2x5x4x8x4x4x16x2xi32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x5x4x8x4x4x16x2xi32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x2x4x16x4xi32>)
-// CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<2x5x4x8x4x4x16x2xi32>)
+// CHECK-SAME:      outs({{.*}} : tensor<2x5x4x8x2x4x16x4xi32>)
+// CHECK-SAME:      permutation = [0, 1, 5, 3, 7, 2, 6, 4]
+// CHECK:         return %[[TRANSPOSE]]
 
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32],
                                     user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
                                     iteration_sizes = [255, 513, ?]>
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32, #encoding>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<255x513xi32, #encoding>> -> tensor<255x513xi32, #encoding>
-  %3 = iree_encoding.unset_encoding %2 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
-  iree_tensor_ext.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [255, 513], strides = [1, 1] : tensor<255x513xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<255x513xi32>>
-  return
+func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8(
+    %arg0: tensor<255x513xi32, #encoding>
+) -> tensor<255x513xi32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<255x513xi32, #encoding> -> tensor<255x513xi32>
+  return %0 : tensor<255x513xi32>
 }
 
-// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8() {
+// CHECK-LABEL: func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%{{.+}} : tensor<2x5x4x8x2x4x16x4xi32>)
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<2x5x4x8x2x4x16x4xi32>)
 // CHECK-SAME:       outs({{.*}} : tensor<2x5x4x8x4x4x16x2xi32>)
 // CHECK-SAME:       permutation = [0, 1, 5, 3, 7, 2, 6, 4]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
@@ -137,7 +112,7 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8() {
 // CHECK-SAME:      inner_dims_pos = [0, 1]
 // CHECK-SAME:      inner_tiles = [128, 128]
 // CHECK-SAME:      : tensor<2x5x128x128xi32> -> tensor<255x513xi32>
-// CHECK:         iree_tensor_ext.dispatch.tensor.store %[[UNPACK]]
+// CHECK:         return %[[UNPACK]]
 
 // -----
 
@@ -147,57 +122,32 @@ func.func @unset_encoding_ACC_unroll8x8x2_MFMA_I32_16x16x64_I8() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @matmul_lowering_MFMA_I32_16x16x64_I8() {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_3) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_3) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
+    %arg0: tensor<?x?xi8, #encoding_lhs>,
+    %arg1: tensor<?x?xi8, #encoding_rhs>,
+    %arg2: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x?xi8, #encoding_lhs>,
+                       tensor<?x?xi8, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %0 : tensor<?x?xi32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x64_I8
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x8x4x4x4x16xi8>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x2x4x16x16xi8>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x8x2x4x16x4xi32>
-// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
+// CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
+// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x64_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -211,57 +161,32 @@ func.func @matmul_lowering_MFMA_I32_16x16x64_I8() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FN, f8E4M3FN, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FN, f8E4M3FN, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FN, f8E4M3FN, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?, ?]>
-#pipeline_layout_4 = #hal.pipeline.layout<constants = 4, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN() {
-  %c0 = arith.constant 0 : index
-  %B = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(0) : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(1) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(2) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(3) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FN, #encoding_lhs>>{%B, %M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FN, #encoding_rhs>>{%B, %K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [%B, %M, %K], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FN, #encoding_lhs>>{%B, %M, %K}
-      -> tensor<?x?x?xf8E4M3FN, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [%B, %K, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf8E4M3FN, #encoding_rhs>>{%B, %K, %N}
-      -> tensor<?x?x?xf8E4M3FN, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
+func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
+    %arg0: tensor<?x?x?xf8E4M3FN, #encoding_lhs>,
+    %arg1: tensor<?x?x?xf8E4M3FN, #encoding_rhs>,
+    %arg2: tensor<?x?x?xf32, #encoding_result>
+) -> tensor<?x?x?xf32, #encoding_result> {
+  %0 = linalg.batch_matmul
+      ins(%arg0, %arg1 : tensor<?x?x?xf8E4M3FN, #encoding_lhs>,
+                         tensor<?x?x?xf8E4M3FN, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?x?xf32, #encoding_result>)
       -> tensor<?x?x?xf32, #encoding_result>
-  %6 = linalg.batch_matmul
-      ins(%3, %4 : tensor<?x?x?xf8E4M3FN, #encoding_lhs>,
-                   tensor<?x?x?xf8E4M3FN, #encoding_rhs>)
-      outs(%5 : tensor<?x?x?xf32, #encoding_result>)
-      -> tensor<?x?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : tensor<?x?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  return
+  return %0 : tensor<?x?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x?x8x4x4x4x32xf8E4M3FN>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x?x4x2x4x16x32xf8E4M3FN>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
+// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x128_F8E4M3FN, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 
@@ -271,57 +196,32 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN() {
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2]>
-#pipeline_layout_4 = #hal.pipeline.layout<constants = 4, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16() {
-  %c0 = arith.constant 0 : index
-  %B = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(0) : index
-  %M = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(1) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(2) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout_4) ordinal(3) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_lhs>>{%B, %M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_rhs>>{%B, %K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout_4) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [%B, %M, %K], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_lhs>>{%B, %M, %K}
-      -> tensor<?x?x?xbf16, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [%B, %K, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xbf16, #encoding_rhs>>{%B, %K, %N}
-      -> tensor<?x?x?xbf16, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
+func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
+    %arg0: tensor<?x?x?xbf16, #encoding_lhs>,
+    %arg1: tensor<?x?x?xbf16, #encoding_rhs>,
+    %arg2: tensor<?x?x?xf32, #encoding_result>
+) -> tensor<?x?x?xf32, #encoding_result> {
+  %0 = linalg.batch_matmul
+      ins(%arg0, %arg1 : tensor<?x?x?xbf16, #encoding_lhs>,
+                         tensor<?x?x?xbf16, #encoding_rhs>)
+      outs(%arg2 : tensor<?x?x?xf32, #encoding_result>)
       -> tensor<?x?x?xf32, #encoding_result>
-  %6 = linalg.batch_matmul
-      ins(%3, %4 : tensor<?x?x?xbf16, #encoding_lhs>,
-                   tensor<?x?x?xbf16, #encoding_rhs>)
-      outs(%5 : tensor<?x?x?xf32, #encoding_result>)
-      -> tensor<?x?x?xf32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [%B, %M, %N], strides = [1, 1, 1]
-      : tensor<?x?x?xf32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32, #encoding_result>>{%B, %M, %N}
-  return
+  return %0 : tensor<?x?x?xf32, #encoding_result>
 }
+
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16
-// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
-// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
-// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x?x8x4x4x4x8xbf16>
-// CHECK-DAG:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x?x4x2x4x16x8xbf16>
-// CHECK-DAG:   %[[ACC:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x?x4x8x2x4x16x4xf32>
-// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
+// CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
+// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 4>
-// CHECK:       iree_tensor_ext.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]
+// CHECK:       return %[[MMA]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -139,9 +139,9 @@ func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x8x4x4x4x16xi8>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x4x2x4x16x16xi8>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x4x8x2x4x16x4xi32>
 // CHECK-SAME:   ) -> tensor<?x?x4x8x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -178,9 +178,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x8x4x4x4x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x4x2x4x16x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
@@ -213,9 +213,9 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x8x4x4x4x8xbf16>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x4x2x4x16x8xbf16>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK-SAME:   ) -> tensor<?x?x?x4x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
@@ -42,62 +42,25 @@ func.func @matmul_lowering_f32f32f32_riscv(%lhs: tensor<?x?xf32>, %rhs: tensor<?
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-func.func @matmul_lowering_i8i8i32_riscv32_ukernel() attributes {
+func.func @matmul_lowering_i8i8i32_riscv32_ukernel(
+    %lhs: tensor<?x?xi8, #encoding_lhs>,
+    %rhs: tensor<?x?xi8, #encoding_rhs>,
+    %result: tensor<?x?xi32, #encoding_result>
+) -> tensor<?x?xi32, #encoding_result> attributes {
   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple="riscv32-xyz-xyz", ukernels = "all", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
 } {
-  %c0 = arith.constant 0 : index
-  %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %N = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %K = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0)
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_lhs>>{%M, %K}
-      -> tensor<?x?xi8, #encoding_lhs>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?xi8, #encoding_rhs>>{%K, %N}
-      -> tensor<?x?xi8, #encoding_rhs>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
+  %out = linalg.matmul
+      ins(%lhs, %rhs : tensor<?x?xi8, #encoding_lhs>,
+                       tensor<?x?xi8, #encoding_rhs>)
+      outs(%result : tensor<?x?xi32, #encoding_result>)
       -> tensor<?x?xi32, #encoding_result>
-  %6 = linalg.matmul
-      ins(%3, %4 : tensor<?x?xi8, #encoding_lhs>,
-                   tensor<?x?xi8, #encoding_rhs>)
-      outs(%5 : tensor<?x?xi32, #encoding_result>)
-      -> tensor<?x?xi32, #encoding_result>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
-      : tensor<?x?xi32, #encoding_result>
-      -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xi32, #encoding_result>>{%M, %N}
-  return
+  return %out : tensor<?x?xi32, #encoding_result>
 }
-//   CHECK-DAG: #[[$MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
-//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
-// CHECK-LABEL: func @matmul_lowering_i8i8i32_riscv32_ukernel()
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(0)
-//   CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(1)
-//   CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(2)
-//   CHECK-DAG:   %[[TILED_M:.+]] = affine.apply #[[$MAP0]]()[%[[M]]]
-//   CHECK-DAG:   %[[TILED_K:.+]] = affine.apply #[[$MAP1]]()[%[[K]]]
-//       CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x4xi8>>{%[[TILED_M]], %[[TILED_K]]}
-//       CHECK:   %[[TILED_N:.+]] = affine.apply #[[$MAP0]]()[%[[N]]]
-//       CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x4xi8>>{%[[TILED_N]], %[[TILED_K]]}
-//       CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x8xi32>>{%[[TILED_M]], %[[TILED_N]]}
-//       CHECK:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 8, 4], strides = [1, 1, 1, 1]
-//       CHECK:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 8, 4], strides = [1, 1, 1, 1]
-//       CHECK:   %[[OUTS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 8], strides = [1, 1, 1, 1]
-//       CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
-//  CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
-//  CHECK-SAME:       outs(%[[OUTS]] :
-//       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[MMT4D]], %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 8], strides = [1, 1, 1, 1]
+// CHECK-LABEL: func @matmul_lowering_i8i8i32_riscv32_ukernel(
+// CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUTS:[a-zA-Z0-9]+]]
+// CHECK:         %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:      ins(%[[LHS]], %[[RHS]]
+// CHECK-SAME:      outs(%[[OUTS]]
+// CHECK:         return %[[MMT4D]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv.mlir
@@ -57,10 +57,10 @@ func.func @matmul_lowering_i8i8i32_riscv32_ukernel(
   return %out : tensor<?x?xi32, #encoding_result>
 }
 // CHECK-LABEL: func @matmul_lowering_i8i8i32_riscv32_ukernel(
-// CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[OUTS:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?x8x4xi8>
+// CHECK-SAME:    %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?x8x4xi8>
+// CHECK-SAME:    %[[ACC:[a-zA-Z0-9]+]]: tensor<?x?x8x8xi32>
 // CHECK:         %[[MMT4D:.+]] = linalg.mmt4d
 // CHECK-SAME:      ins(%[[LHS]], %[[RHS]]
-// CHECK-SAME:      outs(%[[OUTS]]
+// CHECK-SAME:      outs(%[[ACC]]
 // CHECK:         return %[[MMT4D]]


### PR DESCRIPTION
The revision adapts the tests to move inputs to function arguments and return the final results. It makes the tests focus on the actual testing cases. The HAL bindings and TensorExt ops should be covered in a separate file. Today, they are well covered by x86 tests.

In the future, we will have HAL/TensorExt ops being tested in a separate file and make x86 tests focus on its own logic.

The remaining tests that still abuse HAL/TensorExt ops are:

* materialize_encoding_aarch64.mlir
* materialize_encoding_into_nop.mlir
* materialize_encoding_into_padding.mlir
* materialize_encoding_x86_64.mlir
* materialize_encoding_vmvx.mlir

It is a step towards https://github.com/iree-org/iree/issues/20825