### PR TITLE
[DispatchCreation] Add clean up pattern for fusing pad into split reduction dispatch

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -163,6 +163,7 @@ util.func public @fuse_pad_with_conv(%arg0 : tensor<16x225x225x16xbf16>, %arg1 :
 // FUSE-PAD-LABEL:  @fuse_pad_with_conv(
 //       FUSE-PAD:    %[[DISPATCH:.+]] = flow.dispatch.region
 //       FUSE-PAD:      scf.forall
+//   FUSE-PAD-NOT:        scf.if
 //       FUSE-PAD:        tensor.pad
 //       FUSE-PAD:        linalg.generic
 //       FUSE-PAD:    linalg.reduce

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_split_reduction_dispatches.mlir
@@ -164,6 +164,7 @@ util.func public @fuse_pad_with_conv(%arg0 : tensor<16x225x225x16xbf16>, %arg1 :
 //       FUSE-PAD:    %[[DISPATCH:.+]] = flow.dispatch.region
 //       FUSE-PAD:      scf.forall
 //   FUSE-PAD-NOT:        scf.if
+//       FUSE-PAD:        tensor.extract_slice
 //       FUSE-PAD:        tensor.pad
 //       FUSE-PAD:        linalg.generic
 //       FUSE-PAD:    linalg.reduce


### PR DESCRIPTION
When fusing pad into `scf.forall` within split reduction dispatch, we do not want to generate `zeroSliceGuards`. This PR added a clean up pattern to avoid generating such codes.