### PR TITLE
[NFC][Codegen] Extract dimension expansion helpers into common utilities

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -36,17 +36,6 @@ using TensorDivisibilityInfo =
 
 namespace {
 
-struct RemoveOptimizationBarrier final
-    : public OpRewritePattern<IREE::Util::OptimizationBarrierOp> {
-  using Base::Base;
-
-  LogicalResult matchAndRewrite(IREE::Util::OptimizationBarrierOp barrierOp,
-                                PatternRewriter &rewriter) const override {
-    rewriter.replaceOp(barrierOp, barrierOp.getOperands());
-    return success();
-  }
-};
-
 /// This pass is used to materialize information about dynamic dimensions of
 /// `tensor` operands of an operation in the IR. If a dynamic dimension is
 /// known to be a multiple of a compile-time constant value, this pass
@@ -110,70 +99,15 @@ getTensorDivisibilityInfo(const TensorDynamicDimAnalysis &dynamicDimAnalysis,
 /// inverses of each other. The `util.optimization.barrier` avoid these from
 /// getting folded away during reshape propagation. Return the result of the
 /// `tensor.collapse_shape generated.
-struct ReshapeOps {
-  tensor::ExpandShapeOp expandShapeOp;
-  tensor::CollapseShapeOp collapseShapeOp;
-};
 static std::optional<ReshapeOps>
 blockDynamicDimensionsOfValue(RewriterBase &rewriter,
                               const TensorDivisibilityInfo &divisibilityInfo,
                               Value v) {
-  auto tensorType = dyn_cast<RankedTensorType>(v.getType());
-  if (!tensorType) {
-    return std::nullopt;
+  llvm::SmallDenseMap<unsigned, int64_t> expansionMap;
+  for (auto [index, divisibility] : divisibilityInfo) {
+    expansionMap[index] = static_cast<int64_t>(divisibility.sdiv());
   }
-
-  // Check if we know that the operands have a divisibility information.
-  SmallVector<OpFoldResult> outputShape;
-  SmallVector<ReassociationIndices> reassociation;
-  Location loc = v.getLoc();
-  SmallVector<OpFoldResult> origShape = tensor::getMixedSizes(rewriter, loc, v);
-
-  for (auto [index, dim] : llvm::enumerate(origShape)) {
-    reassociation.emplace_back(ReassociationIndices{});
-
-    // Check if this needs division.
-    if (!tensorType.isDynamicDim(index) || !divisibilityInfo.contains(index)) {
-      reassociation.back().push_back(outputShape.size());
-      outputShape.push_back(dim);
-      continue;
-    }
-
-    // Split the dynamic based on the divisibility info.
-    IREE::Util::ConstantIntDivisibility currDivisibility =
-        divisibilityInfo.lookup(index);
-    uint64_t factor = currDivisibility.sdiv();
-    AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
-    AffineExpr divExpr = s0.floorDiv(factor);
-    OpFoldResult newDynamicDim = affine::makeComposedFoldedAffineApply(
-        rewriter, loc, divExpr, ArrayRef<OpFoldResult>{dim});
-    OpFoldResult newStaticDim = rewriter.getIndexAttr(factor);
-
-    reassociation.back().push_back(outputShape.size());
-    reassociation.back().push_back(outputShape.size() + 1);
-
-    outputShape.push_back(newDynamicDim);
-    outputShape.push_back(newStaticDim);
-  }
-
-  auto staticOutputShape =
-      llvm::map_to_vector(outputShape, [](OpFoldResult ofr) {
-        if (auto staticShapeAttr = dyn_cast<Attribute>(ofr)) {
-          return cast<IntegerAttr>(staticShapeAttr).getInt();
-        }
-        return ShapedType::kDynamic;
-      });
-  auto outputType = RankedTensorType::get(
-      staticOutputShape, tensorType.getElementType(), tensorType.getEncoding());
-
-  auto expandShapeOp = tensor::ExpandShapeOp::create(
-      rewriter, loc, outputType, v, reassociation, outputShape);
-  Value barrier = IREE::Util::OptimizationBarrierOp::create(
-                      rewriter, loc, expandShapeOp.getResult())
-                      .getResult(0);
-  auto collapseShapeOp = tensor::CollapseShapeOp::create(
-      rewriter, loc, tensorType, barrier, reassociation);
-  return ReshapeOps{expandShapeOp, collapseShapeOp};
+  return createDimensionExpansionOps(rewriter, expansionMap, v);
 }
 
 //===---------------------------------------------------------------------===//
@@ -413,7 +347,7 @@ void BlockDynamicDimensionsPass::runOnOperation() {
   // Delete the optimization barrier and run some further cleanup.
   {
     RewritePatternSet removeBarrierOpsPatterns(context);
-    removeBarrierOpsPatterns.insert<RemoveOptimizationBarrier>(context);
+    populateRemoveOptimizationBarrierPatterns(removeBarrierOpsPatterns);
     tensor::ExpandShapeOp::getCanonicalizationPatterns(removeBarrierOpsPatterns,
                                                        context);
     tensor::CollapseShapeOp::getCanonicalizationPatterns(

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -7,9 +7,16 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 #define DEBUG_TYPE "iree-codegen-common-transforms"
@@ -726,6 +733,101 @@ struct SwapCollapseShapeWithSlicePattern
 
 void populateSwapExtractWithCollapsePattern(RewritePatternSet &patterns) {
   patterns.add<SwapCollapseShapeWithSlicePattern>(patterns.getContext());
+}
+
+namespace {
+
+struct RemoveOptimizationBarrier final
+    : public OpRewritePattern<IREE::Util::OptimizationBarrierOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(IREE::Util::OptimizationBarrierOp barrierOp,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOp(barrierOp, barrierOp.getOperands());
+    return success();
+  }
+};
+
+} // namespace
+
+std::optional<ReshapeOps> createDimensionExpansionOps(
+    RewriterBase &rewriter,
+    const llvm::SmallDenseMap<unsigned, int64_t> &expansionMap, Value v) {
+  auto tensorType = dyn_cast<RankedTensorType>(v.getType());
+  if (!tensorType) {
+    return std::nullopt;
+  }
+
+  SmallVector<OpFoldResult> outputShape;
+  SmallVector<ReassociationIndices> reassociation;
+  Location loc = v.getLoc();
+  SmallVector<OpFoldResult> origShape = tensor::getMixedSizes(rewriter, loc, v);
+
+  for (auto [index, dim] : llvm::enumerate(origShape)) {
+    reassociation.emplace_back(ReassociationIndices{});
+
+    if (!expansionMap.contains(index)) {
+      reassociation.back().push_back(outputShape.size());
+      outputShape.push_back(dim);
+      continue;
+    }
+
+    int64_t factor = expansionMap.lookup(index);
+    AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
+    AffineExpr divExpr = s0.floorDiv(factor);
+    OpFoldResult newOuterDim = affine::makeComposedFoldedAffineApply(
+        rewriter, loc, divExpr, ArrayRef<OpFoldResult>{dim});
+    OpFoldResult newInnerDim = rewriter.getIndexAttr(factor);
+
+    reassociation.back().push_back(outputShape.size());
+    reassociation.back().push_back(outputShape.size() + 1);
+
+    outputShape.push_back(newOuterDim);
+    outputShape.push_back(newInnerDim);
+  }
+
+  auto staticOutputShape =
+      llvm::map_to_vector(outputShape, [](OpFoldResult ofr) {
+        if (auto staticShapeAttr = dyn_cast<Attribute>(ofr)) {
+          return cast<IntegerAttr>(staticShapeAttr).getInt();
+        }
+        return ShapedType::kDynamic;
+      });
+  auto outputType = RankedTensorType::get(
+      staticOutputShape, tensorType.getElementType(), tensorType.getEncoding());
+
+  auto expandShapeOp = tensor::ExpandShapeOp::create(
+      rewriter, loc, outputType, v, reassociation, outputShape);
+  Value barrier = IREE::Util::OptimizationBarrierOp::create(
+                      rewriter, loc, expandShapeOp.getResult())
+                      .getResult(0);
+  auto collapseShapeOp = tensor::CollapseShapeOp::create(
+      rewriter, loc, tensorType, barrier, reassociation);
+  return ReshapeOps{expandShapeOp, collapseShapeOp};
+}
+
+void populateRemoveOptimizationBarrierPatterns(RewritePatternSet &patterns) {
+  patterns.insert<RemoveOptimizationBarrier>(patterns.getContext());
+}
+
+void populateReshapePropagationPatterns(RewritePatternSet &patterns,
+                                        linalg::ControlFusionFn controlFn) {
+  if (!controlFn) {
+    controlFn = [](OpOperand *opOperand) {
+      return !isa_and_nonnull<linalg::FillOp, tensor::EmptyOp>(
+          opOperand->get().getDefiningOp());
+    };
+  }
+  linalg::populateFoldReshapeOpsByExpansionPatterns(patterns, controlFn);
+  IREE::LinalgExt::populateFoldReshapeOpsByExpansionPatterns(patterns,
+                                                             controlFn);
+  populateReshapeToInterfaceTensorPatterns(patterns);
+  populateCombineRelayoutOpPatterns(patterns);
+  populateFoldTensorReshapeIntoBufferPatterns(patterns);
+  tensor::populateFoldTensorEmptyPatterns(patterns);
+  tensor::populateBubbleUpExpandShapePatterns(patterns);
+  linalg::FillOp::getCanonicalizationPatterns(patterns, patterns.getContext());
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -207,6 +207,42 @@ void populateCombineRelayoutOpPatterns(
 /// Populate patterns to fuse tilable consumers of forall ops into it.
 void populateFuseTilableForallConsumersPattern(RewritePatternSet &patterns);
 
+//===----------------------------------------------------------------------===//
+// Utilities for iteration space expansion transformations
+//===----------------------------------------------------------------------===//
+
+/// Helper struct to hold the expand/collapse shape ops created for dimension
+/// expansion or blocking transformations.
+struct ReshapeOps {
+  tensor::ExpandShapeOp expandShapeOp;
+  tensor::CollapseShapeOp collapseShapeOp;
+};
+
+/// For a `v` if the dimension is known to be multiple of a compile-time static
+/// value, insert
+///
+/// ```mlir
+/// %v_expand = tensor.expand_shape %v
+/// %barrier = util.optimization.barrier %v
+/// %v_collapse = tensor.collapse_shape %barrier
+/// ```
+///
+/// where the generated `tensor.expand_shape` and `tensor.collapse_shape` are
+/// inverses of each other. The `util.optimization.barrier` avoid these from
+/// getting folded away during reshape propagation. Return the result of the
+/// `tensor.collapse_shape generated.
+std::optional<ReshapeOps> createDimensionExpansionOps(
+    RewriterBase &rewriter,
+    const llvm::SmallDenseMap<unsigned, int64_t> &expansionMap, Value v);
+
+/// Populate patterns to remove optimization barriers.
+void populateRemoveOptimizationBarrierPatterns(RewritePatternSet &patterns);
+
+/// Populate common patterns for reshape propagation used in dimension
+/// expansion passes.
+void populateReshapePropagationPatterns(
+    RewritePatternSet &patterns, linalg::ControlFusionFn controlFn = nullptr);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_


### PR DESCRIPTION
This patch extracts common functionality for dimension expansion into reusable utility functions in Transforms.cpp/h and updates the existing BlockDynamicDimensions pass to use them. This is in preparation for splitting up the PR in static dimension expansion (https://github.com/iree-org/iree/pull/22342).