### PR TITLE
[Codegen][GPU] Allow intentional padding for non-K-major matmul layouts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -646,13 +646,14 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   Type lhsElemType = getElementTypeOrSelf(lhs);
   Type rhsElemType = getElementTypeOrSelf(rhs);
   Type initElemType = getElementTypeOrSelf(init);
-  // TODO (nirvedhmeshram): We only voluntarily allow padded configurations
-  // for tranpose_b layouts as that's where we currently don't have any overhead
-  // for padding. Other layouts still can have overhead and once we fix the root
-  // causes for that we can relax this condition.
+  // We only disallow padded configurations for K-major layouts ([K,M] × [K,N])
+  // where transposedLhs=true and transposedRhs=false. Experiments have shown
+  // that allowing padding for other layout variants (NN, NT, TT) provides
+  // decent performance improvements. Once we fix the root causes for padding
+  // overhead in K-major layouts, we can allow padding for K-major layouts.
   GPUMatmulShapeType problem{
-      getDimBounds(mDims, transposedLhs || !transposedRhs),
-      getDimBounds(nDims, transposedLhs || !transposedRhs),
+      getDimBounds(mDims, transposedLhs && !transposedRhs),
+      getDimBounds(nDims, transposedLhs && !transposedRhs),
       getDimBoundsNoPad(kDims),
       getDimBoundsNoPad(batchDims),
       lhsElemType,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -208,19 +208,26 @@ func.func @conv_chwn_chwf_unaligned_batch(%arg0: tensor<16x193x129x40xbf16>, %ar
 }
 
 // CHECK-LABEL: func.func @conv_chwn_chwf_unaligned_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
-//  CHECK-SAME:     padding = [16, 1, 1, 16, 128]
-//  CHECK-SAME:     promote_operands = [0, 1]
-//  CHECK-SAME:     reduction = [0, 0, 0, 0, 8]
-//  CHECK-SAME:     subgroup = [1, 1, 1, 1, 0]
-//  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0]
 
-// PAD-CONV-GFX942:     padding_conv =  [0, 0, 0, 16, 0, 0, 0]
+// GFX942-SAME:     padding = [64, 1, 1, 64, 128]
+// GFX942-SAME:     promote_operands = [0, 1]
+// GFX942-SAME:     reduction = [0, 0, 0, 0, 8]
+// GFX942-SAME:     subgroup = [2, 1, 1, 1, 0]
+// GFX942-SAME:     workgroup = [64, 1, 1, 64, 0]
+
+// MI300X-SAME:     padding = [32, 1, 1, 64, 128]
+// MI300X-SAME:     promote_operands = [0, 1]
+// MI300X-SAME:     reduction = [0, 0, 0, 0, 8]
+// MI300X-SAME:     subgroup = [1, 1, 1, 1, 0]
+// MI300X-SAME:     workgroup = [32, 1, 1, 64, 0]
+
+// PAD-CONV-GFX942:     padding_conv =  [0, 0, 0, 64, 0, 0, 0]
 
 // -----
 
@@ -318,8 +325,8 @@ func.func @conv_chwn_chwf_aligned_batch(%arg0: tensor<2x192x128x48xbf16>, %arg1:
 }
 
 //         CHECK-LABEL:  func.func @conv_chwn_chwf_aligned_batch
-//     PAD-CONV-GFX942:     padding = [16, 1, 1, 16, 16]
-// PAD-CONV-GFX942-NOT:     padding_conv
+//     PAD-CONV-GFX942:     padding = [64, 1, 1, 64, 16]
+//     PAD-CONV-GFX942:     padding_conv = [0, 0, 0, 64, 0, 0, 0]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_igemm_tile_and_fuse.mlir
@@ -208,26 +208,19 @@ func.func @conv_chwn_chwf_unaligned_batch(%arg0: tensor<16x193x129x40xbf16>, %ar
 }
 
 // CHECK-LABEL: func.func @conv_chwn_chwf_unaligned_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false
 //  CHECK-SAME:   use_igemm_convolution = true
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>
+//  CHECK-SAME:     padding = [16, 1, 1, 16, 128]
+//  CHECK-SAME:     promote_operands = [0, 1]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 8]
+//  CHECK-SAME:     subgroup = [1, 1, 1, 1, 0]
+//  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0]
 
-// GFX942-SAME:     padding = [64, 1, 1, 64, 128]
-// GFX942-SAME:     promote_operands = [0, 1]
-// GFX942-SAME:     reduction = [0, 0, 0, 0, 8]
-// GFX942-SAME:     subgroup = [2, 1, 1, 1, 0]
-// GFX942-SAME:     workgroup = [64, 1, 1, 64, 0]
-
-// MI300X-SAME:     padding = [32, 1, 1, 64, 128]
-// MI300X-SAME:     promote_operands = [0, 1]
-// MI300X-SAME:     reduction = [0, 0, 0, 0, 8]
-// MI300X-SAME:     subgroup = [1, 1, 1, 1, 0]
-// MI300X-SAME:     workgroup = [32, 1, 1, 64, 0]
-
-// PAD-CONV-GFX942:     padding_conv =  [0, 0, 0, 64, 0, 0, 0]
+// PAD-CONV-GFX942:     padding_conv =  [0, 0, 0, 16, 0, 0, 0]
 
 // -----
 
@@ -325,8 +318,8 @@ func.func @conv_chwn_chwf_aligned_batch(%arg0: tensor<2x192x128x48xbf16>, %arg1:
 }
 
 //         CHECK-LABEL:  func.func @conv_chwn_chwf_aligned_batch
-//     PAD-CONV-GFX942:     padding = [64, 1, 1, 64, 16]
-//     PAD-CONV-GFX942:     padding_conv = [0, 0, 0, 64, 0, 0, 0]
+//     PAD-CONV-GFX942:     padding = [16, 1, 1, 16, 16]
+// PAD-CONV-GFX942-NOT:     padding_conv
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -304,12 +304,12 @@ func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x8x577xf32>, %r
 }
 
 // CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 // CHECK:         linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:     reduction = [0, 0, 0, 1]
-// CHECK-SAME:     subgroup = [0, 1, 1, 0]
-// CHECK-SAME:     workgroup = [1, 16, 16, 0]
+// CHECK-SAME:     subgroup = [0, 1, 2, 0]
+// CHECK-SAME:     workgroup = [1, 16, 64, 0]
 
 // -----
 
@@ -409,14 +409,14 @@ func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(%lhs : tensor<12x5
 // schedule with nTileSize of 16 while in reality it should be 8.
 
 // CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul_tiling_check
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 // CHECK:         linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
-// CHECK-SAME:      padding = [1, 16, 64, 4]
+// CHECK-SAME:      padding = [1, 64, 128, 4]
 // CHECK-SAME:      promote_operands = [0, 1]
 // CHECK-SAME:      reduction = [0, 0, 0, 1]
-// CHECK-SAME:      subgroup = [0, 1, 2, 0]
-// CHECK-SAME:      workgroup = [1, 16, 64, 0]
+// CHECK-SAME:      subgroup = [0, 2, 4, 0]
+// CHECK-SAME:      workgroup = [1, 64, 128, 0]
 
 // -----
 


### PR DESCRIPTION
Only disallow intentional padding for K-major layouts ([K,M] × [K,N]) where transposedLhs=true and transposedRhs=false. Experiments have shown that allowing padding for other layout variants (NN, NT, TT) provides decent performance improvements.

This has improved 2.69% of GEMMs from 322 GEMMs we track. In particular, the biggest improvements comes from the cases that would have been excluded because we used to only allow [M, K] [N, K] layouts:

> hipblaslt-bench   --api_method c -m 16384 -n 150000 -k 4096 --lda 16384 --ldb 4096 --ldc 16384   --ldd 16384  --stride_a 0 --stride_b 0   --stride_c 0 --stride_d 0  --alpha   1.000000 --beta 0.000000 --transA N --transB N --batch_count 1  --a_type bf16_r --b_type bf16_r --c_type   bf16_r --d_type bf16_r --scale_type f32_r --bias_type f32_r   --compute_type f32_r

Improved by 79%, from 235860 to 50129 us

> hipblaslt-bench --api_method c   -m 8192 -n 150000 -k 2048 --lda 8192 --ldb 2048 --ldc 8192 --ldd 8192  --stride_a 0 --stride_b 0 --stride_c 0   --stride_d 0  --alpha 1.000000 --beta   0.000000 --transA N --transB N --batch_count 1  --a_type bf16_r --b_type bf16_r --c_type   bf16_r --d_type bf16_r --scale_type f32_r --bias_type f32_r   --compute_type f32_r

Improved by 77%, from 54707 to 12549 us

> hipblaslt-bench --api_method c   -m 4096 -n 150000 -k 16384 --lda 4096 --ldb 16384 --ldc 4096 --ldd 4096  --stride_a 0 --stride_b 0 --stride_c 0   --stride_d 0  --alpha 1.000000 --beta   0.000000 --transA N --transB N --batch_count 1  --a_type bf16_r --b_type bf16_r --c_type   bf16_r --d_type bf16_r --scale_type f32_r --bias_type f32_r   --compute_type f32_r

Improved by 77% from 229361 to 52979 us
