### PR TITLE
[VectorDistribute] Fix transfer_write broadcasting guard

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Utils/Indexing.h"
 #include "iree/compiler/Utils/Permutation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
@@ -435,6 +436,50 @@ struct DistributeTransferWrite final
     }
   }
 
+  FailureOr<Value> getNoOverlapCondition(OpBuilder &b, Location loc,
+                                         NestedLayoutAttr layout) const {
+    ArrayRef<int64_t> threadTile = layout.getThreadTile();
+    ArrayRef<int64_t> threadStrides = layout.getThreadStrides();
+    ArrayRef<int64_t> subgroupTile = layout.getSubgroupTile();
+    // Multiply the subgroup strides by subgroup_size to reflect thread id
+    // relative strides.
+    auto subgroupStrides =
+        llvm::map_to_vector(layout.getSubgroupStrides(),
+                            [&](int64_t x) { return x * subgroupSize; });
+    auto concatTiles =
+        llvm::to_vector(llvm::concat<const int64_t>(subgroupTile, threadTile));
+    auto concatStrides = llvm::to_vector(
+        llvm::concat<const int64_t>(subgroupStrides, threadStrides));
+    SmallVector<int64_t> basis;
+    SmallVector<size_t> dimToResult;
+    if (failed(basisFromSizesStrides(concatTiles, concatStrides, basis,
+                                     dimToResult))) {
+      return failure();
+    }
+
+    // Make the upper bound numThreadsInWorkgroup to remove redundant checks.
+    if (numThreadsInWorkgroup.has_value()) {
+      basis.insert(basis.begin(), numThreadsInWorkgroup.value());
+    }
+    // Create a delinearize operation and check that all results not present in
+    // dimToResult are 0.
+    auto delinearize = affine::AffineDelinearizeIndexOp::create(
+        b, loc, threadId, basis,
+        /*hasOuterbound=*/numThreadsInWorkgroup.has_value());
+    // Get all results which are not in dimToResult and check they are 0.
+    Value condition = arith::ConstantOp::create(b, loc, b.getBoolAttr(true));
+    for (auto [idx, result] : llvm::enumerate(delinearize.getResults())) {
+      if (llvm::is_contained(dimToResult, idx)) {
+        continue;
+      }
+      Value isZero =
+          arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq, result,
+                                arith::ConstantIndexOp::create(b, loc, 0));
+      condition = arith::AndIOp::create(b, loc, condition, isZero);
+    }
+    return condition;
+  }
+
   LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
@@ -496,34 +541,13 @@ struct DistributeTransferWrite final
     assert(delinearized.size() == 2 * rank + 2 &&
            "but has outer-bound is false");
 
-    OpResult subgroupGroupId = delinearized[0];
-    OpResult threadGroupId = delinearized[rank + 1];
-    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-
-    Value doWrite =
-        arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(true));
-
-    // Is it maybe possible that threads with the same lane ID but different
-    // subgroup IDs write to the same address? If so, guard on the subgroup.
-    int64_t basisSize = llvm::product_of(basis);
-    bool mightBeInterSubgroupOverlap = !numThreadsInWorkgroup.has_value() ||
-                                       (basisSize < *numThreadsInWorkgroup);
-    if (mightBeInterSubgroupOverlap) {
-      Value subgroupIsZero = arith::CmpIOp::create(
-          rewriter, loc, arith::CmpIPredicate::eq, subgroupGroupId, zero);
-      doWrite = arith::AndIOp::create(rewriter, loc, doWrite, subgroupIsZero);
+    FailureOr<Value> doWrite =
+        getNoOverlapCondition(rewriter, loc, vectorLayout);
+    if (failed(doWrite)) {
+      return rewriter.notifyMatchFailure(
+          writeOp, "failed to compute no-overlap condition");
     }
-
-    // Do threads within the same subgroup write to the same address? If so,
-    // guard on the lane.
-    bool isIntraSubgroupOverlap = (laneOverlap > 1);
-    if (isIntraSubgroupOverlap) {
-      Value threadIsZero = arith::CmpIOp::create(
-          rewriter, loc, arith::CmpIPredicate::eq, threadGroupId, zero);
-      doWrite = arith::AndIOp::create(rewriter, loc, doWrite, threadIsZero);
-    }
-
-    auto ifOp = scf::IfOp::create(rewriter, loc, doWrite);
+    auto ifOp = scf::IfOp::create(rewriter, loc, doWrite.value());
     rewriter.setInsertionPoint(ifOp.thenYield());
 
     Value distributedVector =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -540,12 +540,6 @@ struct DistributeTransferWrite final
     }
 
     Location loc = writeOp.getLoc();
-    auto delinearizedOp = affine::AffineDelinearizeIndexOp::create(
-        rewriter, loc, threadId, basis, /* has outer-bound */ false);
-    ResultRange delinearized = delinearizedOp.getResults();
-    assert(delinearized.size() == 2 * rank + 2 &&
-           "but has outer-bound is false");
-
     FailureOr<Value> doWrite =
         getNoOverlapCondition(rewriter, loc, vectorLayout);
     if (failed(doWrite)) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -436,6 +436,12 @@ struct DistributeTransferWrite final
     }
   }
 
+  /// Compute a boolean in SIMT semantics that is true for the first vtid and
+  /// stid carrying broadcasted data.
+  ///
+  /// We do this by computing a basis for vtid and stid computation, and adding
+  /// a check for basis elements that are not used (i.e. they are duplicated)
+  /// to be zero.
   FailureOr<Value> getNoOverlapCondition(OpBuilder &b, Location loc,
                                          NestedLayoutAttr layout) const {
     ArrayRef<int64_t> threadTile = layout.getThreadTile();
@@ -456,7 +462,6 @@ struct DistributeTransferWrite final
                                      dimToResult))) {
       return failure();
     }
-
     // Make the upper bound numThreadsInWorkgroup to remove redundant checks.
     if (numThreadsInWorkgroup.has_value()) {
       basis.insert(basis.begin(), numThreadsInWorkgroup.value());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1418,10 +1418,7 @@ builtin.module attributes { transform.with_named_sequence } {
 func.func @undistributed_write(%out: memref<f32, #amdgpu.address_space<fat_raw_buffer>>, %v: vector<f32>) {
   //  CHECK-DAG: %[[ZERO:.*]] = arith.constant 0 : index
   //  CHECK-DAG: %[[TID:.*]] = gpu.thread_id  x
-  //      CHECK: %[[DELIN:.*]]:2 = affine.delinearize_index %[[TID]] into (64)
-  //  CHECK-DAG: %[[SUBGROUP_COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[ZERO]] : index
-  //  CHECK-DAG: %[[LANE_COND:.+]] = arith.cmpi eq, %[[DELIN]]#1, %[[ZERO]] : index
-  //      CHECK: %[[COND:.+]] = arith.andi %[[SUBGROUP_COND]], %[[LANE_COND]] : i1
+  //  CHECK-DAG: %[[COND:.+]] = arith.cmpi eq, %[[TID]], %[[ZERO]] : index
   // CHECK-NEXT: scf.if %[[COND]] {
   //      CHECK:   vector.transfer_write
   // CHECK-NEXT: }
@@ -1443,25 +1440,23 @@ builtin.module attributes { transform.with_named_sequence } {
   subgroup_tile    = [4, 1],
   batch_tile       = [1, 1],
   outer_tile       = [1, 1],
-  thread_tile      = [1, 8],
-  element_tile     = [2, 2],
+  thread_tile      = [2, 8],
+  element_tile     = [1, 2],
   subgroup_strides = [1, 1],
-  thread_strides   = [1, 1]
+  thread_strides   = [32, 1]
 >
 
-// (*subgroup_tile, 'lane_overlap', *thread_tile) is (4, 8, 8).
-//                 (4, 8, 8)
-// thread_id -> (a, b, c, d)
-// Effectively the logic we're checking for is `if (thread.a == 0 and thread.c == 0) { write }`
-// This is valid because the address written to for (a, b, c, d) is the same for all a and c, so
-// we only need to write for one pair, and we pick (a, b) = (0, 0).
-
+// subgroup_size = 64 (default for the transform test_gpu_vector_distribution)
+// A possible thread basis for this distribution would be:
+// thread_basis = [2, 4, 8] and the dimension with size "4" has data broadcasted
+// across all threads (note the thread strides). This test checks if we account
+// for such broadcasts when generating conditional writes.
 // CHECK-LABEL: @partially_distributed_write
 //   CHECK-DAG:    %[[TID:.+]] = gpu.thread_id  x
 //   CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:    %[[DELIN:.*]]:4 = affine.delinearize_index %[[TID:.+]] into (4, 8, 8)
+//       CHECK:    %[[DELIN:.*]]:5 = affine.delinearize_index %[[TID:.+]] into (4, 2, 4, 8)
 //   CHECK-DAG:    %[[SUBGROUP_COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[C0]] : index
-//   CHECK-DAG:    %[[LANE_COND:.+]] = arith.cmpi eq, %[[DELIN]]#2, %[[C0]] : index
+//   CHECK-DAG:    %[[LANE_COND:.+]] = arith.cmpi eq, %[[DELIN]]#3, %[[C0]] : index
 //       CHECK:    %[[COND:.+]] = arith.andi %[[SUBGROUP_COND]], %[[LANE_COND]]
 //       CHECK:    scf.if %[[COND]] {
 //       CHECK:        vector.transfer_write
@@ -1499,7 +1494,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @lanes_fully_distributed
 //   CHECK-DAG:    %[[TID:.+]] = gpu.thread_id
 //   CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:    %[[DELIN:.*]]:2 = affine.delinearize_index %[[TID:.+]] into (64)
+//       CHECK:    %[[DELIN:.*]]:2 = affine.delinearize_index %[[TID:.+]] into (256, 64)
 //       CHECK:    %[[COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[C0]] : index
 //       CHECK:    scf.if %[[COND]] {
 //       CHECK:        vector.transfer_write
@@ -1534,8 +1529,14 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 // CHECK-LABEL: @threads_fully_distributed
-//       CHECK: gpu.thread_id
-//   CHECK-NOT: scf.if
+//       CHECK-DAG: %[[C0:.+]] = arith.constant 0
+//       CHECK: %[[TID:.+]] = gpu.thread_id
+//       CHECK: %[[DELIN:.+]]:2 = affine.delinearize_index %[[TID]] into (64, 64)
+//       CHECK: %[[COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[C0]]
+//       Note that cond is always true here, but this gets resolved after arith
+//       int optimizations.
+//       TODO: Add a folder to affine.delinearize_index to fold it to zero.
+//       CHECK: scf.if %[[COND]]
 //       CHECK: return
 func.func @threads_fully_distributed(%out: memref<100x100xf32, #amdgpu.address_space<fat_raw_buffer>>, %v: vector<64x64xf32>) {
   %w = iree_vector_ext.to_layout %v to layout(#layout_row_major) : vector<64x64xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1494,7 +1494,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @lanes_fully_distributed
 //   CHECK-DAG:    %[[TID:.+]] = gpu.thread_id
 //   CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:    %[[DELIN:.*]]:2 = affine.delinearize_index %[[TID:.+]] into (256, 64)
+//       CHECK:    %[[DELIN:.*]]:2 = affine.delinearize_index %[[TID:.+]] into (4, 64)
 //       CHECK:    %[[COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[C0]] : index
 //       CHECK:    scf.if %[[COND]] {
 //       CHECK:        vector.transfer_write
@@ -1529,14 +1529,8 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 // CHECK-LABEL: @threads_fully_distributed
-//       CHECK-DAG: %[[C0:.+]] = arith.constant 0
-//       CHECK: %[[TID:.+]] = gpu.thread_id
-//       CHECK: %[[DELIN:.+]]:2 = affine.delinearize_index %[[TID]] into (64, 64)
-//       CHECK: %[[COND:.+]] = arith.cmpi eq, %[[DELIN]]#0, %[[C0]]
-//       Note that cond is always true here, but this gets resolved after arith
-//       int optimizations.
-//       TODO: Add a folder to affine.delinearize_index to fold it to zero.
-//       CHECK: scf.if %[[COND]]
+//       CHECK-NOT: scf.if
+//       CHECK: transfer_write
 //       CHECK: return
 func.func @threads_fully_distributed(%out: memref<100x100xf32, #amdgpu.address_space<fat_raw_buffer>>, %v: vector<64x64xf32>) {
   %w = iree_vector_ext.to_layout %v to layout(#layout_row_major) : vector<64x64xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -2,9 +2,9 @@
 
 #nested = #iree_vector_ext.nested_layout<
   subgroup_tile = [2, 1],
-  batch_tile = [2, 1],
+  batch_tile = [8, 1],
   outer_tile = [2, 1],
-  thread_tile = [16, 16],
+  thread_tile = [4, 16],
   element_tile = [2, 8],
 
   subgroup_strides = [1, 0],
@@ -34,13 +34,13 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: func @masked_read_write
 // CHECK: %[[DIM:.+]] = memref.dim %arg0, %c0 : memref<?x128xf16>
 // CHECK: %[[VSID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64) : index, index, index
-// CHECK: %[[VTID:.+]]:3 = affine.delinearize_index %thread_id_x into (16, 16) : index, index, index
+// CHECK: %[[VTID:.+]]:3 = affine.delinearize_index %thread_id_x into (4, 16) : index, index, index
 // CHECK: %[[LASTIDX:.+]] = arith.subi %[[DIM]], %c1 : index
-// CHECK: %[[PACKED_LASTIDX:.+]]:4 = affine.delinearize_index %[[LASTIDX]] into (2, 4, 16, 2) : index, index, index, index
+// CHECK: %[[PACKED_LASTIDX:.+]]:4 = affine.delinearize_index %[[LASTIDX]] into (2, 16, 4, 2) : index, index, index, index
 
-// CHECK: %[[ETILE_VALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c1] by (4, 2) : index
+// CHECK: %[[ETILE_VALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c1] by (16, 2) : index
 // CHECK: %[[ETILE_VALID_BOUND:.+]] = arith.addi %[[ETILE_VALID]], %c1 : index
-// CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (4, 2) : index
+// CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (16, 2) : index
 // CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
 
 // CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
@@ -50,7 +50,7 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %c0 : index
 // CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index
-// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c8, %c0 : index
+// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c32, %c0 : index
 // CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
 // CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c8 : vector<2x8xi1>
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -168,9 +168,14 @@ func.func @reduction(%in: memref<2048xf32>, %out: memref<f32>) {
 
   // Guards on duplicated writes to LDS.
   // Only lane 0 within each subgroup writes.
-  //      CHECK: %[[DELIN:.*]]:4 = affine.delinearize_index %[[THREADIDX]] into (8, 64, 1)
-  //  CHECK-DAG: %[[LANECOND:.*]] = arith.cmpi eq, %[[DELIN]]#2, %[[ZERO]] : index
-  // CHECK-NEXT: scf.if %[[LANECOND]] {
+  //      CHECK: %[[DELIN:.*]]:4 = affine.delinearize_index %[[THREADIDX]] into (512, 8, 64, 1)
+  // This condition is redundant and will be cleaned up after int
+  // optimizations. This can also be fixed with a fold pattern to
+  // affine.delinearize_index.
+  //  CHECK-DAG: %[[SUBGROUPCOND:.*]] = arith.cmpi eq, %[[DELIN]]#0, %[[ZERO]]
+  //  CHECK-DAG: %[[LANECOND:.*]] = arith.cmpi eq, %[[DELIN]]#2, %[[ZERO]]
+  //      CHECK: %[[COND:.*]] = arith.andi %[[SUBGROUPCOND]], %[[LANECOND]]
+  // CHECK-NEXT: scf.if %[[COND]] {
   // CHECK-NEXT: linearize_index
   // CHECK-NEXT: vector.transfer_write {{.*}} #gpu.address_space<workgroup>>
   // CHECK-NEXT: }
@@ -178,11 +183,8 @@ func.func @reduction(%in: memref<2048xf32>, %out: memref<f32>) {
   %11 = vector.broadcast %10 : f32 to vector<f32>
 
   // Guards on duplicated writes to global memory.
-  // Only thread 0 (lane 0 of subgroup 0) writes.
-  //      CHECK: %[[DELIN2:.*]]:2 = affine.delinearize_index %[[THREADIDX]] into (64)
-  //  CHECK-DAG: %[[WGCOND2:.*]] = arith.cmpi eq, %[[DELIN2]]#0, %[[ZERO]] : index
-  //  CHECK-DAG: %[[LANECOND2:.*]] = arith.cmpi eq, %[[DELIN2]]#1, %[[ZERO]] : index
-  //      CHECK: %[[COND2:.*]] = arith.andi %[[WGCOND2]], %[[LANECOND2]] : i1
+  // Only thread 0 writes.
+  //  CHECK-DAG: %[[COND2:.*]] = arith.cmpi eq, %[[THREADIDX]], %[[ZERO]] : index
   // CHECK-NEXT: scf.if %[[COND2]] {
   // CHECK-NEXT: vector.broadcast
   // CHECK-NEXT: vector.transfer_write {{.*}} #amdgpu.address_space<fat_raw_buffer>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -168,7 +168,7 @@ func.func @reduction(%in: memref<2048xf32>, %out: memref<f32>) {
 
   // Guards on duplicated writes to LDS.
   // Only lane 0 within each subgroup writes.
-  //      CHECK: %[[DELIN:.*]]:4 = affine.delinearize_index %[[THREADIDX]] into (512, 8, 64, 1)
+  //      CHECK: %[[DELIN:.*]]:4 = affine.delinearize_index %[[THREADIDX]] into (1, 8, 64, 1)
   // This condition is redundant and will be cleaned up after int
   // optimizations. This can also be fixed with a fold pattern to
   // affine.delinearize_index.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -752,7 +752,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
                                                     #hal.pipeline.binding<storage_buffer>,
                                                     #hal.pipeline.binding<storage_buffer>,
                                                     #hal.pipeline.binding<storage_buffer>]>
-#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [128, 1, 1] subgroup_size = 64, {}>
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_basis = [[2, 2, 1], [0, 1, 2]], workgroup = [64, 128, 0]}>
 
 hal.executable public @matmul_gather_rhs {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -380,7 +380,7 @@ hal.executable private @attention_20x1x64x4096x64 {
                                       lane_basis = [[1, 4, 16], [0, 1, 2]]}
 >
 #translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
-                                               workgroup_size = [64, 1, 1]
+                                               workgroup_size = [128, 1, 1]
                                                subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [


### PR DESCRIPTION
The guard was not taking into account the strides of the layout. This approach takes them into account and computes a better condition in most cases. Also updates a partial write test to do a more complicated test.

ci-extra: test_torch