### PR TITLE
[DispatchCreation] Fuse residual broadcast producers after consumer fusion

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -139,10 +139,20 @@ static void addDispatchRegionCreationPreprocessingPasses(
                 /*fuseTruncateOps=*/clEnableEarlyTruncFusion,
                 /*fuseBroadcastOps=*/false});
       })
+      // 4. Perform elementwise operation fusion again. This is to fuse
+      // broadcast consumer ops that could not be fused earlier.
+      .addPass([]() {
+        return DispatchCreation::createElementwiseOpFusionPass(
+            ElementwiseOpFusionPassOptions{
+                /*intraDispatch=*/false,
+                /*fuseMultiReduction=*/clEnableElementWiseFuseMultiReduction,
+                /*fuseTruncateOps=*/clEnableEarlyTruncFusion,
+                /*fuseBroadcastOps=*/true});
+      })
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
 
-      // 4. After elementwise operation fusion sink reshapes that block
+      // 5. After elementwise operation fusion sink reshapes that block
       //    producer-consumer fusion.
       .addPass(DispatchCreation::createSinkReshapesPass)
       .addPass(IREE::Flow::createCanonicalizePass)


### PR DESCRIPTION
After https://github.com/iree-org/iree/pull/22008 we don't fuse elementwise ops if the consumer is broadcasting the producer, which left some broadcast ops isolated. The new change detects those residual broadcast producers after the consumer fusion and folds them into the same dispatch.

Closes https://github.com/iree-org/iree/issues/22500