### PR TITLE
[DispatchCreation] Enable split reduction by default

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -46,7 +46,7 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
       *this,
       "split-reduction",
       llvm::cl::desc("Enable split reduction for dispatch creation pipeline"),
-      llvm::cl::init(false),
+      llvm::cl::init(true),
   };
   Option<bool> constExprHoisting{
       *this,

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -288,7 +288,9 @@ def SetSplitReductionSizesPass :
     Option<"splitReductionTargetSize", "split-reduction-target-size", "int64_t", "1024",
            "Target tile size for split reduction. Inner reduction "
            "dimensions are tiled first, with the tile size rounded "
-           "up until it evenly divides the iteration domain.">
+           "up until it evenly divides the iteration domain.">,
+    Option<"enableSplitArgCompare", "enable-split-arg-compare", "bool",
+           /*default=*/"false", "Enable setting split reduction size on arg compare ops">
   ];
   let dependentDialects = [];
 }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -289,8 +289,8 @@ def SetSplitReductionSizesPass :
            "Target tile size for split reduction. Inner reduction "
            "dimensions are tiled first, with the tile size rounded "
            "up until it evenly divides the iteration domain.">,
-    Option<"enableSplitArgCompare", "enable-split-arg-compare", "bool",
-           /*default=*/"false", "Enable setting split reduction size on arg compare ops">
+    Option<"enableSplitOuterReduction", "enable-split-outer-reduction", "bool",
+           /*default=*/"false", "Enable setting split reduction size on outer reduction ops">
   ];
   let dependentDialects = [];
 }

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -402,6 +402,15 @@ private:
     // The constants below are determined based on empirical data.
     const int64_t ratioThreshold = 384;
     const int64_t largeKSize = 24576;
+    const int64_t largeMNSize = 4096;
+
+    // When the M or N size is large, the workload tends to distributed across
+    // many workgroups, making split reduction little to no effect.
+    if (mSize >= largeMNSize || nSize >= largeMNSize) {
+      LDBG() << "skipping op; large M or N size";
+      return std::nullopt;
+    }
+
     int64_t ratio = kSize / std::sqrt(mSize * nSize) / batchSize;
     if (ratio <= ratioThreshold && kSize < largeKSize) {
       LDBG() << "skipping op; small reduction size";

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_split_reduction.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --iree-dispatch-creation-pipeline='split-reduction=true' --split-input-file | FileCheck %s
+// RUN: iree-opt %s --iree-dispatch-creation-set-split-reduction-sizes='enable-split-outer-reduction=true' --iree-dispatch-creation-pipeline='split-reduction=true' --split-input-file | FileCheck %s
 
 // CHECK-LABEL: @basic_reduction(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<4096xf32>

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -230,7 +230,7 @@ struct DispatchCreationOptions {
 
   bool enableAggressiveFusion = false;
   bool enableFuseMultiUse = true;
-  bool enableSplitReduction = false;
+  bool enableSplitReduction = true;
 
   // Enables data tiling in dispatch creation phase.
   bool dataTiling = false;


### PR DESCRIPTION
Always enables split reduction for convolutions and GEMMs with large reduction dimensions. Added a pass option to disable split on outer reduction ops such as batch norm or arg_compare ops. Set the option as true to develop and test on these ops.