### PR TITLE
Bump LLVM to llvm/llvm-project@9abbec6

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -638,7 +638,6 @@ public:
         }
         llvm::TargetOptions opt;
         opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-        opt.UnsafeFPMath = false;
         opt.NoInfsFPMath = false;
         opt.NoNaNsFPMath = true;
         // Be extra cautious while this is less tested, and prevent unknown


### PR DESCRIPTION
Still carrying these reverts:
- https://github.com/llvm/llvm-project/pull/160615 (See https://github.com/iree-org/iree/issues/22171)
- https://github.com/llvm/llvm-project/pull/163440 (See https://github.com/iree-org/iree/pull/22354#issuecomment-3424225175)

Fixes: 
- Remove UnsafeFPmath option from llvm target options (https://github.com/llvm/llvm-project/commit/76f15ead0100e1a846f3e8d055d91ac669e297be)

ci-extra: test_torch