### PR TITLE
[DT][NFCI] Implement getOffsetsSizesStrides for GPU padding resolver.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -5,18 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/EncodingUtils.h"
-#include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
-#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Utils/EncodingUtils.h"
-#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
-
-#include <optional>
 
 #define DEBUG_TYPE "iree-codegen-encoding-utils"
 
@@ -124,24 +116,9 @@ LogicalResult MaterializeEncodingTypeConverter::getOffsetsSizesStrides(
     SmallVectorImpl<OpFoldResult> &newOffsets,
     SmallVectorImpl<OpFoldResult> &newSizes,
     SmallVectorImpl<OpFoldResult> &newStrides) const {
-  auto boundType = dyn_cast<RankedTensorType>(type.getBoundType());
-  if (!boundType || !boundType.getEncoding()) {
-    return failure();
-  }
-  // TODO(jornt): The isa<IREE::GPU::GPUPaddingResolverAttr> check is
-  // needed because PaddingAttr is a serializable attribute, but it
-  // relies on its own type conversion for now. Once GPUPaddingResolverAttr
-  // implements `getOffsetsSizesStrides`, this can be removed.
-  if (!isa<IREE::GPU::GPUPaddingResolverAttr>(getLayoutAttr())) {
-    return getLayoutAttr().getOffsetsSizesStrides(
-        builder, loc, type, dynamicDims, offsets, sizes, strides, newOffsets,
-        newSizes, newStrides);
-  }
-  auto boundTensorType = cast<RankedTensorType>(type.getBoundType());
-  newSizes = getMixedValues(boundTensorType.getShape(), dynamicDims, builder);
-  newOffsets.resize(newSizes.size(), builder.getIndexAttr(0));
-  newStrides.resize(newSizes.size(), builder.getIndexAttr(1));
-  return success();
+  return getLayoutAttr().getOffsetsSizesStrides(
+      builder, loc, type, dynamicDims, offsets, sizes, strides, newOffsets,
+      newSizes, newStrides);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -116,95 +116,6 @@ struct MaterializePadEncodingTypeConverter final
   }
 };
 
-/// Pattern to convert `iree_tensor_ext.dispatch.tensor.load` operation when
-/// materializing the encoding.
-struct MaterializeFlowDispatchTensorLoadOp final
-    : OpConversionPattern<IREE::TensorExt::DispatchTensorLoadOp> {
-  using Base::Base;
-
-  LogicalResult
-  matchAndRewrite(IREE::TensorExt::DispatchTensorLoadOp loadOp,
-                  OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // Only handle operations where the load covers the entire
-    // `!iree_tensor_ext.dispatch.tensor` type.
-    if (!loadOp.isLoadOfWholeSource()) {
-      return rewriter.notifyMatchFailure(loadOp, "unhandled partial loads");
-    }
-
-    auto &typeConverter =
-        *getTypeConverter<MaterializePadEncodingTypeConverter>();
-    IREE::TensorExt::DispatchTensorType sourceType = loadOp.getSourceType();
-    auto boundTensorType = cast<RankedTensorType>(sourceType.getBoundType());
-    if (!typeConverter.hasNonZeroPadding(boundTensorType)) {
-      // Let the Nop pattern handle this.
-      return rewriter.notifyMatchFailure(loadOp, "no padding applied");
-    }
-
-    auto paddedType =
-        typeConverter.convertType<RankedTensorType>(boundTensorType);
-    assert(paddedType != boundTensorType && "Expected conversion with padding");
-
-    SmallVector<OpFoldResult> newMixedSizes =
-        getMixedValues(paddedType.getShape(), loadOp.getSourceDims(), rewriter);
-
-    SmallVector<OpFoldResult> newOffsets(newMixedSizes.size(),
-                                         rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult> newStrides(newMixedSizes.size(),
-                                         rewriter.getIndexAttr(1));
-    SmallVector<OpFoldResult> extractSizes = getMixedValues(
-        boundTensorType.getShape(), loadOp.getSourceDims(), rewriter);
-    rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorLoadOp>(
-        loadOp, adaptor.getSource(), loadOp.getSourceDims(), newOffsets,
-        extractSizes, newStrides);
-    return success();
-  }
-};
-
-/// Pattern to convert `iree_tensor_ext.dispatch.tensor.store` operation when
-/// materializing the encoding.
-struct MaterializeFlowDispatchTensorStoreOp final
-    : OpConversionPattern<IREE::TensorExt::DispatchTensorStoreOp> {
-  using Base::Base;
-
-  LogicalResult
-  matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp storeOp,
-                  OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // Only handle operations where the store covers the entire
-    // `!iree_tensor_ext.dispatch.tensor` type.
-    if (!storeOp.isStoreToWholeTarget()) {
-      return rewriter.notifyMatchFailure(storeOp, "unhandled partial stores");
-    }
-
-    auto &typeConverter =
-        *getTypeConverter<MaterializePadEncodingTypeConverter>();
-    IREE::TensorExt::DispatchTensorType targetType = storeOp.getTargetType();
-    auto boundTensorType = cast<RankedTensorType>(targetType.getBoundType());
-    if (!typeConverter.hasNonZeroPadding(boundTensorType)) {
-      // Let the Nop pattern handle this.
-      return rewriter.notifyMatchFailure(storeOp, "no padding applied");
-    }
-
-    IREE::TensorExt::DispatchTensorType newTargetType =
-        typeConverter.convertType<IREE::TensorExt::DispatchTensorType>(
-            targetType);
-    RankedTensorType paddedType = newTargetType.asRankedTensorType();
-
-    Location loc = storeOp.getLoc();
-    SmallVector<OpFoldResult> offsets(paddedType.getRank(),
-                                      rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult> strides(paddedType.getRank(),
-                                      rewriter.getIndexAttr(1));
-    SmallVector<OpFoldResult> sizes =
-        tensor::getMixedSizes(rewriter, loc, adaptor.getValue());
-    rewriter.replaceOpWithNewOp<IREE::TensorExt::DispatchTensorStoreOp>(
-        storeOp, adaptor.getValue(), adaptor.getTarget(),
-        adaptor.getTargetDims(), offsets, sizes, strides);
-    return success();
-  }
-};
-
 /// Pattern to convert `iree_tensor_ext.dispatch.tensor.store` operation when
 /// materializing the encoding. We can not reuse the existing one because it
 /// does not transform new dynamic dimension through interface. The other
@@ -293,9 +204,7 @@ struct MaterializeEncodingIntoPaddingPass final
     // with the exception of a few ops that have to account for padding.
     // We add custom patterns with much higher priority to run before the
     // equivalent 'Nop' patterns.
-    materializeEncodingPattern.add<MaterializeFlowDispatchTensorLoadOp,
-                                   MaterializeFlowDispatchTensorStoreOp,
-                                   MaterializeInterfaceBindingEncoding>(
+    materializeEncodingPattern.add<MaterializeInterfaceBindingEncoding>(
         typeConverter, context, PatternBenefit{100});
 
     if (failed(applyPartialConversion(operation, target,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -590,7 +590,7 @@ struct GPUPadEncodingLayoutMaterializerAttr final
     newOffsets.resize(newSizes.size(), builder.getIndexAttr(0));
     newStrides.resize(newSizes.size(), builder.getIndexAttr(1));
     return success();
-    }
+  }
 
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -574,6 +574,24 @@ struct GPULayoutResolverAttr final
 struct GPUPadEncodingLayoutMaterializerAttr final
     : IREE::Encoding::LayoutMaterializerAttr::ExternalModel<
           GPUPadEncodingLayoutMaterializerAttr, GPUPaddingResolverAttr> {
+
+  LogicalResult getOffsetsSizesStrides(
+      Attribute attr, OpBuilder &builder, Location loc,
+      IREE::TensorExt::DispatchTensorType type, ValueRange dynamicDims,
+      ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> sizes,
+      ArrayRef<OpFoldResult> strides, SmallVectorImpl<OpFoldResult> &newOffsets,
+      SmallVectorImpl<OpFoldResult> &newSizes,
+      SmallVectorImpl<OpFoldResult> &newStrides) const {
+    auto boundType = dyn_cast<RankedTensorType>(type.getBoundType());
+    if (!boundType || !boundType.getEncoding()) {
+      return failure();
+    }
+    newSizes = getMixedValues(boundType.getShape(), dynamicDims, builder);
+    newOffsets.resize(newSizes.size(), builder.getIndexAttr(0));
+    newStrides.resize(newSizes.size(), builder.getIndexAttr(1));
+    return success();
+    }
+
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {


### PR DESCRIPTION
The revision implement the interface method with the existing logic; it allows us to remove padding specific load/store patterns, because they use interfaces.

No new tests are added since it aims to be a refactor PR and tests should be covered by [materialize_encoding_into_padding.mlir](https://github.com/iree-org/iree/blob/3b1730e5fa15a520505000b3f3232bd2a230793b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir)

It is a step towards https://github.com/iree-org/iree/issues/20160