### PR TITLE
[CI] Force CPU torch benchmarks to use Threadripper.

### DIFF
--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,7 +33,7 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
-            runs-on: [ubuntu-24.04, threadripper]
+            runs-on: ubuntu-24.04
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]
@@ -107,6 +107,7 @@ jobs:
               - persistent-cache
               - Linux
               - X64
+              - threadripper
           # MI325
           - name: amdgpu_mi325_gfx942
             markers: "gfx942 or mi325"

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -33,7 +33,7 @@ jobs:
           - name: cpu_task
             markers: "cpu"
             config-file: torch_ops_cpu_llvm_sync.json
-            runs-on: ubuntu-24.04
+            runs-on: [ubuntu-24.04, threadripper]
           - name: amdgpu_hip_gfx1100_O3
             config-file:  torch_ops_gpu_hip_gfx1100_O3.json
             runs-on: [Linux, X64, gfx1100]

--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_benchmark_cpu.json
@@ -36,5 +36,5 @@
         "value": "1x64xi64"
       }
     ],
-    "golden_time_ms": 141.0
+    "golden_time_ms": 170.0
 }


### PR DESCRIPTION
It can be scheduled to a different machine, which makes the benchmark flaky. E.g., it takes ~140 ms on shark55 and ~165 ms on shark10-ci.

We are going to have one more threadripper come back, so threadripper is a better target.

See https://discord.com/channels/689900678990135345/689957613152239638/1436492741151293570 for more discussion.

ci-extra: test_torch