### PR TITLE
[LinalgExt] Decompose sub-byte map_scatter to extract/store

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -326,6 +326,15 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_Op<"map_scatter",
       return getOutputType().getRank();
     }
 
+    // Return the input index at the provided position.
+    Value getInputIndex(int64_t position);
+
+    // Return the output index at the provided position.
+    Value getOutputIndex(int64_t position);
+
+    // Returns the mask value.
+    Value getMask();
+
     // Return true if the map_scatter op has vector semantics.
     bool isVectorized() {
       return isa<VectorType>(getInputType());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeMapScatter.cpp
@@ -7,6 +7,8 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "iree/compiler/Utils/Indexing.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -14,6 +16,8 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-decompose-map-scatter"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
@@ -119,15 +123,29 @@ static Value createFlatOutputBuffer(RewriterBase &rewriter, Location loc,
                                            collapsedShape, collapsedStrides);
 }
 
-/// Decompose an iree_linalg_ext.map_scatter op with a vector input, and a
-/// memref output. The map_scatter op is lowered into a sequence of vector ops
-/// to compute a vector of indices for the elements of the map_scatter input,
-/// and then a vector.scatter op to scatter the input vector to the output
-/// buffer at the indices in the computed index vector. The output buffer is
-/// also flattened to a 1D memref. If the collapse is not possible due to non
-/// collapsible strides, then the decomposition will fail.
-static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
-                                         RewriterBase &rewriter) {
+/// Result of performIndexAndMaskVectorization containing the vectorized
+/// index computation, mask, and the flattened output buffer.
+struct VectorizationResult {
+  /// The vectorized linear indices for scatter destinations.
+  Value indexVector;
+  /// The vectorized mask values for conditional stores.
+  Value maskVector;
+  /// The flattened 1D output buffer.
+  Value flatOutputBuffer;
+};
+
+/// Vectorize the index computation and mask evaluation for a `map_scatter` op.
+/// This creates a `linalg.generic` op that computes linearized output indices
+/// and mask values for all elements of the input vector, then vectorizes it
+/// to produce vector operations. Returns the computed index vector, mask
+/// vector, and flattened output buffer. If `disregardInnerDimension` is true,
+/// the innermost dimension is treated as size 1 for vectorization. This is used
+/// by `decomposeToLoadStore` to decompose the `map_scatter` op into a sequence
+/// of `vector.extract` and `vector.store` operations.
+static FailureOr<VectorizationResult>
+performIndexAndMaskVectorization(MapScatterOp mapScatterOp,
+                                 RewriterBase &rewriter,
+                                 bool disregardInnerDimension = false) {
   Location loc = mapScatterOp.getLoc();
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(mapScatterOp);
@@ -136,7 +154,6 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
   SmallVector<Value> strides;
   Value flatOutputBuffer = createFlatOutputBuffer(
       rewriter, loc, mapScatterOp.getOutput(), outputSizes, strides);
-
   auto inputType = cast<VectorType>(mapScatterOp.getInputType());
   auto bodyBuilder = [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
     auto inlineBodyBuilder = [&](OpBuilder inlineBuilder, Location inlineLoc,
@@ -170,10 +187,14 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
         });
     mapScatterOp.inlineMapScatterBody(b, nestedLoc, indices, inlineBodyBuilder);
   };
-  auto idxInit = tensor::EmptyOp::create(rewriter, loc, inputType.getShape(),
-                                         rewriter.getIndexType());
-  auto maskInit = tensor::EmptyOp::create(rewriter, loc, inputType.getShape(),
-                                          rewriter.getIntegerType(1));
+  SmallVector<int64_t> shape(inputType.getShape());
+  if (disregardInnerDimension) {
+    shape[shape.size() - 1] = 1;
+  }
+  auto idxInit =
+      tensor::EmptyOp::create(rewriter, loc, shape, rewriter.getIndexType());
+  auto maskInit =
+      tensor::EmptyOp::create(rewriter, loc, shape, rewriter.getIntegerType(1));
   SmallVector<AffineMap> maps(
       2, rewriter.getMultiDimIdentityMap(inputType.getRank()));
   SmallVector<utils::IteratorType> iterTypes(inputType.getRank(),
@@ -184,7 +205,7 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
                                 outs, maps, iterTypes, bodyBuilder);
 
   // Lower linearize and delinearize ops before vectorizing, because the
-  // vectorizer can't hendle them.
+  // vectorizer can't handle them.
   SmallVector<affine::AffineLinearizeIndexOp> linearizeOps(
       genericOp.getBody()->getOps<affine::AffineLinearizeIndexOp>());
   for (auto linearizeOp : linearizeOps) {
@@ -216,7 +237,7 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
       result->replacements[0].getDefiningOp<vector::TransferWriteOp>();
   auto maskWriteOp =
       result->replacements[1].getDefiningOp<vector::TransferWriteOp>();
-  if (!indexWriteOp || !maskWriteOp) {
+  if (!indexWriteOp) {
     return failure();
   }
   Value indexVector = indexWriteOp.getVector();
@@ -225,10 +246,89 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
   rewriter.eraseOp(indexWriteOp);
   rewriter.eraseOp(maskWriteOp);
   rewriter.eraseOp(genericOp);
+  return VectorizationResult{indexVector, maskVector, flatOutputBuffer};
+}
+
+/// Decompose the `map_scatter` into a sequence of `vector.extract` and
+/// `vector.store` operations.
+static LogicalResult decomposeToLoadStore(MapScatterOp mapScatterOp,
+                                          RewriterBase &rewriter) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(mapScatterOp);
+  FailureOr<VectorizationResult> vectorizationResult =
+      performIndexAndMaskVectorization(mapScatterOp, rewriter,
+                                       /*disregardInnerDimension=*/true);
+  if (failed(vectorizationResult)) {
+    return failure();
+  }
+  Value indexVector = vectorizationResult->indexVector;
+  Value maskVector = vectorizationResult->maskVector;
+  Value flatOutputBuffer = vectorizationResult->flatOutputBuffer;
+
+  // Flatten all the index and mask vectors, since the scatter op lowering
+  // expects 1D vectors.
+  auto inputType = cast<VectorType>(mapScatterOp.getInputType());
+  const int64_t flatIndexSize =
+      llvm::product_of(inputType.getShape().drop_back());
+  const int64_t flatVectorSize = llvm::product_of(inputType.getShape());
+  Location loc = mapScatterOp.getLoc();
+  auto flatIndexType =
+      VectorType::get({flatIndexSize}, rewriter.getIndexType());
+  indexVector =
+      vector::ShapeCastOp::create(rewriter, loc, flatIndexType, indexVector);
+  auto flatMaskType =
+      VectorType::get({flatIndexSize}, rewriter.getIntegerType(1));
+  maskVector =
+      vector::ShapeCastOp::create(rewriter, loc, flatMaskType, maskVector);
+  auto flatInputType =
+      VectorType::get({flatIndexSize, flatVectorSize / flatIndexSize},
+                      inputType.getElementType());
+  Value inputVector = vector::ShapeCastOp::create(rewriter, loc, flatInputType,
+                                                  mapScatterOp.getInput());
+  for (int64_t i = 0; i < flatIndexSize; ++i) {
+    Value index = arith::ConstantIndexOp::create(rewriter, loc, i);
+    auto extractMask =
+        vector::ExtractOp::create(rewriter, loc, maskVector, index);
+    auto extractIndex =
+        vector::ExtractOp::create(rewriter, loc, indexVector, index);
+    auto extractValue =
+        vector::ExtractOp::create(rewriter, loc, inputVector, index);
+
+    // Only store if mask is true.
+    auto ifOp = scf::IfOp::create(rewriter, loc, extractMask.getResult(),
+                                  /*withElseRegion=*/false);
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(ifOp.thenBlock());
+    vector::StoreOp::create(rewriter, loc, extractValue.getResult(),
+                            flatOutputBuffer, {extractIndex});
+  }
+  rewriter.eraseOp(mapScatterOp);
+  return success();
+}
+
+/// Decompose a map_scatter op into a single `vector.scatter` operation.
+///
+/// The function uses `performIndexAndMaskVectorization` to compute vectorized
+/// indices and masks, then flattens all vectors to 1D and replaces the
+/// `map_scatter` with a single `vector.scatter` operation.
+static LogicalResult decomposeToScatter(MapScatterOp mapScatterOp,
+                                        RewriterBase &rewriter) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(mapScatterOp);
+  FailureOr<VectorizationResult> vectorizationResult =
+      performIndexAndMaskVectorization(mapScatterOp, rewriter,
+                                       /*disregardInnerDimension=*/false);
+  if (failed(vectorizationResult)) {
+    return failure();
+  }
+  Value indexVector = vectorizationResult->indexVector;
+  Value maskVector = vectorizationResult->maskVector;
+  Value flatOutputBuffer = vectorizationResult->flatOutputBuffer;
 
   // Flatten all the vectors, since the scatter op lowering expects 1D vectors.
-  int64_t flatVectorSize = llvm::product_of(inputType.getShape());
-  rewriter.setInsertionPoint(mapScatterOp);
+  auto inputType = cast<VectorType>(mapScatterOp.getInputType());
+  const int64_t flatVectorSize = llvm::product_of(inputType.getShape());
+  Location loc = mapScatterOp.getLoc();
   auto flatIndexType =
       VectorType::get({flatVectorSize}, rewriter.getIndexType());
   indexVector =
@@ -248,6 +348,52 @@ static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
                                                  offsets, indexVector,
                                                  maskVector, inputVector);
   return success();
+}
+
+/// Decompose an `iree_linalg_ext.map_scatter` op with vector input and memref
+/// output. This is the main dispatch function that analyzes the `map_scatter`
+/// operation and chooses the most appropriate decomposition strategy.
+///
+/// Decomposition strategies (in order of preference):
+/// 1. `decomposeToLoadStore`: Used when the innermost dimension mapping is unit
+///    (identity) function from input to output and the mask doesn't depend on
+///    the innermost input index. This vectorizes the index and mask
+///    computations and generates a sequence of `vector.extract`
+///    and `vector.store` operations.
+/// 2. `decomposeToScatter`: The fallback. Used for regular scatter patterns
+///    with types that are >= 8 bits. This vectorizes the index and mask
+///    computations and generates a single `vector.scatter` operation.
+static LogicalResult decomposeMapScatter(MapScatterOp mapScatterOp,
+                                         RewriterBase &rewriter) {
+  Value innermostInputIdx =
+      mapScatterOp.getInputIndex(mapScatterOp.getInputRank() - 1);
+  Value innermostOutputIdx =
+      mapScatterOp.getOutputIndex(mapScatterOp.getOutputRank() - 1);
+  SetVector<Operation *> slice;
+  getForwardSlice(innermostInputIdx, &slice);
+  Operation *maskOp = mapScatterOp.getMask().getDefiningOp();
+  const bool isMaskForwardSlice = maskOp && slice.contains(maskOp);
+  const bool isUnitFunctionOfInnermostInputIdx =
+      isUnitFunctionOf(innermostOutputIdx, innermostInputIdx);
+  if (!isMaskForwardSlice && isUnitFunctionOfInnermostInputIdx) {
+    return decomposeToLoadStore(mapScatterOp, rewriter);
+  }
+  // In case of a sub-byte map_scatter that hasn't been decomposed into a
+  // sequence of extract/store ops above, there is a potential non-contiguous
+  // copy on the inner dimension that is not a multiple of a byte size through a
+  // stride or mask and the map_scatter can't be vectorized, so fail.
+  const int64_t bitWidth = mapScatterOp.getInputType().getElementTypeBitWidth();
+  if (bitWidth < 8) {
+    if (!isUnitFunctionOfInnermostInputIdx) {
+      return mapScatterOp.emitOpError() << "with an access on a sub-byte type "
+                                           "that is not a multiple of the byte "
+                                           "size can't be vectorized";
+    }
+    return mapScatterOp.emitOpError()
+           << "map_scatter on sub-byte type with potentially non "
+              "byte aligned transformation";
+  }
+  return decomposeToScatter(mapScatterOp, rewriter);
 }
 
 namespace {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -65,6 +65,7 @@ def DecomposeMapScatterPass :
   let summary =
       "Decomposes vectorized map_scatter ops into vector ops";
   let dependentDialects = [
+    "::mlir::scf::SCFDialect",
     "::mlir::tensor::TensorDialect",
     "::mlir::vector::VectorDialect",
     "::mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_map_scatter.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter,cse))" \
-// RUN:   --split-input-file %s | FileCheck --check-prefix=CHECK %s
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter{test-preprocessing-patterns=true},cse))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter,canonicalize,cse))" \
+// RUN:   --split-input-file --verify-diagnostics %s | FileCheck --check-prefix=CHECK %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-map-scatter{test-preprocessing-patterns=true},canonicalize,cse))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=PREPROCESSING %s
 
 func.func @identity_map_scatter(
@@ -16,15 +16,25 @@ func.func @identity_map_scatter(
 // CHECK-LABEL: func.func @identity_map_scatter(
 //  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant dense<16> : vector<4x1xindex>
 //   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} memref<4x16xf32> into memref<64xf32>
-//   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
-//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
-//   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
-//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
-//  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
+//       CHECK:   %[[EXTRACT_IDX_0:.+]] = vector.extract %{{.*}}[0, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_0:.+]] = vector.extract %[[INPUT]][0] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_0]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_0]]] : memref<64xf32>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_1:.+]] = vector.extract %{{.*}}[1, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_1:.+]] = vector.extract %[[INPUT]][1] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_1]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_1]]] : memref<64xf32>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_2:.+]] = vector.extract %{{.*}}[2, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_2:.+]] = vector.extract %[[INPUT]][2] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_2]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_2]]] : memref<64xf32>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_3:.+]] = vector.extract %{{.*}}[3, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_3:.+]] = vector.extract %[[INPUT]][3] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_3]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_3]]] : memref<64xf32>, vector<16xf32>
 
 // -----
+
+// This test checks all index and mask computations for the `map_scatter` to `vector.scatter` path.
+// Other tests shouldn't check this to avoid maintenance burden.
 
 func.func @map_scatter_with_linearize_delinearize_idx(
     %input: vector<2x2x64xf32>, %output: memref<4x32x2xf32>
@@ -39,8 +49,37 @@ func.func @map_scatter_with_linearize_delinearize_idx(
   return
 }
 // CHECK-LABEL: func.func @map_scatter_with_linearize_delinearize_idx(
-//   CHECK-NOT:   iree_linalg_ext.map_scatter
-//       CHECK:   vector.scatter
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[MASK:.+]] = arith.constant dense<true> : vector<256xi1>
+//   CHECK-DAG:   %[[CST_64:.+]] = arith.constant dense<64> : vector<2x2x64xindex>
+//   CHECK-DAG:   %[[CST_0:.+]] = arith.constant dense<0> : vector<64xindex>
+//   CHECK-DAG:   %[[CST_2:.+]] = arith.constant dense<2> : vector<64xindex>
+//   CHECK-DAG:   %[[CST_2_3D:.+]] = arith.constant dense<2> : vector<2x2x64xindex>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} : memref<4x32x2xf32> into memref<256xf32>
+//   CHECK-DAG:   %[[STEP_2:.+]] = vector.step : vector<2xindex>
+//   CHECK-DAG:   %[[BROADCAST_64x2x2:.+]] = vector.broadcast %[[STEP_2]] : vector<2xindex> to vector<64x2x2xindex>
+//   CHECK-DAG:   %[[TRANSPOSE_1:.+]] = vector.transpose %[[BROADCAST_64x2x2]], [2, 1, 0] : vector<64x2x2xindex> to vector<2x2x64xindex>
+//   CHECK-DAG:   %[[BROADCAST_2x64x2:.+]] = vector.broadcast %[[STEP_2]] : vector<2xindex> to vector<2x64x2xindex>
+//   CHECK-DAG:   %[[TRANSPOSE_2:.+]] = vector.transpose %[[BROADCAST_2x64x2]], [0, 2, 1] : vector<2x64x2xindex> to vector<2x2x64xindex>
+//   CHECK-DAG:   %[[STEP_64:.+]] = vector.step : vector<64xindex>
+//   CHECK-DAG:   %[[MULI_1:.+]] = arith.muli %[[TRANSPOSE_1]], %[[CST_2_3D]] overflow<nsw> : vector<2x2x64xindex>
+//   CHECK-DAG:   %[[ADDI_1:.+]] = arith.addi %[[MULI_1]], %[[TRANSPOSE_2]] overflow<nsw> : vector<2x2x64xindex>
+//   CHECK-DAG:   %[[FLOORDIVSI:.+]] = arith.floordivsi %[[STEP_64]], %[[CST_2]] : vector<64xindex>
+//   CHECK-DAG:   %[[REMSI:.+]] = arith.remsi %[[STEP_64]], %[[CST_2]] : vector<64xindex>
+//   CHECK-DAG:   %[[CMPI:.+]] = arith.cmpi slt, %[[REMSI]], %[[CST_0]] : vector<64xindex>
+//   CHECK-DAG:   %[[ADDI_2:.+]] = arith.addi %[[REMSI]], %[[CST_2]] overflow<nsw> : vector<64xindex>
+//   CHECK-DAG:   %[[SELECT:.+]] = arith.select %[[CMPI]], %[[ADDI_2]], %[[REMSI]] : vector<64xi1>, vector<64xindex>
+//   CHECK-DAG:   %[[MULI_2:.+]] = arith.muli %[[ADDI_1]], %[[CST_64]] overflow<nsw> : vector<2x2x64xindex>
+//   CHECK-DAG:   %[[MULI_3:.+]] = arith.muli %[[FLOORDIVSI]], %[[CST_2]] overflow<nsw> : vector<64xindex>
+//   CHECK-DAG:   %[[BROADCAST_FINAL:.+]] = vector.broadcast %[[MULI_3]] : vector<64xindex> to vector<2x2x64xindex>
+//   CHECK-DAG:   %[[ADDI_3:.+]] = arith.addi %[[MULI_2]], %[[BROADCAST_FINAL]] overflow<nsw> : vector<2x2x64xindex>
+//       CHECK:   %[[BROADCAST_SELECT:.+]] = vector.broadcast %[[SELECT]] : vector<64xindex> to vector<2x2x64xindex>
+//       CHECK:   %[[ADDI_FINAL:.+]] = arith.addi %[[ADDI_3]], %[[BROADCAST_SELECT]] overflow<nsw> : vector<2x2x64xindex>
+//       CHECK:   %[[SHAPE_CAST_IDX:.+]] = vector.shape_cast %[[ADDI_FINAL]] : vector<2x2x64xindex> to vector<256xindex>
+//       CHECK:   %[[SHAPE_CAST_DATA:.+]] = vector.shape_cast %[[INPUT]] : vector<2x2x64xf32> to vector<256xf32>
+//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]] [%[[SHAPE_CAST_IDX]]], %[[MASK]], %[[SHAPE_CAST_DATA]] : memref<256xf32>, vector<256xindex>, vector<256xi1>, vector<256xf32>
 
 // -----
 
@@ -57,8 +96,15 @@ func.func @map_scatter_with_mask(
   return
 }
 // CHECK-LABEL: func.func @map_scatter_with_mask(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[DIM:.+]] = memref.dim %[[OUTPUT]], %[[C0]] : memref<?xf32>
+//   CHECK-DAG:   %[[STEP:.+]] = vector.step : vector<64xindex>
+//       CHECK:   %[[BROADCAST_DIM:.+]] = vector.broadcast %[[DIM]] : index to vector<64xindex>
+//       CHECK:   %[[CMPI:.+]] = arith.cmpi uge, %[[STEP]], %[[BROADCAST_DIM]] : vector<64xindex>
 //   CHECK-NOT:   iree_linalg_ext.map_scatter
-//       CHECK:   vector.scatter
+//       CHECK:   vector.maskedstore %[[OUTPUT]][%[[C0]]], %[[CMPI]], %[[INPUT]] : memref<?xf32>, vector<64xi1>, vector<64xf32>
 
 // -----
 
@@ -80,7 +126,7 @@ func.func @map_scatter_into_subview(
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} memref<8x32xf32> into memref<256xf32>
 //   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
-//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
+//   CHECK-DAG:   %[[FLAT_MASK:.+]] = arith.constant dense<true> : vector<64xi1>
 //   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
 //       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
 //  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
@@ -114,14 +160,21 @@ func.func @map_scatter_into_collapsible_subview(
 // CHECK-LABEL: func.func @map_scatter_into_collapsible_subview(
 //  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant dense<32> : vector<4x1xindex>
 //   CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
 //   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[SUBVIEW]] {{.*}} memref<4x32xf32{{.*}} into memref<128xf32
-//   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
-//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
-//   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
-//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
-//  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
+//       CHECK:   %[[EXTRACT_IDX_0:.+]] = vector.extract %{{.*}}[0, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_0:.+]] = vector.extract %[[INPUT]][0] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_0]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_0]]] : memref<128xf32, strided<[1]>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_1:.+]] = vector.extract %{{.*}}[1, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_1:.+]] = vector.extract %[[INPUT]][1] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_1]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_1]]] : memref<128xf32, strided<[1]>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_2:.+]] = vector.extract %{{.*}}[2, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_2:.+]] = vector.extract %[[INPUT]][2] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_2]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_2]]] : memref<128xf32, strided<[1]>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_3:.+]] = vector.extract %{{.*}}[3, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_3:.+]] = vector.extract %[[INPUT]][3] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_3]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_3]]] : memref<128xf32, strided<[1]>>, vector<16xf32>
 
 // PREPROCESSING-LABEL: func.func @map_scatter_into_collapsible_subview(
 //  PREPROCESSING:        memref.subview
@@ -146,13 +199,135 @@ func.func @map_scatter_into_strided_output(
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = memref.dim %[[OUTPUT]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = memref.dim %[[OUTPUT]], %[[C1]]
-//   CHECK-DAG:   %{{.*}}, %[[OFFSET:.+]], %{{.*}}:2, %{{.*}} = memref.extract_strided_metadata %[[OUTPUT]]
+//   CHECK-DAG:   %{{.*}}, %[[OFFSET:.+]], %{{.*}}:2, %{{.*}}:2 = memref.extract_strided_metadata %[[OUTPUT]]
 //   CHECK-DAG:   %[[FLAT_SIZE:.+]] = affine.apply #[[$MAP]]()[%[[D0]], %[[D1]]]
 //       CHECK:   %[[FLAT_OUTPUT:.+]] = memref.reinterpret_cast %[[OUTPUT]]
 //  CHECK-SAME:     to offset: [%[[OFFSET]]], sizes: [%[[FLAT_SIZE]]], strides: [1]
 //  CHECK-SAME:     : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
-//   CHECK-DAG:   %[[FLAT_INDICES:.+]] = vector.shape_cast{{.*}} : vector<4x16xindex> to vector<64xindex>
-//   CHECK-DAG:   %[[FLAT_MASK:.+]] = vector.shape_cast{{.*}} : vector<4x16xi1> to vector<64xi1>
-//   CHECK-DAG:   %[[FLAT_INPUT:.+]] = vector.shape_cast %[[INPUT]] : vector<4x16xf32> to vector<64xf32>
-//       CHECK:   vector.scatter %[[FLAT_OUTPUT]][%[[C0]]]
-//  CHECK-SAME:     [%[[FLAT_INDICES]]], %[[FLAT_MASK]], %[[FLAT_INPUT]]
+//       CHECK:   %[[EXTRACT_IDX_0:.+]] = vector.extract %{{.*}}[0, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_0:.+]] = vector.extract %[[INPUT]][0] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_0]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_0]]] : memref<?xf32, strided<[1], offset: ?>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_1:.+]] = vector.extract %{{.*}}[1, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_1:.+]] = vector.extract %[[INPUT]][1] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_1]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_1]]] : memref<?xf32, strided<[1], offset: ?>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_2:.+]] = vector.extract %{{.*}}[2, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_2:.+]] = vector.extract %[[INPUT]][2] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_2]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_2]]] : memref<?xf32, strided<[1], offset: ?>>, vector<16xf32>
+//       CHECK:   %[[EXTRACT_IDX_3:.+]] = vector.extract %{{.*}}[3, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_3:.+]] = vector.extract %[[INPUT]][3] : vector<16xf32> from vector<4x16xf32>
+//       CHECK:   vector.store %[[EXTRACT_3]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_3]]] : memref<?xf32, strided<[1], offset: ?>>, vector<16xf32>
+
+// -----
+
+func.func @map_scatter_sub_byte(
+    %input: vector<4x16xf4E2M1FN>, %output: memref<4x16xf4E2M1FN, strided<[16, 1], offset: ?>>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf4E2M1FN> into memref<4x16xf4E2M1FN, strided<[16, 1], offset: ?>>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_sub_byte
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} memref<4x16xf4E2M1FN{{.*}} into memref<64xf4E2M1FN{{.*}}
+//       CHECK:   %[[EXTRACT_IDX_0:.+]] = vector.extract %{{.*}}[0, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_0:.+]] = vector.extract %[[INPUT]][0] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   vector.store %[[EXTRACT_0]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_0]]] : memref<64xf4E2M1FN, strided<[1], offset: ?>>, vector<16xf4E2M1FN>
+//       CHECK:   %[[EXTRACT_IDX_1:.+]] = vector.extract %{{.*}}[1, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_1:.+]] = vector.extract %[[INPUT]][1] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   vector.store %[[EXTRACT_1]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_1]]] : memref<64xf4E2M1FN, strided<[1], offset: ?>>, vector<16xf4E2M1FN>
+//       CHECK:   %[[EXTRACT_IDX_2:.+]] = vector.extract %{{.*}}[2, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_2:.+]] = vector.extract %[[INPUT]][2] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   vector.store %[[EXTRACT_2]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_2]]] : memref<64xf4E2M1FN, strided<[1], offset: ?>>, vector<16xf4E2M1FN>
+//       CHECK:   %[[EXTRACT_IDX_3:.+]] = vector.extract %{{.*}}[3, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_3:.+]] = vector.extract %[[INPUT]][3] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   vector.store %[[EXTRACT_3]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_3]]] : memref<64xf4E2M1FN, strided<[1], offset: ?>>, vector<16xf4E2M1FN>
+
+// -----
+
+// This test checks all index and mask computations for the `map_scatter` to `vector.extract`/`vector.store` path.
+// Other tests shouldn't check this to avoid maintenance burden.
+
+func.func @map_scatter_sub_byte_with_mask(
+    %input: vector<4x16xf4E2M1FN>, %output: memref<8x16xf4E2M1FN>
+) {
+  %c2 = arith.constant 2 : index
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.cmpi ult, %idx0, %c2 : index
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf4E2M1FN> into memref<8x16xf4E2M1FN>
+  return
+}
+// CHECK-LABEL: func.func @map_scatter_sub_byte_with_mask(
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:     %[[OUTPUT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[CST_16:.+]] = arith.constant dense<16> : vector<4x1xindex>
+//   CHECK-DAG:   %[[CST_2:.+]] = arith.constant dense<2> : vector<4x1xindex>
+//   CHECK-DAG:   %[[FLAT_OUTPUT:.+]] = memref.collapse_shape %[[OUTPUT]] {{.*}} memref<8x16xf4E2M1FN> into memref<128xf4E2M1FN>
+//   CHECK-DAG:   %[[STEP_4:.+]] = vector.step : vector<4xindex>
+//   CHECK-DAG:   %[[BROADCAST_1x4:.+]] = vector.broadcast %[[STEP_4]] : vector<4xindex> to vector<1x4xindex>
+//   CHECK-DAG:   %[[TRANSPOSE:.+]] = vector.transpose %[[BROADCAST_1x4]], [1, 0] : vector<1x4xindex> to vector<4x1xindex>
+//   CHECK-DAG:   %[[STEP_1:.+]] = vector.step : vector<1xindex>
+//   CHECK-DAG:   %[[CMPI:.+]] = arith.cmpi ult, %[[TRANSPOSE]], %[[CST_2]] : vector<4x1xindex>
+//   CHECK-DAG:   %[[MULI:.+]] = arith.muli %[[TRANSPOSE]], %[[CST_16]] overflow<nsw> : vector<4x1xindex>
+//   CHECK-DAG:   %[[BROADCAST_4x1:.+]] = vector.broadcast %[[STEP_1]] : vector<1xindex> to vector<4x1xindex>
+//   CHECK-DAG:   %[[ADDI:.+]] = arith.addi %[[MULI]], %[[BROADCAST_4x1]] overflow<nsw> : vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_COND_0:.+]] = vector.extract %[[CMPI]][0, 0] : i1 from vector<4x1xi1>
+//       CHECK:   %[[EXTRACT_IDX_0:.+]] = vector.extract %[[ADDI]][0, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_DATA_0:.+]] = vector.extract %[[INPUT]][0] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   scf.if %[[EXTRACT_COND_0]] {
+//       CHECK:     vector.store %[[EXTRACT_DATA_0]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_0]]] : memref<128xf4E2M1FN>, vector<16xf4E2M1FN>
+//       CHECK:   }
+//       CHECK:   %[[EXTRACT_COND_1:.+]] = vector.extract %[[CMPI]][1, 0] : i1 from vector<4x1xi1>
+//       CHECK:   %[[EXTRACT_IDX_1:.+]] = vector.extract %[[ADDI]][1, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_DATA_1:.+]] = vector.extract %[[INPUT]][1] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   scf.if %[[EXTRACT_COND_1]] {
+//       CHECK:     vector.store %[[EXTRACT_DATA_1]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_1]]] : memref<128xf4E2M1FN>, vector<16xf4E2M1FN>
+//       CHECK:   }
+//       CHECK:   %[[EXTRACT_COND_2:.+]] = vector.extract %[[CMPI]][2, 0] : i1 from vector<4x1xi1>
+//       CHECK:   %[[EXTRACT_IDX_2:.+]] = vector.extract %[[ADDI]][2, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_DATA_2:.+]] = vector.extract %[[INPUT]][2] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//       CHECK:   scf.if %[[EXTRACT_COND_2]] {
+//       CHECK:     vector.store %[[EXTRACT_DATA_2]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_2]]] : memref<128xf4E2M1FN>, vector<16xf4E2M1FN>
+//       CHECK:   }
+//       CHECK:   %[[EXTRACT_COND_3:.+]] = vector.extract %[[CMPI]][3, 0] : i1 from vector<4x1xi1>
+//       CHECK:   %[[EXTRACT_IDX_3:.+]] = vector.extract %[[ADDI]][3, 0] : index from vector<4x1xindex>
+//       CHECK:   %[[EXTRACT_DATA_3:.+]] = vector.extract %[[INPUT]][3] : vector<16xf4E2M1FN> from vector<4x16xf4E2M1FN>
+//   CHECK-NOT:   iree_linalg_ext.map_scatter
+//       CHECK:   scf.if %[[EXTRACT_COND_3]] {
+//       CHECK:     vector.store %[[EXTRACT_DATA_3]], %[[FLAT_OUTPUT]][%[[EXTRACT_IDX_3]]] : memref<128xf4E2M1FN>, vector<16xf4E2M1FN>
+//       CHECK:   }
+
+// -----
+
+func.func @map_scatter_sub_byte_not_unit_stride(
+    %input: vector<2x2xf4E2M1FN>, %output: memref<2x4xf4E2M1FN>
+) {
+  // expected-error@+1 {{with an access on a sub-byte type that is not a multiple of the byte size can't be vectorized}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      %1 = affine.apply affine_map<(d0) -> (d0 * 2)>(%idx1)
+      iree_linalg_ext.yield %idx0, %1, %mask : index, index, i1
+  } : vector<2x2xf4E2M1FN> into memref<2x4xf4E2M1FN>
+  return
+}
+
+// -----
+
+func.func @map_scatter_with_mask_on_inner_dim(
+    %input: vector<4x16xf4E2M1FN>, %output: memref<8x16xf4E2M1FN>
+) {
+  %c4 = arith.constant 4 : index
+  // expected-error@+1 {{on sub-byte type with potentially non byte aligned transformation}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.cmpi ult, %idx1, %c4 : index
+      iree_linalg_ext.yield %idx0, %idx1, %mask : index, index, i1
+  } : vector<4x16xf4E2M1FN> into memref<8x16xf4E2M1FN>
+  return
+}

--- a/compiler/src/iree/compiler/Utils/Indexing.cpp
+++ b/compiler/src/iree/compiler/Utils/Indexing.cpp
@@ -148,7 +148,7 @@ std::optional<int64_t> getCoefficient(Value a, Value b) {
   if (a == b) {
     return 1;
   }
-  auto applyOp = dyn_cast<affine::AffineApplyOp>(a.getDefiningOp());
+  auto applyOp = dyn_cast_if_present<affine::AffineApplyOp>(a.getDefiningOp());
   if (!applyOp) {
     return std::nullopt;
   }


### PR DESCRIPTION
Resolves: https://github.com/iree-org/iree/issues/22215

Vectorizes `map_scatter` on sub-byte types with contiguous accesses that are a multiple of a byte size to a sequence of `vector.extract` and `vector.store` operations.