### PR TITLE
[CI][TorchModels] Add SDXL int8 model to Torch Models CI.

### DIFF
--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942.json
@@ -1,0 +1,10 @@
+{
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_int8mm_f16attn.mlir",
+    "compiler_flags" : [
+        "--iree-hal-target-device=hip",
+        "--iree-hip-target=gfx942",
+        "--iree-opt-level=O3",
+        "--iree-execution-model=async-external",
+        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
+    ]
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
@@ -1,0 +1,54 @@
+{
+  "type": "benchmark",
+  "markers" : [
+    "hip",
+    "mi325",
+    "new"
+  ],
+  "modules": [
+    "sdxl/modules/punet_gfx942"
+  ],
+  "weights" : [
+    {
+      "type": "url",
+      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_int8.irpa",
+      "scope": "model"
+    }
+  ],
+  "run_args" : [
+    "--hip_use_streams=true",
+    "--hip_allow_inline_execution=true",
+    "--device_allocator=caching",
+    "--function=main",
+    "--device=hip",
+    "--benchmark_repetitions=10",
+    "--benchmark_min_warmup_time=3.0"
+  ],
+  "inputs" : [
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input0.bin",
+      "value": "1x4x128x128xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input1.bin",
+      "value": "1xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input2.bin",
+      "value": "2x64x2048xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input3.bin",
+      "value": "2x1280xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input4.bin",
+      "value": "2x6xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input5.bin",
+      "value": "1xf16"
+    }
+  ],
+  "golden_time_ms" : 47.0
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
@@ -3,7 +3,7 @@
   "markers" : [
     "hip",
     "mi325",
-    "new"
+    "punet"
   ],
   "modules": [
     "sdxl/modules/punet_gfx942"
@@ -11,7 +11,7 @@
   "weights" : [
     {
       "type": "url",
-      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_int8.irpa",
+      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_int8.irpa",
       "scope": "model"
     }
   ],
@@ -26,29 +26,29 @@
   ],
   "inputs" : [
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input0.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input0.bin",
       "value": "1x4x128x128xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input1.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input1.bin",
       "value": "1xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input2.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input2.bin",
       "value": "2x64x2048xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input3.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input3.bin",
       "value": "2x1280xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input4.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input4.bin",
       "value": "2x6xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input5.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input5.bin",
       "value": "1xf16"
     }
   ],
-  "golden_time_ms" : 47.0
+  "golden_time_ms" : 45.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
@@ -3,9 +3,9 @@
   "markers" : [
     "hip",
     "gfx942",
-    "new"
+    "punet"
   ],
   "module": "sdxl/modules/punet_gfx942",
   "golden_dispatch_count" : 1482,
-  "golden_binary_size" : 1880000
+  "golden_binary_size" : 2000000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
@@ -1,0 +1,11 @@
+{
+  "type" : "compstat",
+  "markers" : [
+    "hip",
+    "gfx942",
+    "new"
+  ],
+  "module": "sdxl/modules/punet_gfx942",
+  "golden_dispatch_count" : 1482,
+  "golden_binary_size" : 1880000
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_quality_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_quality_gfx942.json
@@ -3,7 +3,7 @@
   "markers": [
     "hip",
     "gfx942",
-    "new"
+    "punet"
   ],
   "modules": [
     "sdxl/modules/punet_gfx942"
@@ -11,7 +11,7 @@
   "weights" : [
     {
       "type": "url",
-      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_int8.irpa",
+      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_int8.irpa",
       "scope": "model"
     }
   ],
@@ -20,37 +20,37 @@
     "--hip_allow_inline_execution=true",
     "--device_allocator=caching",
     "--function=main",
-    "--device=hip"    
+    "--device=hip"
   ],
   "inputs" : [
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input0.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input0.bin",
       "value": "1x4x128x128xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input1.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input1.bin",
       "value": "1xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input2.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input2.bin",
       "value": "2x64x2048xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input3.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input3.bin",
       "value": "2x1280xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input4.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input4.bin",
       "value": "2x6xf16"
     },
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input5.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_input5.bin",
       "value": "1xf16"
     }
   ],
   "expected_outputs" : [
     {
-      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_output_v2.bin",
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_output_v2.bin",
       "value": "1x4x128x128xf16"
     }
   ]

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_quality_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_quality_gfx942.json
@@ -1,0 +1,57 @@
+{
+  "type" : "quality",
+  "markers": [
+    "hip",
+    "gfx942",
+    "new"
+  ],
+  "modules": [
+    "sdxl/modules/punet_gfx942"
+  ],
+  "weights" : [
+    {
+      "type": "url",
+      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_int8.irpa",
+      "scope": "model"
+    }
+  ],
+  "run_args" : [
+    "--hip_use_streams=true",
+    "--hip_allow_inline_execution=true",
+    "--device_allocator=caching",
+    "--function=main",
+    "--device=hip"    
+  ],
+  "inputs" : [
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input0.bin",
+      "value": "1x4x128x128xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input1.bin",
+      "value": "1xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input2.bin",
+      "value": "2x64x2048xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input3.bin",
+      "value": "2x1280xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input4.bin",
+      "value": "2x6xf16"
+    },
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_input5.bin",
+      "value": "1xf16"
+    }
+  ],
+  "expected_outputs" : [
+    {
+      "url" : "https://sharkpublic.blob.core.windows.net/sharkpublic/iree_ci/sdxl/punet/punet_output_v2.bin",
+      "value": "1x4x128x128xf16"
+    }
+  ]
+}


### PR DESCRIPTION
This adds to CI, int8 quantized SDXL that has been used for MLPerf submissions in the past. Its a bit tricky to get the MLIR to use for this, but this is what is currently being tracked in https://github.com/nod-ai/iree-model-benchmark/tree/main/sdxl/int8-model with some santization of compilation flags used.
This test use tuning. That will be added as follow up.

ci-extra: test_torch