### PR TITLE
Fixes value bounds interface for ExpandShapeOp

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -408,7 +408,7 @@ struct ExpandShapeOpValueBoundsInterface
                                        ValueBoundsConstraintSet &cstr) const {
     auto expandOp = cast<memref::ExpandShapeOp>(op);
     assert(value == expandOp.getResult() && "invalid value");
-    cstr.bound(value)[dim] == expandOp.getOutputShape()[dim];
+    cstr.bound(value)[dim] == expandOp.getMixedOutputShape()[dim];
   }
 };
 


### PR DESCRIPTION
This was causing an assertion failure in llama 8b fp8 reported by @pdhirajkumarprasad. I will need to fix this as well in upstream and will add a testcase there. Then this will be removed here once upstream is integrated.