### PR TITLE
Fix `iree.build` source directory being gitignore'd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@
 /build/
 /build-*/
 Testing/
+/compiler/build/
+/runtime/build/
+/integrations/tensorflow/python_projects/iree_tf/build/
+/integrations/tensorflow/python_projects/iree_tflite/build/
 
 # Bazel artifacts
 **/bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -22,11 +22,9 @@
 .DS_Store
 
 # CMake artifacts
-build/
-build-*/
+/build/
+/build-*/
 Testing/
-# Include iree.build package
-!compiler/bindings/python/iree/compiler/build/
 
 # Bazel artifacts
 **/bazel-*


### PR DESCRIPTION
The gitignore path is currently wrong (it should be `iree/build`, not `iree/compiler/build`). This switches to selectively ignoring `build` directories instead of selectively un-ignoring, since that seems safer.