### PR TITLE
[Codegen] Allow iree_codegen.swizzle_hint to operate on tensors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -3126,42 +3126,34 @@ func.func @transfer_gather(%source : tensor<?x64xf16>, %indices: vector<8xindex>
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @swizzle_hint() {
+func.func @swizzle_hint(%arg0: tensor<1024xf32>) -> tensor<1024xf32> {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
   %c64 = arith.constant 63 : index
   %c512 = arith.constant 512 : index
-  %arg0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024xf32>>
-  %arg1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
-    : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024xf32>>
-  %0 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0], sizes=[1024], strides=[1]
-    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024xf32>> -> tensor<1024xf32>
   %temp = bufferization.alloc_tensor() : tensor<512xf32>
   %swizzled.temp = iree_codegen.swizzle_hint %temp[#iree_codegen.rotate_rows<256, 4>] : tensor<512xf32>
   %1 = scf.forall (%arg2) in (64) shared_outs(%arg3 = %swizzled.temp) -> tensor<512xf32> {
     %off = arith.muli %arg2, %c4 : index
-    %slice = tensor.extract_slice %0[%off] [4] [1] : tensor<1024xf32> to tensor<4xf32>
+    %slice = tensor.extract_slice %arg0[%off] [4] [1] : tensor<1024xf32> to tensor<4xf32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %slice into %arg3[%off] [4] [1] : tensor<4xf32> into tensor<512xf32>
     }
   } {mapping = [#gpu.thread<linear_dim_0>]}
   // Somewhat convoluted swap-things-around "kernel" to provide a minimal example
   // showing that swizzle hints persist on a tensor.
-  scf.forall (%arg2) in (64) {
+  %ret.init = tensor.empty() : tensor<1024xf32>
+  %ret = scf.forall (%arg2) in (64) shared_outs(%arg3 = %ret.init) -> tensor<1024xf32> {
     %arg2.reversed = arith.subi %c64, %arg2 : index
     %off.rev = arith.muli %arg2.reversed, %c4 : index
     %off = arith.muli %arg2, %c4 : index
     %slice = tensor.extract_slice %1[%off.rev] [4] [1] : tensor<512xf32> to tensor<4xf32>
-    iree_tensor_ext.dispatch.tensor.store %slice, %arg1, offsets=[%off], sizes=[4], strides=[1]
-      : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024xf32>>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %slice into %arg3[%off] [4] [1] : tensor<4xf32> into tensor<1024xf32>
+    }
   } {mapping = [#gpu.thread<linear_dim_0>]}
 
-  return
+  return %ret : tensor<1024xf32>
 }
 
 // CHECK-LABEL: func.func @swizzle_hint

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -119,8 +119,8 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     SameOperandsAndResultType, Pure]> {
   let summary = [{Hint to swizzle accesses according to an access pattern.}];
   let description = [{
-    Optimization hint to swizzle all accesses to a memref or tensor this takes a
-    view of. This only affects reads/writes immediately consuming this operation
+    Optimization hint to swizzle all accesses to the memref or tensor that this takes a
+    view of. This only affects reads/writes that immediately consume this operation
     and is best effort. If the desired swizzling is not apparently possible, this
     op will no-op. As a result, it should not be relied on for correctness.
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -124,7 +124,7 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     and is best effort. If the desired swizzling is not apparently possible, this
     op will no-op. As a result, it should not be relied on for correctness.
 
-    Any subviews on this operation will cause swizzle application to fail. The
+    Any subviews on this operation will cause the swizzle application to fail. The
     expectation is for all view like operations to fold into the accessing ops
     (loads/stores) before this op takes effect.
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -119,13 +119,13 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     SameOperandsAndResultType, Pure]> {
   let summary = [{Hint to swizzle accesses according to an access pattern.}];
   let description = [{
-    Optimization hint to swizzle all accesses to the memref this takes a view
-    of. This only affects reads/writes immediately consuming this operation and
-    is best effort. If the desired swizzling is not apparently possible, this
+    Optimization hint to swizzle all accesses to a memref or tensor this takes a
+    view of. This only affects reads/writes immediately consuming this operation
+    and is best effort. If the desired swizzling is not apparently possible, this
     op will no-op. As a result, it should not be relied on for correctness.
 
-    Any subviews on this operation will cause swizzling to fail. The expectation
-    is for all view like operations to fold into the accessing ops
+    Any subviews on this operation will cause swizzle application to fail. The
+    expectation is for all view like operations to fold into the accessing ops
     (loads/stores) before this op takes effect.
 
     Note that this only rewrites direct users. If there are any aliased loads
@@ -156,9 +156,9 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     is otherwise perfectly legal.
   }];
 
-  let arguments = (ins MemRefRankOf<[AnyType], [1]>:$operand,
+  let arguments = (ins RankedTensorOrMemRefOf<[AnyType], [1]>:$operand,
                        IREECodegen_AnySwizzleAttr:$swizzle);
-  let results = (outs MemRefRankOf<[AnyType], [1]>:$result);
+  let results = (outs RankedTensorOrMemRefOf<[AnyType], [1]>:$result);
 
   let assemblyFormat = [{
     $operand `[` $swizzle attr-dict `]` `:` type($result)

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -264,8 +264,9 @@ struct SwizzleHintOpInterface final
     auto hintOp = cast<IREE::Codegen::SwizzleHintOp>(op);
     FailureOr<Value> maybeBuffer =
         getBuffer(rewriter, hintOp.getOperand(), options, state);
-    if (failed(maybeBuffer))
+    if (failed(maybeBuffer)) {
       return failure();
+    }
     replaceOpWithNewBufferizedOp<IREE::Codegen::SwizzleHintOp>(
         rewriter, op, *maybeBuffer, hintOp.getSwizzle());
     return success();

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -267,10 +267,8 @@ struct SwizzleHintOpInterface
         getBuffer(rewriter, hintOp.getOperand(), options, state);
     if (failed(maybeBuffer))
       return failure();
-    Value operandMemref = *maybeBuffer;
-
     replaceOpWithNewBufferizedOp<IREE::Codegen::SwizzleHintOp>(
-        rewriter, op, operandMemref, hintOp.getSwizzle());
+        rewriter, op, *maybeBuffer, hintOp.getSwizzle());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -235,8 +235,8 @@ struct StoreToBufferOpInterface
   }
 };
 
-struct SwizzleHintOpInterface
-    : public BufferizableOpInterface::ExternalModel<
+struct SwizzleHintOpInterface final
+    : BufferizableOpInterface::ExternalModel<
           SwizzleHintOpInterface, IREE::Codegen::SwizzleHintOp> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -236,26 +236,25 @@ struct StoreToBufferOpInterface
 };
 
 struct SwizzleHintOpInterface final
-    : BufferizableOpInterface::ExternalModel<
-          SwizzleHintOpInterface, IREE::Codegen::SwizzleHintOp> {
-  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
-                              const AnalysisState &state) const {
+    : BufferizableOpInterface::ExternalModel<SwizzleHintOpInterface,
+                                             IREE::Codegen::SwizzleHintOp> {
+  bool bufferizesToMemoryRead(Operation *, OpOperand &,
+                              const AnalysisState &) const {
     return false;
   }
 
-  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
-                               const AnalysisState &state) const {
+  bool bufferizesToMemoryWrite(Operation *, OpOperand &,
+                               const AnalysisState &) const {
     return false;
   }
 
-  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
-                            const AnalysisState &state) const {
+  bool mustBufferizeInPlace(Operation *, OpOperand &,
+                            const AnalysisState &) const {
     return true;
   }
 
   bufferization::AliasingValueList
-  getAliasingValues(Operation *op, OpOperand &opOperand,
-                    const AnalysisState &state) const {
+  getAliasingValues(Operation *op, OpOperand &, const AnalysisState &) const {
     return {{op->getResult(0), BufferRelation::Equivalent, /*definite=*/true}};
   }
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -17,7 +17,6 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
-#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"
@@ -27,7 +26,6 @@
 #include "mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
@@ -233,6 +231,46 @@ struct StoreToBufferOpInterface
       return failure();
 
     rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+struct SwizzleHintOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          SwizzleHintOpInterface, IREE::Codegen::SwizzleHintOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return false;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return false;
+  }
+
+  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
+                            const AnalysisState &state) const {
+    return true;
+  }
+
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *op, OpOperand &opOperand,
+                    const AnalysisState &state) const {
+    return {{op->getResult(0), BufferRelation::Equivalent, /*definite=*/true}};
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto hintOp = cast<IREE::Codegen::SwizzleHintOp>(op);
+    FailureOr<Value> maybeBuffer =
+        getBuffer(rewriter, hintOp.getOperand(), options, state);
+    if (failed(maybeBuffer))
+      return failure();
+    Value operandMemref = *maybeBuffer;
+
+    replaceOpWithNewBufferizedOp<IREE::Codegen::SwizzleHintOp>(
+        rewriter, op, operandMemref, hintOp.getSwizzle());
     return success();
   }
 };
@@ -687,14 +725,15 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
         IREE::TensorExt::DispatchTensorStoreOp::attachInterface<
             DispatchTensorStoreOpSubsetInsertionInterface>(*ctx);
       });
-  registry.addExtension(
-      +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
-        IREE::Codegen::LoadFromBufferOp::attachInterface<
-            LoadFromBufferOpInterface, LoadFromBufferOpSubsetInterface>(*ctx);
-        IREE::Codegen::StoreToBufferOp::attachInterface<
-            StoreToBufferOpInterface, StoreToBufferOpSubsetInterface,
-            StoreToBufferOpSubsetInsertionInterface>(*ctx);
-      });
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::Codegen::IREECodegenDialect *dialect) {
+    IREE::Codegen::LoadFromBufferOp::attachInterface<
+        LoadFromBufferOpInterface, LoadFromBufferOpSubsetInterface>(*ctx);
+    IREE::Codegen::StoreToBufferOp::attachInterface<
+        StoreToBufferOpInterface, StoreToBufferOpSubsetInterface,
+        StoreToBufferOpSubsetInsertionInterface>(*ctx);
+    IREE::Codegen::SwizzleHintOp::attachInterface<SwizzleHintOpInterface>(*ctx);
+  });
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::LinalgExt::IREELinalgExtDialect *dialect) {
         LinalgExtOpInterfaceHelper<


### PR DESCRIPTION
This change will allow us to introduce swizzle hints during promotion when needed for performance (such as on MXFP4).