### PR TITLE
Migrate custom LDBG macro to LLVM’s built-in debug logging

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -25,8 +25,6 @@
 #include <cassert>
 
 #define DEBUG_TYPE "iree-encoding-attrs"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::Encoding {
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -23,8 +24,6 @@
 #include "mlir/Transforms/RegionUtils.h"
 
 #define DEBUG_TYPE "iree-linalgExt-utils"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
@@ -447,15 +446,15 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   auto outputType = llvm::cast<ShapedType>(output.getType());
 
   if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
-    LDBG("[unimplemented] expected 'filterType' and 'inputType' to have static "
-         "shapes.");
+    LDBG() << "[unimplemented] expected 'filterType' and 'inputType' to have "
+              "static shapes.";
     return failure();
   }
 
   // TODO: Support pooling operations. For pooling ops, the input/output channel
   // size will be categorized as the additional batch dimension.
   if (convDims.outputChannel.empty() || convDims.inputChannel.empty()) {
-    LDBG("[unimplemented] expected no pooling operations");
+    LDBG() << "[unimplemented] expected no pooling operations.";
     return failure();
   }
   auto filterShape = filterType.getShape();
@@ -480,7 +479,7 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   std::optional<int64_t> outputImageFirstDim = outputMap.getResultPosition(
       getAffineDimExpr(outputImagePos[0], outputMap.getContext()));
   if (!outputImageFirstDim || !outputChannelLastDim) {
-    LDBG("output image or output channel dim not found in output.");
+    LDBG() << "output image or output channel dim not found in output.";
     return failure();
   }
   if (outputChannelLastDim.value() < outputImageFirstDim.value())

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -18,8 +18,6 @@
 #include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "iree-global-opt-generalize-linalg-named-ops"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::GlobalOptimization {
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Preprocessing/Common/Passes.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/LogicalResult.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -20,8 +21,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-preprocessing-convert-conv-filter-to-channels-last"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::Preprocessing {
 
@@ -265,15 +264,15 @@ public:
 
     RewritePatternSet patterns(context);
     if (filterLayout == "hwfc") {
-      LDBG("Converting filter layout to hwfc.");
+      LDBG() << "Converting filter layout to hwfc.";
       patterns.add<ConvertHwcfToHwfc>(context);
     } else if (filterLayout == "fhwc") {
-      LDBG("Converting filter layout to fhwc.");
+      LDBG() << "Converting filter layout to fhwc.";
       patterns.add<ConvertHwcfToFhwc, ConvertGenericChwfToFhwc>(context);
     } else {
-      LDBG("convert-filter-to-channels-last pass didn't apply since an "
-           "unsupported layout is given. Please use hwfc or fhwc as pass "
-           "filter-layout option.");
+      LDBG() << "convert-filter-to-channels-last pass didn't apply since an "
+                "unsupported layout is given. Please use hwfc or fhwc as pass "
+                "filter-layout option.";
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -8,6 +8,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -22,8 +23,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-preprocessing-convert-conv-to-channels-last"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::Preprocessing {
 
@@ -672,7 +671,7 @@ public:
       }
     }
 
-    LDBG("after converting convolutions to channels last\n" << *op);
+    LDBG() << "after converting convolutions to channels last\n" << *op;
 
     // Propagate packs introduced by the conversion patterns through adjacent
     // pads. Note that packs introduced by the above patterns will never include
@@ -688,7 +687,7 @@ public:
       }
     }
 
-    LDBG("after propagating packs/unpacks\n" << *op);
+    LDBG() << "after propagating packs/unpacks\n" << *op;
 
     // Run pack/unpack canonicalization to try to cancel any packs.
     {
@@ -701,7 +700,7 @@ public:
       }
     }
 
-    LDBG("after canonicalizing packs/unpacks\n" << *op);
+    LDBG() << "after canonicalizing packs/unpacks\n" << *op;
 
     // Generalize leftover packs and unpacks that are just transposes to allow
     // for transpose propagation and unit dim folding to handle them more
@@ -715,7 +714,7 @@ public:
       }
     }
 
-    LDBG("after generalizing all remaining packs/unpacks\n" << *op);
+    LDBG() << "after generalizing all remaining packs/unpacks\n" << *op;
   }
 };
 


### PR DESCRIPTION
This change removes IREE’s local LDBG macro definition in favor of the LLVM-provided version introduced in https://github.com/llvm/llvm-project/pull/143704.

This update is also in preparation for https://github.com/llvm/llvm-project/pull/165429, which would otherwise cause a macro redefinition error due to the existing local LDBG definition.