### PR TITLE
Bump LLVM to llvm/llvm-project@c8cf393

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -216,7 +216,7 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
     tilingInterfaceOp.emitWarning("failed to pad op");
     return failure();
   }
-  const auto &padResult = maybePadResult.value();
+  const linalg::PadTilingInterfaceResult &padResult = maybePadResult.value();
   rewriter.replaceOp(tilingInterfaceOp, padResult.replacements);
   TilingInterface paddedOp = padResult.paddedOp;
   Location loc = paddedOp.getLoc();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadConvs.cpp
@@ -33,12 +33,12 @@ static LogicalResult padToStaticSizes(RewriterBase &rewriter,
                      .setPaddingValues(paddingValues)
                      .setPadToMultipleOf(true);
 
-  SmallVector<tensor::PadOp> padOps;
-  FailureOr<TilingInterface> maybePaddedOp =
-      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options, padOps);
-  if (failed(maybePaddedOp)) {
+  FailureOr<linalg::PadTilingInterfaceResult> maybePadResult =
+      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options);
+  if (failed(maybePadResult)) {
     return tilingInterfaceOp->emitOpError("failed to pad op");
   }
+  rewriter.replaceOp(tilingInterfaceOp, maybePadResult->replacements);
 
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
@@ -632,4 +632,4 @@ func.func @reinterpret_cast_lowering_dynamic_zero_offset() -> f32 {
 }
 // CHECK-LABEL: func @reinterpret_cast_lowering_dynamic_zero_offset()
 //       CHECK:   %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:   memref.reinterpret_cast %{{.+}} to offset: [%[[C0]]], sizes: [], strides: [] : memref<?xf32> to memref<f32, strided<[], offset: ?>>
+//       CHECK:   memref.reinterpret_cast %{{.+}} to offset: [0], sizes: [], strides: [] : memref<?xf32> to memref<f32, strided<[]>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -349,7 +349,7 @@ struct ConvertToROCDLPass final
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);
       populateMathToROCDLConversionPatterns(converter, llvmPatterns,
-                                            /* chipset= */ std::nullopt);
+                                            /*chipset=*/*maybeChipset);
       ub::populateUBToLLVMConversionPatterns(converter, llvmPatterns);
 
       if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -348,7 +348,8 @@ struct ConvertToROCDLPass final
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);
-      populateMathToROCDLConversionPatterns(converter, llvmPatterns);
+      populateMathToROCDLConversionPatterns(converter, llvmPatterns,
+                                            /* chipset= */ std::nullopt);
       ub::populateUBToLLVMConversionPatterns(converter, llvmPatterns);
 
       if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -292,7 +292,7 @@ module {
 //       CHECK:   %[[MLOOP:.+]] = scf.for %[[M:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x2x4xf32>)
 //       CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x2x4xf32>)
 //   CHECK-DAG:       %[[kParts:.+]]:2 = affine.delinearize_index %[[K]] into (2, 2) : index, index
-//   CHECK-DAG:       %[[hIdx:.+]] = affine.apply #[[$MAP]](%[[M]], %[[kParts]]#1)
+//   CHECK-DAG:       %[[hIdx:.+]] = affine.apply #[[$MAP]](%[[kParts]]#1, %[[M]])
 //       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIdx]], %[[kParts]]#0] [1, 1, 1] [1, 1, 1] : tensor<1x3x2xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M]], %[[K]]] [1, 1, 1] [1, 1, 1] : tensor<1x2x4xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -292,7 +292,7 @@ module {
 //       CHECK:   %[[MLOOP:.+]] = scf.for %[[M:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x2x4xf32>)
 //       CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x2x4xf32>)
 //   CHECK-DAG:       %[[kParts:.+]]:2 = affine.delinearize_index %[[K]] into (2, 2) : index, index
-//   CHECK-DAG:       %[[hIdx:.+]] = affine.apply #[[$MAP]](%[[kParts]]#1, %[[M]])
+//   CHECK-DAG:       %[[hIdx:.+]] = affine.apply #[[$MAP]](%[[M]], %[[kParts]]#1)
 //       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIdx]], %[[kParts]]#0] [1, 1, 1] [1, 1, 1] : tensor<1x3x2xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M]], %[[K]]] [1, 1, 1] [1, 1, 1] : tensor<1x2x4xf32> to tensor<1x1x1xf32>
 //       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>


### PR DESCRIPTION
New Revert:
- https://github.com/llvm/llvm-project/commit/8c05b5cca8784814cf11ac9d85c4ab59d2952ca5 causes numerical errors see (https://github.com/iree-org/iree/pull/22354#issuecomment-3424225175)

Still carrying these reverts:
- https://github.com/llvm/llvm-project/pull/160615 (See https://github.com/iree-org/iree/issues/22171)

Fixes:
- API change to linalg::rewriteAsPaddedOp (https://github.com/llvm/llvm-project/commit/1508a8ec8d62ab1e9bdc8b7e0dbaaec9075b631f)
- API change to populateMathToROCDLConversionPatterns (https://github.com/llvm/llvm-project/commit/fbbffc11690c0f47bdc74939b290696df4c1c061)
- Changes to lit tests