### PR TITLE
[LinalgExt] Don't force MxK layout for im2col output

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_derived_thread_config.mlir
@@ -179,7 +179,7 @@ module {
       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
       m_offset = [0] * [1] k_offset = [0] * [1]
       batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-      input_k_perm = [0, 1, 2]
+      input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
       ins(%2 : tensor<2x34x34x128xf16>)
       outs(%3 : tensor<2x128x8xf16>) -> tensor<2x128x8xf16>
     return %4 : tensor<2x128x8xf16>
@@ -204,7 +204,7 @@ module {
       strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
       m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
       batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-      input_k_perm = [0, 1, 2]
+      input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
       ins(%2 : tensor<16x26x18x32xbf16>)
       outs(%3 : tensor<32x1x1x32xbf16>) -> tensor<32x1x1x32xbf16>
     return %4 : tensor<32x1x1x32xbf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -201,7 +201,7 @@ func.func @promote_with_cache_swizzle(%a: tensor<2x34x34x128xf32>, %b: tensor<2x
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
     m_offset = [0] * [1] k_offset = [0] * [1]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-    input_k_perm = [0, 1, 2]
+    input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x128xf32>)
     outs(%im2col_empty : tensor<2x128x8xf32>) -> tensor<2x128x8xf32>
 
@@ -242,7 +242,7 @@ func.func @promote_with_cache_swizzle_f4(%a: tensor<2x34x34x128xf4E2M1FN>, %b: t
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
     m_offset = [0] * [1] k_offset = [0] * [1]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-    input_k_perm = [0, 1, 2]
+    input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x128xf4E2M1FN>)
     outs(%im2col_empty : tensor<2x128x8xf4E2M1FN>) -> tensor<2x128x8xf4E2M1FN>
 
@@ -281,7 +281,7 @@ func.func @promote_with_cache_swizzle_f4_no_stride(%a: tensor<2x34x34x129xf4E2M1
     strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
     m_offset = [0] * [1] k_offset = [0] * [1]
     batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-    input_k_perm = [0, 1, 2]
+    input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
     ins(%a : tensor<2x34x34x129xf4E2M1FN>)
     outs(%im2col_empty : tensor<2x129x8xf4E2M1FN>) -> tensor<2x129x8xf4E2M1FN>
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -46,11 +46,12 @@ static SmallVector<int64_t> getVectorSizeTileSizes(int64_t rank,
 /// would give tile sizes of [1, 1, 4] no matter what because we won't be able
 /// to collapse the vector.transfer_read that results from this choice of tile
 /// size.
-static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
-    ArrayRef<int64_t> loopRanges, int64_t numThreads, int64_t vectorSize,
-    bool allowMultiDimCollapse = true, bool vectorizeOutermost = false) {
+static SmallVector<int64_t>
+getVectorTileSizesFromLoopRanges(ArrayRef<int64_t> loopRanges,
+                                 int64_t numThreads, int64_t vectorSize,
+                                 bool allowMultiDimCollapse = true) {
   int64_t rank = loopRanges.size();
-  int64_t targetDim = vectorizeOutermost ? 0 : rank - 1;
+  int64_t targetDim = rank - 1;
   int64_t targetRange = loopRanges[targetDim];
 
   // If any loop ranges are dynamic, default to a simple vector size based
@@ -80,12 +81,11 @@ static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
   }
 
   // Let the tile size for the target dim be the smaller of the vector size and
-  // the target loop range. Return here, if `allowMultiDimCollapse` is false, or
-  // `vectorizeOutermost` is true, because we don't expect consecutive
-  // dimensions to be vectorizable contiguously for these cases.
+  // the target loop range. Return here, if `allowMultiDimCollapse` is false,
+  // because we don't expect consecutive dimensions to be vectorizable
+  // contiguously for these cases.
   tileSizes[targetDim] = std::min(targetRange, maxVectorSize);
-  if (targetRange >= maxVectorSize || !allowMultiDimCollapse ||
-      vectorizeOutermost) {
+  if (targetRange >= maxVectorSize || !allowMultiDimCollapse) {
     return tileSizes;
   }
 
@@ -124,7 +124,7 @@ SmallVector<int64_t> deriveLinalgOpThreadTileSizes(linalg::LinalgOp linalgOp,
   return tileSizes;
 }
 
-SmallVector<int64_t>
+static SmallVector<int64_t>
 deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
                               int64_t numThreads) {
   if (!im2colOp.hasPureTensorSemantics()) {
@@ -135,20 +135,10 @@ deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
                        getElementTypeOrSelf(im2colOp->getResultTypes()[0])
                            .getIntOrFloatBitWidth();
 
-  // If the im2col input tensor has the batch dim at last, im2col output tensor
-  // has an implicit transpose to move the batch dim in front, and tiling should
-  // be along the batch dim. Currently only a single batch dim is supported for
-  // tiling along the batch dim.
-  unsigned innerDim = im2colOp.getInputRank() - 1;
-  bool singleBatchDimInnermost = im2colOp.getBatchPos().size() == 1 &&
-                                 im2colOp.getBatchPos().back() == innerDim;
-  bool vectorizeOutermost = singleBatchDimInnermost ? true : false;
-
   // Im2col cannot coalesce past the inner/outer most dim so always default to
   // only the inner/outer most tile size being the vector size (or smaller).
   return getVectorTileSizesFromLoopRanges(loopRanges, numThreads, vectorSize,
-                                          /*allowMultiDimCollapse=*/false,
-                                          vectorizeOutermost);
+                                          /*allowMultiDimCollapse=*/false);
 }
 
 SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -143,8 +143,7 @@ deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
   SmallVector<int64_t> vectorizableOutputDims = vectorizationMap[innerInputDim];
   std::optional<int64_t> vectorizableDim = std::nullopt;
   if (!vectorizableOutputDims.empty()) {
-    vectorizableDim = *std::max_element(vectorizableOutputDims.begin(),
-                                        vectorizableOutputDims.end());
+    vectorizableDim = *llvm::max_element(vectorizableOutputDims);
   }
 
   // Im2col cannot coalesce past the inner/outer most dim so always default to

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
@@ -614,6 +615,69 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
 // Im2colOp
 //===----------------------------------------------------------------------===//
 
+static std::optional<int64_t>
+chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
+                     SmallVector<Range> iterationDomain,
+                     SmallVector<OpFoldResult> inputSizes,
+                     OpFoldResult kOffset) {
+  int64_t innerInputDim = im2colOp.getInputRank() - 1;
+  SmallVector<SmallVector<int64_t>> vectorizationMap =
+      im2colOp.getInputToOutputDimVectorizationMap();
+  SmallVector<int64_t> vectorizableOutputDims = vectorizationMap[innerInputDim];
+  if (vectorizableOutputDims.empty()) {
+    return std::nullopt;
+  }
+  SmallVector<int64_t> kOutputDims = im2colOp.getKOutputDims();
+  SetVector<int64_t> kDimSet(kOutputDims.begin(), kOutputDims.end());
+  SetVector<int64_t> kPosSet(im2colOp.getKPos().begin(),
+                             im2colOp.getKPos().end());
+  // There may be multiple output dims that we can vectorize, so prioritize the
+  // innermost dims first.
+  std::sort(vectorizableOutputDims.begin(), vectorizableOutputDims.end());
+  // Check each dim in order from innermost to outermost, and return the first
+  // one that is vectorizable.
+  while (!vectorizableOutputDims.empty()) {
+    int64_t outputDimToVectorize = vectorizableOutputDims.pop_back_val();
+    OpFoldResult outputDimSize = iterationDomain[outputDimToVectorize].size;
+    auto constTileSize = getConstantIntValue(outputDimSize);
+    if (constTileSize) {
+      outputDimSize = b.getIndexAttr(constTileSize.value());
+    }
+
+    // If a K dim is being vectorized, then it is contiguous along either the
+    // input channel dimension, or the filter kernel window. If it is contiguous
+    // along the kernel window, then the actual inner slice size is equal to the
+    // size of the corresponding kernel window dimension. Otherwise, the inner
+    // slice size is just the size of the input tensor's inner dimension.
+    OpFoldResult innerSliceSize = inputSizes[innerInputDim];
+    if (kDimSet.contains(outputDimToVectorize)) {
+      for (auto [kernelSize, mPos] :
+           llvm::zip_equal(im2colOp.getMixedKernelSize(), im2colOp.getMPos())) {
+        if (mPos == innerInputDim) {
+          innerSliceSize = kernelSize;
+        }
+      }
+    }
+
+    // If the input slice is contiguous along the innermost dimension, then it
+    // is vectorizable. If it is not, then move on to the next innermost dim.
+    SmallVector<int64_t> mOutputDims = im2colOp.getMOutputDims();
+    SetVector<int64_t> mDimSet(mOutputDims.begin(), mOutputDims.end());
+    OpFoldResult offset = b.getIndexAttr(0);
+    if (kDimSet.contains(outputDimToVectorize)) {
+      offset = kOffset;
+    } else if (mDimSet.contains(outputDimToVectorize)) {
+      // TODO(Max191): Support vectorization along the M dimension.
+      continue;
+    }
+    if (!willBeContiguousSlice(innerSliceSize, outputDimSize, offset)) {
+      continue;
+    }
+    return outputDimToVectorize;
+  }
+  return std::nullopt;
+}
+
 /// Decomposition implementation for iree_linalg_ext.im2col op.
 /// The im2col op is decomposed into serial loops of `insert->extract->copy`.
 /// The decomposition supports leaving either the `batch` or `K` dimension
@@ -631,6 +695,7 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
 ///       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 ///       m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
 ///       batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+///       input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
 ///       ins(%in : tensor<2x34x34x640xf32>)
 ///       outs(%out : tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
 /// ```
@@ -685,53 +750,16 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   // dim at last, im2col output tensor has an implicit transpose to move the
   // batch dim in front, and tiling should be along the batch dim.
   SmallVector<Range> iterationDomain(getIterationDomain(b));
-  unsigned innerDim = getInputRank() - 1;
-  // Currently only a single batch dim is supported for tiling along batch dim.
-  // TODO: generalize to support multi-batch dimensions.
-  bool singleBatchDimInnermost =
-      getBatchPos().size() == 1 && getBatchPos().front() == innerDim;
-  OpFoldResult innerInputTileSize = singleBatchDimInnermost
-                                        ? iterationDomain.front().size
-                                        : iterationDomain.back().size;
-  auto constTileSize = getConstantIntValue(innerInputTileSize);
-  if (constTileSize) {
-    innerInputTileSize = b.getIndexAttr(constTileSize.value());
-  }
-
   SmallVector<OpFoldResult> inputSizes =
       tensor::getMixedSizes(b, loc, getInput());
-  SetVector<int64_t> batchPosSet(getBatchPos().begin(), getBatchPos().end());
-  OpFoldResult innerSliceSize;
-  for (int idx = inputSizes.size() - 1; idx >= 0; --idx) {
-    if (!singleBatchDimInnermost && batchPosSet.contains(idx)) {
-      continue;
-    }
-    innerSliceSize = inputSizes[idx];
-    // If the innermost non-batch dimension is an m_pos dimension, then use the
-    // corresponding kernel_size instead of the input tensor size. This is
-    // because the slice will be of size `kernel_size` at some offset
-    // `i * kernel_size` in this case.
-    for (auto [mPos, kernelSize] :
-         llvm::zip_equal(getMPos(), getMixedKernelSize())) {
-      if (mPos == idx) {
-        innerSliceSize = kernelSize;
-      }
-    }
-    break;
-  }
+  std::optional<unsigned> maybeOutputDimToVectorize =
+      chooseDimToVectorize(b, loc, *this, iterationDomain, inputSizes, kOffset);
 
-  // Check if the input slice is contiguous along the innermost dimension.
-  bool contiguousAlongK =
-      getKPos().back() == innerDim &&
-      willBeContiguousSlice(innerSliceSize, innerInputTileSize, kOffset);
-  bool contiguousAlongB =
-      singleBatchDimInnermost &&
-      willBeContiguousSlice(innerSliceSize, innerInputTileSize,
-                            /*offset=*/b.getIndexAttr(0));
-  if (contiguousAlongK) {
-    iterationDomain.pop_back();
-  } else if (contiguousAlongB) {
-    iterationDomain.erase(iterationDomain.begin());
+  OpFoldResult innerInputTileSize;
+  if (maybeOutputDimToVectorize.has_value()) {
+    unsigned outputDimToVectorize = maybeOutputDimToVectorize.value();
+    innerInputTileSize = iterationDomain[outputDimToVectorize].size;
+    iterationDomain.erase(iterationDomain.begin() + outputDimToVectorize);
   } else {
     innerInputTileSize = b.getIndexAttr(1);
   }
@@ -750,6 +778,10 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   SmallVector<Value> ivs;
   for (scf::ForOp loop : loopNest.loops) {
     ivs.push_back(loop.getInductionVar());
+  }
+  if (maybeOutputDimToVectorize.has_value()) {
+    Value zero = arith::ConstantIndexOp::create(b, loc, 0);
+    ivs.insert(ivs.begin() + maybeOutputDimToVectorize.value(), zero);
   }
 
   // Step 2: Compute indices into the input tensor for extract_slice.
@@ -786,6 +818,7 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   for (auto [idx, mPos] : enumerate(getMPos())) {
     mKernelIdx[mPos] = idx;
   }
+  SetVector<int64_t> batchPosSet(getBatchPos().begin(), getBatchPos().end());
   for (auto [idx, size] : enumerate(inputSizes)) {
     if (batchPosSet.contains(idx))
       continue;
@@ -804,12 +837,8 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   OpFoldResult kIndex = kOffset;
   for (auto [i, ivIdx, stride] :
        llvm::enumerate(getKOutputDims(), getMixedKStrides())) {
-    if (contiguousAlongB) {
-      // Batch loop doesn't exist, adjust the ivIdx.
-      ivIdx--;
-    }
-    if (contiguousAlongK && i == getMixedKOffset().size() - 1) {
-      break;
+    if (isConstantIntValue(ivs[ivIdx], 0)) {
+      continue;
     }
     OpFoldResult ivOffset = mulOfrs(b, nestedLoc, stride, ivs[ivIdx]);
     kIndex = addOfrs(b, nestedLoc, kIndex, ivOffset);
@@ -840,13 +869,8 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   // computed as the delinearized im2col result M offset (in the convolution
   // result iteration space), plus the convolutional window offsets computed
   // above.
-  SmallVector<int64_t> mOutDims = getMOutputDims();
   SmallVector<OpFoldResult> mIvs, mOutStrides(getMixedMStrides());
   for (auto [idx, dim] : llvm::enumerate(getMOutputDims())) {
-    if (contiguousAlongB) {
-      // Batch loop doesn't exist, adjust the dim.
-      dim--;
-    }
     mIvs.push_back(ivs[dim]);
   }
   OpFoldResult linearMIv = linearizeIndex(mIvs, mOutStrides);
@@ -880,22 +904,16 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
     sliceSizes[mPos] = one;
   }
 
-  // Set the batch and K size for the input tensor.
-  const int64_t kPos = getKPos().front();
-  if (contiguousAlongB) {
-    const int64_t bPos = getBatchPos().front();
-    sliceSizes[bPos] = innerInputTileSize;
-  } else {
-    sliceSizes[kPos] = innerInputTileSize;
-  }
+  sliceSizes.back() = innerInputTileSize;
 
   // Set the batch and K offsets for the input tensor.
+  const int64_t kPos = getKPos().front();
   sliceOffsets[kPos] = inputKOffset.front();
-  if (!contiguousAlongB) {
-    int ivIdx = 0;
-    for (auto bPos : getBatchPos()) {
-      sliceOffsets[bPos] = ivs[ivIdx++];
-    }
+  int ivIdx = 0;
+  SmallVector<int64_t> inverseOutputPerm =
+      invertPermutationVector(getOutputPerm());
+  for (auto bPos : getBatchPos()) {
+    sliceOffsets[bPos] = ivs[inverseOutputPerm[ivIdx++]];
   }
 
   // Step 3. Decompose the im2col op into:
@@ -910,77 +928,61 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
   int64_t inputRank = getInputRank();
   int64_t outputRank = getOutputRank();
 
-  // For now, only extract a 1D slice when the batch dimension corresponds to a
-  // contiguous slice and produces a rank reduced/expanded result.
-  // TODO: check if 1d slice extraction can be used for all cases and thus
-  // simplify the codes.
-  SmallVector<OpFoldResult> inputTileSizes;
-  if (contiguousAlongB && inputRank != outputRank) {
-    inputTileSizes.push_back(innerInputTileSize);
-  } else {
-    int64_t minRank = std::min<int64_t>(inputRank, outputRank);
-    for (int i = 0; i < minRank - 1; i++) {
-      inputTileSizes.push_back(b.getIndexAttr(1));
+  // For now, only extract a 1D slice when the vectorized dim is not innermost
+  // in the output, and the input and output ranks are different. Otherwise,
+  // try to preserve the original rank to avoid rank reducing slices.
+  int64_t sliceRank = std::min<int64_t>(inputRank, outputRank);
+  SmallVector<int64_t> inputToOutputSlicePerm =
+      llvm::to_vector(llvm::seq<int64_t>(0, sliceRank));
+  if (maybeOutputDimToVectorize.has_value()) {
+    int64_t outputDimToVectorize = maybeOutputDimToVectorize.value();
+    if (inputRank == outputRank) {
+      inputToOutputSlicePerm[outputDimToVectorize] = outputRank - 1;
+      inputToOutputSlicePerm[outputRank - 1] = outputDimToVectorize;
+    } else if (outputDimToVectorize != outputRank - 1) {
+      sliceRank = 1;
+      inputToOutputSlicePerm = {0};
     }
-    inputTileSizes.push_back(innerInputTileSize);
   }
-
+  SmallVector<OpFoldResult> inputTileSizes(sliceRank, b.getIndexAttr(1));
+  inputTileSizes.back() = innerInputTileSize;
   SmallVector<int64_t> tileSizeStatic;
-  SmallVector<Value> tileSizeDynamic;
-  dispatchIndexOpFoldResults(inputTileSizes, tileSizeDynamic, tileSizeStatic);
+  std::tie(tileSizeStatic, std::ignore) = decomposeMixedValues(inputTileSizes);
   auto extractType = cast<RankedTensorType>(outputType.clone(tileSizeStatic));
   auto extract =
       tensor::ExtractSliceOp::create(b, nestedLoc, extractType, inputSlice,
                                      sliceOffsets, sliceSizes, sliceStrides);
-
   // Insert the slice into the destination tensor.
   sliceOffsets = SmallVector<OpFoldResult>(outputRank, zero);
+  for (auto [idx, iv] : llvm::enumerate(ivs)) {
+    sliceOffsets[idx] = iv;
+  }
   sliceSizes = SmallVector<OpFoldResult>(outputRank, one);
+  if (maybeOutputDimToVectorize.has_value()) {
+    sliceSizes[maybeOutputDimToVectorize.value()] = innerInputTileSize;
+  }
   sliceStrides = SmallVector<OpFoldResult>(outputRank, one);
-  if (contiguousAlongB) {
-    sliceSizes.front() = innerInputTileSize;
-    for (auto [idx, iv] : llvm::enumerate(ivs)) {
-      sliceOffsets[idx + 1] = iv;
-    }
-  } else {
-    sliceSizes.back() = innerInputTileSize;
-    for (auto [idx, iv] : llvm::enumerate(ivs)) {
-      sliceOffsets[idx] = iv;
-    }
-  }
 
-  Value inputForInsert;
-  // If the batch dimension is untiled in the loop nest, transpose the
-  // dimensions to match the output order (Batch, M, K).
-  if (contiguousAlongB && inputRank == outputRank) {
-    SmallVector<int64_t> transposePerm;
-    transposePerm.append(getBatchPos().begin(), getBatchPos().end());
-    transposePerm.append(getMPos().begin(), getMPos().end());
-    transposePerm.append(getKPos().begin(), getKPos().end());
-    ArrayRef<int64_t> extractShape = extractType.getShape();
-    SmallVector<int64_t> emptyShape =
-        applyPermutation(extractShape, transposePerm);
-    auto empty = tensor::EmptyOp::create(b, nestedLoc, emptyShape,
-                                         outputType.getElementType());
-    auto transposeOp = linalg::TransposeOp::create(b, nestedLoc, extract, empty,
-                                                   transposePerm);
-    inputForInsert = transposeOp->getResult(0);
-  } else {
-    // Insert a `linalg.copy` so there is something to vectorize in the
-    // decomposition. Without this copy, the extract and insert slice ops
-    // do not get vectorized, and the sequence becomes a scalar memref.copy.
-    // This memref.copy could be vectorized after bufferization, but it is
-    // probably better to vectorize during generic vectorization.
-    Value copyDest = tensor::ExtractSliceOp::create(
-        b, nestedLoc, extractType, loopNest.loops.back().getRegionIterArg(0),
-        sliceOffsets, sliceSizes, sliceStrides);
-    auto copiedSlice =
-        linalg::CopyOp::create(b, nestedLoc, extract.getResult(), copyDest);
-    inputForInsert = copiedSlice.getResult(0);
-  }
-
+  // Insert a `linalg.copy` so there is something to vectorize in the
+  // decomposition. Without this copy, the extract and insert slice ops
+  // do not get vectorized, and the sequence becomes a scalar memref.copy.
+  // This memref.copy could be vectorized after bufferization, but it is
+  // probably better to vectorize during generic vectorization.
+  SmallVector<int64_t> outputSliceShape =
+      applyPermutation(tileSizeStatic, inputToOutputSlicePerm);
+  RankedTensorType outputSliceType = extractType.clone(outputSliceShape);
+  Value copyDest = tensor::ExtractSliceOp::create(
+      b, nestedLoc, outputSliceType, loopNest.loops.back().getRegionIterArg(0),
+      sliceOffsets, sliceSizes, sliceStrides);
+  Value copiedSlice =
+      isIdentityPermutation(inputToOutputSlicePerm)
+          ? linalg::CopyOp::create(b, nestedLoc, extract.getResult(), copyDest)
+                .getResult(0)
+          : linalg::TransposeOp::create(b, nestedLoc, extract.getResult(),
+                                        copyDest, inputToOutputSlicePerm)
+                ->getResult(0);
   auto insert = tensor::InsertSliceOp::create(
-      b, nestedLoc, inputForInsert, loopNest.loops.back().getRegionIterArg(0),
+      b, nestedLoc, copiedSlice, loopNest.loops.back().getRegionIterArg(0),
       sliceOffsets, sliceSizes, sliceStrides);
   auto yieldOp =
       cast<scf::YieldOp>(loopNest.loops.back().getBody()->getTerminator());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2400,12 +2400,9 @@ SmallVector<int64_t> Im2colOp::getKOutputDims() {
 
 SmallVector<SmallVector<int64_t>>
 Im2colOp::getInputToOutputDimVectorizationMap() {
-  SetVector<int64_t> batchInputDims;
-  batchInputDims.insert(getBatchPos().begin(), getBatchPos().end());
-  SetVector<int64_t> mInputDims;
-  mInputDims.insert(getMPos().begin(), getMPos().end());
-  SetVector<int64_t> kInputDims;
-  kInputDims.insert(getKPos().begin(), getKPos().end());
+  SetVector<int64_t> batchInputDims(llvm::from_range, getBatchPos());
+  SetVector<int64_t> mInputDims(llvm::from_range, getMPos());
+  SetVector<int64_t> kInputDims(llvm::from_range, getKPos());
   SmallVector<SmallVector<int64_t>> vectorizationMap;
   vectorizationMap.resize(getInputRank());
   SmallVector<int64_t> batchOutputDims = getBatchOutputDims();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2374,32 +2374,96 @@ void Im2colOp::setMixedMStrides(SmallVector<OpFoldResult> mStrides) {
 }
 
 SmallVector<int64_t> Im2colOp::getBatchOutputDims() {
-  return llvm::to_vector(llvm::seq<int64_t>(0, getBatchPos().size()));
+  SmallVector<int64_t> inverseOutPerm =
+      invertPermutationVector(getOutputPerm());
+  return llvm::map_to_vector(llvm::seq<int64_t>(0, getBatchPos().size()),
+                             [&](int64_t dim) { return inverseOutPerm[dim]; });
 }
 
 SmallVector<int64_t> Im2colOp::getMOutputDims() {
   int64_t begin = getBatchPos().size();
   int64_t end = begin + getMixedMOffset().size();
-  return llvm::to_vector(llvm::seq<int64_t>(begin, end));
+  SmallVector<int64_t> inverseOutPerm =
+      invertPermutationVector(getOutputPerm());
+  return llvm::map_to_vector(llvm::seq<int64_t>(begin, end),
+                             [&](int64_t dim) { return inverseOutPerm[dim]; });
 }
 
 SmallVector<int64_t> Im2colOp::getKOutputDims() {
   int64_t begin = getBatchPos().size() + getMixedMOffset().size();
   int64_t end = begin + getMixedKOffset().size();
-  return llvm::to_vector(llvm::seq<int64_t>(begin, end));
+  SmallVector<int64_t> inverseOutPerm =
+      invertPermutationVector(getOutputPerm());
+  return llvm::map_to_vector(llvm::seq<int64_t>(begin, end),
+                             [&](int64_t dim) { return inverseOutPerm[dim]; });
+}
+
+SmallVector<SmallVector<int64_t>>
+Im2colOp::getInputToOutputDimVectorizationMap() {
+  SetVector<int64_t> batchInputDims;
+  batchInputDims.insert(getBatchPos().begin(), getBatchPos().end());
+  SetVector<int64_t> mInputDims;
+  mInputDims.insert(getMPos().begin(), getMPos().end());
+  SetVector<int64_t> kInputDims;
+  kInputDims.insert(getKPos().begin(), getKPos().end());
+  SmallVector<SmallVector<int64_t>> vectorizationMap;
+  vectorizationMap.resize(getInputRank());
+  SmallVector<int64_t> batchOutputDims = getBatchOutputDims();
+  if (batchInputDims.size() == batchOutputDims.size()) {
+    for (auto [batchInputDim, batchOutputDim] :
+         llvm::zip_equal(batchInputDims, batchOutputDims)) {
+      vectorizationMap[batchInputDim] = {batchOutputDim};
+    }
+  } else {
+    vectorizationMap[batchInputDims.back()].push_back(batchOutputDims.back());
+  }
+  SmallVector<int64_t> mOutputDims = getMOutputDims();
+  if (mInputDims.size() == mOutputDims.size()) {
+    for (auto [mInputDim, mOutputDim] :
+         llvm::zip_equal(mInputDims, mOutputDims)) {
+      vectorizationMap[mInputDim] = {mOutputDim};
+    }
+  } else {
+    vectorizationMap[mInputDims.back()].push_back(mOutputDims.back());
+  }
+  SmallVector<int64_t> kOutputDims = getKOutputDims();
+  // Compute the input dimensions captured by the K output dimensions, in the
+  // order that they appear in kOutputDims. The canonical order for the input
+  // K dims is just the order that they appear in the input tensor. Get the
+  // dims in this order, and then apply the input_k_perm to get the dims in the
+  // order that they are represented in the output tensor.
+  SmallVector<int64_t> orderedKInputDims;
+  for (int64_t dim = 0; dim < getInputRank(); ++dim) {
+    if (batchInputDims.contains(dim)) {
+      continue;
+    }
+    if (kInputDims.contains(dim)) {
+      orderedKInputDims.push_back(dim);
+      continue;
+    }
+    orderedKInputDims.push_back(dim);
+  }
+  applyPermutationToVector(orderedKInputDims, getInputKPerm());
+  if (orderedKInputDims.size() == kOutputDims.size()) {
+    for (auto [kInputDim, kOutputDim] :
+         llvm::zip_equal(orderedKInputDims, kOutputDims)) {
+      vectorizationMap[kInputDim].push_back(kOutputDim);
+    }
+  } else {
+    vectorizationMap[orderedKInputDims.back()].push_back(kOutputDims.back());
+  }
+  return vectorizationMap;
 }
 
 /// Custom builder methods for im2col op.
-void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
-                     Value output, ArrayRef<int64_t> strides,
-                     ArrayRef<int64_t> dilations,
-                     ArrayRef<OpFoldResult> kernelSize,
-                     ArrayRef<OpFoldResult> mOffset,
-                     ArrayRef<OpFoldResult> mStrides,
-                     ArrayRef<OpFoldResult> kOffset,
-                     ArrayRef<OpFoldResult> kStrides,
-                     ArrayRef<int64_t> batchPos, ArrayRef<int64_t> mPos,
-                     ArrayRef<int64_t> kPos, ArrayRef<int64_t> inputKPerm) {
+void Im2colOp::build(
+    OpBuilder &builder, OperationState &state, Value input, Value output,
+    ArrayRef<int64_t> strides, ArrayRef<int64_t> dilations,
+    ArrayRef<OpFoldResult> kernelSize, ArrayRef<OpFoldResult> mOffset,
+    ArrayRef<OpFoldResult> mStrides, ArrayRef<OpFoldResult> kOffset,
+    ArrayRef<OpFoldResult> kStrides, ArrayRef<int64_t> batchPos,
+    ArrayRef<int64_t> mPos, ArrayRef<int64_t> kPos,
+    ArrayRef<int64_t> inputKPerm, ArrayRef<int64_t> outputPerm) {
   assert(strides.size() == kernelSize.size() &&
          dilations.size() == kernelSize.size() &&
          mPos.size() == kernelSize.size() &&
@@ -2428,7 +2492,8 @@ void Im2colOp::build(OpBuilder &builder, OperationState &state, Value input,
         builder.getDenseI64ArrayAttr(staticKStrides),
         builder.getDenseI64ArrayAttr(batchPos),
         builder.getDenseI64ArrayAttr(mPos), builder.getDenseI64ArrayAttr(kPos),
-        builder.getDenseI64ArrayAttr(inputKPerm));
+        builder.getDenseI64ArrayAttr(inputKPerm),
+        builder.getDenseI64ArrayAttr(outputPerm));
 }
 
 LogicalResult Im2colOp::verify() {
@@ -2525,12 +2590,22 @@ LogicalResult Im2colOp::verify() {
   // Verify input and output shapes.
   ArrayRef<int64_t> inputShape = inputType.getShape();
   ArrayRef<int64_t> outputShape = outputType.getShape();
+  ArrayRef<int64_t> outputPerm = getOutputPerm();
+  if (!isPermutationVector(outputPerm)) {
+    return op->emitOpError("expected output_perm to be a permutation");
+  }
+  if (outputPerm.size() != outputShape.size()) {
+    return op->emitOpError(
+        "expected output_perm to have the same rank as the result");
+  }
+
   // When the op is tiled, the m and k dimensions of the output are tiled, but
   // they are not tiled in the input, so we cannot verify the output size of
   // these dimensions. Only verify the shape of the batch dimensions.
   SmallVector<int64_t> expectedOutputShape(outputShape);
+  SmallVector<int64_t> inverseOutputPerm = invertPermutationVector(outputPerm);
   for (auto [idx, pos] : llvm::enumerate(batchPos)) {
-    expectedOutputShape[idx] = inputShape[pos];
+    expectedOutputShape[inverseOutputPerm[idx]] = inputShape[pos];
   }
   if (failed(verifyCompatibleShape(expectedOutputShape, outputShape))) {
     return op->emitOpError("incompatible output shape");

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1205,6 +1205,7 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
           strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
           m_offset = [0] * [1] k_offset = [0] * [1]
           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
           ins(%in : tensor<2x34x34x640xf32>)
           outs(%out : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
     ```
@@ -1253,6 +1254,11 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     indicates that the input layout is already aligned with the filter layout
     in terms of reduction dimensions, so no transposition of indices is necessary
     before slice extraction.
+
+    The `output_perm` attribute defines the layout of the result with respect to
+    the canonical `BxMxK` layout. The layout of the result can be determined by
+    applying the permutation to the `BxMxK` layout. For instance, an
+    `output_perm = [2, 0, 1]` indicates the result is in a `KxMxB` layout.
   }];
 
   let arguments = (ins AnyShaped:$input, AnyShaped:$output,
@@ -1271,7 +1277,8 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
                        DenseI64ArrayAttr:$batch_pos,
                        DenseI64ArrayAttr:$m_pos,
                        DenseI64ArrayAttr:$k_pos,
-                       DenseI64ArrayAttr:$input_k_perm);
+                       DenseI64ArrayAttr:$input_k_perm,
+                       DenseI64ArrayAttr:$output_perm);
 
   let results = (outs Variadic<AnyShaped>:$results);
   let hasFolder = 1;
@@ -1291,6 +1298,7 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     `m_pos` `=` $m_pos
     `k_pos` `=` $k_pos
     `input_k_perm` `=` $input_k_perm
+    `output_perm` `=` $output_perm
     `ins` `(` $input `:` type($input) `)`
     `outs` `(` $output `:` type($output) `)`
     (`->` type($results)^)?
@@ -1308,7 +1316,8 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
       "ArrayRef<int64_t>":$batch_dimensions,
       "ArrayRef<int64_t>":$m_dimensions,
       "ArrayRef<int64_t>":$k_dimensions,
-      "ArrayRef<int64_t>":$input_k_perm)>
+      "ArrayRef<int64_t>":$input_k_perm,
+      "ArrayRef<int64_t>":$output_perm)>
   ];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
@@ -1329,6 +1338,21 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     SmallVector<int64_t> getBatchOutputDims();
     SmallVector<int64_t> getMOutputDims();
     SmallVector<int64_t> getKOutputDims();
+
+    // Returns the mapping from input dimensions to the corresponding set of
+    // output dimensions that can vectorize along with them. A pair of input and
+    // output dims are vectorizable together if incrementing the output
+    // dimension by 1 will also increment the input dimension by exactly 1.
+    // Each input dim can have zero or more corresponding output dims. If an
+    // input dim maps to multiple output dims, then the input dim can vectorize
+    // with any one of the corresponding output dims.
+    //
+    // This method does not find vectorizable dims if output dims are partially
+    // collapsed. For example, it computes K dim mapping for standard conv_2d if
+    // the K dim is fully collapsed or fully expanded (inlcuding all input
+    // channel and filter loop dims), but otherwise omits mappings for the K
+    // dims.
+    SmallVector<SmallVector<int64_t>> getInputToOutputDimVectorizationMap();
 
     // Return op metadata.
     SmallVector<OpFoldResult> getMixedKernelSize();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1092,6 +1092,7 @@ func.func @illegal_im2col_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x10
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1106,6 +1107,7 @@ func.func @illegal_im2col_dilations(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1120,6 +1122,7 @@ func.func @illegal_im2col_kernel_size(%arg0: tensor<2x34x34x640xf32>) -> tensor<
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1134,6 +1137,7 @@ func.func @illegal_im2col_m_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
            m_offset = [0, 0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1148,6 +1152,7 @@ func.func @illegal_im2col_k_offset(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
            m_offset = [0] * [1] k_offset = [0, 0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1162,6 +1167,7 @@ func.func @illegal_im2col_m_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x
            m_offset = [0] * [0] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1176,6 +1182,7 @@ func.func @illegal_im2col_k_strides(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x
            m_offset = [0] * [1] k_offset = [0] * [2]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1190,6 +1197,7 @@ func.func @illegal_im2col_input_rank(%arg0: tensor<1x2x34x34x640xf32>) -> tensor
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<1x2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1204,6 +1212,7 @@ func.func @illegal_im2col_output_rank(%arg0: tensor<2x34x34x640xf32>) -> tensor<
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2, 3]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x9x640xf32>) -> tensor<2x1024x9x640xf32>
   return %1 : tensor<2x1024x9x640xf32>
@@ -1218,6 +1227,7 @@ func.func @illegal_im2col_perm_num(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1225,13 +1235,45 @@ func.func @illegal_im2col_perm_num(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1
 
 // -----
 
-func.func @illegal_im2col_perm_value(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+func.func @illegal_im2col_k_perm_value(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %0 = tensor.empty() : tensor<2x1024x5760xf32>
   // expected-error @+1 {{expected input_k_perm to be a permutation of [0, 3)}}
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [1, 2, 3]
+           output_perm = [0, 1, 2]
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
+  return %1 : tensor<2x1024x5760xf32>
+}
+
+// -----
+
+func.func @illegal_im2col_output_perm_value(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+  %0 = tensor.empty() : tensor<2x1024x5760xf32>
+  // expected-error @+1 {{expected output_perm to be a permutation}}
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           m_offset = [0] * [1] k_offset = [0] * [1]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [1, 2, 3]
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
+  return %1 : tensor<2x1024x5760xf32>
+}
+
+
+// -----
+
+func.func @illegal_im2col_output_perm_rank(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
+  %0 = tensor.empty() : tensor<2x1024x5760xf32>
+  // expected-error @+1 {{expected output_perm to have the same rank as the result}}
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           m_offset = [0] * [1] k_offset = [0] * [1]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2, 3]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1469,6 +1469,7 @@ func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1480,9 +1481,35 @@ func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
 // CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
 // CHECK:         return %[[D1]] : tensor<2x1024x5760xf32>
+
+// -----
+
+func.func @im2col_output_perm(%arg0: tensor<2x34x34x640xf32>) -> tensor<5760x2x1024xf32> {
+  %0 = tensor.empty() : tensor<5760x2x1024xf32>
+  %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+           m_offset = [0] * [1] k_offset = [0] * [1]
+           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+           input_k_perm = [0, 1, 2]
+           output_perm = [2, 0, 1]
+           ins(%arg0 : tensor<2x34x34x640xf32>)
+           outs(%0 : tensor<5760x2x1024xf32>) -> tensor<5760x2x1024xf32>
+  return %1 : tensor<5760x2x1024xf32>
+}
+// CHECK-LABEL: func.func @im2col_output_perm(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x34x34x640xf32>
+// CHECK:         %[[D0:.+]] = tensor.empty() : tensor<5760x2x1024xf32>
+// CHECK:         %[[D1:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [2, 0, 1]
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<2x34x34x640xf32>)
+// CHECK-SAME:      outs(%[[D0]] : tensor<5760x2x1024xf32>) -> tensor<5760x2x1024xf32>
+// CHECK:         return %[[D1]] : tensor<5760x2x1024xf32>
 
 // -----
 
@@ -1493,6 +1520,7 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
            m_offset = [%mOffset] * [1] k_offset = [%kOffset] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<?x?x?x?xf32>)
            outs(%0 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   return %1 : tensor<?x?x?xf32>
@@ -1505,6 +1533,7 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
 // CHECK-SAME:      m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<?x?x?x?xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:         return %[[D1]] : tensor<?x?x?xf32>
@@ -1517,6 +1546,7 @@ func.func @im2col_strided(%arg0: tensor<2x65x96x640xf32>) -> tensor<2x1024x5760x
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x65x96x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1528,6 +1558,7 @@ func.func @im2col_strided(%arg0: tensor<2x65x96x640xf32>) -> tensor<2x1024x5760x
 // CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x65x96x640xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
 // CHECK:         return %[[D1]] : tensor<2x1024x5760xf32>
@@ -1540,6 +1571,7 @@ func.func @im2col_dilated(%arg0: tensor<2x44x46x640xf32>) -> tensor<2x1024x5760x
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x44x46x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1551,6 +1583,7 @@ func.func @im2col_dilated(%arg0: tensor<2x44x46x640xf32>) -> tensor<2x1024x5760x
 // CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x44x46x640xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
 // CHECK:         return %[[D1]] : tensor<2x1024x5760xf32>
@@ -1563,6 +1596,7 @@ func.func @im2col_strided_dilated_mixed_kernel(%arg0: tensor<2x172x101x640xf32>)
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x172x101x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1574,6 +1608,7 @@ func.func @im2col_strided_dilated_mixed_kernel(%arg0: tensor<2x172x101x640xf32>)
 // CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:      batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x172x101x640xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
 // CHECK:         return %[[D1]] : tensor<2x1024x5760xf32>
@@ -1586,6 +1621,7 @@ func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2
            m_offset = [0] * [1] k_offset = [0] * [1]
            batch_pos = [1] m_pos = [3, 2] k_pos = [0]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2]
            ins(%arg0 : tensor<640x2x101x172xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1597,6 +1633,7 @@ func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2
 // CHECK-SAME:      m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:      batch_pos = [1] m_pos = [3, 2] k_pos = [0]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<640x2x101x172xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
 // CHECK:         return %[[D1]] : tensor<2x1024x5760xf32>
@@ -1609,6 +1646,7 @@ func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x128x8
            m_offset = [0, 0] * [8, 1] k_offset = [0, 0] * [64, 1]
            batch_pos = [0, 1] m_pos = [2, 3] k_pos = [4]
            input_k_perm = [0, 1, 2]
+           output_perm = [0, 1, 2, 3, 4, 5]
            ins(%arg0 : tensor<2x3x34x34x640xf32>)
            outs(%0 : tensor<2x3x128x8x90x64xf32>) -> tensor<2x3x128x8x90x64xf32>
   return %1 : tensor<2x3x128x8x90x64xf32>
@@ -1620,6 +1658,7 @@ func.func @im2col_expanded(%arg0: tensor<2x3x34x34x640xf32>) -> tensor<2x3x128x8
 // CHECK-SAME:      m_offset = [0, 0] * [8, 1] k_offset = [0, 0] * [64, 1]
 // CHECK-SAME:      batch_pos = [0, 1] m_pos = [2, 3] k_pos = [4]
 // CHECK-SAME:      input_k_perm = [0, 1, 2]
+// CHECK-SAME:      output_perm = [0, 1, 2, 3, 4, 5]
 // CHECK-SAME:      ins(%[[ARG0]] : tensor<2x3x34x34x640xf32>)
 // CHECK-SAME:      outs(%[[D0]] : tensor<2x3x128x8x90x64xf32>) -> tensor<2x3x128x8x90x64xf32>
 // CHECK:         return %[[D1]] : tensor<2x3x128x8x90x64xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -199,6 +199,7 @@ public:
 
     // Batch dims for the im2col also include the depth/group dimensions of the
     // conv.
+    SmallVector<int64_t> outputPerm = igemmConvDetails.im2colOutputPerm;
     auto im2colBatchIterDims =
         llvm::to_vector(llvm::concat<unsigned>(convDims.depth, convDims.batch));
     SmallVector<int64_t> batchPos(im2colBatchIterDims.size());
@@ -210,7 +211,7 @@ public:
       int64_t igemmInputDim = igemmConvDetails.getIgemmInputImageMap()
                                   .getResultPosition(igemmDimExpr)
                                   .value();
-      batchPos[igemmInputDim] = im2colInputDim;
+      batchPos[outputPerm[igemmInputDim]] = im2colInputDim;
     }
 
     SmallVector<int64_t> mPos;
@@ -263,13 +264,15 @@ public:
     }
     colTensorShape.append(mShape);
     colTensorShape.append(kShape);
+
+    applyPermutationToVector(colTensorShape, outputPerm);
     Value colTensor = tensor::EmptyOp::create(rewriter, loc, colTensorShape,
                                               inputType.getElementType());
     Value img2ColTensor =
         IREE::LinalgExt::Im2colOp::create(
             rewriter, loc, input, /*output=*/colTensor, convDims.strides,
             convDims.dilations, kernelSizes, mOffset, mBasis, kOffset, kBasis,
-            batchPos, mPos, kPos, inputKPerm)
+            batchPos, mPos, kPos, inputKPerm, outputPerm)
             .getResult(0);
 
     Value reshapedFilter = tensor::CollapseShapeOp::create(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -19,7 +19,7 @@ util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
@@ -54,7 +54,7 @@ util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3]] : tensor<16x4x3x3xf32> into tensor<16x36xf32>
@@ -89,7 +89,7 @@ util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf16>) -> tensor<1x14x14x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
@@ -126,7 +126,7 @@ util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4
 // CHECK-SAME:   strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [7, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x7x7x36xf16>) -> tensor<1x7x7x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
@@ -164,7 +164,7 @@ util.func public @conv_dilated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4
 // CHECK-SAME:   strides = [1, 1] dilations = [2, 2] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [12, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x12x12x36xf32>) -> tensor<1x12x12x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
@@ -273,7 +273,7 @@ util.func public @conv_1d_ncw_fcw_transpose_maps(%arg0: tensor<1x8x130xf32>, %ar
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
 // CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1]
+// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x8x130xf32>)
 // CHECK-SAME:   outs(%[[EMPTY2]] : tensor<1x128x24xf32>) -> tensor<1x128x24xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<16x8x3xf32> into tensor<16x24xf32>
@@ -303,25 +303,25 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 }
 
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d0)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4, d3)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_chwn_chwf(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x288xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x24x16x288xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<288x3x3x288xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<288x3x3x6144xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
 // CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x18x288xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<288x3x3x6144xf32>) -> tensor<288x3x3x6144xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<3x3x6144x288xf32>) -> tensor<3x3x6144x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<16x24x16x288xf32> into tensor<6144x288xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<6144x288xf32>, tensor<288x3x3x6144xf32>)
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<6144x288xf32>, tensor<3x3x6144x288xf32>)
 // CHECK-SAME:   outs(%[[ARG2]] : tensor<288x3x3x288xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
@@ -343,26 +343,26 @@ util.func public @conv_2d_hwcn_hwcf(%arg0: tensor<26x18x16x288xf32>, %arg1: tens
   util.return %0 : tensor<3x3x288x288xf32>
 }
 
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d0, d1, d4)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4, d3)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d2)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_hwcn_hwcf(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<26x18x16x288xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<24x16x16x288xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<3x3x288x288xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<288x3x3x6144xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
 // CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [3] m_pos = [0, 1] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<26x18x16x288xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<288x3x3x6144xf32>) -> tensor<288x3x3x6144xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<3x3x6144x288xf32>) -> tensor<3x3x6144x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<24x16x16x288xf32> into tensor<6144x288xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<288x3x3x6144xf32>,  tensor<6144x288xf32>)
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<3x3x6144x288xf32>, tensor<6144x288xf32>)
 // CHECK-SAME:   outs(%[[ARG2]] : tensor<3x3x288x288xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
@@ -421,25 +421,26 @@ module {
   }
 }
 
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d1, d4)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_nhwc_fhc_two_batch(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x16x96xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<96x3x96xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<16x24x16x96xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<16x16x24x288xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<16x24x16x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
 // CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0, 2] m_pos = [1] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 2, 1, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x16x96xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<16x16x24x288xf32>) -> tensor<16x16x24x288xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<16x24x16x288xf32>) -> tensor<16x24x16x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<96x3x96xf32> into tensor<96x288xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<16x16x24x288xf32>, tensor<96x288xf32>)
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<16x24x16x288xf32>, tensor<96x288xf32>)
 // CHECK:      util.return %[[MATMUL]] : tensor<16x24x16x96xf32>
 
 // -----
@@ -500,21 +501,21 @@ util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
   util.return %0 : tensor<2x8x8x7x16xf32>
 }
 //                                            n   h   w   g   f   c
-// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d3, d1, d2, d5)>
+// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d5)>
 // CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_nhwgc_gfhwc(
 // CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x10x10x7x4xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<7x16x3x3x4xf32>]]
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x8x8x7x16xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<2x7x8x8x36xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<2x8x8x7x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0, 3] m_pos = [1, 2] k_pos = [4]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 2, 3, 1, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
-// CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])
+// CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]]) -> [[LHS_T]]
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[RHS_T:tensor<7x16x36xf32>]]
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUT_MAP]]]
@@ -546,9 +547,9 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: ten
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
-// CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])
+// CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUT_MAP]]]
@@ -587,6 +588,7 @@ util.func public @conv_2d_ngchw_fgchw_gnfhw(%arg0: tensor<2x7x4x10x10xf32>, %arg
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -10,7 +10,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
             m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<2x34x34x640xf32>)
             outs(%0 : tensor<2x?x4xf32>) -> tensor<2x?x4xf32>
     return %7 : tensor<2x?x4xf32>
@@ -55,7 +55,7 @@ module {
             strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
             m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
             batch_pos = [1] m_pos = [3, 2] k_pos = [0]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<640x2x101x172xf32>)
             outs(%0 : tensor<2x?x?xf32>) -> tensor<2x?x?xf32>
     return %8 : tensor<2x?x?xf32>
@@ -101,7 +101,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
             m_offset = [%m0, %m1] * [%m_stride, 1] k_offset = [%k, 0] * [4, 1]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x34x34x640xf32>)
             outs(%0 : tensor<2x?x?x2x4xf32>) -> tensor<2x?x?x2x4xf32>
     return %7 : tensor<2x?x?x2x4xf32>
@@ -151,7 +151,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
             m_offset = [%m0, %m1] * [32, 1] k_offset = [%k, 0] * [4, 1]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x640x34x34xf32>)
             outs(%0 : tensor<2x1x1x2x4xf32>) -> tensor<2x1x1x2x4xf32>
     return %7 : tensor<2x1x1x2x4xf32>
@@ -172,7 +172,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
             m_offset = [%m_off] * [1] k_offset = [%k_off] * [1]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<2x34x34x640xf32>)
             outs(%0 : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
     return %7 : tensor<2x2x4xf32>
@@ -197,9 +197,9 @@ module {
 //   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
 //   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
 //       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C0]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT_TILE]][%[[C0]], %[[C0]], 0] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
+//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT_TILE]][%[[C0]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
 //       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT0:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT_TILE]][%[[C0]], %[[C0]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
+//       CHECK-UNROLL:   %[[INSERT0:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT_TILE]][%[[C0]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
 
 //  Second iteration
 //
@@ -209,9 +209,9 @@ module {
 //   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
 //   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
 //       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C0]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT0]][%[[C0]], %[[C1]], 0] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
+//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT0]][%[[C0]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
 //       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT1:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT0]][%[[C0]], %[[C1]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
+//       CHECK-UNROLL:   %[[INSERT1:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT0]][%[[C0]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
 
 //  Third iteration
 //
@@ -221,9 +221,9 @@ module {
 //   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
 //   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
 //       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C1]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT1]][%[[C1]], %[[C0]], 0] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
+//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT1]][%[[C1]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
 //       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT2:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT1]][%[[C1]], %[[C0]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
+//       CHECK-UNROLL:   %[[INSERT2:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT1]][%[[C1]], %[[C0]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
 
 //  Fourth iteration
 //
@@ -233,9 +233,9 @@ module {
 //   CHECK-UNROLL-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0)[%[[kParts]]#0]
 //   CHECK-UNROLL-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1)[%[[kParts]]#1]
 //       CHECK-UNROLL:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[C1]], %[[hIDX]], %[[wIDX]], %[[kParts]]#2] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x34x34x640xf32> to tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT2]][%[[C1]], %[[C1]], 0] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
+//       CHECK-UNROLL:   %[[OUT_SLICE:.+]] = tensor.extract_slice %[[INSERT2]][%[[C1]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<2x2x4xf32> to tensor<1x1x4xf32>
 //       CHECK-UNROLL:   %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
-//       CHECK-UNROLL:   %[[INSERT3:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT2]][%[[C1]], %[[C1]], 0] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
+//       CHECK-UNROLL:   %[[INSERT3:.+]] = tensor.insert_slice %[[COPY]] into %[[INSERT2]][%[[C1]], %[[C1]], %[[C0]]] [1, 1, 4] [1, 1, 1] : tensor<1x1x4xf32> into tensor<2x2x4xf32>
 
 //       CHECK-UNROLL:   return %[[INSERT3]] : tensor<2x2x4xf32>
 
@@ -252,7 +252,7 @@ module {
   %im2col = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
                               m_offset = [0, 0] * [2, 1] k_offset = [0] * [1]
                               batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-                              input_k_perm = [0, 1, 2]
+                              input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
                               ins(%padded : tensor<1x8x9x9xf32>)
                               outs(%empty : tensor<1x2x2x12xf32>) -> tensor<1x2x2x12xf32>
   return %im2col : tensor<1x2x2x12xf32>
@@ -275,7 +275,7 @@ module {
     %1 = iree_linalg_ext.im2col strides = [1] dilations = [1] kernel_size = [2]
                             m_offset = [0] * [1] k_offset = [0] * [1]
                             batch_pos = [0] m_pos = [1] k_pos = [2]
-                            input_k_perm = [1, 0]
+                            input_k_perm = [1, 0] output_perm = [0, 1, 2]
                             ins(%arg0 : tensor<1x3x2xf32>)
                             outs(%0 : tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
     return %1 : tensor<1x2x4xf32>
@@ -309,7 +309,7 @@ module {
     %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
                             m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
                             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-                            input_k_perm = [2, 0, 1]
+                            input_k_perm = [2, 0, 1] output_perm = [0, 1, 2, 3]
                             ins(%arg0 : tensor<1x16x16x4xf32>)
                             outs(%0 : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
     return %1 : tensor<1x14x14x36xf32>
@@ -350,7 +350,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
             m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3] * [1]
             batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
             ins(%arg0 : tensor<16x26x18x4xf32>)
             outs(%0 : tensor<4x2x2x2xf32>) -> tensor<4x2x2x2xf32>
     return %1 : tensor<4x2x2x2xf32>
@@ -379,8 +379,8 @@ module {
 //   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
 //   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
 //       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
-//       CHECK:       %[[EMPTY:.+]] = tensor.empty() : tensor<4x1x1x1xf32>
-//       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[EMPTY]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
+//       CHECK:       %[[INIT:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1] : tensor<4x2x2x2xf32> to tensor<4x1x1x1xf32>
+//       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[INIT]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
 //       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1] : tensor<4x1x1x1xf32> into tensor<4x2x2x2xf32>
 //       CHECK:      scf.yield %[[INSERT]] : tensor<4x2x2x2xf32>
 //       CHECK:    scf.yield %[[kLOOP]] : tensor<4x2x2x2xf32>
@@ -396,7 +396,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
             m_offset = [%arg1] * [1] k_offset = [%arg2] * [1]
             batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
             ins(%arg0 : tensor<16x26x18x4xf32>)
             outs(%0 : tensor<4x?x?xf32>) -> tensor<4x?x?xf32>
     return %1 : tensor<4x?x?xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -390,6 +390,102 @@ module {
 // -----
 
 module {
+  func.func @im2col_chwn_output_perm(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<2x2x2x4xf32> {
+    %0 = tensor.empty() : tensor<2x2x2x4xf32>
+    %1 = iree_linalg_ext.im2col
+            strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
+            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3] * [1]
+            batch_pos = [3] m_pos = [1, 2] k_pos = [0]
+            input_k_perm = [0, 1, 2] output_perm = [3, 1, 2, 0]
+            ins(%arg0 : tensor<16x26x18x4xf32>)
+            outs(%0 : tensor<2x2x2x4xf32>) -> tensor<2x2x2x4xf32>
+    return %1 : tensor<2x2x2x4xf32>
+  }
+}
+
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
+//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-LABEL: func.func @im2col_chwn_output_perm
+//  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x4xf32>
+//  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG3:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+//       CHECK: %[[INIT:.+]] = tensor.empty() : tensor<2x2x2x4xf32>
+//       CHECK: %[[LOOP0:.+]] = scf.for %[[IV0:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[INIT]])
+//       CHECK:   %[[LOOP1:.+]] = scf.for %[[IV1:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG4]])
+//       CHECK:     %[[LOOP2:.+]] = scf.for %[[IV2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG6:.+]] = %[[ARG5]])
+//   CHECK-DAG:       %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[IV0]])[%[[ARG3]]]
+//   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
+//   CHECK-DAG:       %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[IV1]], %[[IV2]])[%[[ARG1]], %[[ARG2]]]
+//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
+//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
+//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<16x26x18x4xf32> to tensor<1x1x1x4xf32>
+//       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[ARG6]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<2x2x2x4xf32> to tensor<1x1x1x4xf32>
+//       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x4xf32>)
+//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[ARG6]][%[[IV0]], %[[IV1]], %[[IV2]], 0] [1, 1, 1, 4] [1, 1, 1, 1] : tensor<1x1x1x4xf32> into tensor<2x2x2x4xf32>
+//       CHECK:       scf.yield %[[INSERT]] : tensor<2x2x2x4xf32>
+//       CHECK:     scf.yield %[[LOOP2]] : tensor<2x2x2x4xf32>
+//       CHECK:   scf.yield %[[LOOP1]] : tensor<2x2x2x4xf32>
+//       CHECK: return %[[LOOP0]] : tensor<2x2x2x4xf32>
+
+// -----
+
+module {
+  func.func @im2col_chwn_output_perm_expanded(%arg0: tensor<16x26x18x2x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<2x2x2x2x2x4xf32> {
+    %0 = tensor.empty() : tensor<2x2x2x2x2x4xf32>
+    %1 = iree_linalg_ext.im2col
+            strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
+            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3, 0] * [2, 1]
+            batch_pos = [3, 4] m_pos = [1, 2] k_pos = [0]
+            input_k_perm = [0, 1, 2] output_perm = [4, 5, 2, 3, 0, 1]
+            ins(%arg0 : tensor<16x26x18x2x4xf32>)
+            outs(%0 : tensor<2x2x2x2x2x4xf32>) -> tensor<2x2x2x2x2x4xf32>
+    return %1 : tensor<2x2x2x2x2x4xf32>
+  }
+}
+
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1)[s0] -> (d0 + d1 * 2 + s0 * 2)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
+//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-LABEL: func.func @im2col_chwn_output_perm_expanded
+//  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x2x4xf32>
+//  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG3:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+//       CHECK: %[[INIT:.+]] = tensor.empty() : tensor<2x2x2x2x2x4xf32>
+//       CHECK: %[[LOOP0:.+]] = scf.for %[[IV0:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[INIT]])
+//       CHECK:   %[[LOOP1:.+]] = scf.for %[[IV1:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG4]])
+//       CHECK:     %[[LOOP2:.+]] = scf.for %[[IV2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG6:.+]] = %[[ARG5]])
+//       CHECK:       %[[LOOP3:.+]] = scf.for %[[IV3:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[ARG6]])
+//       CHECK:         %[[LOOP4:.+]] = scf.for %[[IV4:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8:.+]] = %[[ARG7]])
+//   CHECK-DAG:           %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[IV1]], %[[IV0]])[%[[ARG3]]]
+//   CHECK-DAG:           %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
+//   CHECK-DAG:           %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[IV2]], %[[IV3]])[%[[ARG1]], %[[ARG2]]]
+//   CHECK-DAG:           %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
+//   CHECK-DAG:           %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
+//   CHECK-DAG:           %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
+//       CHECK:           %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], %[[IV4]], 0] [1, 1, 1, 1, 4] [1, 1, 1, 1, 1] : tensor<16x26x18x2x4xf32> to tensor<1x1x1x1x4xf32>
+//       CHECK:           %[[OUT_SLICE:.+]] = tensor.extract_slice %[[ARG8]][%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]], %[[IV4]], 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1] : tensor<2x2x2x2x2x4xf32> to tensor<1x1x1x1x4xf32>
+//       CHECK:           %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1x4xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1x4xf32>)
+//       CHECK:           %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[ARG8]][%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]], %[[IV4]], 0] [1, 1, 1, 1, 1, 4] [1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x4xf32> into tensor<2x2x2x2x2x4xf32>
+//       CHECK:           scf.yield %[[INSERT]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK:         scf.yield %[[LOOP4]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK:       scf.yield %[[LOOP3]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK:     scf.yield %[[LOOP2]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK:   scf.yield %[[LOOP1]] : tensor<2x2x2x2x2x4xf32>
+//       CHECK: return %[[LOOP0]] : tensor<2x2x2x2x2x4xf32>
+
+// -----
+
+module {
   func.func @im2col_chwn_rank_reduce(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %m_size: index, %k_size: index) -> tensor<4x?x?xf32> {
     %0 = tensor.empty(%m_size, %k_size) : tensor<4x?x?xf32>
     %1 = iree_linalg_ext.im2col

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1031,7 +1031,7 @@ func.func @im2col(%arg0: tensor<2x34x34x640xf32>) -> tensor<2x1024x5760xf32> {
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
            m_offset = [34] * [1] k_offset = [1000] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-           input_k_perm = [0, 1, 2]
+           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<2x34x34x640xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1071,7 +1071,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
 // CHECK-SAME:           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:           input_k_perm = [0, 1, 2]
+// CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
 // CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<1x34x34x640xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x4xf32>) -> tensor<1x?x4xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
@@ -1089,7 +1089,7 @@ func.func @im2col_transposed_m_pos(%arg0: tensor<640x2x101x172xf32>) -> tensor<2
   %1 = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
            m_offset = [42] * [1] k_offset = [7] * [1]
            batch_pos = [1] m_pos = [3, 2] k_pos = [0]
-           input_k_perm = [0, 1, 2]
+           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<640x2x101x172xf32>)
            outs(%0 : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
   return %1 : tensor<2x1024x5760xf32>
@@ -1131,7 +1131,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [5, 3] dilations = [4, 7] kernel_size = [5, 2]
 // CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
 // CHECK-SAME:           batch_pos = [1] m_pos = [3, 2] k_pos = [0]
-// CHECK-SAME:           input_k_perm = [0, 1, 2]
+// CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
 // CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<640x1x101x172xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x?xf32>) -> tensor<1x?x?xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
@@ -1150,7 +1150,7 @@ func.func @im2col_dynamic(%arg0: tensor<?x?x?x?xf32>, %s0: index, %s1: index, %s
   %1 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
            m_offset = [%mOffset] * [1] k_offset = [%kOffset] * [1]
            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-           input_k_perm = [0, 1, 2]
+           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
            ins(%arg0 : tensor<?x?x?x?xf32>)
            outs(%0 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
   return %1 : tensor<?x?x?xf32>
@@ -1196,7 +1196,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK:              %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:           m_offset = [%[[MOFFSET]]] * [1] k_offset = [%[[KOFFSET]]] * [1]
 // CHECK-SAME:           batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:           input_k_perm = [0, 1, 2]
+// CHECK-SAME:           input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
 // CHECK-SAME:           ins(%[[EXTRACTED_SLICE]] : tensor<?x?x?x?xf32>)
 // CHECK-SAME:           outs(%[[EXTRACTED_SLICE_0]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:              %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG6]]
@@ -1216,7 +1216,7 @@ module {
             strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
             m_offset = [0, 0] * [%m_stride, 1] k_offset = [0, 0] * [4, 1]
             batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-            input_k_perm = [0, 1, 2]
+            input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
             ins(%arg0 : tensor<2x34x34x640xf32>)
             outs(%0 : tensor<2x32x32x1440x4xf32>) -> tensor<2x32x32x1440x4xf32>
     return %7 : tensor<2x32x32x1440x4xf32>
@@ -1265,7 +1265,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK:                  %[[IM2COL:.+]] = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:               m_offset = [%[[ARG3]], %[[ARG5]]] * [%[[M_STRIDE]], 1] k_offset = [%[[ARG7]], %[[ARG9]]] * [4, 1]
 // CHECK-SAME:               batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:               input_k_perm = [0, 1, 2]
+// CHECK-SAME:               input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3, 4]
 // CHECK-SAME:               ins(%[[EXTRACTED_SLICE]] : tensor<1x34x34x640xf32>)
 // CHECK-SAME:               outs(%[[EXTRACTED_SLICE_0]] : tensor<1x?x?x?x2xf32>) -> tensor<1x?x?x?x2xf32>
 // CHECK:                  %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[IM2COL]] into %[[ARG10]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -180,6 +180,10 @@ struct IGEMMGenericConvDetails {
   SmallVector<ReassociationIndices> filterReassocIndices;
   /// The iterator type list for a convolution with IGEMM indexing. .
   SmallVector<utils::IteratorType> igemmLoopIterators;
+  /// The output permutation for the im2col tensor with respect to a layout of
+  /// BxMxK. The result of the permutation should match the order that the
+  /// output dims are represented in the input tensor.
+  SmallVector<int64_t> im2colOutputPerm;
   /// Indicates if the OutputChannel is before the OutputImage in the output.
   /// This determines our lhs/rhs ordering.
   bool isOutputChannelFirst;


### PR DESCRIPTION
Introduces a new field, `output_perm`, to the `iree_linalg_ext.im2col` op, and allows the dims in the im2col result to assume any permutation. The `output_perm` represents the permutation from the canonical `B0xB1x...xM0xM1x...xK0xK1x...` layout to the actual result layout.

Without the result dim order constraint, the im2col op can now maintain the inner contiguous dims from the input in the output tensor. This allows for more flexibility in the kinds of transformations we do when copying from global to shared memory.

This PR also updates the `ConvertConvToIm2ColOpPass` so that the im2col op produces an output in the same dim order as the input tensor, which makes the codegen path more similar to what we have for regular GEMM. With this change, the global to shared memory copy will behave the same for convolution as it does for GEMM.

### Benchmark results ###

The following are the geomeans of the speedup with (new) vs. without (old) this PR, computed as `benchmark_time_old / benchmark_time_new` (`> 1` indicates performance improvement). The benchmark times were collected on an MI300X chip, and are subject to noisy measurements, but they give a good indication of the performance impact.

Speedup geomean for all convs: `1.04`
Speedup geomean for forward convs: `1.003`
Speedup geomean for backwards data convs: `0.996`
Speedup geomean for backwards weight convs: `1.13`

ci-extra: test_torch