### PR TITLE
[Codegen] Add WorkgroupCountHintOp to defer populating the workgroup count

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -147,6 +147,7 @@ iree_compiler_cc_library(
         "ReplaceSlowMinMaxOps.cpp",
         "ReshapePatterns.cpp",
         "ResolveSwizzleHints.cpp",
+        "ResolveWorkgroupCountHints.cpp",
         "SpecializeExports.cpp",
         "SplitFullPartialTransferPass.cpp",
         "StripCompilationInfoPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -140,6 +140,7 @@ iree_cc_library(
     "ReplaceSlowMinMaxOps.cpp"
     "ReshapePatterns.cpp"
     "ResolveSwizzleHints.cpp"
+    "ResolveWorkgroupCountHints.cpp"
     "SpecializeExports.cpp"
     "SplitFullPartialTransferPass.cpp"
     "StripCompilationInfoPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -307,6 +307,11 @@ def ReconcileTranslationInfoPass
   ];
 }
 
+def ResolveWorkgroupCountHintsPass
+    : Pass<"iree-codegen-resolve-workgroup-count-hints", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Materialize workgroup count hints in the workgroup count region per export.";
+}
+
 def ReplaceSlowMinMaxOpsPass
     : InterfacePass<"iree-codegen-replace-slow-min-max-ops", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -310,6 +310,87 @@ def ReconcileTranslationInfoPass
 def ResolveWorkgroupCountHintsPass
     : Pass<"iree-codegen-resolve-workgroup-count-hints", "IREE::HAL::ExecutableVariantOp"> {
   let summary = "Materialize workgroup count hints in the workgroup count region per export.";
+  let description = [{
+    Resolves `iree_codegen.workgroup_count_hint` ops by materializing a globally
+    agreeable workgroup count per export. This pass performs a depth-first walk
+    of the target variant's call graph constructing the necessary information to
+    materialize workgroup count hints for that function.
+
+    #### Supported IR Structure
+
+    The pass expects executable variants containing exports with associated
+    entry point functions. Each entry point function (or functions it calls)
+    may contain `iree_codegen.workgroup_count_hint` ops:
+
+    ```mlir
+    hal.executable.export @entry_point
+        count(%device: !hal.device, %workload: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %workload
+      hal.return %x, %y, %z : index, index, index
+    }
+    module {
+      func.func @entry_point(%device: !hal.device) {
+        %workload = iree_tensor_ext.dispatch.workload.ordinal %val, 0 : index
+        iree_codegen.workgroup_count_hint sizes(%workload)
+      }
+    }
+    ```
+
+    #### Supported Control Flow
+
+    The pass handles the following control flow patterns:
+
+    1. **Direct hints**: Workgroup count hints directly in entry point functions.
+
+    2. **Transitive function calls**: Hints in functions called (directly or
+       transitively) from the entry point. The backward slice of operands
+       required to compute the hint is tracked across call boundaries.
+
+    3. **Conditional hints (`scf.if`)**: When hints are wrapped in `scf.if`
+       operations, the conditions are preserved in the workgroup count region
+       if possible.
+       ```mlir
+       %o0 = iree_tensor_ext.dispatch.workload.ordinal ...
+       %o1 = iree_tensor_ext.dispatch.workload.ordinal ...
+       %cond = arith.cmpi ..., %o0, %o1
+       scf.if %cond {
+         iree_codegen.workgroup_count_hint sizes(%x, %y, %z)
+       } else {
+         iree_codegen.workgroup_count_hint sizes(%a, %b, %c)
+       }
+       ```
+       This generates an `scf.if` in the workgroup count region rather than
+       pessimistically taking the maximum.
+
+    #### Resolution of Multiple Hints
+
+    When multiple `workgroup_count_hint` ops contribute to the same export
+    (either directly or through function calls), the final workgroup count
+    is computed as the **elementwise maximum** across all hints:
+
+    ```mlir
+    // Given:
+    iree_codegen.workgroup_count_hint sizes(%x, %y, %z)
+    iree_codegen.workgroup_count_hint sizes(%a, %b, %c)
+
+    // Resolves to:
+    %wx = arith.maxsi %x, %a
+    %wy = arith.maxsi %y, %b
+    %wz = arith.maxsi %z, %c
+    hal.return %wx, %wy, %wz
+    ```
+
+    #### Backward Slice Requirements
+
+    The backward slice of hint operands must consist only of:
+    - `iree_tensor_ext.dispatch.workload.ordinal` ops (leaf values)
+    - Pure/side-effect-free operations
+    - Function arguments (for transitive call support)
+
+    Operations with memory effects or that depend on device-local values
+    (e.g., `hal.interface.*` ops, workgroup/thread IDs) result in a compiler
+    error for hint operands and omit conditionals for `scf.if` operands.
+  }];
 }
 
 def ReplaceSlowMinMaxOpsPass

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
@@ -1,0 +1,1043 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//=== ResolveWorkgroupCountHints.cpp -------------------------------------===//
+//
+// Resolves `iree_codegen.workgroup_count_hint` ops by materializing a globally
+// agreeable workgroup count per export. This pass performs a depth first walk
+// of the target variant's call graph constructing the necessary information to
+// materialize workgroup count hints for that function.
+//
+// Workgroup counts are materialized by again walking the callgraph starting
+// from each exported function and mapping the required operands to construct
+// the hints for a function using the operands of the callsite we're traversing
+// from.
+//
+// Additionally any conditional statements (scf.if ops) transitively wrapping
+// a workgroup count hint are tracked and materialized in the workgroup count
+// region as well. This avoids pessimizing the workgroup count for situations
+// where we are switching implementations on uniform host provided parameters
+// (workloads/device queries).
+//
+// TODO: Implement device query support.
+//
+//===---------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTraits.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_RESOLVEWORKGROUPCOUNTHINTSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+class ResolveWorkgroupCountHintsPass final
+    : public impl::ResolveWorkgroupCountHintsPassBase<
+          ResolveWorkgroupCountHintsPass> {
+public:
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+//===---------------------------------------------------------------------===//
+// Utilities
+//===---------------------------------------------------------------------===//
+
+static Value negateValue(RewriterBase &rewriter, Location loc, Value v) {
+  auto one =
+      arith::ConstantIntOp::create(rewriter, loc, rewriter.getI1Type(), 1);
+  return arith::XOrIOp::create(rewriter, loc, v, one);
+}
+
+static Value andValues(RewriterBase &rewriter, Location loc, Value l, Value r) {
+  return arith::AndIOp::create(rewriter, loc, l, r);
+}
+
+static SmallVector<Value, 3> maxValueVectors(RewriterBase &rewriter,
+                                             Location loc, ArrayRef<Value> l,
+                                             ArrayRef<Value> r) {
+  SmallVector<Value, 3> max;
+  for (auto [lv, rv] : llvm::zip_equal(l, r)) {
+    max.push_back(arith::MaxSIOp::create(rewriter, loc, lv, rv));
+  }
+  return max;
+}
+
+using OperandWalkFn = std::function<LogicalResult(OpOperand &)>;
+static LogicalResult walkOperandsAndCapturesImpl(Operation *root,
+                                                 Operation *curr,
+                                                 DominanceInfo &dominance,
+                                                 OperandWalkFn callback) {
+  for (OpOperand &operand : curr->getOpOperands()) {
+    if (dominance.properlyDominates(operand.get(), root)) {
+      if (failed(callback(operand))) {
+        return failure();
+      }
+    }
+  }
+
+  for (Region &region : root->getRegions()) {
+    for (Block &body : region.getBlocks()) {
+      for (Operation &op : body.getOperations()) {
+        if (failed(
+                walkOperandsAndCapturesImpl(root, &op, dominance, callback))) {
+          return failure();
+        }
+      }
+    }
+  }
+  return success();
+}
+
+// Recursive walk of all operands and implicit captures of |root|. This
+// allows fetching all values transitively required by |root|. If
+// |skipCaptures| is set, this will skip lookup of implicit captures for
+// |root| only.
+static LogicalResult walkOperandsAndCaptures(Operation *root,
+                                             OperandWalkFn callback,
+                                             bool skipCaptures) {
+  for (OpOperand &operand : root->getOpOperands()) {
+    if (failed(callback(operand))) {
+      return failure();
+    }
+  }
+
+  if (skipCaptures) {
+    return success();
+  }
+
+  // Dominance for checking operand capture is maybe more expensive for the
+  // first query of an operation per block, but caches the info for subsequent
+  // queries.
+  DominanceInfo dominance(root);
+  for (Region &region : root->getRegions()) {
+    for (Block &body : region.getBlocks()) {
+      for (Operation &op : body.getOperations()) {
+        if (failed(
+                walkOperandsAndCapturesImpl(root, &op, dominance, callback))) {
+          return failure();
+        }
+      }
+    }
+  }
+  return success();
+}
+
+static LogicalResult getBackwardOrdinalSliceImpl(
+    Operation *op, DenseSet<Operation *> &visited,
+    SetVector<Operation *> *backwardSlice,
+    SetVector<BlockArgument> &funcArgLeaves,
+    SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> &ordinalLeaves,
+    bool skipCaptures = false, bool inclusive = true) {
+  if (auto ordinal = dyn_cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(op)) {
+    ordinalLeaves.insert(ordinal);
+    return success();
+  }
+
+  auto processOperand = [&](OpOperand &operand) {
+    if (Operation *definingOp = operand.get().getDefiningOp()) {
+      if (backwardSlice->count(definingOp) == 0 &&
+          visited.insert(definingOp).second) {
+        // Memory effecting ops or hal.interface ops are illegal outside of
+        // executables. This is possible if the code branches on a value
+        // resident on the device rather than a host provided param.
+        // In such cases we will ignore those conditionals. If a hint op
+        // directly depends on an illegal op that is a hard error however.
+        if (!isMemoryEffectFree(definingOp) ||
+            definingOp->hasTrait<OpTrait::IREE::HAL::ExecutableInterfaceOp>()) {
+          return failure();
+        }
+        return getBackwardOrdinalSliceImpl(definingOp, visited, backwardSlice,
+                                           funcArgLeaves, ordinalLeaves);
+      }
+
+      visited.erase(definingOp);
+    } else if (auto blockArg = dyn_cast<BlockArgument>(operand.get())) {
+      // Function op arguments are terminal. Everything else is treated as a
+      // failure.
+      auto funcOp =
+          dyn_cast<FunctionOpInterface>(blockArg.getOwner()->getParentOp());
+      if (!funcOp) {
+        return failure();
+      }
+      funcArgLeaves.insert(blockArg);
+    } else {
+      return failure();
+    }
+
+    return success();
+  };
+  if (failed(walkOperandsAndCaptures(op, processOperand, skipCaptures))) {
+    return failure();
+  }
+
+  if (inclusive) {
+    backwardSlice->insert(op);
+  }
+  return success();
+}
+
+// Looks up the backward slice of |op| including implicit captures and populates
+// |funcArgLeaves| with all required function arguments of the immediately
+// enclosing function and |ordinalLeaves| with all defining
+// `tensor_ext.dispatch.workload.ordinal` ops.
+//
+// Returns failure if a valid backward slice could not be found. This occurs if
+// the slice includes a non-function block argument or an unsupported operation
+// (memory effecting or non-uniform like a workgroup id).
+//
+// `getBackwardsSlice` silently skips or passes through block arguments meaning
+// we can't capture function args. Roll our own impl that does what we need.
+static LogicalResult getBackwardOrdinalSlice(
+    Operation *op, SetVector<Operation *> &backwardSlice,
+    SetVector<BlockArgument> &funcArgLeaves,
+    SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> &ordinalLeaves,
+    bool skipCaptures = true, bool inclusive = false) {
+  DenseSet<Operation *> visited;
+  LogicalResult res =
+      getBackwardOrdinalSliceImpl(op, visited, &backwardSlice, funcArgLeaves,
+                                  ordinalLeaves, skipCaptures, inclusive);
+  if (succeeded(res)) {
+    // Topological sort for cloning later. On failure the slice is not used
+    // so no need.
+    topologicalSort(backwardSlice);
+  }
+  return res;
+}
+
+//===---------------------------------------------------------------------===//
+// State + Processing
+//===---------------------------------------------------------------------===//
+
+/// All the state and processing functions needed to materialize workgroup
+/// counts are defined in this section. A structure for the state as well as
+/// as well as processing functions that populate that state are provided for
+/// the following IR constructs:
+///
+///  - `scf.if`
+///  - `iree_codegen.workgroup_count_hint`
+///  - `OpOperand`
+///  - `CallOpInterface`
+///  - `FunctionOpInterface`
+
+/// ================
+/// *** `scf.if` ***
+/// ================
+///   - ConditionSlice
+///   - processCondition
+///
+/// Processes + holds state for `scf.if` ops wrapping `workgroup_count_hint`
+/// ops. This allows optimizing the workgroup count for cases where the count
+/// is switched on kernel uniform values. For example:
+///
+/// ```
+/// %cond = hal.interface.constant.load ordinal(0) : i1
+/// scf.if %cond {
+///   iree_codegen.workgroup_count_hint(1, 2, 3)
+/// } else {
+///   iree_codegen.workgroup_count_hint(4, 5, 6)
+/// }
+/// ```
+///
+/// This will generate (effectively):
+///
+/// ```
+/// hal.executable.export count(%cond: i1)
+///   %x, %y, %z = scf.if %cond {
+///     scf.yield %c1, %c2, %c3
+///   } else {
+///     scf.yield %c4, %c5, %c6
+///   }
+///   hal.return %x, %y, %z
+/// ```
+///
+/// As opposed to the more pessimistic:
+///
+/// ```
+/// hal.executable.export count(%cond: i1)
+///   %x, %y, %z = max(1, 4), max(2, 5), max(3, 6) = 4, 5, 6
+///   hal.return %x, %y, %z
+/// ```
+struct ConditionSlice {
+  // The condition on which to predicate.
+  Value cond;
+  // The program slice that produces this condition.
+  SetVector<Operation *> slice;
+  // Arguments of the parent function that are inputs to the slice.
+  SetVector<BlockArgument> funcArgLeaves;
+  // Workload ordinals that are inputs to the slice.
+  SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinalLeaves;
+  // Whether or not to negate the condition (i.e. else branch).
+  bool negate = false;
+};
+
+static void processCondition(scf::IfOp ifOp, bool isInElseBranch,
+                             std::vector<ConditionSlice> &slices) {
+  ConditionSlice slice;
+  slice.negate = isInElseBranch;
+  LogicalResult res = getBackwardOrdinalSlice(
+      ifOp, slice.slice, slice.funcArgLeaves, slice.ordinalLeaves);
+  if (succeeded(res)) {
+    slice.cond = ifOp.getCondition();
+    slices.push_back(std::move(slice));
+  }
+}
+
+// Populates |slices| with all conditional descriptors wrapping |base| within
+// the current function. Skips all conditionals not statically resolvable in
+// terms of function args, ordinals, and legal ops.
+static void processConditionsFromBase(Operation *base,
+                                      std::vector<ConditionSlice> &slices) {
+  Operation *parent = base->getParentOp();
+  Operation *child = base;
+  while (parent && !isa<FunctionOpInterface>(parent)) {
+    if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
+      processCondition(ifOp,
+                       /*isInElseRegion=*/child->getBlock()->getParent() ==
+                           &ifOp.getElseRegion(),
+                       slices);
+    }
+
+    // We need to walk the ancestor chain one at a time to track the child (and
+    // thus which branch we come up in).
+    child = parent;
+    parent = parent->getParentOp();
+  }
+}
+
+/// ===========================================
+/// *** `iree_codegen.workgroup_count_hint` ***
+/// ===========================================
+///   - HintSlice
+///   - processHint
+///
+/// Processes + holds state for `workgroup_count_hint` ops. Hints are processed
+/// individually and only hold the state needed to resolve it in the context of
+/// the function it is contained within. This populates:
+///
+///  - The backward program slice of the operands to the hint op.
+///  - All operands of the enclosing function the backward slice depends on.
+///  - All `iree_tensor_ext.dispatch.workload.ordinal` ops the slice depends on.
+///  - The ConditionSlices of all `scf.if` ops that are ancestors of the hint.
+struct HintSlice {
+  IREE::Codegen::WorkgroupCountHintOp hintOp;
+  // The program slice that produces the operands to the hint op.
+  SetVector<Operation *> slice;
+  // Arguments of the parent function that are inputs to the slice.
+  SetVector<BlockArgument> funcArgLeaves;
+  // Workload ordinals that are inputs to the slice.
+  SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinalLeaves;
+  // List of conditions on which to predicate this count hint.
+  std::vector<ConditionSlice> conditions;
+};
+
+static LogicalResult processHint(IREE::Codegen::WorkgroupCountHintOp hintOp,
+                                 HintSlice &slice) {
+  processConditionsFromBase(hintOp, slice.conditions);
+  if (failed(getBackwardOrdinalSlice(hintOp, slice.slice, slice.funcArgLeaves,
+                                     slice.ordinalLeaves))) {
+    return hintOp->emitOpError(
+        "failed to resolve workgroup count hint in terms of workload ordinals");
+  }
+  slice.hintOp = hintOp;
+  return success();
+}
+
+/// ===================
+/// *** `OpOperand` ***
+/// ===================
+///   - OperandSlice
+///   - processOperand
+
+/// Descriptor of a program slice for the producers of an individual operand.
+struct OperandSlice {
+  OpOperand *operand;
+  // The program slice that produces this operand.
+  SetVector<Operation *> slice;
+  // Arguments of the parent function that are inputs to the slice.
+  SetVector<BlockArgument> funcArgLeaves;
+  // Workload ordinals that are inputs to the slice.
+  SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinalLeaves;
+};
+
+// If possible, appends to |slices| with a new backwards program slice that
+// produces |operand|. On failure |slices| remains unchanged.
+static LogicalResult processOperand(OpOperand &operand,
+                                    std::vector<OperandSlice> &slices) {
+  OperandSlice slice;
+  slice.operand = &operand;
+  if (auto blockArg = dyn_cast<BlockArgument>(operand.get())) {
+    auto funcOp =
+        dyn_cast<FunctionOpInterface>(blockArg.getOwner()->getParentOp());
+    if (!funcOp) {
+      return failure();
+    }
+    slice.funcArgLeaves.insert(blockArg);
+    slices.push_back(std::move(slice));
+    return success();
+  }
+
+  Operation *definingOp = operand.get().getDefiningOp();
+  if (!isMemoryEffectFree(definingOp) ||
+      definingOp->hasTrait<OpTrait::IREE::HAL::ExecutableInterfaceOp>()) {
+    return failure();
+  }
+
+  LogicalResult res = getBackwardOrdinalSlice(
+      definingOp, slice.slice, slice.funcArgLeaves, slice.ordinalLeaves,
+      /*skipCaptures=*/false, /*inclusive=*/true);
+  if (succeeded(res)) {
+    slices.push_back(std::move(slice));
+  }
+  return res;
+}
+
+/// =========================
+/// *** `CallOpInterface` ***
+/// =========================
+///   - CallSlice
+///   - processCall
+
+/// Descriptor of a program slice for a function call in terms of workload
+/// ordinals and the parent function. Backward slices are stored per operand
+/// in case when materializing a function, one of the optional operands wasn't
+/// resolvable in terms of workload ordinals and legal ops. This allows us to
+/// skip dependent conditionals per callsite rather than globally pessimizing.
+/// The per operand approach potentially introduces repeat IR, however CSE
+/// should be able to clean it up as only pure ops are legal.
+struct CallSlice {
+  // Cache the callee to avoid repeat symbol table lookups.
+  FunctionOpInterface callee;
+  // List of program slices for each optional operand.
+  std::vector<OperandSlice> optionalOperands;
+  // List of program slices for each required operand.
+  std::vector<OperandSlice> requiredOperands;
+  // List of conditions on which to predicate this function call.
+  std::vector<ConditionSlice> conditions;
+};
+
+/// =============================
+/// *** `FunctionOpInterface` ***
+/// =============================
+///   - FuncSlice
+///   - processFunc
+struct FunctionSlice {
+  // List of operands that may optionally resolve in terms of workload ordinals.
+  // These are operands that are only used as arguments to conditions.
+  SetVector<BlockArgument> optionalOperands;
+  // List of operands that are required to resolve in terms of workload
+  // ordinals. These are operands for workgroup count hints.
+  SetVector<BlockArgument> requiredOperands;
+  // List of workgroup count hints contained within this function.
+  std::vector<HintSlice> hints;
+  // List of function calls contained within this function.
+  std::vector<CallSlice> calls;
+  bool valid = false;
+  bool required = true;
+};
+
+/// Implementation of call processing. Assumes the call transitively calls a
+/// `workgroup_count_hint` op and returns failure if the call can't be resolved
+/// in terms of valid operands the same way a hint op is (function args and
+/// ordinal ops).
+static LogicalResult processCall(CallOpInterface callOp,
+                                 FunctionOpInterface callee, CallSlice &slice,
+                                 FunctionSlice &funcSlice) {
+  assert(funcSlice.valid && funcSlice.required &&
+         "unexpected processing of an invalid or non-required function call");
+
+  MutableOperandRange callOperands = callOp.getArgOperandsMutable();
+  processConditionsFromBase(callOp, slice.conditions);
+
+  FunctionOpInterface::BlockArgListType funcArgs = callee.getArguments();
+  for (BlockArgument argument : funcArgs) {
+    OpOperand &operand = callOperands[argument.getArgNumber()];
+    if (funcSlice.requiredOperands.contains(argument)) {
+      if (failed(processOperand(operand, slice.requiredOperands))) {
+        callOp->emitOpError("failed to resolve operand ")
+            << operand.getOperandNumber()
+            << " required to resolve workgroup count in terms of workload "
+               "ordinals.";
+        return failure();
+      }
+    } else if (funcSlice.optionalOperands.contains(argument)) {
+      if (failed(processOperand(operand, slice.optionalOperands))) {
+        continue;
+      }
+    }
+  }
+  return success();
+}
+
+/// Recursive walk of the callgraph, populating the state of each function along
+/// the way. A function is required to materialize if it directly or
+/// transitively calls a `workgroup_count_hint` op. Calls that don't call
+/// functions that may reach a `workgroup_count_hint` aren't added to the list
+/// of calls in the FunctionSlice created for |func|.
+static LogicalResult
+processFunction(FunctionOpInterface func, SymbolTableCollection &symbolTables,
+                llvm::DenseMap<FunctionOpInterface, FunctionSlice> &slices) {
+  auto res = slices.try_emplace(func);
+  if (!res.second) {
+    // Recursion check. We don't support recursively called hints so fail if
+    // this slice hasn't been marked valid (i.e. re-visited while processing
+    // itself).
+    if (!res.first->second.valid) {
+      func->emitOpError(
+          "detected recursive call when resolving workgroup count hints");
+      return failure();
+    }
+    return success();
+  }
+
+  FunctionSlice &slice = res.first->second;
+  // Ignore external functions. Since workgroup count hints don't have execution
+  // semantics we can safely assume external functions don't include them. If we
+  // wanted a way to define workgroup counts externally we would need to
+  // introduce a special function op for it.
+  if (func.isExternal()) {
+    slice.valid = true;
+    slice.required = false;
+    return success();
+  }
+
+  if (func.walk([&](IREE::Codegen::WorkgroupCountHintOp hintOp) {
+            HintSlice &hintSlice = slice.hints.emplace_back();
+            if (failed(processHint(hintOp, hintSlice))) {
+              return WalkResult::interrupt();
+            }
+            slice.requiredOperands.insert_range(hintSlice.funcArgLeaves);
+            for (ConditionSlice &condition : hintSlice.conditions) {
+              slice.optionalOperands.insert_range(condition.funcArgLeaves);
+            }
+            return WalkResult::advance();
+          })
+          .wasInterrupted()) {
+    return failure();
+  }
+
+  if (func.walk([&](CallOpInterface callOp) {
+            CallInterfaceCallable callable = callOp.getCallableForCallee();
+            // Fail on indirect calls for now.
+            if (isa<Value>(callable)) {
+              return WalkResult::interrupt();
+            }
+            auto targetSymbol = cast<SymbolRefAttr>(callable);
+            FunctionOpInterface callee = cast<FunctionOpInterface>(
+                symbolTables.lookupNearestSymbolFrom(callOp, targetSymbol));
+            if (failed(processFunction(callee, symbolTables, slices))) {
+              return WalkResult::interrupt();
+            }
+            FunctionSlice &transitiveSlice = slices[callee];
+            // We can skip the processing of a call if the callee isn't required
+            // for workgroup count.
+            if (!transitiveSlice.required) {
+              return WalkResult::advance();
+            }
+            CallSlice &callSlice = slice.calls.emplace_back();
+            if (failed(
+                    processCall(callOp, callee, callSlice, transitiveSlice))) {
+              return WalkResult::interrupt();
+            }
+            callSlice.callee = callee;
+            for (ConditionSlice &condition : callSlice.conditions) {
+              slice.optionalOperands.insert_range(condition.funcArgLeaves);
+            }
+            for (OperandSlice &optionalOperand : callSlice.optionalOperands) {
+              slice.optionalOperands.insert_range(
+                  optionalOperand.funcArgLeaves);
+            }
+            for (OperandSlice &requiredOperand : callSlice.requiredOperands) {
+              slice.requiredOperands.insert_range(
+                  requiredOperand.funcArgLeaves);
+            }
+            return WalkResult::advance();
+          })
+          .wasInterrupted()) {
+    return failure();
+  }
+
+  // Subtract off any required operands that are also marked as optional
+  // operands.
+  slice.optionalOperands.set_subtract(slice.requiredOperands);
+
+  // Mark the function slice as valid. This way if the overall walk revisits it
+  // we will skip reprocessing it.
+  slice.valid = true;
+
+  // If this function transitively calls no hints then it isn't required to
+  // construct the workgroup count region. This culls processing of calls to
+  // this function.
+  if (slice.hints.empty() && slice.calls.empty()) {
+    slice.required = false;
+  }
+  return success();
+}
+
+//===---------------------------------------------------------------------===//
+// Workgroup Count Materialization
+//===---------------------------------------------------------------------===//
+
+/// Materializes a program slice. All |ordinals| are remapped to corresponding
+/// values in |workloadVals|. All dependent function arguments should already
+/// have been remapped and can be queried directly from |map|.
+static LogicalResult materializeSlice(
+    RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+    SetVector<Operation *> &slice,
+    SetVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> &ordinals) {
+  for (auto ordinalOp : ordinals) {
+    // Map `tensor_ext.dispatch.workload.ordinal` op with the corresponding
+    // operand of the `tensor_ext.dispatch.workgroup_count_default` operation.
+    int64_t ordinal = ordinalOp.getOrdinal().getSExtValue();
+    if (ordinal >= workloadVals.size()) {
+      return ordinalOp.emitOpError(
+          "ordinal number is higher than the number of workloads captured in "
+          "the workgroup count region");
+    }
+    map.map(ordinalOp.getResult(), workloadVals[ordinal]);
+  }
+  for (auto op : slice) {
+    // TODO(#13038) This is a WAR for ops ending up in workgroup count
+    // computation. They should not. Some pre-processing at MaterializeEncoding
+    // time might make these go away.
+    if (isa<IREE::Codegen::QueryTileSizesOp>(op)) {
+      Value constVal =
+          arith::ConstantIndexOp::create(rewriter, op->getLoc(), 16);
+      for (auto result : op->getResults()) {
+        map.map(result, constVal);
+      }
+      continue;
+    }
+    rewriter.clone(*op, map);
+  }
+  return success();
+}
+
+/// Materializes a single combined `scf.if` based on the list of
+/// ConditionSlices. If no slices successfully materialize, this produces no
+/// new IR.
+static FailureOr<Operation *>
+materializeConditions(RewriterBase &rewriter, IRMapping &map, Location loc,
+                      ValueRange workloadVals,
+                      std::vector<ConditionSlice> &conditions) {
+  Value acc;
+  for (ConditionSlice &condition : conditions) {
+    if (!llvm::all_of(condition.funcArgLeaves,
+                      [&](BlockArgument b) { return map.contains(b); })) {
+      continue;
+    }
+
+    if (failed(materializeSlice(rewriter, map, workloadVals, condition.slice,
+                                condition.ordinalLeaves))) {
+      return failure();
+    }
+
+    Value newCond = map.lookupOrNull(condition.cond);
+    if (!newCond) {
+      return failure();
+    }
+
+    if (condition.negate) {
+      newCond = negateValue(rewriter, loc, newCond);
+    }
+
+    if (!acc) {
+      acc = newCond;
+    } else {
+      acc = andValues(rewriter, loc, acc, newCond);
+    }
+  }
+
+  // Use a placeholder for the values returned by the scf.if. The builder for
+  // scf.if infers the return types from the types yielded by its body, so we
+  // need a placeholder producer at the time when we construct the if (which is
+  // before its contents have been cloned in).
+  Operation *maybePlaceholder = nullptr;
+  if (acc) {
+    scf::IfOp::create(
+        rewriter, loc, acc, /*thenBuilder=*/
+        [&](OpBuilder &b, Location l) {
+          Type indexType = b.getIndexType();
+          maybePlaceholder = UnrealizedConversionCastOp::create(
+              b, l, TypeRange{indexType, indexType, indexType}, ValueRange());
+          scf::YieldOp::create(b, l, maybePlaceholder->getResults());
+        },
+        /*elseBuilder=*/
+        [&](OpBuilder &b, Location l) {
+          auto zero = arith::ConstantIndexOp::create(b, l, 0);
+          scf::YieldOp::create(b, l, {zero, zero, zero});
+        });
+  }
+  return maybePlaceholder;
+}
+
+/// Materializes the IR for the provided HintSlice using the given mapping at
+/// the current insertion point. This amounts to cloning all of the IR cached
+/// in `hintSlice.slice` and remapping function args and ordinals based on the
+/// provided |map| + |workloadVals|.
+static FailureOr<SmallVector<Value, 3>> materializeHint(RewriterBase &rewriter,
+                                                        IRMapping &map,
+                                                        ValueRange workloadVals,
+                                                        HintSlice &hintSlice) {
+  Location loc = hintSlice.hintOp.getLoc();
+  // If an scf.if wrapping the cloned hint producers is generated, a placeholder
+  // `unrealized_conversion_cast` op is generated as a placeholder for the
+  // values returned by the cloned backwards slice described in |hintSlice|.
+  // The IR would look something like:
+  //
+  // scf.if %cond {
+  //   %x, %y, %z = builtin.unrealized_conversion_cast // no operands
+  //   scf.yield %x, %y, %z
+  // } else {
+  //   %c0 = arith.constant 0 : index
+  //   scf.yield %c0, %c0, %c0
+  // }
+  FailureOr<Operation *> maybePlaceholder = materializeConditions(
+      rewriter, map, loc, workloadVals, hintSlice.conditions);
+  if (failed(maybePlaceholder)) {
+    hintSlice.hintOp->emitOpError("failed to materialize conditions.");
+    return failure();
+  }
+
+  Operation *placeholder = maybePlaceholder.value();
+  if (placeholder) {
+    rewriter.setInsertionPoint(placeholder);
+  }
+
+  if (failed(materializeSlice(rewriter, map, workloadVals, hintSlice.slice,
+                              hintSlice.ordinalLeaves))) {
+    hintSlice.hintOp->emitOpError("failed to materialize operand slice.");
+    return failure();
+  }
+
+  SmallVector<Value, 3> sizes;
+  for (OpFoldResult size : hintSlice.hintOp.getMixedSizes()) {
+    if (auto v = dyn_cast<Value>(size)) {
+      sizes.push_back(map.lookup(v));
+    } else {
+      sizes.push_back(getValueOrCreateConstantIndexOp(rewriter, loc, size));
+    }
+  }
+
+  while (sizes.size() < 3) {
+    sizes.push_back(arith::ConstantIndexOp::create(rewriter, loc, 1));
+  }
+
+  if (placeholder) {
+    Operation *parent = placeholder->getParentOp();
+    SmallVector<Value, 3> newSizes = parent->getResults();
+    rewriter.replaceOp(placeholder, sizes);
+    sizes = newSizes;
+    // Put the insertion point back to immediately after the enclosing `scf.if`.
+    rewriter.setInsertionPointAfter(parent);
+  }
+
+  return sizes;
+}
+
+// Forward declare for the recursive call.
+static FailureOr<SmallVector<Value, 3>>
+materializeFunc(RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+                FunctionSlice &funcSlice,
+                llvm::DenseMap<FunctionOpInterface, FunctionSlice> sliceMap);
+
+/// Materializes the IR for the provided CallSlice using the given mapping at
+/// the current insertion point. This amounts to cloning all of the IR cached
+/// in `operandSlice.slice` for each required and optional operand.
+/// If one of the optional operands is not resolvable in terms of clonable ops
+/// (e.g. hal.interface.* ops or memory effecting ops that can't live on the
+/// host), then the conditional op(s) that depend on that optional operands
+/// aren't generated.
+static FailureOr<SmallVector<Value, 3>>
+materializeCall(RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+                CallSlice &callSlice,
+                llvm::DenseMap<FunctionOpInterface, FunctionSlice> sliceMap) {
+  Location loc = callSlice.callee.getLoc();
+  FailureOr<Operation *> maybePlaceholder = materializeConditions(
+      rewriter, map, loc, workloadVals, callSlice.conditions);
+  if (failed(maybePlaceholder)) {
+    callSlice.callee->emitOpError(
+        "failed to materialize conditions for function call.");
+    return failure();
+  }
+
+  Operation *placeholder = maybePlaceholder.value();
+  if (placeholder) {
+    rewriter.setInsertionPoint(placeholder);
+  }
+
+  FunctionOpInterface::BlockArgListType funcArgs =
+      callSlice.callee.getArguments();
+  SmallVector<BlockArgument> argsToUnmap;
+  auto pushOperandSlice = [&](OperandSlice &operandSlice) {
+    if (failed(materializeSlice(rewriter, map, workloadVals, operandSlice.slice,
+                                operandSlice.ordinalLeaves))) {
+      return failure();
+    }
+    // Link the cloned slice for this operand to the basic block arg of the
+    // callee. The function arg is added to `argsToUnmap` so that we can remove
+    // the mapping after processing this callsite (and risking stale mappings).
+    Value curr = map.lookup(operandSlice.operand->get());
+    BlockArgument bbArg = funcArgs[operandSlice.operand->getOperandNumber()];
+    map.map(bbArg, curr);
+    argsToUnmap.push_back(bbArg);
+    return success();
+  };
+
+  for (OperandSlice &operandSlice : callSlice.requiredOperands) {
+    assert(llvm::all_of(operandSlice.funcArgLeaves,
+                        [&](BlockArgument b) { return map.contains(b); }) &&
+           "unexpected unmapped required operand");
+    if (failed(pushOperandSlice(operandSlice))) {
+      callSlice.callee->emitOpError(
+          "failed to materialize operand slice for function call.");
+      return failure();
+    }
+  }
+
+  for (OperandSlice &operandSlice : callSlice.optionalOperands) {
+    if (!llvm::all_of(operandSlice.funcArgLeaves,
+                      [&](BlockArgument b) { return map.contains(b); })) {
+      continue;
+    }
+    if (failed(pushOperandSlice(operandSlice))) {
+      return failure();
+    }
+  }
+
+  FailureOr<SmallVector<Value, 3>> sizes = materializeFunc(
+      rewriter, map, workloadVals, sliceMap[callSlice.callee], sliceMap);
+  if (failed(sizes)) {
+    return failure();
+  }
+
+  // Erase the arg mapping for the function args. Each call to a function
+  // provides a different mapping and may have a different set of optional
+  // args.
+  for (Value v : argsToUnmap) {
+    map.erase(v);
+  }
+
+  assert(sizes->size() == 3 &&
+         "function materialization produced too few values");
+
+  if (placeholder) {
+    Operation *parent = placeholder->getParentOp();
+    SmallVector<Value, 3> newSizes = parent->getResults();
+    rewriter.replaceOp(placeholder, *sizes);
+    *sizes = newSizes;
+    rewriter.setInsertionPointAfter(parent);
+  }
+
+  return *sizes;
+}
+
+/// Materializes the IR for all contained hint and required call ops at the
+/// current insertion point and then takes the maximum values of each
+/// elementwise. For example:
+///
+/// ```
+/// func.func @entry_point() {
+///   iree_codegen.workgroup_count_hint %x, %y, %z
+///   iree_codegen.workgroup_count_hint %a, %b, %c
+///   func.call @constant_hint()
+/// }
+/// func.func @constant_hint() {
+///   iree_codegen.workgroup_count_hint 1, 2, 3
+/// }
+/// ```
+///
+/// This would resolve to:
+///
+/// ```
+/// hal.executable.export @entry_point count(%x, %y, %z, %a, %b, %c) {
+///   %wx = max(%x, %a, 1)
+///   %wy = max(%y, %b, 2)
+///   %wz = max(%z, %c, 3)
+///   hal.return %wx, %wy, %wz
+/// }
+/// ```
+static FailureOr<SmallVector<Value, 3>>
+materializeFunc(RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+                FunctionSlice &funcSlice,
+                llvm::DenseMap<FunctionOpInterface, FunctionSlice> sliceMap) {
+  SmallVector<Value, 3> results;
+  for (HintSlice &hint : funcSlice.hints) {
+    FailureOr<SmallVector<Value, 3>> newVals =
+        materializeHint(rewriter, map, workloadVals, hint);
+    if (failed(newVals)) {
+      return failure();
+    }
+
+    if (results.empty()) {
+      results = newVals.value();
+    } else {
+      results = maxValueVectors(rewriter, hint.hintOp.getLoc(), results,
+                                newVals.value());
+    }
+  }
+
+  for (CallSlice &call : funcSlice.calls) {
+    FailureOr<SmallVector<Value, 3>> newVals =
+        materializeCall(rewriter, map, workloadVals, call, sliceMap);
+    if (failed(newVals)) {
+      return failure();
+    }
+
+    if (results.empty()) {
+      results = newVals.value();
+    } else {
+      results = maxValueVectors(rewriter, call.callee.getLoc(), results,
+                                newVals.value());
+    }
+  }
+
+  if (results.empty()) {
+    // Something went wrong with error catching during analysis or
+    // materialization.
+    return failure();
+  }
+  return results;
+}
+
+/// Replaces the given `workgroup_count_from_slice` op with the program slice
+/// described by the FunctionSlice |root|.
+static LogicalResult replaceFromSliceOpWithFunctionSlice(
+    RewriterBase &rewriter,
+    IREE::TensorExt::DispatchWorkgroupCountFromSliceOp fromSliceOp,
+    FunctionSlice &root,
+    llvm::DenseMap<FunctionOpInterface, FunctionSlice> sliceMap) {
+  ValueRange workloadVals = fromSliceOp.getOperands();
+  IRMapping map;
+  FailureOr<SmallVector<Value, 3>> results =
+      materializeFunc(rewriter, map, workloadVals, root, sliceMap);
+  if (failed(results)) {
+    return failure();
+  }
+  rewriter.replaceOp(fromSliceOp, results.value());
+  return success();
+}
+
+} // namespace
+
+//===---------------------------------------------------------------------===//
+// Pass Impl
+//===---------------------------------------------------------------------===//
+
+void ResolveWorkgroupCountHintsPass::runOnOperation() {
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp innerModuleOp = variantOp.getInnerModule();
+
+  // Run the analysis. If a function that contains a `workgroup_count_hint`
+  // fails processing, this results in a pass failure. Diagnostic information
+  // is emitted by the root cause of the failure so no failure message is
+  // needed here.
+  llvm::DenseMap<FunctionOpInterface, FunctionSlice> slices;
+  SymbolTableCollection symbolTables;
+  if (innerModuleOp
+          .walk([&](FunctionOpInterface func) -> WalkResult {
+            // Always skip on success. This skips walking inside the body of
+            // each function and saves on the outer most walk. `processFunction`
+            // walks the body so this still ends up as a full module walk.
+            if (slices.contains(func)) {
+              return WalkResult::skip();
+            }
+            return failed(processFunction(func, symbolTables, slices))
+                       ? WalkResult::interrupt()
+                       : WalkResult::skip();
+          })
+          .wasInterrupted()) {
+    return signalPassFailure();
+  }
+
+  // Rewrite all `workgroup_count_from_slice` ops based on the result of the
+  // analysis.
+  IRRewriter rewriter(variantOp);
+  for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+    auto rootFuncOp = llvm::dyn_cast_if_present<FunctionOpInterface>(
+        symbolTables.lookupNearestSymbolFrom(innerModuleOp,
+                                             exportOp.getSymNameAttr()));
+    if (!rootFuncOp || rootFuncOp.isExternal()) {
+      // Skip external functions.
+      continue;
+    }
+
+    auto sliceIt = slices.find(rootFuncOp);
+    bool hasSlice = sliceIt != slices.end();
+    IREE::TensorExt::DispatchWorkgroupCountFromSliceOp fromSliceOp;
+    if (!exportOp.getWorkgroupCountBody()
+             ->walk([&](Operation *op) -> WalkResult {
+               fromSliceOp =
+                   dyn_cast<IREE::TensorExt::DispatchWorkgroupCountFromSliceOp>(
+                       op);
+               return fromSliceOp ? WalkResult::interrupt()
+                                  : WalkResult::advance();
+             })
+             .wasInterrupted()) {
+      if (hasSlice && sliceIt->second.required) {
+        exportOp->emitOpError("exporting function with a workgroup count hint "
+                              "yet `workgroup_count_from_slice` not found.");
+        return signalPassFailure();
+      }
+      continue;
+    }
+
+    if (!hasSlice || !sliceIt->second.required || !sliceIt->second.valid) {
+      exportOp->emitOpError(
+          "exporting function with `workgroup_count_from_slice` yet no "
+          "`workgroup_count_hint` found.");
+      return signalPassFailure();
+    }
+
+    FunctionSlice &root = sliceIt->second;
+    rewriter.setInsertionPoint(fromSliceOp);
+    if (failed(replaceFromSliceOpWithFunctionSlice(rewriter, fromSliceOp, root,
+                                                   slices))) {
+      return signalPassFailure();
+    }
+
+    if (exportOp.getWorkgroupCountBody()
+            ->walk([](Operation *op) {
+              return isa<IREE::TensorExt::DispatchWorkgroupCountFromSliceOp>(op)
+                         ? WalkResult::interrupt()
+                         : WalkResult::advance();
+            })
+            .wasInterrupted()) {
+      exportOp->emitOpError(
+          "failed to convert all `workgroup_count_from_slice` ops.");
+      return signalPassFailure();
+    }
+  }
+
+  // Erase all ordinals and hints.
+  SmallVector<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinals;
+  SmallVector<IREE::Codegen::WorkgroupCountHintOp> hints;
+  variantOp.walk([&](Operation *op) {
+    if (auto ordinal =
+            dyn_cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(op)) {
+      ordinals.push_back(ordinal);
+    } else if (auto hint = dyn_cast<IREE::Codegen::WorkgroupCountHintOp>(op)) {
+      hints.push_back(hint);
+    }
+  });
+
+  for (auto ordinal : ordinals) {
+    rewriter.replaceOp(ordinal, ordinal.getOperand());
+  }
+  for (auto hint : hints) {
+    rewriter.eraseOp(hint);
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -109,6 +109,7 @@ iree_lit_test_suite(
             "remove_dead_allocs.mlir",
             "remove_single_iteration_loop.mlir",
             "resolve_swizzle_hints.mlir",
+            "resolve_workgroup_count_hints.mlir",
             "repeated_matcher_use.mlir",
             "replace_slow_min_max_ops.mlir",
             "specialize_exports.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -107,6 +107,7 @@ iree_lit_test_suite(
     "repeated_matcher_use.mlir"
     "replace_slow_min_max_ops.mlir"
     "resolve_swizzle_hints.mlir"
+    "resolve_workgroup_count_hints.mlir"
     "specialize_exports.mlir"
     "strip_compilation_info.mlir"
     "test_partitionable_loops_interface.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_workgroup_count_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_workgroup_count_hints.mlir
@@ -1,0 +1,454 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-resolve-workgroup-count-hints, canonicalize, cse)))" \
+// RUN:   %s --verify-diagnostics --allow-unregistered-dialect | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @resolve_multiple_calls {
+  hal.executable.variant public @resolve_multiple_calls target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout) count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
+      func.func @fn1() {
+        iree_codegen.workgroup_count_hint(1, 5, 3)
+        return
+      }
+      func.func @fn2() {
+        iree_codegen.workgroup_count_hint(4, 2, 6)
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @resolve_multiple_calls
+//       CHECK:   hal.executable.export public @entry_point
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device) -> (index, index, index)
+//       CHECK:     hal.return %c4, %c5, %c6 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @resolve_multiple_hints {
+  hal.executable.variant public @resolve_multiple_calls target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        iree_codegen.workgroup_count_hint(%o0)
+        iree_codegen.workgroup_count_hint(%o1)
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @resolve_multiple_hints
+//       CHECK:   hal.executable.export public @entry_point
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[MAX:.+]] = arith.maxsi %[[ARG1]], %[[ARG2]] : index
+//       CHECK:     hal.return %[[MAX]], %c1, %c1 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @resolve_multiple_conditioned_hints {
+  hal.executable.variant public @resolve_multiple_calls target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %b = arith.cmpi slt, %o0, %o1 : index
+        scf.if %b {
+          iree_codegen.workgroup_count_hint(1, 2, 3)
+        } else {
+          iree_codegen.workgroup_count_hint(4, 5, 6)
+        }
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @resolve_multiple_conditioned_hints
+//       CHECK:   hal.executable.export public @entry_point
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[CMP1:.+]] = arith.cmpi slt, %[[ARG1]], %[[ARG2]] : index
+//       CHECK:     %[[SEL1:.+]] = arith.select %[[CMP1]], %c1, %c0 : index
+//       CHECK:     %[[SEL2:.+]] = arith.select %[[CMP1]], %c2, %c0 : index
+//       CHECK:     %[[SEL3:.+]] = arith.select %[[CMP1]], %c3, %c0 : index
+//       CHECK:     %[[CMP2:.+]] = arith.cmpi sge, %[[ARG1]], %[[ARG2]] : index
+//       CHECK:     %[[SEL4:.+]] = arith.select %[[CMP2]], %c4, %c0 : index
+//       CHECK:     %[[SEL5:.+]] = arith.select %[[CMP2]], %c5, %c0 : index
+//       CHECK:     %[[SEL6:.+]] = arith.select %[[CMP2]], %c6, %c0 : index
+//       CHECK:     %[[MAX1:.+]] = arith.maxsi %[[SEL1]], %[[SEL4]] : index
+//       CHECK:     %[[MAX2:.+]] = arith.maxsi %[[SEL2]], %[[SEL5]] : index
+//       CHECK:     %[[MAX3:.+]] = arith.maxsi %[[SEL3]], %[[SEL6]] : index
+//       CHECK:     hal.return %[[MAX1]], %[[MAX2]], %[[MAX3]] : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @two_entry_points_shared_function {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point1 layout(#pipeline_layout) count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @entry_point2 layout(#pipeline_layout) count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point1() {
+        %c3 = arith.constant 3 : index
+        func.call @shared_fn(%c3) : (index) -> ()
+        return
+      }
+      func.func @entry_point2() {
+        %c7 = arith.constant 7 : index
+        func.call @shared_fn(%c7) : (index) -> ()
+        return
+      }
+      func.func @shared_fn(%arg0: index) {
+        iree_codegen.workgroup_count_hint(%arg0)
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @two_entry_points_shared_function
+//       CHECK:   hal.executable.export public @entry_point1
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device) -> (index, index, index)
+//       CHECK:     hal.return %c3, %c1, %c1 : index, index, index
+//       CHECK:   hal.executable.export public @entry_point2
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device) -> (index, index, index)
+//       CHECK:     hal.return %c7, %c1, %c1 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @multiple_entry_points_two_hints_shared_fn {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point1 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @entry_point2 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point1() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %c5 = arith.constant 5 : index
+        %cmp = arith.cmpi slt, %o0, %c5 : index
+        scf.if %cmp {
+          func.call @helper_fn(%o0) : (index) -> ()
+        }
+        return
+      }
+      func.func @entry_point2() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %c2 = arith.constant 2 : index
+        %mul = arith.muli %o0, %c2 : index
+        func.call @helper_fn(%mul) : (index) -> ()
+        return
+      }
+      func.func @helper_fn(%arg0: index) {
+        iree_codegen.workgroup_count_hint(%arg0, 1, 1)
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @multiple_entry_points_two_hints_shared_fn
+//       CHECK:   hal.executable.export public @entry_point1
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG1:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[CMP:.+]] = arith.cmpi slt, %[[ARG1]], %c5 : index
+//       CHECK:     %[[SEL1:.+]] = arith.select %[[CMP]], %[[ARG1]], %c0 : index
+//       CHECK:     %[[SEL2:.+]] = arith.select %[[CMP]], %c1, %c0 : index
+//       CHECK:     hal.return %[[SEL1]], %[[SEL2]], %[[SEL2]] : index, index, index
+//       CHECK:   hal.executable.export public @entry_point2
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG2:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[MUL:.+]] = arith.muli %[[ARG2]], %c2 : index
+//       CHECK:     hal.return %[[MUL]], %c1, %c1 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @function_chain_increment {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        func.call @increment_once(%o0) : (index) -> ()
+        return
+      }
+      func.func @increment_once(%arg0: index) {
+        %c1 = arith.constant 1 : index
+        %add = arith.addi %arg0, %c1 : index
+        func.call @increment_twice(%add) : (index) -> ()
+        return
+      }
+      func.func @increment_twice(%arg0: index) {
+        %c1 = arith.constant 1 : index
+        %add = arith.addi %arg0, %c1 : index
+        iree_codegen.workgroup_count_hint(%add, 2, 3)
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @function_chain_increment
+//       CHECK:   hal.executable.export public @entry_point
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[ADD:.+]] = arith.addi %[[ARG]], %c2 : index
+//       CHECK:     hal.return %[[ADD]], %c2, %c3 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @nested_scf_if {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %c10 = arith.constant 10 : index
+        %c20 = arith.constant 20 : index
+        %cmp1 = arith.cmpi slt, %o0, %c10 : index
+        scf.if %cmp1 {
+          %cmp2 = arith.cmpi slt, %o1, %c20 : index
+          scf.if %cmp2 {
+            iree_codegen.workgroup_count_hint(%o0, %o1, 5)
+          }
+        }
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @nested_scf_if
+//       CHECK:   hal.executable.export public @entry_point
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[CMP1:.+]] = arith.cmpi slt, %[[ARG2]], %c20 : index
+//       CHECK:     %[[CMP2:.+]] = arith.cmpi slt, %[[ARG1]], %c10 : index
+//       CHECK:     %[[AND:.+]] = arith.andi %[[CMP1]], %[[CMP2]] : i1
+//       CHECK:     %[[SEL1:.+]] = arith.select %[[AND]], %[[ARG1]], %c0 : index
+//       CHECK:     %[[SEL2:.+]] = arith.select %[[AND]], %[[ARG2]], %c0 : index
+//       CHECK:     %[[SEL3:.+]] = arith.select %[[AND]], %c5, %c0 : index
+//       CHECK:     hal.return %[[SEL1]], %[[SEL2]], %[[SEL3]] : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @optional_i1_param {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point1 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @entry_point2 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @entry_point3 layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0, %arg1)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point1() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %cmp = arith.cmpi slt, %o0, %o1 : index
+        func.call @shared_fn_with_i1(%cmp, %o0, %o1) : (i1, index, index) -> ()
+        return
+      }
+      func.func @entry_point2() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %c0 = arith.constant 0 : index
+        %binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<i1>
+        %loaded = memref.load %binding[] : memref<i1>
+        func.call @shared_fn_with_i1(%loaded, %o0, %o1) : (i1, index, index) -> ()
+        return
+      }
+      func.func @entry_point3() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %b = arith.index_cast %cst1 : index to i1
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        func.call @shared_fn_with_i1(%b, %o0, %o0) : (i1, index, index) -> ()
+        return
+      }
+      func.func @shared_fn_with_i1(%arg0: i1, %arg1: index, %arg2: index) {
+        scf.if %arg0 {
+          iree_codegen.workgroup_count_hint(%arg1, %arg2, 1)
+        } else {
+          iree_codegen.workgroup_count_hint(%arg2, %arg1, 2)
+        }
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable private @optional_i1_param
+//       CHECK:   hal.executable.export public @entry_point1
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[CMP1:.+]] = arith.cmpi slt, %[[ARG1]], %[[ARG2]] : index
+//       CHECK:     %[[SEL1:.+]] = arith.select %[[CMP1]], %[[ARG1]], %c0 : index
+//       CHECK:     %[[SEL2:.+]] = arith.select %[[CMP1]], %[[ARG2]], %c0 : index
+//       CHECK:     %[[SEL3:.+]] = arith.select %[[CMP1]], %c1, %c0 : index
+//       CHECK:     %[[CMP2:.+]] = arith.cmpi sge, %[[ARG1]], %[[ARG2]] : index
+//       CHECK:     %[[SEL4:.+]] = arith.select %[[CMP2]], %[[ARG2]], %c0 : index
+//       CHECK:     %[[SEL5:.+]] = arith.select %[[CMP2]], %[[ARG1]], %c0 : index
+//       CHECK:     %[[SEL6:.+]] = arith.select %[[CMP2]], %c2, %c0 : index
+//       CHECK:     %[[MAX1:.+]] = arith.maxsi %[[SEL1]], %[[SEL4]] : index
+//       CHECK:     %[[MAX2:.+]] = arith.maxsi %[[SEL2]], %[[SEL5]] : index
+//       CHECK:     %[[MAX3:.+]] = arith.maxsi %[[SEL3]], %[[SEL6]] : index
+//       CHECK:     hal.return %[[MAX1]], %[[MAX2]], %[[MAX3]] : index, index, index
+//       CHECK:   hal.executable.export public @entry_point2
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index) -> (index, index, index)
+//       CHECK:     %[[MAX:.+]] = arith.maxsi %[[ARG3]], %[[ARG4]] : index
+//       CHECK:     hal.return %[[MAX]], %[[MAX]], %c2 : index, index, index
+//       CHECK:   hal.executable.export public @entry_point3
+//  CHECK-SAME:     layout({{.+}}) count(%{{.+}}: !hal.device, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index) -> (index, index, index)
+//       CHECK:     hal.return %[[ARG3]], %[[ARG3]], %c2 : index, index, index
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @recursive_function_error {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        func.call @recursive_fn(%o0) : (index) -> ()
+        return
+      }
+      // expected-error @+1 {{detected recursive call when resolving workgroup count hints}}
+      func.func @recursive_fn(%arg0: index) {
+        func.call @recursive_fn(%arg0) : (index) -> ()
+        iree_codegen.workgroup_count_hint(%arg0, 1, 1)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @ordinal_out_of_bounds_error {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device, %arg0: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice(%arg0)
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %o0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        // expected-error @+1 {{ordinal number is higher than the number of workloads captured in the workgroup count region}}
+        %o1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        // expected-error @+1 {{failed to materialize operand slice}}
+        iree_codegen.workgroup_count_hint(%o0, %o1, 1)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @hint_operand_not_ordinal_error {
+  hal.executable.variant public @variant target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point layout(#pipeline_layout)
+        count(%device: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point() {
+        %c0 = arith.constant 0 : index
+        %binding = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<index>
+        %loaded = memref.load %binding[] : memref<index>
+        // expected-error @+1 {{failed to resolve workgroup count hint in terms of workload ordinals}}
+        iree_codegen.workgroup_count_hint(%loaded, 1, 1)
+        return
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -97,6 +97,7 @@ iree_compiler_cc_library(
         ":UKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_library(
     MLIRViewLikeInterface
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
     iree::compiler::Dialect::Util::IR
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/LLVM.h"
@@ -393,4 +394,46 @@ std::optional<SmallVector<int64_t, 4>> InnerTiledOp::getShapeForUnroll() {
   SmallVector<int64_t, 4> shape;
   getIterationBounds(shape);
   return shape;
+}
+
+//===----------------------------------------------------------------------===//
+// WorkgroupCountHintOp
+//===----------------------------------------------------------------------===//
+
+ParseResult WorkgroupCountHintOp::parse(OpAsmParser &parser,
+                                        OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand, 3> dynamicSizes;
+  DenseI64ArrayAttr staticSizesAttr;
+
+  if (parseDynamicIndexList(parser, dynamicSizes, staticSizesAttr,
+                            /*valueTypes=*/{},
+                            /*delimiter=*/AsmParser::Delimiter::Paren)) {
+    return failure();
+  }
+
+  // All sizes are of index type. `parseDynamicIndexList` does not set the sizes
+  // correctly when used as a custom directive so manually infer it from the
+  // number of parsed sizes.
+  IndexType indexType = parser.getBuilder().getIndexType();
+  SmallVector<Type> dynamicSizeTypes(dynamicSizes.size(), indexType);
+
+  if (parser.resolveOperands(dynamicSizes, dynamicSizeTypes,
+                             parser.getCurrentLocation(), result.operands)) {
+    return failure();
+  }
+
+  result.addAttribute("static_sizes", staticSizesAttr);
+  if (parser.parseOptionalAttrDict(result.attributes)) {
+    return failure();
+  }
+
+  return success();
+}
+
+void WorkgroupCountHintOp::print(OpAsmPrinter &printer) {
+  printDynamicIndexList(printer, getOperation(), getSizes(), getStaticSizes(),
+                        /*valueTypes=*/{},
+                        /*delimiter=*/AsmParser::Delimiter::Paren);
+  printer.printOptionalAttrDict((*this)->getAttrs(),
+                                /*elidedAttrs=*/{"static_sizes"});
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -505,33 +505,48 @@ def IREECodegen_WorkgroupCountHintOp :
 
   let description = [{
     Captures a set of values to use as the workgroup count. The backward slice
-    starting from this op's operands are cloned into the workgroup count region
+    starting from this op's operands is cloned into the workgroup count region
     of all transitive callers.
 
-    If `maxDim` is specified, the outer most sizes are linearized down to the
-    `maxDim`th count. `maxDim` is zero-indexed. If multiple hints inform the
-    same entry point, the maximum per dim is used as the count along that dim.
-    For example,
+    The sizes are specified in logical order (innermost to outermost), matching
+    the workgroup count region's (x, y, z) convention. If fewer than 3 sizes
+    are provided, the remaining dimensions default to 1.
 
-    ```
+    If multiple hints inform the same entry point, the **elementwise maximum**
+    across all hints is used as the count along each dimension. For example:
+
+    ```mlir
     hal.executable.export @entry_point
     module {
-      func @entry_point() {
-        iree_codegen.workgroup_count_hint sizes(%a, %b) maxDim(0)
-        iree_codegen.workgroup_count_hint sizes(%c, %d, %e) maxDim(1)
+      func.func @entry_point() {
+        iree_codegen.workgroup_count_hint sizes(%a, %b, %c)
+        iree_codegen.workgroup_count_hint sizes(%x, %y, %z)
       }
     }
     ```
 
-    resolves to
+    resolves to:
 
-    ```
+    ```mlir
     hal.executable.export @entry_point {
-      return max(%a * %b, %c), %d, %e
+      %wx = arith.maxsi %a, %x
+      %wy = arith.maxsi %b, %y
+      %wz = arith.maxsi %c, %z
+      hal.return %wx, %wy, %wz
     }
     ```
 
-    `maxDim` must be ∈ {0, 1, 2} = {x, y, z}.
+    #### Common Usage: Linearized Workgroup Counts
+
+    The most common use case for this operation involves computing a linearized
+    (1-D) workgroup count and specifying it as a single size.
+
+    ```mlir
+    %num_workgroups = arith.ceildivui %total_iterations, %tile_size : index
+    iree_codegen.workgroup_count_hint sizes(%num_workgroups)
+    ```
+
+    This results in `(%num_workgroups, 1, 1)` as the final workgroup count.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -15,6 +15,7 @@ include "iree/compiler/Utils/CommonTypeConstraints.td"
 include "mlir/Dialect/Linalg/IR/LinalgBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/Properties.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/TilingInterface.td"
@@ -492,6 +493,61 @@ def IREECodegen_InnerTiledOp : Op<IREECodegen_Dialect, "inner_tiled", [
   }];
 
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// HintWorkgroupCountOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_WorkgroupCountHintOp :
+    Op<IREECodegen_Dialect, "workgroup_count_hint", []> {
+  let summary = [{Hints at the workgroup count to set}];
+
+  let description = [{
+    Captures a set of values to use as the workgroup count. The backward slice
+    starting from this op's operands are cloned into the workgroup count region
+    of all transitive callers.
+
+    If `maxDim` is specified, the outer most sizes are linearized down to the
+    `maxDim`th count. `maxDim` is zero-indexed. If multiple hints inform the
+    same entry point, the maximum per dim is used as the count along that dim.
+    For example,
+
+    ```
+    hal.executable.export @entry_point
+    module {
+      func @entry_point() {
+        iree_codegen.workgroup_count_hint sizes(%a, %b) maxDim(0)
+        iree_codegen.workgroup_count_hint sizes(%c, %d, %e) maxDim(1)
+      }
+    }
+    ```
+
+    resolves to
+
+    ```
+    hal.executable.export @entry_point {
+      return max(%a * %b, %c), %d, %e
+    }
+    ```
+
+    `maxDim` must be ∈ {0, 1, 2} = {x, y, z}.
+  }];
+
+  let arguments = (ins
+    Variadic<Index>:$sizes,
+    DenseI64ArrayAttr:$static_sizes
+  );
+  let results = (outs);
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns a vector with all the static and dynamic sizes.
+    SmallVector<OpFoldResult> getMixedSizes() {
+      OpBuilder builder(getContext());
+      return ::mlir::getMixedValues(getStaticSizes(), getSizes(), builder);
+    }
+  }];
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -352,6 +352,38 @@ template void hoistStaticallyBoundAllocationsInFunc<memref::AllocaOp>(
 // Lowering `iree_tensor_ext.dispatch.workgroup_count_from_slice` operation.
 //===---------------------------------------------------------------------===//
 
+LogicalResult materializeSliceFromOrdinals(
+    RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+    ArrayRef<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinals,
+    ArrayRef<Operation *> slice) {
+  for (auto ordinalOp : ordinals) {
+    // Map `tensor_ext.dispatch.workload.ordinal` op with the corresponding
+    // workload value.
+    int64_t ordinal = ordinalOp.getOrdinal().getSExtValue();
+    if (ordinal >= static_cast<int64_t>(workloadVals.size())) {
+      return ordinalOp.emitOpError(
+          "ordinal number is higher than the number of workloads captured in "
+          "the workgroup count region");
+    }
+    map.map(ordinalOp.getResult(), workloadVals[ordinal]);
+  }
+  for (auto op : slice) {
+    // TODO(#13038) This is a WAR for these ops ending up in workgroup count
+    // computation. They should not. Some pre-processing at MaterializeEncoding
+    // time might make these go away.
+    if (isa<IREE::Codegen::QueryTileSizesOp>(op)) {
+      Value constVal =
+          arith::ConstantIndexOp::create(rewriter, op->getLoc(), 16);
+      for (auto result : op->getResults()) {
+        map.map(result, constVal);
+      }
+      continue;
+    }
+    rewriter.clone(*op, map);
+  }
+  return success();
+}
+
 FailureOr<SmallVector<OpFoldResult>> materializeWorkgroupCountComputation(
     RewriterBase &rewriter, mlir::FunctionOpInterface entryPointFn,
     ArrayRef<OpFoldResult> workgroupCount, ValueRange workloadVals) {
@@ -379,35 +411,12 @@ FailureOr<SmallVector<OpFoldResult>> materializeWorkgroupCountComputation(
   auto slicedOps = llvm::to_vector(slice);
   mlir::computeTopologicalSorting(slicedOps);
 
-  // Insert the slice into workgroup count region with all `hal.constant.index`
-  // operations replaced with arguments (drop the front argument since that is
-  // `hal.device`).
+  // Insert the slice into workgroup count region with all ordinal operations
+  // replaced with the corresponding workload values.
   IRMapping map;
-  for (auto ordinalOp : leaves) {
-    // Map `flow.dispatch.constant_ordinal` op with the corresponding operand of
-    // the `flow.dispatch.workgroup_count_default` operation.
-    int64_t ordinal = ordinalOp.getOrdinal().getSExtValue();
-    if (ordinal >= workloadVals.size()) {
-      return ordinalOp.emitOpError(
-          "ordinal number is higher than the number of workloads captured in "
-          "the workgroup count region");
-    }
-    map.map(ordinalOp.getResult(),
-            workloadVals[ordinalOp.getOrdinal().getSExtValue()]);
-  }
-  for (auto op : slice) {
-    // TODO(#13038) This is a WAR for the these ops ending up in workgroup count
-    // computation. They should not. Some pre-processing at MaterializeEncoding
-    // time might make these go away.
-    if (isa<IREE::Codegen::QueryTileSizesOp>(op)) {
-      Value constVal =
-          arith::ConstantIndexOp::create(rewriter, op->getLoc(), 16);
-      for (auto result : op->getResults()) {
-        map.map(result, constVal);
-      }
-      continue;
-    }
-    rewriter.clone(*op, map);
+  if (failed(materializeSliceFromOrdinals(rewriter, map, workloadVals, leaves,
+                                          slicedOps))) {
+    return failure();
   }
   SmallVector<OpFoldResult> results;
   // Since the workgroup count at HAL level is in x, y, z form, process the

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -125,6 +125,15 @@ void analyseAllocsForPacking(mlir::FunctionOpInterface funcOp,
 void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
                 ArrayRef<AliasGroup> aliasGroups);
 
+/// Materialize the provided slice at the current insertion point. The leaves of
+/// the slice are expected to be `iree_tensor_ext.workload.ordinal` ops that
+/// are mapped to the corresponding `workloadVals`. The `map` is updated with
+/// the mapping from the original ops to the cloned ops.
+LogicalResult materializeSliceFromOrdinals(
+    RewriterBase &rewriter, IRMapping &map, ValueRange workloadVals,
+    ArrayRef<IREE::TensorExt::DispatchWorkloadOrdinalOp> ordinals,
+    ArrayRef<Operation *> slice);
+
 /// Materialize the backward slice starting at the values in `workgroupCount`
 /// at the current insertion point of the `rewriter`. The leaves of the slice
 /// are expected to be `iree_tensor_ext.workload.ordinal` ops that

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
     hdrs = [
         "HALDialect.h",
         "HALOps.h",
+        "HALTraits.h",
         "HALTypes.h",
     ],
     textual_hdrs = [

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "HALDialect.h"
     "HALOps.h"
+    "HALTraits.h"
     "HALTypes.h"
   TEXTUAL_HDRS
     "HALAttrInterfaces.cpp.inc"

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -17,6 +17,13 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
+// HAL traits
+//===----------------------------------------------------------------------===//
+
+// Denotes that an operation is part of the executable interface.
+def HAL_ExecutableInterfaceOp : NativeOpTrait<"IREE::HAL::ExecutableInterfaceOp">;
+
+//===----------------------------------------------------------------------===//
 // Base dialect op/type/attr/interface classes
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 
+#include "iree/compiler/Dialect/HAL/IR/HALTraits.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -3440,6 +3440,7 @@ let opDocGroup = OpGroupInterfaceOps in {
 
 class HAL_InterfaceWorkgroupOp<string mnemonic, list<Trait> traits = []>
   : HAL_PureOp<mnemonic, !listconcat(traits, [
+      HAL_ExecutableInterfaceOp,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
       DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>])> {
   let arguments = (ins
@@ -3514,7 +3515,9 @@ def HAL_InterfaceWorkgroupSizeOp : HAL_InterfaceWorkgroupOp<"interface.workgroup
   }];
 }
 
-def HAL_InterfaceConstantLoadOp : HAL_PureOp<"interface.constant.load"> {
+def HAL_InterfaceConstantLoadOp : HAL_PureOp<"interface.constant.load", [
+    HAL_ExecutableInterfaceOp,
+]> {
   let summary = [{Loads a constant value from the interface constant block.}];
   let description = [{
     Loads a scalar constant value from an executable IO push constant block.
@@ -3557,6 +3560,7 @@ def HAL_InterfaceConstantLoadOp : HAL_PureOp<"interface.constant.load"> {
 def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan", [
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface, ["reifyResultShapes"]>,
+  HAL_ExecutableInterfaceOp,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{Returns an alias to a subspan of interface binding data.}];

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTraits.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTraits.h
@@ -1,0 +1,23 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_HAL_IR_HALTRAITS_H_
+#define IREE_COMPILER_DIALECT_HAL_IR_HALTRAITS_H_
+
+#include "mlir/IR/OpDefinition.h"
+
+namespace mlir ::OpTrait::IREE::HAL {
+
+template <typename ConcreteType>
+class ExecutableInterfaceOp
+    : public OpTrait::TraitBase<ConcreteType, ExecutableInterfaceOp> {
+public:
+  static LogicalResult verifyTrait(Operation *op) { return success(); }
+};
+
+} // namespace mlir::OpTrait::IREE::HAL
+
+#endif // IREE_COMPILER_DIALECT_HAL_IR_HALTRAITS_H_


### PR DESCRIPTION
Currently ReconcileTranslationInfoPass is responsible for:
1. Comparing translation_info for consistency
2. Converting `scf.forall` with workgroup mapping to explicit uses of mapping ids.
3. Populating workgroup count regions based on the trip count of the resolved `scf.forall` op(s).

(3) requires the pass to nest at the variant level and precludes any other code paths from being involved with workgroup count resolution. This PR adds an operation + resolver pass for hinting at the workgroup count. In a follow up ReconcileTranslationInfoPass will be updated to generate these ops directly.