### PR TITLE
[CI][Torch] Update dispatch counts after non-determinism fix

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942",
-  "golden_dispatch_count": 1517,
+  "golden_dispatch_count": 1485,
   "golden_binary_size": 3000000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "sdxl/modules/clip_gfx942",
-  "golden_dispatch_count": 794,
+  "golden_dispatch_count": 792,
   "golden_binary_size": 460000
 }


### PR DESCRIPTION
These dispatch counts were kept at a higher value because of non-determinism in dispatch counts which was fixed by: https://github.com/iree-org/iree/commit/188c42ce8867b7a0f153f8dd0a9dcaa984d8df23 . Tightining the dispatch count check since it's deterministic now.

ci-extra: test_torch