### PR TITLE
[e2e] Use remarks to verify ukernel match

### DIFF
--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -119,7 +119,10 @@ function(iree_e2e_runner_test)
     add_custom_command(
       TARGET "${_NAME}${_RULE_VARIANT_NAME}"
       POST_BUILD
-      COMMAND bash -c "if [ -f '${_REMARKS_FILE}' ] && grep -q '${_RULE_CHECK_REMARKS_PATTERN}' '${_REMARKS_FILE}'; then echo '✓ Found expected ukernel pattern: ${_RULE_CHECK_REMARKS_PATTERN}'; else echo 'ERROR: Expected pattern ${_RULE_CHECK_REMARKS_PATTERN} not found in remarks' >&2; exit 1; fi"
+      COMMAND "${Python3_EXECUTABLE}"
+              "${PROJECT_SOURCE_DIR}/build_tools/scripts/check_remarks_pattern.py"
+              "${_REMARKS_FILE}"
+              "${_RULE_CHECK_REMARKS_PATTERN}"
       VERBATIM
     )
   endif()

--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -30,6 +30,9 @@
 #   TEST_DEFINED: Whether to define a test target.
 #   TEST_DISABLED: The test target will be skipped and its status will be
 #       'Not Run'.
+#   REMARKS_FILTER: Emit all remarks whose category matches the given regex pattern. If empty, no remarks are emitted.
+#       Only applied to the test module, not the calls module.
+#   CHECK_REMARKS_PATTERN: Pattern to search for in the emitted remarks.
 function(iree_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -43,7 +46,7 @@ function(iree_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;VARIANT_NAME;TESTS_SRC;TESTS_VMFB;CALLS_SRC;CALLS_VMFB;TRACE;TARGET_BACKEND;DRIVER;TEST_RUNNER;TEST_DEFINED;TEST_DISABLED"
+    "NAME;TEST_TYPE;VARIANT_NAME;TESTS_SRC;TESTS_VMFB;CALLS_SRC;CALLS_VMFB;TRACE;TARGET_BACKEND;DRIVER;TEST_RUNNER;TEST_DEFINED;TEST_DISABLED;REMARKS_FILTER;CHECK_REMARKS_PATTERN"
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
@@ -60,6 +63,18 @@ function(iree_e2e_runner_test)
     "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
   )
 
+  # Emit remarks if REMARKS_FILTER is specified.
+  # Only enable remarks for the test module, not the calls module.
+  set(_REMARKS_FILE "")
+  set(_REMARKS_FLAGS "")
+  if(_RULE_REMARKS_FILTER)
+    set(_REMARKS_FILE "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_NAME}_${_RULE_TEST_TYPE}_remarks.yaml")
+    set(_REMARKS_FLAGS
+      "--remarks-filter=${_RULE_REMARKS_FILTER}"
+      "--remarks-output-file=${_REMARKS_FILE}"
+    )
+  endif()
+
   if(NOT TARGET "${_NAME}_${_RULE_TEST_TYPE}_module")
     iree_bytecode_module(
       NAME
@@ -71,6 +86,7 @@ function(iree_e2e_runner_test)
       FLAGS
         "${_BASE_COMPILER_FLAGS}"
         "${_RULE_COMPILER_FLAGS}"
+        "${_REMARKS_FLAGS}"
     )
   endif()
 
@@ -97,6 +113,16 @@ function(iree_e2e_runner_test)
     "${_NAME}_calls_module"
     "${_RULE_TEST_RUNNER}"
   )
+
+  # Add POST_BUILD command to check remarks if CHECK_REMARKS_PATTERN is specified
+  if(_RULE_CHECK_REMARKS_PATTERN)
+    add_custom_command(
+      TARGET "${_NAME}${_RULE_VARIANT_NAME}"
+      POST_BUILD
+      COMMAND bash -c "if [ -f '${_REMARKS_FILE}' ] && grep -q '${_RULE_CHECK_REMARKS_PATTERN}' '${_REMARKS_FILE}'; then echo '✓ Found expected ukernel pattern: ${_RULE_CHECK_REMARKS_PATTERN}'; else echo 'ERROR: Expected pattern ${_RULE_CHECK_REMARKS_PATTERN} not found in remarks' >&2; exit 1; fi"
+      VERBATIM
+    )
+  endif()
 
   add_dependencies(iree-test-deps "${_NAME}${_RULE_VARIANT_NAME}")
 
@@ -145,6 +171,9 @@ endfunction()
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 #   TEST_RUNNER: trace-runner program to run.
+#   REMARKS_FILTER: Emit all remarks whose category matches the given regex pattern. If empty, no remarks are emitted.
+#       Only applied to the test module, not the calls module.
+#   CHECK_REMARKS_PATTERN: Pattern to search for in the emitted remarks.
 function(iree_single_backend_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -157,7 +186,7 @@ function(iree_single_backend_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;GENERATOR;TARGET_BACKEND;DRIVER;TEST_RUNNER"
+    "NAME;TEST_TYPE;GENERATOR;TARGET_BACKEND;DRIVER;TEST_RUNNER;REMARKS_FILTER;CHECK_REMARKS_PATTERN"
     "GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
@@ -306,6 +335,8 @@ function(iree_single_backend_e2e_runner_test)
       LABELS ${_RULE_LABELS}
       TEST_DEFINED ${_TEST_DEFINED}
       TEST_DISABLED ${_TEST_DISABLED}
+      REMARKS_FILTER ${_RULE_REMARKS_FILTER}
+      CHECK_REMARKS_PATTERN ${_RULE_CHECK_REMARKS_PATTERN}
     )
     # Note we are relying on the fact that the target created by
     # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -339,6 +370,8 @@ function(iree_single_backend_e2e_runner_test)
         LABELS ${_RULE_LABELS}
         TEST_DEFINED ${_TEST_DEFINED}
         TEST_DISABLED ${_TEST_DISABLED}
+        REMARKS_FILTER ${_RULE_REMARKS_FILTER}
+        CHECK_REMARKS_PATTERN ${_RULE_CHECK_REMARKS_PATTERN}
       )
       # Note we are relying on the fact that the target created by
       # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -352,6 +385,7 @@ function(iree_single_backend_e2e_runner_test)
       list(APPEND _TSAN_COMPILER_FLAGS "--iree-llvmcpu-sanitize=thread")
       iree_e2e_runner_test(
         NAME ${_RULE_NAME}
+        TEST_TYPE ${_RULE_TEST_TYPE}
         VARIANT_NAME "_tsan"
         TESTS_SRC ${_TESTS_SRC}
         TESTS_VMFB ${_TESTS_VMFB}
@@ -365,6 +399,8 @@ function(iree_single_backend_e2e_runner_test)
         LABELS ${_RULE_LABELS}
         TEST_DEFINED ${_TEST_DEFINED}
         TEST_DISABLED ${_TEST_DISABLED}
+        REMARKS_FILTER ${_RULE_REMARKS_FILTER}
+        CHECK_REMARKS_PATTERN ${_RULE_CHECK_REMARKS_PATTERN}
       )
       # Note we are relying on the fact that the target created by
       # iree_e2e_runner_test is _NAME, even though we passed _RULE_NAME to it,
@@ -415,6 +451,9 @@ endfunction()
 #       and cpu_features is a comma-separated list of LLVM target attributes
 #       to enable. Example:
 #         x86_64:avx2_fma:+avx,+avx2,+fma
+#   REMARKS_FILTER: Emit all remarks whose category matches the given regex pattern. If empty, no remarks are emitted.
+#       Only applied to the test module, not the calls module.
+#   CHECK_REMARKS_PATTERN: Pattern to search for in the emitted remarks.
 function(iree_generated_e2e_runner_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -423,7 +462,7 @@ function(iree_generated_e2e_runner_test)
   cmake_parse_arguments(
     _RULE
     ""
-    "NAME;TEST_TYPE;GENERATOR;TEST_RUNNER"
+    "NAME;TEST_TYPE;GENERATOR;TEST_RUNNER;REMARKS_FILTER;CHECK_REMARKS_PATTERN"
     "TARGET_BACKENDS;DRIVERS;GENERATOR_ARGS;COMPILER_FLAGS;RUNNER_ARGS;LABELS;TARGET_CPU_FEATURES_VARIANTS"
     ${ARGN}
   )
@@ -494,6 +533,10 @@ function(iree_generated_e2e_runner_test)
           ${_RULE_RUNNER_ARGS}
         LABELS
           ${_LABELS}
+        REMARKS_FILTER
+          ${_RULE_REMARKS_FILTER}
+        CHECK_REMARKS_PATTERN
+          ${_RULE_CHECK_REMARKS_PATTERN}
       )
     endforeach()
   endforeach()

--- a/build_tools/scripts/check_remarks_pattern.py
+++ b/build_tools/scripts/check_remarks_pattern.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Checks if a pattern exists in a remarks YAML file.
+#
+# This script is used to verify that expected ukernels or patterns appear in
+# the compiler's remark output. It performs a simple string search in the
+# remarks file.
+#
+# To check if a pattern exists in a remarks file:
+#   python check_remarks_pattern.py remarks.yaml "pingpong_medium_f8E4M3FNUZ"
+
+import argparse
+import pathlib
+import sys
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Remarks pattern checker")
+    parser.add_argument(
+        "remarks_file", help="Path to the remarks YAML file", type=pathlib.Path
+    )
+    parser.add_argument(
+        "pattern", help="Pattern to search for (e.g., ukernel name)", type=str
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main(args):
+    # Check if file exists.
+    if not args.remarks_file.exists():
+        print(
+            f"ERROR: Remarks file not found: {args.remarks_file}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Read file and search for pattern.
+    try:
+        with open(args.remarks_file, "r", encoding="utf-8") as f:
+            content = f.read()
+            if args.pattern in content:
+                print(f"✓ Found expected pattern: {args.pattern}")
+            else:
+                print(
+                    f"ERROR: Expected pattern '{args.pattern}' not found in remarks",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: Failed to read remarks file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(parse_arguments())

--- a/compiler/bindings/c/iree/compiler/embedding_api.h
+++ b/compiler/bindings/c/iree/compiler/embedding_api.h
@@ -248,6 +248,12 @@ IREE_EMBED_EXPORTED void ireeCompilerInvocationSetDumpCompilationPhasesTo(
 IREE_EMBED_EXPORTED void
 ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *inv, bool enable);
 
+// Setup remark filtering and output yaml file.
+IREE_EMBED_EXPORTED void
+ireeCompilerInvocationSetupRemarks(iree_compiler_invocation_t *inv,
+                                   const char *remarksFilter,
+                                   const char *remarksOutputFile);
+
 // Runs a compilation pipeline.
 // Returns false and emits diagnostics on failure.
 enum iree_compiler_pipeline_t {

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -399,8 +399,7 @@ public:
       }
       // Emit remark using structured API.
       remark::analysis(op->getLoc(),
-                       remark::RemarkOpts::name("UKernel").category(
-                           "ApplyBuiltinPDLPatternsDriverPass"))
+                       remark::RemarkOpts::name("UKernel").category(getName()))
           << ukernelDesc.getUkernelName().str();
       if (ukernelSymbols.contains(ukernelDesc.getUkernelName())) {
         return WalkResult::advance();

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/PDL/IR/PDL.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Remarks.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Parser/Parser.h"
@@ -396,6 +397,11 @@ public:
       if (!builtinName || !ukernelDesc) {
         return WalkResult::advance();
       }
+      // Emit remark using structured API.
+      remark::analysis(op->getLoc(),
+                       remark::RemarkOpts::name("UKernel").category(
+                           "ApplyBuiltinPDLPatternsDriverPass"))
+          << ukernelDesc.getUkernelName().str();
       if (ukernelSymbols.contains(ukernelDesc.getUkernelName())) {
         return WalkResult::advance();
       }

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns_driver.mlir
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/test/apply_builtin_ukernel_pdl_patterns_driver.mlir
@@ -1,6 +1,10 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-rocm-apply-builtin-pdl-patterns-driver{enable-tensor-ukernels=true})' \
 // RUN:   --mlir-print-local-scope --split-input-file %s | FileCheck %s
 
+// Test remarks output for ukernels
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-rocm-apply-builtin-pdl-patterns-driver{enable-tensor-ukernels=true})' \
+// RUN:   --remarks-filter=".*" --split-input-file %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS
+
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
@@ -50,6 +54,13 @@ module attributes {
 // CHECK-LABEL: util.func private @pingpong_medium_f8E4M3FNUZ_expanded
 // CHECK:         iree_codegen.inner_tiled
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_medium_f8E4M3FNUZ_expanded
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_medium_f8E4M3FNUZ_expanded
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
@@ -92,6 +103,10 @@ module attributes {
 // CHECK-LABEL: util.func private @pingpong_large_f8E4M3FNUZ_expanded
 // CHECK:         iree_codegen.inner_tiled
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_large_f8E4M3FNUZ_expanded
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -133,6 +148,10 @@ module attributes {
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_large_f16", tensor>
 // CHECK-LABEL: util.func private @pingpong_large_f16
 // CHECK:         iree_codegen.inner_tiled
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_large_f16
 
 // -----
 
@@ -218,6 +237,10 @@ module attributes {
 // CHECK-LABEL: util.func private @pingpong_medium_f16_expanded
 // CHECK:         iree_codegen.inner_tiled
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_medium_f16_expanded
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
@@ -259,6 +282,10 @@ module attributes {
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_large_f16_expanded", tensor>
 // CHECK-LABEL: util.func private @pingpong_large_f16_expanded
 // CHECK:         iree_codegen.inner_tiled
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_large_f16_expanded
 
 // -----
 
@@ -302,6 +329,10 @@ module attributes {
 // CHECK-LABEL: util.func private @pingpong_large_bf16
 // CHECK:         iree_codegen.inner_tiled
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_large_bf16
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
@@ -343,6 +374,10 @@ module attributes {
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_large_bf16_expanded", tensor>
 // CHECK-LABEL: util.func private @pingpong_large_bf16_expanded
 // CHECK:         iree_codegen.inner_tiled
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_large_bf16_expanded
 
 // -----
 
@@ -386,6 +421,10 @@ module attributes {
 // CHECK-LABEL: util.func private @pingpong_medium_bf16_expanded
 // CHECK:         iree_codegen.inner_tiled
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_medium_bf16_expanded
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -420,6 +459,10 @@ module attributes {
 // CHECK-LABEL: @inner_tiled_f8_large
 // CHECK:         iree_codegen.inner_tiled
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f8E4M3FNUZ", tensor>
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_dt_large_f8E4M3FNUZ
 
 // -----
 
@@ -456,6 +499,10 @@ module attributes {
 // CHECK:         iree_codegen.inner_tiled
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_dt_medium_f8E4M3FNUZ", tensor>
 
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_dt_medium_f8E4M3FNUZ
+
 // -----
 
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
@@ -490,3 +537,7 @@ module attributes {
 // CHECK-LABEL: @inner_tiled_f16_large
 // CHECK:         iree_codegen.inner_tiled
 // CHECK-SAME:      iree_codegen.ukernel = #iree_codegen.ukernel_descriptor<"pingpong_dt_large_f16", tensor>
+
+// CHECK-REMARKS:      [Analysis] UKernel
+// CHECK-REMARKS-SAME:   Category:ApplyBuiltinPDLPatternsDriverPass
+// CHECK-REMARKS-SAME:   Remark=pingpong_dt_large_f16

--- a/compiler/src/iree/compiler/API/Internal/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/Internal/BUILD.bazel
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Tools:init_passes_and_dialects",
         "//compiler/src/iree/compiler/Tools:version",
         "//compiler/src/iree/compiler/Utils",
+        "@llvm-project//llvm:Remarks",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TargetParser",
         "@llvm-project//mlir:BuiltinToLLVMIRTranslation",
@@ -42,6 +43,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Debug",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:RemarkStreamer",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "CompilerDriver.cpp"
     "Diagnostics.cpp"
   DEPS
+    LLVMRemarks
     LLVMSupport
     LLVMTargetParser
     MLIRBuiltinToLLVMIRTranslation
@@ -27,6 +28,7 @@ iree_cc_library(
     MLIRDebug
     MLIRIR
     MLIRParser
+    MLIRRemarkStreamer
     MLIRSupport
     iree::compiler::ConstEval
     iree::compiler::Dialect::VM::Target::Bytecode

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -857,15 +857,10 @@ bool Invocation::initializeInvocation() {
     mlir::remark::RemarkCategories cats{/*all=*/remarksFilter, /*passed=*/"",
                                         /*missed=*/"", /*analysis=*/"",
                                         /*failed=*/""};
-    // Always use REMARK_POLICY_ALL for now.
-    auto createPolicy = []()
-        -> std::unique_ptr<mlir::remark::detail::RemarkEmittingPolicyBase> {
-      return std::make_unique<mlir::remark::RemarkEmittingPolicyAll>();
-    };
-    // Always use YAML streamer for now.
+    // Always use YAML streamer and REMARK_POLICY_ALL for now.
     if (failed(mlir::remark::enableOptimizationRemarksWithLLVMStreamer(
             session.context, remarksOutputFile, llvm::remarks::Format::YAML,
-            createPolicy(), cats))) {
+            std::make_unique<mlir::remark::RemarkEmittingPolicyAll>(), cats))) {
       emitError(UnknownLoc::get(&session.context))
           << "Failed to enable optimization remarks with YAML streamer";
       return false;

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -54,12 +54,14 @@
 #include "iree/compiler/embedding_api.h"
 #include "iree/compiler/mlir_interop.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
@@ -74,8 +76,10 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Remarks.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Remark/RemarkStreamer.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -738,6 +742,10 @@ struct Invocation {
                              void *userData) = nullptr;
   void *diagnosticCallbackUserData = nullptr;
   int diagnosticCallbackFlags = 0;
+
+  // Remark options.
+  std::string remarksFilter;
+  std::string remarksOutputFile;
 };
 
 Invocation::Invocation(Session &session) : session(session) {
@@ -778,6 +786,7 @@ std::unique_ptr<PassManager> Invocation::createPassManager() {
   }
   passManager->addInstrumentation(std::make_unique<PassTracing>());
   passManager->enableVerifier(enableVerifier);
+
   for (auto &init : passManagerInitializers) {
     init(*passManager);
   }
@@ -838,6 +847,27 @@ bool Invocation::initializeInvocation() {
         }
         diag << ")";
       }
+      return false;
+    }
+  }
+
+  // Setup remarks.
+  if (!remarksFilter.empty()) {
+    // Only use remarksFilter for now.
+    mlir::remark::RemarkCategories cats{/*all=*/remarksFilter, /*passed=*/"",
+                                        /*missed=*/"", /*analysis=*/"",
+                                        /*failed=*/""};
+    // Always use REMARK_POLICY_ALL for now.
+    auto createPolicy = []()
+        -> std::unique_ptr<mlir::remark::detail::RemarkEmittingPolicyBase> {
+      return std::make_unique<mlir::remark::RemarkEmittingPolicyAll>();
+    };
+    // Always use YAML streamer for now.
+    if (failed(mlir::remark::enableOptimizationRemarksWithLLVMStreamer(
+            session.context, remarksOutputFile, llvm::remarks::Format::YAML,
+            createPolicy(), cats))) {
+      emitError(UnknownLoc::get(&session.context))
+          << "Failed to enable optimization remarks with YAML streamer";
       return false;
     }
   }
@@ -1468,6 +1498,13 @@ void ireeCompilerInvocationSetDumpCompilationPhasesTo(
 void ireeCompilerInvocationSetVerifyIR(iree_compiler_invocation_t *inv,
                                        bool enable) {
   unwrap(inv)->enableVerifier = enable;
+}
+
+void ireeCompilerInvocationSetupRemarks(iree_compiler_invocation_t *inv,
+                                        const char *remarksFilter,
+                                        const char *remarksOutputFile) {
+  unwrap(inv)->remarksFilter = remarksFilter;
+  unwrap(inv)->remarksOutputFile = remarksOutputFile;
 }
 
 bool ireeCompilerInvocationPipeline(iree_compiler_invocation_t *inv,

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -152,6 +152,18 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
                          "generating compile-to or VM MLIR output."),
           llvm::cl::init(std::nullopt));
 
+  // Remark options.
+  llvm::cl::opt<std::string> remarksFilter(
+      "remarks-filter",
+      llvm::cl::desc("Emit all remarks whose category matches the given regex "
+                     "pattern. If empty, no remarks are emitted."),
+      llvm::cl::init(""));
+
+  llvm::cl::opt<std::string> remarksOutputFile(
+      "remarks-output-file",
+      llvm::cl::desc("Output file for remarks in YAML format."),
+      llvm::cl::init("mlir-remarks.yaml"));
+
   // Misc options.
   llvm::cl::opt<bool> splitInputFile(
       "split-input-file",
@@ -245,6 +257,13 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
     ireeCompilerInvocationSetDumpCompilationPhasesTo(
         r.inv, dumpCompilationPhasesTo.c_str());
     ireeCompilerInvocationSetVerifyIR(r.inv, verifyIR);
+
+    // Setup remarks.
+    if (!remarksFilter.empty()) {
+      ireeCompilerInvocationSetupRemarks(r.inv, remarksFilter.c_str(),
+                                         remarksOutputFile.c_str());
+    }
+
     if (!ireeCompilerInvocationParseSource(r.inv, source))
       return false;
 

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1500,6 +1500,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_medium_f8E4M3FNUZ_expanded"
 )
 
 iree_generated_e2e_runner_test(
@@ -1532,6 +1536,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_large_f8E4M3FNUZ_expanded"
 )
 
 iree_generated_e2e_runner_test(
@@ -1589,6 +1597,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_dt_medium_f8E4M3FNUZ"
 )
 
 iree_generated_e2e_runner_test(
@@ -1619,6 +1631,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_dt_large_f8E4M3FNUZ"
 )
 
 iree_generated_e2e_runner_test(
@@ -1737,6 +1753,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_medium_f16_expanded"
 )
 
 iree_generated_e2e_runner_test(
@@ -1769,6 +1789,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_large_f16"
 )
 
 iree_generated_e2e_runner_test(
@@ -1801,6 +1825,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_large_f16_expanded"
 )
 
 
@@ -1815,7 +1843,7 @@ iree_generated_e2e_runner_test(
     "--lhs_rhs_type=f16"
     "--acc_type=f32"
     "--shapes=custom_mnk"
-    "--mnk=1024,1024,1024"
+    "--mnk=1024,32832,1024"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -1832,6 +1860,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_dt_large_f16"
 )
 
 iree_generated_e2e_runner_test(
@@ -1864,6 +1896,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_medium_bf16_expanded"
 )
 
 iree_generated_e2e_runner_test(
@@ -1896,6 +1932,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_large_bf16"
 )
 
 
@@ -1929,6 +1969,10 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-${_CDNA_ARCH}"
+  REMARKS_FILTER
+    "ApplyBuiltinPDLPatternsDriverPass"
+  CHECK_REMARKS_PATTERN
+    "pingpong_large_bf16_expanded"
 )
 
 endif()


### PR DESCRIPTION
Certain e2e matmul tests expect that a particular ukernel is actually selected (so that numerical correctness for that ukernel can be verified). However, we currently only check ukernel selection through lit tests.

This PR integrates the use of MLIR [RemarkEngine](https://mlir.llvm.org/docs/Remarks/) by adding two new flags to `iree-compile`:
- `remarks-filter`: emit all remarks whose category matches the given regex pattern. If empty, no remarks are emitted.
- `remarks-output-file`: output file for remarks in YAML format.

Then in e2e tests, a post-build verification checks if the expected string (currently the ukernel name) appears in the remarks YAML file.

Closes: #22443

ci-extra: windows_x64_msvc