### PR TITLE
[Codegen] Move GPUApplyPaddingLevel to an interface implementation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -116,6 +116,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:TensorMaskingOpInterface",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -150,6 +150,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
+    iree::compiler::Codegen::Interfaces::TensorMaskingOpInterface
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
     iree::compiler::Codegen::Utils::VectorOpUtils

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
+#include "iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/ADT/DenseSet.h"
@@ -60,120 +61,60 @@ getTiledOps(Operation *funcOp, IREE::GPU::TilingLevel tilingLevel) {
   return targets;
 }
 
-/// For a reduction dimension of a linalg operation `linalgOp`,
-///
-/// 1) `loopIndex` is the index of the loop in `linalgOp` that is reduced,
-/// 2) `operand` is the first operand indexed by the reduction dimension,
-/// 3) `operandDim` is the dimension of the operand that's reduced.
-///
-/// Example. Consider the generic below with 2 reduction dimensions.
-///
-/// ```mlir
-/// #map = affine_map<(d0, d1) -> (d1, d0)>
-/// #map1 = affine_map<(d0, d1) -> (d0, d1)>
-/// #map2 = affine_map<(d0, d1) -> ()>
-/// [...]
-/// %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
-///                      iterator_types = ["reduction", "reduction"]}
-///                      ins(%arg0, %arg1 : tensor<?x?xf16>, tensor<?x?xf16>)
-///                      outs(%arg2 : tensor<f16>)
-/// [...]
-/// ```
-///
-/// d0 has reduction info (loopIndex = 0, operand = %arg0, operandDim = 1),
-/// d1 has reduction info (loopIndex = 1, operand = %arg0, operandDim = 0).
-namespace {
-struct ReductionDimInfo {
-public:
-  unsigned loopIndex;
-  unsigned operandDim;
-  Value operand;
-};
-} // namespace
+static void makePadDPS(RewriterBase &rewriter, tensor::PadOp padOp) {
+  Location loc = padOp.getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfter(padOp);
 
-static FailureOr<SmallVector<ReductionDimInfo>>
-getReductionInfo(linalg::LinalgOp linalgOp) {
-  SmallVector<AffineMap> indexingMaps = linalgOp.getIndexingMapsArray();
-  SmallVector<utils::IteratorType> iteratorTypes =
-      linalgOp.getIteratorTypesArray();
+  // Record users for RAUW before creating new users.
+  llvm::SmallDenseSet<Operation *> users(padOp.getResult().getUsers().begin(),
+                                         padOp.getResult().getUsers().end());
 
-  unsigned numReductionDims =
-      llvm::count(iteratorTypes, utils::IteratorType::reduction);
-  SmallVector<ReductionDimInfo> reductionDimInfos;
-  reductionDimInfos.reserve(numReductionDims);
+  RankedTensorType tensorTy = padOp.getResultType();
+  int64_t rank = tensorTy.getRank();
+  // TODO: Use getMixedSizes.
+  SmallVector<OpFoldResult> sizes(rank, OpFoldResult());
+  for (int64_t i = 0; i < rank; ++i) {
+    sizes[i] = rewriter.createOrFold<tensor::DimOp>(loc, padOp.getResult(), i);
+    if (auto v = dyn_cast<Value>(sizes[i]))
+      sizes[i] = getAsOpFoldResult(v);
+  }
 
-  for (unsigned loopIdx = 0, endIdx = iteratorTypes.size(); loopIdx < endIdx;
-       ++loopIdx) {
-    if (!linalg::isReductionIterator(iteratorTypes[loopIdx]))
-      continue;
+  Value out = tensor::EmptyOp::create(rewriter, loc, sizes,
+                                      getElementTypeOrSelf(tensorTy));
+  auto copied = linalg::CopyOp::create(rewriter, loc, padOp.getResult(), out);
+  rewriter.replaceUsesWithIf(padOp.getResult(), copied.getResult(0),
+                             [&](OpOperand &opOperand) {
+                               return users.contains(opOperand.getOwner());
+                             });
+}
 
-    AffineExpr loopIdxExpr = getAffineDimExpr(loopIdx, linalgOp.getContext());
-    for (auto [operandIndex, indexingMap] : llvm::enumerate(indexingMaps)) {
-      if (std::optional<unsigned> index =
-              indexingMap.getResultPosition(loopIdxExpr)) {
-        Value operand = linalgOp->getOperand(operandIndex);
-        reductionDimInfos.push_back({loopIdx, index.value(), operand});
-        break;
-      }
+struct MaskListener : public RewriterBase::Listener {
+  void notifyOperationInserted(Operation *op,
+                               RewriterBase::InsertPoint previous) override {
+    if (auto padOp = dyn_cast<tensor::PadOp>(op)) {
+      pads.push_back(padOp);
     }
   }
 
-  if (reductionDimInfos.size() != numReductionDims)
-    return failure();
+  void notifyOperationErased(Operation *op) override {
+    if (auto padOp = dyn_cast<tensor::PadOp>(op)) {
+      pads.erase(std::remove(pads.begin(), pads.end(), padOp), pads.end());
+    }
+  }
 
-  return reductionDimInfos;
-}
+  SmallVector<tensor::PadOp> pads;
+};
 
 static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
                                        TilingInterface tilingInterfaceOp,
                                        IREE::GPU::TilingLevel tilingLevel) {
-  // 1.a. Get padding values. The default should be poison, instead of 0.
-  //
-  // TODO(newling) pad with poison. Requires
-  //
-  // https://github.com/iree-org/iree/pull/21573
-  // https://github.com/llvm/llvm-project/pull/152003
-  // https://github.com/iree-org/iree/issues/21575
-  //
-  // The linalg operations can be padded with any value because we rewrite the
-  // basic block to select the reduction identity for the yielded value if the
-  // index corresponds to the padded part of the tensor.
-  //
-  // Non-linalg operations require special handling.
-  // TODO: Extract the special handling into an upstream PaddingOpInterface.
-
-  SmallVector<Attribute> paddingValues;
-  for (Value operand : tilingInterfaceOp.getOperation()->getOperands()) {
-    paddingValues.push_back(
-        rewriter.getZeroAttr(getElementTypeOrSelf(operand.getType())));
+  auto tensorMaskingOp =
+      dyn_cast<TensorMaskingOpInterface>(tilingInterfaceOp.getOperation());
+  if (!tensorMaskingOp) {
+    return failure();
   }
 
-  // 1.b. Special adjustment for OnlineAttention mask padding.
-  if (auto onlineAttentionOp = dyn_cast<IREE::LinalgExt::OnlineAttentionOp>(
-          tilingInterfaceOp.getOperation())) {
-    TypedValue<ShapedType> mask = onlineAttentionOp.getMask();
-    if (!mask) {
-      tilingInterfaceOp.emitRemark(
-          "failed to pad op: requires a mask operand to pad to the "
-          "proper value. Consider materializing the mask operand "
-          "explicitly.");
-      return failure();
-    }
-    Type maskEltType = getElementTypeOrSelf(mask.getType());
-    if (!llvm::isa<FloatType>(maskEltType)) {
-      tilingInterfaceOp.emitRemark(
-          "failed to pad op: -inf requires a float type");
-      return failure();
-    }
-    int64_t idx = onlineAttentionOp.getMaskMutable()
-                      .getAsOperandRange()
-                      .getBeginOperandIndex();
-    const auto &fltSemantics = cast<FloatType>(maskEltType).getFloatSemantics();
-    paddingValues[idx] = rewriter.getFloatAttr(
-        maskEltType, APFloat::getInf(fltSemantics, /*Negative=*/true));
-  }
-
-  // 2. Get padding sizes from tileSizes.
   SmallVector<int64_t> tileSizes =
       getLoweringConfig(tilingInterfaceOp)
           .getStaticTilingLevelSizes(llvm::to_underlying(tilingLevel),
@@ -181,155 +122,13 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
   SmallVector<OpFoldResult> padSizes =
       getAsIndexOpFoldResult(rewriter.getContext(), tileSizes);
 
-  // 3. Set options.
-  linalg::PadTilingInterfaceOptions options =
-      linalg::PadTilingInterfaceOptions()
-          .setPaddingSizes(padSizes)
-          .setPaddingValues(paddingValues)
-          .setPadToMultipleOf(true);
-
-  LLVM_DEBUG(DBGS() << "Start padding " << *tilingInterfaceOp << "\n";
-             DBGS() << "--with tile sizes: "
-                    << llvm::interleaved_array(options.paddingSizes) << "\n";
-             DBGS() << "--with padding values: "
-                    << llvm::interleaved_array(options.paddingValues) << "\n";
-             DBGS() << "--with padToMultipleOf: " << options.padToMultipleOf
-                    << "\n");
-
-  // For linalg ops, we will rewrite the basic block in a way that means padded
-  // parts of tensors are never read. This is useful to avoid inferring what
-  // padding values should be for non-trivial basic blocks.
-  FailureOr<SmallVector<ReductionDimInfo>> reductionDimInfo;
-  if (auto linalgOp =
-          dyn_cast<linalg::LinalgOp>(tilingInterfaceOp.getOperation())) {
-    reductionDimInfo = getReductionInfo(linalgOp);
-    if (failed(reductionDimInfo)) {
-      tilingInterfaceOp.emitWarning("failed to map reduction dimensions");
-      return failure();
-    }
-  }
-
-  // 4. Pad.
-  FailureOr<linalg::PadTilingInterfaceResult> maybePadResult =
-      linalg::rewriteAsPaddedOp(rewriter, tilingInterfaceOp, options);
-  if (failed(maybePadResult)) {
-    tilingInterfaceOp.emitWarning("failed to pad op");
+  FailureOr<SmallVector<Value>> result =
+      tensorMaskingOp.getMaskedImplementation(rewriter, padSizes);
+  if (failed(result)) {
     return failure();
   }
-  const linalg::PadTilingInterfaceResult &padResult = maybePadResult.value();
-  rewriter.replaceOp(tilingInterfaceOp, padResult.replacements);
-  TilingInterface paddedOp = padResult.paddedOp;
-  Location loc = paddedOp.getLoc();
 
-  if (auto paddedLinalgOp =
-          dyn_cast<linalg::LinalgOp>(paddedOp.getOperation())) {
-    Block *block = paddedLinalgOp.getBlock();
-    SmallVector<int64_t> paddedLoopRanges =
-        paddedLinalgOp.getStaticLoopRanges();
-
-    SmallVector<Operation *> reductions;
-    for (auto [index, initOpOperand] :
-         llvm::enumerate(paddedLinalgOp.getDpsInitsMutable())) {
-      SmallVector<Operation *> combinerOps;
-      matchReduction(paddedLinalgOp.getRegionOutputArgs(), index, combinerOps);
-      reductions.insert(reductions.begin(), combinerOps.begin(),
-                        combinerOps.end());
-    }
-
-    for (Operation *reduction : reductions) {
-      std::optional<TypedAttr> reductionIdentity =
-          arith::getNeutralElement(reduction);
-      if (!reductionIdentity.has_value()) {
-        paddedOp.emitWarning("failed to get neutral element for reduction");
-        return failure();
-      }
-
-      // Get the sizes of the reduction dimensions before padding:
-      rewriter.setInsertionPoint(paddedOp.getOperation());
-      SmallVector<std::pair<unsigned, Value>> reductionDimSizes;
-      assert(succeeded(reductionDimInfo) &&
-             "obtained with confirmation earlier");
-      for (auto &&dimInfo : reductionDimInfo.value()) {
-        Value redDimSize = rewriter.createOrFold<tensor::DimOp>(
-            loc, dimInfo.operand, dimInfo.operandDim);
-        reductionDimSizes.push_back({dimInfo.loopIndex, redDimSize});
-      }
-
-      // Add a check within the block to see if the current iteration over the
-      // loops is inside or outside the padded part of the iteration space.
-      rewriter.setInsertionPoint(reduction);
-      SmallVector<Value> conds;
-      for (auto &&[dimension, unpaddedSize] : reductionDimSizes) {
-        Value cond;
-
-        // First check if the condition 'index < unpaddedSize' is always true,
-        // and directly optimize for this case.
-        int64_t lhs = paddedLoopRanges[dimension];
-        std::optional<int64_t> rhs = getConstantIntValue(unpaddedSize);
-        if (lhs != ShapedType::kDynamic && lhs <= rhs) {
-          cond = arith::ConstantOp::create(rewriter, loc,
-                                           rewriter.getBoolAttr(true));
-        } else {
-          Value redDimIndex = linalg::IndexOp::create(rewriter, loc, dimension);
-          cond = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ult,
-                                       redDimIndex, unpaddedSize);
-        }
-        conds.push_back(cond);
-      }
-      Value reductionIdentityValue =
-          arith::ConstantOp::create(rewriter, loc, reductionIdentity.value());
-      assert(conds.size() > 0);
-      Value cond = conds[0];
-      for (Value nxtCond : llvm::drop_begin(conds, 1)) {
-        cond = arith::AndIOp::create(rewriter, loc, cond, nxtCond);
-      }
-
-      // Find the reduction op operand that is reduced with the carried output.
-      if (reduction->getNumOperands() != 2) {
-        paddedOp.emitWarning("expected a reduction operation with 2 operands");
-        return failure();
-      }
-      Value carry = block->getArguments().back();
-      unsigned uncarryIndex = reduction->getOperand(0) == carry ? 1 : 0;
-      Value uncarried = reduction->getOperand(uncarryIndex);
-
-      // Select the reduction identity value if in the padding region.
-      Value selected = arith::SelectOp::create(rewriter, loc, cond, uncarried,
-                                               reductionIdentityValue);
-      IRMapping mapping;
-      mapping.map(reduction->getOperand(uncarryIndex), selected);
-      Operation *redClone = rewriter.clone(*reduction, mapping);
-      rewriter.replaceOp(reduction, redClone);
-    }
-  }
-
-  // 5. For each PadOp, create a linalg::CopyOp to allow dim propagations.
-  for (tensor::PadOp padOp : padResult.padOps) {
-    OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPointAfter(padOp);
-
-    // Record users for RAUW before creating new users.
-    llvm::SmallDenseSet<Operation *> users(padOp.getResult().getUsers().begin(),
-                                           padOp.getResult().getUsers().end());
-
-    RankedTensorType tensorTy = padOp.getResultType();
-    int64_t rank = tensorTy.getRank();
-    SmallVector<OpFoldResult> sizes(rank, OpFoldResult());
-    for (int64_t i = 0; i < rank; ++i) {
-      sizes[i] =
-          rewriter.createOrFold<tensor::DimOp>(loc, padOp.getResult(), i);
-      if (auto v = dyn_cast<Value>(sizes[i]))
-        sizes[i] = getAsOpFoldResult(v);
-    }
-
-    Value out = tensor::EmptyOp::create(rewriter, loc, sizes,
-                                        getElementTypeOrSelf(tensorTy));
-    auto copied = linalg::CopyOp::create(rewriter, loc, padOp.getResult(), out);
-    rewriter.replaceUsesWithIf(padOp.getResult(), copied.getResult(0),
-                               [&](OpOperand &opOperand) {
-                                 return users.contains(opOperand.getOwner());
-                               });
-  }
+  rewriter.replaceOp(tilingInterfaceOp.getOperation(), result.value());
 
   return success();
 }
@@ -339,10 +138,18 @@ void GPUApplyPaddingLevelPass::runOnOperation() {
   llvm::SmallDenseSet<TilingInterface> targetOps =
       getTiledOps(funcOp, tilingLevel);
 
-  IRRewriter rewriter(funcOp);
+  MaskListener maskListener;
+  IRRewriter rewriter(funcOp, &maskListener);
   for (TilingInterface op : targetOps) {
     // If some op does not get padded, that is fine for now.
     (void)applyPaddingLevel(rewriter, op, tilingLevel);
+  }
+
+  // To workaround tensor.pad ops not being DPS and causing issues with dim
+  // reification, we explicitly make tensor.pad ops DPS by add a no-op
+  // linalg.copy on their result.
+  for (tensor::PadOp padOp : maskListener.pads) {
+    makePadDPS(rewriter, padOp);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_online_attention.mlir
@@ -11,7 +11,6 @@
 //                                                        batch, m, k1, k2
 #lowering_config = #iree_gpu.lowering_config<{reduction = [   0, 0,  0, 32]}>
 
-// CHECK-LABEL: func.func @online_attention_fail_to_pad_no_mask
 func.func @online_attention_fail_to_pad_no_mask(%query: tensor<192x1024x64xf32>, %key: tensor<192x?x64xf32>, %value: tensor<192x?x64xf32>) -> tensor<192x1024x64xf32> {
   %scale = arith.constant 1.0 : f32
 
@@ -25,10 +24,7 @@ func.func @online_attention_fail_to_pad_no_mask(%query: tensor<192x1024x64xf32>,
   %acc_fill = linalg.fill ins(%max_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
   %sum_fill = linalg.fill ins(%sum_ident : f32) outs(%row_red_empty : tensor<192x1024xf32>) -> tensor<192x1024xf32>
 
-  //  CHECK-NOT: tensor.pad
-  //      CHECK: iree_linalg_ext.online_attention {{.*}} ins(%{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}
-  // CHECK-SAME:   : tensor<192x1024x64xf32>, tensor<192x?x64xf32>, tensor<192x?x64xf32>, f32)
-  // expected-remark@+1{{failed to pad op: requires a mask operand to pad to the proper value. Consider materializing the mask operand explicitly.}}
+  // expected-error@+1{{Padding OnlineAttention without existing mask is not yet supported}}
   %out:3 = iree_linalg_ext.online_attention
         {
           indexing_maps = [#mapQ, #mapK, #mapV, #mapS, #mapO, #mapR, #mapR],
@@ -118,7 +114,6 @@ func.func @online_attention_tile_then_pad_7(%n_batches: index, %query: tensor<?x
   %acc_fill = linalg.fill ins(%max_ident : f32) outs(%row_red_empty : tensor<?x1021xf32>) -> tensor<?x1021xf32>
   %sum_fill = linalg.fill ins(%sum_ident : f32) outs(%row_red_empty : tensor<?x1021xf32>) -> tensor<?x1021xf32>
 
-  //         CHECK: arith.constant 0xFF800000 : f32
   // CHECK-COUNT-7: tensor.pad
   //         CHECK: iree_linalg_ext.online_attention {{.*}} ins(%{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}, %{{[0-9a-z_]*}}
   //    CHECK-SAME:   : tensor<4x8x64xf32>, tensor<4x32x64xf32>, tensor<4x32x64xf32>, f32, tensor<4x8xf32>)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_partial_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_padding_partial_reduction.mlir
@@ -23,10 +23,10 @@
 //  CHECK:                   tensor.pad %arg0 low[0, 0] high[0, %[[CEIL]]
 //  CHECK:                   linalg.generic
 //  CHECK:                   ^bb0(
-//  CHECK:                   arith.subf
-//  CHECK:  %[[EXP:.+]]    = math.exp
 //  CHECK:  %[[INDEX1:.+]] = linalg.index 1 : index
 //  CHECK:  %[[CMP:.+]]    = arith.cmpi ult, %[[INDEX1]], %[[DIMARG0]] : index
+//  CHECK:                   arith.subf
+//  CHECK:  %[[EXP:.+]]    = math.exp
 //  CHECK:  %[[SELECT:.+]] = arith.select %[[CMP]], %[[EXP:.+]], %[[ZEROF32]] : f32
 //  CHECK:  %[[ADD:.+]]   = arith.addf %[[SELECT]], %out : f32
 //  CHECK:  linalg.yield %[[ADD]] : f32
@@ -123,9 +123,9 @@ func.func @min_reduction(%arg0: tensor<1x?xf32>, %arg1: tensor<1xf32>) -> tensor
 //   CHECK-DAG: %[[DIMARG0:.+]] = tensor.dim %arg0, %[[C1]] : tensor<1x?xf16>
 //       CHECK: linalg.generic
 //       CHECK: ^bb0(
-//       CHECK: %[[MUL:.+]] = arith.mulf
 //       CHECK: %[[INDEX1:.+]]  = linalg.index 1 : index
 //       CHECK: %[[CMP:.+]]     = arith.cmpi ult, %[[INDEX1]], %[[DIMARG0]] : index
+//       CHECK: %[[MUL:.+]] = arith.mulf
 //       CHECK: %[[SELECT:.+]]  = arith.select %[[CMP]], %[[MUL]], %[[ZERO]] : f16
 //       CHECK: %[[ADD:.+]]    = arith.addf %out, %[[SELECT]] : f16
 //       CHECK: linalg.yield %[[ADD]] : f16
@@ -159,10 +159,10 @@ func.func @standard_inner_product(%arg0 : tensor<1x?xf16>, %arg1 : tensor<1x?xf1
 //   CHECK-NOT:                   tensor.pad
 //       CHECK:                   linalg.generic
 //       CHECK:                   ^bb0(
-//       CHECK: %[[MUL:.+]]     = arith.mulf
-//       CHECK: %[[TRUNC:.+]]   = arith.truncf %[[MUL]] : f32 to f16
 //       CHECK: %[[INDEX1:.+]]  = linalg.index 1 : index
 //       CHECK: %[[CMP:.+]]     = arith.cmpi ult, %[[INDEX1]], %[[DIMARG0]] : index
+//       CHECK: %[[MUL:.+]]     = arith.mulf
+//       CHECK: %[[TRUNC:.+]]   = arith.truncf %[[MUL]] : f32 to f16
 //       CHECK: %[[SELECT:.+]]  = arith.select %[[CMP]], %[[TRUNC]], %[[ZERO]] : f16
 //       CHECK: %[[ADD:.+]]     = arith.addf %out, %[[SELECT]] : f16
 //       CHECK: linalg.yield %[[ADD]] : f16
@@ -191,8 +191,8 @@ func.func @standard_inner_product_with_trunc(%arg0 : tensor<1x?xf32>, %arg1 : te
 
 // CHECK-LABEL: product_of_sum_reduction
 //       CHECK: %[[ONE:.+]] = arith.constant 1.000000e+00 : f16
-//       CHECK: %[[ADD:.+]] = arith.addf
 //       CHECK: %[[CMP:.+]] = arith.cmpi
+//       CHECK: %[[ADD:.+]] = arith.addf
 //       CHECK: arith.select %[[CMP]], %[[ADD]], %[[ONE]] : f16
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
@@ -223,12 +223,12 @@ func.func @product_of_sum_reduction(%arg0 : tensor<1x?xf16>, %arg1 : tensor<1x?x
 //   CHECK-DAG: %[[DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?xf16>
 //   CHECK-DAG: %[[DIM1:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?xf16>
 //       CHECK: linalg.generic
-//   CHECK-DAG: %[[MUL:.+]] = arith.mulf
 //   CHECK-DAG: %[[INDEX0:.+]] = linalg.index 0 : index
 //   CHECK-DAG: %[[INDEX1:.+]] = linalg.index 1 : index
 //   CHECK-DAG: %[[CMP0:.+]] = arith.cmpi ult, %[[INDEX0]], %[[DIM1]] : index
 //   CHECK-DAG: %[[CMP1:.+]] = arith.cmpi ult, %[[INDEX1]], %[[DIM0]] : index
 //       CHECK: %[[AND:.+]] = arith.andi %[[CMP0]], %[[CMP1]] : i1
+//   CHECK-DAG: %[[MUL:.+]] = arith.mulf
 //       CHECK: %[[SELECT:.+]] = arith.select %[[AND]], %[[MUL]], %[[ZEROF16]] : f16
 //       CHECK: %[[ADD:.+]] = arith.addf %out, %[[SELECT]] : f16
 #map = affine_map<(d0, d1) -> (d1, d0)>

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -255,6 +255,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:UBDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -249,8 +249,13 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":TensorMaskingOpInterfaceGen",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:UBDialect",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -16,6 +16,7 @@ package(
 exports_files([
     "ProcessorOpInterfaces.td",
     "UKernelOpInterface.td",
+    "TensorMaskingOpInterface.td",
 ])
 
 iree_td_library(
@@ -25,6 +26,7 @@ iree_td_library(
             "PartitionableLoopsInterface.td",
             "ProcessorOpInterfaces.td",
             "UKernelOpInterface.td",
+            "TensorMaskingOpInterface.td",
         ],
         include = ["*.td"],
     ),
@@ -46,6 +48,7 @@ iree_compiler_cc_library(
         ":PartitionableLoopsInterface",
         ":ProcessorOpInterfaces",
         ":UKernelOpInterface",
+        ":TensorMaskingOpInterface",
         "//compiler/src/iree/compiler/Codegen/ExternalInterfaces:ExternalModels",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions:LinalgExtExtensions",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
@@ -230,4 +233,40 @@ iree_gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ProcessorOpInterfaces.td",
     deps = [":td_files"],
+)
+
+iree_compiler_cc_library(
+    name = "TensorMaskingOpInterface",
+    srcs = [
+        "TensorMaskingOpInterface.cpp",
+    ],
+    hdrs = [
+        "TensorMaskingOpInterface.h",
+    ],
+    textual_hdrs = [
+        "TensorMaskingOpInterface.cpp.inc",
+        "TensorMaskingOpInterface.h.inc",
+    ],
+    deps = [
+        ":TensorMaskingOpInterfaceGen",
+        "@llvm-project//mlir:FunctionInterfaces",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+iree_gentbl_cc_library(
+    name = "TensorMaskingOpInterfaceGen",
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "TensorMaskingOpInterface.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "TensorMaskingOpInterface.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TensorMaskingOpInterface.td",
+    deps = ["@llvm-project//mlir:OpBaseTdFiles"],
 )

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     ::BufferizationInterfaces
     ::PartitionableLoopsInterface
     ::ProcessorOpInterfaces
+    ::TensorMaskingOpInterface
     ::UKernelOpInterface
     IREELinalgTransformDialect
     MLIRAMDGPUDialect
@@ -174,6 +175,33 @@ iree_tablegen_library(
   OUTS
     --gen-op-interface-decls ProcessorOpInterfaces.h.inc
     --gen-op-interface-defs ProcessorOpInterfaces.cpp.inc
+)
+
+iree_cc_library(
+  NAME
+    TensorMaskingOpInterface
+  HDRS
+    "TensorMaskingOpInterface.h"
+  TEXTUAL_HDRS
+    "TensorMaskingOpInterface.cpp.inc"
+    "TensorMaskingOpInterface.h.inc"
+  SRCS
+    "TensorMaskingOpInterface.cpp"
+  DEPS
+    ::TensorMaskingOpInterfaceGen
+    MLIRFunctionInterfaces
+    MLIRIR
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    TensorMaskingOpInterfaceGen
+  TD_FILE
+    "TensorMaskingOpInterface.td"
+  OUTS
+    --gen-op-interface-decls TensorMaskingOpInterface.h.inc
+    --gen-op-interface-defs TensorMaskingOpInterface.cpp.inc
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -189,8 +189,13 @@ iree_cc_library(
     "TensorMaskingOpInterface.cpp"
   DEPS
     ::TensorMaskingOpInterfaceGen
+    MLIRAnalysis
+    MLIRArithDialect
     MLIRFunctionInterfaces
     MLIRIR
+    MLIRLinalgDialect
+    MLIRUBDialect
+    iree::compiler::Dialect::LinalgExt::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -194,6 +194,7 @@ iree_cc_library(
     MLIRFunctionInterfaces
     MLIRIR
     MLIRLinalgDialect
+    MLIRLinalgTransforms
     MLIRUBDialect
     iree::compiler::Dialect::LinalgExt::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -15,6 +15,7 @@
 // have a better registration mechanism.
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
+#include "iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h"
 #include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.h"
@@ -47,6 +48,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   registerProcessorOpInterfaceExternalModels(registry);
   registerCodegenExternalInterfaces(registry);
   registerBufferizationInterfaces(registry);
+  registerTensorMaskingOpInterface(registry);
   // TODO: Remove this dependency once the transform dialect extensions
   // have a better registration mechanism.
   // TODO: when warranted, move to its own file.

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -1,0 +1,271 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms//Transforms.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::iree_compiler {
+
+#include "iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp.inc" // IWYU pragma: keep
+
+namespace {
+
+static bool isIterationCarriedArg(OpOperand &arg, linalg::GenericOp op) {
+  auto bbArg = dyn_cast<BlockArgument>(arg.get());
+  if (!bbArg) {
+    return false;
+  }
+  OpOperand *inputOperand = op.getMatchingOpOperand(bbArg);
+  return op.isDpsInit(inputOperand);
+}
+
+static FailureOr<linalg::PadTilingInterfaceResult>
+maskTilingInterfaceOp(OpBuilder &b, Operation *op,
+                      ArrayRef<OpFoldResult> padMultiples) {
+  auto poison = ub::PoisonAttr::get(b.getContext());
+  SmallVector<Attribute> padValues(op->getNumOperands(), poison);
+  TilingInterface tilingInterfaceOp = cast<TilingInterface>(op);
+  // Set options.
+  linalg::PadTilingInterfaceOptions options =
+      linalg::PadTilingInterfaceOptions()
+          .setPaddingSizes(padMultiples)
+          .setPaddingValues(padValues)
+          .setPadToMultipleOf(true);
+
+  FailureOr<linalg::PadTilingInterfaceResult> result =
+      linalg::rewriteAsPaddedOp(b, tilingInterfaceOp, options);
+  return result;
+}
+
+static SmallVector<OpFoldResult>
+getBoundsToGuard(OpBuilder &b, Operation *unpaddedOp, Operation *paddedOp) {
+  OpBuilder::InsertionGuard guard(b);
+  auto unpaddedIface = cast<TilingInterface>(unpaddedOp);
+  auto paddedIface = cast<TilingInterface>(paddedOp);
+  b.setInsertionPoint(unpaddedOp);
+  SmallVector<Range> oldItSpace = unpaddedIface.getIterationDomain(b);
+  b.setInsertionPoint(paddedOp);
+  SmallVector<Range> newItSpace = paddedIface.getIterationDomain(b);
+  SmallVector<OpFoldResult> oldDims =
+      llvm::map_to_vector(oldItSpace, [&](Range r) { return r.size; });
+  SmallVector<OpFoldResult> newDims =
+      llvm::map_to_vector(newItSpace, [&](Range r) { return r.size; });
+  for (auto [oldDim, newDim, itType] : llvm::zip_equal(
+           oldDims, newDims, unpaddedIface.getLoopIteratorTypes())) {
+    // Non-reduction dimensions don't need to be guarded, as they will be
+    // guarded at the user of the mask.
+    if (!linalg::isReductionIterator(itType)) {
+      oldDim = OpFoldResult();
+      continue;
+    }
+    // If both the old and new dim are equal, no need to guard.
+    if (oldDim == newDim) {
+      oldDim = OpFoldResult();
+      continue;
+    }
+  }
+  return oldDims;
+}
+
+/// For a dimension to be in bounds in the linalg op's body:
+///
+///  %is_in_bounds(%dim) = linalg.index %dim < tensor.dim %dim (of the old
+///  op)
+///
+/// With this, we can check if the reduction needs to use a neutral element
+/// by checking if the current iteration is in bounds for all reduction
+/// dimensions.
+static OpFoldResult isGenericIterationInBounds(OpBuilder &b, Location loc,
+                                               ArrayRef<OpFoldResult> bounds) {
+  OpFoldResult isReductionInBounds = b.getBoolAttr(true);
+  for (auto [index, bound] : llvm::enumerate(bounds)) {
+    if (!bound) {
+      continue;
+    }
+    Value loopIdx = linalg::IndexOp::create(b, loc, index);
+    Value isInBounds = arith::CmpIOp::create(
+        b, loc, arith::CmpIPredicate::ult, loopIdx,
+        getValueOrCreateConstantIndexOp(b, loc, bounds[index]));
+    isReductionInBounds = b.createOrFold<arith::AndIOp>(
+        loc, getValueOrCreateConstantIntOp(b, loc, isReductionInBounds),
+        isInBounds);
+  }
+  return isReductionInBounds;
+}
+
+/// Given a masked tensor operand indexed in the operation using `map` of an
+/// operation with bounds `bounds`, select the neutral element when the operand
+///  out of bounds. If a bound for a dim is null, assume it is in bounds.
+static void selectNeutralElementForReducedDims(OpBuilder &b, OpOperand &operand,
+                                               arith::AtomicRMWKind kind,
+                                               ArrayRef<OpFoldResult> bounds,
+                                               AffineMap map) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(operand.getOwner());
+  Location loc = operand.getOwner()->getLoc();
+  // Get the neutral element for masking.
+  Value neutralEl = arith::getIdentityValue(
+      kind, getElementTypeOrSelf(operand.get().getType()), b, loc,
+      /*useOnlyFiniteValue=*/false);
+  // Compute operand bounds from iteration space bounds.
+  SmallVector<OpFoldResult> operandBounds = applyPermutationMap(map, bounds);
+  AffineMap elwiseMap =
+      AffineMap::getMultiDimIdentityMap(operandBounds.size(), b.getContext());
+  SmallVector<OpFoldResult> operandDims =
+      tensor::getMixedSizes(b, loc, operand.get());
+  auto emptyOp =
+      tensor::EmptyOp::create(b, loc, operandDims, neutralEl.getType());
+  Type operandTy = emptyOp.getType();
+  // Create a elementwise linalg.generic to select the neutral element.
+  auto genericOp = linalg::GenericOp::create(
+      b, loc, {operandTy}, {operand.get()}, {emptyOp.getResult()},
+      {elwiseMap, elwiseMap},
+      SmallVector<utils::IteratorType>(operandBounds.size(),
+                                       utils::IteratorType::parallel),
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        // Check if the loop iterations go out of bounds.
+        OpFoldResult inBounds =
+            isGenericIterationInBounds(b, loc, operandBounds);
+        Value selected = b.createOrFold<arith::SelectOp>(
+            loc, getValueOrCreateConstantIntOp(b, loc, inBounds), args[0],
+            neutralEl);
+        b.create<linalg::YieldOp>(loc, selected);
+      });
+  operand.set(genericOp.getResult(0));
+}
+
+struct LinalgGenericOpInterface final
+    : TensorMaskingOpInterface::ExternalModel<LinalgGenericOpInterface,
+                                              linalg::GenericOp> {
+
+  FailureOr<SmallVector<Value>>
+  getMaskedImplementation(Operation *op, OpBuilder &builder,
+                          ArrayRef<OpFoldResult> padMultiples) const {
+    FailureOr<linalg::PadTilingInterfaceResult> result =
+        maskTilingInterfaceOp(builder, op, padMultiples);
+    // Properly mask the reductions to avoid reducing poison values.
+    auto paddedGeneric =
+        cast<linalg::GenericOp>(result->paddedOp.getOperation());
+    // TODO: Add special handling for Contraction/Convolution with no selects in
+    // the body.
+    auto linalgOp = cast<linalg::GenericOp>(op);
+    if (failed(maskReductionsInGenericBody(builder, linalgOp, paddedGeneric))) {
+      return failure();
+    }
+    return result->replacements;
+  }
+
+private:
+  /// Mask the poison inputs for reductions by selecting the neutral element on
+  /// the masked out-of-bounds iterations.
+  LogicalResult
+  maskReductionsInGenericBody(OpBuilder &builder, linalg::GenericOp oldLinalgOp,
+                              linalg::GenericOp paddedLinalgOp) const {
+    Location loc = paddedLinalgOp.getLoc();
+    builder.setInsertionPointToStart(paddedLinalgOp.getBody());
+    SmallVector<OpFoldResult> oldBounds =
+        getBoundsToGuard(builder, oldLinalgOp, paddedLinalgOp);
+    OpFoldResult isReductionInBounds =
+        isGenericIterationInBounds(builder, loc, oldBounds);
+
+    SmallVector<Operation *> reductions;
+    for (auto [index, initOpOperand] :
+         llvm::enumerate(paddedLinalgOp.getDpsInitsMutable())) {
+      SmallVector<Operation *> combinerOps;
+      matchReduction(paddedLinalgOp.getRegionOutputArgs(), index, combinerOps);
+      reductions.insert(reductions.begin(), combinerOps.begin(),
+                        combinerOps.end());
+    }
+
+    for (Operation *reduction : reductions) {
+      std::optional<TypedAttr> reductionIdentity =
+          arith::getNeutralElement(reduction);
+      if (!reductionIdentity.has_value()) {
+        paddedLinalgOp.emitError("failed to get neutral element for reduction");
+        return failure();
+      }
+      // Mask out inputs on out-of-bounds iterations.
+      builder.setInsertionPoint(reduction);
+      for (OpOperand &opOperand : reduction->getOpOperands()) {
+        if (!isIterationCarriedArg(opOperand, paddedLinalgOp)) {
+          Value neutralElValue = arith::ConstantOp::create(
+              builder, loc, reductionIdentity.value());
+          Value selected = builder.createOrFold<arith::SelectOp>(
+              loc,
+              getValueOrCreateConstantIntOp(builder, loc, isReductionInBounds),
+              opOperand.get(), neutralElValue);
+          opOperand.set(selected);
+        }
+      }
+    }
+
+    return success();
+  }
+};
+
+struct OnlineAttentionOpInterface final
+    : TensorMaskingOpInterface::ExternalModel<
+          OnlineAttentionOpInterface, IREE::LinalgExt::OnlineAttentionOp> {
+
+  FailureOr<SmallVector<Value>>
+  getMaskedImplementation(Operation *op, OpBuilder &builder,
+                          ArrayRef<OpFoldResult> padMultiples) const {
+    auto onlineAttentionOp = cast<IREE::LinalgExt::OnlineAttentionOp>(op);
+    if (!onlineAttentionOp.getMask()) {
+      op->emitError(
+          "Padding OnlineAttention without existing mask is not yet supported");
+      return failure();
+    }
+
+    FailureOr<linalg::PadTilingInterfaceResult> result =
+        maskTilingInterfaceOp(builder, op, padMultiples);
+    if (failed(result)) {
+      op->emitError("failed to pad op");
+      return failure();
+    }
+    // Select neutral values for masked out-of-bounds iterations.
+    auto paddedOp = cast<IREE::LinalgExt::OnlineAttentionOp>(result->paddedOp);
+    SmallVector<OpFoldResult> bounds = getBoundsToGuard(builder, op, paddedOp);
+
+    selectNeutralElementForReducedDims(builder, paddedOp.getQueryMutable(),
+                                       arith::AtomicRMWKind::addf, bounds,
+                                       paddedOp.getQueryMap());
+    selectNeutralElementForReducedDims(builder, paddedOp.getKeyMutable(),
+                                       arith::AtomicRMWKind::addf, bounds,
+                                       paddedOp.getKeyMap());
+    selectNeutralElementForReducedDims(builder, paddedOp.getValueMutable(),
+                                       arith::AtomicRMWKind::addf, bounds,
+                                       paddedOp.getValueMap());
+    if (paddedOp.getMask()) {
+      selectNeutralElementForReducedDims(builder, paddedOp.getMaskMutable()[0],
+                                         arith::AtomicRMWKind::maximumf, bounds,
+                                         *paddedOp.getMaskMap());
+    }
+    return result->replacements;
+  }
+};
+
+} // namespace
+
+void registerTensorMaskingOpInterface(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
+    linalg::GenericOp::attachInterface<LinalgGenericOpInterface>(*ctx);
+  });
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::LinalgExt::IREELinalgExtDialect *dialect) {
+        IREE::LinalgExt::OnlineAttentionOp::attachInterface<
+            OnlineAttentionOpInterface>(*ctx);
+      });
+}
+
+}; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -57,9 +57,9 @@ getBoundsToGuard(OpBuilder &b, Operation *unpaddedOp, Operation *paddedOp) {
   b.setInsertionPoint(paddedOp);
   SmallVector<Range> newItSpace = paddedIface.getIterationDomain(b);
   SmallVector<OpFoldResult> oldDims =
-      llvm::map_to_vector(oldItSpace, [&](Range r) { return r.size; });
+      llvm::map_to_vector(oldItSpace, [](Range r) { return r.size; });
   SmallVector<OpFoldResult> newDims =
-      llvm::map_to_vector(newItSpace, [&](Range r) { return r.size; });
+      llvm::map_to_vector(newItSpace, [](Range r) { return r.size; });
   for (auto [oldDim, newDim, itType] : llvm::zip_equal(
            oldDims, newDims, unpaddedIface.getLoopIteratorTypes())) {
     // Non-reduction dimensions don't need to be guarded, as they will be
@@ -139,7 +139,7 @@ static void selectNeutralElementForReducedDims(OpBuilder &b, OpOperand &operand,
         Value selected = b.createOrFold<arith::SelectOp>(
             loc, getValueOrCreateConstantIntOp(b, loc, inBounds), args[0],
             neutralEl);
-        b.create<linalg::YieldOp>(loc, selected);
+        linalg::YieldOp::create(b, loc, selected);
       });
   operand.set(genericOp.getResult(0));
 }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.cpp
@@ -10,7 +10,7 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/Transforms//Transforms.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h
@@ -1,0 +1,23 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE_H_
+#define IREE_COMPILER_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE_H_
+
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+
+// clang-format off
+#include "iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.h.inc" // IWYU pragma: export
+// clang-format on
+
+namespace mlir::iree_compiler {
+
+void registerTensorMaskingOpInterface(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE_H_

--- a/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/TensorMaskingOpInterface.td
@@ -1,0 +1,29 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE
+#define IREE_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def TensorMaskingOpInterface : OpInterface<"TensorMaskingOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler";
+
+  let description = [{}];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{}],
+      /*retTy=*/"FailureOr<SmallVector<Value>>",
+      /*methodName=*/"getMaskedImplementation",
+      /*args=*/(ins
+        "OpBuilder &":$builder,
+        "ArrayRef<OpFoldResult>":$padMultiples)
+    >,
+  ];
+}
+
+#endif // IREE_CODEGEN_INTERFACES_TENSOR_MASKING_OP_INTERFACE


### PR DESCRIPTION
- Moves the per-op logic of GPUApplyPaddingLevel to a TensorMaskingOpInterface. This interface will be used for propagating padding/masking in future.
- The interface is called "TensorMaskingOpInterface" because it considers masking using poison values instead of padding using a specific value and then adds a select to select the neutral element for the reduction. This is closer to what vector masking does and is more general.
- The test changes are due to some insertion point differences for the select (which are inconsequential in the end).

ci-extra: test_torch