### PR TITLE
[DT][NFC] Fix coding style / standards issues for encoding materialization.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -194,8 +194,7 @@ struct MaterializeInterfaceBindingEncoding
       return rewriter.notifyMatchFailure(subspanOp, "bound type already valid");
     }
 
-    auto *typeConverter = static_cast<const MaterializeEncodingTypeConverter *>(
-        getTypeConverter());
+    auto typeConverter = getTypeConverter<MaterializeEncodingTypeConverter>();
     // Get the dynamic dims of the target.
     Location loc = subspanOp.getLoc();
     SmallVector<Value> newDynamicDims = subspanOp.getDynamicDims();
@@ -231,8 +230,7 @@ struct MaterializeTensorExtDispatchTensorLoadOp
                   ConversionPatternRewriter &rewriter) const override {
     auto sourceType = loadOp.getSourceType();
     auto boundTensorType = cast<RankedTensorType>(sourceType.getBoundType());
-    auto *typeConverter = static_cast<const MaterializeEncodingTypeConverter *>(
-        getTypeConverter());
+    auto typeConverter = getTypeConverter<MaterializeEncodingTypeConverter>();
     if (typeConverter->convertType(boundTensorType) == boundTensorType) {
       return rewriter.notifyMatchFailure(loadOp, "bound type already valid");
     }
@@ -267,9 +265,7 @@ struct MaterializeTensorExtDispatchTensorStoreOp
                   ConversionPatternRewriter &rewriter) const override {
     auto targetType = storeOp.getTargetType();
     auto boundTensorType = cast<RankedTensorType>(targetType.getBoundType());
-    auto *typeConverter = static_cast<const MaterializeEncodingTypeConverter *>(
-        getTypeConverter());
-
+    auto typeConverter = getTypeConverter<MaterializeEncodingTypeConverter>();
     if (typeConverter->convertType(boundTensorType) == boundTensorType) {
       return rewriter.notifyMatchFailure(storeOp, "bound type already valid");
     }
@@ -306,8 +302,8 @@ struct MaterializeOperation : public OpConversionPattern<OpTy> {
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
-        this->getTypeConverter());
+    auto converter =
+        this->template getTypeConverter<MaterializeEncodingTypeConverter>();
     FailureOr<Operation *> convertedOp =
         lowerOpWithEncoding(rewriter, op, adaptor.getOperands(), *converter);
     if (failed(convertedOp))
@@ -369,8 +365,7 @@ struct SetEncodingOpLoweringConversion
       rewriter.replaceOp(encodingOp, adaptor.getSource());
       return success();
     }
-    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
-        getTypeConverter());
+    auto converter = getTypeConverter<MaterializeEncodingTypeConverter>();
     auto packedValue = lowerSetEncodingOpToPackOp(
         rewriter, encodingOp, adaptor.getSource(), *converter);
     if (failed(packedValue)) {
@@ -432,9 +427,7 @@ struct UnsetEncodingOpLoweringConversion
   matchAndRewrite(IREE::Encoding::UnsetEncodingOp unsetEncodingOp,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
-        getTypeConverter());
-
+    auto converter = getTypeConverter<MaterializeEncodingTypeConverter>();
     MaterializeEncodingInfo encodingInfo =
         converter->getEncodingInfo(unsetEncodingOp.getSource().getType());
     if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
@@ -505,9 +498,7 @@ public:
   LogicalResult
   matchAndRewrite(linalg::LinalgOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
-        this->getTypeConverter());
-
+    auto converter = getTypeConverter<MaterializeEncodingTypeConverter>();
     IREE::Encoding::LayoutMaterializerAttr layoutAttr =
         converter->getLayoutAttr();
     SmallVector<Type> convertedResTypes;

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -65,7 +65,7 @@ public:
   Type convertType(Attribute attr, Type type) const {
     EncodingLayoutAttr layoutAttr = cast<EncodingLayoutAttr>(attr);
     return TypeSwitch<Type, Type>(type)
-        .template Case<RankedTensorType>([&](auto type) {
+        .Case([&](RankedTensorType type) {
           // For a given tensor type with an encoding, return the materialized
           // type to use for it. If no encoding is set, then return the tensor
           // type itself.
@@ -108,16 +108,15 @@ public:
           newShape.append(swizzledTileShape);
           return RankedTensorType::get(newShape, packedType.getElementType());
         })
-        .template Case<IREE::TensorExt::DispatchTensorType>(
-            [&](auto dispatchTensorType) {
-              Type boundType = dispatchTensorType.getBoundType();
-              Type convertedBoundType = convertType(attr, boundType);
-              if (convertedBoundType == boundType) {
-                return dispatchTensorType;
-              }
-              return IREE::TensorExt::DispatchTensorType::get(
-                  dispatchTensorType.getAccess(), convertedBoundType);
-            })
+        .Case([&](IREE::TensorExt::DispatchTensorType dispatchTensorType) {
+          Type boundType = dispatchTensorType.getBoundType();
+          Type convertedBoundType = convertType(attr, boundType);
+          if (convertedBoundType == boundType) {
+            return dispatchTensorType;
+          }
+          return IREE::TensorExt::DispatchTensorType::get(
+              dispatchTensorType.getAccess(), convertedBoundType);
+        })
         .Default([&](auto concreteType) { return concreteType; });
   }
 


### PR DESCRIPTION
The revision refactors type converter access patterns in MLIR conversion patterns to use the templated `getTypeConverter<T>()` method instead of `static_cast`, and simplifies `TypeSwitch` calls by removing unnecessary `.template Case<>` syntax.

Key changes:
- Replaced manual `static_cast` patterns with the safer templated `getTypeConverter<MaterializeEncodingTypeConverter>()` method
- Simplified `TypeSwitch` syntax from `.template Case<Type>` to `.Case` with explicit parameter types
- Removed unnecessary trailing whitespace and improved code formatting