### PR TITLE
[CI][TorchModels] Update llama 8b fp16 golden time

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 42.0
+    "golden_time_ms": 29.5
 }


### PR DESCRIPTION
The latency of the prefill phase of llama 8b f16 with sequence length 128 should have improved with this PR: https://github.com/iree-org/iree/pull/22393, so bumping the golden time here.