### PR TITLE
[CI][TorchModels] Update SDXL int8 model CI (1/2)

### DIFF
--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942_v2.json
@@ -5,6 +5,6 @@
         "--iree-hip-target=gfx942",
         "--iree-opt-level=O3",
         "--iree-execution-model=async-external",
-        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
+        "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline)"
     ]
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/modules/punet_gfx942_v2.json
@@ -1,0 +1,10 @@
+{
+    "mlir": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet_v2/punet_int8mm_f16attn.mlir",
+    "compiler_flags" : [
+        "--iree-hal-target-device=hip",
+        "--iree-hip-target=gfx942",
+        "--iree-opt-level=O3",
+        "--iree-execution-model=async-external",
+        "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics{pad-target-type=conv})"
+    ]
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
@@ -1,0 +1,54 @@
+{
+  "type": "benchmark",
+  "markers" : [
+    "hip",
+    "mi325",
+    "punet"
+  ],
+  "modules": [
+    "sdxl/modules/punet_gfx942_v2"
+  ],
+  "weights" : [
+    {
+      "type": "url",
+      "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_int8.irpa",
+      "scope": "model"
+    }
+  ],
+  "run_args" : [
+    "--hip_use_streams=true",
+    "--hip_allow_inline_execution=true",
+    "--device_allocator=caching",
+    "--function=run_forward",
+    "--device=hip",
+    "--benchmark_repetitions=10",
+    "--benchmark_min_warmup_time=3.0"
+  ],
+  "inputs" : [
+    {
+      "value": "1x4x128x128xf16"
+    },
+    {      
+      "value": "2x64x2048xf16"
+    },
+    {      
+      "value": "2x1280xf16"
+    },
+    {      
+      "value": "2x6xf16"
+    },
+    {      
+      "value": "1xf16"
+    },
+    {
+      "value": "1xsi64"
+    },
+    {
+      "value": "100xf32"
+    },
+    {
+      "value": "100xf32"
+    }    
+  ],
+  "golden_time_ms" : 43.5
+}

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
@@ -34,5 +34,5 @@
     { "value": "100xf32" },
     { "value": "100xf32" }
   ],
-  "golden_time_ms": 43.5
+  "golden_time_ms": 44.28
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_benchmark_mi325_v2.json
@@ -1,6 +1,6 @@
 {
   "type": "benchmark",
-  "markers" : [
+  "markers": [
     "hip",
     "mi325",
     "punet"
@@ -8,14 +8,14 @@
   "modules": [
     "sdxl/modules/punet_gfx942_v2"
   ],
-  "weights" : [
+  "weights": [
     {
       "type": "url",
       "url": "https://sharkpublic.blob.core.windows.net/sharkpublic/iree-test-suites/torch-models/sdxl/punet/punet_int8.irpa",
       "scope": "model"
     }
   ],
-  "run_args" : [
+  "run_args": [
     "--hip_use_streams=true",
     "--hip_allow_inline_execution=true",
     "--device_allocator=caching",
@@ -24,31 +24,15 @@
     "--benchmark_repetitions=10",
     "--benchmark_min_warmup_time=3.0"
   ],
-  "inputs" : [
-    {
-      "value": "1x4x128x128xf16"
-    },
-    {      
-      "value": "2x64x2048xf16"
-    },
-    {      
-      "value": "2x1280xf16"
-    },
-    {      
-      "value": "2x6xf16"
-    },
-    {      
-      "value": "1xf16"
-    },
-    {
-      "value": "1xsi64"
-    },
-    {
-      "value": "100xf32"
-    },
-    {
-      "value": "100xf32"
-    }    
+  "inputs": [
+    { "value": "1x4x128x128xf16" },
+    { "value": "2x64x2048xf16" },
+    { "value": "2x1280xf16" },
+    { "value": "2x6xf16" },
+    { "value": "1xf16" },
+    { "value": "1xsi64" },
+    { "value": "100xf32" },
+    { "value": "100xf32" }
   ],
-  "golden_time_ms" : 43.5
+  "golden_time_ms": 43.5
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942.json
@@ -5,7 +5,7 @@
     "gfx942",
     "punet"
   ],
-  "module": "sdxl/modules/punet_gfx942",
-  "golden_dispatch_count" : 1482,
+  "module": "sdxl/modules/punet_gfx942_v2",
+  "golden_dispatch_count" : 1530,
   "golden_binary_size" : 2000000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942_v2.json
@@ -5,7 +5,7 @@
     "gfx942",
     "punet"
   ],
-  "module": "sdxl/modules/punet_gfx942",
-  "golden_dispatch_count" : 1482,
+  "module": "sdxl/modules/punet_gfx942_v2",
+  "golden_dispatch_count" : 1530,
   "golden_binary_size" : 2000000
 }


### PR DESCRIPTION
We have newly exported MLIR that should be faster than the old MLIR. It has a different entry point and signature, so we can't update the tests exactly since we don't have generated input/output updated yet. For now I've updated the compstat test and made a new test that uses random inputs.

ci-extra: test_torch