### PR TITLE
[Integrate] Bump LLVM to llvm/llvm-project@1508a8e

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
@@ -33,12 +33,12 @@ static LogicalResult padToStaticSizes(RewriterBase &rewriter,
                      .setPaddingValues(paddingValues)
                      .setPadToMultipleOf(true);
 
-  SmallVector<tensor::PadOp> padOps;
-  FailureOr<TilingInterface> maybePaddedOp =
-      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options, padOps);
-  if (failed(maybePaddedOp)) {
+  FailureOr<linalg::PadTilingInterfaceResult> maybePadResult =
+      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options);
+  if (failed(maybePadResult)) {
     return tilingInterfaceOp->emitOpError("failed to pad op");
   }
+  rewriter.replaceOp(tilingInterfaceOp, maybePadResult->replacements);
 
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -348,7 +348,8 @@ struct ConvertToROCDLPass final
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);
-      populateMathToROCDLConversionPatterns(converter, llvmPatterns);
+      populateMathToROCDLConversionPatterns(converter, llvmPatterns,
+                                            /* chipset= */ std::nullopt);
       ub::populateUBToLLVMConversionPatterns(converter, llvmPatterns);
 
       if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {


### PR DESCRIPTION
(I'm doing this quick integrate because I made the main upstream change in this bump, so not blind)

FYI: @MaheshRavishankar (current week gardener)
FYI @Muzammiluddin-Syed-ECE (next week gardener)

Still carrying one same revert: llvm/llvm-project#160615. See #22171 for description

Fixes: 
- (my) API change to  linalg::rewriteAsPaddedOp
- API change to populateMathToROCDLConversionPatterns which takes optional chipset 