### PR TITLE
[NFC] Replace all uses of OpBuilder.create<OpTy> with OpTy::create

### DIFF
--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -259,8 +259,8 @@ private:
       IREE::Util::ReturnOp::create(exitBuilder, exitLoc);
       returnOp.erase();
     }
-
-    OpBuilder::atBlockBegin(returnBlock).create<IREE::Util::ReturnOp>(loc);
+    OpBuilder builder = OpBuilder::atBlockBegin(returnBlock);
+    IREE::Util::ReturnOp::create(builder, loc);
 
     return calcFuncOp;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
@@ -22,9 +22,9 @@ static Value evalErfPolynomial(Value x, Value t, ArrayRef<Value> coeffs,
                                RewriterBase &rewriter, Location loc) {
   Value acc = coeffs[0];
   for (size_t i = 1; i < coeffs.size(); ++i) {
-    acc = rewriter.create<math::FmaOp>(loc, t, acc, coeffs[i]);
+    acc = math::FmaOp::create(rewriter, loc, t, acc, coeffs[i]);
   }
-  return rewriter.create<math::FmaOp>(loc, x, acc, x);
+  return math::FmaOp::create(rewriter, loc, x, acc, x);
 }
 
 // Pattern to lower math.erf to its device lib implementation
@@ -51,18 +51,19 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
       if (resVecType) {
         SmallVector<Attribute> values(resVecType.getNumElements(),
                                       rewriter.getF32FloatAttr(v));
-        return rewriter.create<arith::ConstantOp>(
-            loc, resVecType, DenseElementsAttr::get(resVecType, values));
+        return arith::ConstantOp::create(
+            rewriter, loc, resVecType,
+            DenseElementsAttr::get(resVecType, values));
       } else {
-        return rewriter.create<arith::ConstantOp>(loc, rewriter.getF32Type(),
-                                                  rewriter.getF32FloatAttr(v));
+        return arith::ConstantOp::create(rewriter, loc, rewriter.getF32Type(),
+                                         rewriter.getF32FloatAttr(v));
       }
     };
 
     Value one = createConst(1.0f);
-    Value ax = rewriter.create<math::AbsFOp>(loc, input);
-    Value cmp =
-        rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLT, ax, one);
+    Value ax = math::AbsFOp::create(rewriter, loc, input);
+    Value cmp = arith::CmpFOp::create(rewriter, loc, arith::CmpFPredicate::OLT,
+                                      ax, one);
 
     // Coefficients for |x| < 1.0.
     const SmallVector<Value, 6> coeffs1 = {
@@ -80,23 +81,23 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
     Value result;
     if (resultType.isF32()) {
       // For scalar types, use scf.if.
-      auto ifOp = rewriter.create<scf::IfOp>(loc, resultType, cmp,
-                                             /*withElseRegion=*/true);
+      auto ifOp = scf::IfOp::create(rewriter, loc, resultType, cmp,
+                                    /*withElseRegion=*/true);
 
       // Then region: |x| < 1.0 - evaluate polynomial.
       rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
-      Value t = rewriter.create<arith::MulFOp>(loc, ax, ax);
+      Value t = arith::MulFOp::create(rewriter, loc, ax, ax);
       Value result1 = evalErfPolynomial(ax, t, coeffs1, rewriter, loc);
-      rewriter.create<scf::YieldOp>(loc, result1);
+      scf::YieldOp::create(rewriter, loc, result1);
 
       // Else region: |x| >= 1.0 - evaluate different polynomial and
       // post-processing.
       rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
       Value p2 = evalErfPolynomial(ax, ax, coeffs2, rewriter, loc);
-      Value negP2 = rewriter.create<arith::NegFOp>(loc, p2);
-      Value expNegP2 = rewriter.create<math::ExpOp>(loc, negP2);
-      Value result2 = rewriter.create<arith::SubFOp>(loc, one, expNegP2);
-      rewriter.create<scf::YieldOp>(loc, result2);
+      Value negP2 = arith::NegFOp::create(rewriter, loc, p2);
+      Value expNegP2 = math::ExpOp::create(rewriter, loc, negP2);
+      Value result2 = arith::SubFOp::create(rewriter, loc, one, expNegP2);
+      scf::YieldOp::create(rewriter, loc, result2);
 
       rewriter.setInsertionPointAfter(ifOp);
       result = ifOp.getResult(0);
@@ -107,23 +108,23 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
       // the conditional logic element-wise.
 
       // Compute t = ax * ax for the first polynomial.
-      Value t = rewriter.create<arith::MulFOp>(loc, ax, ax);
+      Value t = arith::MulFOp::create(rewriter, loc, ax, ax);
 
       // Compute first polynomial (for |x| < 1.0).
       Value result1 = evalErfPolynomial(ax, t, coeffs1, rewriter, loc);
 
       // Compute second polynomial (for |x| >= 1.0).
       Value p2 = evalErfPolynomial(ax, ax, coeffs2, rewriter, loc);
-      Value negP2 = rewriter.create<arith::NegFOp>(loc, p2);
-      Value expNegP2 = rewriter.create<math::ExpOp>(loc, negP2);
-      Value result2 = rewriter.create<arith::SubFOp>(loc, one, expNegP2);
+      Value negP2 = arith::NegFOp::create(rewriter, loc, p2);
+      Value expNegP2 = math::ExpOp::create(rewriter, loc, negP2);
+      Value result2 = arith::SubFOp::create(rewriter, loc, one, expNegP2);
 
       // Select between the two results based on the condition.
-      result = rewriter.create<arith::SelectOp>(loc, cmp, result1, result2);
+      result = arith::SelectOp::create(rewriter, loc, cmp, result1, result2);
     }
 
     // Restore the sign.
-    Value finalResult = rewriter.create<math::CopySignOp>(loc, result, input);
+    Value finalResult = math::CopySignOp::create(rewriter, loc, result, input);
     rewriter.replaceOp(op, finalResult);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -353,8 +353,8 @@ struct CoalescedGatherDMAOpBufferizationInterface
       if (forallOp) {
         // Insert the memref version before the in_parallel block.
         rewriter.setInsertionPoint(parentOp);
-        rewriter.create<IREE::GPU::CoalescedGatherDMAOp>(
-            gatherOp.getLoc(), initBuffer->getType(), *indicesBuffer,
+        IREE::GPU::CoalescedGatherDMAOp::create(
+            rewriter, gatherOp.getLoc(), initBuffer->getType(), *indicesBuffer,
             *sourceBuffer, *initBuffer);
         // The result is the same as the init buffer.
         bufferization::replaceOpWithBufferizedValues(rewriter, op, *initBuffer);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1957,11 +1957,10 @@ Value ExecutableVariantOp::buildCondition(Value device, OpBuilder &builder) {
     IRMapping mapper;
     mapper.map(conditionOp.getRegion().getArgument(0), device);
     conditionOp.getRegion().cloneInto(&regionOp.getRegion(), mapper);
-
     for (auto returnOp :
          llvm::make_early_inc_range(regionOp.getOps<IREE::HAL::ReturnOp>())) {
-      OpBuilder(returnOp).create<scf::YieldOp>(returnOp.getLoc(),
-                                               returnOp.getOperands());
+      OpBuilder builder(returnOp);
+      scf::YieldOp::create(builder, returnOp.getLoc(), returnOp.getOperands());
       returnOp.erase();
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -133,8 +133,9 @@ static SmallVector<Value> inlineConstantBlockOp(
   // Replace the hal.return with a func.return.
   for (auto returnOp :
        llvm::make_early_inc_range(funcOp.getOps<IREE::HAL::ReturnOp>())) {
-    OpBuilder(returnOp).create<IREE::Util::ReturnOp>(returnOp.getLoc(),
-                                                     returnOp.getOperands());
+    OpBuilder builder(returnOp);
+    IREE::Util::ReturnOp::create(builder, returnOp.getLoc(),
+                                 returnOp.getOperands());
     returnOp.erase();
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
@@ -203,8 +203,9 @@ static IREE::Util::FuncOp outlineMemoizeRegionBody(
   // cloneRegionBefore is unfriendly and requires that we poke into the block
   // list to get the first block and insert the branch to it.
   auto &entryBlock = funcOp.getBlocks().front();
-  OpBuilder::atBlockEnd(&entryBlock)
-      .create<cf::BranchOp>(memoizeOp.getLoc(), entryBlock.getNextNode());
+  OpBuilder entryBuilder = OpBuilder::atBlockEnd(&entryBlock);
+  cf::BranchOp::create(entryBuilder, memoizeOp.getLoc(),
+                       entryBlock.getNextNode());
 
   // Rewrite hal.return ops to util.return.
   for (auto returnOp :

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveExportOrdinals.cpp
@@ -32,8 +32,9 @@ struct ResolveExportOrdinalsPass
         auto exportOp =
             symbolTable.lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
                 ordinalOp, ordinalOp.getEntryPointAttr());
-        Value value = OpBuilder(ordinalOp).create<arith::ConstantIndexOp>(
-            ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
+        OpBuilder builder(ordinalOp);
+        Value value = arith::ConstantIndexOp::create(
+            builder, ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
         ordinalOp.replaceAllUsesWith(value);
         ordinalOp.erase();
       });

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -1062,8 +1062,9 @@ static bool insertBindingOp(BlockArgument arg,
 // this.
 static void convertReturnOps(Region &region) {
   region.walk([](IREE::Flow::ReturnOp oldOp) {
-    OpBuilder(oldOp).create<IREE::Stream::ReturnOp>(oldOp.getLoc(),
-                                                    oldOp.getOperands());
+    OpBuilder builder(oldOp);
+    IREE::Stream::ReturnOp::create(builder, oldOp.getLoc(),
+                                   oldOp.getOperands());
     oldOp.erase();
   });
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -246,8 +246,8 @@ struct MemoizedCmdZeros {
     if (it != parentZeros.end()) {
       return it->second;
     }
-    auto zero =
-        OpBuilder(parentOp).create<arith::ConstantIndexOp>(op->getLoc(), 0);
+    OpBuilder builder(parentOp);
+    auto zero = arith::ConstantIndexOp::create(builder, op->getLoc(), 0);
     parentZeros[parentOp] = zero;
     return zero;
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1971,7 +1971,8 @@ allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
   scope.replaceRootOp(newExecuteOp);
 
   // Drop the operands on the yield op now that all are aliased.
-  OpBuilder(yieldOp).create<IREE::Stream::YieldOp>(yieldOp.getLoc());
+  OpBuilder yieldOpBuilder(yieldOp);
+  IREE::Stream::YieldOp::create(yieldOpBuilder, yieldOp.getLoc());
   yieldOp.erase();
 
   // Apply mappings from the parent execute op into all waves; as we allocate
@@ -2062,17 +2063,19 @@ allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
 }
 
 static LogicalResult convertAsyncLoadOp(IREE::Stream::AsyncLoadOp asyncOp) {
-  auto newOp = OpBuilder(asyncOp).create<IREE::Stream::ResourceLoadOp>(
-      asyncOp.getLoc(), asyncOp.getResult().getType(), asyncOp.getSource(),
-      asyncOp.getSourceSize(), asyncOp.getSourceOffset());
+  OpBuilder builder(asyncOp);
+  auto newOp = IREE::Stream::ResourceLoadOp::create(
+      builder, asyncOp.getLoc(), asyncOp.getResult().getType(),
+      asyncOp.getSource(), asyncOp.getSourceSize(), asyncOp.getSourceOffset());
   asyncOp.replaceAllUsesWith(newOp.getResult());
   asyncOp.erase();
   return success();
 }
 
 static LogicalResult convertAsyncStoreOp(IREE::Stream::AsyncStoreOp asyncOp) {
-  auto newOp = OpBuilder(asyncOp).create<IREE::Stream::ResourceStoreOp>(
-      asyncOp.getLoc(), asyncOp.getTarget(), asyncOp.getTargetSize(),
+  OpBuilder builder(asyncOp);
+  auto newOp = IREE::Stream::ResourceStoreOp::create(
+      builder, asyncOp.getLoc(), asyncOp.getTarget(), asyncOp.getTargetSize(),
       asyncOp.getTargetOffset(), asyncOp.getValue());
   asyncOp.replaceAllUsesWith(newOp.getTarget());
   asyncOp.erase();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -234,9 +234,9 @@ struct MemoizedCmdConstants {
     if (it != parentMap.end()) {
       return it->second;
     }
+    OpBuilder builder(parentOp);
     auto constantValue =
-        OpBuilder(parentOp)
-            .create<arith::ConstantIndexOp>(op->getLoc(), value)
+        arith::ConstantIndexOp::create(builder, op->getLoc(), value)
             .getResult();
     parentMap.insert({value, constantValue});
     return constantValue;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -617,10 +617,11 @@ static bool applyCallChanges(FuncAnalysis &analysis,
 
   // Fully replace call op because we may have changed result count.
   // TODO(benvanik): update tied operands, arg_attrs, and res_attrs.
-  auto newCallOp = OpBuilder(callOp).create<IREE::Util::CallOp>(
-      callOp.getLoc(), newResultTypes, callOp.getCalleeAttr(), newOperands,
-      /*tied_operands=*/ArrayAttr{},
-      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
+  auto newCallOp =
+      IREE::Util::CallOp::create(builder, callOp.getLoc(), newResultTypes,
+                                 callOp.getCalleeAttr(), newOperands,
+                                 /*tied_operands=*/ArrayAttr{},
+                                 /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
   newCallOp->setDialectAttrs(callOp->getDialectAttrs());
 
   // Remap live old results -> new results.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -617,11 +617,12 @@ static bool applyCallChanges(FuncAnalysis &analysis,
 
   // Fully replace call op because we may have changed result count.
   // TODO(benvanik): update tied operands, arg_attrs, and res_attrs.
-  auto newCallOp =
-      IREE::Util::CallOp::create(builder, callOp.getLoc(), newResultTypes,
-                                 callOp.getCalleeAttr(), newOperands,
-                                 /*tied_operands=*/ArrayAttr{},
-                                 /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
+  OpBuilder newCallBuilder(callOp);
+  auto newCallOp = IREE::Util::CallOp::create(
+      newCallBuilder, callOp.getLoc(), newResultTypes, callOp.getCalleeAttr(),
+      newOperands,
+      /*tied_operands=*/ArrayAttr{},
+      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
   newCallOp->setDialectAttrs(callOp->getDialectAttrs());
 
   // Remap live old results -> new results.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
@@ -382,8 +382,8 @@ struct UnreachableOpConversion
   matchAndRewrite(IREE::Util::UnreachableOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Create INTERNAL status code (13) for unreachable code.
-    auto status = rewriter.create<IREE::VM::ConstI32Op>(
-        op.getLoc(), rewriter.getI32IntegerAttr(13));
+    auto status = IREE::VM::ConstI32Op::create(rewriter, op.getLoc(),
+                                               rewriter.getI32IntegerAttr(13));
     rewriter.replaceOpWithNewOp<IREE::VM::FailOp>(op, status.getResult(),
                                                   op.getMessageAttr());
     return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -55,7 +55,8 @@ appendOrCreateInitFuncOp(IREE::VM::ModuleOp moduleOp, StringRef name,
   auto returnOps = llvm::to_vector(funcOp.getOps<IREE::VM::ReturnOp>());
   for (auto returnOp :
        llvm::make_early_inc_range(funcOp.getOps<IREE::VM::ReturnOp>())) {
-    OpBuilder(returnOp).create<IREE::VM::BranchOp>(returnOp.getLoc(), newBlock);
+    OpBuilder builder(returnOp);
+    IREE::VM::BranchOp::create(builder, returnOp.getLoc(), newBlock);
     returnOp.erase();
   }
 

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -262,8 +262,9 @@ public:
         // TODO(benvanik): see if we can allow this through; today it will pin
         // the function argument (constants most likely) and cause us to fail to
         // remove it later on.
-        Value dummySize = OpBuilder(sizeOp).create<arith::ConstantIndexOp>(
-            sizeOp.getLoc(), 0xCAFEF00D);
+        OpBuilder builder(sizeOp);
+        Value dummySize = arith::ConstantIndexOp::create(
+            builder, sizeOp.getLoc(), 0xCAFEF00D);
         sizeOp.replaceAllUsesWith(dummySize);
         sizeOp.erase();
         continue;

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/ResolveExportOrdinals.cpp
@@ -33,8 +33,9 @@ public:
         auto exportOp =
             symbolTable.lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
                 ordinalOp, ordinalOp.getEntryPointAttr());
-        Value value = OpBuilder(ordinalOp).create<arith::ConstantIndexOp>(
-            ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
+        OpBuilder builder(ordinalOp);
+        Value value = arith::ConstantIndexOp::create(
+            builder, ordinalOp.getLoc(), exportOp.getOrdinalAttr().getInt());
         ordinalOp.replaceAllUsesWith(value);
         ordinalOp.erase();
       });


### PR DESCRIPTION
In preparation for this upstream commit: https://github.com/llvm/llvm-project/commit/c0b42ec05344707d94805ec795a7bc8d33a09594