### PR TITLE
Update split reduction cutoff conditions

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -206,7 +206,6 @@ private:
       return std::nullopt;
     }
 
-    AffineMap inputMap = linalgOp.getMatchingIndexingMap(input);
     AffineMap filterMap = linalgOp.getMatchingIndexingMap(filter);
     AffineMap outputMap = linalgOp.getMatchingIndexingMap(output);
 
@@ -271,36 +270,34 @@ private:
     int64_t depthSize = getSizeAt(outputShape, depthPos);
 
     // The constants below are determined based on empirical data.
-    const int64_t largeDimSize = 512;
-    const int64_t mediumDimSize = 128;
-    const int64_t smallDimSize = 32;
+    const int64_t largeParallelSize = 512;
+    const int64_t largeReductionSize = 8192;
+    const int64_t ratioThreshold = 64;
 
     // When the batch and output channel sizes are large, the workload tends
     // to distributed across many workgroups, making split reduction little to
     // no effect.
-    if (outputChannelSize >= largeDimSize && batchSize >= largeDimSize) {
+    if (outputChannelSize >= largeParallelSize &&
+        batchSize >= largeParallelSize) {
       LDBG() << "skipping op; large output channel or batch size";
       return std::nullopt;
     }
 
-    // When the input spatial sizes are small while the batch and output channel
-    // sizes are relatively larger, split reduction often has no effect or even
-    // degrades performance.
-    for (auto dim : convDims->filterLoop) {
-      for (auto [idx, e] : llvm::enumerate(inputMap.getResults())) {
-        if (e.isFunctionOfDim(dim) && inputShape[idx] < smallDimSize &&
-            outputChannelSize > mediumDimSize && batchSize > mediumDimSize) {
-          LDBG() << "skipping op; small input spatial size";
-          return std::nullopt;
-        }
-      }
+    // When the reduction size is small relative to the output sizes, split
+    // reduction often has no effect or even degrades performance.
+    SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
+    int64_t reductionSize = std::accumulate(tileSizes.begin(), tileSizes.end(),
+                                            1, std::multiplies<>());
+    int64_t ratio = reductionSize / std::sqrt(outputChannelSize * batchSize);
+    if (ratio <= ratioThreshold && reductionSize < largeReductionSize) {
+      LDBG() << "skipping op; small reduction size";
+      return std::nullopt;
     }
 
     // Tile sizes are determined based on output (parallel dimension) sizes.
     // For larger outputs, the workload tends to be distributed across more
     // workgroups, thereby reducing the need for extensive splitting along the
     // reduction dimensions.
-    SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
     int64_t outputSize = outputChannelSize * batchSize * imageSize * depthSize;
     int64_t limitParallelLoops;
     if (outputSize < 32 * 32) {
@@ -387,8 +384,10 @@ private:
     // empty, return 1.
     auto getSizeAt = [&shapes](ArrayRef<unsigned> idx) {
       int64_t totalSize = 1;
-      for (unsigned i : idx)
+      for (unsigned i : idx) {
+        assert(!ShapedType::isDynamic(shapes[i]));
         totalSize *= shapes[i];
+      }
       return totalSize;
     };
 

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -286,8 +286,7 @@ private:
     // When the reduction size is small relative to the output sizes, split
     // reduction often has no effect or even degrades performance.
     SmallVector<int64_t> tileSizes = std::move(*maybeSizes);
-    int64_t reductionSize = std::accumulate(tileSizes.begin(), tileSizes.end(),
-                                            1, std::multiplies<>());
+    int64_t reductionSize = llvm::product_of(tileSizes);
     int64_t ratio = reductionSize / std::sqrt(outputChannelSize * batchSize);
     if (ratio <= ratioThreshold && reductionSize < largeReductionSize) {
       LDBG() << "skipping op; small reduction size";

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_split_reduction_sizes_conv.mlir
@@ -77,14 +77,14 @@ util.func public @no_split_large_N_F_sizes(%arg0: tensor<16x98x50x1024xf32>, %ar
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @no_split_small_H_W_sizes(%arg0: tensor<16x26x18x288xf32>, %arg1: tensor<16x24x16x288xf32>, %arg2: tensor<288x3x3x288xf32>) -> tensor<288x3x3x288xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x18x288xf32>, tensor<16x24x16x288xf32>) outs(%arg2 : tensor<288x3x3x288xf32>) {
+util.func public @no_split_small_H_W_sizes(%arg0: tensor<16x26x18x96xf32>, %arg1: tensor<16x24x16x96xf32>, %arg2: tensor<96x3x3x96xf32>) -> tensor<96x3x3x96xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x18x96xf32>, tensor<16x24x16x96xf32>) outs(%arg2 : tensor<96x3x3x96xf32>) {
   ^bb0(%in: f32, %in_3: f32, %out: f32):
     %12 = arith.mulf %in, %in_3 : f32
     %13 = arith.addf %out, %12 : f32
     linalg.yield %13 : f32
-  } -> tensor<288x3x3x288xf32>
-  util.return %0 : tensor<288x3x3x288xf32>
+  } -> tensor<96x3x3x96xf32>
+  util.return %0 : tensor<96x3x3x96xf32>
 }
 
 // CHECK-LABEL:  @no_split_small_H_W_sizes


### PR DESCRIPTION
The main change of this PR is to slightly simplify the cutoff condition for split reduction. Instead of setting cutoff values for each individual dimensions, it now compares the ratio between the reduction size and the output size. The ratio threshold is adjusted to exclude small-shape edge cases where split reduction caused performance regressions.