### PR TITLE
Adding markAllAnalysesPreserved to verification passes.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
@@ -36,6 +36,9 @@ struct VerifyInputLegalityPass
                                                           target))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 } // namespace

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
@@ -167,6 +167,9 @@ struct VerifyDevicesPass
         }
       }
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAffinities.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAffinities.cpp
@@ -62,6 +62,9 @@ struct VerifyAffinitiesPass
             })
             .wasInterrupted())
       return signalPassFailure();
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAsyncAccessRanges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyAsyncAccessRanges.cpp
@@ -128,6 +128,9 @@ struct VerifyAsyncAccessRangesPass
             .wasInterrupted()) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -259,6 +259,9 @@ struct VerifyInputPass
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 
@@ -294,6 +297,9 @@ struct VerifyLoweringToTensorsPass
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 
@@ -315,6 +321,9 @@ struct VerifyLoweringToAsyncResourcesPass
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 
@@ -366,6 +375,9 @@ struct VerifyLoweringToAsyncPass
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 
@@ -394,6 +406,9 @@ struct VerifyLoweringToCmdPass
     if (failed(verifier.run(getOperation()))) {
       return signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyStructuredControlFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/VerifyStructuredControlFlow.cpp
@@ -45,6 +45,9 @@ struct VerifyStructuredControlFlowPass
     if (result.wasInterrupted()) {
       signalPassFailure();
     }
+
+    // Preserve all analyses since this is a read-only verification pass.
+    markAllAnalysesPreserved();
   }
 };
 


### PR DESCRIPTION
Verification passes are read-only and don't modify the IR so they should preserve all analyses to avoid unnecessary recomputation in the pass pipeline. We don't use too many analyses today we expect to survive across them but will start to in the future and it's good hygiene.

Part of #16168 PR sequence (1/6).