### PR TITLE
[DT] Mark partial slices unsupported in padding encoding resolver.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -586,6 +586,14 @@ struct GPUPadEncodingLayoutMaterializerAttr final
     if (!boundType || !boundType.getEncoding()) {
       return failure();
     }
+    // Only handle cases where the slice spans the whole
+    // `!iree_tensor_ext.dispatch.tensor` type.
+    // TODO(hanchung): Enable partial slices. It was copied from pattern's
+    // implementaion, i.e., the users, and it can be dropped after we move the
+    // checks to the interface implementations.
+    if (!type.doesSliceSpanWholeTensor(dynamicDims, offsets, sizes, strides)) {
+      return failure();
+    }
     newSizes = getMixedValues(boundType.getShape(), dynamicDims, builder);
     newOffsets.resize(newSizes.size(), builder.getIndexAttr(0));
     newStrides.resize(newSizes.size(), builder.getIndexAttr(1));


### PR DESCRIPTION
The implementation was wrong; the tests are missing. It addresses a post review comment: https://github.com/iree-org/iree/pull/22339/files#r2438738373