### PR TITLE
Remove value bounds interface for ExpandShapeOp

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -51,7 +51,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgOpsIncGen",
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:MLProgramDialect",
-        "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:ValueBoundsOpInterface",
     ],

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -38,7 +38,6 @@ iree_cc_library(
     MLIRLinalgOpsIncGenLib
     MLIRLinalgStructuredOpsIncGenLib
     MLIRMLProgramDialect
-    MLIRMemRefDialect
     MLIRTensorDialect
     MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Encoding::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
@@ -400,18 +399,6 @@ struct HoistableLinalgOpInterfaceHelper {
   }
 };
 
-/// TODO(jtuyls): Remove when added to upstream.
-struct ExpandShapeOpValueBoundsInterface
-    : public ValueBoundsOpInterface::ExternalModel<
-          ExpandShapeOpValueBoundsInterface, memref::ExpandShapeOp> {
-  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
-                                       ValueBoundsConstraintSet &cstr) const {
-    auto expandOp = cast<memref::ExpandShapeOp>(op);
-    assert(value == expandOp.getResult() && "invalid value");
-    cstr.bound(value)[dim] == expandOp.getOutputShape()[dim];
-  }
-};
-
 } // namespace
 
 void registerUtilExternalModels(DialectRegistry &registry) {
@@ -529,12 +516,6 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         IREE::Util::AssumeIntOp::attachInterface<
             UtilAssumeIntValueBoundsOpInterface>(*context);
       });
-
-  registry.addExtension(+[](MLIRContext *context,
-                            memref::MemRefDialect *dialect) {
-    memref::ExpandShapeOp::attachInterface<ExpandShapeOpValueBoundsInterface>(
-        *context);
-  });
 }
 
 } // namespace mlir::iree_compiler


### PR DESCRIPTION
This is included in upstream now, so can be removed: https://github.com/iree-org/llvm-project/blob/90a67589b3e15f4375df85dea64cf0d3940a4d5f/mlir/lib/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.cpp#L62