### PR TITLE
[Codegen][Tuner] Extend ireeGPUTargetInfo constructor with new added attributes

### DIFF
--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_DIALECTS_IREE_GPU_H
 #define IREE_COMPILER_DIALECTS_IREE_GPU_H
 
-#include <cstdint>
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 

--- a/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
+++ b/compiler/bindings/c/iree/compiler/dialects/iree_gpu.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECTS_IREE_GPU_H
 #define IREE_COMPILER_DIALECTS_IREE_GPU_H
 
+#include <cstdint>
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 
@@ -170,6 +171,7 @@ MLIR_CAPI_EXPORTED ireeGPUTargetInfo ireeGPUTargetInfoGet(
     MlirContext mlirCtx, const char *arch, const int32_t *subgroupChoices,
     size_t numSubgroupChoices, const int32_t *workgroupSizes,
     size_t numWorkgroupSizes, int32_t threadCount, int32_t memoryBytes,
+    uint32_t wgpCount, int32_t simdsPerWgp,
     const mma_intrinsic_enum_t *mmaIntrinsics, size_t numMmaIntrinsics);
 
 // Extracts MMA intrinsic values and their virtual status from an ArrayAttr.

--- a/compiler/bindings/python/IREECompilerDialectsModule.cpp
+++ b/compiler/bindings/python/IREECompilerDialectsModule.cpp
@@ -501,7 +501,8 @@ NB_MODULE(_ireeCompilerDialects, m) {
              const std::string &arch,
              const std::vector<int32_t> &subgroupChoices,
              const std::vector<int32_t> &workgroupSizes, int32_t threadCount,
-             int32_t memoryBytes, const py::list &mmaIntrinsicObjs) {
+             int32_t memoryBytes, int32_t wgpCount, int32_t simdsPerWgp,
+             const py::list &mmaIntrinsicObjs) {
             std::vector<mma_intrinsic_enum_t> mmaIntrinsicVals;
             py::module_ gpuModule = py::module_::import_(kGpuModuleImportPath);
             py::object mmaIntrinsicClass =
@@ -518,15 +519,20 @@ NB_MODULE(_ireeCompilerDialects, m) {
                   py::cast<mma_intrinsic_enum_t>(item.attr("value")));
             }
 
+            if (wgpCount < 0) {
+              throw py::value_error("workgroup_count must be non-negative");
+            }
+
             *self = ireeGPUTargetInfoGet(
                 context, arch.c_str(), subgroupChoices.data(),
                 subgroupChoices.size(), workgroupSizes.data(),
-                workgroupSizes.size(), threadCount, memoryBytes,
-                mmaIntrinsicVals.data(), mmaIntrinsicVals.size());
+                workgroupSizes.size(), threadCount, memoryBytes, wgpCount,
+                simdsPerWgp, mmaIntrinsicVals.data(), mmaIntrinsicVals.size());
           },
           "context"_a, "arch"_a, "subgroup_size_choices"_a,
           "max_workgroup_sizes"_a, "max_thread_count_per_workgroup"_a,
-          "max_workgroup_memory_bytes"_a, "mma_intrinsics"_a = py::list{},
+          "max_workgroup_memory_bytes"_a, "workgroup_count"_a,
+          "simds_per_workgroup"_a, "mma_intrinsics"_a = py::list{},
           "Create a GPUTargetInfo with the given parameters")
       .def_static(
           "get_gpu_target_info", &ireeHALExecutableTargetAttrGetGPUTargetInfo,

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -498,8 +498,8 @@ def gpu_target_info_constructor():
         max_workgroup_sizes=[256, 512, 1024],
         max_thread_count_per_workgroup=1024,
         max_workgroup_memory_bytes=65536,
-        workgroup_count = 304,
-        simds_per_workgroup = 4,
+        workgroup_count=304,
+        simds_per_workgroup=4,
         mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x4_F32,
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -555,8 +555,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304,
-            simds_per_workgroup = 4,
+            workgroup_count=304,
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong arch type"
@@ -571,8 +571,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304,
-            simds_per_workgroup = 4,
+            workgroup_count=304,
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong subgroup_size_choices type"
@@ -587,8 +587,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256.0, 512, 1024],  # should be list of int.
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304,
-            simds_per_workgroup = 4,
+            workgroup_count=304,
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_workgroup_sizes type"
@@ -603,8 +603,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024.0,  # should be int.
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304,
-            simds_per_workgroup = 4,
+            workgroup_count=304,
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_thread_count_per_workgroup type"
@@ -619,8 +619,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536.0,  # should be int.
-            workgroup_count = 304,
-            simds_per_workgroup = 4,
+            workgroup_count=304,
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_workgroup_memory_bytes type"
@@ -635,8 +635,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304.0,  # should be int.
-            simds_per_workgroup = 4,
+            workgroup_count=304.0,  # should be int.
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong workgroup_count type"
@@ -651,8 +651,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = -304,  # should be non-negative.
-            simds_per_workgroup = 4,
+            workgroup_count=-304,  # should be non-negative.
+            simds_per_workgroup=4,
             mma_intrinsics=[],
         )
         assert False, "Expected ValueError for negative workgroup_count"
@@ -667,14 +667,14 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count = 304,
-            simds_per_workgroup = 4.0,  # should be int.
+            workgroup_count=304,
+            simds_per_workgroup=4.0,  # should be int.
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong simds_per_workgroup type"
     except TypeError:
         pass
-    
+
     try:
         iree_gpu.TargetInfo(
             context=context,

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -498,6 +498,8 @@ def gpu_target_info_constructor():
         max_workgroup_sizes=[256, 512, 1024],
         max_thread_count_per_workgroup=1024,
         max_workgroup_memory_bytes=65536,
+        workgroup_count = 304,
+        simds_per_workgroup = 4,
         mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x4_F32,
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -523,6 +525,12 @@ def gpu_target_info_constructor():
     assert (
         target_info.max_workgroup_memory_bytes == 65536
     ), f"Expected max_workgroup_memory_bytes 65536, got {target_info.max_workgroup_memory_bytes}"
+    assert (
+        target_info.workgroup_count == 304
+    ), f"Expected workgroup_count 304, got {target_info.workgroup_count}"
+    assert (
+        target_info.simds_per_workgroup == 4
+    ), f"Expected simds_per_workgroup 4, got {target_info.simds_per_workgroup}"
     mma_intrinsics = target_info.mma_intrinsics
     assert mma_intrinsics == [
         iree_gpu.MMAIntrinsic.MFMA_F32_16x16x4_F32,
@@ -547,6 +555,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
+            workgroup_count = 304,
+            simds_per_workgroup = 4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong arch type"
@@ -561,6 +571,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
+            workgroup_count = 304,
+            simds_per_workgroup = 4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong subgroup_size_choices type"
@@ -575,6 +587,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256.0, 512, 1024],  # should be list of int.
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
+            workgroup_count = 304,
+            simds_per_workgroup = 4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_workgroup_sizes type"
@@ -589,6 +603,8 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024.0,  # should be int.
             max_workgroup_memory_bytes=65536,
+            workgroup_count = 304,
+            simds_per_workgroup = 4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_thread_count_per_workgroup type"
@@ -603,12 +619,62 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536.0,  # should be int.
+            workgroup_count = 304,
+            simds_per_workgroup = 4,
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong max_workgroup_memory_bytes type"
     except TypeError:
         pass
 
+    try:
+        iree_gpu.TargetInfo(
+            context=context,
+            arch="gfx942",
+            subgroup_size_choices=[32, 64],
+            max_workgroup_sizes=[256, 512, 1024],
+            max_thread_count_per_workgroup=1024,
+            max_workgroup_memory_bytes=65536,
+            workgroup_count = 304.0,  # should be int.
+            simds_per_workgroup = 4,
+            mma_intrinsics=[],
+        )
+        assert False, "Expected TypeError for wrong workgroup_count type"
+    except TypeError:
+        pass
+
+    try:
+        iree_gpu.TargetInfo(
+            context=context,
+            arch="gfx942",
+            subgroup_size_choices=[32, 64],
+            max_workgroup_sizes=[256, 512, 1024],
+            max_thread_count_per_workgroup=1024,
+            max_workgroup_memory_bytes=65536,
+            workgroup_count = -304,  # should be non-negative.
+            simds_per_workgroup = 4,
+            mma_intrinsics=[],
+        )
+        assert False, "Expected ValueError for negative workgroup_count"
+    except ValueError:
+        pass
+
+    try:
+        iree_gpu.TargetInfo(
+            context=context,
+            arch="gfx942",
+            subgroup_size_choices=[32, 64],
+            max_workgroup_sizes=[256, 512, 1024],
+            max_thread_count_per_workgroup=1024,
+            max_workgroup_memory_bytes=65536,
+            workgroup_count = 304,
+            simds_per_workgroup = 4.0,  # should be int.
+            mma_intrinsics=[],
+        )
+        assert False, "Expected TypeError for wrong simds_per_workgroup type"
+    except TypeError:
+        pass
+    
     try:
         iree_gpu.TargetInfo(
             context=context,

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -668,7 +668,7 @@ def gpu_target_info_constructor_error_cases():
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
             workgroup_count=304,
-            simds_per_workgroup=4.0,  # should be int.
+            simds_per_workgroup=4.0,  # Should be int.
             mma_intrinsics=[],
         )
         assert False, "Expected TypeError for wrong simds_per_workgroup type"

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -651,7 +651,7 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count=-304,  # should be non-negative.
+            workgroup_count=-304,  # Should be non-negative.
             simds_per_workgroup=4,
             mma_intrinsics=[],
         )

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -635,7 +635,7 @@ def gpu_target_info_constructor_error_cases():
             max_workgroup_sizes=[256, 512, 1024],
             max_thread_count_per_workgroup=1024,
             max_workgroup_memory_bytes=65536,
-            workgroup_count=304.0,  # should be int.
+            workgroup_count=304.0,  # Should be int.
             simds_per_workgroup=4,
             mma_intrinsics=[],
         )

--- a/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEGPUDialectCAPI.cpp
@@ -447,6 +447,7 @@ ireeGPUTargetInfo ireeGPUTargetInfoGet(
     MlirContext mlirCtx, const char *arch, const int32_t *subgroupChoices,
     size_t numSubgroupChoices, const int32_t *workgroupSizes,
     size_t numWorkgroupSizes, int32_t threadCount, int32_t memoryBytes,
+    uint32_t wgpCount, int32_t simdsPerWgp,
     const mma_intrinsic_enum_t *mmaIntrinsics, size_t numMmaIntrinsics) {
   assert(!mlirContextIsNull(mlirCtx) && "mlirCtx cannot be null");
   assert(arch && "arch cannot be null");
@@ -468,6 +469,8 @@ ireeGPUTargetInfo ireeGPUTargetInfoGet(
 
   targetInfo.maxThreadCountPerWorkgroup = threadCount;
   targetInfo.maxWorkgroupMemoryBytes = memoryBytes;
+  targetInfo.wgpCount = wgpCount;
+  targetInfo.simdsPerWgp = simdsPerWgp;
 
   std::vector<mlir::Attribute> mmaIntrinsicAttrs;
   mmaIntrinsicAttrs.reserve(numMmaIntrinsics);


### PR DESCRIPTION
This PR completes the changes added in [PR](https://github.com/iree-org/iree/pull/22527).
In the previous PR, 2 new attr `workgroup_count` and `simds_per_workgroup` were only added as read-only arguments of `TargetInfo`.
This PR added these 2 attributes as constructor parameters in both the cpp function and python bindings.