### PR TITLE
Better diagnostic in `inner_tiled` verification

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -109,7 +109,7 @@ func.func @mma_inner_tiled_invalid_element_type(%lhs: tensor<?x?x4xf32>, %rhs: t
 // -----
 
 func.func @mma_inner_tiled_invalid_inner_types(%lhs: tensor<?x?x3xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-  // expected-error @+1 {{operation parallel semantics can't be inferred as either distributed or undistributed}}
+  // expected-error @+1 {{op tile shapes do not match, regardless of semantics. The semantics that this op comes closest to matching is: Distributed. However, even under that assumption, there is still a mismatch in operand 0, which has type tensor<?x?x3xf16>, whose inner tile dimensions have an element count of 3, which doesn't match the target vector type vector<4xf16>}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [affine_map<(i, j, k) -> (i, k)>, affine_map<(i, j, k) -> (k, j)>, affine_map<(i, j, k) -> (i, j)>],
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],


### PR DESCRIPTION
The `inner_tiled` op supports both pre- and post-thread-distribution semantics, a.k.a. "undistributed" vs "distributed". This mode switch is implicit and inferred from operand shapes and MFMA vector shapes. This makes it nontrivial to generate a good diagnostic when sizes don't line up, as in that case we have technically lost out only way to infer which semantics were intended.

This PR recovers what can be recovered with a minimal amount of complexity. A "magnitude" is associated to differences between the actual vs. expected sizes under each semantics. The diagnostic is then tailored to the semantics with the smaller "magnitude" of error.

The estimation is kept very naive and can be refined in the future as needed.

I tried to add "rank" as a metric that we try to match, in addition to "element count".  This didn't work: it turns out that we rely on tolerating mismatched unit dims everywhere.