### PR TITLE
Fix non-deterministic hoisting

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -174,7 +174,7 @@ private:
   //   LoadGlobalOp.result -> GlobalOp
   //   ConstantOp.result -> ConstantOp
   // Entries can come from the whole program.
-  llvm::DenseMap<Value, Operation *> constantRoots;
+  llvm::MapVector<Value, Operation *> constantRoots;
 
   // Map of analyzed value to corresponding info struct.
   llvm::DenseMap<Value, ConstValueInfo *> constInfoMap;

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h
@@ -8,7 +8,7 @@
 #define IREE_COMPILER_DIALECT_IREE_UTIL_ANALYSIS_CONSTANT_OP_ORACLE_H_
 
 #include "iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SetVector.h"
 #include "mlir/IR/Operation.h"
 
 namespace mlir::iree_compiler::IREE::Util {
@@ -25,7 +25,7 @@ struct ConstExprOpInfo {
   // Producer values that must be const-expr for this op to be considered
   // const-expr. This minimally includes operands, and for region-based ops
   // may include implicit captures.
-  llvm::SmallPtrSet<Value, 8> producers;
+  llvm::SmallSetVector<Value, 8> producers;
 
   // Gets information for an op.
   // Whether an op can be considered a pure expression, producing a constant if

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.h
@@ -403,7 +403,7 @@ private:
   DenseMap<StringRef, TraversalAction> dialectActions;
   DenseMap<OperationName, TraversalAction> opActions;
 
-  DenseMap<Operation *, std::unique_ptr<GlobalInfo>> globalInfos;
+  llvm::MapVector<Operation *, std::unique_ptr<GlobalInfo>> globalInfos;
   DenseMap<StringRef, GlobalInfo *> globalInfosByName;
   ModuleAnalysisManager analysisManager;
 };


### PR DESCRIPTION
This change ensures that `allocedConstInfos` has a deterministic order by changing some Map/Set types to MapVector/SetVector for deterministic iteration order. Previously, it was sorted topologically but this is not enough to ensure that hoisting doesn't lead to different results. 



Fixes torch_models post-submit failures. E.g. https://github.com/iree-org/iree/actions/runs/18539817006/job/52844787373

ci-extra: test_torch