### PR TITLE
[GPU] Add consumer fusion for GPUApplyTilingLevel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -77,8 +77,9 @@ void GPUApplyTilingLevelPass::runOnOperation() {
       getTiledOps(funcOp, tilingLevel);
 
   IRRewriter rewriter(funcOp);
-  if (failed(applyTileAndFuseToEachRoot(rewriter, targetOps, tilingLevel,
-                                        allowZeroSlices))) {
+  if (failed(applyTileAndFuseToEachRoot(
+          rewriter, targetOps, tilingLevel, allowZeroSlices,
+          /*targetTileMap=*/std::nullopt, fuseConsumers))) {
     funcOp.emitError() << "tiling of level "
                        << IREE::GPU::stringifyEnum(tilingLevel) << " failed\n";
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -356,7 +356,9 @@ def GPUApplyTilingLevelPass :
            /*default=*/"true",
            "Allow pad fusion to generate zero size slices">,
     Option<"normalizeLoops", "normalize-loops", "bool", "false",
-           "Enable normalization for scf loops">
+           "Enable normalization for scf loops">,
+    Option<"fuseConsumers", "fuse-consumers", "bool", /*default=*/"true",
+           "Enable fusing consumers into scf.forall during tiling">
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -271,7 +271,8 @@ LogicalResult applyTileAndFuseToEachRoot(
     IREE::GPU::TilingLevel tilingLevel, bool allowZeroSlices,
     std::optional<
         llvm::SmallDenseMap<TilingInterface, SmallVector<OpFoldResult>>>
-        targetTileMap) {
+        targetTileMap,
+    bool fuseConsumers) {
   MLIRContext *context = rewriter.getContext();
   for (TilingInterface tilingInterfaceOp : payloadOps) {
     mlir::DominanceInfo dominanceInfo(tilingInterfaceOp);
@@ -454,7 +455,8 @@ LogicalResult applyTileAndFuseToEachRoot(
     }
 
     // Consumer fusion for scf.forall ops.
-    if (tilingOptions.loopType == scf::SCFTilingOptions::LoopType::ForallOp) {
+    if (fuseConsumers &&
+        tilingOptions.loopType == scf::SCFTilingOptions::LoopType::ForallOp) {
       FailureOr<std::queue<Operation *>> newFusionOpportunities =
           fuseConsumersIntoForall(
               rewriter, tiledResults->tiledAndFusedOps.getArrayRef(),

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -48,7 +48,8 @@ LogicalResult applyTileAndFuseToEachRoot(
     IREE::GPU::TilingLevel tilingLevel, bool allowZeroSlices,
     std::optional<
         llvm::SmallDenseMap<TilingInterface, SmallVector<OpFoldResult>>>
-        targetTileMap = std::nullopt);
+        targetTileMap = std::nullopt,
+    bool fuseConsumers = true);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -490,6 +490,10 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Thread;
     options.normalizeLoops = pipelineOptions.useIgemmConvolution;
+    // TileAndFuse currently relies on no consumer fusion to order fusion.
+    // Disable consumer fusion to maintain this.
+    // TODO: Fix this by choosing which consumers to fuse to what.
+    options.fuseConsumers = false;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
     funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
@@ -497,6 +501,10 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   {
     GPUApplyTilingLevelPassOptions options;
     options.tilingLevel = IREE::GPU::TilingLevel::Subgroup;
+    // TileAndFuse currently relies on no consumer fusion to order fusion.
+    // Disable consumer fusion to maintain this.
+    // TODO: Fix this by choosing which consumers to fuse to what.
+    options.fuseConsumers = false;
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
   }
   funcPassManager.addPass(IREE::GPU::createDistributeInnerTiledToLanesPass());


### PR DESCRIPTION
This patch adds consumer fusion for scf.forall loop type to GPUApplyPaddingLevel. It uses the existing implementation being used for scf.forall workgroup tile and fuse pass.

This is not enabled for thread/subgroup tiling in TileAndFuse pipeline because TileAndFuse implicitly relies on only producer fusion to ensure ops end up in the correct scf.forall operation.