### PR TITLE
[TensorExt] Add barrier ops and roundtrip tests 1/2

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -382,6 +382,38 @@ void DispatchWorkloadOrdinalOp::inferResultRanges(
   setResultRange(getResult(), argRanges[0]);
 }
 
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.barrier.start
+//===----------------------------------------------------------------------===//
+
+LogicalResult BarrierStartOp::verify() {
+  BarrierStartOp op = *this;
+  if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
+    return failure();
+  }
+
+  if (op.getValue().getType() != op.getResult().getType()) {
+    return op.emitOpError("value and result types must match");
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.barrier.end
+//===----------------------------------------------------------------------===//
+
+LogicalResult BarrierEndOp::verify() {
+  BarrierEndOp op = *this;
+  if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
+    return failure();
+  }
+
+  if (op.getValue().getType() != op.getResult().getType()) {
+    return op.emitOpError("value and result types must match");
+  }
+  return success();
+}
+
 } // namespace mlir::iree_compiler::IREE::TensorExt
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -483,13 +483,6 @@ def IREETensorExt_BarrierStartOp : IREETensorExt_PureOp<"barrier.start", [
     attr-dict-with-keyword
   }];
 
-  let builders = [
-    OpBuilder<(ins "Value":$value), [{
-      build($_builder, $_state, value.getType(), value,
-            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
-    }]>,
-  ];
-
   let extraClassDeclaration = [{
     ValueRange getOperandDynamicDims(unsigned idx) { return getValueDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
@@ -521,13 +514,6 @@ def IREETensorExt_BarrierEndOp : IREETensorExt_PureOp<"barrier.end", [
     type($result)
     attr-dict-with-keyword
   }];
-
-  let builders = [
-    OpBuilder<(ins "Value":$value), [{
-      build($_builder, $_state, value.getType(), value,
-            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
-    }]>,
-  ];
 
   let extraClassDeclaration = [{
     ValueRange getOperandDynamicDims(unsigned idx) { return getValueDims(); }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -455,4 +455,86 @@ def IREETensorExt_DispatchWorkloadOrdinalOp :
   let hasFolder = 1;
 }
 
+//===---------------------------------------------------------------------===//
+// Barrier Ops
+//===---------------------------------------------------------------------===//
+
+def IREETensorExt_BarrierStartOp : IREETensorExt_PureOp<"barrier.start", [
+  Util_ShapeAwareOp,
+]> {
+  let summary = "Tensor barrier start operation";
+  let description = [{
+    This barrier prevents certain transformations (like reshape propagation)
+    from moving operations down across this boundary.
+    The operand is returned as the result with identical type.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$value,
+    IREETensorExt_ShapeDynamicDims:$value_dims
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+  let assemblyFormat = [{
+    $value `:` type($value) (`{` $value_dims^ `}`)? `->`
+    type($result)
+    attr-dict-with-keyword
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$value), [{
+      build($_builder, $_state, value.getType(), value,
+            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return getValueDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def IREETensorExt_BarrierEndOp : IREETensorExt_PureOp<"barrier.end", [
+  Util_ShapeAwareOp,
+]> {
+  let summary = "Tensor barrier end operation";
+  let description = [{
+    This barrier prevents certain transformations (like reshape propagation)
+    from moving operations up across this boundary.
+    The operand is returned as the result with identical type.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$value,
+    IREETensorExt_ShapeDynamicDims:$value_dims
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+  let assemblyFormat = [{
+    $value `:` type($value) (`{` $value_dims^ `}`)? `->`
+    type($result)
+    attr-dict-with-keyword
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$value), [{
+      build($_builder, $_state, value.getType(), value,
+            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return getValueDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif  // IREE_DIALECT_TENSOR_EXT_OPS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
             "dispatch_tensor_folding.mlir",
             "dispatch_workload_ordinal_folding.mlir",
             "inline.mlir",
+            "invalid.mlir",
             "roundtrip.mlir",
             "tensor_ext_folding.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "dispatch_tensor_folding.mlir"
     "dispatch_workload_ordinal_folding.mlir"
     "inline.mlir"
+    "invalid.mlir"
     "roundtrip.mlir"
     "tensor_ext_folding.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics %s
+
+util.func public @barrier_start_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value and result types must match}}
+  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
+  util.return %0 : tensor<8x4xf32>
+}
+
+// -----
+
+util.func public @barrier_start_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
+  util.return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+util.func public @barrier_start_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
+  util.return %0 : tensor<4x8xf32>
+}
+
+// -----
+
+util.func public @barrier_end_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value and result types must match}}
+  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
+  util.return %0 : tensor<8x4xf32>
+}
+
+// -----
+
+util.func public @barrier_end_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
+  util.return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+util.func public @barrier_end_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
+  util.return %0 : tensor<4x8xf32>
+}

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -48,3 +48,41 @@ util.func public @tensorBitCastDynamic(%arg0: tensor<?x16xi32>, %arg1: index, %a
   %0 = iree_tensor_ext.bitcast %arg0 : tensor<?x16xi32>{%arg1} -> tensor<?x?x4x8xi16>{%arg2, %arg3}
   util.return %0 : tensor<?x?x4x8xi16>
 }
+
+// -----
+
+// CHECK-LABEL: @barrier_start_static
+util.func public @barrier_start_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK: iree_tensor_ext.barrier.start
+  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  util.return %0 : tensor<4x8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @barrier_start_dynamic
+// CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
+util.func public @barrier_start_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
+  // CHECK: iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+  util.return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @barrier_end_static
+util.func public @barrier_end_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK: iree_tensor_ext.barrier.end
+  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  util.return %0 : tensor<4x8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @barrier_end_dynamic
+// CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
+util.func public @barrier_end_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
+  // CHECK: iree_tensor_ext.barrier.end %[[ARG0]] : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+  util.return %0 : tensor<?x?xf32>
+}


### PR DESCRIPTION
Add `iree_tensor_ext.barrier.start` and `iree_tensor_ext.barrier.end` operations to control where reshape operations can be propagated during compilation. These barriers prevent undesirable reshape movement, which is useful for controlling reshape propagation at the edges of the program where reshapes exist to convert between function ABI shapes and program dimensionality.