### PR TITLE
[Integrate] Drop the revert of llvm/llvm-project@fcf79e5

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -7,9 +7,11 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMS_H_
 
+#include <optional>
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
 namespace mlir::bufferization {
@@ -73,9 +75,10 @@ struct IREETilingResult {
   SmallVector<OpFoldResult> tileOffsets;
   SmallVector<OpFoldResult> tileSizes;
 };
-FailureOr<IREETilingResult>
-tileDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
-                          linalg::LinalgTilingOptions options);
+FailureOr<IREETilingResult> tileDispatchUsingSCFForOp(
+    RewriterBase &rewriter, TilingInterface op,
+    linalg::LinalgTilingOptions options,
+    const std::optional<llvm::SmallBitVector> &skipTileLoops = std::nullopt);
 
 namespace IREE::VectorExt {
 class VectorLayoutInterface;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -154,6 +154,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorToSPIRV",
         "@llvm-project//mlir:TensorTransforms",
+        "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TosaDialect",
         "@llvm-project//mlir:TosaToArith",
         "@llvm-project//mlir:TransformDialect",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -124,6 +124,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorToSPIRV
     MLIRTensorTransforms
+    MLIRTilingInterface
     MLIRTosaDialect
     MLIRTosaToArith
     MLIRTransformDialect

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -58,14 +58,11 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:     %[[WG_TARGET:.+]] = memref.subview %[[ARG2]]
 //       CHECK:     %[[TID_X:.+]] = gpu.thread_id x
 //       CHECK:     %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK:     %[[TID_Y:.+]] = gpu.thread_id y
-//       CHECK:     %[[DIM_Y:.+]] = gpu.block_dim y
-//       CHECK:     scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:       scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:         %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][%[[IV_Y]], %[[IV_X]]] [1, 1] [1, 1]
-//       CHECK:         %[[T_INDEX:.+]] = memref.subview %[[WG_INDEX]][%[[IV_Y]], 0] [1, 1] [1, 1]
-//       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
-//       CHECK:         iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
-//  CHECK-SAME:           ins(%[[T_UPDATE]], %[[T_INDEX]]
-//  CHECK-SAME:           outs(%[[T_TARGET]]
+//       CHECK:     scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:       %[[T_UPDATE:.+]] = memref.subview %[[WG_UPDATE]][0, %[[IV_X]]] [1, 1] [1, 1]
+//       CHECK:       %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
+//       CHECK:       %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
+//       CHECK:       iree_linalg_ext.scatter
+//  CHECK-SAME:         unique_indices(true)
+//  CHECK-SAME:         ins(%[[T_UPDATE]], %[[T_INDEX]]
+//  CHECK-SAME:         outs(%[[T_TARGET]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
@@ -50,11 +50,10 @@ util.func public @layoutDynamic(%size_a: index, %size_b: index) -> (index, index
   // CHECK-DAG: %c0 = arith.constant 0 : index
   // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
-  // CHECK-DAG: %1 = arith.addi %0, %c0 : index
-  // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index
-  // CHECK-DAG: %3 = arith.addi %1, %2 : index
+  // CHECK-DAG: %1 = util.align %[[SIZE_B]], %c16 : index
+  // CHECK-DAG: %2 = arith.addi %0, %1 : index
 
-  // CHECK: util.return %3, %c0, %1, %c0
+  // CHECK: util.return %2, %c0, %0, %c0
   util.return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
 }
 
@@ -82,8 +81,8 @@ util.func public @layoutMixedStaticDynamic(%size_a: index, %size_b: index) -> (i
   }) : index
 
   // CHECK-DAG: %c0 = arith.constant 0 : index
-  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %c208 = arith.constant 208 : index
+  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %0 = util.align %[[SIZE_A]], %c16 : index
   // CHECK-DAG: %1 = arith.addi %0, %c208 : index
   // CHECK-DAG: %2 = util.align %[[SIZE_B]], %c16 : index


### PR DESCRIPTION
It fixes `tileDispatchUsingSCFForOp` tiling decisions. When deciding skip trivial tiling dimensions, the function should                                                                                                consider the cases where workgroup size is larger than tile size.                                                                                                      In such cases, we should not simply fold the tiling as it is wrong.                                                                                                    

`tileDispatchUsingSCFForOp` does not have the way to get the workgroup size, so the fix is to plumb the skip decision into the function.

Carrying reverts:
- https://github.com/iree-org/llvm-project/commit/33d3ba67dd2145f9f4d6b78d91c7a9211153819e, asking questions in original PR https://github.com/llvm/llvm-project/pull/157330#issuecomment-3487738664

Closes https://github.com/iree-org/iree/issues/22171