### PR TITLE
[ukernels] Add missing specializations on gfx942/gfx950 and associated e2e tests 

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/specialization/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/specialization/BUILD.bazel
@@ -26,6 +26,7 @@ endif()
 # Target archs for specialization patternsets. https://llvm.org/docs/AMDGPUUsage.html#processors
 gpu_archs = [
     "gfx942",
+    "gfx950",
 ]
 
 specialization_patterns_mlir_files = [

--- a/compiler/plugins/target/ROCM/builtins/specialization/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/specialization/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_c_embed_data(
     iree_specialization_patterns_amdgpu
   SRCS
     "specialization_patterns_gfx942.mlir"
+    "specialization_patterns_gfx950.mlir"
   C_FILE_OUTPUT
     "iree_specialization_patterns_amdgpu.c"
   H_FILE_OUTPUT
@@ -32,6 +33,7 @@ iree_lit_test_suite(
     verify_specialization_patterns_amdgpu
   SRCS
     "specialization_patterns_gfx942.mlir"
+    "specialization_patterns_gfx950.mlir"
   TOOLS
     iree-opt
 )

--- a/compiler/plugins/target/ROCM/builtins/specialization/specialization_patterns_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/specialization/specialization_patterns_gfx942.mlir
@@ -33,6 +33,37 @@ pdl.pattern @f16_pingpong : benefit(1) {
   }
 }
 
+pdl.pattern @bf16_pingpong : benefit(1) {
+  %imaps = pdl.attribute = [
+    affine_map<(d0, d1, d2) -> (d0, d2)>,
+    affine_map<(d0, d1, d2) -> (d1, d2)>,
+    affine_map<(d0, d1, d2) -> (d0, d1)>
+  ]
+  %elemtypes = pdl.attribute = [bf16, bf16, f32]
+  %operands = pdl.operands
+  %types = pdl.types
+  %matmul = pdl.operation (%operands : !pdl.range<value>) -> (%types : !pdl.range<type>)
+  pdl.apply_native_constraint "matchContraction"(
+        %matmul, %elemtypes, %imaps
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+  // Skip if the operation already has ranges.
+  %attr_name = pdl.attribute = "iree_codegen.specialization_ranges"
+  pdl.apply_native_constraint "hasAttr"(
+        %matmul, %attr_name
+        : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  pdl.rewrite %matmul {
+    %ranges = pdl.attribute = #util<int.assumption.multi_array[
+        [<umin = 2048, udiv = 256>, <umin = 2048, udiv = 256>, <udiv = 64>], // Large pingpong
+        [<umin = 1024, udiv = 128>, <umin = 1024, udiv = 128>, <udiv = 64>]  // Medium pingpong
+      ]>
+    pdl.apply_native_rewrite "annotateOperation"(
+        %matmul, %attr_name, %ranges
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}
+
 pdl.pattern @f8E4M3_pingpong : benefit(1) {
   %imaps = pdl.attribute = [
     affine_map<(d0, d1, d2) -> (d0, d2)>,

--- a/compiler/plugins/target/ROCM/builtins/specialization/specialization_patterns_gfx950.mlir
+++ b/compiler/plugins/target/ROCM/builtins/specialization/specialization_patterns_gfx950.mlir
@@ -1,0 +1,96 @@
+// RUN: iree-opt %s
+
+// PDL pattern spec to annotate operations with specialization ranges.
+
+pdl.pattern @f16_pingpong : benefit(1) {
+  %imaps = pdl.attribute = [
+    affine_map<(d0, d1, d2) -> (d0, d2)>,
+    affine_map<(d0, d1, d2) -> (d1, d2)>,
+    affine_map<(d0, d1, d2) -> (d0, d1)>
+  ]
+  %elemtypes = pdl.attribute = [f16, f16, f32]
+  %operands = pdl.operands
+  %types = pdl.types
+  %matmul = pdl.operation (%operands : !pdl.range<value>) -> (%types : !pdl.range<type>)
+  pdl.apply_native_constraint "matchContraction"(
+        %matmul, %elemtypes, %imaps
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+  // Skip if the operation already has ranges.
+  %attr_name = pdl.attribute = "iree_codegen.specialization_ranges"
+  pdl.apply_native_constraint "hasAttr"(
+        %matmul, %attr_name
+        : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  pdl.rewrite %matmul {
+    %ranges = pdl.attribute = #util<int.assumption.multi_array[
+        [<umin = 2048, udiv = 256>, <umin = 2048, udiv = 256>, <udiv = 64>], // Large pingpong
+        [<umin = 1024, udiv = 128>, <umin = 1024, udiv = 128>, <udiv = 64>]  // Medium pingpong
+      ]>
+    pdl.apply_native_rewrite "annotateOperation"(
+        %matmul, %attr_name, %ranges
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}
+
+pdl.pattern @bf16_pingpong : benefit(1) {
+  %imaps = pdl.attribute = [
+    affine_map<(d0, d1, d2) -> (d0, d2)>,
+    affine_map<(d0, d1, d2) -> (d1, d2)>,
+    affine_map<(d0, d1, d2) -> (d0, d1)>
+  ]
+  %elemtypes = pdl.attribute = [bf16, bf16, f32]
+  %operands = pdl.operands
+  %types = pdl.types
+  %matmul = pdl.operation (%operands : !pdl.range<value>) -> (%types : !pdl.range<type>)
+  pdl.apply_native_constraint "matchContraction"(
+        %matmul, %elemtypes, %imaps
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+  // Skip if the operation already has ranges.
+  %attr_name = pdl.attribute = "iree_codegen.specialization_ranges"
+  pdl.apply_native_constraint "hasAttr"(
+        %matmul, %attr_name
+        : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  pdl.rewrite %matmul {
+    %ranges = pdl.attribute = #util<int.assumption.multi_array[
+        [<umin = 2048, udiv = 256>, <umin = 2048, udiv = 256>, <udiv = 64>], // Large pingpong
+        [<umin = 1024, udiv = 128>, <umin = 1024, udiv = 128>, <udiv = 64>]  // Medium pingpong
+      ]>
+    pdl.apply_native_rewrite "annotateOperation"(
+        %matmul, %attr_name, %ranges
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}
+
+pdl.pattern @f8E4M3_pingpong : benefit(1) {
+  %imaps = pdl.attribute = [
+    affine_map<(d0, d1, d2) -> (d0, d2)>,
+    affine_map<(d0, d1, d2) -> (d1, d2)>,
+    affine_map<(d0, d1, d2) -> (d0, d1)>
+  ]
+  %elemtypes = pdl.attribute = [f8E4M3FN, f8E4M3FN, f32]
+  %operands = pdl.operands
+  %types = pdl.types
+  %matmul = pdl.operation (%operands : !pdl.range<value>) -> (%types : !pdl.range<type>)
+  pdl.apply_native_constraint "matchContraction"(
+        %matmul, %elemtypes, %imaps
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+
+  // Skip if the operation already has ranges.
+  %attr_name = pdl.attribute = "iree_codegen.specialization_ranges"
+  pdl.apply_native_constraint "hasAttr"(
+        %matmul, %attr_name
+        : !pdl.operation, !pdl.attribute) {isNegated = true}
+
+  pdl.rewrite %matmul {
+    %ranges = pdl.attribute = #util<int.assumption.multi_array[
+        [<umin = 2048, udiv = 256>, <umin = 2048, udiv = 256>, <udiv = 128>], // Large pingpong
+        [<umin = 1024, udiv = 128>, <umin = 1024, udiv = 128>, <udiv = 128>]  // Medium pingpong
+      ]>
+    pdl.apply_native_rewrite "annotateOperation"(
+        %matmul, %attr_name, %ranges
+        : !pdl.operation, !pdl.attribute, !pdl.attribute)
+  }
+}

--- a/tests/e2e/attention/generate_e2e_attention_tests.py
+++ b/tests/e2e/attention/generate_e2e_attention_tests.py
@@ -362,6 +362,7 @@ def generate(
     calls = []
 
     for shape in get_test_shapes(shapes_id):
+        print(shape)
         function = generate_function(
             query_type,
             key_type,

--- a/tests/e2e/attention/generate_e2e_attention_tests.py
+++ b/tests/e2e/attention/generate_e2e_attention_tests.py
@@ -362,7 +362,6 @@ def generate(
     calls = []
 
     for shape in get_test_shapes(shapes_id):
-        print(shape)
         function = generate_function(
             query_type,
             key_type,

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1472,6 +1472,71 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_${_F8E4M3_TYPE}_medium_expanded
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=${_F8E4M3_TYPE}"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=1152,1024,1024"
+    "--dynamic_mask=true,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_${_F8E4M3_TYPE}_large_expanded
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=${_F8E4M3_TYPE}"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=2048,2048,2048"
+    "--dynamic_mask=true,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+    "--iree-hal-dump-executable-files-to=files"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_${_CDNA_ARCH}_dt_${_F8E4M3_TYPE}
   TEST_TYPE
     matmul
@@ -1645,7 +1710,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_f16f16f32_large
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_f16f16f32_medium_expanded
   TEST_TYPE
     matmul
   GENERATOR
@@ -1654,7 +1719,8 @@ iree_generated_e2e_runner_test(
     "--lhs_rhs_type=f16"
     "--acc_type=f32"
     "--shapes=custom_mnk"
-    "--mnk=1024,1024,1024"
+    "--mnk=1152,1024,1024"
+    "--dynamic_mask=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1665,6 +1731,39 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_f16f16f32_large
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=1024,1024,1024"
+    "--dynamic_mask=false,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
   LABELS
     "noasan"
     "nomsan"
@@ -1684,7 +1783,7 @@ iree_generated_e2e_runner_test(
     "--lhs_rhs_type=f16"
     "--acc_type=f32"
     "--shapes=custom_mnk"
-    "--mnk=2048,2048,2048"
+    "--mnk=2048,2048,4096"
     "--dynamic_mask=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
@@ -1738,7 +1837,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_bf16bf16f32_large
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_bf16bf16f32_medium_expanded
   TEST_TYPE
     matmul
   GENERATOR
@@ -1747,7 +1846,8 @@ iree_generated_e2e_runner_test(
     "--lhs_rhs_type=bf16"
     "--acc_type=f32"
     "--shapes=custom_mnk"
-    "--mnk=1024,1024,1024"
+    "--mnk=1152,1024,1024"
+    "--dynamic_mask=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1758,6 +1858,72 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_bf16bf16f32_large
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=2048,2048,2048"
+    "--dynamic_mask=false,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_bf16bf16f32_large_expanded
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=bf16"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=2048,2048,2048"
+    "--dynamic_mask=true,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1482,7 +1482,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1514,7 +1514,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1719,7 +1719,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1751,7 +1751,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1024,1024,1024"
-    "--is_dynamic=false,false,false"
+    "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1783,7 +1783,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,4096"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1846,7 +1846,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1878,7 +1878,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--is_dynamic=false,false,false"
+    "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1911,7 +1911,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--is_dynamic=true,false,false"
+    "--mnk_dynamicities=dynamic,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1482,7 +1482,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1514,7 +1514,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1720,7 +1720,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1752,7 +1752,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1024,1024,1024"
-    "--dynamic_mask=false,false,false"
+    "--is_dynamic=false,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1784,7 +1784,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,4096"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1847,7 +1847,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=1152,1024,1024"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1879,7 +1879,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--dynamic_mask=false,false,false"
+    "--is_dynamic=false,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
@@ -1912,7 +1912,7 @@ iree_generated_e2e_runner_test(
     "--acc_type=f32"
     "--shapes=custom_mnk"
     "--mnk=2048,2048,2048"
-    "--dynamic_mask=true,false,false"
+    "--is_dynamic=true,false,false"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1673,6 +1673,38 @@ iree_generated_e2e_runner_test(
     "requires-gpu-${_CDNA_ARCH}"
 )
 
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_${_CDNA_ARCH}_tensor_ukernel_f16f16f32_large_expanded
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=custom_mnk"
+    "--mnk=2048,2048,2048"
+    "--dynamic_mask=true,false,false"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-hip-enable-tensor-ukernels"
+    "--iree-hip-specialize-dispatches"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-${_CDNA_ARCH}"
+)
+
 
 iree_generated_e2e_runner_test(
   NAME

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1526,7 +1526,6 @@ iree_generated_e2e_runner_test(
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-hip-enable-tensor-ukernels"
     "--iree-hip-specialize-dispatches"
-    "--iree-hal-dump-executable-files-to=files"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/matmul/common.py
+++ b/tests/e2e/matmul/common.py
@@ -69,33 +69,33 @@ class ShapesId(enum.Enum):
             raise ValueError(f"Invalid --mnk format: {e}")
 
     @classmethod
-    def set_dynamicity_mnk(cls, shapes_id, dynamicity_string):
+    def set_dynamicity(cls, shapes_id, dynamicity_string):
         """Parse and set MNK dynamicity from command line argument."""
         if shapes_id != cls.CUSTOM_MNK:
             if dynamicity_string:
                 raise ValueError(
-                    "--dynamicity can only be used with --shapes=custom_mnk"
+                    "--is_dynamic can only be used with --shapes=custom_mnk"
                 )
             return
 
         try:
             dynamicity_parts = dynamicity_string.split(",")
             if len(dynamicity_parts) != 3:
-                raise ValueError("--dynamicity must have exactly 3 values: m,n,k")
-            # cls.custom_dynamic_mask = tuple(bool(x.lower()=="true") for x in dynamicity_parts)
-            cls.custom_dynamic_mask = tuple(
+                raise ValueError(
+                    "--is_dynamic must have exactly 3 values: bool,bool,bool"
+                )
+            cls.custom_dynamicity = tuple(
                 Dynamicity.DYNAMIC if (x.lower() == "true") else Dynamicity.STATIC
                 for x in dynamicity_parts
             )
-            print("Parsing : ", cls.custom_dynamic_mask)
         except ValueError as e:
-            raise ValueError(f"Invalid --dynamic_mask format: {e}")
+            raise ValueError(f"Invalid --is_dynamic format: {e}")
 
 
 # Class attribute to store custom MNK values
 ShapesId.custom_mnk_values = None
-# Class attribute to store custom dynamic mask
-ShapesId.custom_dynamic_mask = None
+# Class attribute to store custom dynamicities for MNK
+ShapesId.custom_dynamicity = None
 
 
 # Returns the list of Dynamicity's to use for the collection of shapes
@@ -103,8 +103,8 @@ ShapesId.custom_dynamic_mask = None
 def get_dynamicities(shapes_id: ShapesId):
     if shapes_id == ShapesId.EASY_LARGE_STATIC:
         return [(Dynamicity.STATIC, Dynamicity.STATIC, Dynamicity.STATIC)]
-    elif shapes_id.custom_dynamic_mask:
-        return [shapes_id.custom_dynamic_mask]
+    elif shapes_id.custom_dynamicity:
+        return [shapes_id.custom_dynamicity]
     else:
         return [
             (Dynamicity.DYNAMIC, Dynamicity.DYNAMIC, Dynamicity.DYNAMIC),

--- a/tests/e2e/matmul/common.py
+++ b/tests/e2e/matmul/common.py
@@ -78,18 +78,19 @@ class ShapesId(enum.Enum):
                 )
             return
 
-        try:
-            dynamicity_parts = dynamicity_string.split(",")
-            if len(dynamicity_parts) != 3:
-                raise ValueError(
-                    "--is_dynamic must have exactly 3 values: bool,bool,bool"
+        if not dynamicity_string:
+            try:
+                dynamicity_parts = dynamicity_string.split(",")
+                if len(dynamicity_parts) != 3:
+                    raise ValueError(
+                        "--is_dynamic must have exactly 3 values: bool,bool,bool"
+                    )
+                cls.custom_dynamicity = tuple(
+                    Dynamicity.DYNAMIC if (x.lower() == "true") else Dynamicity.STATIC
+                    for x in dynamicity_parts
                 )
-            cls.custom_dynamicity = tuple(
-                Dynamicity.DYNAMIC if (x.lower() == "true") else Dynamicity.STATIC
-                for x in dynamicity_parts
-            )
-        except ValueError as e:
-            raise ValueError(f"Invalid --is_dynamic format: {e}")
+            except ValueError as e:
+                raise ValueError(f"Invalid --is_dynamic format: {e}")
 
 
 # Class attribute to store custom MNK values

--- a/tests/e2e/matmul/common.py
+++ b/tests/e2e/matmul/common.py
@@ -78,7 +78,7 @@ class ShapesId(enum.Enum):
                 )
             return
 
-        if not dynamicity_string:
+        if dynamicity_string:
             try:
                 dynamicity_parts = dynamicity_string.split(",")
                 if len(dynamicity_parts) != 3:

--- a/tests/e2e/matmul/common.py
+++ b/tests/e2e/matmul/common.py
@@ -74,7 +74,7 @@ class ShapesId(enum.Enum):
         if shapes_id != cls.CUSTOM_MNK:
             if dynamicity_string:
                 raise ValueError(
-                    "--is_dynamic can only be used with --shapes=custom_mnk"
+                    "--mnk_dynamicities can only be used with --shapes=custom_mnk"
                 )
             return
 
@@ -83,14 +83,19 @@ class ShapesId(enum.Enum):
                 dynamicity_parts = dynamicity_string.split(",")
                 if len(dynamicity_parts) != 3:
                     raise ValueError(
-                        "--is_dynamic must have exactly 3 values: bool,bool,bool"
+                        "--mnk_dynamicities must have exactly 3 values, each being either 'dynamic' or 'static'"
                     )
+                allowed_values = {"dynamic", "static"}
+                for x in dynamicity_parts:
+                    if x.lower() not in allowed_values:
+                        raise ValueError(f"Invalid dynamicity value: {x}")
+
                 cls.custom_dynamicity = tuple(
-                    Dynamicity.DYNAMIC if (x.lower() == "true") else Dynamicity.STATIC
+                    Dynamicity.DYNAMIC if x.lower() == "dynamic" else Dynamicity.STATIC
                     for x in dynamicity_parts
                 )
             except ValueError as e:
-                raise ValueError(f"Invalid --is_dynamic format: {e}")
+                raise ValueError(f"Invalid --mnk_dynamicities format: {e}")
 
 
 # Class attribute to store custom MNK values

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -149,9 +149,6 @@ def generate_function(
         + ", ".join([name + ": !hal.buffer_view" for name, ty in args])
         + ") -> !hal.buffer_view"
     )
-    print("-----")
-    print(func_name)
-    print(func_definition)
     return MLIRFunction(
         name=func_name,
         signature=signature,

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -107,13 +107,25 @@ def generate_function(
 
     if not shape.accumulate:
         literal_zero_for_acc_type = "0.0" if "f" in acc_type.value else "0"
-        if acc_r == "?":
+        if acc_r == "?" and acc_c == "?":
             func_definition += (
                 f"  %c0 = arith.constant 0 : index\n"
                 f"  %c1 = arith.constant 1 : index\n"
                 f"  %acc_dim0 = tensor.dim %lhs, %c0 : {lhs_tensor_type}\n"
                 f"  %acc_dim1 = tensor.dim %rhs, %c1 : {rhs_tensor_type}\n"
                 f"  %init_acc = tensor.empty(%acc_dim0, %acc_dim1) : {acc_tensor_type}\n"
+            )
+        elif acc_r == "?":
+            func_definition += (
+                f"  %c0 = arith.constant 0 : index\n"
+                f"  %acc_dim0 = tensor.dim %lhs, %c0 : {lhs_tensor_type}\n"
+                f"  %init_acc = tensor.empty(%acc_dim0) : {acc_tensor_type}\n"
+            )
+        elif acc_c == "?":
+            func_definition += (
+                f"  %c1 = arith.constant 1 : index\n"
+                f"  %acc_dim1 = tensor.dim %rhs, %c1 : {rhs_tensor_type}\n"
+                f"  %init_acc = tensor.empty(%acc_dim1) : {acc_tensor_type}\n"
             )
         else:
             func_definition += f"  %init_acc = tensor.empty() : {acc_tensor_type}\n"
@@ -137,6 +149,9 @@ def generate_function(
         + ", ".join([name + ": !hal.buffer_view" for name, ty in args])
         + ") -> !hal.buffer_view"
     )
+    print("-----")
+    print(func_name)
+    print(func_definition)
     return MLIRFunction(
         name=func_name,
         signature=signature,

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -246,9 +246,9 @@ def parse_arguments():
         required=False,
     )
     parser.add_argument(
-        "--is_dynamic",
+        "--mnk_dynamicities",
         type=str,
-        help="Custom dynamicity mask for m,n,k. Format: bool,bool,bool (e.g., is_dynamic=True,False,False)",
+        help="Custom dynamicity mask for m,n,k. Format: dynamic|static,dynamic|static,dynamic|static (e.g., --mnk_dynamicities=dynamic,static,static)",
         required=False,
     )
     return parser.parse_args()
@@ -301,7 +301,7 @@ def main(args):
     # Parse custom MNK values if provided
     shapes_id = ShapesId(args.shapes)
     ShapesId.set_custom_mnk(shapes_id, args.mnk)
-    ShapesId.set_dynamicity(shapes_id, args.is_dynamic)
+    ShapesId.set_dynamicity(shapes_id, args.mnk_dynamicities)
 
     (functions, calls) = generate(
         lhs_rhs_type=MatrixElemTypeId(args.lhs_rhs_type),

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -118,7 +118,6 @@ def generate(
     ):
         for shape in get_test_shapes(shapes_id):
             for dynamicity in get_dynamicities(shapes_id):
-                print(dynamicity)
                 function = generate_function(
                     lhs_rhs_type=lhs_rhs_type,
                     acc_type=acc_type,
@@ -247,9 +246,9 @@ def parse_arguments():
         required=False,
     )
     parser.add_argument(
-        "--dynamic_mask",
+        "--is_dynamic",
         type=str,
-        help="Custom dynamicity mask for m,n,k. Format: bool,bool,bool (e.g., dynamic_mask=True,False,False)",
+        help="Custom dynamicity mask for m,n,k. Format: bool,bool,bool (e.g., is_dynamic=True,False,False)",
         required=False,
     )
     return parser.parse_args()
@@ -302,7 +301,7 @@ def main(args):
     # Parse custom MNK values if provided
     shapes_id = ShapesId(args.shapes)
     ShapesId.set_custom_mnk(shapes_id, args.mnk)
-    ShapesId.set_dynamicity_mnk(shapes_id, args.dynamic_mask)
+    ShapesId.set_dynamicity(shapes_id, args.is_dynamic)
 
     (functions, calls) = generate(
         lhs_rhs_type=MatrixElemTypeId(args.lhs_rhs_type),

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -118,6 +118,7 @@ def generate(
     ):
         for shape in get_test_shapes(shapes_id):
             for dynamicity in get_dynamicities(shapes_id):
+                print(dynamicity)
                 function = generate_function(
                     lhs_rhs_type=lhs_rhs_type,
                     acc_type=acc_type,
@@ -245,6 +246,12 @@ def parse_arguments():
         help="Custom MNK values for CUSTOM_MNK shape. Format: m,n,k (e.g., --mnk=64,128,256)",
         required=False,
     )
+    parser.add_argument(
+        "--dynamic_mask",
+        type=str,
+        help="Custom dynamicity mask for m,n,k. Format: bool,bool,bool (e.g., dynamic_mask=True,False,False)",
+        required=False,
+    )
     return parser.parse_args()
 
 
@@ -295,6 +302,7 @@ def main(args):
     # Parse custom MNK values if provided
     shapes_id = ShapesId(args.shapes)
     ShapesId.set_custom_mnk(shapes_id, args.mnk)
+    ShapesId.set_dynamicity_mnk(shapes_id, args.dynamic_mask)
 
     (functions, calls) = generate(
         lhs_rhs_type=MatrixElemTypeId(args.lhs_rhs_type),


### PR DESCRIPTION
The primary purpose of this PR is to add missing e2e tests to cover all combinations of ukernels. We have different ukernels for static and dynamic shapes, so this PR introduces an option to generate_e2e_matmul_tests.py that allows specifying the dynamicity of m, n, and k.

Since ukernels require specialization to be enabled ([see PR #22425](https://github.com/iree-org/iree/pull/22425)), this PR also adds the following missing specializations :
- bf16 on gf942 
- f16, bf16, f8 on gfx950.

This will positively affect performance on dynamic shape matmuls without compile-time bounds information. For example :

```
  !A_size = tensor<?x4096xbf16>
  !B_size = tensor<4096x4096xbf16>
  !C_size = tensor<?x4096xf32>
  
  func.func @matmul(
  %A : !A_size, %B : !B_size) -> !C_size {
  %c0 = arith.constant 0 : index
  %cst = arith.constant 0.000000e+00 : f32
  %m = tensor.dim %A, %c0 : tensor<?x4096xbf16>
  %empty = tensor.empty(%m) : !C_size
  %C = linalg.fill ins(%cst : f32) outs(%empty : !C_size) -> !C_size
  %0 = linalg.matmul 
     indexing_maps = [affine_map<(m, n, k) -> (m, k)>, 
                     affine_map<(m, n, k) -> (n, k)>,// transpose
                     affine_map<(m, n, k) -> (m, n)>]
                     ins(%A, %B : !A_size, !B_size)
                     outs(%C : !C_size) -> !C_size
  return %0 : !C_size
  }
  ```
Before PR: Time (ms): 30.831274
After PR: Time (ms): 0.284123
