### PR TITLE
Bump LLVM to llvm/llvm-project@03e66ae

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyPaddingLevel.cpp
@@ -114,6 +114,8 @@ static LogicalResult applyPaddingLevel(RewriterBase &rewriter,
   SmallVector<OpFoldResult> padSizes =
       getAsIndexOpFoldResult(rewriter.getContext(), tileSizes);
 
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfter(tilingInterfaceOp);
   FailureOr<SmallVector<Value>> result =
       tensorMaskingOp.getMaskedImplementation(rewriter, padSizes);
   if (failed(result)) {


### PR DESCRIPTION
Still carrying two remaining reverts as https://github.com/iree-org/iree/pull/22366

The explicit cherry-pick of https://github.com/llvm/llvm-project/commit/41f65666f6378bba7266be7c662c70074f04ed75 has been dropped since it’s now included in the new LLVM bump

Fix insertion point as https://github.com/llvm/llvm-project/commit/57a0bf46ffdab3ae2cbab7cb593ebb90561f7b8e

ci-extra: test_torch