### PR TITLE
Integrate torch-mlir at llvm/torch-mlir@288cd5e8adb

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -134,6 +134,12 @@ static TypedAttr tryNarrowPatternBits(TypedAttr patternAttr) {
     return patternAttr;
   }
 
+  // Don't handle values <= 8 bits. We are narrowing to a minimum of 8-bits and
+  // we don't have signedness information to know how to extend them.
+  if (oldPattern.getBitWidth() <= 8) {
+    return patternAttr;
+  }
+
   // Try narrowing the pattern.
   auto newPattern = computeRequiredPatternBits(oldPattern);
   if (newPattern.getBitWidth() == oldPattern.getBitWidth())

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -174,6 +174,17 @@ util.func private @NarrowSplatPatternF32() -> !stream.resource<*> {
 
 // -----
 
+// CHECK-LABEL: @NoNarrowSplatPatternI1
+util.func private @NoNarrowSplatPatternI1() -> !stream.resource<*> {
+  %c100 = arith.constant 100 : index
+  %pattern = arith.constant true
+  // CHECK: stream.tensor.splat %true : i1
+  %0 = stream.tensor.splat %pattern : i1 -> tensor<2x2xi1> in !stream.resource<*>{%c100}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @FoldTensorCloneOp
 util.func private @FoldTensorCloneOp(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
   // CHECK-NOT: stream.tensor.clone


### PR DESCRIPTION
Carries cherry-pick https://github.com/iree-org/torch-mlir/commit/42dff729680d5d4da1bdd6968ca18593f4438add (WIP PR https://github.com/llvm/torch-mlir/pull/4358)


Fixes ONNX failure related to i1 tensors.