### PR TITLE
[LinalgExt][NFC] Split the op definition between pure ops and LinalgExt ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
@@ -20,6 +20,7 @@ iree_td_library(
             "LinalgExtBase.td",
             "LinalgExtInterfaces.td",
             "LinalgExtOps.td",
+            "LinalgExtPureOps.td",
         ],
         include = ["*.td"],
     ),
@@ -51,7 +52,7 @@ iree_compiler_cc_library(
         "LinalgExtInterfaces.cpp",
         "LinalgExtInterfaces.cpp.inc",
         "LinalgExtOps.cpp",
-        "LinalgExtOps.cpp.inc",
+        "LinalgExtPureOps.cpp.inc",
         "LinalgExtTypes.cpp.inc",
         "TilingInterfaceImpl.cpp",
     ],
@@ -62,12 +63,17 @@ iree_compiler_cc_library(
         "LinalgExtInterfaces.h",
         "LinalgExtInterfaces.h.inc",
         "LinalgExtOps.h",
-        "LinalgExtOps.h.inc",
+        "LinalgExtPureOps.h.inc",
         "LinalgExtTypes.h.inc",
+    ],
+    textual_hdrs = [
+        "LinalgExtOps.cpp.inc",
+        "LinalgExtOps.h.inc",
     ],
     deps = [
         ":LinalgExtInterfacesIncGen",
         ":LinalgExtOpsIncGen",
+        ":LinalgExtPureOpsIncGen",
         ":LinalgExtTypesGen",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "@llvm-project//llvm:Support",
@@ -114,6 +120,25 @@ iree_gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "LinalgExtInterfaces.td",
     deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "LinalgExtPureOpsIncGen",
+    tbl_outs = [
+        (
+            ["--gen-op-decls"],
+            "LinalgExtPureOps.h.inc",
+        ),
+        (
+            ["--gen-op-defs"],
+            "LinalgExtPureOps.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LinalgExtPureOps.td",
+    deps = [
+        ":td_files",
+    ],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -20,8 +20,11 @@ iree_cc_library(
     "LinalgExtInterfaces.h"
     "LinalgExtInterfaces.h.inc"
     "LinalgExtOps.h"
-    "LinalgExtOps.h.inc"
+    "LinalgExtPureOps.h.inc"
     "LinalgExtTypes.h.inc"
+  TEXTUAL_HDRS
+    "LinalgExtOps.cpp.inc"
+    "LinalgExtOps.h.inc"
   SRCS
     "AggregatedOpInterfaceImpl.cpp"
     "LinalgExtAttrs.cpp.inc"
@@ -30,12 +33,13 @@ iree_cc_library(
     "LinalgExtInterfaces.cpp"
     "LinalgExtInterfaces.cpp.inc"
     "LinalgExtOps.cpp"
-    "LinalgExtOps.cpp.inc"
+    "LinalgExtPureOps.cpp.inc"
     "LinalgExtTypes.cpp.inc"
     "TilingInterfaceImpl.cpp"
   DEPS
     ::LinalgExtInterfacesIncGen
     ::LinalgExtOpsIncGen
+    ::LinalgExtPureOpsIncGen
     ::LinalgExtTypesGen
     LLVMSupport
     MLIRAffineDialect
@@ -73,6 +77,16 @@ iree_tablegen_library(
   OUTS
     --gen-op-interface-decls LinalgExtInterfaces.h.inc
     --gen-op-interface-defs LinalgExtInterfaces.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    LinalgExtPureOpsIncGen
+  TD_FILE
+    "LinalgExtPureOps.td"
+  OUTS
+    --gen-op-decls LinalgExtPureOps.h.inc
+    --gen-op-defs LinalgExtPureOps.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -94,4 +94,12 @@ def SplitReductionMappingAttr :
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Base Op class.
+//===----------------------------------------------------------------------===//
+
+class IREELinalgExt_PureOp<string mnemonic, list<Trait> traits = []> :
+    Op<IREELinalgExt_Dialect, mnemonic, traits> {
+}
+
 #endif // IREE_DIALECT_LINALGEXT_BASE

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -72,6 +72,11 @@ void IREELinalgExtDialect::initialize() {
   addOperations<
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp.inc"
       >();
+
+#define GET_OP_LIST
+  addOperations<
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtPureOps.cpp.inc"
+      >();
 }
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp.inc"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2749,4 +2749,7 @@ DEFINE_OP_GET_EFFECTS(CustomOp)
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp.inc" // IWYU pragma: keep
+
+#define GET_OP_CLASSES
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtPureOps.cpp.inc" // IWYU pragma: keep
 // clang-format: on

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
@@ -26,6 +26,9 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtAttrs.h.inc" // IWYU pragma: export
 
 #define GET_OP_CLASSES
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtPureOps.h.inc" // IWYU pragma: export
+
+#define GET_OP_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h.inc" // IWYU pragma: export
 
 // clang-format on

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -21,10 +21,6 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 // Base class.
 //===----------------------------------------------------------------------===//
 
-class IREELinalgExt_PureOp<string mnemonic, list<Trait> traits = []> :
-    Op<IREELinalgExt_Dialect, mnemonic, traits> {
-}
-
 class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
     IREELinalgExt_PureOp<mnemonic, !listconcat(traits,
         [AttrSizedOperandSegments,
@@ -36,50 +32,6 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
   let hasCustomAssemblyFormat = 1;
   code extraLinalgExtOpClassDeclaration = "";
 }
-
-//===----------------------------------------------------------------------===//
-// Utility ops
-//===----------------------------------------------------------------------===//
-
-def OpGroupUtilityOps : OpDocGroup {
-  let summary = "Utility ops";
-  let description = "";
-}
-
-let opDocGroup = OpGroupUtilityOps in {
-
-def IREELinalgExt_IndexOp : IREELinalgExt_PureOp<"index", [Pure]>,
-    Arguments<(ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim)>,
-    Results<(outs Index:$result)> {
-  let summary = [{LinalgExt index operation.}];
-  let description = [{
-    This operation is a mirror of `linalg.index` operation and has the same
-    semantics, except that `linalg.index` enforces that the parent op is a
-    `LinalgOp`, and the `iree_linalg_ext.index` operation enforces that the
-    parent op is a `IREE::LinalgExt::CustomOp`.
-  }];
-
-  let assemblyFormat = [{ $dim attr-dict `:` type($result) }];
-  let hasVerifier = 1;
-}
-
-def IREELinalgExt_YieldOp : IREELinalgExt_PureOp<"yield", [Pure, ReturnLike, Terminator]> {
-  let summary = [{LinalgExt yield op.}];
-  let description = [{
-    `iree_linalg_ext.yield` is a special terminator operation for blocks inside
-    regions in `iree_linalg_ext` ops.
-  }];
-
-  let arguments = (ins Variadic<AnyType>:$operands);
-
-  let builders = [
-    OpBuilder<(ins), [{ /* nothing to do */ }]>,
-  ];
-
-  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
-}
-
-} // OpGroupUtilityOps
 
 //===----------------------------------------------------------------------===//
 // Non-structured ops

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtPureOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtPureOps.td
@@ -1,0 +1,64 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECT_LINALGEXT_PURE_OPS
+#define IREE_DIALECT_LINALGEXT_PURE_OPS
+
+include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td"
+include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td"
+include "mlir/Dialect/Linalg/IR/LinalgInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/TilingInterface.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
+
+//===----------------------------------------------------------------------===//
+// Utility ops
+//===----------------------------------------------------------------------===//
+
+def OpGroupUtilityOps : OpDocGroup {
+  let summary = "Utility ops";
+  let description = "";
+}
+
+let opDocGroup = OpGroupUtilityOps in {
+
+def IREELinalgExt_IndexOp : IREELinalgExt_PureOp<"index", [Pure]>,
+    Arguments<(ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim)>,
+    Results<(outs Index:$result)> {
+  let summary = [{LinalgExt index operation.}];
+  let description = [{
+    This operation is a mirror of `linalg.index` operation and has the same
+    semantics, except that `linalg.index` enforces that the parent op is a
+    `LinalgOp`, and the `iree_linalg_ext.index` operation enforces that the
+    parent op is a `IREE::LinalgExt::CustomOp`.
+  }];
+
+  let assemblyFormat = [{ $dim attr-dict `:` type($result) }];
+  let hasVerifier = 1;
+}
+
+def IREELinalgExt_YieldOp : IREELinalgExt_PureOp<"yield", [Pure, ReturnLike, Terminator]> {
+  let summary = [{LinalgExt yield op.}];
+  let description = [{
+    `iree_linalg_ext.yield` is a special terminator operation for blocks inside
+    regions in `iree_linalg_ext` ops.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [
+    OpBuilder<(ins), [{ /* nothing to do */ }]>,
+  ];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+}
+
+} // OpGroupUtilityOps
+
+#endif  // IREE_DIALECT_LINALGEXT_PURE_OPS

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -446,33 +446,12 @@ void registerUtilExternalModels(DialectRegistry &registry) {
             >::registerOpInterface(context);
       });
 
-  // TODO(matthias-springer): Use a helper instead of listing all ops. This is
-  // tricky because LinalgExtOps.td includes YieldOp.
   registry.addExtension(+[](MLIRContext *context,
                             IREE::LinalgExt::IREELinalgExtDialect *dialect) {
-    IREE::LinalgExt::ScatterOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::ScatterOp>>(*context);
-    IREE::LinalgExt::SortOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::SortOp>>(*context);
-    IREE::LinalgExt::FftOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::FftOp>>(*context);
-    IREE::LinalgExt::ScanOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::ScanOp>>(*context);
-    IREE::LinalgExt::TopkOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::TopkOp>>(*context);
-    IREE::LinalgExt::WinogradInputTransformOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::WinogradInputTransformOp>>(
-        *context);
-    IREE::LinalgExt::WinogradFilterTransformOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::WinogradFilterTransformOp>>(
-        *context);
-    IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::WinogradOutputTransformOp>>(
-        *context);
-    IREE::LinalgExt::Im2colOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::Im2colOp>>(*context);
-    IREE::LinalgExt::AttentionOp::attachInterface<
-        LinalgOpTiedOpInterface<IREE::LinalgExt::AttentionOp>>(*context);
+    LinalgOpTiedOpInterfaceHelper<
+#define GET_OP_LIST
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp.inc"
+        >::registerOpInterface(context);
   });
 
   // Hoistable Op Interface registration.


### PR DESCRIPTION
Split LinalgExtOp into PureOp and LinalgExtOp. This enables automatically attaching the right interfaces by simply including the generated .cpp.inc files, preventing missed interface attachments.

Closes https://github.com/iree-org/iree/issues/20862

