### PR TITLE
Add Cursor files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 *.user
 *.code-workspace
 
+# Cursor files
+.cursor/
+
 # macOS files
 .DS_Store
 


### PR DESCRIPTION
The Cursor IDE allows for storing metadata in `.cursor` directories within projects, so add `.cursor` to `.gitignore` for developers using cursor.