### PR TITLE
[DT][NFCI] Use no-rollback driver for MaterializeEncoding passes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -151,7 +151,10 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     typeConverter.addTargetMaterialization(castFnArguments);
     typeConverter.addSourceMaterialization(castFnArguments);
 
-    if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
+    mlir::ConversionConfig config;
+    config.allowPatternRollback = false;
+    if (failed(applyPartialConversion(funcOp, target, std::move(patterns),
+                                      config))) {
       return funcOp.emitOpError("materialization failed");
     }
 


### PR DESCRIPTION
No-rollback driver is usually more efficient and debugging friendly, as the state is cleaner. The author of the revision already uses it in some debugging, and it is helpful in terms of debugging messages.

See https://discourse.llvm.org/t/rfc-a-new-one-shot-dialect-conversion-driver for more details.

Fixes https://github.com/iree-org/iree/issues/22452