### PR TITLE
[CI] Add performance tracking graphs

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -6,6 +6,9 @@
 
 name: PkgCI
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   pull_request:
@@ -122,6 +125,14 @@ jobs:
     uses: ./.github/workflows/pkgci_test_pjrt.yml
     with:
       write-caches: ${{ needs.setup.outputs.write-caches }}
+
+  benchmark_graphs:
+    name: Benchmark Graphs
+    needs: [setup, test_torch]
+    # if: ${{ github.repository_owner == 'iree-org' && github.event_name == 'push' && github.ref_name == 'main' }}
+    # !!!!
+    # Uncomment the above line before merging to main.
+    uses: ./.github/workflows/pkgci_benchmark_graphs.yml
 
   ##############################################################################
 

--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -129,9 +129,7 @@ jobs:
   benchmark_graphs:
     name: Benchmark Graphs
     needs: [setup, test_torch]
-    # if: ${{ github.repository_owner == 'iree-org' && github.event_name == 'push' && github.ref_name == 'main' }}
-    # !!!!
-    # Uncomment the above line before merging to main.
+    if: ${{ github.repository_owner == 'iree-org' && github.event_name == 'push' && github.ref_name == 'main' }}
     uses: ./.github/workflows/pkgci_benchmark_graphs.yml
 
   ##############################################################################

--- a/.github/workflows/pkgci_benchmark_graphs.yml
+++ b/.github/workflows/pkgci_benchmark_graphs.yml
@@ -44,7 +44,8 @@ jobs:
           git config --local user.email "github-actions@github.com"
           git config --local user.name "github-actions"
           git add ${OUTPUT_DIR}
-          git commit -m "Update benchmark graphs"
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          git commit -m "Update benchmark graphs for ${SHORT_SHA}"
           git push
         # !!!!
         # Switch to gh-pages branch before merging to main.

--- a/.github/workflows/pkgci_benchmark_graphs.yml
+++ b/.github/workflows/pkgci_benchmark_graphs.yml
@@ -47,9 +47,7 @@ jobs:
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           git commit -m "Update benchmark graphs for ${SHORT_SHA}"
           git push
-        # !!!!
-        # Switch to gh-pages branch before merging to main.
         env:
-          PUBLISH_BRANCH: "gh-pages-test"
+          PUBLISH_BRANCH: "gh-pages"
           OUTPUT_DIR: "./benchmark-tracker/"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgci_benchmark_graphs.yml
+++ b/.github/workflows/pkgci_benchmark_graphs.yml
@@ -1,0 +1,54 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Benchmark Graphs
+
+permissions:
+  contents: write
+
+on:
+  workflow_call:
+
+jobs:
+  summary:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checking out IREE repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: false
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v5.4.0
+        with:
+          python-version: "3.11"
+
+      - name: Generate Benchmark Graphs
+        run: |
+          # Copy the benchmark generation script before switching branches.
+          cp ./build_tools/pkgci/generate_benchmark_graphs.py ./
+          cp ./build_tools/pkgci/gh_utils.py ./
+
+          # Fetch and check out the publish branch for historical data
+          git fetch origin ${PUBLISH_BRANCH}
+          git checkout ${PUBLISH_BRANCH}
+
+          # Generate graphs using artifacts from the current run and history data
+          python ./generate_benchmark_graphs.py \
+            --workflow-run-id ${{ github.run_id }} \
+            --output-dir ${OUTPUT_DIR}
+
+          # Push new graphs.
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "github-actions"
+          git add ${OUTPUT_DIR}
+          git commit -m "Update benchmark graphs"
+          git push
+        # !!!!
+        # Switch to gh-pages branch before merging to main.
+        env:
+          PUBLISH_BRANCH: "gh-pages-test"
+          OUTPUT_DIR: "./benchmark-tracker/"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,7 +33,7 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             cache-dir: /home/nod/iree_tests_cache
-            summary-file: torch_models_cpu_task_summary.json
+            summary-name: torch_models_cpu_task
             runs-on:
               - self-hosted # must come first
               - persistent-cache
@@ -43,7 +43,7 @@ jobs:
           - name: amdgpu_mi325_gfx942
             markers: "gfx942 or mi325"
             cache-dir: /shark-cache/data/iree-regression-cache
-            summary-file: torch_models_amdgpu_mi325_summary.json
+            summary-name: torch_models_amdgpu_mi325
             runs-on: linux-mi325-1gpu-ossci-iree-org
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
@@ -111,5 +111,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ matrix.summary-file }}
+          name: ${{ matrix.summary-name }}_summary.json
           path: ${{ github.workspace }}/iree-test-suites/job_summary.json

--- a/build_tools/pkgci/generate_benchmark_graphs.py
+++ b/build_tools/pkgci/generate_benchmark_graphs.py
@@ -20,9 +20,11 @@ from gh_utils import (
     get_commit_from_run_id,
 )
 
+# Benchmark workflows to track. This needs to be consistent with
+# summary-name fields defined in pkgci_test_torch.yml.
 benchmark_workflows = ["torch_models_cpu_task", "torch_models_amdgpu_mi325"]
 
-max_history_length = 100
+max_history_length = 200
 
 
 def parse_arguments(argv=None):
@@ -43,6 +45,7 @@ def get_benchmark_artifacts_zip_links(run_id: int) -> Dict:
     artifacts = list_gh_artifacts(run_id)
     benchmark_artifacts = {}
     for workflow_name in benchmark_workflows:
+        # Each benchmark workflow uploads a JSON job summary as a zip artifact.
         artifact_name = f"{workflow_name}_summary.json"
         if artifact_name in artifacts:
             benchmark_artifacts[workflow_name] = artifacts[artifact_name]

--- a/build_tools/pkgci/generate_benchmark_graphs.py
+++ b/build_tools/pkgci/generate_benchmark_graphs.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+import argparse
+import json
+import tempfile
+import zipfile
+
+from pathlib import Path
+from typing import List, Dict
+
+from gh_utils import (
+    list_gh_artifacts,
+    fetch_gh_artifact,
+    get_commit_from_run_id,
+)
+
+benchmark_workflows = ["torch_models_cpu_task", "torch_models_amdgpu_mi325"]
+
+max_history_length = 100
+
+
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser(description="Compare CI Benchmarks")
+    parser.add_argument(
+        "--workflow-run-id",
+        help="Fetch artifacts from a specific GitHub workflow using its run ID, like `12125722686`",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Directory to output files",
+    )
+    args = parser.parse_args(argv)
+    return args
+
+
+def get_benchmark_artifacts_zip_links(run_id: int) -> Dict:
+    artifacts = list_gh_artifacts(run_id)
+    benchmark_artifacts = {}
+    for workflow_name in benchmark_workflows:
+        artifact_name = f"{workflow_name}_summary.json"
+        if artifact_name in artifacts:
+            benchmark_artifacts[workflow_name] = artifacts[artifact_name]
+    return benchmark_artifacts
+
+
+def extract_benchmark_json_from_zip(tmpdir_path: Path, url: str) -> Path:
+    zip_path = tmpdir_path / "temp.zip"
+    fetch_gh_artifact(url, zip_path)
+    with zipfile.ZipFile(zip_path) as zip_ref:
+        zip_ref.extractall(tmpdir_path)
+    json_path = tmpdir_path / "job_summary.json"
+    return json_path
+
+
+def process_data(commit_hash: str, data: Dict) -> Dict:
+    # Process data to get relevant information.
+    processed = {"commit_hash": commit_hash, "tests": []}
+    for test in data["benchmark"]["rows"]:
+        processed["tests"].append(
+            {"name": test[0].removesuffix(".json").replace("/", "_"), "time": test[1]}
+        )
+    return processed
+
+
+def append_data_to_history(
+    commit_hash: str, new_result_json: Path, history_results_json: Path
+):
+    # Get the results for the current run.
+    with open(new_result_json, "r") as f:
+        new_results = json.load(f)
+        new_results = process_data(commit_hash, new_results)
+
+    # Append the results to the history.
+    if history_results_json.exists():
+        with open(history_results_json, "r") as f:
+            history_results = json.load(f)
+    else:
+        history_results = []
+    history_results.append(new_results)
+
+    # Keep only the most recent results.
+    if len(history_results) > max_history_length:
+        history_results = history_results[-max_history_length:]
+
+    # Write the updated history back to the file.
+    history_results_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(history_results_json, "w") as f:
+        json.dump(history_results, f, indent=2)
+
+
+def dump_html(results_history: List) -> str:
+    graph_data = {}
+    for entry in results_history:
+        for test in entry["tests"]:
+            name = test["name"]
+            if name not in graph_data:
+                graph_data[name] = {
+                    "commit_hashes": [],
+                    "time": [],
+                }
+
+    time_unit = "ms"
+    for entry in results_history:
+        commit_hash = str(entry["commit_hash"])[:7]
+        local_tests = dict.fromkeys(graph_data.keys(), None)
+        for test in entry["tests"]:
+            local_tests[test["name"]] = test
+        for test_name, test in local_tests.items():
+            graph_data[test_name]["commit_hashes"].append(commit_hash)
+            # So that the time/commit horizontal/x axis is consistent
+            # across tests, even if a test is missing for a commit,
+            # we add time=0 if a test did not run successfully.
+            if not test:
+                graph_data[test_name]["time"].append(0)
+            else:
+                graph_data[test_name]["time"].append(test["time"])
+
+    # Start building the HTML content.
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Benchmark Tracker</title>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <style>
+            body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }
+            .chart-container { width: 80%; margin: 30px auto; }
+            canvas { width: 100%; height: auto; }
+        </style>
+    </head>
+    <body>
+        <h1>Benchmark Tracker</h1>
+    """
+
+    # Add a graph for each test
+    for test_name, data in graph_data.items():
+        html_content += f"""
+        <div class="chart-container">
+            <h2>{test_name}</h2>"""
+        html_content += f"""
+            <canvas id="chart-{test_name.replace(' ', '-')}"></canvas>
+        </div>
+        <script>
+            const ctx_{test_name.replace(' ', '_')} = document.getElementById('chart-{test_name.replace(' ', '-')}')
+            const chart_{test_name.replace(' ', '_')} = new Chart(ctx_{test_name.replace(' ', '_')}, {{
+                type: 'line',
+                data: {{
+                    labels: {data["commit_hashes"]},  // Truncated commit hashes as X-axis labels
+                    datasets: [{{
+                        label: 'Time ({time_unit})',
+                        data: {data["time"]},   // Test time as Y-axis
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        borderWidth: 2
+                    }}]
+                }},
+                options: {{
+                    responsive: true,
+                    scales: {{
+                        x: {{
+                            title: {{
+                                display: true,
+                                text: 'Commit Hash'
+                            }}
+                        }},
+                        y: {{
+                            beginAtZero: true,  // Ensures the Y-axis starts at 0
+                            title: {{
+                                display: true,
+                                text: 'Time ({time_unit})'
+                            }}
+                        }}
+                    }}
+                }}
+            }});
+        </script>
+        """
+
+    # Close the HTML content
+    html_content += """
+    </body>
+    </html>
+    """
+
+    return html_content
+
+
+def process_and_generate(
+    commit_hash: str,
+    new_results_json: Path,
+    history_results_json: Path,
+    html_path: Path,
+):
+    # Append new data to history.
+    append_data_to_history(commit_hash, new_results_json, history_results_json)
+    # Generate and save the HTML file.
+    with open(history_results_json, "r") as f:
+        results_history = json.load(f)
+    html_content = dump_html(results_history)
+    with open(html_path, "w") as f:
+        f.write(html_content)
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    output_dir = Path(args.output_dir)
+    commit_hash = get_commit_from_run_id(args.workflow_run_id)
+    artifact_links = get_benchmark_artifacts_zip_links(args.workflow_run_id)
+
+    # Process each benchmark workflow.
+    for workflow_name, artifact_url in artifact_links.items():
+        history_results_json = output_dir / f"{workflow_name}_history.json"
+        html_path = output_dir / f"{workflow_name}.html"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_results_json = extract_benchmark_json_from_zip(
+                Path(tmpdir), artifact_url
+            )
+            process_and_generate(
+                commit_hash, new_results_json, history_results_json, html_path
+            )

--- a/build_tools/pkgci/gh_utils.py
+++ b/build_tools/pkgci/gh_utils.py
@@ -1,0 +1,110 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import functools
+import json
+import os
+import urllib.request
+from pathlib import Path
+import subprocess
+from typing import Dict
+
+THIS_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = THIS_DIR.parent.parent
+BASE_API_PATH = "/repos/iree-org/iree"
+
+
+def query_gh_api(api_path: str):
+    url = f"https://api.github.com{api_path}"
+    print(f"Querying GitHub API: {url}")
+    gh_token = os.environ.get("GH_TOKEN", "")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {gh_token}",
+    }
+    req = urllib.request.Request(url)
+    for k, v in headers.items():
+        # https://github.com/arduino/report-size-deltas/pull/83
+        req.add_unredirected_header(k, v)
+
+    with urllib.request.urlopen(req) as response:
+        if response.status != 200:
+            raise RuntimeError(
+                f"GitHub API request failed: {response.status} {response.reason}"
+            )
+        contents = response.read()
+        return contents
+
+
+def get_latest_workflow_run_id_for_main() -> int:
+    print(f"Looking up latest workflow run for main branch")
+    # Note: at a high level, we probably want to select one of these:
+    #   A) The latest run that produced package artifacts
+    #   B) The latest run that passed all checks
+    # Instead, we just check for the latest completed workflow. This can miss
+    # runs that are still pending (especially if jobs are queued waiting for
+    # runners) and can include jobs that failed tests (for better or worse).
+    workflow_run_output = query_gh_api(
+        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?branch=main&event=push&status=completed&per_page=1"
+    )
+    workflow_run_json_output = json.loads(workflow_run_output)
+    latest_run = workflow_run_json_output["workflow_runs"][0]
+    print(f"\nFound workflow run: {latest_run['html_url']}")
+    return latest_run["id"]
+
+
+def get_latest_workflow_run_id_for_ref(ref: str) -> int:
+    print(f"Finding workflow run for ref: {ref}")
+    normalized_ref = (
+        subprocess.check_output(["git", "rev-parse", ref], cwd=REPO_ROOT)
+        .decode()
+        .strip()
+    )
+
+    print(f"  Using normalized ref: {normalized_ref}")
+    workflow_run_output = query_gh_api(
+        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?head_sha={normalized_ref}"
+    )
+    workflow_run_json_output = json.loads(workflow_run_output)
+    if workflow_run_json_output["total_count"] == 0:
+        raise RuntimeError("Workflow did not run at this commit")
+
+    latest_run = workflow_run_json_output["workflow_runs"][-1]
+    print(f"\nFound workflow run: {latest_run['html_url']}")
+    return latest_run["id"]
+
+
+@functools.lru_cache
+def list_gh_artifacts(run_id: str) -> Dict[str, str]:
+    print(f"Fetching artifacts for workflow run: {run_id}")
+    output = query_gh_api(f"{BASE_API_PATH}/actions/runs/{run_id}/artifacts")
+    data = json.loads(output)
+    # Uncomment to debug:
+    # print(json.dumps(data, indent=2))
+    artifacts = {
+        rec["name"]: f"{BASE_API_PATH}/actions/artifacts/{rec['id']}/zip"
+        for rec in data["artifacts"]
+    }
+    print("\nFound artifacts:")
+    for k, v in artifacts.items():
+        print(f"  {k}: {v}")
+    return artifacts
+
+
+def get_commit_from_run_id(run_id: int) -> str:
+    print(f"Fetching commit for workflow run: {run_id}")
+    output = query_gh_api(f"{BASE_API_PATH}/actions/runs/{run_id}")
+    data = json.loads(output)
+    commit = data["head_sha"]
+    print(f"Found commit: {commit}")
+    return commit
+
+
+def fetch_gh_artifact(api_path: str, file: Path):
+    print(f"Downloading artifact {api_path}")
+    contents = query_gh_api(api_path)
+    file.write_bytes(contents)

--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -73,22 +73,21 @@ environment variable if you will be fetching artifacts.
 
 from glob import glob
 from pathlib import Path
-from typing import Optional, Dict, Tuple
+from typing import Optional, Tuple
 
 import argparse
-import functools
-import json
 import platform
 import subprocess
 import sys
 import tempfile
 import zipfile
-import os
-import urllib.request
 
-THIS_DIR = Path(__file__).parent.resolve()
-REPO_ROOT = THIS_DIR.parent.parent
-BASE_API_PATH = "/repos/iree-org/iree"
+from gh_utils import (
+    fetch_gh_artifact,
+    get_latest_workflow_run_id_for_main,
+    get_latest_workflow_run_id_for_ref,
+    list_gh_artifacts,
+)
 
 
 def parse_arguments(argv=None):
@@ -125,90 +124,6 @@ def parse_arguments(argv=None):
     )
     args = parser.parse_args(argv)
     return args
-
-
-def query_gh_api(api_path: str):
-    url = f"https://api.github.com{api_path}"
-    print(f"Querying GitHub API: {url}")
-    gh_token = os.environ.get("GH_TOKEN", "")
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {gh_token}",
-    }
-    req = urllib.request.Request(url)
-    for k, v in headers.items():
-        # https://github.com/arduino/report-size-deltas/pull/83
-        req.add_unredirected_header(k, v)
-
-    with urllib.request.urlopen(req) as response:
-        if response.status != 200:
-            raise RuntimeError(
-                f"GitHub API request failed: {response.status} {response.reason}"
-            )
-        contents = response.read()
-        return contents
-
-
-def get_latest_workflow_run_id_for_main() -> int:
-    print(f"Looking up latest workflow run for main branch")
-    # Note: at a high level, we probably want to select one of these:
-    #   A) The latest run that produced package artifacts
-    #   B) The latest run that passed all checks
-    # Instead, we just check for the latest completed workflow. This can miss
-    # runs that are still pending (especially if jobs are queued waiting for
-    # runners) and can include jobs that failed tests (for better or worse).
-    workflow_run_output = query_gh_api(
-        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?branch=main&event=push&status=completed&per_page=1"
-    )
-    workflow_run_json_output = json.loads(workflow_run_output)
-    latest_run = workflow_run_json_output["workflow_runs"][0]
-    print(f"\nFound workflow run: {latest_run['html_url']}")
-    return latest_run["id"]
-
-
-def get_latest_workflow_run_id_for_ref(ref: str) -> int:
-    print(f"Finding workflow run for ref: {ref}")
-    normalized_ref = (
-        subprocess.check_output(["git", "rev-parse", ref], cwd=REPO_ROOT)
-        .decode()
-        .strip()
-    )
-
-    print(f"  Using normalized ref: {normalized_ref}")
-    workflow_run_output = query_gh_api(
-        f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?head_sha={normalized_ref}"
-    )
-    workflow_run_json_output = json.loads(workflow_run_output)
-    if workflow_run_json_output["total_count"] == 0:
-        raise RuntimeError("Workflow did not run at this commit")
-
-    latest_run = workflow_run_json_output["workflow_runs"][-1]
-    print(f"\nFound workflow run: {latest_run['html_url']}")
-    return latest_run["id"]
-
-
-@functools.lru_cache
-def list_gh_artifacts(run_id: str) -> Dict[str, str]:
-    print(f"Fetching artifacts for workflow run: {run_id}")
-    output = query_gh_api(f"{BASE_API_PATH}/actions/runs/{run_id}/artifacts")
-    data = json.loads(output)
-    # Uncomment to debug:
-    # print(json.dumps(data, indent=2))
-    artifacts = {
-        rec["name"]: f"{BASE_API_PATH}/actions/artifacts/{rec['id']}/zip"
-        for rec in data["artifacts"]
-    }
-    print("\nFound artifacts:")
-    for k, v in artifacts.items():
-        print(f"  {k}: {v}")
-    return artifacts
-
-
-def fetch_gh_artifact(api_path: str, file: Path):
-    print(f"Downloading artifact {api_path}")
-    contents = query_gh_api(api_path)
-    file.write_bytes(contents)
 
 
 def find_venv_python(venv_path: Path) -> Optional[Path]:


### PR DESCRIPTION
To make it easier to monitor performance fluctuations across commits, this PR adds a new workflow that generates HTML line charts, where the x-axis represents commit hashes and the y-axis shows execution time for each individual test.

To preview (download and view in a browser): https://github.com/iree-org/iree/blob/gh-pages-test/benchmark-tracker/torch_models_amdgpu_mi325.html

Once landed, the generated webpage will be available at: https://iree.dev/benchmark-tracker/WORKFLOW_NAME.html, where `WORKFLOW_NAME in {"torch_models_cpu_task", "torch_models_amdgpu_mi325"}`

Acknowledgement: Builds upon some features in #22272. Thanks @Groverkss for sharing it!

Closes: #22375
 
ci-extra: test_torch