### PR TITLE
[ci] Switch to new RDNA3 runners

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -58,11 +58,11 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi325')
     uses: ./.github/workflows/pkgci_test_amd_mi325.yml
 
-  test_amd_w7900:
-    name: Test AMD W7900
+  test_amd_7900xtx:
+    name: Test AMD 7900XTX
     needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
-    uses: ./.github/workflows/pkgci_test_amd_w7900.yml
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_7900xtx')
+    uses: ./.github/workflows/pkgci_test_amd_7900xtx.yml
 
   # TODO(#18238): migrate to new runner cluster
   # test_nvidia_t4:
@@ -134,7 +134,7 @@ jobs:
       - unit_test
       - test_amd_mi250
       - test_amd_mi325
-      - test_amd_w7900
+      - test_amd_7900xtx
       # - test_nvidia_t4
       - test_android
       - test_riscv64

--- a/.github/workflows/pkgci_test_amd_7900xtx.yml
+++ b/.github/workflows/pkgci_test_amd_7900xtx.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: PkgCI Test AMD W7900
+name: PkgCI Test AMD 7900XTX
 on:
   workflow_call:
     inputs:
@@ -18,8 +18,8 @@ on:
         default: ""
 
 jobs:
-  test_w7900:
-    runs-on: nodai-amdgpu-w7900-x86-64
+  test_7900xtx:
+    runs-on: iree-7900xtx-1
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -42,15 +42,15 @@ jobs:
           # - name: amdgpu_hip_rdna3_O0
           #   numprocesses: 1
           #   config-file: onnx_ops_gpu_hip_rdna3_O0.json
-          #   runs-on: nodai-amdgpu-w7900-x86-64
+          #   runs-on: iree-7900xtx-1
           - name: amdgpu_hip_rdna3_O3
             numprocesses: 1
             config-file: onnx_ops_gpu_hip_rdna3_O3.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: iree-7900xtx-1
           - name: amdgpu_vulkan_O0
             numprocesses: 4
             config-file: onnx_ops_gpu_vulkan_O0.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: iree-7900xtx-1
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster
@@ -153,10 +153,10 @@ jobs:
           # AMD GPU
           - name: amdgpu_hip_rdna3
             config-file: onnx_models_gpu_hip_rdna3.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: iree-7900xtx-1
           - name: amdgpu_vulkan
             config-file: onnx_models_gpu_vulkan.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: iree-7900xtx-1
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster

--- a/.github/workflows/pkgci_test_pjrt.yml
+++ b/.github/workflows/pkgci_test_pjrt.yml
@@ -33,9 +33,9 @@ jobs:
           - runner: ubuntu-24.04
             pjrt_platform: cuda
           # TODO: enable these AMD runners
-          # - runner: nodai-amdgpu-w7900-x86-64
+          # - runner: iree-7900xtx-1
           #   pjrt_platform: rocm
-          # - runner: nodai-amdgpu-w7900-x86-64
+          # - runner: iree-7900xtx-1
           #   pjrt_platform: vulkan
     name: Build and test
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -160,7 +160,7 @@ jobs:
 
   # These temporary tests are designed for targets who do not have cached
   # artifacts and unable to run quality and benchmark tests
-  # TODO (geomin12): add cached artifact support for w7900
+  # TODO (geomin12): add cached artifact support for 7900xtx
   model-test:
     name: "sharktank_model_tests :: ${{ matrix.name }}"
     runs-on: ${{ matrix.runs-on }}
@@ -168,10 +168,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: rocm_hip_w7900
+          - name: rocm_hip_7900xtx
             rocm-chip: gfx1100
             target: target_hip
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: iree-7900xtx-1
     env:
       VENV_DIR: ${{ github.workspace }}/venv
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages


### PR DESCRIPTION
The old w7900 runner has lots of problems and has been down consistently for a while now. This PR switches to a newly built 7900XTX. Both machines have the same architecture (gfx1100), but have different skus.