### PR TITLE
[TensorExt] Add folder for barrier ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -452,4 +452,30 @@ void DispatchWorkloadOrdinalOp::getCanonicalizationPatterns(
   results.insert<BubbleUpOrdinalOp>(context);
 }
 
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.compute_barrier.start
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ComputeBarrierStartOp::fold(FoldAdaptor adaptor) {
+  // Fold duplicate barriers in a chain:
+  // compute_barrier.start(compute_barrier.start(x)) -> compute_barrier.start(x)
+  if (auto producer = getValue().getDefiningOp<ComputeBarrierStartOp>()) {
+    return producer.getResult();
+  }
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// iree_tensor_ext.compute_barrier.end
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ComputeBarrierEndOp::fold(FoldAdaptor adaptor) {
+  // Fold duplicate barriers in a chain:
+  // compute_barrier.end(compute_barrier.end(x)) -> compute_barrier.end(x)
+  if (auto producer = getValue().getDefiningOp<ComputeBarrierEndOp>()) {
+    return producer.getResult();
+  }
+  return {};
+}
+
 } // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -483,6 +483,7 @@ def IREETensorExt_ComputeBarrierStartOp : IREETensorExt_PureOp<"compute_barrier.
     ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
   }];
 
+  let hasFolder = 1;
   let hasVerifier = 1;
 }
 
@@ -522,6 +523,7 @@ def IREETensorExt_ComputeBarrierEndOp : IREETensorExt_PureOp<"compute_barrier.en
     ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
   }];
 
+  let hasFolder = 1;
   let hasVerifier = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/tensor_ext_folding.mlir
@@ -21,3 +21,27 @@ util.func public @tensorBitCastCastProducer(%arg0: tensor<10x3x6xi8>, %arg1: ind
   util.return %1 : tensor<?x?x3xi16>
   // CHECK-NEXT: util.return %[[CAST]]
 }
+
+// -----
+
+// CHECK-LABEL: @barrierStartFoldDuplicate
+util.func public @barrierStartFoldDuplicate(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK-NEXT: %[[BARRIER:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]] : tensor<4x8xf32> -> tensor<4x8xf32>
+  %1 = iree_tensor_ext.compute_barrier.start %0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK-NEXT: util.return %[[BARRIER]]
+  util.return %1 : tensor<4x8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @barrierEndFoldDuplicate
+util.func public @barrierEndFoldDuplicate(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK-NEXT: %[[BARRIER:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]] : tensor<4x8xf32> -> tensor<4x8xf32>
+  %1 = iree_tensor_ext.compute_barrier.end %0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK-NEXT: util.return %[[BARRIER]]
+  util.return %1 : tensor<4x8xf32>
+}


### PR DESCRIPTION
Adds folder method to remove duplicate `iree_tensor_ext.barrier.*` ops when they form a chain.