### PR TITLE
[Dispatch Creation] Drop unit dims from tensor.extract ops

### DIFF
--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O0.json
@@ -346,6 +346,7 @@
     "onnx/node/generated/test_reduce_sum_empty_set_non_reduced_axis_zero",
     "onnx/node/generated/test_resize_downsample_scales_cubic_align_corners",
     "onnx/node/generated/test_resize_downsample_scales_linear_align_corners",
+    "onnx/node/generated/test_reversesequence_time",
     "onnx/node/generated/test_scan_sum",
     "onnx/node/generated/test_sce_mean_weight",
     "onnx/node/generated/test_sce_mean_weight_ii",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
@@ -352,6 +352,7 @@
     "onnx/node/generated/test_reduce_sum_empty_set_non_reduced_axis_zero",
     "onnx/node/generated/test_resize_downsample_scales_cubic_align_corners",
     "onnx/node/generated/test_resize_downsample_scales_linear_align_corners",
+    "onnx/node/generated/test_reversesequence_time",
     "onnx/node/generated/test_scan_sum",
     "onnx/node/generated/test_sce_mean_weight",
     "onnx/node/generated/test_sce_mean_weight_ii",


### PR DESCRIPTION
Adds pattern for `tensor.extract` to fold unit dimensions. Without this pattern there will be reshapes left in the program which may re-introduce the unit dims when propagated.

The added xfail already has an issue https://github.com/iree-org/iree/issues/20011.