### PR TITLE
[CI][TorchModels] Update flags for CLIP test.

### DIFF
--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "sdxl/modules/clip_gfx942",
-  "golden_dispatch_count": 792,
+  "golden_dispatch_count": 790,
   "golden_binary_size": 460000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
@@ -5,10 +5,7 @@
         "--iree-hip-target=gfx942",
         "--iree-opt-level=O3",
         "--iree-opt-generalize-matmul=false",
-        "--iree-opt-const-eval=false",
-        "--iree-hip-waves-per-eu=2",
         "--iree-llvmgpu-enable-prefetch",
-        "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
     ]

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
@@ -5,7 +5,7 @@
         "--iree-hip-target=gfx942",
         "--iree-opt-level=O3",
         "--iree-opt-generalize-matmul=false",
-	"--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
+        "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/clip_gfx942.json
@@ -5,6 +5,7 @@
         "--iree-hip-target=gfx942",
         "--iree-opt-level=O3",
         "--iree-opt-generalize-matmul=false",
+	"--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
         "--iree-llvmgpu-enable-prefetch",
         "--iree-execution-model=async-external",
         "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"


### PR DESCRIPTION
Dropping some flags that are superfluous and we dont want to really support these.

- `--iree-hip-waves-per-eu=2` is not a flag we really want to support, and looks like compiling with thihs does not actually work as expected since I get a warning saying "expected 2 waves but can schedule only 1"

- `--iree-dispatch-creation-enable-fuse-horizontal-contractions=true` does not seem to have any effect.

- `--iree-opt-const-eval=false`, to re-enable const-eval.

ci-extra: test_torch