### PR TITLE
[Codegen][Tuner] solve name conflicts for merging td specs

### DIFF
--- a/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
+++ b/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
@@ -75,7 +75,7 @@
 // MERGE:         transform.foreach_match
 // MERGE:           @match_mmt -> @apply_op_config,
 // MERGE-NEXT:      @match_attention_2x10x4096x64x64x64_f16 -> @apply_attn_op_config,
-// MERGE-NEXT:      @match_mmt_2048x1280x5120_f16_f16_f32 -> @iree_default_tuning_spec_gfx942_1_apply_op_config
+// MERGE-NEXT:      @match_mmt_2048x1280x5120_f16_f16_f32 -> @apply_op_config_0
 
 // NOTE: The order matters above because `foreach_match` ops performs matching from top to bottom.
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -152,10 +152,8 @@ static void updateNamedSequenceOp(
 
   // Ensure the name is unique by appending a numeric suffix if needed.
   std::string uniqueNewSpecName = specName.str();
-  unsigned suffix = 0;
-  while (seenNames.contains(uniqueNewSpecName)) {
+  for (unsigned suffix = 0; seenNames.contains(uniqueNewSpecName); ++suffix) {
     uniqueNewSpecName = llvm::formatv("{}_{}", specName, suffix).str();
-    ++suffix;
   }
 
   op.setSymName(uniqueNewSpecName);
@@ -222,10 +220,8 @@ static LogicalResult resolveAndMoveNamedSequenceOps(
   }
 
   // Update conflicted named sequence ops.
-  if (!nameConflictOps.empty()) {
-    for (NamedSequenceOp op : nameConflictOps) {
-      updateNamedSequenceOp(op, builder, namedSequenceToUser, seenNames);
-    }
+  for (NamedSequenceOp op : nameConflictOps) {
+    updateNamedSequenceOp(op, builder, namedSequenceToUser, seenNames);
   }
 
   // Move all named sequence ops to the top-level module.

--- a/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
@@ -340,3 +340,54 @@ module @td_module attributes { transform.with_named_sequence } {
 // CHECK:           @match -> @apply_op_config
 // CHECK:           @m0_match -> @m0_apply_op_config
 // CHECK:           @m1_match -> @apply_op_config_1
+
+// -----
+
+// Test that renaming handles secondary conflicts: when @apply_op_config from the
+// second unnamed module is renamed to @m0_apply_op_config, but that name already
+// exists in the same module, it should be further renamed to @m0_apply_op_config_0.
+
+module @td_module_secondary_name_conflict attributes {transform.with_named_sequence} {
+  module attributes {iree_codegen.tuning_spec_with_default_entrypoint, transform.with_named_sequence} {
+    transform.named_sequence @apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
+      transform.yield
+    }
+    transform.named_sequence @match_a(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg0 : !transform.any_op
+    }
+    transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed}) -> !transform.any_op
+        attributes {iree_codegen.tuning_spec_entrypoint} {
+      %updated_root = transform.foreach_match in %arg0
+          @match_a -> @apply_op_config : (!transform.any_op) -> !transform.any_op
+      transform.yield %updated_root : !transform.any_op
+    }
+  }
+  module attributes {iree_codegen.tuning_spec_with_default_entrypoint, transform.with_named_sequence} {
+    transform.named_sequence @apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
+      transform.yield
+    }
+    transform.named_sequence @m0_apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
+      transform.yield
+    }
+    transform.named_sequence @match_b(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg0 : !transform.any_op
+    }
+    transform.named_sequence @match_c(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg0 : !transform.any_op
+    }
+    transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed}) -> !transform.any_op
+        attributes {iree_codegen.tuning_spec_entrypoint} {
+      %updated_root = transform.foreach_match in %arg0
+          @match_b -> @apply_op_config,
+          @match_c -> @m0_apply_op_config : (!transform.any_op) -> !transform.any_op
+      transform.yield %updated_root : !transform.any_op
+    }
+  }
+}
+
+// CHECK-LABEL:   module @td_module_secondary_name_conflict
+// CHECK:         @__kernel_config(
+// CHECK:         transform.foreach_match
+// CHECK:           @match_a -> @apply_op_config
+// CHECK:           @match_b -> @m0_apply_op_config_0
+// CHECK:           @match_c -> @m0_apply_op_config

--- a/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
@@ -268,8 +268,8 @@ module @td_module attributes { transform.with_named_sequence } {
 // CHECK:         @__kernel_config(
 // CHECK:         transform.foreach_match
 // CHECK:           @match -> @apply_op_config
-// CHECK:           @inner_module_b_match -> @inner_module_b_apply_op_config
-// CHECK:           @inner_module_c_match -> @apply_op_config_1
+// CHECK:           @match_0 -> @apply_op_config_0
+// CHECK:           @match_1 -> @apply_op_config_1
 
 // -----
 
@@ -338,14 +338,14 @@ module @td_module attributes { transform.with_named_sequence } {
 // CHECK:         @__kernel_config(
 // CHECK:         transform.foreach_match
 // CHECK:           @match -> @apply_op_config
-// CHECK:           @m0_match -> @m0_apply_op_config
-// CHECK:           @m1_match -> @apply_op_config_1
+// CHECK:           @match_0 -> @apply_op_config_0
+// CHECK:           @match_1 -> @apply_op_config_1
 
 // -----
 
-// Test that renaming handles secondary conflicts: when @apply_op_config from the
-// second unnamed module is renamed to @m0_apply_op_config, but that name already
-// exists in the same module, it should be further renamed to @m0_apply_op_config_0.
+// Test secondary conflict: when @apply_op_config from the second module conflicts
+// and would be renamed to @apply_op_config_0, but @apply_op_config_0 already
+// exists in the same module, it should skip to @apply_op_config_1.
 
 module @td_module_secondary_name_conflict attributes {transform.with_named_sequence} {
   module attributes {iree_codegen.tuning_spec_with_default_entrypoint, transform.with_named_sequence} {
@@ -366,7 +366,7 @@ module @td_module_secondary_name_conflict attributes {transform.with_named_seque
     transform.named_sequence @apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
       transform.yield
     }
-    transform.named_sequence @m0_apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
+    transform.named_sequence @apply_op_config_0(%arg0: !transform.any_op {transform.readonly}) {
       transform.yield
     }
     transform.named_sequence @match_b(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
@@ -379,7 +379,7 @@ module @td_module_secondary_name_conflict attributes {transform.with_named_seque
         attributes {iree_codegen.tuning_spec_entrypoint} {
       %updated_root = transform.foreach_match in %arg0
           @match_b -> @apply_op_config,
-          @match_c -> @m0_apply_op_config : (!transform.any_op) -> !transform.any_op
+          @match_c -> @apply_op_config_0 : (!transform.any_op) -> !transform.any_op
       transform.yield %updated_root : !transform.any_op
     }
   }
@@ -389,5 +389,5 @@ module @td_module_secondary_name_conflict attributes {transform.with_named_seque
 // CHECK:         @__kernel_config(
 // CHECK:         transform.foreach_match
 // CHECK:           @match_a -> @apply_op_config
-// CHECK:           @match_b -> @m0_apply_op_config_0
-// CHECK:           @match_c -> @m0_apply_op_config
+// CHECK:           @match_b -> @apply_op_config_1
+// CHECK:           @match_c -> @apply_op_config_0


### PR DESCRIPTION
**Follow-up fix for:** https://github.com/iree-org/iree/pull/20127  
**Fixes:** https://github.com/iree-org/iree/issues/20673, https://github.com/nod-ai/shark-ai/issues/2440

This issue was discovered while tuning BOO, where the same naming conflict pattern caused the pass to fail.

## Problem

When a module contains both a conflicting name and a suffixed variant of that name, the pass could create duplicate names during conflict resolution.

### Example
```mlir
module {  // First module
  @apply_op_config
}
module {  // Second module
  @apply_op_config        // conflicts → would rename to @apply_op_config_0
  @apply_op_config_0      // but this already exists! → BUG
}
```

The second module's `@apply_op_config` would be renamed to `@apply_op_config_0`, but that name already exists in the same module, creating a duplicate.

## Solution

This PR checks the newly generated name against `seenNames` and increments the numeric suffix until finding a unique name:
- `@apply_op_config` → `@apply_op_config_1` (skipping `_0` since it exists)

The fix uses a simple numeric suffix scheme (e.g., `_0`, `_1`, `_2`) instead of module prefixes for cleaner and more maintainable code.
