### PR TITLE
[CI] Change numprocesses to 1 for amdgpu_vulkan_O0

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -48,7 +48,7 @@ jobs:
             config-file: onnx_ops_gpu_hip_rdna3_O3.json
             runs-on: [Linux, X64, gfx1100]
           - name: amdgpu_vulkan_O0
-            numprocesses: 4
+            numprocesses: 1
             config-file: onnx_ops_gpu_vulkan_O0.json
             runs-on: [Linux, X64, rdna3]
 


### PR DESCRIPTION
There is a kernel bug about using multiple threads. Using multiple threads can hit some kernel mode bug. Thus, we limit it to `1` for CI stability.

Failing sample, where the runner is `shark55-ci`: https://github.com/iree-org/iree/actions/runs/19114203732/job/54619458769