### PR TITLE
[ROCM] Improve f16 medium ukernel bounds

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/ukernel_patterns_gfx942.mlir
@@ -314,10 +314,8 @@ pdl.pattern @annotate_matmul_like_f16_medium_expanded : benefit(1) {
   // M, N >= 1024, K >= 256
   %c1024 = pdl.attribute = 1024
 
-  // TODO: Kernel specialization is needed to apply this strategy selectively at
-  // runtime. Additionally model exports don't specify lower bounds so it is
-  // impossible to use this strategy with this check.
-  // pdl.apply_native_constraint "dimIsBound"(%lhs, %c0, %c4, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
+  // From experimental results, see #22393, we should start using this ukernel if B * M >= 1024.
+  pdl.apply_native_constraint "dimsMultipliedIsBound"(%lhs, %c0, %c1, %c1024, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute, !pdl.attribute)
 
   pdl.apply_native_constraint "dimIsBound"(%rhs, %c0, %c1024, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)
   pdl.apply_native_constraint "dimIsBound"(%lhs, %c2, %c256, %empty : !pdl.value, !pdl.attribute, !pdl.attribute, !pdl.attribute)

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgOpsIncGen",
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:MLProgramDialect",
+        "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:ValueBoundsOpInterface",
     ],

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     MLIRLinalgOpsIncGenLib
     MLIRLinalgStructuredOpsIncGenLib
     MLIRMLProgramDialect
+    MLIRMemRefDialect
     MLIRTensorDialect
     MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Encoding::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
@@ -399,6 +400,18 @@ struct HoistableLinalgOpInterfaceHelper {
   }
 };
 
+/// TODO(jtuyls): Remove when added to upstream.
+struct ExpandShapeOpValueBoundsInterface
+    : public ValueBoundsOpInterface::ExternalModel<
+          ExpandShapeOpValueBoundsInterface, memref::ExpandShapeOp> {
+  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
+                                       ValueBoundsConstraintSet &cstr) const {
+    auto expandOp = cast<memref::ExpandShapeOp>(op);
+    assert(value == expandOp.getResult() && "invalid value");
+    cstr.bound(value)[dim] == expandOp.getOutputShape()[dim];
+  }
+};
+
 } // namespace
 
 void registerUtilExternalModels(DialectRegistry &registry) {
@@ -537,6 +550,12 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         IREE::Util::AssumeIntOp::attachInterface<
             UtilAssumeIntValueBoundsOpInterface>(*context);
       });
+
+  registry.addExtension(+[](MLIRContext *context,
+                            memref::MemRefDialect *dialect) {
+    memref::ExpandShapeOp::attachInterface<ExpandShapeOpValueBoundsInterface>(
+        *context);
+  });
 }
 
 } // namespace mlir::iree_compiler


### PR DESCRIPTION
Stacked on top of: https://github.com/iree-org/iree/pull/22390

As part of enabling the tensor ukernels by default: https://github.com/iree-org/iree/pull/22318

Based on that PR, I used one of the f16 matmul dispatches that is slower in the benchmark tests (see repro below).

**Results on matmul ?x4096x14336:** 

| M        | No UKernel    | UKernel All Medium    | This PR        |
|-----------|---------------|-----------------------|----------------|
| 128       | 0.660 ms      | 0.970 ms              | 0.629 ms       |
| 256       | 0.647 ms      | 1.02 ms               | 0.661 ms       |
| 384       | 0.662 ms      | 0.987 ms              | 0.668 ms       |
| 512       | 0.674 ms      | 0.947 ms              | 0.655 ms       |
| 640       | 0.925 ms      | 1.02 ms               | 0.886 ms       |
| 768       | 0.974 ms      | 1.00 ms               | 0.944 ms       |
| 896       | 0.924 ms      | 0.988 ms              | 0.949 ms       |
| 1024      | 0.883 ms      | 0.899 ms              | 0.865 ms       |
| 1152      | 0.912 ms      | 0.948 ms              | 0.935 ms       |
| 1280      | 1.09 ms       | 1.05 ms               | 0.998 ms       |
| 1408      | 1.22 ms       | 0.972 ms              | 0.997 ms       |
| 1536      | 1.23 ms       | 0.985 ms              | 1.03 ms        |
| 1664      | 1.20 ms       | 1.00 ms               | 0.926 ms       |
| 1792      | 1.20 ms       | 0.983 ms              | 0.968 ms       |
| 1920      | 1.43 ms       | 0.982 ms              | 0.956 ms       |
| 2048      | 1.21 ms       | 1.07 ms               | 1.03 ms        |

From this we can see that using no ukernel is faster that using the medium-sized ukernel if M is below +-1024, so the selection logic is updated here to switch between no ukernel and ukernel at this boundary. I also ran the experiment on the smallest possible matmuls for which the medium-sized f16 ukernel is selected to make sure this PR doesn't regress performance on smaller shapes:

**Results on matmul ?x1024x256:** 

| M         | No UKernel    | UKernel All Medium | This PR       |
|-----------|---------------|--------------------|---------------|
| 128       | 0.543 ms      | 0.559 ms           | 0.543 ms      |
| 256       | 0.560 ms      | 0.557 ms           | 0.595 ms      |
| 384       | 0.520 ms      | 0.563 ms           | 0.605 ms      |
| 512       | 0.560 ms      | 0.534 ms           | 0.479 ms      |
| 640       | 0.575 ms      | 0.495 ms           | 0.578 ms      |
| 768       | 0.567 ms      | 0.565 ms           | 0.566 ms      |
| 896       | 0.524 ms      | 0.576 ms           | 0.600 ms      |
| 1024      | 0.574 ms      | 0.619 ms           | 0.585 ms      |
| 1152      | 0.545 ms      | 0.514 ms           | 0.564 ms      |
| 1280      | 0.545 ms      | 0.506 ms           | 0.538 ms      |
| 1408      | 0.622 ms      | 0.588 ms           | 0.570 ms      |
| 1536      | 0.579 ms      | 0.615 ms           | 0.545 ms      |
| 1664      | 0.586 ms      | 0.607 ms           | 0.553 ms      |
| 1792      | 0.552 ms      | 0.545 ms           | 0.560 ms      |
| 1920      | 0.554 ms      | 0.568 ms           | 0.530 ms      |
| 2048      | 0.529 ms      | 0.524 ms           | 0.573 ms      |

All latencies are pretty similar for using no ukernel, using a medium-sized ukernel and this PR, so the bounds look ok.

**Repro:**
```
module {
  util.func public @test(%arg0: tensor<?x14336xf16>, %arg1: tensor<4096x14336xf16>, %arg2: tensor<?x4096xf16>) -> tensor<?x4096xf16> {
    %c0 = arith.constant 0 : index
    %cst = arith.constant 0.000000e+00 : f32
    %0 = tensor.dim %arg0, %c0 : tensor<?x14336xf16>
    %dim = util.assume.int %0<umin = 128, umax = 524160, udiv = 128> : index
    %17 = tensor.empty(%dim) : tensor<?x4096xf32>
    %18 = linalg.fill ins(%cst : f32) outs(%17 : tensor<?x4096xf32>) -> tensor<?x4096xf32>
    %19 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<?x14336xf16>, tensor<4096x14336xf16>) outs(%18 : tensor<?x4096xf32>) {
    ^bb0(%in: f16, %in_0: f16, %out: f32):
      %22 = arith.extf %in : f16 to f32
      %23 = arith.extf %in_0 : f16 to f32
      %24 = arith.mulf %22, %23 : f32
      %25 = arith.addf %out, %24 : f32
      linalg.yield %25 : f32
    } -> tensor<?x4096xf32>
    %35 = tensor.empty(%dim) : tensor<?x4096xf16>
    %36 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%arg2, %19 : tensor<?x4096xf16>, tensor<?x4096xf32>) outs(%35 : tensor<?x4096xf16>) {
    ^bb0(%in: f16, %in_0: f32, %out: f16):
      %37 = arith.truncf %in_0 : f32 to f16
      %38 = arith.addf %in, %37 : f16
      linalg.yield %38 : f16
    } -> tensor<?x4096xf16>
    util.return %36 : tensor<?x4096xf16>
  }
}
```
**Compile command:**
```
iree-compile repro.mlir \
    --iree-hal-target-device=hip \
    --iree-hip-target=gfx942 \
    -o repro.vmfb \
    --iree-hip-enable-tensor-ukernels=true \
    --iree-hip-specialize-dispatches

```