### PR TITLE
[CI] Force amdgpu_vulkan runner be shark10-ci

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -156,7 +156,8 @@ jobs:
             runs-on: [Linux, X64, gfx1100, persistent-cache]
           - name: amdgpu_vulkan
             config-file: onnx_models_gpu_vulkan.json
-            runs-on: [Linux, X64, rdna3, persistent-cache]
+            # TODO(#22579): Remove `shark10-ci` label. There are vulkan driver issues on other runners.
+            runs-on: [Linux, X64, rdna3, persistent-cache, shark10-ci]
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster


### PR DESCRIPTION
Updated the runner configuration for amdgpu_vulkan to include the shark10-ci label due to Vulkan driver issues. This forces the job to run on shark10-ci only.