### PR TITLE
Add final dispatch name to AMDGPU Register spill warning

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -280,12 +280,17 @@ static void checkRegisterSpilling(IREE::HAL::ExecutableVariantOp &variantOp,
 
   if (!llvm::offloading::amdgpu::getAMDGPUMetaDataFromImage(
           llvm::MemoryBufferRef(obj, ""), infoMap, abiVersion)) {
-    for (const auto &[_, metaData] : infoMap) {
+    for (llvm::StringMapEntry<llvm::offloading::amdgpu::AMDGPUKernelMetaData>
+             &entry : infoMap) {
+      StringRef dispatchName = entry.getKey();
+      llvm::offloading::amdgpu::AMDGPUKernelMetaData &metaData =
+          entry.getValue();
       if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount > 0) {
         emitWarning(variantOp.getLoc())
             << "Register spill: " << "VGPRSpillCount: "
             << metaData.VGPRSpillCount
-            << " / SGPRSpillCount: " << metaData.SGPRSpillCount;
+            << " / SGPRSpillCount: " << metaData.SGPRSpillCount
+            << " / Dispatch: " << dispatchName;
       }
     }
   }

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -280,11 +280,7 @@ static void checkRegisterSpilling(IREE::HAL::ExecutableVariantOp &variantOp,
 
   if (!llvm::offloading::amdgpu::getAMDGPUMetaDataFromImage(
           llvm::MemoryBufferRef(obj, ""), infoMap, abiVersion)) {
-    for (llvm::StringMapEntry<llvm::offloading::amdgpu::AMDGPUKernelMetaData>
-             &entry : infoMap) {
-      StringRef dispatchName = entry.getKey();
-      llvm::offloading::amdgpu::AMDGPUKernelMetaData &metaData =
-          entry.getValue();
+    for (const auto &[dispatchName, metaData] : infoMap) {
       if (metaData.SGPRSpillCount > 0 || metaData.VGPRSpillCount > 0) {
         emitWarning(variantOp.getLoc())
             << "Register spill: " << "VGPRSpillCount: "


### PR DESCRIPTION
Warnings from --iree-hip-enable-register-spill-warning are difficult to interpret when a module is split into many dispatches. Adding the dispatch name to the warning would make debugging easier