### PR TITLE
Adding some Stream canonicalizations and RefineUsage improvements.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -52,17 +52,17 @@ static constexpr bool kFavorTransients = false;
 // Worst state: used for all kinds of things.
 template <typename ElementT>
 class AbstractResourceUsage
-    : public DFX::StateWrapper<DFX::BitIntegerState<uint16_t, 4095, 0>,
+    : public DFX::StateWrapper<DFX::BitIntegerState<uint16_t, 8191, 0>,
                                ElementT> {
 public:
   using BaseType =
-      DFX::StateWrapper<DFX::BitIntegerState<uint16_t, 4095, 0>, ElementT>;
+      DFX::StateWrapper<DFX::BitIntegerState<uint16_t, 8191, 0>, ElementT>;
 
   // Inverted bits matching ResourceUsageBitfield.
   enum {
     NOT_INDIRECT = 1u << 0,
     NOT_EXTERNAL = 1u << 1,
-    NOT_MUTATED = 1u << 2, // beyond definition
+    NOT_MUTATED = 1u << 2,
     NOT_CONSTANT = 1u << 3,
     NOT_TRANSFER_READ = 1u << 4,
     NOT_TRANSFER_WRITE = 1u << 5,
@@ -72,11 +72,12 @@ public:
     NOT_DISPATCH_WRITE = 1u << 9,
     NOT_GLOBAL_READ = 1u << 10,
     NOT_GLOBAL_WRITE = 1u << 11,
+    NOT_GLOBAL_STORAGE = 1u << 12,
 
     BEST_STATE = NOT_INDIRECT | NOT_EXTERNAL | NOT_MUTATED | NOT_CONSTANT |
                  NOT_TRANSFER_READ | NOT_TRANSFER_WRITE | NOT_STAGING_READ |
                  NOT_STAGING_WRITE | NOT_DISPATCH_READ | NOT_DISPATCH_WRITE |
-                 NOT_GLOBAL_READ | NOT_GLOBAL_WRITE,
+                 NOT_GLOBAL_READ | NOT_GLOBAL_WRITE | NOT_GLOBAL_STORAGE,
   };
   static_assert(BEST_STATE == BaseType::getBestState(),
                 "unexpected BEST_STATE value");
@@ -160,6 +161,8 @@ public:
       append("global_read");
     if (!this->isAssumed(NOT_GLOBAL_WRITE))
       append("global_write");
+    if (!this->isAssumed(NOT_GLOBAL_STORAGE))
+      append("global_storage");
     return str.empty() ? "*" : str;
   }
 
@@ -268,7 +271,7 @@ private:
           getState() ^= sourceUsage.getState();
         })
         .Case([&](IREE::Util::GlobalLoadOpInterface op) {
-          removeAssumedBits(NOT_GLOBAL_READ);
+          removeAssumedBits(NOT_GLOBAL_READ | NOT_GLOBAL_STORAGE);
           auto globalType = cast<IREE::Stream::ResourceType>(
               op.getLoadedGlobalValue().getType());
           switch (globalType.getLifetime()) {
@@ -285,7 +288,8 @@ private:
           getState() ^= resultUsage.getState();
         })
         .Case([&](IREE::Util::GlobalLoadIndirectOpInterface op) {
-          removeAssumedBits(NOT_INDIRECT | NOT_GLOBAL_READ);
+          removeAssumedBits(NOT_INDIRECT | NOT_GLOBAL_READ |
+                            NOT_GLOBAL_STORAGE);
           auto &resultUsage = solver.getElementFor<ValueResourceUsage>(
               *this, Position::forValue(op.getLoadedGlobalValue()),
               DFX::Resolution::REQUIRED);
@@ -637,7 +641,7 @@ private:
           getState() ^= resultUsage.getState();
         })
         .Case([&](IREE::Util::GlobalStoreOpInterface op) {
-          removeAssumedBits(NOT_GLOBAL_WRITE);
+          removeAssumedBits(NOT_GLOBAL_WRITE | NOT_GLOBAL_STORAGE);
           auto globalType = cast<IREE::Stream::ResourceType>(
               op.getStoredGlobalValue().getType());
           switch (globalType.getLifetime()) {
@@ -650,7 +654,8 @@ private:
           }
         })
         .Case([&](IREE::Util::GlobalStoreIndirectOpInterface op) {
-          removeAssumedBits(NOT_INDIRECT | NOT_GLOBAL_WRITE);
+          removeAssumedBits(NOT_INDIRECT | NOT_GLOBAL_WRITE |
+                            NOT_GLOBAL_STORAGE);
         })
         .Case([&](IREE::Stream::TensorExportOp op) {
           auto sourceType =

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.h
@@ -21,7 +21,7 @@ namespace mlir::iree_compiler::IREE::Stream {
 enum class ResourceUsageBitfield : uint32_t {
   Indirect = 1u << 0,
   External = 1u << 1,
-  Mutated = 1u << 2, // beyond definition
+  Mutated = 1u << 2,
   Constant = 1u << 3,
   TransferRead = 1u << 4,
   TransferWrite = 1u << 5,
@@ -31,10 +31,12 @@ enum class ResourceUsageBitfield : uint32_t {
   DispatchWrite = 1u << 9,
   GlobalRead = 1u << 10,
   GlobalWrite = 1u << 11,
+  // Value is global storage or references global storage.
+  GlobalStorage = 1u << 12,
 
   Unknown = Indirect | External | Mutated | Constant | TransferRead |
             TransferWrite | StagingRead | StagingWrite | DispatchRead |
-            DispatchWrite | GlobalRead | GlobalWrite,
+            DispatchWrite | GlobalRead | GlobalWrite | GlobalStorage,
 };
 
 inline ResourceUsageBitfield operator|(ResourceUsageBitfield lhs,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -11,7 +11,7 @@ util.func public @importBufferView(%view: !hal.buffer_view) -> tensor<?x?x4xf32>
   //  CHECK-DAG: %[[SIZE:.+]] = stream.tensor.sizeof tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} : index
   //      CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]] : !hal.buffer_view ->
   // CHECK-SAME:     tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[SIZE]]}
-  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.transfer %[[RESOURCE]] :
+  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.clone %[[RESOURCE]] :
   // CHECK-SAME:     !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
   %0 = hal.tensor.import %view : !hal.buffer_view -> tensor<?x?x4xf32>{%dim0, %dim1}
   // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
@@ -26,7 +26,7 @@ util.func public @importBufferViewBitcasting(%view: !hal.buffer_view) -> tensor<
   //  CHECK-DAG: %[[SIZE:.+]] = stream.tensor.sizeof tensor<4xbf16>
   //      CHECK: %[[RESOURCE:.+]] = stream.tensor.import %[[VIEW]] : !hal.buffer_view ->
   // CHECK-SAME:     tensor<2xui32> in !stream.resource<external>{%[[SIZE]]}
-  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.transfer %[[RESOURCE]] :
+  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.clone %[[RESOURCE]] :
   // CHECK-SAME:     !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
   %0 = hal.tensor.import %view : !hal.buffer_view -> tensor<2xui32> as tensor<4xbf16>
   // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
@@ -45,7 +45,7 @@ util.func public @importBufferViewAsync(%view: !hal.buffer_view, %fence: !hal.fe
   //      CHECK: %[[TIMEPOINT:.+]] = stream.timepoint.import %[[FENCE]]
   //      CHECK: %[[SYNC_RESOURCE:.+]] = stream.timepoint.await %[[TIMEPOINT]] => %[[ASYNC_RESOURCE]]
   // CHECK-SAME:     : !stream.resource<external>{%[[SIZE]]}
-  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.transfer %[[SYNC_RESOURCE]]
+  // CHECK-NEXT: %[[RESULT:.+]] = stream.async.clone %[[SYNC_RESOURCE]]
   // CHECK-SAME:     : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
   %0 = hal.tensor.import wait(%fence) => %view : !hal.buffer_view -> tensor<4xf32>
   // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
@@ -57,7 +57,7 @@ util.func public @importBufferViewAsync(%view: !hal.buffer_view, %fence: !hal.fe
 // CHECK-LABEL: @exportBufferView
 // CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index)
 util.func public @exportBufferView(%tensor: tensor<?x?x4xf32>, %dim0: index, %dim1: index) -> !hal.buffer_view {
-  //      CHECK: %[[VIEW:.+]] = stream.async.transfer %[[TENSOR]] :
+  //      CHECK: %[[VIEW:.+]] = stream.async.clone %[[TENSOR]] :
   // CHECK-SAME:     !stream.resource<*>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
   // CHECK-NEXT: %[[RESULT:.+]] = stream.tensor.export %[[VIEW]] :
   // CHECK-SAME:     tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[SIZE]]}
@@ -76,7 +76,7 @@ util.func public @aliasStorage(%tensor: tensor<?x4xf32>, %dim0: index, %storage:
   // CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import %[[STORAGE]] : !hal.buffer -> tensor<?x4xf32>{%[[DIM0]]} in !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[STORAGE_RESOURCE]][%c0 to %[[SIZE]]] : !stream.resource<*>{%[[SIZE]]} -> %[[STORAGE_RESOURCE]] as !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[SLICE:.+]] = stream.async.slice %[[UPDATE]][%c0 to %[[SIZE]]] : !stream.resource<external>{%[[MIN_STORAGE_SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
-  // CHECK: %[[RESULT:.+]] = stream.async.transfer %[[SLICE]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
+  // CHECK: %[[RESULT:.+]] = stream.async.clone %[[SLICE]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
   %0 = hal.tensor.alias %tensor : tensor<?x4xf32>{%dim0} to %storage : !hal.buffer
   // CHECK: util.return %[[RESULT]]
   util.return %0 : tensor<?x4xf32>
@@ -93,7 +93,7 @@ util.func public @aliasStorageAsync(%tensor: tensor<?x4xf32>, %dim0: index, %sto
   // CHECK-DAG: %[[READY_STORAGE:.+]] = stream.timepoint.await %[[TIMEPOINT]] => %[[UNREADY_STORAGE]] : !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[READY_STORAGE]][%c0 to %[[SIZE]]] : !stream.resource<*>{%[[SIZE]]} -> %[[READY_STORAGE]] as !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[SLICE:.+]] = stream.async.slice %[[UPDATE]][%c0 to %[[SIZE]]] : !stream.resource<external>{%[[MIN_STORAGE_SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
-  // CHECK: %[[RESULT:.+]] = stream.async.transfer %[[SLICE]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
+  // CHECK: %[[RESULT:.+]] = stream.async.clone %[[SLICE]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
   %0 = hal.tensor.alias wait(%fence) => %tensor : tensor<?x4xf32>{%dim0} to %storage : !hal.buffer
   // CHECK: util.return %[[RESULT]]
   util.return %0 : tensor<?x4xf32>
@@ -111,4 +111,72 @@ util.func public @tensorBarrier(%tensor0: tensor<3xf32>, %tensor1: tensor<?xf32>
   %0:2 = hal.tensor.barrier join(%tensor0, %tensor1 : tensor<3xf32>, tensor<?xf32>) => %fence : !hal.fence
   // CHECK: util.return %[[TENSOR0_AFTER]], %[[SIZE0]], %[[TENSOR1_AFTER]], %[[SIZE1]]
   util.return %0#0, %0#1 : tensor<3xf32>, tensor<?xf32>
+}
+
+// -----
+
+// Tests import on dev_a while function affinity is dev_b.
+// A clone happens on dev_a (same-affinity lifetime change) but no transfer is inserted yet.
+
+// CHECK-LABEL: @importBufferViewCrossDevice
+// CHECK-SAME: (%[[VIEW:.+]]: !hal.buffer_view)
+// CHECK-SAME: -> (!stream.resource<*>, index)
+util.func public @importBufferViewCrossDevice(%view: !hal.buffer_view) -> tensor<4xf32> attributes {
+  stream.affinity = #hal.device.promise<@dev_b>
+} {
+  //  CHECK-DAG: %[[SIZE:.+]] = stream.tensor.sizeof on(#hal.device.promise<@dev_a>) tensor<4xf32>
+  //      CHECK: %[[RESOURCE:.+]] = stream.tensor.import on(#hal.device.promise<@dev_a>) %[[VIEW]] : !hal.buffer_view ->
+  // CHECK-SAME:     tensor<4xf32> in !stream.resource<external>{%[[SIZE]]}
+  // CHECK-NEXT: %[[CLONE:.+]] = stream.async.clone on(#hal.device.promise<@dev_a>) %[[RESOURCE]] :
+  // CHECK-SAME:     !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
+  %0 = hal.tensor.import on(#hal.device.promise<@dev_a>) %view : !hal.buffer_view -> tensor<4xf32>
+  // CHECK: util.return %[[CLONE]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests export on dev_b while function affinity is dev_a.
+// A clone happens implicitly without affinity.
+
+// CHECK-LABEL: @exportBufferViewCrossDevice
+// CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index)
+util.func public @exportBufferViewCrossDevice(%tensor: tensor<4xf32>) -> !hal.buffer_view attributes {
+  stream.affinity = #hal.device.promise<@dev_a>
+} {
+  //      CHECK: %[[CLONE:.+]] = stream.async.clone %[[TENSOR]] :
+  // CHECK-SAME:     !stream.resource<*>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  // CHECK-NEXT: %[[VIEW:.+]] = stream.tensor.export %[[CLONE]] :
+  // CHECK-SAME:     tensor<4xf32> in !stream.resource<external>{%[[SIZE]]}
+  // CHECK-SAME:     -> !hal.buffer_view
+  %0 = hal.tensor.export on(#hal.device.promise<@dev_b>) %tensor : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: util.return %[[VIEW]]
+  util.return %0 : !hal.buffer_view
+}
+
+// -----
+
+// Tests aliasing storage on dev_b while function affinity is dev_a.
+// This generates a transfer from dev_a to dev_b, operations on dev_b, but no transfer back.
+
+// CHECK-LABEL: @aliasStorageCrossDevice
+// CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[STORAGE:.+]]: !hal.buffer)
+// CHECK-SAME: -> (!stream.resource<*>, index)
+util.func public @aliasStorageCrossDevice(%tensor: tensor<4xf32>, %storage: !hal.buffer) -> tensor<4xf32> attributes {
+  stream.affinity = #hal.device.promise<@dev_a>
+} {
+  //      CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[TENSOR]] : !stream.resource<*>{%[[SIZE]]}
+  // CHECK-SAME:     -> to(#hal.device.promise<@dev_b>) !stream.resource<*>{%[[SIZE]]}
+  //  CHECK-DAG: %[[STORAGE_SIZE:.+]] = stream.tensor.sizeof on(#hal.device.promise<@dev_b>) tensor<4xf32>
+  //      CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import on(#hal.device.promise<@dev_b>) %[[STORAGE]] :
+  // CHECK-SAME:     !hal.buffer -> tensor<4xf32> in !stream.resource<external>{%[[STORAGE_SIZE]]}
+  //      CHECK: %[[UPDATE:.+]] = stream.async.update on(#hal.device.promise<@dev_b>) %[[TRANSFER]], %[[STORAGE_RESOURCE]][%c0 to %[[SIZE]]] :
+  // CHECK-SAME:     !stream.resource<*>{%[[SIZE]]} -> %[[STORAGE_RESOURCE]] as !stream.resource<external>{%[[STORAGE_SIZE]]}
+  //      CHECK: %[[SLICE:.+]] = stream.async.slice on(#hal.device.promise<@dev_b>) %[[UPDATE]][%c0 to %[[SIZE]]] :
+  // CHECK-SAME:     !stream.resource<external>{%[[STORAGE_SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  //      CHECK: %[[CLONE:.+]] = stream.async.clone on(#hal.device.promise<@dev_b>) %[[SLICE]] :
+  // CHECK-SAME:     !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
+  %0 = hal.tensor.alias on(#hal.device.promise<@dev_b>) %tensor : tensor<4xf32> to %storage : !hal.buffer
+  // CHECK: util.return %[[CLONE]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -2216,20 +2216,41 @@ OpFoldResult AsyncTransferOp::fold(FoldAdaptor operands) {
 
 namespace {
 
-// Elides transfer operations that are a no-op (from/to the same affinity and
-// same resource type).
-struct RedundantTransferElision : public OpRewritePattern<AsyncTransferOp> {
+// Converts same-affinity transfers to clones for clearer semantics.
+// Transfers are meant to represent cross-device or staging operations while
+// clones represent copy-on-write operations on the same device. When a transfer
+// has the same source and target affinity (or both are implicit) it's actually
+// a clone operation that may also change the lifetime.
+struct SameAffinityTransferToClone : public OpRewritePattern<AsyncTransferOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(AsyncTransferOp transferOp,
                                 PatternRewriter &rewriter) const override {
-    if (transferOp.getSourceAffinityAttr() ==
-            transferOp.getResultAffinityAttr() &&
-        transferOp.getSource().getType() == transferOp.getResult().getType()) {
-      // Transfer performs no work, elide.
-      rewriter.replaceOp(transferOp, transferOp.getSource());
-      return success();
+    // Check if source and result affinities are the same.
+    // This includes the case where both are null (implicit same affinity).
+    auto sourceAffinityAttr = transferOp.getSourceAffinityAttr();
+    auto resultAffinityAttr = transferOp.getResultAffinityAttr();
+    if (sourceAffinityAttr != resultAffinityAttr) {
+      return failure();
     }
-    return failure();
+
+    // Don't convert if either source or result is staging.
+    // Clone doesn't support staging resources.
+    auto sourceType =
+        cast<IREE::Stream::ResourceType>(transferOp.getSource().getType());
+    auto resultType =
+        cast<IREE::Stream::ResourceType>(transferOp.getResult().getType());
+    if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging ||
+        resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
+      return rewriter.notifyMatchFailure(transferOp, "staging transfer");
+    }
+
+    // Replace with a clone operation using the common affinity.
+    // The clone preserves the lifetime change (e.g., transient -> external).
+    rewriter.replaceOpWithNewOp<AsyncCloneOp>(
+        transferOp, transferOp.getResult().getType(), transferOp.getSource(),
+        transferOp.getSourceSize(), transferOp.getResultSize(),
+        sourceAffinityAttr);
+    return success();
   }
 };
 
@@ -2264,7 +2285,7 @@ struct IntermediateTransferElision : public OpRewritePattern<AsyncTransferOp> {
 void AsyncTransferOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                   MLIRContext *context) {
   // TODO(benvanik): staging propagation (fill of staging -> fill on device).
-  results.insert<RedundantTransferElision>(context);
+  results.insert<SameAffinityTransferToClone>(context);
   results.insert<IntermediateTransferElision>(context);
   results.insert<ElideUnusedOp<AsyncTransferOp>>(context);
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/timepoint_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/timepoint_folding.mlir
@@ -173,7 +173,7 @@ util.func private @SinkAwaitToFirstConsumer(
   cf.cond_br %arg1, ^bb2, ^bb3
 // CHECK: ^bb2:
 ^bb2:
-  // CHECK: = stream.async.transfer %[[READY]]#0
+  // CHECK: = stream.async.clone %[[READY]]#0
   %1 = stream.async.transfer %0#0 : !stream.resource<constant>{%c100} -> !stream.resource<external>{%c100}
   cf.br ^bb4(%1 : !stream.resource<external>)
 // CHECK: ^bb3:
@@ -208,7 +208,7 @@ util.func private @SinkAwaitToFirstConsumerRegion(
   %3 = "fake.region"() ({
     // CHECK: "fake.region"
     %4 = "fake.region"() ({
-      // CHECK: stream.async.transfer
+      // CHECK: stream.async.clone
       %5 = stream.async.transfer %0#0 : !stream.resource<constant>{%c100} -> !stream.resource<external>{%c100}
       // CHECK: "fake.yield"
       "fake.yield"(%5) : (!stream.resource<external>) -> ()

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -31,19 +31,21 @@ util.func public @propagateFuncCaller(%size: index) -> !stream.resource<*> {
 // -----
 
 // Tests that if a tied op (in this case export) is traversed during analysis
-// and the type changes we don't explode.
+// and the type changes we don't explode. The transfer from * to external is
+// preserved by RefineUsagePass and will be elided by ElideAsyncCopiesPass since
+// it's a same-type transfer (external->external after refinement).
 
 // CHECK-LABEL: @transitionTypesAcrossTies
-util.func public @transitionTypesAcrossTies() -> !hal.buffer_view {
+util.func public @transitionTypesAcrossTies() -> !util.buffer {
   %c4 = arith.constant 4 : index
   %c255_i32 = arith.constant 255 : i32
   // CHECK: %[[SPLAT:.+]] = stream.async.splat {{.+}} -> !stream.resource<external>
   %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<*>{%c4}
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[SPLAT]] : !stream.resource<external>{%c4} -> !stream.resource<external>{%c4}
   %1 = stream.async.transfer %0 : !stream.resource<*>{%c4} -> !stream.resource<external>{%c4}
-  // CHECK: stream.tensor.export %[[SPLAT]] : tensor<f32> in !stream.resource<external>{%c4} -> !hal.buffer_view
-  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c4} -> !hal.buffer_view
-  util.return %2 : !hal.buffer_view
+  // CHECK: stream.tensor.export %[[TRANSFER]] : tensor<f32> in !stream.resource<external>{%c4} -> !util.buffer
+  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c4} -> !util.buffer
+  util.return %2 : !util.buffer
 }
 
 // -----
@@ -87,9 +89,9 @@ util.func private @propagateBlocks(%cond: i1, %size: index) -> (!stream.resource
                  ^bb2(%fill0, %bb1_1_new : !stream.resource<*>, !stream.resource<*>)
 // CHECK: ^bb2
 ^bb2(%bb2_0: !stream.resource<*>, %bb2_1: !stream.resource<*>):
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[SELECT]] : !stream.resource<external>{{.+}} -> !stream.resource<external>
   %external_transfer = stream.async.transfer %bb2_1 : !stream.resource<*>{%size} -> !stream.resource<external>{%size}
-  // CHECK: util.return %[[FILL0]], %[[SELECT]] : !stream.resource<transient>, !stream.resource<external>
+  // CHECK: util.return %[[FILL0]], %[[TRANSFER]] : !stream.resource<transient>, !stream.resource<external>
   util.return %bb2_0, %external_transfer : !stream.resource<*>, !stream.resource<external>
 }
 
@@ -102,11 +104,11 @@ util.func private @propagateBlocks(%cond: i1, %size: index) -> (!stream.resource
 // CHECK-SAME: (%[[COND:.+]]: i1, %[[ARG0:.+]]: !stream.resource<transient>, %[[ARG1:.+]]: !stream.resource<external>, %[[SIZE:.+]]: index)
 // CHECK-SAME: -> !stream.resource<external>
 util.func public @conflictResolution(%cond: i1, %arg0: !stream.resource<transient>, %arg1: !stream.resource<external>, %size: index) -> !stream.resource<*> {
-  // CHECK: %[[ARG0_EXT:.+]] = stream.async.transfer %[[ARG0]]
+  // CHECK: %[[ARG0_EXT:.+]] = stream.async.transfer %[[ARG0]] : !stream.resource<transient>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
   %arg0_any = stream.async.transfer %arg0 : !stream.resource<transient>{%size} -> !stream.resource<*>{%size}
-  // CHECK-NOT: stream.async.transfer %[[ARG1]]
+  // CHECK: %[[ARG1_EXT:.+]] = stream.async.transfer %[[ARG1]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
   %arg1_any = stream.async.transfer %arg1 : !stream.resource<external>{%size} -> !stream.resource<*>{%size}
-  // CHECK: %[[RET:.+]] = arith.select %[[COND]], %[[ARG0_EXT]], %[[ARG1]] : !stream.resource<external>
+  // CHECK: %[[RET:.+]] = arith.select %[[COND]], %[[ARG0_EXT]], %[[ARG1_EXT]] : !stream.resource<external>
   %0 = arith.select %cond, %arg0_any, %arg1_any : !stream.resource<*>
   // CHECK: util.return %[[RET]] : !stream.resource<external>
   util.return %0 : !stream.resource<*>
@@ -135,23 +137,31 @@ util.func public @transferResolution(%arg0: !stream.resource<constant>, %size: i
 
 // -----
 
-// Tests that multiple transfers are elided during transfer materialization.
+// Tests that transfer chains are preserved during refinement. The chain
+// constant->*->external becomes constant->transient->external after refinement.
+// Note: A redundant external->external transfer may appear but will be
+// eliminated by ElideAsyncCopiesPass.
 
 // CHECK-LABEL: @transferElision
 // CHECK-SAME: (%[[SIZE:.+]]: index) -> !stream.resource<external>
 util.func public @transferElision(%size: index) -> !stream.resource<external> {
-  // CHECK: %[[ALLOCA:.+]] = stream.async.alloca
+  // CHECK: %[[ALLOCA:.+]] = stream.async.alloca : !stream.resource<constant>{%[[SIZE]]}
   %alloca = stream.async.alloca : !stream.resource<constant>{%size}
+  // CHECK: %[[TRANSFER_TRANSIENT:.+]] = stream.async.transfer %[[ALLOCA]] : !stream.resource<constant>{%[[SIZE]]} -> !stream.resource<transient>{%[[SIZE]]}
   %transfer_any = stream.async.transfer %alloca : !stream.resource<constant>{%size} -> !stream.resource<*>{%size}
-  // CHECK: %[[TRANSFER_EXTERNAL:.+]] = stream.async.transfer %[[ALLOCA]] : !stream.resource<constant>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  // CHECK: %[[TRANSFER_EXTERNAL:.+]] = stream.async.transfer %[[TRANSFER_TRANSIENT]] : !stream.resource<transient>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
   %transfer_external = stream.async.transfer %transfer_any : !stream.resource<*>{%size} -> !stream.resource<external>{%size}
-  // CHECK: util.return %[[TRANSFER_EXTERNAL]]
+  // A redundant transfer may be inserted here but will be eliminated later.
+  // CHECK: %[[TRANSFER_REDUNDANT:.+]] = stream.async.transfer %[[TRANSFER_EXTERNAL]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  // CHECK: util.return %[[TRANSFER_REDUNDANT]] : !stream.resource<external>
   util.return %transfer_external : !stream.resource<external>
 }
 
 // -----
 
-// Tests that global usage propagates through loads/stores.
+// Tests that global usage propagates through loads/stores. Same-type transfers
+// (variable->variable) are preserved during refinement and will be elided by
+// ElideAsyncCopiesPass.
 
 util.global private mutable @variable : !stream.resource<variable>
 util.global private mutable @variable__size : index
@@ -162,18 +172,18 @@ util.func private @globalLoad() -> !stream.resource<*> {
   // CHECK: %[[VALUE:.+]] = util.global.load @variable : !stream.resource<variable>
   %value = util.global.load @variable : !stream.resource<variable>
   %size = util.global.load @variable__size : index
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[VALUE]] : !stream.resource<variable>{%{{.+}}} -> !stream.resource<variable>{%{{.+}}}
   %0 = stream.async.transfer %value : !stream.resource<variable>{%size} -> !stream.resource<*>{%size}
-  // CHECK: util.return %[[VALUE]]
+  // CHECK: util.return %[[TRANSFER]] : !stream.resource<variable>
   util.return %0 : !stream.resource<*>
 }
 
 // CHECK-LABEL: @globalStore
 // CHECK-SAME: (%[[VALUE:.+]]: !stream.resource<variable>, %[[SIZE:.+]]: index)
 util.func private @globalStore(%value: !stream.resource<*>, %size: index) {
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[VALUE]] : !stream.resource<variable>{%[[SIZE]]} -> !stream.resource<variable>{%[[SIZE]]}
   %0 = stream.async.transfer %value : !stream.resource<*>{%size} -> !stream.resource<variable>{%size}
-  // CHECK: util.global.store %[[VALUE]], @variable : !stream.resource<variable>
+  // CHECK: util.global.store %[[TRANSFER]], @variable : !stream.resource<variable>
   util.global.store %0, @variable : !stream.resource<variable>
   util.global.store %size, @variable__size : index
   util.return
@@ -181,90 +191,98 @@ util.func private @globalStore(%value: !stream.resource<*>, %size: index) {
 
 // -----
 
-// Tests that explicit resource allocations are refined.
+// Tests that explicit resource allocations are refined. Same-type transfer
+// (external->external) is preserved during refinement.
 
 // CHECK-LABEL: @explicitAlloc
-util.func public @explicitAlloc() -> !hal.buffer_view {
+util.func public @explicitAlloc() -> !util.buffer {
   %c0 = arith.constant 0 : index
   // CHECK: %[[ALLOC:.+]] = stream.resource.alloc : !stream.resource<external>{%c0}
   %0 = stream.resource.alloc : !stream.resource<*>{%c0}
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[ALLOC]] : !stream.resource<external>{%c0} -> !stream.resource<external>{%c0}
   %1 = stream.async.transfer %0 : !stream.resource<*>{%c0} -> !stream.resource<external>{%c0}
-  // CHECK: stream.tensor.export %[[ALLOC]] : tensor<f32> in !stream.resource<external>{%c0} -> !hal.buffer_view
-  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c0} -> !hal.buffer_view
-  util.return %2 : !hal.buffer_view
+  // CHECK: stream.tensor.export %[[TRANSFER]] : tensor<f32> in !stream.resource<external>{%c0} -> !util.buffer
+  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c0} -> !util.buffer
+  util.return %2 : !util.buffer
 }
 
 // -----
 
 // Tests that async allocations that escape are turned into non-transient allocs.
+// Same-type transfer (external->external) is preserved during refinement.
 
 // CHECK-LABEL: @escapingAlloca
-util.func public @escapingAlloca() -> !hal.buffer_view {
+util.func public @escapingAlloca() -> !util.buffer {
   %c123 = arith.constant 123 : index
   // CHECK: %[[ALLOCA:.+]] = stream.async.alloca : !stream.resource<external>{%c123}
   %0 = stream.async.alloca : !stream.resource<*>{%c123}
-  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[ALLOCA]] : !stream.resource<external>{%c123} -> !stream.resource<external>{%c123}
   %1 = stream.async.transfer %0 : !stream.resource<*>{%c123} -> !stream.resource<external>{%c123}
-  // CHECK: stream.tensor.export %[[ALLOCA]] : tensor<f32> in !stream.resource<external>{%c123} -> !hal.buffer_view
-  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c123} -> !hal.buffer_view
-  util.return %2 : !hal.buffer_view
+  // CHECK: stream.tensor.export %[[TRANSFER]] : tensor<f32> in !stream.resource<external>{%c123} -> !util.buffer
+  %2 = stream.tensor.export %1 : tensor<f32> in !stream.resource<external>{%c123} -> !util.buffer
+  util.return %2 : !util.buffer
 }
 
 // -----
 
+// Tests scf.if with resources. Both branches must yield the same type, and
+// function arguments are refined based on usage in both branches.
+
 // CHECK-LABEL: @testIf
+// CHECK-SAME: (%[[COND:.+]]: i1, %[[ARG1:.+]]: !stream.resource<external>, %[[ARG2:.+]]: !stream.resource<external>)
+// CHECK-SAME: -> !stream.resource<external>
 util.func public @testIf(%arg0: i1, %arg1: !stream.resource<*>, %arg2: !stream.resource<*>) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
-  // CHECK: %[[IF:.+]] = scf.if
-  // CHECK-SAME: !stream.resource<external>
+  // CHECK: %[[IF:.+]] = scf.if %[[COND]] -> (!stream.resource<external>)
   %if = scf.if %arg0 -> (!stream.resource<*>) {
-    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch
-    // CHECK-SAME: !stream.resource<external>
-    // CHECK-SAME: !stream.resource<external>
-    // CHECK-SAME: -> !stream.resource<external>
+    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch @disp(%[[ARG1]][%c0 to %c4 for %c4], %[[ARG2]][%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}, !stream.resource<external>{%c4}) -> !stream.resource<external>{%c4}
     %disp = stream.async.dispatch @disp(%arg1[%c0 to %c4 for %c4], %arg2[%c0 to %c4 for %c4]) : (!stream.resource<*>{%c4}, !stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
-    // CHECK: scf.yield
-    // CHECK-SAME: !stream.resource<external>
+    // CHECK: scf.yield %[[DISPATCH]] : !stream.resource<external>
     scf.yield %disp : !stream.resource<*>
   } else {
-    // CHECK: scf.yield
-    // CHECK-SAME: !stream.resource<external>
+    // CHECK: scf.yield %[[ARG1]] : !stream.resource<external>
     scf.yield %arg1 : !stream.resource<*>
   }
+  // CHECK: util.return %[[IF]] : !stream.resource<external>
   util.return %if : !stream.resource<*>
 }
 
 // -----
 
-// CHECK: @testWhile
+// Tests scf.while with resources. Loop arguments are refined based on usage
+// across both before and after regions.
+
+// CHECK-LABEL: @testWhile
+// CHECK-SAME: (%[[ARG0:.+]]: i32, %[[ARG1:.+]]: !stream.resource<external>)
+// CHECK-SAME: -> (i32, !stream.resource<external>)
 util.func public @testWhile(%arg0: i32, %arg1: !stream.resource<*>) -> (i32, !stream.resource<*>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : i32
   %c4 = arith.constant 4 : index
   %c10 = arith.constant 10 : i32
-  // CHECK: scf.while
-  // CHECK-SAME: (i32, !stream.resource<external>)
-  // CHECK-SAME: (i32, !stream.resource<external>)
+  // CHECK: %[[WHILE:.+]]:2 = scf.while (%[[ARG2:.+]] = %[[ARG0]], %[[ARG3:.+]] = %[[ARG1]]) : (i32, !stream.resource<external>) -> (i32, !stream.resource<external>)
   %while:2 = scf.while (%arg2 = %arg0, %arg3 = %arg1) : (i32, !stream.resource<*>) -> (i32, !stream.resource<*>) {
     %cmp = arith.cmpi slt, %arg2, %c10 : i32
-    // CHECK: scf.condition
-    // CHECK-SAME: !stream.resource<external>
+    // CHECK: scf.condition(%{{.+}}) %[[ARG2]], %[[ARG3]] : i32, !stream.resource<external>
     scf.condition(%cmp) %arg2, %arg3 : i32, !stream.resource<*>
   } do {
   ^bb0(%arg2: i32, %arg3: !stream.resource<*>):
     %add = arith.addi %arg2, %c1 : i32
+    // CHECK: %[[DISPATCH:.+]] = stream.async.dispatch @disp(%[[ARG3]][%c0 to %c4 for %c4], %[[ARG1]][%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}, !stream.resource<external>{%c4}) -> !stream.resource<external>{%c4}
     %disp = stream.async.dispatch @disp(%arg3[%c0 to %c4 for %c4], %arg1[%c0 to %c4 for %c4]) : (!stream.resource<*>{%c4}, !stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
-    // CHECK: scf.yield
-    // CHECK-SAME: !stream.resource<external>
+    // CHECK: scf.yield %{{.+}}, %[[DISPATCH]] : i32, !stream.resource<external>
     scf.yield %add, %disp : i32, !stream.resource<*>
   }
-  // CHECK: util.return %[[IF]]#0, %[[IF]]#1 : i32, !stream.resource<external>
+  // CHECK: util.return %[[WHILE]]#0, %[[WHILE]]#1 : i32, !stream.resource<external>
   util.return %while#0, %while#1 : i32, !stream.resource<*>
 }
 
 // -----
+
+// Tests scf.while with type-changing dispatch in condition region. The dispatch
+// produces transient which must transfer to staging for stream.async.load.
+// Same-type transfer at end (external->external) is preserved.
 
 // CHECK-LABEL: @testWhileRecurse
 // CHECK-SAME: %[[ARG0:.+]]: !stream.resource<external>
@@ -302,17 +320,23 @@ util.func public @testWhileRecurse(%arg0 : !stream.resource<*>) -> !stream.resou
     // CHECK: scf.yield %[[DISPATCH]], %[[C4]] : !stream.resource<external>, index
     scf.yield %dispatch, %c4 : !stream.resource<*>, index
   }
+  // CHECK: %[[RESULT_TRANSFER:.+]] = stream.async.transfer %[[WHILE]]#0 : !stream.resource<external>{%[[WHILE]]#1} -> !stream.resource<external>{%[[WHILE]]#1}
   %transfer = stream.async.transfer %while#0 : !stream.resource<*>{%while#1} -> !stream.resource<external>{%while#1}
 
-  // CHECK: util.return %[[WHILE]]#0
+  // CHECK: util.return %[[RESULT_TRANSFER]] : !stream.resource<external>
   util.return %transfer : !stream.resource<external>
 }
 
 // -----
 
+// Tests scf.for with iter_args. The loop body uses transient resources for
+// intermediate computation, with external input and output. Same-type transfer
+// at end (external->external) is preserved.
+
 // CHECK-LABEL: @testForOp
 // CHECK-SAME: %[[ARG0:.+]]: index
 // CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>
+// CHECK-SAME: -> !stream.resource<external>
 util.func public @testForOp(%arg0 : index, %arg1 : !stream.resource<*>) -> !stream.resource<external> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -321,7 +345,7 @@ util.func public @testForOp(%arg0 : index, %arg1 : !stream.resource<*>) -> !stre
   // CHECK: %[[C0:.+]] = arith.constant 0 : index
   // CHECK: %[[C1:.+]] = arith.constant 1 : index
   // CHECK: %[[C4:.+]] = arith.constant 4 : index
-  // CHECK: %[[DISP0:.+]] = stream.async.dispatch @dispatch0(%arg1[%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<external>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
+  // CHECK: %[[DISP0:.+]] = stream.async.dispatch @dispatch0(%[[ARG1]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<external>{%[[C4]]}) -> !stream.resource<transient>{%[[C4]]}
   %dispatch6 = stream.async.dispatch @dispatch0(%arg1[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
 
   // CHECK: %[[FOR:.+]] = scf.for %[[ARG2:.+]] = %[[C0]] to %[[ARG0]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[DISP0]]) -> (!stream.resource<transient>) {
@@ -338,8 +362,166 @@ util.func public @testForOp(%arg0 : index, %arg1 : !stream.resource<*>) -> !stre
 
   // CHECK: %[[DISP4:.+]] = stream.async.dispatch @dispatch4(%[[FOR]][%[[C0]] to %[[ARG0]] for %[[ARG0]]]) : (!stream.resource<transient>{%[[C4]]}) -> !stream.resource<external>{%[[C4]]}
   %dispatch5 = stream.async.dispatch @dispatch4(%for[%c0 to %arg0 for %arg0]) : (!stream.resource<*>{%c4}) -> !stream.resource<*>{%c4}
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[DISP4]] : !stream.resource<external>{%[[ARG0]]} -> !stream.resource<external>{%[[ARG0]]}
   %transfer = stream.async.transfer %dispatch5 : !stream.resource<*>{%arg0} -> !stream.resource<external>{%arg0}
 
-  // CHECK: util.return %[[DISP4]] : !stream.resource<external>
+  // CHECK: util.return %[[TRANSFER]] : !stream.resource<external>
   util.return %transfer : !stream.resource<external>
+}
+
+// -----
+
+// Tests that constant resources stored to globals preserve their constant
+// lifetime even when they have external usage (e.g., being returned).
+
+util.global private mutable @constant_global : !stream.resource<constant>
+
+// CHECK-LABEL: @constant_global_with_external_use
+util.func public @constant_global_with_external_use() -> !stream.resource<*> {
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[CONST:.+]] = stream.async.constant : !stream.resource<constant>{%[[C4:.+]]}
+  %const = stream.async.constant : !stream.resource<*>{%c4} = dense<1.0> : tensor<f32>
+  // Transfer to ensure the value can be used as both constant (for store) and external (for return).
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[CONST]] : !stream.resource<constant>{%[[C4]]} -> !stream.resource<constant>{%[[C4]]}
+  %0 = stream.async.transfer %const : !stream.resource<*>{%c4} -> !stream.resource<constant>{%c4}
+  // CHECK: util.global.store %[[TRANSFER]], @constant_global : !stream.resource<constant>
+  util.global.store %0, @constant_global : !stream.resource<constant>
+  // CHECK: util.return %[[CONST]] : !stream.resource<constant>
+  util.return %const : !stream.resource<*>
+}
+
+// -----
+
+// Tests that non-constant globals correctly become External when used
+// externally, and the Global+Constant special case doesn't interfere.
+
+util.global private mutable @variable_global : !stream.resource<variable>
+
+// CHECK-LABEL: @variable_global_with_external_use
+util.func public @variable_global_with_external_use() -> !stream.resource<*> {
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[VAR:.+]] = stream.async.alloca : !stream.resource<external>{%[[C4:.+]]}
+  %var = stream.async.alloca : !stream.resource<*>{%c4}
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[VAR]] : !stream.resource<external>{%[[C4]]} -> !stream.resource<variable>{%[[C4]]}
+  %0 = stream.async.transfer %var : !stream.resource<*>{%c4} -> !stream.resource<variable>{%c4}
+  // CHECK: util.global.store %[[TRANSFER]], @variable_global : !stream.resource<variable>
+  util.global.store %0, @variable_global : !stream.resource<variable>
+  // CHECK: util.return %[[VAR]] : !stream.resource<external>
+  util.return %var : !stream.resource<*>
+}
+
+// -----
+
+// Tests that the Global+Constant special case ONLY applies when Global bit
+// is set - constants used externally but NOT stored to globals should become
+// External.
+
+// CHECK-LABEL: @constant_external_without_global
+util.func public @constant_external_without_global() -> !stream.resource<*> {
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[CONST:.+]] = stream.async.constant : !stream.resource<external>{%[[C4:.+]]}
+  %const = stream.async.constant : !stream.resource<*>{%c4} = dense<1.0> : tensor<f32>
+  // CHECK: util.return %[[CONST]] : !stream.resource<external>
+  util.return %const : !stream.resource<*>
+}
+
+// -----
+
+// Tests that staging operations don't interfere with the Global+Constant
+// priority.
+
+util.global private mutable @constant_global_staging : !stream.resource<constant>
+
+// CHECK-LABEL: @constant_global_with_staging
+util.func public @constant_global_with_staging(%arg0: !stream.resource<staging>) -> !stream.resource<staging> {
+  %c4 = arith.constant 4 : index
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[CONST:.+]] = stream.async.constant : !stream.resource<constant>{%[[C4:.+]]}
+  %const = stream.async.constant : !stream.resource<*>{%c4} = dense<2.0> : tensor<f32>
+  // CHECK: %[[STAGING:.+]] = stream.async.transfer %[[CONST]] : !stream.resource<constant>{%[[C4]]} -> !stream.resource<staging>{%[[C4]]}
+  %0 = stream.async.transfer %const : !stream.resource<*>{%c4} -> !stream.resource<staging>{%c4}
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[CONST]] : !stream.resource<constant>{%[[C4]]} -> !stream.resource<constant>{%[[C4]]}
+  %1 = stream.async.transfer %const : !stream.resource<*>{%c4} -> !stream.resource<constant>{%c4}
+  // CHECK: util.global.store %[[TRANSFER]], @constant_global_staging : !stream.resource<constant>
+  util.global.store %1, @constant_global_staging : !stream.resource<constant>
+  // CHECK: util.return %[[STAGING]]
+  util.return %0 : !stream.resource<staging>
+}
+
+// -----
+
+// Tests that constant globals preserve Constant lifetime even when used
+// externally (copy-on-write optimization).
+
+util.global private @const_weights : !stream.resource<constant>
+
+// CHECK-LABEL: @load_constant_global_external_use
+util.func public @load_constant_global_external_use() -> !stream.resource<constant> {
+  // CHECK: %[[LOADED:.+]] = util.global.load @const_weights : !stream.resource<constant>
+  %loaded = util.global.load @const_weights : !stream.resource<constant>
+  // Should stay constant despite external use.
+  // CHECK: util.return %[[LOADED]] : !stream.resource<constant>
+  util.return %loaded : !stream.resource<constant>
+}
+
+// -----
+
+// Tests that constant globals preserve Constant lifetime when transferred
+// to staging (should insert transfer, not change source lifetime).
+
+util.global private @const_data : !stream.resource<constant>
+
+// CHECK-LABEL: @load_constant_global_staging_use
+util.func public @load_constant_global_staging_use() -> !stream.resource<staging> {
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[LOADED:.+]] = util.global.load @const_data : !stream.resource<constant>
+  %loaded = util.global.load @const_data : !stream.resource<constant>
+  // CHECK: %[[STAGING:.+]] = stream.async.transfer %[[LOADED]] : !stream.resource<constant>{%c4} -> !stream.resource<staging>{%c4}
+  %staging = stream.async.transfer %loaded : !stream.resource<constant>{%c4} -> !stream.resource<staging>{%c4}
+  // CHECK: util.return %[[STAGING]] : !stream.resource<staging>
+  util.return %staging : !stream.resource<staging>
+}
+
+// -----
+
+// Tests that variable globals correctly become External when used externally
+// (no GlobalStorage+Constant optimization should apply).
+
+util.global private mutable @var_state : !stream.resource<variable>
+
+// CHECK-LABEL: @load_variable_global_external_use
+util.func public @load_variable_global_external_use() -> !stream.resource<external> {
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[LOADED:.+]] = util.global.load @var_state : !stream.resource<variable>
+  %loaded = util.global.load @var_state : !stream.resource<variable>
+  // Should become External (mutable data used externally).
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[LOADED]] : !stream.resource<variable>{%c4} -> !stream.resource<external>{%c4}
+  %result = stream.async.transfer %loaded : !stream.resource<variable>{%c4} -> !stream.resource<external>{%c4}
+  // CHECK: util.return %[[TRANSFER]] : !stream.resource<external>
+  util.return %result : !stream.resource<external>
+}
+
+// -----
+
+// Tests that globals loaded into control flow preserve storage identity.
+
+util.global private @const_model : !stream.resource<constant>
+
+// CHECK-LABEL: @load_constant_global_control_flow
+util.func public @load_constant_global_control_flow(%cond: i1) -> !stream.resource<constant> {
+  // CHECK: %[[LOADED:.+]] = util.global.load @const_model : !stream.resource<constant>
+  %loaded = util.global.load @const_model : !stream.resource<constant>
+  %c4 = arith.constant 4 : index
+  // CHECK: %[[RESULT:.+]] = scf.if %{{.+}} -> (!stream.resource<constant>)
+  %result = scf.if %cond -> !stream.resource<constant> {
+    // CHECK: scf.yield %[[LOADED]] : !stream.resource<constant>
+    scf.yield %loaded : !stream.resource<constant>
+  } else {
+    // CHECK: %[[OTHER:.+]] = stream.async.constant : !stream.resource<constant>
+    %other = stream.async.constant : !stream.resource<constant>{%c4} = dense<0.0> : tensor<f32>
+    // CHECK: scf.yield %[[OTHER]] : !stream.resource<constant>
+    scf.yield %other : !stream.resource<constant>
+  }
+  // CHECK: util.return %[[RESULT]] : !stream.resource<constant>
+  util.return %result : !stream.resource<constant>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -435,7 +435,7 @@ util.func public @cloneAcrossPartitions(%cond: i1) -> (!stream.resource<external
   %upload = stream.async.transfer %updated : !stream.resource<staging>{%c1} -> !stream.resource<transient>{%c1}
   // CHECK-NEXT: stream.async.dispatch
   %dispatch1 = stream.async.dispatch @ex::@dispatch1[%c1, %c1, %c1](%upload[%c0 to %c1 for %c1], %splat[%c0 to %c1 for %c1]) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
-  // CHECK-NEXT: stream.async.transfer
+  // CHECK-NEXT: stream.async.clone
   %result = stream.async.transfer %dispatch1 : !stream.resource<transient>{%c1} -> !stream.resource<external>{%c1}
   // CHECK: %[[PARTITION1:.+]] = stream.timepoint.await
 


### PR DESCRIPTION
This finally allows us to turn transfers into clones when possible (same source/target) and remove some special casing around it. The load-bearing behavior was things like returning constants from public functions and other internal<->external interop that would cause mapping to resource lifetime to go pear-shaped and either produce incorrect programs (well, "underspecified" programs) or additional copies. We may still be underspecified but now are at least fast and consistent.

The new GlobalStorage bit during usage analysis lets us fix correctness issues with constant returns from public functions and internal/external interop.

There's a growing need to change up `!stream.resource<...>` a bit to better model the high-fidelity usage information we capture so we can better map it to HAL buffers but that is left for future cleanup for now.

Part of #16168 PR sequence (3/6).