### PR TITLE
[CI][TorchModels] Add data-tiling for Llama 8B Fp8 on gfx942

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 250.5
+    "golden_time_ms": 275.55
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
@@ -1,0 +1,10 @@
+{
+  "type": "compstat",
+  "markers": [
+    "hip",
+    "gfx942"
+  ],
+  "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
+  "golden_dispatch_count": 1517,
+  "golden_binary_size": 3000000
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
-  "golden_dispatch_count": 1517,
+  "golden_dispatch_count": 1711,
   "golden_binary_size": 3000000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
@@ -6,5 +6,5 @@
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
   "golden_dispatch_count": 1711,
-  "golden_binary_size": 3000000
+  "golden_binary_size": 3300000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 53.0
+    "golden_time_ms": 58.3
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 8.0
+    "golden_time_ms": 53.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -1,0 +1,43 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp8/modules/llama_gfx942_data_tiling"
+    ],
+    "weights": [
+        {
+            "type": "random",
+            "scope": "model",
+            "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
+            "seed": 42
+        }
+    ],
+    "run_args": [
+        "--function=decode_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x1xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x4xi64"
+      },
+      {
+        "value": "34x2097152xf8E4M3FNUZ"
+      }
+    ],
+    "golden_time_ms": 8.0
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 55
+    "golden_time_ms": 60.5
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 10.5
+    "golden_time_ms": 55
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -1,0 +1,43 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp8/modules/llama_gfx942_data_tiling"
+    ],
+    "weights": [
+        {
+            "type": "random",
+            "scope": "model",
+            "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
+            "seed": 42
+        }
+    ],
+    "run_args": [
+        "--function=decode_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x1xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x64xi64"
+      },
+      {
+        "value": "34x2097152xf8E4M3FNUZ"
+      }
+    ],
+    "golden_time_ms": 10.5
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/modules/llama_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/modules/llama_gfx942_data_tiling.json
@@ -1,0 +1,15 @@
+{
+  "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/llama_8b_fp8/bs4.mlir",
+  "compiler_flags": [
+      "--iree-hal-target-device=hip",
+      "--iree-hip-target=gfx942",
+      "--iree-opt-level=O3",
+      "--iree-dispatch-creation-propagate-collapse-across-expands=true",
+      "--iree-hip-enable-tensor-ukernels",
+      "--iree-hip-specialize-dispatches",
+      "--iree-stream-resource-memory-model=discrete",
+      "--iree-hal-indirect-command-buffers=true",
+      "--iree-hal-memoization=true",
+      "--iree-dispatch-creation-data-tiling"
+  ]
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 28.5
+    "golden_time_ms": 31.35
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
@@ -1,0 +1,40 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp8/modules/llama_gfx942_data_tiling"
+    ],
+    "weights": [
+        {
+            "type": "random",
+            "scope": "model",
+            "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
+            "seed": 42
+        }
+    ],
+    "run_args": [
+        "--function=prefill_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x128xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x4xi64"
+      },
+      {
+        "value": "34x2097152xf8E4M3FNUZ"
+      }
+    ],
+    "golden_time_ms": 26.0
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 26.0
+    "golden_time_ms": 28.5
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 201.5
+    "golden_time_ms": 221.65
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -1,0 +1,40 @@
+{
+    "type": "benchmark",
+    "markers": [
+        "hip",
+        "mi325"
+    ],
+    "modules": [
+        "llama_8b_fp8/modules/llama_gfx942_data_tiling"
+    ],
+    "weights": [
+        {
+            "type": "random",
+            "scope": "model",
+            "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
+            "seed": 42
+        }
+    ],
+    "run_args": [
+        "--function=prefill_bs4",
+        "--device=hip",
+        "--benchmark_repetitions=10",
+        "--benchmark_min_warmup_time=3.0"
+    ],
+
+    "inputs": [
+      {
+        "value": "4x2048xi64"
+      },
+      {
+        "value": "4xi64"
+      },
+      {
+        "value": "4x64xi64"
+      },
+      {
+        "value": "34x2097152xf8E4M3FNUZ"
+      }
+    ],
+    "golden_time_ms": 180.0
+}

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325_data_tiling.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 180.0
+    "golden_time_ms": 201.5
 }


### PR DESCRIPTION
-- This commit adds data-tiling benchmark tests for Llama 8B on gfx942.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>

Summary:

No. of dispatches for NON-DATA-TILED: 1485 
No. of dispatches for DATA-TILED: 1711

`DECODE`
```
       NON-DATA TILED   |      DATA-TILED
128  |    8.26          |        53
2048 |    11.14         |        55
```
`PREFILL`
```
       NON-DATA TILED   |      DATA-TILED
128  |    27            |        28.5
2048 |    169.6         |        201.5
```

ci-extra: test_torch