### PR TITLE
[CodeGen][Tuner] Add bindings to query SIMDs and CUs info

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -158,6 +158,8 @@ struct ireeGPUTargetInfo {
   int32_t maxThreadCountPerWorkgroup; // Max threads per workgroup.
   int32_t maxWorkgroupMemoryBytes;    // Max workgroup memory.
   MlirAttribute mmaIntrinsics;        // MMA Intrinsics.
+  uint32_t wgpCount;                  // Workgroup count (CUs).
+  int32_t simdsPerWgp;                // Optional SIMD num.
 };
 
 // Queries GPU target info from the given `ExecutableTargetAttr` attribute.

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -553,6 +553,14 @@ NB_MODULE(_ireeCompilerDialects, m) {
                    [](const ireeGPUTargetInfo &self) -> int64_t {
                      return self.maxWorkgroupMemoryBytes;
                    })
+      .def_prop_ro("workgroup_count",
+                   [](const ireeGPUTargetInfo &self) -> int64_t {
+                     return self.wgpCount;
+                   })
+      .def_prop_ro("simds_per_workgroup",
+                   [](const ireeGPUTargetInfo &self) -> int64_t {
+                     return self.simdsPerWgp;
+                   })
       .def_prop_ro(
           "mma_intrinsics", [](const ireeGPUTargetInfo &self) -> py::list {
             if (mlirAttributeIsNull(self.mmaIntrinsics) ||

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -446,7 +446,7 @@ def gpu_target_info_attribute_parsing():
 
     arch = gpu_target_info.arch
     assert arch == "gfx942", f"Expected arch 'gfx942', got '{arch}'"
-    
+
     workgroup_count = gpu_target_info.workgroup_count
     simds_per_workgroup = gpu_target_info.simds_per_workgroup
     assert (

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -425,8 +425,10 @@ def gpu_target_info_attribute_parsing():
                     max_workgroup_sizes = [256, 512, 1024],
                     max_thread_count_per_workgroup = 1024,
                     max_workgroup_memory_bytes = 65536,
-                    max_workgroup_counts = [256, 512, 1024]
-                    >
+                    max_workgroup_counts = [256, 512, 1024],
+                    simds_per_wgp = 4
+                    >,
+                    chip = <wgp_count = 304, sku = "mi300x">
                 >
                 }>
             ) {
@@ -444,6 +446,11 @@ def gpu_target_info_attribute_parsing():
 
     arch = gpu_target_info.arch
     assert arch == "gfx942", f"Expected arch 'gfx942', got '{arch}'"
+    
+    workgroup_count = gpu_target_info.workgroup_count
+    simds_per_workgroup = gpu_target_info.simds_per_workgroup
+    assert workgroup_count == 304, f"Expected workgroup_count 304, got {workgroup_count}"
+    assert simds_per_workgroup == 4, f"Expected simds_per_workgroup 4, got {simds_per_workgroup}"
 
     subgroup_size_choices = gpu_target_info.subgroup_size_choices
     assert subgroup_size_choices == [

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -449,8 +449,12 @@ def gpu_target_info_attribute_parsing():
     
     workgroup_count = gpu_target_info.workgroup_count
     simds_per_workgroup = gpu_target_info.simds_per_workgroup
-    assert workgroup_count == 304, f"Expected workgroup_count 304, got {workgroup_count}"
-    assert simds_per_workgroup == 4, f"Expected simds_per_workgroup 4, got {simds_per_workgroup}"
+    assert (
+        workgroup_count == 304
+    ), f"Expected workgroup_count 304, got {workgroup_count}"
+    assert (
+        simds_per_workgroup == 4
+    ), f"Expected simds_per_workgroup 4, got {simds_per_workgroup}"
 
     subgroup_size_choices = gpu_target_info.subgroup_size_choices
     assert subgroup_size_choices == [

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -411,10 +411,14 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
       wgpAttr.getMaxThreadCountPerWorkgroup();
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
 
-  mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip();
+  if (wgpAttr) {
+    targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp();
+  }
 
-  targetInfo.wgpCount = chipAttr ? chipAttr.getWgpCount() : 0;
-  targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(0);
+  mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip();
+  if (chipAttr) {
+    targetInfo.wgpCount = chipAttr.getWgpCount();
+  }
 
   targetInfo.mmaIntrinsics = wrap(builder.getArrayAttr({}));
   mlir::iree_compiler::IREE::GPU::MMAOpsArrayAttr mmaOpsArray =

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -412,12 +412,12 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
 
   targetInfo.simdsPerWgp =
-    wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
+      wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
 
   if (mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr =
-    gpuTargetAttr.getChip()) {
-      targetInfo.wgpCount = chipAttr.getWgpCount();
-    }
+          gpuTargetAttr.getChip()) {
+    targetInfo.wgpCount = chipAttr.getWgpCount();
+  }
 
   targetInfo.mmaIntrinsics = wrap(builder.getArrayAttr({}));
   mlir::iree_compiler::IREE::GPU::MMAOpsArrayAttr mmaOpsArray =

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -410,9 +410,7 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
   targetInfo.maxThreadCountPerWorkgroup =
       wgpAttr.getMaxThreadCountPerWorkgroup();
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
-
-  targetInfo.simdsPerWgp =
-      wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
+  targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(0);
 
   if (mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr =
           gpuTargetAttr.getChip()) {

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -411,11 +411,13 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
       wgpAttr.getMaxThreadCountPerWorkgroup();
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
 
-  targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
+  targetInfo.simdsPerWgp =
+    wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
 
-  if (mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip()) {
-    targetInfo.wgpCount = chipAttr.getWgpCount();
-  }
+  if (mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr =
+    gpuTargetAttr.getChip()) {
+      targetInfo.wgpCount = chipAttr.getWgpCount();
+    }
 
   targetInfo.mmaIntrinsics = wrap(builder.getArrayAttr({}));
   mlir::iree_compiler::IREE::GPU::MMAOpsArrayAttr mmaOpsArray =

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -411,9 +411,7 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
       wgpAttr.getMaxThreadCountPerWorkgroup();
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
 
-  if (wgpAttr) {
-    targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp();
-  }
+  targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
 
   mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip();
   if (chipAttr) {

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -413,8 +413,7 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
 
   targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(targetInfo.simdsPerWgp);
 
-  mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip();
-  if (chipAttr) {
+  if (mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip()) {
     targetInfo.wgpCount = chipAttr.getWgpCount();
   }
 

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -411,6 +411,11 @@ ireeHALExecutableTargetAttrGetGPUTargetInfo(MlirAttribute attr) {
       wgpAttr.getMaxThreadCountPerWorkgroup();
   targetInfo.maxWorkgroupMemoryBytes = wgpAttr.getMaxWorkgroupMemoryBytes();
 
+  mlir::iree_compiler::IREE::GPU::TargetChipAttr chipAttr = gpuTargetAttr.getChip();
+
+  targetInfo.wgpCount = chipAttr ? chipAttr.getWgpCount() : 0;
+  targetInfo.simdsPerWgp = wgpAttr.getSimdsPerWgp().value_or(0);
+
   targetInfo.mmaIntrinsics = wrap(builder.getArrayAttr({}));
   mlir::iree_compiler::IREE::GPU::MMAOpsArrayAttr mmaOpsArray =
       wgpAttr.getMma();


### PR DESCRIPTION
To support new candidate ordering feature added in the tuner, see details [here](https://github.com/nod-ai/shark-ai/pull/2555), this PR adds extra attribute in IREE GPU Python bindings, to query SIMDs and CUs info.