### PR TITLE
[Codegen] Use llvm accumulate wrappers. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -1,4 +1,5 @@
 // Copyright 2024 The IREE Authors
+//
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -544,8 +544,8 @@ TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
 /// indices accordingly.
 static void remove(TileSwizzle &swizzle, size_t idx) {
   assert(idx < swizzle.expandShape.size() && "idx out of bounds");
-  const size_t startIdx = std::accumulate(
-      std::begin(swizzle.expandShape), std::begin(swizzle.expandShape) + idx, 0,
+  const size_t startIdx = llvm::accumulate(
+      ArrayRef(swizzle.expandShape).take_front(idx), size_t(0),
       [](size_t idx, const TileSwizzle::ExpandShapeDimVectorType &dims)
           -> size_t { return idx + dims.size(); });
   const size_t endIdx = startIdx + swizzle.expandShape[idx].size();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1775,9 +1775,7 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
       }
       if (vectorSize == 1) // assume there is fastpath + slowpath
         vectorSize = 4;
-      int64_t problemSize = std::accumulate(
-          shape.begin(), shape.end(), 1,
-          [](const int64_t &a, const int64_t &b) { return a * b; });
+      int64_t problemSize = llvm::product_of(shape);
       if ((problemSize / (preferredSubgroupSize * vectorSize)) < 64) {
         vectorSize = 1;
         break;


### PR DESCRIPTION
`std::accumulate` is bug-prone because the return type depends on the initial value passed in and not on the binary function or the element types. `llvm::product_of` and `llvm::sum_of` use the correct accumulator type by default.

Also remove the `prod` helper that tried to do the same thing by going through a ShapedType helper, and fix some minor formatting issues.