### PR TITLE
Adding SILENCE_DEPRECATIONS option to LLVM external projects cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,7 +897,7 @@ else()
   if(IREE_INPUT_STABLEHLO)
     message(STATUS "Configuring third_party/stablehlo")
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
-    iree_llvm_add_external_project(stablehlo ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stablehlo)
+    iree_llvm_add_external_project(stablehlo ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stablehlo SILENCE_DEPRECATIONS)
     list(POP_BACK CMAKE_MESSAGE_INDENT)
   endif()
 

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -261,17 +261,37 @@ macro(iree_llvm_set_bundled_cmake_options)
   message(VERBOSE "Building LLVM Projects: ${LLVM_ENABLE_PROJECTS}")
 endmacro()
 
-# iree_add_llvm_external_project(name location)
+# iree_add_llvm_external_project(name location [SILENCE_DEPRECATIONS])
 # Adds a project as if by appending to the LLVM_EXTERNAL_PROJECTS CMake
 # variable. This is done by setting the same top-level variables that the LLVM
 # machinery is expected to export and including the sub directory explicitly.
 # The project binary dir will be llvm-external-projects/${name}
 # Call this after appropriate LLVM/MLIR packages have been loaded.
+#
+# Options:
+#   SILENCE_DEPRECATIONS:
+#     Suppresses all deprecation warnings for this external project. Useful for
+#     third-party dependencies that use deprecated APIs and are slow to update.
 function(iree_llvm_add_external_project name location)
+  cmake_parse_arguments(_RULE "SILENCE_DEPRECATIONS" "" "" ${ARGN})
+
   message(STATUS "Adding LLVM external project ${name} -> ${location}")
   if(NOT EXISTS "${location}/CMakeLists.txt")
     message(FATAL_ERROR "External project location ${location} is not valid")
   endif()
+
+  # Optionally silence warnings for this external project.
+  # Modification is in function scope only, so parent scope is unaffected.
+  if(_RULE_SILENCE_DEPRECATIONS)
+    if(MSVC)
+      # MSVC: C4996 is the deprecation warning.
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
+    else()
+      # GCC/Clang: Use standard deprecation warning flag.
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+    endif()
+  endif()
+
   add_subdirectory(${location} "llvm-external-projects/${name}" EXCLUDE_FROM_ALL)
 endfunction()
 


### PR DESCRIPTION
(for StableHLO)
We'll probably use it in the future for other things, but for now it's targeted at just deprecation warnings (as we know we don't care about those... until they hurt).