### PR TITLE
[LinalgExt] Added TilingInterface support for ExpReductionOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2290,6 +2290,21 @@ LogicalResult ExpReductionOp::verify() {
     }
   }
 
+  for (Value &input : getDpsInputs()) {
+    auto type = input.getType();
+    if (!llvm::isa<ShapedType>(type))
+      return op->emitOpError("input must have a shaped type");
+  }
+
+  for (Value init : getDpsInits()) {
+    auto type = init.getType();
+    if (!llvm::isa<ShapedType>(type))
+      return op->emitOpError("init must have a shaped type");
+  }
+
+  if (!linalg::allIndexingsAreProjectedPermutation(*this))
+    return op->emitOpError("all indexing maps must be projected permutations");
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2265,6 +2265,14 @@ void OnlineAttentionOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 // ExpReductionOp
 //===----------------------------------------------------------------------===//
 
+bool ExpReductionOp::hasIndexSemantics() {
+  return !this->getBody()->getOps<linalg::IndexOp>().empty();
+}
+
+std::string ExpReductionOp::getLibraryCallName() {
+  return linalg::generateLibraryCallName(getOperation());
+}
+
 LogicalResult ExpReductionOp::verify() {
   Operation *op = getOperation();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2286,18 +2286,6 @@ LogicalResult ExpReductionOp::verify() {
     }
   }
 
-  for (Value &input : getDpsInputs()) {
-    auto type = input.getType();
-    if (!llvm::isa<ShapedType>(type))
-      return op->emitOpError("input must have a shaped type");
-  }
-
-  for (Value init : getDpsInits()) {
-    auto type = init.getType();
-    if (!llvm::isa<ShapedType>(type))
-      return op->emitOpError("init must have a shaped type");
-  }
-
   if (!allIndexingsAreProjectedPermutation(*this))
     return op->emitOpError("all indexing maps must be projected permutations");
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2290,6 +2290,10 @@ LogicalResult ExpReductionOp::verify() {
     return op->emitOpError("all indexing maps must be projected permutations");
   }
 
+  if (!getBody()->getOps<linalg::IndexOp>().empty()) {
+    return op->emitOpError("linalg.index is not supported in body");
+  }
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2286,8 +2286,9 @@ LogicalResult ExpReductionOp::verify() {
     }
   }
 
-  if (!allIndexingsAreProjectedPermutation(*this))
+  if (!allIndexingsAreProjectedPermutation(*this)) {
     return op->emitOpError("all indexing maps must be projected permutations");
+  }
 
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1007,8 +1007,19 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
 // ExpReduction
 //===----------------------------------------------------------------------===//
 
-def IREELinalgExt_ExpReductionOp : IREELinalgExt_Op<"exp_reduction",
-    [AttrSizedOperandSegments]> {
+def IREELinalgExt_ExpReductionOp : IREELinalgExt_Op<"exp_reduction", [
+  DeclareOpInterfaceMethods<LinalgStructuredInterface, [
+    "getLibraryCallName"
+  ]>,
+  DeclareOpInterfaceMethods<TilingInterface,
+  [
+    "getLoopIteratorTypes",
+    "getIterationDomain",
+    "getTiledImplementation",
+    "getResultTilePosition",
+    "generateResultTileValue"
+  ]>
+]> {
   let summary = [{
     A linalg.generic extension with support for exponential reduction.
   }];

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1008,6 +1008,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_ExpReductionOp : IREELinalgExt_Op<"exp_reduction", [
+  AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<LinalgStructuredInterface, [
     "getLibraryCallName",
     "getIteratorTypesArray"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1009,7 +1009,8 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
 
 def IREELinalgExt_ExpReductionOp : IREELinalgExt_Op<"exp_reduction", [
   DeclareOpInterfaceMethods<LinalgStructuredInterface, [
-    "getLibraryCallName"
+    "getLibraryCallName",
+    "getIteratorTypesArray"
   ]>,
   DeclareOpInterfaceMethods<TilingInterface,
   [

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1009,10 +1009,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_Op<"online_attention",
 
 def IREELinalgExt_ExpReductionOp : IREELinalgExt_Op<"exp_reduction", [
   AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<LinalgStructuredInterface, [
-    "getLibraryCallName",
-    "getIteratorTypesArray"
-  ]>,
+  DeclareOpInterfaceMethods<IndexingMapOpInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
   [
     "getLoopIteratorTypes",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1951,8 +1951,12 @@ ExpReductionOp::getTiledImplementation(OpBuilder &b,
                 v.getDefiningOp());
           }),
       [](Value v) -> Operation * { return v.getDefiningOp(); });
-  SmallVector<Type> resultTensorTypes =
-      getTensorOutputTypes(linalgOp, tiledOperands);
+  SmallVector<Type, 4> resultTensorTypes;
+  if (getNumResults()) {
+    resultTensorTypes = llvm::map_to_vector<4>(
+        tiledOperands, [](Value v) { return v.getType(); });
+  }
+
   Operation *tiledOp = mlir::clone(b, *this, resultTensorTypes, tiledOperands);
   offsetIndices(b, cast<linalg::LinalgOp>(tiledOp), offsets);
   return TilingResult{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1961,6 +1961,11 @@ FailureOr<TilingResult>
 ExpReductionOp::getTiledImplementation(OpBuilder &b,
                                        ArrayRef<OpFoldResult> offsets,
                                        ArrayRef<OpFoldResult> sizes) {
+  if (!getBody()->getOps<linalg::IndexOp>().empty()) {
+    return getOperation()->emitOpError(
+        "tiling of operations using linalg.index is not supported for now");
+  }
+
   Location loc = getLoc();
   auto indexingMapOp = cast<IndexingMapOpInterface>(getOperation());
   SmallVector<Value> valuesToTile = getOperands();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1946,13 +1946,12 @@ SmallVector<utils::IteratorType> ExpReductionOp::getLoopIteratorTypes() {
 
 SmallVector<Range> ExpReductionOp::getIterationDomain(OpBuilder &b) {
   Location loc = getLoc();
-  SmallVector<OpFoldResult> allShapesSizes =
-      createFlatListOfOperandDims(b, loc, getOperation());
-  AffineMap map = getShapesToLoopsMap();
-
   OpFoldResult zero = b.getIndexAttr(0);
   OpFoldResult one = b.getIndexAttr(1);
 
+  SmallVector<OpFoldResult> allShapesSizes =
+      createFlatListOfOperandDims(b, loc, getOperation());
+  AffineMap map = getShapesToLoopsMap();
   return llvm::map_to_vector(map.getResults(), [&](AffineExpr loopExpr) {
     OpFoldResult ofr =
         affine::makeComposedFoldedAffineApply(b, loc, loopExpr, allShapesSizes);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -89,7 +89,7 @@ createFlatListOfOperandDims(OpBuilder &b, Location loc, Operation *op) {
 }
 
 /// Permutes the offset and size arrays by the result indexes of the provided
-/// affine map
+/// affine map.
 static SmallVector<Range> getPermutedRange(AffineMap permutation,
                                            ArrayRef<OpFoldResult> offsets,
                                            ArrayRef<OpFoldResult> sizes) {
@@ -99,11 +99,7 @@ static SmallVector<Range> getPermutedRange(AffineMap permutation,
   SmallVector<Range> output;
   for (AffineExpr dimExpr : permutation.getResults()) {
     int dim = cast<AffineDimExpr>(dimExpr).getPosition();
-    Range dimRange;
-    dimRange.offset = offsets[dim];
-    dimRange.size = sizes[dim];
-    dimRange.stride = one;
-    output.push_back(dimRange);
+    output.push_back(Range{offsets[dim], sizes[dim], one});
   }
   return output;
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1912,6 +1912,10 @@ createFlatListOfOperandDims(ExpReductionOp op, OpBuilder &b, Location loc) {
   return res;
 }
 
+SmallVector<utils::IteratorType> ExpReductionOp::getIteratorTypesArray() {
+  return getLoopIteratorTypes();
+}
+
 SmallVector<Range> ExpReductionOp::getIterationDomain(OpBuilder &b) {
   ExpReductionOp op = *this;
   OpBuilder::InsertionGuard g(b);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -68,11 +68,13 @@ getStaticOrReifiedInputDims(OpBuilder &builder, Location loc, Value input,
 }
 
 static int64_t getRank(OpOperand &opOperand) {
-  Type type = opOperand.get().getType();
-  if (type.isIntOrIndexOrFloat()) {
+  ShapedType type = dyn_cast<ShapedType>(opOperand.get().getType());
+  if (!type) {
+    assert(opOperand.get().getType().isIntOrIndexOrFloat() &&
+           "unshaped type should be int or index or float");
     return 0;
   }
-  return cast<RankedTensorType>(type).getRank();
+  return type.getRank();
 }
 
 /// Method similar to `LinalgOp`s that concatenates shapes of all operands.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1998,8 +1998,13 @@ LogicalResult ExpReductionOp::getResultTilePosition(
   OpOperand *outOperand = getDpsInitOperand(resultNumber);
   AffineMap indexingMap = indexingMapOp.getMatchingIndexingMap(outOperand);
   SmallVector<Range> range = getPermutedRange(indexingMap, offsets, sizes);
-  resultOffsets = llvm::map_to_vector(range, [](Range &r) { return r.offset; });
-  resultSizes = llvm::map_to_vector(range, [](Range &r) { return r.size; });
+
+  resultOffsets.resize(range.size());
+  resultSizes.resize(range.size());
+  for (auto [index, r] : llvm::enumerate(range)) {
+    resultOffsets[index] = r.offset;
+    resultSizes[index] = r.size;
+  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -80,8 +80,8 @@ static SmallVector<OpFoldResult>
 createFlatListOfOperandDims(OpBuilder &b, Location loc, Operation *op) {
   SmallVector<OpFoldResult> res;
   for (OpOperand &opOperand : op->getOpOperands()) {
-    for (int64_t i = 0, e = getRank(opOperand); i < e; ++i) {
-      res.push_back(linalg::createFoldedDimOp(b, loc, opOperand.get(), i));
+    for (auto dim : llvm::seq(getRank(opOperand))) {
+      res.push_back(linalg::createFoldedDimOp(b, loc, opOperand.get(), dim));
     }
   }
   return res;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -3201,9 +3201,9 @@ LogicalResult OnlineAttentionOp::getPartialResultTilePosition(
 /// `getIterationDomain` of `LinalgOp`s.
 
 SmallVector<utils::IteratorType> CustomOp::getLoopIteratorTypes() {
-  return llvm::to_vector(getIteratorTypes()
-                             .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
-                                              utils::IteratorType>());
+  return llvm::map_to_vector(getIteratorTypes(), [](Attribute attr) {
+    return cast<IREE::LinalgExt::IteratorTypeAttr>(attr).getValue();
+  });
 }
 
 SmallVector<Range> CustomOp::getIterationDomainForDimensions(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1905,8 +1905,9 @@ static SmallVector<OpFoldResult>
 createFlatListOfOperandDims(ExpReductionOp op, OpBuilder &b, Location loc) {
   SmallVector<OpFoldResult> res;
   for (OpOperand &opOperand : op->getOpOperands()) {
-    for (int64_t i = 0, e = op.getRank(&opOperand); i < e; ++i)
+    for (int64_t i = 0, e = op.getRank(&opOperand); i < e; ++i) {
       res.push_back(linalg::createFoldedDimOp(b, loc, opOperand.get(), i));
+    }
   }
   return res;
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1916,9 +1916,11 @@ SmallVector<Range> UnPackOp::getIterationDomain(OpBuilder &builder) {
 //===----------------------------------------------------------------------===//
 
 SmallVector<utils::IteratorType> ExpReductionOp::getLoopIteratorTypes() {
-  return llvm::map_to_vector(getIteratorTypes(), [](Attribute attr) {
-    return cast<IREE::LinalgExt::IteratorTypeAttr>(attr).getValue();
-  });
+  SmallVector<utils::IteratorType> iteratorTypes(
+      getIteratorTypes()
+          .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
+                           utils::IteratorType>());
+  return iteratorTypes;
 }
 SmallVector<utils::IteratorType> ExpReductionOp::getIteratorTypesArray() {
   return getLoopIteratorTypes();
@@ -3220,9 +3222,11 @@ LogicalResult OnlineAttentionOp::getPartialResultTilePosition(
 /// `getIterationDomain` of `LinalgOp`s.
 
 SmallVector<utils::IteratorType> CustomOp::getLoopIteratorTypes() {
-  return llvm::map_to_vector(getIteratorTypes(), [](Attribute attr) {
-    return cast<IREE::LinalgExt::IteratorTypeAttr>(attr).getValue();
-  });
+  SmallVector<utils::IteratorType> iteratorTypes(
+      getIteratorTypes()
+          .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
+                           utils::IteratorType>());
+  return iteratorTypes;
 }
 
 SmallVector<Range> CustomOp::getIterationDomainForDimensions(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1939,6 +1939,10 @@ ExpReductionOp::getTiledImplementation(OpBuilder &b,
   // Leave the `sizeBounds` value empty. That is only needed when the `sizes`
   // specified could lead to out of bounds accesses.
   Location loc = getLoc();
+
+  IndexingMapOpInterface indexingMapOp =
+      cast<IndexingMapOpInterface>(getOperation());
+
   linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(getOperation());
   SmallVector<Value> valuesToTile = linalgOp->getOperands();
   SmallVector<Value> tiledOperands =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -67,6 +67,7 @@ getStaticOrReifiedInputDims(OpBuilder &builder, Location loc, Value input,
   return success();
 }
 
+/// gets the rank of the opOperand's type
 static int64_t getRank(OpOperand &opOperand) {
   ShapedType type = dyn_cast<ShapedType>(opOperand.get().getType());
   if (!type) {
@@ -89,6 +90,8 @@ createFlatListOfOperandDims(OpBuilder &b, Location loc, Operation *op) {
   return res;
 }
 
+/// permutes the offset and size arrays by the result indexes of the provided
+/// affine map
 static SmallVector<Range> getPermutedRange(AffineMap permutation,
                                            ArrayRef<OpFoldResult> offsets,
                                            ArrayRef<OpFoldResult> sizes) {
@@ -1936,11 +1939,9 @@ SmallVector<Range> UnPackOp::getIterationDomain(OpBuilder &builder) {
 //===----------------------------------------------------------------------===//
 
 SmallVector<utils::IteratorType> ExpReductionOp::getLoopIteratorTypes() {
-  SmallVector<utils::IteratorType> iteratorTypes(
-      getIteratorTypes()
-          .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
-                           utils::IteratorType>());
-  return iteratorTypes;
+  return llvm::to_vector(getIteratorTypes()
+                             .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
+                                              utils::IteratorType>());
 }
 
 SmallVector<Range> ExpReductionOp::getIterationDomain(OpBuilder &b) {
@@ -1970,7 +1971,6 @@ ExpReductionOp::getTiledImplementation(OpBuilder &b,
 
   Location loc = getLoc();
   auto indexingMapOp = cast<IndexingMapOpInterface>(getOperation());
-  SmallVector<Value> valuesToTile = getOperands();
   SmallVector<Value> tiledOperands;
   SmallVector<Operation *> generatedSlices;
   for (OpOperand &opOperand : getOperation()->getOpOperands()) {
@@ -3213,11 +3213,9 @@ LogicalResult OnlineAttentionOp::getPartialResultTilePosition(
 /// `getIterationDomain` of `LinalgOp`s.
 
 SmallVector<utils::IteratorType> CustomOp::getLoopIteratorTypes() {
-  SmallVector<utils::IteratorType> iteratorTypes(
-      getIteratorTypes()
-          .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
-                           utils::IteratorType>());
-  return iteratorTypes;
+  return llvm::to_vector(getIteratorTypes()
+                             .getAsValueRange<IREE::LinalgExt::IteratorTypeAttr,
+                                              utils::IteratorType>());
 }
 
 SmallVector<Range> CustomOp::getIterationDomainForDimensions(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1992,14 +1992,17 @@ ExpReductionOp::generateResultTileValue(OpBuilder &b, unsigned resultNumber,
           b, resultNumber, offsets, sizes, mappedOffsets, mappedSizes))) {
     return failure();
   }
+
   FailureOr<TilingResult> tilingResult =
       getTiledImplementation(b, mappedOffsets, mappedSizes);
 
-  if (failed(tilingResult))
+  if (failed(tilingResult)) {
     return failure();
+  }
 
-  if (tilingResult->tiledOps.size() != 1)
+  if (tilingResult->tiledOps.size() != 1) {
     return emitOpError("failed to generate tiled implementation");
+  }
 
   return TilingResult{
       tilingResult->tiledOps,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1945,18 +1945,18 @@ SmallVector<utils::IteratorType> ExpReductionOp::getLoopIteratorTypes() {
 }
 
 SmallVector<Range> ExpReductionOp::getIterationDomain(OpBuilder &b) {
-  ExpReductionOp op = *this;
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPoint(op);
   Location loc = getLoc();
   SmallVector<OpFoldResult> allShapesSizes =
-      createFlatListOfOperandDims(b, loc, op);
+      createFlatListOfOperandDims(b, loc, getOperation());
   AffineMap map = getShapesToLoopsMap();
+
+  OpFoldResult zero = b.getIndexAttr(0);
+  OpFoldResult one = b.getIndexAttr(1);
 
   return llvm::map_to_vector(map.getResults(), [&](AffineExpr loopExpr) {
     OpFoldResult ofr =
         affine::makeComposedFoldedAffineApply(b, loc, loopExpr, allShapesSizes);
-    return Range{b.getIndexAttr(0), ofr, b.getIndexAttr(1)};
+    return Range{zero, ofr, one};
   });
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -69,7 +69,7 @@ getStaticOrReifiedInputDims(OpBuilder &builder, Location loc, Value input,
 
 /// Returns the rank of the Value's type, and 0 if it is not a ShapedType.
 static int64_t getRank(Value v) {
-  ShapedType type = dyn_cast<ShapedType>(v.getType());
+  auto type = dyn_cast<ShapedType>(v.getType());
   if (type) {
     return type.getRank();
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1085,7 +1085,7 @@ func.func @exp_reduction_index_check(%S: tensor<2x3xf32>) -> tensor<2xf32> {
 
 // -----
 
-func.func @exp_reduction_shaped_init(%S: f32) -> tensor<2xf32> {
+func.func @exp_reduction_shaped_input(%S: f32) -> tensor<2xf32> {
   %M = tensor.empty() : tensor<2xf32>
   %out = tensor.empty() : tensor<2xf32>
 
@@ -1113,7 +1113,7 @@ func.func @exp_reduction_shaped_init(%S: f32) -> tensor<2xf32> {
 
 // -----
 
-func.func @exp_reduction_projected(%S: tensor<2x3xf32>, %M : f32) -> tensor<2xf32> {
+func.func @exp_reduction_shaped_init(%S: tensor<2x3xf32>, %M : f32) -> tensor<2xf32> {
   %out = tensor.empty() : tensor<2xf32>
 
   // expected-error@+1 {{operand #1 must be variadic of ranked tensor of any type values, but got 'f32'}}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1029,7 +1029,7 @@ func.func @unpack_mismatch_inner_tile_size_and_output_shape(
 
 // -----
 
-func.func @exp_reduction(%S: tensor<2x3xf32>) -> tensor<2xf32> {
+func.func @exp_reduction_non_zero(%S: tensor<2x3xf32>) -> tensor<2xf32> {
   %M = tensor.empty() : tensor<2xf32>
   %out = tensor.empty() : tensor<2xf32>
 
@@ -1057,7 +1057,7 @@ func.func @exp_reduction(%S: tensor<2x3xf32>) -> tensor<2xf32> {
 
 // -----
 
-func.func @exp_reduction(%S: tensor<2x3xf32>) -> tensor<2xf32> {
+func.func @exp_reduction_index_check(%S: tensor<2x3xf32>) -> tensor<2xf32> {
   %M = tensor.empty() : tensor<2xf32>
   %out = tensor.empty() : tensor<2xf32>
 
@@ -1082,6 +1082,90 @@ func.func @exp_reduction(%S: tensor<2x3xf32>) -> tensor<2xf32> {
   } -> tensor<2xf32>, tensor<2xf32>
   return %sum : tensor<2xf32>
 }
+
+// -----
+
+func.func @exp_reduction_shaped_init(%S: f32) -> tensor<2xf32> {
+  %M = tensor.empty() : tensor<2xf32>
+  %out = tensor.empty() : tensor<2xf32>
+
+  // expected-error@+1 {{operand #0 must be variadic of ranked tensor of any type values, but got 'f32'}}
+  %max, %sum = iree_linalg_ext.exp_reduction {
+    indexing_maps = [
+      affine_map<(M,N)->()>,
+      affine_map<(M,N)->(M)>,
+      affine_map<(M,N)->(M)>
+    ],
+    iterator_types = [
+      #iree_linalg_ext.iterator_type<parallel>,
+      #iree_linalg_ext.iterator_type<reduction>
+    ],
+    exp_reduced_operands = [1]
+  } ins(%S: f32)
+    outs(%M, %out: tensor<2xf32>, tensor<2xf32>)
+  {
+  ^bb0(%s: f32, %m: f32, %o: f32):
+    %add = arith.addf %s, %o: f32
+    iree_linalg_ext.yield %m, %add: f32, f32
+  } -> tensor<2xf32>, tensor<2xf32>
+  return %sum : tensor<2xf32>
+}
+
+// -----
+
+func.func @exp_reduction_projected(%S: tensor<2x3xf32>, %M : f32) -> tensor<2xf32> {
+  %out = tensor.empty() : tensor<2xf32>
+
+  // expected-error@+1 {{operand #1 must be variadic of ranked tensor of any type values, but got 'f32'}}
+  %max, %sum = iree_linalg_ext.exp_reduction {
+    indexing_maps = [
+      affine_map<(M,N)->(M,N)>,
+      affine_map<(M,N)->()>,
+      affine_map<(M,N)->(M)>
+    ],
+    iterator_types = [
+      #iree_linalg_ext.iterator_type<parallel>,
+      #iree_linalg_ext.iterator_type<reduction>
+    ],
+    exp_reduced_operands = [1]
+  } ins(%S: tensor<2x3xf32>)
+    outs(%M, %out: f32, tensor<2xf32>)
+  {
+  ^bb0(%s: f32, %m: f32, %o: f32):
+    %add = arith.addf %s, %o: f32
+    iree_linalg_ext.yield %m, %add: f32, f32
+  } -> f32, tensor<2xf32>
+  return %sum : tensor<2xf32>
+}
+
+// -----
+
+func.func @exp_reduction_projected(%S: tensor<2x3xf32>) -> tensor<2xf32> {
+  %M = tensor.empty() : tensor<2xf32>
+  %out = tensor.empty() : tensor<2xf32>
+
+  // expected-error@+1 {{all indexing maps must be projected permutations}}
+  %max, %sum = iree_linalg_ext.exp_reduction {
+    indexing_maps = [
+      affine_map<(M,N)[s0]->(M,N)>,
+      affine_map<(M,N)->(M)>,
+      affine_map<(M,N)->(M)>
+    ],
+    iterator_types = [
+      #iree_linalg_ext.iterator_type<parallel>,
+      #iree_linalg_ext.iterator_type<reduction>
+    ],
+    exp_reduced_operands = [1]
+  } ins(%S: tensor<2x3xf32>)
+    outs(%M, %out: tensor<2xf32>, tensor<2xf32>)
+  {
+  ^bb0(%s: f32, %m: f32, %o: f32):
+    %add = arith.addf %s, %o: f32
+    iree_linalg_ext.yield %m, %add: f32, f32
+  } -> tensor<2xf32>, tensor<2xf32>
+  return %sum : tensor<2xf32>
+}
+
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1088,6 +1088,127 @@ module attributes { transform.with_named_sequence } {
 // CHECK:           scf.yield %[[INS0]], %[[INS1]]
 // CHECK:         return %[[RESULT]]#0, %[[RESULT]]#1
 
+
+// -----
+
+func.func @exp_reduction_tile_tensor_static_uniform(
+    %S: tensor<100x10xf32>,
+    %M: tensor<100xf32>,
+    %out: tensor<100xf32>
+) -> (tensor<100xf32>, tensor<100xf32>) {
+    %max, %sum = iree_linalg_ext.exp_reduction {
+    indexing_maps = [
+      affine_map<(M,N)->(M,N)>,
+      affine_map<(M,N)->(M)>,
+      affine_map<(M,N)->(M)>
+    ],
+    iterator_types = [
+      #iree_linalg_ext.iterator_type<parallel>,
+      #iree_linalg_ext.iterator_type<reduction>
+    ],
+    exp_reduced_operands = [1]
+  } ins(%S: tensor<100x10xf32>)
+    outs(%M, %out: tensor<100xf32>, tensor<100xf32>)
+  {
+  ^bb0(%s: f32, %m: f32, %o: f32):
+    %add = arith.addf %s, %o: f32
+    iree_linalg_ext.yield %m, %add: f32, f32
+  } -> tensor<100xf32>, tensor<100xf32>
+  return %max, %sum : tensor<100xf32>, tensor<100xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["iree_linalg_ext.exp_reduction"]} in %module_op
+         : (!transform.any_op) -> !transform.any_op
+    %1, %loops = transform.structured.tile_using_for %0 tile_sizes [10, 0]
+         : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:       func.func @exp_reduction_tile_tensor_static_uniform
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK:         %[[RESULT:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C100]] step %[[C10]] iter_args(%[[V0:.+]] = %[[ARG1]], %[[V1:.+]] = %[[ARG2]])
+// CHECK:           %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[IV]], 0] [10, 10] [1, 1]
+// CHECK:           %[[SLICE1:.+]] = tensor.extract_slice %[[V0]][%[[IV]]] [10] [1]
+// CHECK:           %[[SLICE2:.+]] = tensor.extract_slice %[[V1]][%[[IV]]] [10] [1]
+// CHECK:           %[[CMP:.+]]:2 = iree_linalg_ext.exp_reduction
+// CHECK-SAME:      ins(%[[SLICE0]]
+// CHECK-SAME:      outs(%[[SLICE1]], %[[SLICE2]]
+// CHECK:           %[[INS0:.+]] = tensor.insert_slice %[[CMP]]#0 into %[[V0]][%[[IV]]] [10] [1]
+// CHECK:           %[[INS1:.+]] = tensor.insert_slice %[[CMP]]#1 into %[[V1]][%[[IV]]] [10] [1]
+// CHECK:           scf.yield %[[INS0]], %[[INS1]]
+// CHECK:         return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+func.func @exp_reduction_tile_tensor_static_nonuniform(
+    %S: tensor<104x10xf32>,
+    %M: tensor<104xf32>,
+    %out: tensor<104xf32>
+) -> (tensor<104xf32>, tensor<104xf32>) {
+    %max, %sum = iree_linalg_ext.exp_reduction {
+    indexing_maps = [
+      affine_map<(M,N)->(M,N)>,
+      affine_map<(M,N)->(M)>,
+      affine_map<(M,N)->(M)>
+    ],
+    iterator_types = [
+      #iree_linalg_ext.iterator_type<parallel>,
+      #iree_linalg_ext.iterator_type<reduction>
+    ],
+    exp_reduced_operands = [1]
+  } ins(%S: tensor<104x10xf32>)
+    outs(%M, %out: tensor<104xf32>, tensor<104xf32>)
+  {
+  ^bb0(%s: f32, %m: f32, %o: f32):
+    %add = arith.addf %s, %o: f32
+    iree_linalg_ext.yield %m, %add: f32, f32
+  } -> tensor<104xf32>, tensor<104xf32>
+  return %max, %sum : tensor<104xf32>, tensor<104xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["iree_linalg_ext.exp_reduction"]} in %module_op
+         : (!transform.any_op) -> !transform.any_op
+    %1, %loops = transform.structured.tile_using_for %0 tile_sizes [10, 0]
+         : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+
+// CHECK-DAG:  #[[MAP0:.+]] = affine_map<(d0) -> (-d0 + 104, 10)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:       func.func @exp_reduction_tile_tensor_static_nonuniform
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C104:.+]] = arith.constant 104 : index
+// CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
+// CHECK:         %[[RESULT:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[C104]] step %[[C10]] iter_args(%[[V0:.+]] = %[[ARG1]], %[[V1:.+]] = %[[ARG2]])
+// CHECK:           %[[MIN:.+]] = affine.min #[[MAP0]](%[[IV]])
+// CHECK:           %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[IV]], 0] [%[[MIN]], 10] [1, 1]
+// CHECK:           %[[SLICE1:.+]] = tensor.extract_slice %[[V0]][%[[IV]]] [%[[MIN]]] [1]
+// CHECK:           %[[SLICE2:.+]] = tensor.extract_slice %[[V1]][%[[IV]]] [%[[MIN]]] [1]
+// CHECK:           %[[CMP:.+]]:2 = iree_linalg_ext.exp_reduction
+// CHECK-SAME:      ins(%[[SLICE0]]
+// CHECK-SAME:      outs(%[[SLICE1]], %[[SLICE2]]
+// CHECK:           %[[INS0:.+]] = tensor.insert_slice %[[CMP]]#0 into %[[V0]][%[[IV]]] [%[[MIN]]] [1]
+// CHECK:           %[[INS1:.+]] = tensor.insert_slice %[[CMP]]#1 into %[[V1]][%[[IV]]] [%[[MIN]]] [1]
+// CHECK:           scf.yield %[[INS0]], %[[INS1]]
+// CHECK:         return %[[RESULT]]#0, %[[RESULT]]#1
+
 // -----
 
 func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {


### PR DESCRIPTION
This is part 2 of #21761. In this PR, we:
- Added TilingInterface to ExpReductionOp.
- Added LinalgStructuredInterface to ExpReductionOp. 
- Added invalid and tiling tests
  - ExpReductionOp now does not accept use of linalg.index.
  - All indexing maps used by ExpReductionOp must now be projected permutations.
- Refactored logic shared with other components:
  - AttentionOp's `getPermutedRange` utility function is shared
  - CustomOp's `createFlatListOfOperandDims` utility function is shared 
  - The `StaticizeLinalgExtOp` rewrite now calls a utility function `allIndexingsAreProjectedPermutation` to check for all indexing maps being permutations.

Co-authored-by: Kunwar Grover [groverkss@gmail.com](mailto:groverkss@gmail.com)