### PR TITLE
Implement `subgroups_k` in data-tiled MMA layouts

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMUkernelBitcodeSupport.cpp
@@ -221,6 +221,10 @@ static std::optional<int64_t> expensivelyEvaluateSharedMemoryBytes(
         "Bitcode does not contain a function named {}.", queryFuncName));
     return {};
   }
+  if (mma.getSubgroupsK() != 1) {
+    // SubgroupsK not supported by current bitcode ukernels.
+    return {};
+  }
   auto constI32 = [](int32_t val) {
     llvm::GenericValue v;
     v.IntVal = APInt(32, val);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -46,11 +46,12 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, TileSwizzle::Dim dim) {
-  if (dim.size == dim.distributionSize) {
-    return os << dim.size << "(" << dim.kind << ")";
+  if (dim.size != dim.distributionSize &&
+      dim.kind == TileSwizzle::Dim::Kind::CrossThread) {
+    return os << dim.size << "|" << dim.distributionSize << "(" << dim.kind
+              << ")";
   }
-  return os << dim.size << "|" << dim.distributionSize << "(" << dim.kind
-            << ")";
+  return os << dim.size << "(" << dim.kind << ")";
 }
 
 static llvm::raw_ostream &

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -820,7 +820,8 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
 }
 
 int64_t DataTiledMMAAttr::getFlatWorkgroupSize() const {
-  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN();
+  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN() *
+         getSubgroupsK();
 }
 
 /// Increment the mutable vector `indices` to traverse the index space below
@@ -972,7 +973,7 @@ IREE::Codegen::TileMxNxKxKb DataTiledMMAAttr::getTileMNKKb() const {
       getMNKShapeFromIntrinsic(getIntrinsic());
   innerTile.M *= getIntrinsicsM() * getSubgroupsM();
   innerTile.N *= getIntrinsicsN() * getSubgroupsN();
-  innerTile.K *= getIntrinsicsK();
+  innerTile.K *= getIntrinsicsK() * getSubgroupsK();
   return innerTile;
 }
 
@@ -1584,7 +1585,7 @@ IREE::Codegen::TileMxNxKxKb DataTiledScaledMMAAttr::getTileMNKKb() const {
       getMNKKbShapeFromScaledIntrinsic(getIntrinsic());
   innerTile.M *= getIntrinsicsM() * getSubgroupsM();
   innerTile.N *= getIntrinsicsN() * getSubgroupsN();
-  innerTile.K *= getIntrinsicsK();
+  innerTile.K *= getIntrinsicsK() * getSubgroupsK();
   return innerTile;
 }
 
@@ -1741,7 +1742,8 @@ int64_t DataTiledScaledMMAAttr::getSubgroupSize() const {
 }
 
 int64_t DataTiledScaledMMAAttr::getFlatWorkgroupSize() const {
-  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN();
+  return getSubgroupSize() * getSubgroupsM() * getSubgroupsN() *
+         getSubgroupsK();
 }
 
 LogicalResult

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -368,14 +368,25 @@ def IREEGPU_DataTiledMMAAttr :
 
   let assemblyFormat = "`<` struct(params) `>`";
 
-  let parameters = (ins
-    EnumParameter<IREEGPU_MMAIntrinsic>:$intrinsic,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the M dimension.">:$intrinsics_m,
-    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the M dimension.">:$subgroups_m,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the N dimension.">:$intrinsics_n,
-    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the N dimension.">:$subgroups_n,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the K dimension, with interleaved layout.">:$intrinsics_k
-  );
+  let parameters = (ins EnumParameter<IREEGPU_MMAIntrinsic>:$intrinsic,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Intrinsic count along the M dimension.">:$intrinsics_m,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the M dimension.">:$subgroups_m,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Intrinsic count along the N dimension.">:$intrinsics_n,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the N dimension.">:$subgroups_n,
+      DefaultValuedParameter<"int64_t", "1",
+                             "Intrinsic count along the K dimension, with "
+                             "interleaved layout.">:$intrinsics_k,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the K dimension.">:$subgroups_k);
 }
 
 def IREEGPU_DataTiledScaledMMAAttr :
@@ -414,17 +425,27 @@ def IREEGPU_DataTiledScaledMMAAttr :
 
   let assemblyFormat = "`<` struct(params) `>`";
 
-  let parameters = (ins
-    EnumParameter<IREEGPU_ScaledMMAIntrinsic>:$intrinsic,
-    "::mlir::Type":$lhs_elem_type,
-    "::mlir::Type":$rhs_elem_type,
-    "::mlir::Type":$acc_elem_type,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the M dimension.">:$intrinsics_m,
-    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the M dimension.">:$subgroups_m,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the N dimension.">:$intrinsics_n,
-    DefaultValuedParameter<"int64_t", "1", "Subgroup count along the N dimension.">:$subgroups_n,
-    DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the K dimension, with interleaved layout.">:$intrinsics_k
-  );
+  let parameters = (ins EnumParameter<IREEGPU_ScaledMMAIntrinsic>:$intrinsic,
+      "::mlir::Type":$lhs_elem_type, "::mlir::Type":$rhs_elem_type,
+      "::mlir::Type":$acc_elem_type,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Intrinsic count along the M dimension.">:$intrinsics_m,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the M dimension.">:$subgroups_m,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Intrinsic count along the N dimension.">:$intrinsics_n,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the N dimension.">:$subgroups_n,
+      DefaultValuedParameter<"int64_t", "1",
+                             "Intrinsic count along the K dimension, with "
+                             "interleaved layout.">:$intrinsics_k,
+      DefaultValuedParameter<
+                        "int64_t", "1",
+                        "Subgroup count along the K dimension.">:$subgroups_k);
 }
 
 def IREEGPU_VirtualMMAIntrinsicAttr

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -73,6 +73,16 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_m = 2>
 
 module {
+  func.func @test_data_tiled_mfma_f32_16x16x4_f32_subgroups_k() attributes {
+      mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_k = 2>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_mfma_f32_16x16x4_f32
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_k = 2>
+
+
+module {
   func.func @test_data_tiled_mfma_f32_16x16x16_f16() attributes {
       mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_F16, intrinsics_m = 1, subgroups_n = 2, intrinsics_k = 2>} {
     return

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -290,6 +290,10 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   int subgroupsN = *wgp.getSimdsPerWgp();
   int intrinsicsM = totalUnrollM / subgroupsM;
   int intrinsicsN = totalUnrollN / subgroupsN;
+  // We currently never generate subgroupsK != 1, as subgroupsK requires
+  // specific partial-accumulator-reduction in the kernel, currently only done
+  // in some microkernels that would provide their own DataTiledMMAAttr.
+  int subgroupsK = 1;
 
   //
   // Step 3: Adjust the unrolling factors when there is a narrow dimension.
@@ -312,14 +316,14 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   if (auto intrinsicMma = dyn_cast<MMAAttr>(intrinsicAttr)) {
     return DataTiledMMAAttr::get(ctx, intrinsicMma.getIntrinsic(), intrinsicsM,
                                  subgroupsM, intrinsicsN, subgroupsN,
-                                 intrinsicsK);
+                                 intrinsicsK, subgroupsK);
   }
   auto intrinsicScaledMma = cast<ScaledMMAAttr>(intrinsicAttr);
   return DataTiledScaledMMAAttr::get(
       ctx, intrinsicScaledMma.getIntrinsic(),
       intrinsicScaledMma.getLhsElemType(), intrinsicScaledMma.getRhsElemType(),
       intrinsicScaledMma.getAccElemType(), intrinsicsM, subgroupsM, intrinsicsN,
-      subgroupsN, intrinsicsK);
+      subgroupsN, intrinsicsK, subgroupsK);
 }
 
 static Operation *lowerContractionOrScaledContractionOpToInnerTiledOp(


### PR DESCRIPTION
Fixes #22206.

The motivation is that subgroups_k is something that some non-data-tiled ukernels already do, so this should unblock having data-tiled kernels doing the same:
https://github.com/qedawkins/iree/blob/01d0ff8f6123300af453cc83ac13021e89a3f3f0/compiler/plugins/target/ROCM/builtins/ukernel/mlir/iree_mlir_ukernel_mmt_8x64_f4f4f32_gfx950.mlir#L302

Codegen is not currently able to lower this correctly, so this is ukernel-only for the time being.  It would be nontrivial (though feasible) to teach codegen to do this, so it's not clear if we even want to.
