### PR TITLE
[runtime] Require aligned memory accesses by default

### DIFF
--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -309,19 +309,6 @@ static inline void iree_page_align_range(void* base_address,
 // Alignment-safe memory accesses
 //===----------------------------------------------------------------------===//
 
-// Map little-endian byte indices in memory to the host memory order indices.
-#if defined(IREE_ENDIANNESS_LITTLE)
-#define IREE_LE_IDX_1(i) (i)
-#define IREE_LE_IDX_2(i) (i)
-#define IREE_LE_IDX_4(i) (i)
-#define IREE_LE_IDX_8(i) (i)
-#else
-#define IREE_LE_IDX_1(i) (i)
-#define IREE_LE_IDX_2(i) (1 - (i))
-#define IREE_LE_IDX_4(i) (3 - (i))
-#define IREE_LE_IDX_8(i) (7 - (i))
-#endif  // IREE_ENDIANNESS_*
-
 #if IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_8
 
 static inline uint8_t iree_unaligned_load_le_u8(const uint8_t* ptr) {
@@ -352,13 +339,14 @@ static inline void iree_unaligned_store_le_u8(uint8_t* ptr, uint8_t value) {
 
 static inline uint16_t iree_unaligned_load_le_u16(const uint16_t* ptr) {
   const uint8_t* p = (const uint8_t*)ptr;
-  return ((uint16_t)p[IREE_LE_IDX_2(0)]) | ((uint16_t)p[IREE_LE_IDX_2(1)] << 8);
+  uint16_t value = 0;
+  memcpy(&value, p, sizeof(value));
+  return value;
 }
 
 static inline void iree_unaligned_store_le_u16(uint16_t* ptr, uint16_t value) {
   uint8_t* p = (uint8_t*)ptr;
-  p[IREE_LE_IDX_2(0)] = value;
-  p[IREE_LE_IDX_2(1)] = value >> 8;
+  memcpy(p, &value, sizeof(value));
 }
 
 #else
@@ -381,29 +369,24 @@ static inline void iree_unaligned_store_le_u16(uint16_t* ptr, uint16_t value) {
 
 static inline uint32_t iree_unaligned_load_le_u32(const uint32_t* ptr) {
   const uint8_t* p = (const uint8_t*)ptr;
-  return ((uint32_t)p[IREE_LE_IDX_4(0)]) |
-         ((uint32_t)p[IREE_LE_IDX_4(1)] << 8) |
-         ((uint32_t)p[IREE_LE_IDX_4(2)] << 16) |
-         ((uint32_t)p[IREE_LE_IDX_4(3)] << 24);
+  uint32_t value = 0;
+  memcpy(&value, p, sizeof(value));
+  return value;
 }
 static inline float iree_unaligned_load_le_f32(const float* ptr) {
-  uint32_t uint_value = iree_unaligned_load_le_u32((const uint32_t*)ptr);
+  uint8_t* p = (uint8_t*)ptr;
   float value;
-  memcpy(&value, &uint_value, sizeof(value));
+  memcpy(&value, p, sizeof(value));
   return value;
 }
 
 static inline void iree_unaligned_store_le_u32(uint32_t* ptr, uint32_t value) {
   uint8_t* p = (uint8_t*)ptr;
-  p[IREE_LE_IDX_4(0)] = value;
-  p[IREE_LE_IDX_4(1)] = value >> 8;
-  p[IREE_LE_IDX_4(2)] = value >> 16;
-  p[IREE_LE_IDX_4(3)] = value >> 24;
+  memcpy(p, &value, sizeof(value));
 }
 static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
-  uint32_t uint_value;
-  memcpy(&uint_value, &value, sizeof(value));
-  iree_unaligned_store_le_u32((uint32_t*)ptr, uint_value);
+  uint8_t* p = (uint8_t*)ptr;
+  memcpy(p, &value, sizeof(value));
 }
 
 #else
@@ -428,37 +411,24 @@ static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
 
 static inline uint64_t iree_unaligned_load_le_u64(const uint64_t* ptr) {
   const uint8_t* p = (const uint8_t*)ptr;
-  return ((uint64_t)p[IREE_LE_IDX_8(0)]) |
-         ((uint64_t)p[IREE_LE_IDX_8(1)] << 8) |
-         ((uint64_t)p[IREE_LE_IDX_8(2)] << 16) |
-         ((uint64_t)p[IREE_LE_IDX_8(3)] << 24) |
-         ((uint64_t)p[IREE_LE_IDX_8(4)] << 32) |
-         ((uint64_t)p[IREE_LE_IDX_8(5)] << 40) |
-         ((uint64_t)p[IREE_LE_IDX_8(6)] << 48) |
-         ((uint64_t)p[IREE_LE_IDX_8(7)] << 56);
+  uint64_t value = 0;
+  memcpy(&value, p, sizeof(value));
+  return value;
 }
 static inline double iree_unaligned_load_le_f64(const double* ptr) {
-  uint64_t uint_value = iree_unaligned_load_le_u64((const uint64_t*)ptr);
+  uint8_t* p = (uint8_t*)ptr;
   double value;
-  memcpy(&value, &uint_value, sizeof(value));
+  memcpy(&value, p, sizeof(value));
   return value;
 }
 
 static inline void iree_unaligned_store_le_u64(uint64_t* ptr, uint64_t value) {
   uint8_t* p = (uint8_t*)ptr;
-  p[IREE_LE_IDX_8(0)] = value;
-  p[IREE_LE_IDX_8(1)] = value >> 8;
-  p[IREE_LE_IDX_8(2)] = value >> 16;
-  p[IREE_LE_IDX_8(3)] = value >> 24;
-  p[IREE_LE_IDX_8(4)] = value >> 32;
-  p[IREE_LE_IDX_8(5)] = value >> 40;
-  p[IREE_LE_IDX_8(6)] = value >> 48;
-  p[IREE_LE_IDX_8(7)] = value >> 56;
+  memcpy(p, &value, sizeof(value));
 }
 static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
-  uint64_t uint_value;
-  memcpy(&uint_value, &value, sizeof(value));
-  iree_unaligned_store_le_u64((uint64_t*)ptr, uint_value);
+  uint8_t* p = (uint8_t*)ptr;
+  memcpy(&value, p, sizeof(value));
 }
 
 #else
@@ -484,7 +454,7 @@ static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
 // Dereferences |ptr| and returns the value.
 // Automatically handles unaligned accesses on architectures that may not
 // support them natively (or efficiently). Memory is treated as little-endian.
-#define iree_unaligned_load_le(ptr)                                               \
+#define iree_unaligned_load_le(ptr)                                            \
   _Generic((ptr),                                                              \
         int8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \
        uint8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -338,15 +338,13 @@ static inline void iree_unaligned_store_le_u8(uint8_t* ptr, uint8_t value) {
 #if IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_16
 
 static inline uint16_t iree_unaligned_load_le_u16(const uint16_t* ptr) {
-  const uint8_t* p = (const uint8_t*)ptr;
-  uint16_t value = 0;
-  memcpy(&value, p, sizeof(value));
+  uint16_t value;
+  memcpy(&value, ptr, sizeof(value));
   return value;
 }
 
 static inline void iree_unaligned_store_le_u16(uint16_t* ptr, uint16_t value) {
-  uint8_t* p = (uint8_t*)ptr;
-  memcpy(p, &value, sizeof(value));
+  memcpy(ptr, &value, sizeof(value));
 }
 
 #else
@@ -368,25 +366,21 @@ static inline void iree_unaligned_store_le_u16(uint16_t* ptr, uint16_t value) {
 #if IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_32
 
 static inline uint32_t iree_unaligned_load_le_u32(const uint32_t* ptr) {
-  const uint8_t* p = (const uint8_t*)ptr;
-  uint32_t value = 0;
-  memcpy(&value, p, sizeof(value));
+  uint32_t value;
+  memcpy(&value, ptr, sizeof(value));
   return value;
 }
 static inline float iree_unaligned_load_le_f32(const float* ptr) {
-  uint8_t* p = (uint8_t*)ptr;
   float value;
-  memcpy(&value, p, sizeof(value));
+  memcpy(&value, ptr, sizeof(value));
   return value;
 }
 
 static inline void iree_unaligned_store_le_u32(uint32_t* ptr, uint32_t value) {
-  uint8_t* p = (uint8_t*)ptr;
-  memcpy(p, &value, sizeof(value));
+  memcpy(ptr, &value, sizeof(value));
 }
 static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
-  uint8_t* p = (uint8_t*)ptr;
-  memcpy(p, &value, sizeof(value));
+  memcpy(ptr, &value, sizeof(value));
 }
 
 #else
@@ -411,7 +405,7 @@ static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
 
 static inline uint64_t iree_unaligned_load_le_u64(const uint64_t* ptr) {
   const uint8_t* p = (const uint8_t*)ptr;
-  uint64_t value = 0;
+  uint64_t value;
   memcpy(&value, p, sizeof(value));
   return value;
 }

--- a/runtime/src/iree/base/target_platform.h
+++ b/runtime/src/iree/base/target_platform.h
@@ -142,32 +142,11 @@ enum iree_arch_enum_e {
 
 #if !defined(IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED)
 
-#if defined(IREE_ARCH_ARM_32) || defined(IREE_ARCH_ARM_64)
-
-// Armv6‑M and Armv8-M (w/o the main extension) do not support unaligned access.
-// The -munaligned-access and -mno-unaligned-access flags control this.
-// https://www.keil.com/support/man/docs/armclang_ref/armclang_ref_sam1444138667173.htm
-#if !defined(__ARM_FEATURE_UNALIGNED)
-#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 1
-#else
-#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 0
-#endif  // !__ARM_FEATURE_UNALIGNED
-
-// Unaligned support is only available for singles on Armv7-M.
-// Therefore, aligned memory access is enforced for 64-bit data types.
-#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64 1
-
-#elif defined(IREE_ARCH_RISCV_32) || defined(IREE_ARCH_RISCV_64)
-
-// Though unaligned access is part of the base spec it is allowed to be
-// implemented with trap handlers. Bare-metal systems likely won't have these
-// handlers and even on systems that do (linux) we don't want to be trapping for
-// every load/store.
+// Unless disabled by the user, require all memory access to be aligned. This is
+// because unaligned accesses are considered Undefined Behavior (UB) by the
+// C/C++ standards, even if the hardware supports them.
 #define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 1
 
-#else
-#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 0
-#endif  // IREE_ARCH_*
 #endif  // !IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
 
 // Set IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_* to the value of


### PR DESCRIPTION
The C/C++ standards require all memory accesses to be aligned, even if the target hardware allows for unaligned accesses. Change the default to require alignment, so that we get closer to being UB-warning free when running with the UBSan enabled.

Advanced users can choose to disable this via the build system.

Also simplify the implementation of unaligned loads/stores and rely on `memcpy` being a compiler intrinsic.

Issue: https://github.com/iree-org/iree/issues/22555

ci-extra: test_torch, windows_x64_msvc