### PR TITLE
[LinalgExt] Add iree_linalg_ext.unmask

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1385,6 +1385,36 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Unmask
+//===----------------------------------------------------------------------===//
+
+def IREELinalgExt_UnMaskOp : IREELinalgExt_PureOp<"unmask", [
+  AllTypesMatch<["dest", "result"]>,
+  Pure,
+  DestinationStyleOpInterface
+  ]> {
+  let summary = "";
+  let description = [{}];
+  let arguments = (ins AnyRankedTensor:$src,
+                       AnyRankedTensor:$dest);
+  let results = (outs AnyShaped:$result);
+  let assemblyFormat = [{
+    attr-dict
+    $src `into` $dest `:` type($src) `->` type($result)
+  }];
+  let hasVerifier = 1;
+  let hasFolder = 1;
+
+  let extraClassDeclaration = [{
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() {
+      return getDestMutable();
+    }
+  }];
+}
+
 } // OpGroupNonStructuredOps
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -232,3 +232,12 @@ func.func public @convert_identity_map_scatter_into_copy(
 //  CHECK-NOT:   iree_linalg_ext.map_scatter
 //      CHECK:   %[[COPY:.+]] = linalg.copy ins(%[[ARG0]]{{.*}} outs(%[[ARG1]]
 //      CHECK:   return %[[COPY]]
+
+// -----
+
+func.func @unmask(%src: tensor<4x4xf32>, %dst: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %0 = iree_linalg_ext.unmask %src into %dst : tensor<4x4xf32> -> tensor<4x4xf32>
+  return %0 : tensor<4x4xf32>
+}
+// CHECK-LABEL: func @unmask
+// CHECK-NOT: iree_linalg_ext.unmask

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1817,3 +1817,11 @@ func.func @index_op_invalid_dim(%arg0 : tensor<?xindex>) -> tensor<?xindex> {
   } -> tensor<?xindex>
   return %0 : tensor<?xindex>
 }
+
+// -----
+
+func.func @unmask(%src: tensor<4x4xf32>, %dst: tensor<4x5xf32>) -> tensor<4x5xf32> {
+  // expected-error @+1 {{expected source dimension 1 to be greater than or equal to destination dimension}}
+  %0 = iree_linalg_ext.unmask %src into %dst : tensor<4x4xf32> -> tensor<4x5xf32>
+  return %0 : tensor<4x5xf32>
+}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -2186,3 +2186,12 @@ func.func @split_reduction_mapping(%arg0 : index,
 //  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<1>,
 //  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<0>,
 //  CHECK-SAME:       #iree_linalg_ext.split_reduction_mapping<2>]
+
+// -----
+
+func.func @unmask(%src: tensor<4x4xf32>, %dst: tensor<4x?xf32>) -> tensor<4x?xf32> {
+  %0 = iree_linalg_ext.unmask %src into %dst : tensor<4x4xf32> -> tensor<4x?xf32>
+  return %0 : tensor<4x?xf32>
+}
+// CHECK-LABEL: @unmask
+// CHECK: iree_linalg_ext.unmask %{{.*}} into %{{.*}} : tensor<4x4xf32> -> tensor<4x?xf32>


### PR DESCRIPTION
This patch adds iree_linalg_ext.unmask operation to represent a "masked copy" to a destination tensor. This operation is very similar to a tensor.extract_slice, but explicitly gives vectorization/bufferization a hint that this operation should always be thought of as a copy.