### PR TITLE
[CI] Refresh golden values for failing benchmarks: min(val*1.1, val+5ms)

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 5.5
+    "golden_time_ms": 6.05
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 6.9
+    "golden_time_ms": 7.8
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp16/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf16"
       }
     ],
-    "golden_time_ms": 242.0
+    "golden_time_ms": 250.5
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 7.3
+    "golden_time_ms": 8.26
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 10.0
+    "golden_time_ms": 11.14
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq128_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 24.3
+    "golden_time_ms": 27.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 164.6
+    "golden_time_ms": 169.6
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_mi325.json
@@ -36,5 +36,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time_ms": 7.3
+    "golden_time_ms": 8.0
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325.json
@@ -50,5 +50,5 @@
       "value": "1xf16"
     }
   ],
-  "golden_time_ms" : 41.6
+  "golden_time_ms" : 46.2
 }


### PR DESCRIPTION
Based on the discussion on discord, we set the golden values to `std::min(val * 1.1, val + 5ms)`: https://discord.com/channels/689900678990135345/689957613152239638/1436476349400486031

10% is the usual max delta across chips from the same SKU

ci-extra: test_torch