### PR TITLE
[CI] Make rdna3 runner requirements more fine-grained

### DIFF
--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_w7900:
-    runs-on: iree-w7900x2
+    runs-on: iree-w7900
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_w7900:
-    runs-on: iree-w7900
+    runs-on: [Linux, X64, iree-w7900]
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -46,11 +46,11 @@ jobs:
           - name: amdgpu_hip_rdna3_O3
             numprocesses: 1
             config-file: onnx_ops_gpu_hip_rdna3_O3.json
-            runs-on: iree-w7900x2
+            runs-on: [Linux, X64, gfx1100]
           - name: amdgpu_vulkan_O0
             numprocesses: 4
             config-file: onnx_ops_gpu_vulkan_O0.json
-            runs-on: iree-w7900x2
+            runs-on: [Linux, X64, rdna3]
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster
@@ -153,10 +153,10 @@ jobs:
           # AMD GPU
           - name: amdgpu_hip_rdna3
             config-file: onnx_models_gpu_hip_rdna3.json
-            runs-on: iree-w7900x2
+            runs-on: [Linux, X64, gfx1100, persistent-cache]
           - name: amdgpu_vulkan
             config-file: onnx_models_gpu_vulkan.json
-            runs-on: iree-w7900x2
+            runs-on: [Linux, X64, rdna3, persistent-cache]
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -171,7 +171,7 @@ jobs:
           - name: rocm_hip_w7900
             rocm-chip: gfx1100
             target: target_hip
-            runs-on: iree-w7900x2
+            runs-on: [Linux, X64, iree-w7900x2, persistent-cache]
     env:
       VENV_DIR: ${{ github.workspace }}/venv
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages


### PR DESCRIPTION
I added more fine-grained labels to our runners with different levels of granularity, so that our tests can pick any runner that's suitable for running them, and reduce dependency on a specific runner being available.

For example, these are the labels for the `shark10-ci` runner, from most to least specific:
* `shark10-ci` -- matches the machine hostname
* `iree-w7900x2` -- self-hosted IREE CI machine with two W7900 GPUs
* `iree-w7900` -- self-hosted IREE CI machine with at least one W7900 GPU
* `gfx1100` -- machine with a GPU with the gfx1100 target
* `rdna3` -- machine with any rdna3-series GPU
* `threadripper` -- machine with a Threadripper CPU
* `zen4` -- machine with any zen4 CPU
* `X64` -- machine with an X64 CPU
* `Linux` -- linux host OS
* `persistent-cache` -- machine with a persistent cache for model files in `$HOME/iree_tests_cache`

Most of the tests don't need the two-gpu configuration, or even a specific GPU SKU. This PR relaxes the CI job requirements so that any suitable runner can pick those up.
