### PR TITLE
Bump LLVM to llvm/llvm-project@683e2bf

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -74,6 +74,7 @@ class TargetConverter:
                     "MLIRLinalgStructuredOpsIncGenLib"
                 ],
                 "@llvm-project//mlir:ShapeTransforms": ["MLIRShapeOpsTransforms"],
+                "@llvm-project//mlir:FromLLVMIRTranslation": ["MLIRTargetLLVMIRImport"],
                 "@llvm-project//mlir:ToLLVMIRTranslation": ["MLIRTargetLLVMIRExport"],
                 "@llvm-project//mlir:mlir-translate": ["mlir-translate"],
                 "@llvm-project//mlir:MlirLspServerLib": ["MLIRLspServerLib"],

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -12,6 +12,7 @@
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/Target/LLVMIR.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/CAPI/IR.h"

--- a/compiler/src/iree/compiler/API/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:CAPITransformDialect",
         "@llvm-project//mlir:CAPITransformDialectTransforms",
         "@llvm-project//mlir:CAPITransforms",
+        "@llvm-project//mlir:FromLLVMIRTranslation",
     ],
 )
 

--- a/compiler/src/iree/compiler/API/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/BUILD.bazel
@@ -44,6 +44,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:CAPILLVM",
         "@llvm-project//mlir:CAPILinalg",
         "@llvm-project//mlir:CAPIPDL",
+        "@llvm-project//mlir:CAPITarget",
         "@llvm-project//mlir:CAPITransformDialect",
         "@llvm-project//mlir:CAPITransformDialectTransforms",
         "@llvm-project//mlir:CAPITransforms",

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     MLIRCAPILLVM
     MLIRCAPILinalg
     MLIRCAPIPDL
+    MLIRCAPITarget
     MLIRCAPITransformDialect
     MLIRCAPITransformDialectTransforms
     MLIRCAPITransforms
@@ -75,6 +76,7 @@ set(_EXPORT_OBJECT_LIBS
   obj.MLIRCAPILLVM
   obj.MLIRCAPILinalg
   obj.MLIRCAPIPDL
+  obj.MLIRCAPITarget
   obj.MLIRCAPITransforms
   obj.MLIRCAPITransformDialect
   obj.MLIRCAPITransformDialectTransforms

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     MLIRCAPITransformDialect
     MLIRCAPITransformDialectTransforms
     MLIRCAPITransforms
+    MLIRTargetLLVMIRImport
     iree::compiler::API::Internal::CompilerDriver
     iree::compiler::API::Internal::IREECodegenDialectCAPI
     iree::compiler::API::Internal::IREECompileToolEntryPoint
@@ -80,6 +81,7 @@ set(_EXPORT_OBJECT_LIBS
   obj.MLIRCAPITransforms
   obj.MLIRCAPITransformDialect
   obj.MLIRCAPITransformDialectTransforms
+  obj.MLIRTargetLLVMIRImport
   iree_compiler_API_Internal_CompilerDriver.objects
   iree_compiler_API_Internal_IREECompileToolEntryPoint.objects
   iree_compiler_API_Internal_IREECodegenDialectCAPI.objects

--- a/compiler/src/iree/compiler/API/Internal/LLDToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/LLDToolEntryPoint.cpp
@@ -62,8 +62,9 @@ static Flavor getFlavor(StringRef s) {
       .CasesLower("ld", "ld.lld", "gnu", Gnu)
       .CasesLower("wasm", "ld-wasm", Wasm)
       .CaseLower("link", WinLink)
-      .CasesLower("ld64", "ld64.lld", "darwin", "darwinnew",
-                  "ld64.lld.darwinnew", Darwin)
+      .CasesLower(
+          {"ld64", "ld64.lld", "darwin", "darwinnew", "ld64.lld.darwinnew"},
+          Darwin)
       .Default(Invalid);
 }
 


### PR DESCRIPTION
Still carrying these reverts:
- https://github.com/llvm/llvm-project/pull/160615 (See https://github.com/iree-org/iree/issues/22171)
- https://github.com/llvm/llvm-project/pull/163440 (See https://github.com/iree-org/iree/pull/22354#issuecomment-3424225175)

Fixes: 
- Remove deprecated references to `.CaseLowers`
- Added dependencies required due to new added dependency to LLVMIR https://github.com/llvm/llvm-project/pull/163881