### PR TITLE
Improving support for iree_codegen.extract_strided_metadata.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/EmulateNarrowType.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -573,9 +574,10 @@ private:
 struct EmulateNarrowTypePass final
     : impl::EmulateNarrowTypePassBase<EmulateNarrowTypePass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<arith::ArithDialect, func::FuncDialect,
-                    memref::MemRefDialect, vector::VectorDialect,
-                    affine::AffineDialect, IREE::HAL::HALDialect>();
+    registry
+        .insert<arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                vector::VectorDialect, affine::AffineDialect,
+                IREE::Codegen::IREECodegenDialect, IREE::HAL::HALDialect>();
   }
 
   void runOnOperation() override {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -45,6 +45,27 @@ static AffineMap getMulMap(MLIRContext *context) {
   return AffineMap::get(0, 2, s0 * s1);
 }
 
+/// Walks up the def-use chain to find the HAL interface binding subspan
+/// that a memref value derives from, passing through transparent wrapper ops.
+static std::optional<IREE::HAL::InterfaceBindingSubspanOp>
+getSourceInterfaceBinding(Value memrefValue) {
+  Value source = memrefValue;
+  // Walk through transparent wrapper operations.
+  while (source) {
+    if (auto binding =
+            source.getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>()) {
+      return binding;
+    }
+    if (auto assumeAlign = source.getDefiningOp<memref::AssumeAlignmentOp>()) {
+      source = assumeAlign.getOperand();
+      continue;
+    }
+    // No more transparent ops to pass through.
+    break;
+  }
+  return std::nullopt;
+}
+
 /// Returns the strides based on the sizes assuming that the `memref`
 /// has default layout, i.e. it is not a result of a subview.
 static SmallVector<OpFoldResult>
@@ -128,23 +149,39 @@ replaceOffsetSizesAndStridesWith(RewriterBase &rewriter, OpTy op,
 
 namespace {
 
-struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
+/// Converts memref.extract_strided_metadata to
+/// iree_codegen.extract_strided_metadata when the source derives from a HAL
+/// interface binding. This preserves SSA links through buffer binding
+/// optimizations that update offsets.
+struct ConvertMemRefExtractMetadataToIREECodegen
     : public OpRewritePattern<memref::ExtractStridedMetadataOp> {
-  using Base::Base;
+  using OpRewritePattern<memref::ExtractStridedMetadataOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(memref::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
-    auto binding =
-        op.getSource()
-            .template getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
+    if (!getSourceInterfaceBinding(op.getSource()))
+      return failure();
+    // Replace with iree_codegen version which doesn't fold.
+    rewriter.replaceOpWithNewOp<IREE::Codegen::ExtractStridedMetadataOp>(
+        op, op.getSource());
+    return success();
+  }
+};
+
+struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
+    : public OpRewritePattern<IREE::Codegen::ExtractStridedMetadataOp> {
+  using Base::Base;
+  LogicalResult matchAndRewrite(IREE::Codegen::ExtractStridedMetadataOp op,
+                                PatternRewriter &rewriter) const override {
+    auto binding = getSourceInterfaceBinding(op.getSource());
     if (!binding)
       return failure();
-    auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
+    auto memRefType = llvm::cast<MemRefType>(binding->getResult().getType());
 
     auto loc = op.getLoc();
     OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPoint(binding);
+    rewriter.setInsertionPoint(*binding);
     FailureOr<DescriptorInfo> resultDescriptor =
-        resolveBufferDescriptorForInterfaceBinding(binding, rewriter, loc);
+        resolveBufferDescriptorForInterfaceBinding(*binding, rewriter, loc);
     if (failed(resultDescriptor)) {
       return rewriter.notifyMatchFailure(
           op, "failed to resolve descriptor with source being binding op");
@@ -196,16 +233,16 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     IREE::HAL::InterfaceBindingSubspanOp newBinding;
     if (bindsBasePointer) {
       newBufferType = memRefType;
-      newBinding = binding;
+      newBinding = *binding;
     } else {
       newBufferType = MemRefType::get(
           staticLinearShape, memRefType.getElementType(),
           MemRefLayoutAttrInterface(), memRefType.getMemorySpace());
       Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
       newBinding = IREE::HAL::InterfaceBindingSubspanOp::create(
-          rewriter, loc, newBufferType, binding.getLayoutAttr(),
-          binding.getBindingAttr(), zero, dynamicLinearShape,
-          binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
+          rewriter, loc, newBufferType, binding->getLayoutAttr(),
+          binding->getBindingAttr(), zero, dynamicLinearShape,
+          binding->getAlignmentAttr(), binding->getDescriptorFlagsAttr());
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);
@@ -236,14 +273,24 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
   }
 };
 
-// Converts IREE::Codegen::ExtractStridedMetadataOp to
-// MemRef::ExtractStridedMetadataOp
-struct ConvertCodegenIREEExtractMetadataToMemRef
+/// Converts iree_codegen.extract_strided_metadata to
+/// memref.extract_strided_metadata. Only applies when the source is NOT from
+/// a HAL binding (those are resolved by
+/// ResolveExtractMetadataFromHalInterfaceBindingSubspan).
+struct ConvertIREECodegenExtractMetadataToMemRef
     : public OpRewritePattern<IREE::Codegen::ExtractStridedMetadataOp> {
   using OpRewritePattern<
       IREE::Codegen::ExtractStridedMetadataOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::Codegen::ExtractStridedMetadataOp op,
                                 PatternRewriter &rewriter) const override {
+    // GUARD: Don't convert back to memref if source is still from HAL binding.
+    // Pattern ResolveExtractMetadataFromHalInterfaceBindingSubspan must
+    // resolve these first to preserve SSA links through buffer binding
+    // optimizations.
+    if (getSourceInterfaceBinding(op.getSource()))
+      return failure();
+
+    // Only convert ops that don't have HAL bindings (or are already resolved).
     rewriter.replaceOpWithNewOp<memref::ExtractStridedMetadataOp>(
         op, op.getSource());
     return success();
@@ -271,10 +318,24 @@ void populateIREEResolveExtractStridedMetadataPatterns(
     memref::populateResolveExtractStridedMetadataPatterns(patterns);
   }
   amdgpu::populateAmdgpuResolveStridedMetadataPatterns(patterns);
+
+  // NOTE: the pattern benefits below are a secondary defense: each pattern
+  // guards itself and only runs if required so they shouldn't be required but
+  // since we're doing the back-and-forth this helps make it explicit. Ideally
+  // we'd do this in two passes (fully resolve -> convert back to memref for
+  // subsequent passes expecting it).
+
+  // Convert memref extract ops to iree_codegen version to preserve SSA links.
+  patterns.insert<ConvertMemRefExtractMetadataToIREECodegen>(
+      patterns.getContext(), PatternBenefit(1));
+  // Resolve iree_codegen extract ops from HAL bindings to concrete values.
+  // Highest benefit ensures this runs before the fallback conversion.
   patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
-      patterns.getContext());
-  patterns.insert<ConvertCodegenIREEExtractMetadataToMemRef>(
-      patterns.getContext());
+      patterns.getContext(), PatternBenefit(3));
+  // Convert remaining iree_codegen extract ops to memref for upstream
+  // resolution. Lowest benefit ensures HAL binding resolution happens first.
+  patterns.insert<ConvertIREECodegenExtractMetadataToMemRef>(
+      patterns.getContext(), PatternBenefit(0));
 }
 
 void IREEExpandStridedMetadataPass::runOnOperation() {
@@ -289,7 +350,8 @@ void IREEExpandStridedMetadataPass::runOnOperation() {
   if (!allowUnresolved) {
     SmallVector<Operation *> remaining;
     getOperation()->walk([&](Operation *op) {
-      if (isa<memref::ExtractStridedMetadataOp>(op)) {
+      if (isa<memref::ExtractStridedMetadataOp,
+              IREE::Codegen::ExtractStridedMetadataOp>(op)) {
         remaining.push_back(op);
       }
     });

--- a/samples/custom_dispatch/cpu/embedded/functions.c
+++ b/samples/custom_dispatch/cpu/embedded/functions.c
@@ -35,50 +35,34 @@
 
 // `ret = lhs * rhs`
 //
-// Conforms to ABI:
-// #hal.pipeline.layout<constants = 1, bindings = [
-//   #hal.pipeline.binding<storage_buffer, ReadOnly>,
-//   #hal.pipeline.binding<storage_buffer, ReadOnly>,
-//   #hal.pipeline.binding<storage_buffer>
-// ]>
+// Simplified ABI with llvm.bareptr=true and extract_strided_metadata.
 // With a workgroup size of 64x1x1.
-void simple_mul_workgroup(
-    // vvvv simplification pending (buffer + offset)
-    const float* restrict binding0, const float* restrict binding0_aligned,
-    size_t binding0_offset, size_t binding0_size, size_t binding0_stride,
-    const float* restrict binding1, const float* restrict binding1_aligned,
-    size_t binding1_offset, size_t binding1_size, size_t binding1_stride,
-    float* restrict binding2, float* restrict binding2_aligned,
-    size_t binding2_offset, size_t binding2_size, size_t binding2_stride,
-    // ^^^^ simplification pending (buffer + offset)
-    size_t dim, size_t tid) {
+void simple_mul_workgroup(const float* restrict binding0,
+                          size_t binding0_offset,
+                          const float* restrict binding1,
+                          size_t binding1_offset, float* restrict binding2,
+                          size_t binding2_offset, size_t dim, size_t tid) {
   size_t end = tid + 64;
   if (end > dim) end = dim;
   for (size_t i = tid; i < end; ++i) {
-    binding2[i] = binding0[i] * binding1[i];
+    binding2[binding2_offset + i] =
+        binding0[binding0_offset + i] * binding1[binding1_offset + i];
   }
 }
 
 // `rhs *= lhs`
 //
-// Conforms to ABI:
-// #hal.pipeline.layout<constants = 1, bindings = [
-//   #hal.pipeline.binding<storage_buffer, ReadOnly>,
-//   #hal.pipeline.binding<storage_buffer>
-// ]>
+// Simplified ABI with llvm.bareptr=true and extract_strided_metadata.
 // With a workgroup size of 64x1x1.
-void simple_mul_inplace_workgroup(
-    // vvvv simplification pending (buffer + offset)
-    const float* restrict binding0, const float* restrict binding0_aligned,
-    size_t binding0_offset, size_t binding0_size, size_t binding0_stride,
-    float* restrict binding1, float* restrict binding1_aligned,
-    size_t binding1_offset, size_t binding1_size, size_t binding1_stride,
-    // ^^^^ simplification pending (buffer + offset)
-    size_t dim, size_t tid) {
+void simple_mul_inplace_workgroup(const float* restrict binding0,
+                                  size_t binding0_offset,
+                                  float* restrict binding1,
+                                  size_t binding1_offset, size_t dim,
+                                  size_t tid) {
   size_t end = tid + 64;
   if (end > dim) end = dim;
   for (size_t i = tid; i < end; ++i) {
-    binding1[i] *= binding0[i];
+    binding1[binding1_offset + i] *= binding0[binding0_offset + i];
   }
 }
 
@@ -104,8 +88,8 @@ void simple_mul_abs_negate_workgroup(
   size_t end = tid + 64;
   if (end > dim) end = dim;
   for (size_t i = tid; i < end; ++i) {
-    float prod = binding0[i] * binding1[i];
+    float prod = binding0[binding0_offset + i] * binding1[binding1_offset + i];
     if (prod >= 0) prod = -prod;
-    binding2[i] = prod + 1;
+    binding2[binding2_offset + i] = prod + 1;
   }
 }

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec.mlir
@@ -21,9 +21,9 @@ module attributes {transform.with_named_sequence} {
         %lhs = stream.binding.subspan %arg0[%c0] : !stream.binding -> memref<?x?xf32>{%m, %k}
         %rhs = stream.binding.subspan %arg1[%c0] : !stream.binding -> memref<?x?xf32>{%k, %n}
         %result = stream.binding.subspan %arg2[%c0] : !stream.binding -> memref<?x?xf32>{%m, %n}
-        %p0, %o0, %s00, %s01, %t00, %t01 = memref.extract_strided_metadata %lhs : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
-        %p1, %o1, %s10, %s11, %t10, %t11 = memref.extract_strided_metadata %rhs : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
-        %p2, %o2, %s20, %s21, %t20, %t21 = memref.extract_strided_metadata %result : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
+        %p0, %o0, %s00, %s01, %t00, %t01 = iree_codegen.extract_strided_metadata %lhs : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
+        %p1, %o1, %s10, %s11, %t10, %t11 = iree_codegen.extract_strided_metadata %rhs : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
+        %p2, %o2, %s20, %s21, %t20, %t21 = iree_codegen.extract_strided_metadata %result : memref<?x?xf32> -> memref<f32>, index, index, index, index, index
         func.call @mlp_external(%p0, %o0, %p1, %o1, %p2, %o2, %arg3, %arg4, %arg5, %do_relu) : (memref<f32>, index, memref<f32>, index, memref<f32>, index, i32, i32, i32, i1) -> ()
         return
       }

--- a/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
+++ b/samples/custom_dispatch/cpu/plugin/standalone_example.mlir
@@ -85,11 +85,11 @@ module @example {
         // The default `memref` lowering contains additional fields that might not be
         // always required. In this example, we only need the base and offset of the
         // `memref`s. So extract the base and offset from the memrefs.
-        %base0, %offset0, %size0, %stride0 = memref.extract_strided_metadata %memref0
+        %base0, %offset0, %size0, %stride0 = iree_codegen.extract_strided_metadata %memref0
             : memref<?xf32> -> memref<f32>, index, index, index
-        %base1, %offset1, %size1, %stride1 = memref.extract_strided_metadata %memref1
+        %base1, %offset1, %size1, %stride1 = iree_codegen.extract_strided_metadata %memref1
             : memref<?xf32> -> memref<f32>, index, index, index
-        %base2, %offset2, %size2, %stride2 = memref.extract_strided_metadata %memref2
+        %base2, %offset2, %size2, %stride2 = iree_codegen.extract_strided_metadata %memref2
             : memref<?xf32> -> memref<f32>, index, index, index
 
         // Call the externally defined C function with an (almost) plain C

--- a/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/standalone_plugin.c
@@ -67,7 +67,7 @@ static int simple_mul_workgroup(void* params_ptr, void* context,
     // where to read the data from for this invocation of the function.
     params->binding2[params->binding2_offset + i] =
         params->binding0[params->binding0_offset + i] *
-        params->binding1[params->binding2_offset + i];
+        params->binding1[params->binding1_offset + i];
   }
   return 0;
 }

--- a/samples/custom_dispatch/cpu/plugin/system_example.mlir
+++ b/samples/custom_dispatch/cpu/plugin/system_example.mlir
@@ -93,11 +93,11 @@ module @example {
         %memref1 = stream.binding.subspan %binding1[%c0] : !stream.binding -> memref<?xf32>{%dim}
         %memref2 = stream.binding.subspan %binding2[%c0] : !stream.binding -> memref<?xf32>{%dim}
 
-        %base0, %offset0, %size0, %stride0 = memref.extract_strided_metadata %memref0
+        %base0, %offset0, %size0, %stride0 = iree_codegen.extract_strided_metadata %memref0
             : memref<?xf32> -> memref<f32>, index, index, index
-        %base1, %offset1, %size1, %stride1 = memref.extract_strided_metadata %memref1
+        %base1, %offset1, %size1, %stride1 = iree_codegen.extract_strided_metadata %memref1
             : memref<?xf32> -> memref<f32>, index, index, index
-        %base2, %offset2, %size2, %stride2 = memref.extract_strided_metadata %memref2
+        %base2, %offset2, %size2, %stride2 = iree_codegen.extract_strided_metadata %memref2
             : memref<?xf32> -> memref<f32>, index, index, index
 
 

--- a/samples/custom_dispatch/cpu/plugin/system_plugin.c
+++ b/samples/custom_dispatch/cpu/plugin/system_plugin.c
@@ -87,7 +87,7 @@ static int simple_mul_workgroup(void* params_ptr, void* context,
   for (size_t i = 0; i < params->size; ++i) {
     params->binding2[params->binding2_offset + i] =
         params->binding0[params->binding0_offset + i] *
-        params->binding1[params->binding2_offset + i];
+        params->binding1[params->binding1_offset + i];
     fprintf(plugin->file, "mul[%zu:%zu](%g * %g = %g)\n", params->tid, i,
             params->binding0[params->binding0_offset + i],
             params->binding1[params->binding1_offset + i],


### PR DESCRIPTION
The existing handling was inconsistently converting the better iree_codegen op into the memref op which dropped information - now instead we convert upstream into iree_codegen and use that for our patterns before at the end going back to memref. This also adds support for walking over metadata ops on the way to the binding (like assume_alignment) - it's still not great (won't support functions/control flow/etc) but generally we don't want bindings used outside of the entry point function anyway.

This uncovered we could finally kill some TODOs in our samples _and_ it exposed most were broken unless they all had unique buffers and zero offsets and no alignments. I discovered this while adding a better buffer reuse path that caused anything using the extract_strided_metadata op to start failing due to the round-tripping through upstream. There's probably better approaches or different ways we could do this, but this was required for correctness and felt like the minimal change that is still in-line with what the code seems to expect. And it lets us shrink those samples a lot!