### PR TITLE
[ROCM] Enable dispatch specialization by default

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -87,7 +87,7 @@ struct ROCMOptions {
       GPU::kDataTilingEncodingLayoutResolverName;
   bool slpVectorization = true;
   bool globalISel = false;
-  bool specializeDispatches = false;
+  bool specializeDispatches = true;
   bool enableTensorUKernels = false;
   IREE::Codegen::DenormalFpMath denormalFpMathF32 =
       IREE::Codegen::DenormalFpMath::None;
@@ -213,6 +213,11 @@ struct ROCMOptions {
                          "'xnack'; but seen '")
                << feature << "'";
       }
+    }
+    if (enableTensorUKernels && !specializeDispatches) {
+      return emitError(builder.getUnknownLoc())
+             << "--iree-hip-enable-ukernels=true requires "
+                "--iree-hip-specialize-dispatches to be enabled as well";
     }
     return success();
   }


### PR DESCRIPTION
To enable tensor-based ukernels by default (https://github.com/iree-org/iree/pull/22318), we will also need `--iree-hip-specialize-dispatches` to set by default to get the best overall performance. Trying that here to avoid/prefetch issues that have been coming up because this flag wasn't set in some test/locally. For example: https://github.com/iree-org/iree/issues/22421.