### PR TITLE
Update Lit test checks caused by upstream fcf79e5

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -58,14 +58,11 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:     %[[WG_TARGET:.+]] = memref.subview %[[ARG2]]
 //       CHECK:     %[[TID_X:.+]] = gpu.thread_id x
 //       CHECK:     %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK:     %[[TID_Y:.+]] = gpu.thread_id y
-//       CHECK:     %[[DIM_Y:.+]] = gpu.block_dim y
-//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:         %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][%[[IV_Y]], %[[IV_X]]] [1, 1] [1, 1]
-//       CHECK:         %[[T_INDEX:.+]] = memref.subview %[[WG_INDEX]][%[[IV_Y]], 0] [1, 1] [1, 1]
-//       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
-//       CHECK:         iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
-//  CHECK-SAME:           ins(%[[T_UPDATE]], %[[T_INDEX]]
-//  CHECK-SAME:           outs(%[[T_TARGET]]
+//       CHECK:     scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:       %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][0, %[[IV_X]]] [1, 1] [1, 1]
+//       CHECK:       %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
+//       CHECK:       %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
+//       CHECK:       iree_linalg_ext.scatter
+//  CHECK-SAME:         unique_indices(true)
+//  CHECK-SAME:         ins(%[[T_UPDATE]], %[[T_INDEX]]
+//  CHECK-SAME:         outs(%[[T_TARGET]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
@@ -50,11 +50,10 @@ util.func public @layoutDynamic(%size_a: index, %size_b: index) -> (index, index
   // CHECK-DAG: %c0 = arith.constant 0 : index
   // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
-  // CHECK-DAG: %1 = arith.addi %0, %c0 : index
-  // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index
-  // CHECK-DAG: %3 = arith.addi %1, %2 : index
+  // CHECK-DAG: %1 = util.align %[[SIZE_B]], %c16 : index
+  // CHECK-DAG: %2 = arith.addi %0, %1 : index
 
-  // CHECK: util.return %3, %c0, %1, %c0
+  // CHECK: util.return %2, %c0, %0, %c0
   util.return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
 }
 
@@ -82,8 +81,8 @@ util.func public @layoutMixedStaticDynamic(%size_a: index, %size_b: index) -> (i
   }) : index
 
   // CHECK-DAG: %c0 = arith.constant 0 : index
-  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %c208 = arith.constant 208 : index
+  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
   // CHECK-DAG: %1 = arith.addi %0, %c208 : index
   // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index


### PR DESCRIPTION
This patch is required for dropping the revert of:                                                                                                                     https://github.com/llvm/llvm-project/commit/fcf79e5276299c351b924f7a08f6c3c6a6c6a1ee

Closes https://github.com/iree-org/iree/issues/22171