### PR TITLE
Enable tensor ukernels by default

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMAttrs.cpp
@@ -81,18 +81,26 @@ static bool checkIterationSizeConstraints(ArrayRef<int64_t> iterationSizes,
     if (indexVal < 0 || indexVal >= iterationSizes.size()) {
       return false;
     }
+    // For now, assume a dynamic dimension is very large.
     if (IntegerAttr sizeMin = constraint.getSizeMin()) {
-      if (iterationSizes[indexVal] < sizeMin.getInt()) {
+      if (!ShapedType::isDynamic(iterationSizes[indexVal]) &&
+          iterationSizes[indexVal] < sizeMin.getInt()) {
         return false;
       }
     }
     if (IntegerAttr sizeMax = constraint.getSizeMax()) {
+      if (ShapedType::isDynamic(iterationSizes[indexVal])) {
+        return false;
+      }
       if (iterationSizes[indexVal] > sizeMax.getInt()) {
         return false;
       }
     }
     if (IntegerAttr sizeDiv = constraint.getSizeDiv()) {
       if (sizeDiv.getInt() <= 0) {
+        return false;
+      }
+      if (ShapedType::isDynamic(iterationSizes[indexVal])) {
         return false;
       }
       if (iterationSizes[indexVal] % sizeDiv.getInt()) {

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -88,7 +88,9 @@ struct ROCMOptions {
   bool slpVectorization = true;
   bool globalISel = false;
   bool specializeDispatches = false;
-  bool enableTensorUKernels = false;
+  // The tensor ukernels are enabled by default as they provide the best
+  // performance.
+  bool enableTensorUKernels = true;
   IREE::Codegen::DenormalFpMath denormalFpMathF32 =
       IREE::Codegen::DenormalFpMath::None;
   bool enableRegSpillWarning = false;
@@ -369,11 +371,6 @@ public:
       }
     }
 
-    addConfig("ukernels", b.getStringAttr(options.enableROCMUkernels));
-    if (options.enableROCMUkernels != "none") {
-      addConfig("iree_codegen.ukernel_provider",
-                IREE::ROCM::UKernelProviderAttr::get(context));
-    }
     if (options.wavesPerEu > 0) {
       addConfigWavesPerEu(b.getContext(), options.wavesPerEu, configItems);
     }
@@ -382,7 +379,11 @@ public:
                                  configItems);
     }
 
-    if (options.enableTensorUKernels) {
+    addConfig("ukernels", b.getStringAttr(options.enableROCMUkernels));
+    if (options.enableROCMUkernels != "none") {
+      addConfig(kUKernelProviderName,
+                IREE::ROCM::UKernelProviderAttr::get(context));
+    } else if (options.enableTensorUKernels) {
       addConfig(kUKernelProviderName,
                 IREE::ROCM::TensorUKernelProviderAttr::get(context));
     }

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f16.mlir
@@ -17,7 +17,13 @@
 util.func @pingpong_dt_large_f16(%lhs_base: !lhs_base_ty, %rhs_base: !rhs_base_ty, %unused_acc: !acc_base_ty) -> !acc_base_ty attributes {
   ukernel_info = #rocm.ukernel_info<
     match = {
-      types = [f16, f16, f32]
+      types = [f16, f16, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<
+          index = 0,
+          size_min = 512
+        >
+      ]
     },
     mma = #iree_gpu.data_tiled_mma_layout<
       intrinsic = MFMA_F32_16x16x16_F16,

--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
@@ -726,10 +726,9 @@ pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_medium : benefit(1) {
   pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
 
   // Pingpong on outer K dim, this kernel has 2 pingpong stages.
-  %empty = pdl.attribute = {}
   %c1 = pdl.attribute = 1
   %c2 = pdl.attribute = 2
-  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c2, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+  pdl.apply_native_constraint "dimIsMultipleOf"(%rhs, %c1, %c2 : !pdl.value, !pdl.attribute, !pdl.attribute)
 
   pdl.rewrite {
     // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
@@ -783,10 +782,9 @@ pdl.pattern @annotate_inner_tiled_f8E4M3FNUZ_large : benefit(2) {
   pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
 
   // Pingpong on outer K dim, this kernel has 4 pingpong stages.
-  %empty = pdl.attribute = {}
   %c1 = pdl.attribute = 1
   %c4 = pdl.attribute = 4
-  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+  pdl.apply_native_constraint "dimIsMultipleOf"(%rhs, %c1, %c4 : !pdl.value, !pdl.attribute, !pdl.attribute)
 
   pdl.rewrite {
     // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.
@@ -840,10 +838,9 @@ pdl.pattern @annotate_inner_tiled_f16_large : benefit(1) {
   pdl.apply_native_constraint "matchCastCompatibleType"(%rhs, %rhs_cast_type : !pdl.value, !pdl.type)
 
   // Pingpong on outer K dim, this kernel has 4 pingpong stages.
-  %empty = pdl.attribute = {}
   %c1 = pdl.attribute = 1
   %c4 = pdl.attribute = 4
-  pdl.apply_native_constraint "dimIsBound"(%rhs, %c1, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+  pdl.apply_native_constraint "dimIsMultipleOf"(%rhs, %c1, %c4 : !pdl.value, !pdl.attribute, !pdl.attribute)
 
   pdl.rewrite {
     // Call the C++ "annotateOperation" utility to add the attributes to the matched linalg.generic op.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1499,6 +1499,34 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_${_CDNA_ARCH}_dt_no_tensor_ukernel_${_F8E4M3_TYPE}
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=${_F8E4M3_TYPE}"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-dispatch-creation-data-tiling"
+    "--iree-hip-enable-tensor-ukernels=false"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_${_CDNA_ARCH}_dt_${_F8E4M3_TYPE}_tensor_ukernel_medium
   TEST_TYPE
     matmul
@@ -1635,6 +1663,37 @@ iree_generated_e2e_runner_test(
     "--iree-dispatch-creation-data-tiling"
     "--iree-dispatch-creation-set-encoding-strategy=padding"
     "--iree-hip-encoding-layout-resolver=pad"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_no_tensor_ukernel_f16f16f32_large
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=1024,1024,1024"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels=false"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
This enables the MLIR tensor ukernels by default as they provide the best performance. All benchmark/production workloads I am aware of seem to set this flag to true already, so this should reduce the number of flags needed and avoid sudden regressions when people forget to set/carry the flag.

I will follow up with PRs in other repos that remove the usage of this flag.

@MaheshRavishankar Do we want to run an additional (nightly) test suite on this to make sure it's stable?

ci-extra: test_torch