### PR TITLE
[Codegen] Implement value bounds interface for LoadFromBufferOp

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns.mlir
@@ -643,3 +643,41 @@ func.func @negative_matmul_bf16_expanded_large_no_zero_fill(%arg0: tensor<1x256x
 // GFX950-LABEL: @negative_matmul_bf16_expanded_large_no_zero_fill
 // GFX950-NOT:     compilation_info = #iree_codegen.compilation_info
 // GFX950-NOT:     iree_codegen.ukernel = #iree_codegen.ukernel_descriptor
+
+// -----
+
+// Test that `load_from_buffer` propagates constraints for dynamic dimensions.
+
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @matmul_f8_load_from_buffer(%arg0: index) -> tensor<1x128x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = util.assume.int %arg0<umin = 512, udiv = 128> : index
+  %1 = memref.alloc(%0) : memref<1x128x?xf8E4M3FNUZ>
+  %2 = memref.alloc(%0) : memref<1024x?xf8E4M3FNUZ>
+  %3 = iree_codegen.load_from_buffer %1 : memref<1x128x?xf8E4M3FNUZ> -> tensor<1x128x?xf8E4M3FNUZ>
+  %4 = iree_codegen.load_from_buffer %2 : memref<1024x?xf8E4M3FNUZ> -> tensor<1024x?xf8E4M3FNUZ>
+  %5 = tensor.empty() : tensor<1x128x1024xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x128x1024xf32>) -> tensor<1x128x1024xf32>
+  %7 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x128x?xf8E4M3FNUZ>, tensor<1024x?xf8E4M3FNUZ>) outs(%6 : tensor<1x128x1024xf32>) {
+  ^bb0(%in: f8E4M3FNUZ, %in_0: f8E4M3FNUZ, %out: f32):
+    %8 = arith.extf %in : f8E4M3FNUZ to f32
+    %9 = arith.extf %in_0 : f8E4M3FNUZ to f32
+    %10 = arith.mulf %8, %9 : f32
+    %11 = arith.addf %out, %10 : f32
+    linalg.yield %11 : f32
+  } -> tensor<1x128x1024xf32>
+  return %7 : tensor<1x128x1024xf32>
+}
+// GFX942-LABEL: @matmul_f8_load_from_buffer
+// GFX942:         linalg.generic
+// GFX942-SAME:      compilation_info = #iree_codegen.compilation_info
+// GFX942-SAME:      lowering_config =
+// GFX942-SAME:      workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>
+// GFX942-SAME:      translation_info =
+// GFX942-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8E4M3FNUZ_expanded", tensor>
+// GFX950-LABEL: @matmul_f8_load_from_buffer
+// GFX950:         linalg.generic
+// GFX950-NOT:      compilation_info = #iree_codegen.compilation_info
+// GFX950-NOT:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_medium_f8E4M3FNUZ_expanded", tensor>

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -18,12 +18,14 @@ iree_compiler_cc_library(
         "CPUEncodingExternalModels.cpp",
         "GPUEncodingExternalModels.cpp",
         "Interfaces.cpp",
+        "UtilExternalModels.cpp",
         "Utils.cpp",
     ],
     hdrs = [
         "CPUEncodingExternalModels.h",
         "GPUEncodingExternalModels.h",
         "Interfaces.h",
+        "UtilExternalModels.h",
         "Utils.h",
     ],
     deps = [
@@ -44,5 +46,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -17,11 +17,13 @@ iree_cc_library(
     "CPUEncodingExternalModels.h"
     "GPUEncodingExternalModels.h"
     "Interfaces.h"
+    "UtilExternalModels.h"
     "Utils.h"
   SRCS
     "CPUEncodingExternalModels.cpp"
     "GPUEncodingExternalModels.cpp"
     "Interfaces.cpp"
+    "UtilExternalModels.cpp"
     "Utils.cpp"
   DEPS
     LLVMSupport
@@ -30,6 +32,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRTensorDialect
+    MLIRValueBoundsOpInterface
     iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Interfaces.cpp
@@ -8,10 +8,12 @@
 
 #include "iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.h"
 #include "iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.h"
+#include "iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.h"
 
 namespace mlir::iree_compiler {
 
 void registerCodegenExternalInterfaces(DialectRegistry &registry) {
+  IREE::Codegen::registerUtilExternalModels(registry);
   IREE::CPU::registerCPUEncodingExternalModels(registry);
   IREE::GPU::registerGPUEncodingExternalModels(registry);
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.cpp
@@ -1,0 +1,42 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// ValueBoundsOpInterface
+//===----------------------------------------------------------------------===//
+
+struct LoadFromBufferOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<
+          LoadFromBufferOpInterface, IREE::Codegen::LoadFromBufferOp> {
+  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
+                                       ValueBoundsConstraintSet &cstr) const {
+    auto loadOp = cast<IREE::Codegen::LoadFromBufferOp>(op);
+    assert(value == loadOp.getResult() && "invalid value");
+    cstr.bound(value)[dim] == cstr.getExpr(loadOp.getBuffer(), dim);
+  }
+};
+
+} // namespace
+
+void registerUtilExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::Codegen::IREECodegenDialect *dialect) {
+    IREE::Codegen::LoadFromBufferOp::attachInterface<LoadFromBufferOpInterface>(
+        *context);
+  });
+}
+
+} // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/UtilExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILEXTERNALMODELS_H_
+#define IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+void registerUtilExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler::IREE::Codegen
+
+#endif // IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILEXTERNALMODELS_H_


### PR DESCRIPTION
I encountered the LoadFromBufferOp blocking derivation of the value bounds when trying to select the right ukernel for specialized dispatches.

Example dispatch:
```mlir
func.func @test_dispatch_0_matmul_like_Dx4096x14336_f16xf16xf32_0_1() {
  %c32_i64 = arith.constant 32 : i64
  %cst = arith.constant 0.000000e+00 : f32
  %c0 = arith.constant 0 : index
  %0 = hal.interface.constant.load layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
  %1 = hal.interface.constant.load layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
  %2 = hal.interface.constant.load layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(2) : i32
  %3 = hal.interface.constant.load layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(3) : i32
  %4 = hal.interface.constant.load layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(4) : i32
  %5 = arith.extui %1 : i32 to i64
  %6 = arith.shli %5, %c32_i64 : i64
  %7 = arith.extui %0 : i32 to i64
  %8 = arith.ori %7, %6 : i64
  %9 = arith.index_castui %8 : i64 to index
  %10 = arith.extui %3 : i32 to i64
  %11 = arith.shli %10, %c32_i64 : i64
  %12 = arith.extui %2 : i32 to i64
  %13 = arith.ori %12, %11 : i64
  %14 = arith.index_castui %13 : i64 to index
  %15 = arith.index_castui %4 : i32 to index
  %16:3 = util.assume.int 
      %9<umin = 0, umax = 9007199254740991>, 
      %14<umin = 0, umax = 9007199254740991>, 
      %15<umin = 128, umax = 524160, udiv = 128>
    : index, index, index
  %17 = hal.interface.binding.subspan layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4096x14336xf16, #hal.descriptor_type<storage_buffer>>
  %18 = amdgpu.fat_raw_buffer_cast %17 resetOffset : memref<4096x14336xf16, #hal.descriptor_type<storage_buffer>> to memref<4096x14336xf16, #amdgpu.address_space<fat_raw_buffer>>
  %19 = iree_tensor_ext.dispatch.workload.ordinal %16#0, 0 : index
  %20 = iree_tensor_ext.dispatch.workload.ordinal %16#1, 1 : index
  %21 = iree_tensor_ext.dispatch.workload.ordinal %16#2, 2 : index
  %22 = hal.interface.binding.subspan layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<?x14336xf16, #hal.descriptor_type<storage_buffer>>{%19}
  %23 = hal.interface.binding.subspan layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<?x4096xf16, #hal.descriptor_type<storage_buffer>>{%20}
  %24 = hal.interface.binding.subspan layout(<constants = 5, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) : memref<?x4096xf16, #hal.descriptor_type<storage_buffer>>{%21}
  %25 = iree_codegen.load_from_buffer %18 : memref<4096x14336xf16, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4096x14336xf16>
  %26 = affine.apply affine_map<()[s0] -> (s0 floordiv 128)>()[%21]
  %27 = tensor.empty(%26) : tensor<?x128x4096xf32>
  %28 = linalg.fill ins(%cst : f32) outs(%27 : tensor<?x128x4096xf32>) -> tensor<?x128x4096xf32>
  %29 = affine.apply affine_map<()[s0] -> (s0 floordiv 128)>()[%19]
  %expand_shape = memref.expand_shape %24 [[0, 1], [2]] output_shape [%29, 128, 4096] : memref<?x4096xf16, #hal.descriptor_type<storage_buffer>> into memref<?x128x4096xf16, #hal.descriptor_type<storage_buffer>>
  %expand_shape_0 = memref.expand_shape %23 [[0, 1], [2]] output_shape [%29, 128, 4096] : memref<?x4096xf16, #hal.descriptor_type<storage_buffer>> into memref<?x128x4096xf16, #hal.descriptor_type<storage_buffer>>
  %expand_shape_1 = memref.expand_shape %22 [[0, 1], [2]] output_shape [%29, 128, 14336] : memref<?x14336xf16, #hal.descriptor_type<storage_buffer>> into memref<?x128x14336xf16, #hal.descriptor_type<storage_buffer>>
  %30 = iree_codegen.load_from_buffer %expand_shape_1 : memref<?x128x14336xf16, #hal.descriptor_type<storage_buffer>> -> tensor<?x128x14336xf16>
  %31 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%30, %25 : tensor<?x128x14336xf16>, tensor<4096x14336xf16>) outs(%28 : tensor<?x128x4096xf32>) {
  ^bb0(%in: f16, %in_2: f16, %out: f32):
    %35 = arith.extf %in : f16 to f32
    %36 = arith.extf %in_2 : f16 to f32
    %37 = arith.mulf %35, %36 : f32
    %38 = arith.addf %out, %37 : f32
    linalg.yield %38 : f32
  } -> tensor<?x128x4096xf32>
  %32 = tensor.empty(%26) : tensor<?x128x4096xf16>
  %33 = iree_codegen.load_from_buffer %expand_shape_0 : memref<?x128x4096xf16, #hal.descriptor_type<storage_buffer>> -> tensor<?x128x4096xf16>
  %34 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%33, %31 : tensor<?x128x4096xf16>, tensor<?x128x4096xf32>) outs(%32 : tensor<?x128x4096xf16>) {
  ^bb0(%in: f16, %in_2: f32, %out: f16):
    %35 = arith.truncf %in_2 : f32 to f16
    %36 = arith.addf %in, %35 : f16
    linalg.yield %36 : f16
  } -> tensor<?x128x4096xf16>
  iree_codegen.store_to_buffer %34, %expand_shape : tensor<?x128x4096xf16> into memref<?x128x4096xf16, #hal.descriptor_type<storage_buffer>>
  return
}
```