### PR TITLE
[DT] Add support for layout transfer in MaterializeEncoding pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -99,6 +99,12 @@ FailureOr<Value> lowerUnsetEncodingToUnpackOp(
     RewriterBase &rewriter, IREE::Encoding::UnsetEncodingOp encodingOp,
     Value packedValue, const MaterializeEncodingTypeConverter &typeConverter);
 
+/// Populates the set of patterns that decompose load/store ops that have
+/// mismatched layout types.
+void populateDecomposeMismatchedLayoutLoadStoreOpsPatterns(
+    RewritePatternSet &patterns,
+    MaterializeEncodingTypeConverter &typeConverter);
+
 /// Populates the set of patterns that lowers operations with encoding types to
 /// operations without encodings.
 void populateMaterializeEncodingPatterns(

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-materialize-encoding"
 
@@ -66,7 +67,6 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                                detail::TestingResolverKind::kNone) {
   MLIRContext *ctx = funcOp.getContext();
   {
-    RewritePatternSet patterns(ctx);
     DictionaryAttr targetConfig =
         targetAttr ? targetAttr.getConfiguration() : nullptr;
     auto getTestTargetResolverOrIdentityResolver =
@@ -131,6 +131,24 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
 
     MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo);
     MaterializeEncodingConversionTarget target(*ctx);
+
+    // Decompose mismatched encodings in load/store ops before actual encoding
+    // materialization.
+    // When a load/store op has mismatched source and result encodings that
+    // materialize to different layouts, decompose it into a sequence of
+    // load/store + unset_encoding + set_encoding ops. This phase uses greedy
+    // pattern rewriting to handle these layout transfer cases before the main
+    // dialect conversion. It is needed because no-fallback conversion driver
+    // requires all the immediate ops to be legal, but the patterns can
+    // introduce illegal load/store ops because they still have encodings.
+    {
+      RewritePatternSet patterns(ctx);
+      populateDecomposeMismatchedLayoutLoadStoreOpsPatterns(patterns,
+                                                            typeConverter);
+      walkAndApplyPatterns(funcOp, std::move(patterns));
+    }
+
+    RewritePatternSet patterns(ctx);
     populateMaterializeEncodingPatterns(patterns, target, typeConverter);
 
     // Replace any unrealized conversions to tensor.cast ops if they come from

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -355,13 +355,7 @@ struct DecomposeMismatchEncodingTensorLoadOp
         rewriter, loc, boundTensorType, loadOp.getSource(),
         loadOp.getSourceDims(), loadOp.getMixedOffsets(),
         loadOp.getMixedSizes(), loadOp.getMixedStrides());
-    SmallVector<Value> dynamicDims;
-    for (OpFoldResult value : loadOp.getMixedSizes()) {
-      if (isa<Attribute>(value)) {
-        continue;
-      }
-      dynamicDims.push_back(cast<Value>(value));
-    }
+    SmallVector<Value> dynamicDims = llvm::to_vector(loadOp.getSizes());
     result =
         generateEncodingTransferOps(rewriter, result, dynamicDims, destType);
     rewriter.replaceOp(loadOp, result);
@@ -415,13 +409,7 @@ struct DecomposeMismatchEncodingTensorStoreOp
            << storeOp;
     Location loc = storeOp.getLoc();
     Value valueToStore = storeOp.getValue();
-    SmallVector<Value> dynamicDims;
-    for (OpFoldResult value : storeOp.getMixedSizes()) {
-      if (isa<Attribute>(value)) {
-        continue;
-      }
-      dynamicDims.push_back(cast<Value>(value));
-    }
+    SmallVector<Value> dynamicDims = llvm::to_vector(storeOp.getSizes());
     valueToStore = generateEncodingTransferOps(rewriter, valueToStore,
                                                dynamicDims, boundTensorType);
     IREE::TensorExt::DispatchTensorStoreOp::create(
@@ -435,8 +423,6 @@ struct DecomposeMismatchEncodingTensorStoreOp
 private:
   MaterializeEncodingTypeConverter &typeConverter;
 };
-
-
 
 //===---------------------------------------------------------------------===//
 // Patterns to lower ops with encodings. These are written as

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
@@ -942,3 +942,30 @@ func.func @do_not_crash_on_non_ranked_tensor_type() {
   return
 }
 // CHECK-LABEL: func.func @do_not_crash_on_non_ranked_tensor_type
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d3, d4, d0, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+#pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+func.func @do_not_crash_on_non_encoded_tensors(%offset0: index, %offset1: index, %size: index) attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>, target_triple = "x86_64-xyz-xyz"}>
+} {
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
+  %3 = arith.index_castui %0 : i32 to index
+  %4 = arith.index_castui %1 : i32 to index
+  %5 = arith.index_castui %2 : i32 to index
+  %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%offset0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x?x32x4x32xf16>>{%size}
+  %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%offset1) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x2x32x?x32xf16>>{%size}
+  %10 = tensor.empty(%size) : tensor<4x2x32x?x32xf16>
+  %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0, 0, 0, 0], sizes = [1, %size, 32, 4, 32], strides = [1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x?x32x4x32xf16>>{%size} -> tensor<?x32x4x32xf16>
+  %12 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%11 : tensor<?x32x4x32xf16>) outs(%10 : tensor<4x2x32x?x32xf16>) {
+  ^bb0(%in: f16, %out: f16):
+    linalg.yield %in : f16
+  } -> tensor<4x2x32x?x32xf16>
+  iree_tensor_ext.dispatch.tensor.store %12, %9, offsets = [0, 0, 0, 0, 0], sizes = [4, 2, 32, %size, 32], strides = [1, 1, 1, 1, 1] : tensor<4x2x32x?x32xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x2x32x?x32xf16>>{%size}
+  return
+}
+// CHECK-LABEL: func.func @do_not_crash_on_non_encoded_tensors

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
@@ -930,3 +930,15 @@ func.func @store_with_layout_transfer_partial_dynamic(%src: tensor<1024x?xf32, #
 //       CHECK:   %[[PACK:.+]] = linalg.pack %[[UNPACK]]
 //  CHECK-SAME:       outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [1, 16]
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[PACK]], %[[BINDING]]
+
+// -----
+
+func.func @do_not_crash_on_non_ranked_tensor_type() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>) binding(0) alignment(32) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:f32>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer>, #hal.pipeline.binding<storage_buffer>]>) binding(1) alignment(32) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:f32>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !iree_tensor_ext.dispatch.tensor<readonly:f32> -> tensor<f32>
+  iree_tensor_ext.dispatch.tensor.store %2, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !iree_tensor_ext.dispatch.tensor<writeonly:f32>
+  return
+}
+// CHECK-LABEL: func.func @do_not_crash_on_non_ranked_tensor_type


### PR DESCRIPTION
The revision adds another phase before materialization that breaks layout mismatched load/store ops into the matched load/store op plus encoding ops.

The new phase is needed because the no-rollback conversion driver requires the intermediate IR being legal. We can update the code to generate the final result, but it makes codebase complicated. Running an additional phase that uses cheap `walkAndApplyPatterns` driver is better.

Fixes https://github.com/iree-org/iree/issues/19896