### PR TITLE
Revert "[CI] Change numprocesses to 1 for amdgpu_vulkan_O0"

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -48,7 +48,7 @@ jobs:
             config-file: onnx_ops_gpu_hip_rdna3_O3.json
             runs-on: [Linux, X64, gfx1100]
           - name: amdgpu_vulkan_O0
-            numprocesses: 1
+            numprocesses: 4
             config-file: onnx_ops_gpu_vulkan_O0.json
             runs-on: [Linux, X64, rdna3]
 


### PR DESCRIPTION
Reverts iree-org/iree#22567

I made a mistake when I'm debugging `Test ONNX / test_onnx_models :: amdgpu_vulkan` issue. The original change was for `Test OONX / test_onnx_ops :: amdgpu_vulkan_O0`. It reverts the change.

This is no longer needed, because:

- It updated wrong config.
- We just identify that the job passes on other runners, and the issue may be driver.