### PR TITLE
[DispatchCreation] Set split reduction size for ArgCompare

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -476,22 +476,17 @@ private:
     ArrayRef<int64_t> inputShape = inputType.getShape();
     int64_t reductionDim = argCompareOp.getDimension();
     int64_t reductionSize = inputShape[reductionDim];
-
-    if (reductionSize == ShapedType::kDynamic) {
+    if (ShapedType::isDynamic(reductionSize)) {
       return std::nullopt;
     }
-
     if (reductionSize < splitReductionTargetSize) {
       return std::nullopt;
     }
-
     int64_t tileSize = findSmallestFactorWithLowerBound(
                            reductionSize, splitReductionTargetSize)
                            .value_or(reductionSize);
-
     LDBG() << "arg_compare split: dim=" << reductionDim
            << " size=" << reductionSize << " tile=" << tileSize;
-
     return SmallVector<int64_t>{tileSize};
   }
 };

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -107,6 +108,12 @@ struct SetSplitReductionSizesPass final
 
       // --- Case 3: Matmul-like operations ---
       if (auto tileSizes = getMatmulLikeReductionSizes(tilingOp)) {
+        IREE::LinalgExt::setSplitReductionAttribute(tilingOp, *tileSizes);
+        return;
+      }
+
+      // --- Case 4: arg_compare operations ---
+      if (auto tileSizes = getArgCompareReductionSizes(tilingOp)) {
         IREE::LinalgExt::setSplitReductionAttribute(tilingOp, *tileSizes);
         return;
       }
@@ -454,6 +461,41 @@ private:
     }
 
     return tileSizes;
+  }
+
+  /// Determine split reduction sizes specifically for arg_compare operations.
+  std::optional<SmallVector<int64_t>>
+  getArgCompareReductionSizes(PartialReductionOpInterface op) const {
+    auto argCompareOp =
+        dyn_cast<IREE::LinalgExt::ArgCompareOp>(op.getOperation());
+    if (!argCompareOp) {
+      return std::nullopt;
+    }
+
+    ShapedType inputType = argCompareOp.getInputType();
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    int64_t reductionDim = argCompareOp.getDimension();
+    int64_t reductionSize = inputShape[reductionDim];
+
+    if (reductionSize == ShapedType::kDynamic) {
+      return std::nullopt;
+    }
+
+    // This threshold is set heuristically without extensive empirical data.
+    // It may be refined in the future as more practical cases are encountered.
+    const int64_t minSizeToSplit = 1024;
+    if (reductionSize < minSizeToSplit) {
+      return std::nullopt;
+    }
+
+    int64_t tileSize = findSmallestFactorWithLowerBound(
+                           reductionSize, splitReductionTargetSize)
+                           .value_or(reductionSize);
+
+    LDBG() << "arg_compare split: dim=" << reductionDim
+           << " size=" << reductionSize << " tile=" << tileSize;
+
+    return SmallVector<int64_t>{tileSize};
   }
 };
 } // namespace

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -481,10 +481,7 @@ private:
       return std::nullopt;
     }
 
-    // This threshold is set heuristically without extensive empirical data.
-    // It may be refined in the future as more practical cases are encountered.
-    const int64_t minSizeToSplit = 1024;
-    if (reductionSize < minSizeToSplit) {
+    if (reductionSize < splitReductionTargetSize) {
       return std::nullopt;
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
@@ -222,3 +222,25 @@ util.func public @arg_compare_small_inner_reduction(%arg0: tensor<4x1x512xf16>)
 
   util.return %res#1 : tensor<4x1xi32>
 }
+
+// -----
+
+// CHECK-LABEL: @arg_compare_dynamic_inner_reduction
+util.func public @arg_compare_dynamic_inner_reduction(%arg0: tensor<4x1x?xf16>, %d0: index)
+    -> tensor<4x1xi32> {
+  // Dynamic reduction dimension should not be tiled.
+  // CHECK-NOT: iree_linalg_ext.split_reduction
+  %init_val = tensor.empty() : tensor<4x1xf16>
+  %init_idx = tensor.empty() : tensor<4x1xi32>
+
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(2)
+    ins(%arg0 : tensor<4x1x?xf16>)
+    outs(%init_val, %init_idx : tensor<4x1xf16>, tensor<4x1xi32>) {
+  ^bb0(%arg1: f16, %arg2: f16):
+    %cmp = arith.cmpf ogt, %arg1, %arg2 : f16
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4x1xf16>, tensor<4x1xi32>
+
+  util.return %res#1 : tensor<4x1xi32>
+}

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
@@ -179,3 +179,24 @@ util.func public @arg_compare_negative_outer_dynamic_reduction(
 
   util.return %res_val, %res_idx : tensor<64xf32>, tensor<64xindex>
 }
+
+// -----
+
+// CHECK-LABEL: @arg_compare_large_inner_reduction
+util.func public @arg_compare_large_inner_reduction(%arg0: tensor<4x1x128256xf16>)
+    -> tensor<4x1xi32> {
+  // CHECK: iree_linalg_ext.split_reduction = [1336 : index]
+  %init_val = tensor.empty() : tensor<4x1xf16>
+  %init_idx = tensor.empty() : tensor<4x1xi32>
+
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(2)
+    ins(%arg0 : tensor<4x1x128256xf16>)
+    outs(%init_val, %init_idx : tensor<4x1xf16>, tensor<4x1xi32>) {
+  ^bb0(%arg1: f16, %arg2: f16):
+    %cmp = arith.cmpf ogt, %arg1, %arg2 : f16
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4x1xf16>, tensor<4x1xi32>
+
+  util.return %res#1 : tensor<4x1xi32>
+}

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_outer_reduction.mlir
@@ -200,3 +200,25 @@ util.func public @arg_compare_large_inner_reduction(%arg0: tensor<4x1x128256xf16
 
   util.return %res#1 : tensor<4x1xi32>
 }
+
+// -----
+
+// CHECK-LABEL: @arg_compare_small_inner_reduction
+util.func public @arg_compare_small_inner_reduction(%arg0: tensor<4x1x512xf16>)
+    -> tensor<4x1xi32> {
+  // Reduction dimension (512) is below the threshold (1024), so no split.
+  // CHECK-NOT: iree_linalg_ext.split_reduction
+  %init_val = tensor.empty() : tensor<4x1xf16>
+  %init_idx = tensor.empty() : tensor<4x1xi32>
+
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(2)
+    ins(%arg0 : tensor<4x1x512xf16>)
+    outs(%init_val, %init_idx : tensor<4x1xf16>, tensor<4x1xi32>) {
+  ^bb0(%arg1: f16, %arg2: f16):
+    %cmp = arith.cmpf ogt, %arg1, %arg2 : f16
+    iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4x1xf16>, tensor<4x1xi32>
+
+  util.return %res#1 : tensor<4x1xi32>
+}


### PR DESCRIPTION
Per request here: https://github.com/iree-org/iree/pull/22379#pullrequestreview-3370476772

Debugging the arg_compare op compilation issue in llama 8b fp16 quality tests from PR #22379. 

### Problem:

The issue is with this `arg_compare` operation: 
```mlir
    %29:2 = iree_linalg_ext.arg_compare dimension(2) ins(%28 : tensor<4x1x128256xf16>) outs(%11, %12 : tensor<4x1xf16>, tensor<4x1xi32>) {
    ^bb0(%arg5: f16, %arg6: f16):
      %31 = arith.cmpf ogt, %arg5, %arg6 : f16
      iree_linalg_ext.yield %31 : i1
    } -> tensor<4x1xf16>, tensor<4x1xi32>
```
Without split-reduction support, the entire reduction along dimension 2 (128,256 elements) is processed along `LLVMGPUDistribute` pipeline , which attempts to allocate the entire reduction dimension to shared memory. This exceeds the 64KB shared memory limit and causes compilation failures.

### Solution
This PR extends the `SetSplitReductionSizesPass` to support splitting large reduction dimensions in `iree_linalg_ext.arg_compare` operations.

Another solution is to support arg_compare op along VectorDistribute pipeline (on my plate), which will takes longer time to implement. Therefore, let's solve the problem from dispatch creation stage first as an immediate solution.