### PR TITLE
Harmonize `*ScaledMMAAttr` operand order and drop `MMAFragment`

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
@@ -81,7 +81,7 @@ getCInnermostStaticCrossIntrinsicDim(IREE::Codegen::InnerTiledOp op) {
   }
   auto mma = cast<IREE::GPU::DataTiledMMAAttr>(op.getKind());
   IREE::Codegen::TileSwizzle accSwizzle =
-      getSwizzle(mma, IREE::GPU::MMAFragment::Acc);
+      getSwizzle(mma, IREE::GPU::kMMAOperandAcc);
   SmallVector<IREE::Codegen::TileSwizzle::Dim> swizzleDims;
   for (IREE::Codegen::TileSwizzle::ExpandShapeDimVectorType group :
        accSwizzle.expandShape) {

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -320,26 +320,24 @@ MlirAttribute ireeGPULoweringConfigAttrGetMmaKind(MlirAttribute attr) {
 }
 
 ireeGPUMMASingleSubgroupLayout
-ireeGPUGetSingleSubgroupLayout(MlirAttribute attr, uint32_t fragment) {
+ireeGPUGetSingleSubgroupLayout(MlirAttribute attr, uint32_t operandIndex) {
   assert((ireeAttributeIsAGPUMMAIntrinsicAttr(attr) ||
           ireeAttributeIsAGPUVirtualMMAIntrinsicAttr(attr)) &&
          "Expected MMA or VirtualMMA Intrinsic");
 
   mlir::Attribute baseAttr = unwrap(attr);
   mlir::iree_compiler::IREE::GPU::MMASingleSubgroupLayout layout;
-  mlir::iree_compiler::IREE::GPU::MMAFragment frag =
-      static_cast<mlir::iree_compiler::IREE::GPU::MMAFragment>(fragment);
 
   if (auto intrinsicAttr =
           llvm::dyn_cast<mlir::iree_compiler::IREE::GPU::MMAIntrinsicAttr>(
               baseAttr)) {
     layout = mlir::iree_compiler::IREE::GPU::getSingleSubgroupLayout(
-        intrinsicAttr.getValue(), frag);
+        intrinsicAttr.getValue(), operandIndex);
   } else if (auto virtualIntrinsicAttr = llvm::dyn_cast<
                  mlir::iree_compiler::IREE::GPU::VirtualMMAIntrinsicAttr>(
                  baseAttr)) {
     layout = mlir::iree_compiler::IREE::GPU::getSingleSubgroupLayout(
-        virtualIntrinsicAttr.getValue(), frag);
+        virtualIntrinsicAttr.getValue(), operandIndex);
   } else {
     assert(false &&
            "Unreachable: attribute must be MMA or VirtualMMA intrinsic");

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -59,17 +59,17 @@ static LogicalResult isIntrinsicLayoutCompatible(
   auto [lhsK, rhsK] = opInfo.getOperandKIndex();
   auto [accM, accN] = opInfo.getResultMNIndex();
   if (failed(isSubgroupLayoutCompatible(
-          getSingleSubgroupLayout(intrinsic, IREE::GPU::MMAFragment::Lhs),
+          getSingleSubgroupLayout(intrinsic, IREE::GPU::kMMAOperandLhs),
           lhsLayout, lhsM, lhsK))) {
     return failure();
   }
   if (failed(isSubgroupLayoutCompatible(
-          getSingleSubgroupLayout(intrinsic, IREE::GPU::MMAFragment::Rhs),
+          getSingleSubgroupLayout(intrinsic, IREE::GPU::kMMAOperandRhs),
           rhsLayout, rhsK, rhsN))) {
     return failure();
   }
   if (failed(isSubgroupLayoutCompatible(
-          getSingleSubgroupLayout(intrinsic, IREE::GPU::MMAFragment::Acc),
+          getSingleSubgroupLayout(intrinsic, IREE::GPU::kMMAOperandAcc),
           accLayout, accM, accN))) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -797,9 +797,9 @@ FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
       const GPUIntrinsicType &intrinsicA = intrinsics[qkIndex];
       const GPUIntrinsicType &intrinsicB = intrinsics[pvIndex];
       if (!matchLayout(getSingleSubgroupLayout(intrinsicA.mmaKind,
-                                               IREE::GPU::MMAFragment::Acc),
+                                               IREE::GPU::kMMAOperandAcc),
                        getSingleSubgroupLayout(intrinsicB.mmaKind,
-                                               IREE::GPU::MMAFragment::Acc))) {
+                                               IREE::GPU::kMMAOperandAcc))) {
         continue;
       }
 
@@ -807,14 +807,14 @@ FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
       // intrinsicB.
       bool canReuseAOutForBLhs =
           matchLayout(getSingleSubgroupLayout(intrinsicA.mmaKind,
-                                              IREE::GPU::MMAFragment::Acc),
+                                              IREE::GPU::kMMAOperandAcc),
                       getSingleSubgroupLayout(intrinsicB.mmaKind,
-                                              IREE::GPU::MMAFragment::Lhs));
+                                              IREE::GPU::kMMAOperandLhs));
       bool canReuseAOutForBRhs =
           matchLayout(getSingleSubgroupLayout(intrinsicA.mmaKind,
-                                              IREE::GPU::MMAFragment::Acc),
+                                              IREE::GPU::kMMAOperandAcc),
                       getSingleSubgroupLayout(intrinsicB.mmaKind,
-                                              IREE::GPU::MMAFragment::Rhs));
+                                              IREE::GPU::kMMAOperandRhs));
       intrinsicPairs.push_back(
           {intrinsicA, intrinsicB, canReuseAOutForBLhs || canReuseAOutForBRhs});
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pack_to_instrinsics.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pack_to_instrinsics.mlir
@@ -90,13 +90,13 @@ module {
 //       CHECK:   iree_codegen.inner_tiled
 //  CHECK-SAME:     indexing_maps =
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 //  CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>}>
-// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
+// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
 
 // -----
 
@@ -129,13 +129,13 @@ module {
 //       CHECK:   iree_codegen.inner_tiled
 //  CHECK-SAME:     indexing_maps =
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 //  CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>}>
-// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
+// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x?x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
 
 // -----
 
@@ -168,13 +168,13 @@ module {
 //       CHECK:   iree_codegen.inner_tiled
 //  CHECK-SAME:     indexing_maps =
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 //  CHECK-SAME:       affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 //  CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f8E8M0FNU, rhs_elem_type = f8E8M0FNU, acc_elem_type = f32>}>
-// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
+// CHECK-SAME:      permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x?x32x2x32xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -101,39 +101,13 @@ static void interleave(TileSwizzle &swizzle, size_t srcIdx, int expandedIdx) {
 template <typename MMAIntrinsicTy>
 static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
                                        unsigned operandIdx) {
-  IREE::GPU::MMASingleSubgroupLayout layout;
+  IREE::GPU::MMASingleSubgroupLayout layout =
+      IREE::GPU::getSingleSubgroupLayout(intrinsic, operandIdx);
   const bool isScaled =
       std::is_same<MMAIntrinsicTy, IREE::GPU::ScaledMMAIntrinsic>::value;
-  const unsigned lhsIdx = 0;
-  const unsigned rhsIdx = 1;
-  const unsigned lhsScalesIdx = 2;
-  const unsigned rhsScalesIdx = 3;
-  const bool isLHSorRHS = operandIdx == lhsIdx || operandIdx == rhsIdx;
-  if (isScaled) {
-    // The operand mapping for `getSingleSubgroupLayout` follows a different
-    // operand order than is used for TileSwizzle, so we need to remap the
-    // operandIdx to get the right layout. The layouts for TileSwizzle vs.
-    // `getSingleSubgroupLayout` are shown below:
-    //             | TileSwizzle | getSingleSubgroupLayout
-    //         LHS | 0           | 0
-    //         RHS | 1           | 2
-    //  LHS Scales | 2           | 1
-    //  RHS Scales | 3           | 3
-    //         ACC | 4           | 4
-    // TODO(Max191): Decide on a consistent operand order for both.
-    int64_t layoutOperandIdx = operandIdx;
-    if (operandIdx == rhsIdx) {
-      layoutOperandIdx = 2;
-    } else if (operandIdx == lhsScalesIdx) {
-      layoutOperandIdx = 1;
-    }
-    layout = IREE::GPU::getSingleSubgroupLayout(
-        static_cast<ScaledMMAIntrinsic>(intrinsic), layoutOperandIdx);
-  } else {
-    layout = IREE::GPU::getSingleSubgroupLayout(
-        static_cast<MMAIntrinsic>(intrinsic),
-        static_cast<IREE::GPU::MMAFragment>(operandIdx));
-  }
+  const bool isLhs = isIntrinsicLhs<MMAIntrinsicTy>(operandIdx);
+  const bool isRhs = isIntrinsicRhs<MMAIntrinsicTy>(operandIdx);
+  const bool isRhsScale = isIntrinsicRhsScale<MMAIntrinsicTy>(operandIdx);
 
   // MMASingleSubgroupLayout has non-transposed RHS and RHS scales, but
   // TileSwizzle has transposed RHS and RHS scales, so reorder the `layout`
@@ -143,7 +117,7 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
     // rotate right by 1 element to swap [K, Kb] and N.
     std::rotate(v.begin(), v.end() - 1, v.end());
   };
-  if (operandIdx == rhsIdx || (isScaled && operandIdx == rhsScalesIdx)) {
+  if (isRhs || isRhsScale) {
     swapRHSKAndN(layout.outer);
     swapRHSKAndN(layout.thread);
     swapRHSKAndN(layout.tstrides);
@@ -155,7 +129,7 @@ static TileSwizzle getIntrinsicSwizzle(MMAIntrinsicTy intrinsic,
   // All other operands (and LHS/RHS for non-scaled matmuls) have 2 source
   // dimensions. These correspond to the arrays in `layout` all having a
   // matching size. Let's just guard that assumption with one assert here.
-  const unsigned numSrcDims = isScaled && isLHSorRHS ? 3 : 2;
+  const unsigned numSrcDims = isScaled && (isLhs || isRhs) ? 3 : 2;
   assert(layout.thread.size() == numSrcDims &&
          "expected layout rank to match the number of source dims");
   swizzle.expandShape.resize(numSrcDims);
@@ -233,16 +207,14 @@ static size_t getInnermostNonInternalDimIdx(
 template <typename MMAAttrTy>
 static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
   TileSwizzle swizzle = getIntrinsicSwizzle(mma.getIntrinsic(), operandIdx);
-  const bool isScaled =
-      std::is_same<MMAAttrTy, IREE::GPU::DataTiledScaledMMAAttr>::value;
-  const unsigned lhsIdx = 0;
-  const unsigned rhsIdx = 1;
-  const unsigned lhsScalesIdx = 2;
-  const unsigned rhsScalesIdx = 3;
-  const unsigned accIdx = isScaled ? 4 : 2;
-  const bool isRhsScales = isScaled && operandIdx == rhsScalesIdx;
-  const bool isLhsScales = isScaled && operandIdx == lhsScalesIdx;
-  if (operandIdx == lhsIdx || isLhsScales) {
+  using MMAIntrinsicTy = decltype(mma.getIntrinsic());
+  const bool isScaled = std::is_same<MMAIntrinsicTy, ScaledMMAIntrinsic>::value;
+  const bool isLhs = isIntrinsicLhs<MMAIntrinsicTy>(operandIdx);
+  const bool isRhs = isIntrinsicRhs<MMAIntrinsicTy>(operandIdx);
+  const bool isAcc = isIntrinsicAcc<MMAIntrinsicTy>(operandIdx);
+  const bool isLhsScale = isIntrinsicLhsScale<MMAIntrinsicTy>(operandIdx);
+  const bool isRhsScale = isIntrinsicRhsScale<MMAIntrinsicTy>(operandIdx);
+  if (isLhs || isLhsScale) {
     // A-matrix (LHS). Source dimensions are M (index 0) and K (index 1).
     // Unroll on K with interleaving, then on M.
     if (mma.getIntrinsicsK() > 1) {
@@ -253,10 +225,10 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
       // the unrolled scales with each vector load, so we need to interleave at
       // the very last dimension for the scales. For the LHS, we load in blocks,
       // so we don't need to interleave.
-      if (isLhsScales) {
+      if (isLhsScale) {
         interleavingIdx = swizzle.expandShape[1].size() - 1;
       }
-      if (!isScaled || isLhsScales) {
+      if (!isScaled || isLhsScale) {
         interleave(swizzle, 1, interleavingIdx);
       }
     }
@@ -272,7 +244,7 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
                            mma.getSubgroupsM() * mma.getSubgroupsN());
       expand(swizzle, 0, dim);
     }
-  } else if (operandIdx == rhsIdx || isRhsScales) {
+  } else if (isRhs || isRhsScale) {
     // B-matrix (RHS). Since the pack ops already took care of transposing B,
     // source dimensions are N (index 0) and K (index 1).
     // Unroll on K with interleaving, then on N.
@@ -282,10 +254,10 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
           getInnermostNonInternalDimIdx(swizzle.expandShape[1]);
       // Like with the LHS above, we want to interleave such that we load all
       // the unrolled scales with each vector load.
-      if (isRhsScales) {
+      if (isRhsScale) {
         interleavingIdx = swizzle.expandShape[1].size() - 1;
       }
-      if (!isScaled || isRhsScales) {
+      if (!isScaled || isRhsScale) {
         interleave(swizzle, 1, interleavingIdx);
       }
     }
@@ -295,7 +267,7 @@ static TileSwizzle getSwizzleImpl(MMAAttrTy mma, unsigned operandIdx) {
     if (mma.getSubgroupsN() > 1) {
       expand(swizzle, 0, {Kind::CrossThread, mma.getSubgroupsN()});
     }
-  } else if (operandIdx == accIdx) {
+  } else if (isAcc) {
     // C-matrix (accumulator). Source dimensions are M (index 0) and N (index
     // 1). Unroll on N, then on M.
     if (mma.getIntrinsicsN() > 1) {
@@ -319,9 +291,8 @@ TileSwizzle getSwizzle(IREE::GPU::DataTiledScaledMMAAttr scaledMma,
   return getSwizzleImpl(scaledMma, operandIdx);
 }
 
-TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
-                       IREE::GPU::MMAFragment fragment) {
-  return getSwizzleImpl(mma, static_cast<unsigned>(fragment));
+TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma, int operandIndex) {
+  return getSwizzleImpl(mma, operandIndex);
 }
 
 /// Remove the expanded dimensions for this index and update the permutation by

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h
@@ -22,7 +22,7 @@ SmallVector<int64_t> sliceSwizzledShape(
 /// Returns the swizzle for the full data-tiled-mma tile, including all the
 /// relevant unrolling and expansion factors.
 Codegen::TileSwizzle getSwizzle(IREE::GPU::DataTiledMMAAttr mma,
-                                IREE::GPU::MMAFragment fragment);
+                                int operandIndex);
 
 /// Returns the swizzle for the full data-tiled-scaled-mma tile, including all
 /// the relevant unrolling and expansion factors.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -199,7 +199,7 @@ getUnsupportedMNKShape(MMAIntrinsic intrinsic) {
 }
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
-                                                MMAFragment fragment) {
+                                                int operandIndex) {
   auto mfmaLhs16xK = [](int64_t k) -> MMASingleSubgroupLayout {
     assert(k % 4 == 0 && "doesn't support blocked MFMAs");
     return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
@@ -231,64 +231,64 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
 
   switch (intrinsic) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(4);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(4);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   // Note: the returned layout for f64 differs than for other MFMAs
   case MMAIntrinsic::MFMA_F64_16x16x4_F64:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(4);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(4);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{4, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{1, 1}};
     }
   case MMAIntrinsic::MFMA_F32_16x16x8_BF16: {
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(8);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(8);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   }
   case MMAIntrinsic::MFMA_F32_32x32x4_BF16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs32xK(4);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx32(4);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc32x32;
     }
   case MMAIntrinsic::MFMA_I32_16x16x16_I8:
   case MMAIntrinsic::MFMA_F32_16x16x16_F16:
   case MMAIntrinsic::MFMA_F32_16x16x16_BF16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(16);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(16);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   case MMAIntrinsic::MFMA_I32_32x32x8_I8:
   case MMAIntrinsic::MFMA_F32_32x32x8_F16:
   case MMAIntrinsic::MFMA_F32_32x32x8_BF16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs32xK(8);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx32(8);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc32x32;
     }
   case MMAIntrinsic::MFMA_F32_16x16x32_F16:
@@ -302,12 +302,12 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
   case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FN_F8E5M2:
   case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2_F8E4M3FN:
   case MMAIntrinsic::MFMA_I32_16x16x32_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(32);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(32);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   case MMAIntrinsic::MFMA_F32_32x32x16_F16:
@@ -321,81 +321,81 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
   case MMAIntrinsic::MFMA_F32_32x32x16_F8E4M3FN_F8E5M2:
   case MMAIntrinsic::MFMA_F32_32x32x16_F8E5M2_F8E4M3FN:
   case MMAIntrinsic::MFMA_I32_32x32x16_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs32xK(16);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx32(16);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc32x32;
     }
   case MMAIntrinsic::MFMA_I32_16x16x64_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(64);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(64);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   case MMAIntrinsic::MFMA_I32_32x32x32_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs32xK(32);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx32(32);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc32x32;
     }
   case MMAIntrinsic::MFMA_F32_16x16x128_F8E5M2:
   case MMAIntrinsic::MFMA_F32_16x16x128_F8E5M2_F8E4M3FN:
   case MMAIntrinsic::MFMA_F32_16x16x128_F8E4M3FN:
   case MMAIntrinsic::MFMA_F32_16x16x128_F8E4M3FN_F8E5M2:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs16xK(128);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx16(128);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc16x16;
     }
   case MMAIntrinsic::MFMA_F32_32x32x64_F8E5M2:
   case MMAIntrinsic::MFMA_F32_32x32x64_F8E5M2_F8E4M3FN:
   case MMAIntrinsic::MFMA_F32_32x32x64_F8E4M3FN:
   case MMAIntrinsic::MFMA_F32_32x32x64_F8E4M3FN_F8E5M2:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return mfmaLhs32xK(64);
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return mfmaRhsKx32(64);
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return mfmaAcc32x32;
     }
 
   case MMAIntrinsic::WMMAR3_F32_16x16x16_F16:
   case MMAIntrinsic::WMMAR3_F32_16x16x16_BF16:
   case MMAIntrinsic::WMMAR3_I32_16x16x16_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{16, 1}, /*strides=*/{1, 0},
               /*element=*/{1, 16}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
               /*element=*/{16, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{8, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{1, 1}};
     }
   case MMAIntrinsic::WMMAR3_F16_16x16x16_F16:
   case MMAIntrinsic::WMMAR3_BF16_16x16x16_BF16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{16, 1}, /*strides=*/{1, 0},
               /*element=*/{1, 16}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
               /*element=*/{16, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{16, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
               /*element=*/{1, 1}};
     }
@@ -413,27 +413,27 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
   case MMAIntrinsic::WMMAR4_F32_16x16x16_F8E4M3FN:
   case MMAIntrinsic::WMMAR4_F32_16x16x16_F8E4M3FN_F8E5M2:
   case MMAIntrinsic::WMMAR4_I32_16x16x16_I8:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{16, 2}, /*strides=*/{1, 16},
               /*element=*/{1, 8}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{8, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{8, 1}};
     }
   case MMAIntrinsic::WMMAR4_F16_16x16x16_F16:
   case MMAIntrinsic::WMMAR4_BF16_16x16x16_BF16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{16, 2}, /*strides=*/{1, 16},
               /*element=*/{1, 8}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{8, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 16}, /*tstrides=*/{16, 1},
               /*element=*/{8, 1}};
     }
@@ -446,10 +446,10 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
 }
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
-                                                MMAFragment fragment,
+                                                int operandIndex,
                                                 bool colMajor) {
   MMASingleSubgroupLayout baseLayout =
-      getSingleSubgroupLayout(intrinsic, fragment);
+      getSingleSubgroupLayout(intrinsic, operandIndex);
   assert(baseLayout.element.size() == 2 && "expected 2d layout");
   if (colMajor) {
     std::swap(baseLayout.element[0], baseLayout.element[1]);
@@ -461,10 +461,10 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
 }
 
 MMASingleSubgroupLayout
-getSingleSubgroupLayout(VirtualMMAIntrinsic virtualIntrinsic,
-                        MMAFragment fragment, bool colMajor) {
+getSingleSubgroupLayout(VirtualMMAIntrinsic virtualIntrinsic, int operandIndex,
+                        bool colMajor) {
   MMASingleSubgroupLayout baseLayout =
-      getSingleSubgroupLayout(virtualIntrinsic, fragment);
+      getSingleSubgroupLayout(virtualIntrinsic, operandIndex);
   assert(baseLayout.element.size() == 2 && "expected 2d layout");
   if (colMajor) {
     std::swap(baseLayout.element[0], baseLayout.element[1]);
@@ -488,8 +488,8 @@ struct OpaqueMmaLayout {
 static std::tuple<int64_t, int64_t, int64_t>
 getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {
   if (is_AMD(intrinsic)) {
-    auto lhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Lhs);
-    auto rhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Rhs);
+    auto lhs = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
+    auto rhs = getSingleSubgroupLayout(intrinsic, kMMAOperandRhs);
     return {lhs.outer[0] * lhs.thread[0] * lhs.element[0],
             rhs.outer[1] * rhs.thread[1] * rhs.element[1],
             lhs.outer[1] * lhs.thread[1] * lhs.element[1]};
@@ -517,18 +517,18 @@ static OpaqueMmaLayout getOpaqueMMALayout(MLIRContext *context,
 
 MMASingleSubgroupLayout
 getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
-                        MMAFragment fragment) {
+                        int operandIndex) {
   if (auto mmaAttr = dyn_cast<MMAAttr>(mmaKind)) {
     // |colMajor| indicates that the accumulator layout should be returned
     // column major.
-    return IREE::GPU::getSingleSubgroupLayout(mmaAttr.getIntrinsic(), fragment,
-                                              fragment == MMAFragment::Acc &&
-                                                  mmaAttr.getColMajor());
+    return IREE::GPU::getSingleSubgroupLayout(
+        mmaAttr.getIntrinsic(), operandIndex,
+        operandIndex == kMMAOperandAcc && mmaAttr.getColMajor());
   }
   if (auto vmmaAttr = dyn_cast<VirtualMMAAttr>(mmaKind)) {
-    return IREE::GPU::getSingleSubgroupLayout(vmmaAttr.getIntrinsic(), fragment,
-                                              fragment == MMAFragment::Acc &&
-                                                  vmmaAttr.getColMajor());
+    return IREE::GPU::getSingleSubgroupLayout(
+        vmmaAttr.getIntrinsic(), operandIndex,
+        operandIndex == kMMAOperandAcc && vmmaAttr.getColMajor());
   }
   assert(false && "unhandled MMA Interface type.");
   return {};
@@ -572,12 +572,12 @@ void MMAAttr::getUndistributedTileTypes(
 template <typename MMAIntrinsicType>
 static VectorType getThreadVectorType(MLIRContext *context,
                                       MMAIntrinsicType intrinsic,
-                                      MMAFragment fragment) {
+                                      int operandIndex) {
   auto o = getOpaqueMMALayout(context, intrinsic);
-  auto s = getSingleSubgroupLayout(intrinsic, fragment);
-  Type elemType = (fragment == MMAFragment::Lhs)   ? o.aType
-                  : (fragment == MMAFragment::Rhs) ? o.bType
-                                                   : o.cType;
+  auto s = getSingleSubgroupLayout(intrinsic, operandIndex);
+  Type elemType = isIntrinsicLhs<MMAIntrinsicType>(operandIndex)   ? o.aType
+                  : isIntrinsicRhs<MMAIntrinsicType>(operandIndex) ? o.bType
+                                                                   : o.cType;
   return VectorType::get(
       {s.element[0] * s.element[1] * s.outer[0] * s.outer[1]}, elemType);
 }
@@ -586,9 +586,9 @@ void MMAAttr::getDistributedTileTypes(
     SmallVectorImpl<VectorType> &result) const {
   MLIRContext *context = getContext();
   MMAIntrinsic intrinsic = getIntrinsic();
-  result.assign({getThreadVectorType(context, intrinsic, MMAFragment::Lhs),
-                 getThreadVectorType(context, intrinsic, MMAFragment::Rhs),
-                 getThreadVectorType(context, intrinsic, MMAFragment::Acc)});
+  result.assign({getThreadVectorType(context, intrinsic, kMMAOperandLhs),
+                 getThreadVectorType(context, intrinsic, kMMAOperandRhs),
+                 getThreadVectorType(context, intrinsic, kMMAOperandAcc)});
 }
 
 std::optional<SmallVector<int64_t, 2>>
@@ -597,7 +597,7 @@ MMAAttr::getUndistributedTileDimExpansion(int64_t operandIndex,
   assert(operandIndex <= 2 && "invalid operand index");
   assert(dim < 2 && "pre-expansion inner tiles all have two elements");
   MMASingleSubgroupLayout layout =
-      getSingleSubgroupLayout(*this, static_cast<MMAFragment>(operandIndex));
+      getSingleSubgroupLayout(*this, static_cast<int>(operandIndex));
   if (layout.outer[dim] > 1) {
     return SmallVector<int64_t, 2>{layout.outer[dim],
                                    layout.element[dim] * layout.thread[dim]};
@@ -786,9 +786,9 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
   assert(operandIndex <= 2 && "Must index valid MMA operand");
-  auto fragment = static_cast<IREE::GPU::MMAFragment>(operandIndex);
-  MMASingleSubgroupLayout subgroupLayout = getSingleSubgroupLayout(
-      getIntrinsic(), fragment, fragment == MMAFragment::Acc && getColMajor());
+  MMASingleSubgroupLayout subgroupLayout =
+      getSingleSubgroupLayout(getIntrinsic(), operandIndex,
+                              operandIndex == kMMAOperandAcc && getColMajor());
   SmallVector<OpFoldResult> canonicalOffsets;
   SmallVector<OpFoldResult> canonicalSizes;
   if (failed(populateCanonicalOffsetsSizesAndStrides(
@@ -895,19 +895,19 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
   }
 
   // Prepare Lhs/Rhs/Acc operand slices to feed the intrinsic.
-  TileSwizzle lhsSwizzle = getSwizzle(*this, MMAFragment::Lhs);
+  TileSwizzle lhsSwizzle = getSwizzle(*this, kMMAOperandLhs);
   LDBG() << "DataTiledMMAAttr::buildMmaOperation";
   LDBG() << "    lhsSwizzle: " << lhsSwizzle;
   SmallVector<Value> intrinsicsLhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
 
-  TileSwizzle rhsSwizzle = getSwizzle(*this, MMAFragment::Rhs);
+  TileSwizzle rhsSwizzle = getSwizzle(*this, kMMAOperandRhs);
   LDBG() << "DataTiledMMAAttr::buildMmaOperation";
   LDBG() << "    rhsSwizzle: " << rhsSwizzle;
   SmallVector<Value> intrinsicsRhs =
       distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
 
-  TileSwizzle accSwizzle = getSwizzle(*this, MMAFragment::Acc);
+  TileSwizzle accSwizzle = getSwizzle(*this, kMMAOperandAcc);
   LDBG() << "DataTiledMMAAttr::buildMmaOperation";
   LDBG() << "    accSwizzle: " << accSwizzle;
 
@@ -916,7 +916,7 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
 
   MMAIntrinsic intrinsic = getIntrinsic();
   VectorType intrinCType =
-      getThreadVectorType(builder.getContext(), intrinsic, MMAFragment::Acc);
+      getThreadVectorType(builder.getContext(), intrinsic, kMMAOperandAcc);
 
   // Loop over the 3 unroll_{m,n,k} dimensions to create the intrinsics.
   for (int mu = 0; mu < getIntrinsicsM(); ++mu) {
@@ -963,8 +963,7 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
 }
 
 TileSwizzle DataTiledMMAAttr::getTileSwizzle(unsigned operandIndex) const {
-  auto fragment = static_cast<IREE::GPU::MMAFragment>(operandIndex);
-  return getSwizzle(*this, fragment);
+  return getSwizzle(*this, operandIndex);
 }
 
 IREE::Codegen::TileMxNxKxKb DataTiledMMAAttr::getTileMNKKb() const {
@@ -1033,8 +1032,8 @@ static OpaqueMmaLayout getOpaqueMMALayout(MLIRContext *context,
                                           VirtualMMAIntrinsic intrinsic) {
   OpaqueMmaLayout o;
   std::tie(o.aType, o.bType, o.cType) = getABCElementTypes(context, intrinsic);
-  auto lhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Lhs);
-  auto rhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Rhs);
+  auto lhs = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
+  auto rhs = getSingleSubgroupLayout(intrinsic, kMMAOperandRhs);
   o.mSize = lhs.outer[0] * lhs.thread[0] * lhs.element[0];
   o.kSize = lhs.outer[1] * lhs.thread[1] * lhs.element[1];
   o.nSize = rhs.outer[1] * rhs.thread[1] * rhs.element[1];
@@ -1063,9 +1062,9 @@ void VirtualMMAAttr::getDistributedTileTypes(
     SmallVectorImpl<VectorType> &result) const {
   MLIRContext *context = getContext();
   VirtualMMAIntrinsic intrinsic = getIntrinsic();
-  result.assign({getThreadVectorType(context, intrinsic, MMAFragment::Lhs),
-                 getThreadVectorType(context, intrinsic, MMAFragment::Rhs),
-                 getThreadVectorType(context, intrinsic, MMAFragment::Acc)});
+  result.assign({getThreadVectorType(context, intrinsic, kMMAOperandLhs),
+                 getThreadVectorType(context, intrinsic, kMMAOperandRhs),
+                 getThreadVectorType(context, intrinsic, kMMAOperandAcc)});
 }
 
 int64_t VirtualMMAAttr::getSubgroupSize() const {
@@ -1096,9 +1095,9 @@ LogicalResult VirtualMMAAttr::populateOperandOffsetsSizesStrides(
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
   assert(operandIndex <= 2 && "Must index valid MMA operand");
-  auto fragment = static_cast<IREE::GPU::MMAFragment>(operandIndex);
-  MMASingleSubgroupLayout subgroupLayout = getSingleSubgroupLayout(
-      getIntrinsic(), fragment, fragment == MMAFragment::Acc && getColMajor());
+  MMASingleSubgroupLayout subgroupLayout =
+      getSingleSubgroupLayout(getIntrinsic(), operandIndex,
+                              operandIndex == kMMAOperandAcc && getColMajor());
   SmallVector<OpFoldResult> canonicalOffsets;
   SmallVector<OpFoldResult> canonicalSizes;
   if (failed(populateCanonicalOffsetsSizesAndStrides(
@@ -1201,53 +1200,53 @@ int64_t VirtualMMAAttr::getBlockSize() const {
 }
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
-                                                MMAFragment fragment) {
+                                                int operandIndex) {
   switch (intrinsic) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
               /*element=*/{1, 8}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{8, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{4, 1}};
     }
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 2}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
               /*element=*/{1, 4}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{2, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{4, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{4, 1}};
     }
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*tstrides=*/{1, 32},
               /*element=*/{1, 8}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{8, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{4, 1}};
     }
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
-    switch (fragment) {
-    case MMAFragment::Lhs:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
       return {/*outer=*/{1, 2}, /*thread=*/{32, 2}, /*tstrides=*/{1, 32},
               /*element=*/{1, 4}};
-    case MMAFragment::Rhs:
+    case kMMAOperandRhs:
       return {/*outer=*/{2, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{4, 1}};
-    case MMAFragment::Acc:
+    case kMMAOperandAcc:
       return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{4, 1}};
     }
@@ -1276,40 +1275,40 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
   switch (intrinsic) {
   case ScaledMMAIntrinsic::MFMA_SCALE_F32_16x16x128_B32:
     switch (operandIndex) {
-    case 0: // LHS
+    case kScaledMMAOperandLhs:
       return {/*outer=*/{1, 1, 1}, /*thread=*/{16, 4, 1},
               /*tstrides=*/{1, 16, 1},
               /*element=*/{1, 1, 32}};
-    case 1: // LHS scales
-      return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
-              /*element=*/{1, 1}};
-    case 2: // RHS
+    case kScaledMMAOperandRhs:
       return {/*outer=*/{1, 1, 1}, /*thread=*/{4, 1, 16},
               /*tstrides=*/{16, 1, 1},
               /*element=*/{1, 32, 1}};
-    case 3: // RHS scale
+    case kScaledMMAOperandLhsScale:
+      return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*tstrides=*/{1, 16},
+              /*element=*/{1, 1}};
+    case kScaledMMAOperandRhsScale:
       return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*tstrides=*/{16, 1},
               /*element=*/{1, 1}};
-    case 4: // acc
+    case kScaledMMAOperandAcc:
       return mfmaAcc16x16;
     }
   case ScaledMMAIntrinsic::MFMA_SCALE_F32_32x32x64_B32:
     switch (operandIndex) {
-    case 0: // LHS
+    case kScaledMMAOperandLhs:
       return {/*outer=*/{1, 1, 1}, /*thread=*/{32, 2, 1},
               /*tstrides=*/{1, 32, 1},
               /*element=*/{1, 1, 32}};
-    case 1: // LHS scales
-      return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*tstrides=*/{1, 32},
-              /*element=*/{1, 1}};
-    case 2: // RHS
+    case kScaledMMAOperandRhs:
       return {/*outer=*/{1, 1, 1}, /*thread=*/{2, 1, 32},
               /*tstrides=*/{32, 1, 1},
               /*element=*/{1, 32, 1}};
-    case 3: // RHS scales
+    case kScaledMMAOperandLhsScale:
+      return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*tstrides=*/{1, 32},
+              /*element=*/{1, 1}};
+    case kScaledMMAOperandRhsScale:
       return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*tstrides=*/{32, 1},
               /*element=*/{1, 1}};
-    case 4: // Acc
+    case kScaledMMAOperandAcc:
       return mfmaAcc32x32;
     }
   }
@@ -1333,7 +1332,7 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
                                                 bool isAccColMajor) {
   MMASingleSubgroupLayout baseLayout =
       getSingleSubgroupLayout(intrinsic, operandIndex);
-  if (operandIndex == 4 && isAccColMajor) {
+  if (operandIndex == kScaledMMAOperandAcc && isAccColMajor) {
     std::swap(baseLayout.outer[0], baseLayout.outer[1]);
     std::swap(baseLayout.thread[0], baseLayout.thread[1]);
     std::swap(baseLayout.tstrides[0], baseLayout.tstrides[1]);
@@ -1358,7 +1357,9 @@ SmallVector<Type> ScaledMMAAttr::getSupportedOutputTypes(MLIRContext *ctx) {
 
 LogicalResult
 ScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
-  if (failed(verifyMmaIndexingMaps({maps[0], maps[2], maps[4]}))) {
+  if (failed(verifyMmaIndexingMaps({maps[kScaledMMAOperandLhs],
+                                    maps[kScaledMMAOperandRhs],
+                                    maps[kScaledMMAOperandAcc]}))) {
     return failure();
   }
 
@@ -1370,13 +1371,15 @@ ScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
   // Note: the below conditions are a best guess and may be too strict.
 
   // Check LHS scales aren't using indexes that LHS isn't.
-  if (llvm::any_of(resExprs[1],
-                   [&](auto e) { return !resExprs[0].contains(e); })) {
+  if (llvm::any_of(resExprs[kScaledMMAOperandLhsScale], [&](auto e) {
+        return !resExprs[kScaledMMAOperandLhs].contains(e);
+      })) {
     return failure();
   }
   // Check RHS scales aren't using indexes that RHS isn't.
-  if (llvm::any_of(resExprs[3],
-                   [&](auto e) { return !resExprs[2].contains(e); })) {
+  if (llvm::any_of(resExprs[kScaledMMAOperandRhsScale], [&](auto e) {
+        return !resExprs[kScaledMMAOperandRhs].contains(e);
+      })) {
     return failure();
   }
   return success();
@@ -1385,9 +1388,9 @@ ScaledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
 void ScaledMMAAttr::getUndistributedTileTypes(
     SmallVectorImpl<VectorType> &results) const {
   MMASingleSubgroupLayout lhsLayout =
-      getSingleSubgroupLayout(getIntrinsic(), 0);
+      getSingleSubgroupLayout(getIntrinsic(), kScaledMMAOperandLhs);
   MMASingleSubgroupLayout rhsLayout =
-      getSingleSubgroupLayout(getIntrinsic(), 2);
+      getSingleSubgroupLayout(getIntrinsic(), kScaledMMAOperandRhs);
 
   int64_t blockSize = getBlockSize();
   int64_t m = lhsLayout.outer[0] * lhsLayout.thread[0] * lhsLayout.element[0];
@@ -1405,8 +1408,8 @@ void ScaledMMAAttr::getUndistributedTileTypes(
   Type scaleType = Float8E8M0FNUType::get(getContext());
 
   results.push_back(VectorType::get({m, kScale, blockSize}, lhsType));
-  results.push_back(VectorType::get({m, kScale}, scaleType));
   results.push_back(VectorType::get({kScale, blockSize, n}, rhsType));
+  results.push_back(VectorType::get({m, kScale}, scaleType));
   results.push_back(VectorType::get({kScale, n}, scaleType));
   results.push_back(VectorType::get({m, n}, accType));
 }
@@ -1418,7 +1421,7 @@ void ScaledMMAAttr::getDistributedTileTypes(
   Type accType = getAccElemType();
   Type scaleType = Float8E8M0FNUType::get(getContext());
 
-  std::array<Type, 5> argTypes = {lhsType, scaleType, rhsType, scaleType,
+  std::array<Type, 5> argTypes = {lhsType, rhsType, scaleType, scaleType,
                                   accType};
   for (auto [opIndex, type] : llvm::enumerate(argTypes)) {
     MMASingleSubgroupLayout layout =
@@ -1432,7 +1435,7 @@ void ScaledMMAAttr::getDistributedTileTypes(
 std::optional<SmallVector<int64_t, 2>>
 ScaledMMAAttr::getUndistributedTileDimExpansion(int64_t operandIndex,
                                                 int64_t dim) const {
-  assert(operandIndex <= 4 && "invalid operand index");
+  assert(operandIndex <= kScaledMMAOperandAcc && "invalid operand index");
   MMASingleSubgroupLayout layout =
       getSingleSubgroupLayout(getIntrinsic(), operandIndex, getColMajor());
   if (layout.outer[dim] > 1) {
@@ -1456,7 +1459,7 @@ LogicalResult ScaledMMAAttr::populateOperandOffsetsSizesStrides(
     ArrayRef<int64_t> permutation, SmallVectorImpl<OpFoldResult> &offsets,
     SmallVectorImpl<OpFoldResult> &sizes,
     SmallVectorImpl<OpFoldResult> &strides) const {
-  assert(operandIndex <= 4 && "Scaled MFMA has 5 operands");
+  assert(operandIndex <= kScaledMMAOperandAcc && "Scaled MFMA has 5 operands");
 
   MMASingleSubgroupLayout subgroupLayout =
       getSingleSubgroupLayout(getIntrinsic(), operandIndex, getColMajor());
@@ -1510,14 +1513,14 @@ LogicalResult ScaledMMAAttr::buildUnderlyingOperations(
     return padded;
   };
 
-  Value lhs = inputs[0];
-  Value lhsScales = padScales(inputs[1]);
-  Value rhs = inputs[2];
-  Value rhsScales = padScales(inputs[3]);
+  Value lhs = inputs[kScaledMMAOperandLhs];
+  Value rhs = inputs[kScaledMMAOperandRhs];
+  Value lhsScales = padScales(inputs[kScaledMMAOperandLhsScale]);
+  Value rhsScales = padScales(inputs[kScaledMMAOperandRhsScale]);
   Value acc = outputs[0];
 
-  ArrayRef<int64_t> lhsShape = subgroupTypes[0].getShape();
-  ArrayRef<int64_t> rhsShape = subgroupTypes[2].getShape();
+  ArrayRef<int64_t> lhsShape = subgroupTypes[kScaledMMAOperandLhs].getShape();
+  ArrayRef<int64_t> rhsShape = subgroupTypes[kScaledMMAOperandRhs].getShape();
   int64_t m = lhsShape[0];
   // We use m x [k / kPerBlock] x blockSize as the LHS pre-distribution shape
   // since this makes the higher-level tiling clearer.
@@ -1551,8 +1554,10 @@ DataTiledScaledMMAAttr::getTileSwizzle(unsigned operandIndex) const {
 
 static std::tuple<int64_t, int64_t, int64_t, int64_t>
 getMNKKbShapeFromScaledIntrinsic(ScaledMMAIntrinsic intrinsic) {
-  MMASingleSubgroupLayout lhs = getSingleSubgroupLayout(intrinsic, 0);
-  MMASingleSubgroupLayout rhs = getSingleSubgroupLayout(intrinsic, 2);
+  MMASingleSubgroupLayout lhs =
+      getSingleSubgroupLayout(intrinsic, kScaledMMAOperandLhs);
+  MMASingleSubgroupLayout rhs =
+      getSingleSubgroupLayout(intrinsic, kScaledMMAOperandRhs);
   int64_t m = lhs.outer[0] * lhs.thread[0] * lhs.element[0];
   int64_t n = rhs.outer[2] * rhs.thread[2] * rhs.element[2];
   int64_t k = lhs.outer[1] * lhs.thread[1] * lhs.element[1];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -222,23 +222,64 @@ int64_t getKSize(MMAIntrinsic intrinsic);
 /// Returns the subgroup size used by the given MMA intrinsic.
 int64_t getIntrinsicSubgroupSize(MMAIntrinsic intrinsic);
 
-MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
-                                                MMAFragment fragment);
+constexpr int kMMAOperandLhs = 0;
+constexpr int kMMAOperandRhs = 1;
+constexpr int kMMAOperandAcc = 2;
+constexpr int kScaledMMAOperandLhs = 0;
+constexpr int kScaledMMAOperandRhs = 1;
+constexpr int kScaledMMAOperandLhsScale = 2;
+constexpr int kScaledMMAOperandRhsScale = 3;
+constexpr int kScaledMMAOperandAcc = 4;
+
+template <typename MMAIntrinsicType>
+int isIntrinsicLhs(int operandIndex) {
+  return operandIndex == (std::is_same_v<MMAIntrinsicType, ScaledMMAIntrinsic>
+                              ? kScaledMMAOperandLhs
+                              : kMMAOperandLhs);
+}
+template <typename MMAIntrinsicType>
+int isIntrinsicRhs(int operandIndex) {
+  return operandIndex == (std::is_same_v<MMAIntrinsicType, ScaledMMAIntrinsic>
+                              ? kScaledMMAOperandRhs
+                              : kMMAOperandRhs);
+}
+template <typename MMAIntrinsicType>
+int isIntrinsicAcc(int operandIndex) {
+  return operandIndex == (std::is_same_v<MMAIntrinsicType, ScaledMMAIntrinsic>
+                              ? kScaledMMAOperandAcc
+                              : kMMAOperandAcc);
+}
+
+template <typename MMAIntrinsicType>
+int isIntrinsicLhsScale(int operandIndex) {
+  return std::is_same_v<MMAIntrinsicType, ScaledMMAIntrinsic>
+             ? (operandIndex == kScaledMMAOperandLhsScale)
+             : false;
+}
+template <typename MMAIntrinsicType>
+int isIntrinsicRhsScale(int operandIndex) {
+  return std::is_same_v<MMAIntrinsicType, ScaledMMAIntrinsic>
+             ? (operandIndex == kScaledMMAOperandRhsScale)
+             : false;
+}
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
-                                                MMAFragment fragment,
+                                                int operandIndex);
+
+MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
+                                                int operandIndex,
                                                 bool colMajor);
 
 MMASingleSubgroupLayout
-getSingleSubgroupLayout(VirtualMMAIntrinsic virtualIntrinsic,
-                        MMAFragment fragment, bool colMajor);
+getSingleSubgroupLayout(VirtualMMAIntrinsic virtualIntrinsic, int operandIndex,
+                        bool colMajor);
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(VirtualMMAIntrinsic intrinsic,
-                                                MMAFragment fragment);
+                                                int operandIndex);
 
 MMASingleSubgroupLayout
 getSingleSubgroupLayout(IREE::Codegen::InnerTileDescAttrInterface mmaKind,
-                        MMAFragment fragment);
+                        int operandIndex);
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(ScaledMMAIntrinsic intrinsic,
                                                 int64_t operandIndex);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -318,17 +318,6 @@ def IREEGPU_VirtualMMAIntrinsic : IREEGPU_I32EnumAttr<"VirtualMMAIntrinsic",
       VMFMA_F32_32x32x16_F8E4M3FNUZ,
     ]>;
 
-def MMA_LHS : I32EnumAttrCase<"Lhs", 0>;
-def MMA_RHS : I32EnumAttrCase<"Rhs", 1>;
-def MMA_ACC : I32EnumAttrCase<"Acc", 2>;
-
-def IREEGPU_MMAFragment : IREEGPU_I32EnumAttr<"MMAFragment",
-    "Descriptor for a particular fragment of an MMA operation", [
-      MMA_LHS,
-      MMA_RHS,
-      MMA_ACC
-    ]>;
-
 // Enum for scaled mma intrinsic, loosely matching the MMAIntrinsic enum above
 // but not including the input types.
 //

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_inner_tiled_ops.mlir
@@ -342,15 +342,14 @@ func.func @data_tiled_scaled_1x1x1_tensor_multi_mma(
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
-func.func @vector_scaled_multi_mma(%lhs: vector<2x3x1x32xf4E2M1FN>, %lhsScale: vector<2x3x1xf8E8M0FNU>,
-    %rhs: vector<3x1x5x32xf8E4M3FN>, %rhsScale: vector<3x5x1xf8E8M0FNU>,
+func.func @vector_scaled_multi_mma(%lhs: vector<2x3x1x32xf4E2M1FN>, %rhs: vector<3x1x5x32xf8E4M3FN>, %lhsScale: vector<2x3x1xf8E8M0FNU>,%rhsScale: vector<3x5x1xf8E8M0FNU>,
     %acc: vector<2x5x4xf32>) -> vector<2x5x4xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -359,15 +358,14 @@ func.func @vector_scaled_multi_mma(%lhs: vector<2x3x1x32xf4E2M1FN>, %lhsScale: v
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : vector<2x3x1x32xf4E2M1FN>, vector<2x3x1xf8E8M0FNU>,
-    vector<3x1x5x32xf8E4M3FN>, vector<3x5x1xf8E8M0FNU>
+  } : vector<2x3x1x32xf4E2M1FN>, vector<3x1x5x32xf8E4M3FN>, vector<2x3x1xf8E8M0FNU>, vector<3x5x1xf8E8M0FNU>
     into vector<2x5x4xf32>
   return %0 : vector<2x5x4xf32>
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
@@ -376,22 +374,21 @@ func.func @vector_scaled_multi_mma(%lhs: vector<2x3x1x32xf4E2M1FN>, %lhsScale: v
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
 //  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
 //  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
-//  CHECK-SAME:     : vector<2x3x1x32xf4E2M1FN>, vector<2x3x1xf8E8M0FNU>, vector<3x1x5x32xf8E4M3FN>, vector<3x5x1xf8E8M0FNU> into vector<2x5x4xf32>
+//  CHECK-SAME:     : vector<2x3x1x32xf4E2M1FN>, vector<3x1x5x32xf8E4M3FN>, vector<2x3x1xf8E8M0FNU>, vector<3x5x1xf8E8M0FNU> into vector<2x5x4xf32>
 
 // -----
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %lhsScale: tensor<?x?x1xf8E8M0FNU>,
-    %rhs: tensor<?x1x?x32xf8E4M3FN>, %rhsScale: tensor<?x?x1xf8E8M0FNU>,
+func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %rhs: tensor<?x1x?x32xf8E4M3FN>, %lhsScale: tensor<?x?x1xf8E8M0FNU>, %rhsScale: tensor<?x?x1xf8E8M0FNU>,
     %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -400,15 +397,14 @@ func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %lhsScale: t
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : tensor<?x?x1x32xf4E2M1FN>, tensor<?x?x1xf8E8M0FNU>,
-    tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU>
+  } : tensor<?x?x1x32xf4E2M1FN>, tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU>, tensor<?x?x1xf8E8M0FNU>
     into tensor<?x?x4xf32>
   return %0 : tensor<?x?x4xf32>
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
@@ -417,7 +413,7 @@ func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %lhsScale: t
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
 //  CHECK-SAME:       iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
 //  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
-//  CHECK-SAME:     : tensor<?x?x1x32xf4E2M1FN>, tensor<?x?x1xf8E8M0FNU>, tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU> into tensor<?x?x4xf32>
+//  CHECK-SAME:     : tensor<?x?x1x32xf4E2M1FN>, tensor<?x1x?x32xf8E4M3FN>, tensor<?x?x1xf8E8M0FNU>, tensor<?x?x1xf8E8M0FNU> into tensor<?x?x4xf32>
 
 // -----
 
@@ -428,10 +424,9 @@ func.func @tensor_scaled_multi_mma(%lhs: tensor<?x?x1x32xf4E2M1FN>, %lhsScale: t
  affine_map<() -> ()>,
  affine_map<() -> ()>
 ]
-func.func @single_scaled_multi_mma(%lhs: vector<32xf4E2M1FN>, %lhsScale: vector<1xf8E8M0FNU>,
-    %rhs: vector<32xf8E4M3FN>, %rhsScale: vector<1xf8E8M0FNU>,
+func.func @single_scaled_multi_mma(%lhs: vector<32xf4E2M1FN>, %rhs: vector<32xf8E4M3FN>, %lhsScale: vector<1xf8E8M0FNU>, %rhsScale: vector<1xf8E8M0FNU>,
     %acc: vector<4xf32>) -> vector<4xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [],
     kind = #iree_gpu.scaled_mma_layout<
@@ -440,8 +435,7 @@ func.func @single_scaled_multi_mma(%lhs: vector<32xf4E2M1FN>, %lhsScale: vector<
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>,
-    vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>
+  } : vector<32xf4E2M1FN>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>, vector<1xf8E8M0FNU>
     into vector<4xf32>
   return %0 : vector<4xf32>
 }
@@ -453,22 +447,21 @@ func.func @single_scaled_multi_mma(%lhs: vector<32xf4E2M1FN>, %lhsScale: vector<
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]], #[[$MAP]]]
 //  CHECK-SAME:       iterator_types = []
 //  CHECK-SAME:       kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
-//  CHECK-SAME:     : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU> into vector<4xf32>
+//  CHECK-SAME:     : vector<32xf4E2M1FN>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>, vector<1xf8E8M0FNU> into vector<4xf32>
 
 // -----
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @tensor_subgroup_scaled_multi_mma(%lhs: tensor<?x?x2x16x4x32xf4E2M1FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>,
-    %rhs: tensor<?x2x?x4x32x16xf8E4M3FN>, %rhsScale: tensor<?x?x4x16xf8E8M0FNU>,
+func.func @tensor_subgroup_scaled_multi_mma(%lhs: tensor<?x?x2x16x4x32xf4E2M1FN>, %rhs: tensor<?x2x?x4x32x16xf8E4M3FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>, %rhsScale: tensor<?x?x4x16xf8E8M0FNU>,
     %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs,%rhs,  %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -477,15 +470,14 @@ func.func @tensor_subgroup_scaled_multi_mma(%lhs: tensor<?x?x2x16x4x32xf4E2M1FN>
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
-  } : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>,
-    tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x4x16xf8E8M0FNU>
+  } : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU>
     into tensor<?x?x16x16xf32>
   return %0 : tensor<?x?x16x16xf32>
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
@@ -494,22 +486,21 @@ func.func @tensor_subgroup_scaled_multi_mma(%lhs: tensor<?x?x2x16x4x32xf4E2M1FN>
 //  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
 //  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
 //  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>
-//  CHECK-SAME:     : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x16x16xf32>
+//  CHECK-SAME:     : tensor<?x?x2x16x4x32xf4E2M1FN>, tensor<?x2x?x4x32x16xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x4x16xf8E8M0FNU> into tensor<?x?x16x16xf32>
 
 // -----
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma(%lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>,
-    %rhs: tensor<?x1x?x16x4x32xf8E4M3FN>, %rhsScale: tensor<?x?x16x4xf8E8M0FNU>,
+func.func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma(%lhs: tensor<?x?x1x16x4x32xf4E2M1FN>, %rhs: tensor<?x1x?x16x4x32xf8E4M3FN>, %lhsScale: tensor<?x?x16x4xf8E8M0FNU>, %rhsScale: tensor<?x?x16x4xf8E8M0FNU>,
     %acc: tensor<?x?x16x16xf32>) -> tensor<?x?x16x16xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -518,18 +509,16 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma(%lhs: tensor<?x?x
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>,
-    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1>]
-  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>,
-    tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>
+  } : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x16x4xf8E8M0FNU>
     into tensor<?x?x16x16xf32>
   return %0 : tensor<?x?x16x16xf32>
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
@@ -538,23 +527,22 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_multi_mma(%lhs: tensor<?x?x
 //  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
 //  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
 //  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
-//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
+//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x1x16x4x32xf4E2M1FN>, tensor<?x1x?x16x4x32xf8E4M3FN>, tensor<?x?x16x4xf8E8M0FNU>, tensor<?x?x16x4xf8E8M0FNU> into tensor<?x?x16x16xf32>
 
 // -----
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>,
-    %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
+func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
     %acc: tensor<?x?x32x32xf32>) -> tensor<?x?x32x32xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -563,18 +551,16 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: te
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>,
-    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1>]
-  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>,
-    tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>
+  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>
     into tensor<?x?x32x32xf32>
   return %0 : tensor<?x?x32x32xf32>
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
@@ -583,5 +569,5 @@ func.func @tensor_subgroup_scaled_matmul_transpose_b_32x32x64_multi_mma(%lhs: te
 //  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]],
 //  CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
 //  CHECK-SAME:     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
-//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>, array<i64: 2, 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
-//  CHECK-SAME:     : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>
+//  CHECK-SAME:     permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>, array<i64: 0, 1>]
+//  CHECK-SAME:     : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU> into tensor<?x?x32x32xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -254,9 +254,10 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
       auto [m, n, k, kB] = smma.getScaledMNKShape();
       SmallVector<Type> elementTypes;
       smma.getElementTypes(elementTypes);
-      intrinsics.emplace_back(GPUIntrinsicType({m}, {n}, {k, kB}, {},
-                                               elementTypes[0], elementTypes[2],
-                                               elementTypes[4], smma));
+      intrinsics.emplace_back(GPUIntrinsicType(
+          {m}, {n}, {k, kB}, {}, elementTypes[kScaledMMAOperandLhs],
+          elementTypes[kScaledMMAOperandRhs],
+          elementTypes[kScaledMMAOperandAcc], smma));
     }
   } else {
     for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_inner_tiled.mlir
@@ -256,16 +256,15 @@ module attributes { transform.with_named_sequence } {
  affine_map<() -> ()>
 ]
 func.func @lower_inner_tiled_mfma_scale_f32_16x16x128_b32(
-      %lhs: vector<32xf4E2M1FN>, %lhsScale: vector<1xf8E8M0FNU>,
-      %rhs: vector<32xf8E4M3FN>, %rhsScale: vector<1xf8E8M0FNU>,
+      %lhs: vector<32xf4E2M1FN>, %rhs: vector<32xf8E4M3FN>, %lhsScale: vector<1xf8E8M0FNU>, %rhsScale: vector<1xf8E8M0FNU>,
       %acc: vector<4xf32>) -> vector<4xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [],
     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32,
       lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU> into vector<4xf32>
+  } : vector<32xf4E2M1FN>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>, vector<1xf8E8M0FNU> into vector<4xf32>
   return %0 : vector<4xf32>
 }
 
@@ -281,8 +280,8 @@ module attributes { transform.with_named_sequence } {
 
 // CHECK-LABEL: func @lower_inner_tiled_mfma_scale_f32_16x16x128_b32
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<32xf4E2M1FN>
-//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<32xf8E4M3FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<4xf32>
 //  CHECK: %[[CST:.+]] = arith.constant dense<5.877470e-39> : vector<4xf8E8M0FNU>
@@ -303,16 +302,15 @@ module attributes { transform.with_named_sequence } {
  affine_map<() -> ()>
 ]
 func.func @lower_inner_tiled_mfma_scale_f32_32x32x64_b32(
-      %lhs: vector<32xf4E2M1FN>, %lhsScale: vector<1xf8E8M0FNU>,
-      %rhs: vector<32xf8E4M3FN>, %rhsScale: vector<1xf8E8M0FNU>,
+      %lhs: vector<32xf4E2M1FN>, %rhs: vector<32xf8E4M3FN>, %lhsScale: vector<1xf8E8M0FNU>, %rhsScale: vector<1xf8E8M0FNU>,
       %acc: vector<16xf32>) -> vector<16xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [],
     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32,
       lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : vector<32xf4E2M1FN>, vector<1xf8E8M0FNU>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU> into vector<16xf32>
+  } : vector<32xf4E2M1FN>, vector<32xf8E4M3FN>, vector<1xf8E8M0FNU>, vector<1xf8E8M0FNU> into vector<16xf32>
   return %0 : vector<16xf32>
 }
 
@@ -328,8 +326,8 @@ module attributes { transform.with_named_sequence } {
 
 // CHECK-LABEL: func @lower_inner_tiled_mfma_scale_f32_32x32x64_b32
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<32xf4E2M1FN>
-//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<32xf8E4M3FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: vector<1xf8E8M0FNU>
 //  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<16xf32>
 //  CHECK: %[[CST:.+]] = arith.constant dense<5.877470e-39> : vector<4xf8E8M0FNU>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
@@ -102,21 +102,20 @@ module attributes { transform.with_named_sequence } {
 // 2 x 32).
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
-func.func @unroll_scaled_multi_mma(%lhs: vector<1x2x2x32xf4E2M1FN>, %lhsScale: vector<1x2x1xf8E8M0FNU>,
-    %rhs: vector<2x2x1x32xf8E4M3FN>, %rhsScale: vector<2x1x1xf8E8M0FNU>,
+func.func @unroll_scaled_multi_mma(%lhs: vector<1x2x2x32xf4E2M1FN>, %rhs: vector<2x2x1x32xf8E4M3FN>, %lhsScale: vector<1x2x1xf8E8M0FNU>, %rhsScale: vector<2x1x1xf8E8M0FNU>,
     %acc: vector<1x1x4xf32>) -> vector<1x1x4xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32,
       lhs_elem_type = f4E2M1FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = true, opaque = false>
-  } : vector<1x2x2x32xf4E2M1FN>, vector<1x2x1xf8E8M0FNU>, vector<2x2x1x32xf8E4M3FN>, vector<2x1x1xf8E8M0FNU> into vector<1x1x4xf32>
+  } : vector<1x2x2x32xf4E2M1FN>, vector<2x2x1x32xf8E4M3FN>, vector<1x2x1xf8E8M0FNU>, vector<2x1x1xf8E8M0FNU> into vector<1x1x4xf32>
   return %0 : vector<1x1x4xf32>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/distribute_inner_tiled_to_lanes.mlir
@@ -771,16 +771,16 @@ func.func @data_tiled_scaled_1x1x1_tensor_multi_mma(
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4E2M1FN>, %lhsScale: tensor<3x5x16x4xf8E8M0FNU>,
-    %rhs: tensor<5x1x7x4x32x16xf8E4M3FN>, %rhsScale: tensor<5x7x4x16xf8E8M0FNU>,
+func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4E2M1FN>, %rhs: tensor<5x1x7x4x32x16xf8E4M3FN>,
+    %lhsScale: tensor<3x5x16x4xf8E8M0FNU>, %rhsScale: tensor<5x7x4x16xf8E8M0FNU>,
     %acc: tensor<3x7x16x16xf32>) -> tensor<3x7x16x16xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -789,34 +789,34 @@ func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>
-  } : tensor<3x5x1x16x4x32xf4E2M1FN>, tensor<3x5x16x4xf8E8M0FNU>,
-    tensor<5x1x7x4x32x16xf8E4M3FN>, tensor<5x7x4x16xf8E8M0FNU>
+  } : tensor<3x5x1x16x4x32xf4E2M1FN>, tensor<5x1x7x4x32x16xf8E4M3FN>,
+      tensor<3x5x16x4xf8E8M0FNU>, tensor<5x7x4x16xf8E8M0FNU>
     into tensor<3x7x16x16xf32>
   return %0 : tensor<3x7x16x16xf32>
 }
 
 // CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-// CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
 // CHECK-DAG: #[[$MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
 // CHECK-DAG: #[[$MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 
 // CHECK-LABEL: func @scaled_matmul_f32_16x16x128_b32_fp4_fp8
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x1x16x4x32xf4E2M1FN>
-//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x1x7x4x32x16xf8E4M3FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x4x16xf8E8M0FNU>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (4, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 1, 1, 1, 32]
-//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#1, 0, %[[ID]]#2] [5, 1, 7, 1, 32, 1]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#1, %[[ID]]#2] [5, 7, 1, 1]
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
-//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]], #[[$MAP3]], #[[$MAP4]]]
-//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x1x7x1x32x1xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
+//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<5x1x7x1x32x1xf8E4M3FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
 //       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]
 
@@ -827,16 +827,15 @@ func.func @scaled_matmul_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x1x16x4x32xf4
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x32xf4E2M1FN>, %lhsScale: tensor<3x5x16x4xf8E8M0FNU>,
-    %rhs: tensor<5x4x7x16x4x32xf8E4M3FN>, %rhsScale: tensor<5x7x16x4xf8E8M0FNU>,
+func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x32xf4E2M1FN>, %rhs: tensor<5x4x7x16x4x32xf8E4M3FN>, %lhsScale: tensor<3x5x16x4xf8E8M0FNU>, %rhsScale: tensor<5x7x16x4xf8E8M0FNU>,
     %acc: tensor<3x7x16x16xf32>) -> tensor<3x7x16x16xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -844,31 +843,30 @@ func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x3
       lhs_elem_type = f4E2M1FN,
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
-      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1>],
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>
-  } : tensor<3x5x4x16x4x32xf4E2M1FN>, tensor<3x5x16x4xf8E8M0FNU>,
-    tensor<5x4x7x16x4x32xf8E4M3FN>, tensor<5x7x16x4xf8E8M0FNU>
+  } : tensor<3x5x4x16x4x32xf4E2M1FN>, tensor<5x4x7x16x4x32xf8E4M3FN>,
+      tensor<3x5x16x4xf8E8M0FNU>, tensor<5x7x16x4xf8E8M0FNU>
     into tensor<3x7x16x16xf32>
   return %0 : tensor<3x7x16x16xf32>
 }
 
 // CHECK-LABEL: func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x4x16x4x32xf4E2M1FN>
-//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x4x7x16x4x32xf8E4M3FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x16x4xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x16x4xf8E8M0FNU>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x16x16xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (4, 16)
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (4, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 4, 1, 1, 32]
-//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [5, 4, 7, 1, 1, 32]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [5, 7, 1, 1]
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
-//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
-//  CHECK-SAME:       : tensor<3x5x4x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x4x7x1x1x32xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       : tensor<3x5x4x1x1x32xf4E2M1FN>, tensor<5x4x7x1x1x32xf8E4M3FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x1xf32>
 //       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 1]
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]
 
@@ -876,16 +874,15 @@ func.func @scaled_matmul_trb_f32_16x16x128_b32_fp4_fp8(%lhs: tensor<3x5x4x16x4x3
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8(%lhs: tensor<3x5x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<3x5x32x2xf8E8M0FNU>,
-    %rhs: tensor<5x1x7x32x2x32xf8E4M3FN>, %rhsScale: tensor<5x7x32x2xf8E8M0FNU>,
+func.func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8(%lhs: tensor<3x5x1x32x2x32xf4E2M1FN>, %rhs: tensor<5x1x7x32x2x32xf8E4M3FN>, %lhsScale: tensor<3x5x32x2xf8E8M0FNU>, %rhsScale: tensor<5x7x32x2xf8E8M0FNU>,
     %acc: tensor<3x7x4x8x32xf32>) -> tensor<3x7x4x8x32xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -893,31 +890,29 @@ func.func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8(%lhs: tensor<3x5x1x32x2x32
       lhs_elem_type = f4E2M1FN,
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
-      permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+      permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1, 2>],
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>
-  } : tensor<3x5x1x32x2x32xf4E2M1FN>, tensor<3x5x32x2xf8E8M0FNU>,
-    tensor<5x1x7x32x2x32xf8E4M3FN>, tensor<5x7x32x2xf8E8M0FNU>
+  } : tensor<3x5x1x32x2x32xf4E2M1FN>, tensor<5x1x7x32x2x32xf8E4M3FN>, tensor<3x5x32x2xf8E8M0FNU>, tensor<5x7x32x2xf8E8M0FNU>
     into tensor<3x7x4x8x32xf32>
   return %0 : tensor<3x7x4x8x32xf32>
 }
 
 // CHECK-LABEL: func @scaled_matmul_trb_f32_32x32x64_b32_fp4_fp8
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<3x5x1x32x2x32xf4E2M1FN>
-//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x32x2xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<5x1x7x32x2x32xf8E4M3FN>
+//  CHECK-SAME:   %[[LHS_SCALE:[A-Za-z0-9]+]]: tensor<3x5x32x2xf8E8M0FNU>
 //  CHECK-SAME:   %[[RHS_SCALE:[A-Za-z0-9]+]]: tensor<5x7x32x2xf8E8M0FNU>
 //       CHECK:   scf.forall (%[[LANEID:.+]]) in (64) shared_outs(%[[ACC:.+]] = {{.*}}) -> (tensor<3x7x4x8x32xf32>)
 //   CHECK-DAG:     %[[ID:.+]]:3 = affine.delinearize_index %[[LANEID]] into (2, 32)
 //   CHECK-DAG:     %[[IDY:.+]] = affine.linearize_index disjoint [%[[ID]]#1, %c0] by (2, 4)
 //   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [3, 5, 1, 1, 1, 32]
-//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, 0, %[[ID]]#2, %[[ID]]#1, 0] [5, 1, 7, 1, 1, 32]
+//   CHECK-DAG:     %[[LHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[LHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [3, 5, 1, 1]
 //   CHECK-DAG:     %[[RHS_SCALE_SLICE:.+]] = tensor.extract_slice %[[RHS_SCALE]][0, 0, %[[ID]]#2, %[[ID]]#1] [5, 7, 1, 1]
 //   CHECK-DAG:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ACC]][0, 0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 4, 1]
-//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
-//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x1x7x1x1x32xf8E4M3FN>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x4x1xf32>
+//       CHECK:     %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS_SLICE]], %[[RHS_SLICE]], %[[LHS_SCALE_SLICE]], %[[RHS_SCALE_SLICE]]) outs(%[[ACC_SLICE]])
+//  CHECK-SAME:       : tensor<3x5x1x1x1x32xf4E2M1FN>, tensor<5x1x7x1x1x32xf8E4M3FN>, tensor<3x5x1x1xf8E8M0FNU>, tensor<5x7x1x1xf8E8M0FNU> into tensor<3x7x4x4x1xf32>
 //       CHECK:     tensor.parallel_insert_slice %[[MMA]] into %[[ACC]][0, 0, 0, %[[IDY]], %[[ID]]#2] [3, 7, 4, 4, 1]
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/expand_undistributed_inner_tiles.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/expand_undistributed_inner_tiles.mlir
@@ -422,16 +422,15 @@ func.func @concretize_WMMAR4_I32_16x16x16_I8(%lhs: tensor<16x16xi8>, %rhs: tenso
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @expand_output_tile_scaled_mfma_32x32x64(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>,
-    %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
+func.func @expand_output_tile_scaled_mfma_32x32x64(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
     %acc: tensor<?x?x32x32xf32>) -> tensor<?x?x32x32xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -440,11 +439,9 @@ func.func @expand_output_tile_scaled_mfma_32x32x64(%lhs: tensor<?x?x1x32x2x32xf4
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>,
-    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+    permutations = [array<i64: 0, 1, 2>, array<i64: 2, 0, 1>, array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1>]
-  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>,
-    tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>
+  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>
     into tensor<?x?x32x32xf32>
   return %0 : tensor<?x?x32x32xf32>
 }
@@ -460,16 +457,15 @@ func.func @expand_output_tile_scaled_mfma_32x32x64(%lhs: tensor<?x?x1x32x2x32xf4
 
 #contraction_accesses = [
  affine_map<(i, j, k, b) -> (i, k, b)>,
- affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, b, j)>,
+ affine_map<(i, j, k, b) -> (i, k)>,
  affine_map<(i, j, k, b) -> (k, j)>,
  affine_map<(i, j, k, b) -> (i, j)>
 ]
 
-func.func @expand_output_tile_scaled_mfma_32x32x64_col_major(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>,
-    %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
+func.func @expand_output_tile_scaled_mfma_32x32x64_col_major(%lhs: tensor<?x?x1x32x2x32xf4E2M1FN>, %rhs: tensor<?x1x?x32x2x32xf8E4M3FN>, %lhsScale: tensor<?x?x32x2xf8E8M0FNU>, %rhsScale: tensor<?x?x32x2xf8E8M0FNU>,
     %acc: tensor<?x?x32x32xf32>) -> tensor<?x?x32x32xf32> {
-  %0 = iree_codegen.inner_tiled ins(%lhs, %lhsScale, %rhs, %rhsScale) outs(%acc) {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs, %lhsScale, %rhsScale) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>],
     kind = #iree_gpu.scaled_mma_layout<
@@ -478,11 +474,9 @@ func.func @expand_output_tile_scaled_mfma_32x32x64_col_major(%lhs: tensor<?x?x1x
       rhs_elem_type = f8E4M3FN,
       acc_elem_type = f32, col_major = true>,
     semantics = #iree_gpu.mma_semantics<distributed = false, opaque = true>,
-    permutations = [array<i64: 0, 1, 2>, array<i64: 0, 1>,
-      array<i64: 2, 0, 1>, array<i64: 1, 0>,
+    permutations = [array<i64: 0, 1, 2>,array<i64: 2, 0, 1>,  array<i64: 0, 1>, array<i64: 1, 0>,
       array<i64: 0, 1>]
-  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x?x32x2xf8E8M0FNU>,
-    tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>
+  } : tensor<?x?x1x32x2x32xf4E2M1FN>, tensor<?x1x?x32x2x32xf8E4M3FN>, tensor<?x?x32x2xf8E8M0FNU>, tensor<?x?x32x2xf8E8M0FNU>
     into tensor<?x?x32x32xf32>
   return %0 : tensor<?x?x32x32xf32>
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -170,10 +170,10 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     // to the total LHS and RHS sizes, because we use these sizes to select the
     // unrolling factors for M, N, and K, which affect both the input and the
     // scale operands.
-    intrinsicSizeBitsLHS =
-        sizeInBits(vectorTypes[0]) + sizeInBits(vectorTypes[1]);
-    intrinsicSizeBitsRHS =
-        sizeInBits(vectorTypes[2]) + sizeInBits(vectorTypes[3]);
+    intrinsicSizeBitsLHS = sizeInBits(vectorTypes[kScaledMMAOperandLhs]) +
+                           sizeInBits(vectorTypes[kScaledMMAOperandLhsScale]);
+    intrinsicSizeBitsRHS = sizeInBits(vectorTypes[kScaledMMAOperandRhs]) +
+                           sizeInBits(vectorTypes[kScaledMMAOperandRhsScale]);
     intrinsicSizeBitsACC = sizeInBits(vectorTypes[4]);
     intrinsicMSize = getMSize(intrinsicScaledMma.getIntrinsic());
     intrinsicNSize = getNSize(intrinsicScaledMma.getIntrinsic());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -204,8 +204,8 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
   // MMA intrinsics can be weird and usually don't have a single subgroup
   // iteration space, so we need to find their value subgroup iteration space
   // indvidually.
-  auto getFragmentLayout = [&](IREE::GPU::MMAFragment fragment,
-                               int64_t outerDim, int64_t innerDim,
+  auto getFragmentLayout = [&](int operandIndex, int64_t outerDim,
+                               int64_t innerDim,
                                AffineMap map) -> VectorLayoutInterface {
     // Note that the struct MMASingleSubgroupLayout contains the partial layout
     // for the canonical (M, K) x (K, N) -> (M, N) matmul form. We treat the
@@ -217,7 +217,7 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
     SmallVector<int64_t> threadStrides(rank, 0);
 
     MMASingleSubgroupLayout subgroupLayout =
-        IREE::GPU::getSingleSubgroupLayout(intrinsic, fragment);
+        IREE::GPU::getSingleSubgroupLayout(intrinsic, operandIndex);
     outerCounts[outerDim] = subgroupLayout.outer[0];
     outerCounts[innerDim] = subgroupLayout.outer[1];
     threadCounts[outerDim] = subgroupLayout.thread[0];
@@ -235,15 +235,12 @@ getContractionLayout(Operation *candidate, ArrayRef<int64_t> bounds,
     return fragmentSpaceLayout.apply(map);
   };
 
-  VectorLayoutInterface lhs =
-      getFragmentLayout(IREE::GPU::MMAFragment::Lhs, innerMDim, innerKDim,
-                        contractIndexingMaps[0]);
-  VectorLayoutInterface rhs =
-      getFragmentLayout(IREE::GPU::MMAFragment::Rhs, innerKDim, innerNDim,
-                        contractIndexingMaps[1]);
-  VectorLayoutInterface acc =
-      getFragmentLayout(IREE::GPU::MMAFragment::Acc, innerMDim, innerNDim,
-                        contractIndexingMaps[2]);
+  VectorLayoutInterface lhs = getFragmentLayout(
+      IREE::GPU::kMMAOperandLhs, innerMDim, innerKDim, contractIndexingMaps[0]);
+  VectorLayoutInterface rhs = getFragmentLayout(
+      IREE::GPU::kMMAOperandRhs, innerKDim, innerNDim, contractIndexingMaps[1]);
+  VectorLayoutInterface acc = getFragmentLayout(
+      IREE::GPU::kMMAOperandAcc, innerMDim, innerNDim, contractIndexingMaps[2]);
 
   return ContractionLayout{lhs, rhs, acc};
 }
@@ -459,11 +456,14 @@ static LogicalResult setAttentionMatmulAnchor(RewriterBase &rewriter,
   IREE::Codegen::InnerTileDescAttrInterface pvIntrinsic =
       getIntrinsic(pvMatmul);
   IREE::GPU::MMASingleSubgroupLayout lhsLayout =
-      getSingleSubgroupLayout(pvIntrinsic, IREE::GPU::MMAFragment::Lhs);
+      IREE::GPU::getSingleSubgroupLayout(pvIntrinsic,
+                                         IREE::GPU::kMMAOperandLhs);
   IREE::GPU::MMASingleSubgroupLayout rhsLayout =
-      getSingleSubgroupLayout(pvIntrinsic, IREE::GPU::MMAFragment::Rhs);
+      IREE::GPU::getSingleSubgroupLayout(pvIntrinsic,
+                                         IREE::GPU::kMMAOperandRhs);
   IREE::GPU::MMASingleSubgroupLayout outLayout =
-      getSingleSubgroupLayout(qkIntrinsic, IREE::GPU::MMAFragment::Acc);
+      IREE::GPU::getSingleSubgroupLayout(qkIntrinsic,
+                                         IREE::GPU::kMMAOperandAcc);
 
   auto matchLayout = [](IREE::GPU::MMASingleSubgroupLayout layoutA,
                         IREE::GPU::MMASingleSubgroupLayout layoutB) -> bool {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -9,7 +9,7 @@
 #scale_n = affine_map<(M, N, Ko, Kb) -> (N, Ko)>
 #out_map = affine_map<(M, N, Ko, Kb) -> (M, N)>
 func.func @scaled_matmul(
-    %A: tensor<1024x512x32xf4E2M1FN>, %B: tensor<1024x512x32xf4E2M1FN>, %A_scales: tensor<1024x512xf8E8M0FNU>, %B_scales: tensor<1024x512xf8E8M0FNU>, %C: tensor<1024x1024xf32>) -> tensor<1024x1024xf32> {
+    %A: tensor<1024x512x32xf4E2M1FN>, %B: tensor<1024x512x32xf4E2M1FN>, %B_scales: tensor<1024x512xf8E8M0FNU>, %A_scales: tensor<1024x512xf8E8M0FNU>, %C: tensor<1024x1024xf32>) -> tensor<1024x1024xf32> {
   %0 = linalg.generic {
     indexing_maps = [#lhs_map, #rhs_map, #scale_m, #scale_n, #out_map],
     iterator_types = ["parallel", "parallel", "reduction", "reduction"]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
@@ -122,7 +122,7 @@ inferIteratorsFromOutMap(AffineMap map) {
   return iterators;
 }
 
-bool isScaledContractionBody(Block &block) {
+static bool isScaledContractionBody(Block &block) {
   if (block.empty() || !block.back().mightHaveTrait<OpTrait::IsTerminator>()) {
     LDBG() << "no terminator in the block";
     return false;


### PR DESCRIPTION
This PR does multiple things that were easier done all at once:
1. Harmonize `*ScaledMMAAttr` operand order:
   * The operand order of `ScaledMMAAttr` was `lhs, lhs_scale, rhs, rhs_scale`, while the operand order of `DataTiledScaledMMAAttr` was `lhs, rhs, lhs_scale, rhs_scale`.
   * This PR changes `ScaledMMAAttr` to match the `DataTiledScaledMMAAttr` convention. This propagates to a change of operand order in the enclosing `inner_tiled` ops.
2. Drop `MMAFragment`:
   * There used to be a TableGen enum `MMAFragment`, that had unclear semantics: the enum values were sometimes used as opaque symbolic enums to refer to operand by "role", e.g. "Lhs", and sometimes used as the underlying integer values as operand indices, e.g. "Rhs == 1". This was originally OK as all MMA-like ops had the same 3 operands Lhs, Rhs, Acc. But when ScaledMMAAttr was introduced, that didn't... scale: now the preexisting enum value "Rhs == 1" didn't equal anymore the corresponding operand index under the `lhs, lhs_scale, rhs, rhs_scale` convention (1 != 2) and even regardless of convention, the enum value "Acc ==2" never corresponded to operand index anymore (2 != 4).
   * This PR drops MMAFragment and generalizes the use of plain integer `operandIndex`.
   * This is made reasonable to implement by the harmonization of operand orders (above 1.). If we tried doing this without 1., then we would feel more of a need for opaque "role" enums to replace MMAFragment without having to fix up operand indices between two conventions.
3. Drop some logic that only existed to make up for the discrepancy between convensions and the fuzzy semantics of MMAFragment.