### PR TITLE
[ci] Remove gh installation for mi325 ci

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi325.yml
+++ b/.github/workflows/pkgci_test_amd_mi325.yml
@@ -43,11 +43,6 @@ jobs:
         with:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
-      - name: Install dependencies
-        if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         if: ${{ inputs.artifact_run_id == '' }}
         with:


### PR DESCRIPTION
setup_venv.py doesn't need gh cli after https://github.com/iree-org/iree/pull/22211