### PR TITLE
Catch MLIR ukernel parsing errors

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -345,11 +345,16 @@ public:
           rocmDialect->getBuiltin(builtinName.str());
       if (!maybeBuiltin) {
         moduleOp.emitOpError()
-            << "could not find builtin with name " << builtinName.str();
+            << "could not find builtin module with name " << builtinName.str();
         return WalkResult::interrupt();
       }
-      OwningOpRef<ModuleOp> builtinModule =
-          parseSourceString<ModuleOp>(*maybeBuiltin, ctx);
+      OwningOpRef<ModuleOp> builtinModule = parseSourceString<ModuleOp>(
+          *maybeBuiltin, ctx, /*sourceName=*/builtinName.str());
+      if (!builtinModule) {
+        moduleOp.emitOpError()
+            << "failed to parse builtin module with name " << builtinName.str();
+        return WalkResult::interrupt();
+      }
       Operation *symbolTableOp =
           SymbolTable::getNearestSymbolTable(builtinModule.get());
       SymbolTable symbolTable(symbolTableOp);

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -341,18 +341,19 @@ public:
       if (ukernelSymbols.contains(ukernelDesc.getUkernelName())) {
         return WalkResult::advance();
       }
+      std::string builtinNameStr = builtinName.str();
       std::optional<StringRef> maybeBuiltin =
-          rocmDialect->getBuiltin(builtinName.str());
+          rocmDialect->getBuiltin(builtinNameStr);
       if (!maybeBuiltin) {
         moduleOp.emitOpError()
-            << "could not find builtin module with name " << builtinName.str();
+            << "could not find builtin module with name " << builtinNameStr;
         return WalkResult::interrupt();
       }
       OwningOpRef<ModuleOp> builtinModule = parseSourceString<ModuleOp>(
-          *maybeBuiltin, ctx, /*sourceName=*/builtinName.str());
+          *maybeBuiltin, ctx, /*sourceName=*/builtinNameStr);
       if (!builtinModule) {
         moduleOp.emitOpError()
-            << "failed to parse builtin module with name " << builtinName.str();
+            << "failed to parse builtin module with name " << builtinNameStr;
         return WalkResult::interrupt();
       }
       Operation *symbolTableOp =


### PR DESCRIPTION
MLIR ukernels are lazily parsed when used. When they fail to parse, this was manifesting itself as a compiler crash (null dereference) here:
https://github.com/iree-org/iree/blob/59ce62fd8a3686c45d00bfce197cd15f38697f0d/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp#L354
as in that case, `builtinModule.get()` is null.

This PR reports an op error when parsing failed, so the code doesn't reach this place anymroe and the crash is avoided.

To make the parser's internal diagnostics themselves more helpful, this PR also passes a `sourceName` argument to `parseSourceString` so that they now directly refer to a meaningful location in the MLIR ukernel files.