### PR TITLE
Fix LLD support in BYO LLVM builds

### DIFF
--- a/build_tools/llvm/byo_llvm.sh
+++ b/build_tools/llvm/byo_llvm.sh
@@ -135,7 +135,7 @@ do_build_mlir() {
 
 print_iree_config() {
   llvm_cmake_dir="${IREE_BYOLLVM_INSTALL_DIR}/llvm/lib/cmake/llvm"
-  lld_cmake_dir="${IREE_BYOLLVM_INSTALL_DIR}/llvm/lib/cmake/lld"
+  lld_cmake_dir="${IREE_BYOLLVM_BUILD_DIR}/llvm/lib/cmake/lld"
   clang_cmake_dir="${IREE_BYOLLVM_INSTALL_DIR}/llvm/lib/cmake/clang"
   mlir_cmake_dir="${IREE_BYOLLVM_BUILD_DIR}/mlir/lib/cmake/mlir"
 

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -164,25 +164,20 @@ iree_cc_library(
 set(_lld_copts)
 set(_lld_deps)
 
-# TODO(#14086): implement linking in the installed-LLVM case.
-if(IREE_BUILD_BUNDLED_LLVM)
-  # Use generator expressions to conditionally include LLD targets, providing
-  # a compiler definition if not available.
-  macro(_add_dependent_lld_target target not_definition)
-    list(APPEND _lld_deps
-      $<TARGET_NAME_IF_EXISTS:${target}>
-      $<IF:$<TARGET_EXISTS:${target}>,lldCommon,>
-    )
-    list(APPEND _lld_copts
-      $<IF:$<TARGET_EXISTS:${target}>,,-D${not_definition}>)
-  endmacro()
-  _add_dependent_lld_target(lldCOFF IREE_COMPILER_LLD_COFF_DISABLED)
-  _add_dependent_lld_target(lldELF IREE_COMPILER_LLD_ELF_DISABLED)
-  _add_dependent_lld_target(lldMachO IREE_COMPILER_LLD_MACHO_DISABLED)
-  _add_dependent_lld_target(lldWasm IREE_COMPILER_LLD_WASM_DISABLED)
-else()
-  list(APPEND _lld_copts -DIREE_COMPILER_LLD_DISABLED)
-endif()
+# Use generator expressions to conditionally include LLD targets, providing
+# a compiler definition if not available.
+macro(_add_dependent_lld_target target not_definition)
+  list(APPEND _lld_deps
+    $<TARGET_NAME_IF_EXISTS:${target}>
+    $<IF:$<TARGET_EXISTS:${target}>,lldCommon,>
+  )
+  list(APPEND _lld_copts
+    $<IF:$<TARGET_EXISTS:${target}>,,-D${not_definition}>)
+endmacro()
+_add_dependent_lld_target(lldCOFF IREE_COMPILER_LLD_COFF_DISABLED)
+_add_dependent_lld_target(lldELF IREE_COMPILER_LLD_ELF_DISABLED)
+_add_dependent_lld_target(lldMachO IREE_COMPILER_LLD_MACHO_DISABLED)
+_add_dependent_lld_target(lldWasm IREE_COMPILER_LLD_WASM_DISABLED)
 
 iree_cc_library(
   NAME


### PR DESCRIPTION
In BYO (Bring Your Own) LLVM builds, iree-lld was being compiled without LLD support, causing linking failures with 'IREE was not built with support for LLD' errors. This affected tests like sink_callback_log_simple and sink_callback_log_async.

The issue had two parts:

1. CMakeLists.txt only linked LLD libraries when IREE_BUILD_BUNDLED_LLVM=ON, leaving BYO builds without LLD support. Fixed by removing the conditional and always attempting to link LLD libraries when available.

2. byo_llvm.sh pointed LLD_DIR to the install directory, which only exports the lld executable target. LLD library targets (lldELF, lldCOFF, etc.) needed for compilation are only available in the build directory. Fixed by changing LLD_DIR to point to the build directory.

These changes resolve #14086 by enabling LLD linking in BYO LLVM builds.