### PR TITLE
Fix BYO LLVM build: handle MLIRTargetLLVMIRImport as non-object library

### DIFF
--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -106,10 +106,11 @@ public:
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<
-        IREE::Encoding::IREEEncodingDialect, IREE::Codegen::IREECodegenDialect,
-        IREE::CPU::IREECPUDialect, IREE::VM::VMDialect, IREE::VMVX::VMVXDialect,
-        IREE::LinalgExt::IREELinalgExtDialect>();
+    registry
+        .insert<IREE::CPU::IREECPUDialect, IREE::Codegen::IREECodegenDialect,
+                IREE::Encoding::IREEEncodingDialect,
+                IREE::LinalgExt::IREELinalgExtDialect, IREE::VM::VMDialect,
+                IREE::VMVX::VMVXDialect>();
   }
 
   IREE::VM::TargetOptions

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/VMVX/Passes.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
@@ -105,10 +106,10 @@ public:
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry
-        .insert<IREE::Codegen::IREECodegenDialect, IREE::CPU::IREECPUDialect,
-                IREE::VM::VMDialect, IREE::VMVX::VMVXDialect,
-                IREE::LinalgExt::IREELinalgExtDialect>();
+    registry.insert<
+        IREE::Encoding::IREEEncodingDialect, IREE::Codegen::IREECodegenDialect,
+        IREE::CPU::IREECPUDialect, IREE::VM::VMDialect, IREE::VMVX::VMVXDialect,
+        IREE::LinalgExt::IREELinalgExtDialect>();
   }
 
   IREE::VM::TargetOptions

--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -82,7 +82,6 @@ set(_EXPORT_OBJECT_LIBS
   obj.MLIRCAPITransforms
   obj.MLIRCAPITransformDialect
   obj.MLIRCAPITransformDialectTransforms
-  obj.MLIRTargetLLVMIRImport
   iree_compiler_API_Internal_CompilerDriver.objects
   iree_compiler_API_Internal_IREECompileToolEntryPoint.objects
   iree_compiler_API_Internal_IREECodegenDialectCAPI.objects
@@ -187,6 +186,11 @@ target_sources(iree_compiler_API_SharedImpl PRIVATE
 # isolated boundary for C consumers.
 target_link_libraries(iree_compiler_API_SharedImpl PRIVATE
   ${_EXPORT_OBJECT_DEPS}
+)
+
+# Link MLIRTargetLLVMIRImport directly since it is not exported as an object library.
+target_link_libraries(iree_compiler_API_SharedImpl PRIVATE
+  MLIRTargetLLVMIRImport
 )
 
 # If not using sanitizers, ask linkers to error on undefined symbols.


### PR DESCRIPTION
## Summary

The fix resolves a **type mismatch issue** introduced when LLVM added `MLIRTargetLLVMIRImport`. IREE's CMake code was trying to use it as an **OBJECT library** (for embedding), but LLVM only exports it as a **STATIC library** (for linking). 

The solution from Claude correctly handles this by:
1. Removing the non-existent object library from the export list
2. Adding the actual static library as a regular dependency

This allows CMake to properly find and link the target without trying to extract object files from a library type that doesn't support it.

It also adds missing Encoding dialect dependency. The issue happened when the job has been failing.

## The Root Cause

When LLVM added the `MLIRTargetLLVMIRImport` target in commit 5a112ded, it was created as a **STATIC library**, not an **OBJECT library**. This is an important distinction:

- **STATIC library** (`.a` or `.lib`): A pre-compiled archive of object files that can be linked into other libraries/executables
- **OBJECT library**: CMake's special concept of a library that exports raw object files (`.o`) for embedding into other libraries

IREE's commit 0dddb175ad9 tried to add `obj.MLIRTargetLLVMIRImport` to the export list, but LLVM only provides `MLIRTargetLLVMIRImport` as a static library, so the object library variant doesn't exist.

The original code was trying to:
- **Extract object files** from `obj.MLIRTargetLLVMIRImport` 
- **Embed them directly** into the shared library
- **Extract and propagate** all transitive dependencies

Our fix instead:
- **Links the whole static library** as a dependency
- **Lets CMake handle** the linking and dependency resolution automatically
- **Avoids the non-existent object library** issue entirely

This is the correct approach because `MLIRTargetLLVMIRImport` is not a CAPI library like the other targets in the list (which are CAPI object libraries meant to be embedded). It's a regular utility library that should be linked normally.