### PR TITLE
[Dispatch Creation] Sink reshapes through reduction ops

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -237,7 +237,7 @@ struct DispatchCreationOptions {
 
   // Enables aggressive reshape movement (bubbling expand/collapse shapes
   // across reduction ops).
-  bool enableAggressiveReshapeMovement = false;
+  bool enableAggressiveReshapeMovement = true;
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<DispatchCreationOptions>;

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
@@ -6,5 +6,5 @@
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
   "golden_dispatch_count": 1711,
-  "golden_binary_size": 3300000
+  "golden_binary_size": 3310000
 }


### PR DESCRIPTION
Testing for CI regressions

List of blockers:
- This causes some missed cases for horizontal fusion [`a379176` (#22341)](https://github.com/iree-org/iree/pull/22341/commits/a379176f49a2dfc6c933b285d0e2e925c143c377)
- Bug in dispatch creation [`b6ca77a` (#22341)](https://github.com/iree-org/iree/pull/22341/commits/b6ca77aef64e99f08702cdb233b3f8b18286e6a1)
- UNRESOLVED: A regression when a transpose gets fused as the consumer of a matmul for the test_torch tests suite on mi325: [Before PR](https://gist.github.com/IanWood1/922590ab01ad78a839f8e382ac10c2c2) and [After PR](https://gist.github.com/IanWood1/b9aaa1591a1e47e587e6309194bc6b09). Possibly related to the flow bitcasts.

ci-extra: test_torch