### PR TITLE
[Codegen][ROCm] Don't branch on undef in `getPaddingConvSize`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -369,8 +369,8 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
 }
 
 struct ConvToIgemmInfo {
-  bool isBatchDimLast;
-  bool isSpatialDimLast;
+  bool isBatchDimLast = false;
+  bool isSpatialDimLast = false;
   linalg::ConvolutionDimensions convDims;
   DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
   DenseMap<int64_t, int64_t> inputChannelDimToSize;


### PR DESCRIPTION
The fields in `ConvToIgemmInfo` were left uninitialized and some code paths would branch on them, which invoked Undefined Behavior in C++.

Fixes: https://github.com/iree-org/iree/issues/22448

ci-extra: windows_x64_msvc