### PR TITLE
[DispatchCreation] Enable splitting multiple reduction dimensions for weight backward convs

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -176,8 +176,10 @@ private:
       return std::nullopt;
     }
 
-    if (convDims->inputChannel.empty() || convDims->outputChannel.empty() ||
-        convDims->batch.empty() || convDims->filterLoop.empty()) {
+    // Require non-empty filter, output channel, and batch dimensions to derive
+    // heuristics. The input channel dimension may be empty.
+    if (convDims->outputChannel.empty() || convDims->batch.empty() ||
+        convDims->filterLoop.empty()) {
       LDBG() << "skipping op; missing convolution dimensions";
       return std::nullopt;
     }
@@ -208,27 +210,43 @@ private:
     AffineMap filterMap = linalgOp.getMatchingIndexingMap(filter);
     AffineMap outputMap = linalgOp.getMatchingIndexingMap(output);
 
-    std::optional<int64_t> batchLastDim = outputMap.getResultPosition(
-        getAffineDimExpr(convDims->batch.back(), outputMap.getContext()));
-    if (!batchLastDim || batchLastDim.value() != outputShape.size() - 1) {
+    auto getDimPositions = [&](ArrayRef<unsigned> dims, const AffineMap &map) {
+      SmallVector<int64_t> positions;
+      for (auto dim : dims) {
+        for (auto [idx, e] : llvm::enumerate(map.getResults())) {
+          if (e.isFunctionOfDim(dim)) {
+            positions.push_back(idx);
+          }
+        }
+      }
+      llvm::sort(positions);
+      return positions;
+    };
+
+    SmallVector<int64_t> batchPos = getDimPositions(convDims->batch, outputMap);
+    SmallVector<int64_t> outputChannelPos =
+        getDimPositions(convDims->outputChannel, outputMap);
+    SmallVector<int64_t> outputImagePos =
+        getDimPositions(convDims->outputImage, outputMap);
+    SmallVector<int64_t> inputChannelPos =
+        getDimPositions(convDims->inputChannel, filterMap);
+    SmallVector<int64_t> filterPos =
+        getDimPositions(convDims->filterLoop, filterMap);
+    SmallVector<int64_t> depthPos = getDimPositions(convDims->depth, outputMap);
+
+    if (outputChannelPos.empty() || batchPos.empty() || filterPos.empty()) {
+      LDBG() << "skipping op; failed to get dim position from the map";
+      return std::nullopt;
+    }
+
+    if (batchPos.back() != outputShape.size() - 1) {
       LDBG() << "skipping op; not batch last layout";
       return std::nullopt;
     }
 
-    std::optional<int64_t> inputChannelDim = filterMap.getResultPosition(
-        getAffineDimExpr(convDims->inputChannel[0], filterMap.getContext()));
-    std::optional<int64_t> filterDim = filterMap.getResultPosition(
-        getAffineDimExpr(convDims->filterLoop[0], filterMap.getContext()));
-    if (!inputChannelDim || !filterDim ||
-        inputChannelDim.value() > filterDim.value()) {
+    if (!inputChannelPos.empty() &&
+        inputChannelPos.front() > filterPos.back()) {
       LDBG() << "skipping op; not channel first layout";
-      return std::nullopt;
-    }
-
-    std::optional<int64_t> outputChannelDim = outputMap.getResultPosition(
-        getAffineDimExpr(convDims->outputChannel[0], outputMap.getContext()));
-    if (!outputChannelDim) {
-      LDBG() << "skipping op; has no output channel dim";
       return std::nullopt;
     }
 
@@ -239,6 +257,20 @@ private:
       return std::nullopt;
     }
 
+    // Compute the product of the specified dimensions. If any dimension list is
+    // empty, return 1.
+    auto getSizeAt = [](ArrayRef<int64_t> shape, ArrayRef<int64_t> pos) {
+      int64_t totalSize = 1;
+      for (unsigned i : pos)
+        totalSize *= shape[i];
+      return totalSize;
+    };
+
+    int64_t outputChannelSize = getSizeAt(outputShape, outputChannelPos);
+    int64_t batchSize = getSizeAt(outputShape, batchPos);
+    int64_t imageSize = getSizeAt(outputShape, outputImagePos);
+    int64_t depthSize = getSizeAt(outputShape, depthPos);
+
     // The constants below are determined based on empirical data.
     const int64_t largeDimSize = 512;
     const int64_t mediumDimSize = 128;
@@ -247,8 +279,6 @@ private:
     // When the batch and output channel sizes are large, the workload tends
     // to distributed across many workgroups, making split reduction little to
     // no effect.
-    int64_t outputChannelSize = outputShape[outputChannelDim.value()];
-    int64_t batchSize = outputShape[batchLastDim.value()];
     if (outputChannelSize >= largeDimSize && batchSize >= largeDimSize) {
       LDBG() << "skipping op; large output channel or batch size";
       return std::nullopt;
@@ -267,15 +297,43 @@ private:
       }
     }
 
-    // Only split along the input channel dimension.
-    // TODO(vivian): split more reduction dimensions if needed.
-    int64_t cDim = inputChannelDim.value();
+    // Tile sizes are determined based on output (parallel dimension) sizes.
+    // For larger outputs, the workload tends to be distributed across more
+    // workgroups, thereby reducing the need for extensive splitting along the
+    // reduction dimensions.
     SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
-    if (tileSizes[cDim] == 1) {
-      LDBG() << "skipping op; input channel size equals to 1";
-      return std::nullopt;
+    int64_t outputSize = outputChannelSize * batchSize * imageSize * depthSize;
+    int64_t limitParallelLoops;
+    if (outputSize < 32 * 32) {
+      limitParallelLoops = 2048;
+    } else if (outputSize < 128 * 128) {
+      limitParallelLoops = 128;
+    } else if (outputSize < 256 * 256) {
+      limitParallelLoops = 64;
+    } else if (outputSize < 512 * 512) {
+      limitParallelLoops = 16;
+    } else {
+      limitParallelLoops = std::min<int64_t>(16, tileSizes[0]);
     }
-    tileSizes[cDim] = std::ceil(float(tileSizes[cDim]) / largeDimSize);
+
+    // Based on the limitParallelLoops, assign tile size from the outermost
+    // dimension to the innermost.
+    for (int64_t i = 0; i < tileSizes.size(); i++) {
+      int64_t lowerBound = llvm::divideCeil(tileSizes[i], limitParallelLoops);
+      std::optional<int64_t> maybeTileSize =
+          findSmallestFactorWithLowerBound(tileSizes[i], lowerBound);
+      if (!maybeTileSize) {
+        LDBG() << "skipping op; failed to find a split factor";
+        return std::nullopt;
+      }
+      limitParallelLoops /= (tileSizes[i] / maybeTileSize.value());
+      tileSizes[i] = maybeTileSize.value();
+      // If the outer tile size is larger than 1, inner dimensions cannot be
+      // split due to non-contiguous data.
+      if (tileSizes[i] > 1) {
+        break;
+      }
+    }
     return tileSizes;
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -213,11 +213,8 @@ private:
     auto getDimPositions = [&](ArrayRef<unsigned> dims, const AffineMap &map) {
       SmallVector<int64_t> positions;
       for (auto dim : dims) {
-        for (auto [idx, e] : llvm::enumerate(map.getResults())) {
-          if (e.isFunctionOfDim(dim)) {
-            positions.push_back(idx);
-          }
-        }
+        positions.push_back(
+            *map.getResultPosition(getAffineDimExpr(dim, map.getContext())));
       }
       llvm::sort(positions);
       return positions;
@@ -261,8 +258,10 @@ private:
     // empty, return 1.
     auto getSizeAt = [](ArrayRef<int64_t> shape, ArrayRef<int64_t> pos) {
       int64_t totalSize = 1;
-      for (unsigned i : pos)
+      for (unsigned i : pos) {
+        assert(!ShapedType::isDynamic(shape[i]));
         totalSize *= shape[i];
+      }
       return totalSize;
     };
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
@@ -1,9 +1,29 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-split-reduction-sizes))" --split-input-file %s | FileCheck %s
 
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d5, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+module {
+  util.func public @conv_1d_chn_chf(%arg0: tensor<16x50x32x96xf32>, %arg1: tensor<16x48x32x96xf32>, %arg2: tensor<96x3x96xf32>) -> tensor<96x3x96xf32> {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x50x32x96xf32>, tensor<16x48x32x96xf32>) outs(%arg2 : tensor<96x3x96xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %1 = arith.mulf %in, %in_0 : f32
+      %2 = arith.addf %out, %1 : f32
+      linalg.yield %2 : f32
+    } -> tensor<96x3x96xf32>
+    util.return %0 : tensor<96x3x96xf32>
+  }
+}
+
+// CHECK-LABEL: @conv_1d_chn_chf
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 12 : index, 32 : index]
+
+// -----
+
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x227x227x16xf32>, %arg1: tensor<16x225x225x64xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
+util.func public @conv_2d_chwn_chwf_large(%arg0: tensor<16x227x227x16xf32>, %arg1: tensor<16x225x225x64xf32>, %arg2: tensor<64x3x3x16xf32>) -> tensor<64x3x3x16xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x227x227x16xf32>, tensor<16x225x225x64xf32>) outs(%arg2 : tensor<64x3x3x16xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
@@ -13,8 +33,8 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x227x227x16xf32>, %arg1: ten
   util.return %0 : tensor<64x3x3x16xf32>
 }
 
-// CHECK-LABEL: @conv_2d_chwn_chwf
-//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 225 : index, 225 : index]
+// CHECK-LABEL: @conv_2d_chwn_chwf_large
+//       CHECK: iree_linalg_ext.split_reduction = [1 : index, 45 : index, 225 : index]
 
 // -----
 


### PR DESCRIPTION
This PR is a follow-up for https://github.com/iree-org/iree/pull/22275. It removes the constraint that only splitting input channel dimension, and added support to split across multiple dimensions. The heuristics for setting multi-dimension tile sizes is similar to what is for GEMM https://github.com/iree-org/iree/pull/22357. More than half of the tracked weight backward shapes are benefiting from this change.

Example runtime comparison for
`convbfp16 -n 16 -c 16 -H 225 -W 225 -k 64 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100`

- Without split reduction: 19352.8 ms
- Split only the input channel dimension: 1445.1 ms
- Split multiple reduction dimensions: 371.7 ms