### PR TITLE
[build] Use CMake targets from upstream `flatcc` build

### DIFF
--- a/build_tools/third_party/flatcc/CMakeLists.txt
+++ b/build_tools/third_party/flatcc/CMakeLists.txt
@@ -4,138 +4,67 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(FLATCC_ROOT "${IREE_ROOT_DIR}/third_party/flatcc/")
+# ----------------------------------------------------------------------
+# This file mimics the targets in bazel flatcc/BUILD.overlay using only CMake
+# targets provided in flatcc's config package file.
+#
+# Sticking to upstream CMake targets, rather than creating new CMake targets
+# built using source files inside the flatcc submodule, ensures that we could
+# (optionally) build using a system installed version of flatcc with
+# find_package. Upstream's targets are slightly larger than those built by
+# bazel, but LTO should remove any unused code.
+# ----------------------------------------------------------------------
 
-# We don't install any headers because their only use is in built code
-# (not public).
-set(IREE_HDRS_ROOT_PATH OFF)
-# Considered part of the runtime. See runtime/src/CMakeLists.txt.
-set(IREE_INSTALL_LIBRARY_TARGETS_DEFAULT_COMPONENT IREEBundledLibraries)
-set(IREE_INSTALL_LIBRARY_TARGETS_DEFAULT_EXPORT_SET Runtime)
-
-external_cc_library(
-  PACKAGE
-    flatcc
-  NAME
-    runtime
-  ROOT
-    ${FLATCC_ROOT}
-  INCLUDES
-    "${FLATCC_ROOT}/include"
-  SRCS
-    "src/runtime/builder.c"
-    "src/runtime/emitter.c"
-    "src/runtime/json_parser.c"
-    "src/runtime/json_printer.c"
-    "src/runtime/refmap.c"
-  HDRS
-    "include/flatcc/flatcc_accessors.h"
-    "include/flatcc/flatcc_alloc.h"
-    "include/flatcc/flatcc_assert.h"
-    "include/flatcc/flatcc_builder.h"
-    "include/flatcc/flatcc_emitter.h"
-    "include/flatcc/flatcc_endian.h"
-    "include/flatcc/flatcc_epilogue.h"
-    "include/flatcc/flatcc_flatbuffers.h"
-    "include/flatcc/flatcc_identifier.h"
-    "include/flatcc/flatcc_iov.h"
-    "include/flatcc/flatcc_json_parser.h"
-    "include/flatcc/flatcc_json_printer.h"
-    "include/flatcc/flatcc_portable.h"
-    "include/flatcc/flatcc_prologue.h"
-    "include/flatcc/flatcc_refmap.h"
-    "include/flatcc/flatcc_rtconfig.h"
-    "include/flatcc/flatcc_types.h"
-    "include/flatcc/flatcc_unaligned.h"
-    "include/flatcc/flatcc_verifier.h"
-    "include/flatcc/reflection/flatbuffers_common_builder.h"
-    "include/flatcc/reflection/flatbuffers_common_reader.h"
-  DEPS
-    flatcc::parsing
-  PUBLIC
-)
-
-# A limited version of :runtime with only enough to parse and verify.
-external_cc_library(
-  PACKAGE
-    flatcc
-  NAME
-    parsing
-  ROOT
-    ${FLATCC_ROOT}
-  SYSTEM_INCLUDES
-    "${FLATCC_ROOT}/include"
-  SRCS
-    "config/config.h"
-    "src/runtime/verifier.c"
-  HDRS
-    "include/flatcc/flatcc_accessors.h"
-    "include/flatcc/flatcc_alloc.h"
-    "include/flatcc/flatcc_assert.h"
-    "include/flatcc/flatcc_endian.h"
-    "include/flatcc/flatcc_epilogue.h"
-    "include/flatcc/flatcc_flatbuffers.h"
-    "include/flatcc/flatcc_identifier.h"
-    "include/flatcc/flatcc_portable.h"
-    "include/flatcc/flatcc_prologue.h"
-    "include/flatcc/flatcc_rtconfig.h"
-    "include/flatcc/flatcc_types.h"
-    "include/flatcc/flatcc_unaligned.h"
-    "include/flatcc/flatcc_verifier.h"
-    "include/flatcc/reflection/flatbuffers_common_reader.h"
-  PUBLIC
-)
-
+# Configure flatcc build options
 if(IREE_HOST_BIN_DIR)
-  # Just import if IREE_HOST_BIN_DIR is set (e.g. when cross-compiling).
+  set(FLATCC_RTONLY ON) # No need to build CLI, it will be imported
   iree_import_binary(NAME iree-flatcc-cli)
-  return()
+else()
+  set(FLATCC_RTONLY OFF) # Build CLI in addition to runtime library
+endif()
+set(FLATCC_TEST OFF)
+cmake_policy(PUSH)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+add_subdirectory(${IREE_ROOT_DIR}/third_party/flatcc ${CMAKE_CURRENT_BINARY_DIR}/flatcc EXCLUDE_FROM_ALL)
+cmake_policy(POP)
+
+# flatcc sets some properties to odd values, not sure why, we just set them to
+# something normal.
+if(NOT IREE_HOST_BIN_DIR)
+  set_target_properties(flatcc flatccrt flatcc_cli PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/bin"
+  )
+else()
+  set_target_properties(flatccrt PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/flatcc/bin"
+  )
 endif()
 
-# Define our own binary target for the CLI.
-# flatcc's `flatcc_cli` target renames itself to `flatcc` or `flatcc_d`
-# depending on the build configuration, so we prefer to just set our own name.
-add_executable(iree-flatcc-cli
-  "${FLATCC_ROOT}/src/cli/flatcc_cli.c"
-  "${FLATCC_ROOT}/external/hash/cmetrohash64.c"
-  "${FLATCC_ROOT}/external/hash/str_set.c"
-  "${FLATCC_ROOT}/external/hash/ptr_set.c"
-  "${FLATCC_ROOT}/src/compiler/hash_tables/symbol_table.c"
-  "${FLATCC_ROOT}/src/compiler/hash_tables/scope_table.c"
-  "${FLATCC_ROOT}/src/compiler/hash_tables/name_table.c"
-  "${FLATCC_ROOT}/src/compiler/hash_tables/schema_table.c"
-  "${FLATCC_ROOT}/src/compiler/hash_tables/value_set.c"
-  "${FLATCC_ROOT}/src/compiler/fileio.c"
-  "${FLATCC_ROOT}/src/compiler/parser.c"
-  "${FLATCC_ROOT}/src/compiler/semantics.c"
-  "${FLATCC_ROOT}/src/compiler/coerce.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_schema.c"
-  "${FLATCC_ROOT}/src/compiler/flatcc.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_reader.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_sort.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_builder.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_verifier.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_sorter.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_json_parser.c"
-  "${FLATCC_ROOT}/src/compiler/codegen_c_json_printer.c"
-  "${FLATCC_ROOT}/src/runtime/builder.c"
-  "${FLATCC_ROOT}/src/runtime/emitter.c"
-  "${FLATCC_ROOT}/src/runtime/refmap.c"
+# Add aliases to match bazel build
+iree_add_alias_library(flatcc::parsing flatccrt)
+iree_add_alias_library(flatcc::runtime flatccrt)
+
+# Library install
+iree_install_targets(
+  TARGETS flatccrt
+  COMPONENT IREEBundledLibraries
+  EXPORT_SET Runtime
 )
-set_target_properties(iree-flatcc-cli
-  PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${IREE_BINARY_DIR}/tools"
-)
-target_include_directories(iree-flatcc-cli SYSTEM
-  PUBLIC
-    "${FLATCC_ROOT}/external"
-    "${FLATCC_ROOT}/include"
-    "${FLATCC_ROOT}/config"
-)
-install(
-  TARGETS iree-flatcc-cli
-  COMPONENT IREETools-Runtime
-  RUNTIME DESTINATION bin
-  BUNDLE DESTINATION bin
-)
+
+if(NOT IREE_HOST_BIN_DIR)
+  # Create build-time alias for IREE naming
+  add_executable(iree-flatcc-cli ALIAS flatcc_cli)
+
+  # Install the CLI tool, use a variant of the install command that supports
+  # renaming.
+  install(
+    PROGRAMS $<TARGET_FILE:flatcc_cli>
+    DESTINATION bin
+    RENAME iree-flatcc-cli
+    COMPONENT IREETools-Runtime
+  )
+endif()

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -342,10 +342,21 @@ cmake_language(DEFER DIRECTORY \"${IREE_SOURCE_DIR}\"
     iree-create-parameters
     iree-dump-module
     iree-dump-parameters
-    iree-flatcc-cli
     iree-run-module
     ${_EXTRA_INSTALL_TOOL_TARGETS}
   DESTINATION \"${_INSTALL_DIR}/iree/_runtime_libs\"
+  COMPONENT \"${_INSTALL_COMPONENT}\"
+)
+")
+
+# iree-flatcc-cli is an alias of the flatcc_cli target defined in flatcc. Use a
+# variant of the install command that supports renaming.
+cmake_language(EVAL CODE "
+cmake_language(DEFER DIRECTORY \"${IREE_SOURCE_DIR}\"
+  CALL install
+  PROGRAMS \$<TARGET_FILE:flatcc_cli>
+  DESTINATION \"${_INSTALL_DIR}/iree/_runtime_libs\"
+  RENAME iree-flatcc-cli
   COMPONENT \"${_INSTALL_COMPONENT}\"
 )
 ")


### PR DESCRIPTION
This PR changes `flatcc` CMake build to use upstream targets rather than creating new targets around source files inside the flatcc sub-module. Using upstream targets ensures that we could potentially use a system installed version of `flatcc` with `find_package`. The upstream `flatcc` targets are slightly larger than those built by bazel, but LTO should remove any unused code.