### PR TITLE
[StableHLO] Fix reshape canonicalization for dense_resource constants.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -977,7 +977,7 @@ struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
     } 
     
     if (auto denseResourceAttr =
-                   llvm::dyn_cast<DenseResourceElementsAttr>(cstAttr)) {
+                   dyn_cast<DenseResourceElementsAttr>(cstAttr)) {
       rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
           op, DenseResourceElementsAttr::get(
                   op.getType(), denseResourceAttr.getRawHandle()));

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -974,15 +974,14 @@ struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
           op, SplatElementsAttr::get(op.getType(),
                                      splat.getSplatValue<Attribute>()));
       return success();
-    } 
-    
-    if (auto denseResourceAttr =
-                   dyn_cast<DenseResourceElementsAttr>(cstAttr)) {
+    }
+
+    if (auto denseResourceAttr = dyn_cast<DenseResourceElementsAttr>(cstAttr)) {
       rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
-          op, DenseResourceElementsAttr::get(
-                  op.getType(), denseResourceAttr.getRawHandle()));
+          op, DenseResourceElementsAttr::get(op.getType(),
+                                             denseResourceAttr.getRawHandle()));
       return success();
-    } 
+    }
 
     auto elements =
         llvm::to_vector_of<Attribute>(cstAttr.getValues<Attribute>());

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -973,7 +974,15 @@ struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
           op, SplatElementsAttr::get(op.getType(),
                                      splat.getSplatValue<Attribute>()));
       return success();
-    }
+    } 
+    
+    if (auto denseResourceAttr =
+                   llvm::dyn_cast<DenseResourceElementsAttr>(cstAttr)) {
+      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+          op, DenseResourceElementsAttr::get(
+                  op.getType(), denseResourceAttr.getRawHandle()));
+      return success();
+    } 
 
     auto elements =
         llvm::to_vector_of<Attribute>(cstAttr.getValues<Attribute>());

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
@@ -423,14 +423,6 @@ func.func @reshape_dense_resource() -> tensor<8x1x1xf32> {
   return %0 : tensor<8x1x1xf32>
 }
 
-{-#
-  dialect_resources: {
-    builtin: {
-      __elided__: "0x040000000000803F0000004000004040000080400000A0400000C0400000E0400000004100000041"
-    }
-  }
-#-}
-
 // -----
 
 // CHECK-LABEL: func.func @transpose

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
@@ -416,9 +416,9 @@ func.func @merge_consecutive_reshapes(%arg0: tensor<4x4xi32>) -> tensor<16xi32> 
 
 // CHECK-LABEL: func.func @reshape_dense_resource
 func.func @reshape_dense_resource() -> tensor<8x1x1xf32> {
-  %cst = stablehlo.constant dense_resource<torch_tensor_8_torch.float32> : tensor<8xf32>
+  %cst = stablehlo.constant dense_resource<__elided__> : tensor<8xf32>
   %0 = stablehlo.reshape %cst : (tensor<8xf32>) -> tensor<8x1x1xf32>
-  // CHECK: %[[RESULT:.*]] = stablehlo.constant dense_resource<torch_tensor_8_torch.float32> : tensor<8x1x1xf32>
+  // CHECK: %[[RESULT:.*]] = stablehlo.constant dense_resource<__elided__> : tensor<8x1x1xf32>
   // CHECK: return %[[RESULT]]
   return %0 : tensor<8x1x1xf32>
 }
@@ -426,7 +426,7 @@ func.func @reshape_dense_resource() -> tensor<8x1x1xf32> {
 {-#
   dialect_resources: {
     builtin: {
-      torch_tensor_8_torch.float32: "0x0400000084B426BD82A6493D4434F93D0ADA423E4ADE5B3E05613FBE00F8723D30A1CFBD"
+      __elided__: "0x040000000000803F0000004000004040000080400000A0400000C0400000E0400000004100000041"
     }
   }
 #-}

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
@@ -412,6 +412,26 @@ func.func @merge_consecutive_reshapes(%arg0: tensor<4x4xi32>) -> tensor<16xi32> 
 
 // -----
 
+// Test for reshape with dense_resource constants (regression test for crash)
+// CHECK-LABEL: func.func @reshape_dense_resource
+func.func @reshape_dense_resource() -> tensor<8x1x1xf32> {
+  %cst = stablehlo.constant dense_resource<torch_tensor_8_torch.float32> : tensor<8xf32>
+  %0 = stablehlo.reshape %cst : (tensor<8xf32>) -> tensor<8x1x1xf32>
+  // CHECK: %[[RESULT:.*]] = stablehlo.constant dense_resource<torch_tensor_8_torch.float32> : tensor<8x1x1xf32>
+  // CHECK: return %[[RESULT]]
+  return %0 : tensor<8x1x1xf32>
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      torch_tensor_8_torch.float32: "0x0400000084B426BD82A6493D4434F93D0ADA423E4ADE5B3E05613FBE00F8723D30A1CFBD"
+    }
+  }
+#-}
+
+// -----
+
 // CHECK-LABEL: func.func @transpose
 // CHECK-SAME:   ([[ARG0:%.+]]: tensor<2xf32>, [[ARG1:%.+]]: tensor<3x2xf32>, [[ARG2:%.+]]: tensor<f32>)
 func.func @transpose(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf32>, %arg2: tensor<f32>)

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/canonicalization.mlir
@@ -412,7 +412,8 @@ func.func @merge_consecutive_reshapes(%arg0: tensor<4x4xi32>) -> tensor<16xi32> 
 
 // -----
 
-// Test for reshape with dense_resource constants (regression test for crash)
+// Test for reshape with dense_resource constants (regression test for crash).
+
 // CHECK-LABEL: func.func @reshape_dense_resource
 func.func @reshape_dense_resource() -> tensor<8x1x1xf32> {
   %cst = stablehlo.constant dense_resource<torch_tensor_8_torch.float32> : tensor<8xf32>


### PR DESCRIPTION
Handle DenseResourceElementsAttr in Canonicalization.cpp to deal with 1D dense resources.

Fixes: #22230 