### PR TITLE
[Global Opt] Add flag to control edge reshape propagation

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -68,6 +68,15 @@ static llvm::cl::opt<bool> clWarnOnUninitializedValues(
     "iree-global-opt-enable-warn-on-uninitialized-values",
     llvm::cl::desc("Warn on some classes of uses of uninitialized values."),
     llvm::cl::init(true));
+
+static llvm::cl::opt<bool> clEnableEdgeReshapePropagation(
+    "iree-global-opt-experimental-enable-edge-reshape-propagation",
+    llvm::cl::desc(
+        "Enables propagation of reshapes on the edges of the program "
+        "in transpose propagation. This workaround for better performance and "
+        "will be removed soon."),
+    llvm::cl::init(false));
+
 void buildGlobalOptExprHoistingPassPipeline(
     OpPassManager &passManager, const TransformOptions &transformOptions) {
   IREE::Util::ExprHoistingOptions options;
@@ -170,6 +179,8 @@ void buildGlobalOptimizationPassPipeline(
                                transformOptions.aggressiveTransposePropagation;
                            options.enableAttentionVTranspose =
                                clEnableAttentionVTranspose;
+                           options.enableEdgeReshapePropagation =
+                               clEnableEdgeReshapePropagation;
                            return createPropagateLinalgTransposePass(options);
                          })
       .addPass(IREE::Flow::createCanonicalizePass)

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -119,6 +119,8 @@ def PropagateLinalgTransposePass :
             /*default=*/"true", "Enable transposition of attention v operand">,
     Option<"enableConvolutionPropagation", "enable-aggressive-propagation-through-conv", "bool",
             /*default=*/"false", "enable propagation through convolutions">,
+    Option<"enableEdgeReshapePropagation", "enable-edge-reshape-propagation", "bool",
+            /*default=*/"false", "Enable propagation of reshapes on the edges of the program">,
   ];
 }
 


### PR DESCRIPTION
Adds flag to allow users to selectively disable the changes from https://github.com/iree-org/iree/pull/22320. This is a stopgap for cases where not fusing a transpose into a matmul gives better performance.