### PR TITLE
[TensorExt] Rename barrier to compute_barrier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -383,11 +383,11 @@ void DispatchWorkloadOrdinalOp::inferResultRanges(
 }
 
 //===----------------------------------------------------------------------===//
-// iree_tensor_ext.barrier.start
+// iree_tensor_ext.compute_barrier.start
 //===----------------------------------------------------------------------===//
 
-LogicalResult BarrierStartOp::verify() {
-  BarrierStartOp op = *this;
+LogicalResult ComputeBarrierStartOp::verify() {
+  ComputeBarrierStartOp op = *this;
   if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
     return failure();
   }
@@ -399,11 +399,11 @@ LogicalResult BarrierStartOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// iree_tensor_ext.barrier.end
+// iree_tensor_ext.compute_barrier.end
 //===----------------------------------------------------------------------===//
 
-LogicalResult BarrierEndOp::verify() {
-  BarrierEndOp op = *this;
+LogicalResult ComputeBarrierEndOp::verify() {
+  ComputeBarrierEndOp op = *this;
   if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -447,10 +447,10 @@ def IREETensorExt_DispatchWorkloadOrdinalOp :
 // Barrier Ops
 //===---------------------------------------------------------------------===//
 
-def IREETensorExt_BarrierStartOp : IREETensorExt_PureOp<"barrier.start", [
+def IREETensorExt_ComputeBarrierStartOp : IREETensorExt_PureOp<"compute_barrier.start", [
   Util_ShapeAwareOp,
 ]> {
-  let summary = "Tensor barrier start operation";
+  let summary = "Tensor compute barrier start operation";
   let description = [{
     This barrier prevents certain transformations (like reshape propagation)
     from moving operations down across this boundary.
@@ -486,10 +486,10 @@ def IREETensorExt_BarrierStartOp : IREETensorExt_PureOp<"barrier.start", [
   let hasVerifier = 1;
 }
 
-def IREETensorExt_BarrierEndOp : IREETensorExt_PureOp<"barrier.end", [
+def IREETensorExt_ComputeBarrierEndOp : IREETensorExt_PureOp<"compute_barrier.end", [
   Util_ShapeAwareOp,
 ]> {
-  let summary = "Tensor barrier end operation";
+  let summary = "Tensor compute barrier end operation";
   let description = [{
     This barrier prevents certain transformations (like reshape propagation)
     from moving operations up across this boundary.

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -1,47 +1,47 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
 util.func public @barrier_start_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value and result types must match}}
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value and result types must match}}
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
   util.return %0 : tensor<8x4xf32>
 }
 
 // -----
 
 util.func public @barrier_start_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 
 // -----
 
 util.func public @barrier_start_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.start' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 
 // -----
 
 util.func public @barrier_end_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value and result types must match}}
-  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value and result types must match}}
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
   util.return %0 : tensor<8x4xf32>
 }
 
 // -----
 
 util.func public @barrier_end_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 
 // -----
 
 util.func public @barrier_end_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.barrier.end' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -53,8 +53,8 @@ util.func public @tensorBitCastDynamic(%arg0: tensor<?x16xi32>, %arg1: index, %a
 
 // CHECK-LABEL: @barrier_start_static
 util.func public @barrier_start_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  // CHECK: iree_tensor_ext.barrier.start
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK: iree_tensor_ext.compute_barrier.start
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 
@@ -63,8 +63,8 @@ util.func public @barrier_start_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32
 // CHECK-LABEL: @barrier_start_dynamic
 // CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
 util.func public @barrier_start_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  // CHECK: iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+  // CHECK: iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 
@@ -72,8 +72,8 @@ util.func public @barrier_start_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %d
 
 // CHECK-LABEL: @barrier_end_static
 util.func public @barrier_end_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  // CHECK: iree_tensor_ext.barrier.end
-  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  // CHECK: iree_tensor_ext.compute_barrier.end
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 
@@ -82,7 +82,7 @@ util.func public @barrier_end_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> 
 // CHECK-LABEL: @barrier_end_dynamic
 // CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
 util.func public @barrier_end_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  // CHECK: iree_tensor_ext.barrier.end %[[ARG0]] : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
-  %0 = iree_tensor_ext.barrier.end %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+  // CHECK: iree_tensor_ext.compute_barrier.end %[[ARG0]] : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -51,8 +51,8 @@ def InsertTensorBarriersPass :
                   "mlir::FunctionOpInterface"> {
   let summary = "Insert tensor barrier markers around computation regions.";
   let description = [{
-    Walks from function boundaries and inserts iree_tensor_ext.barrier.start
-    and iree_tensor_ext.barrier.end operations at the boundaries of
+    Walks from function boundaries and inserts iree_tensor_ext.compute_barrier.start
+    and iree_tensor_ext.compute_barrier.end operations at the boundaries of
     computation regions (tensor/linalg/linalgext ops). These barriers allow
     controlling where certain transformations like reshape propagation can occur.
 
@@ -69,7 +69,7 @@ def RemoveTensorBarriersPass :
                   "mlir::FunctionOpInterface"> {
   let summary = "Remove tensor barrier markers from the program.";
   let description = [{
-    Removes iree_tensor_ext.barrier.start and iree_tensor_ext.barrier.end
+    Removes iree_tensor_ext.compute_barrier.start and iree_tensor_ext.compute_barrier.end
     operations from the program. These are identity operations that simply
     pass through their operands, so they can be safely removed by replacing
     all uses of their results with their operands.

--- a/compiler/src/iree/compiler/DispatchCreation/RemoveTensorBarriers.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/RemoveTensorBarriers.cpp
@@ -23,10 +23,10 @@ struct RemoveTensorBarriersPass final
     auto funcOp = getOperation();
     IRRewriter rewriter(funcOp.getContext());
 
-    funcOp.walk([&](IREE::TensorExt::BarrierStartOp op) {
+    funcOp.walk([&](IREE::TensorExt::ComputeBarrierStartOp op) {
       rewriter.replaceOp(op, op.getValue());
     });
-    funcOp.walk([&](IREE::TensorExt::BarrierEndOp op) {
+    funcOp.walk([&](IREE::TensorExt::ComputeBarrierEndOp op) {
       rewriter.replaceOp(op, op.getValue());
     });
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/insert_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/insert_tensor_barriers.mlir
@@ -13,7 +13,7 @@ util.func public @simple_linalg(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
   util.return %0 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @simple_linalg
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
@@ -44,7 +44,7 @@ util.func public @multiple_compute_ops(%arg0: tensor<4xf32>) -> tensor<4xf32> {
   util.return %1 : tensor<4xf32>
 }
 // CHECK-LABEL: util.func public @multiple_compute_ops
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC0:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
@@ -72,7 +72,7 @@ util.func public @with_reshapes(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
   util.return %result : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @with_reshapes
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<32xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[START]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
@@ -89,7 +89,7 @@ util.func public @tensor_reshape_only(%arg0: tensor<32xf32>) -> tensor<4x8xf32> 
   util.return %expanded : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @tensor_reshape_only
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<32xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[START]]
 //       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[EXPANDED]]
@@ -135,7 +135,7 @@ util.func public @with_hal_barrier_dynamic(%arg0: tensor<?xf32>, %arg1: !hal.fen
 }
 // Verifies that tensor.dim doesn't trigger barrier insertion (metadata ops).
 // CHECK-LABEL: util.func public @with_hal_barrier_dynamic
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !hal.fence
 //   CHECK-NOT:   compute_barrier.start
 //       CHECK:   %[[BARRIER:.+]]:2 = hal.tensor.barrier join(%[[ARG0]], %[[ARG0]]
@@ -165,7 +165,7 @@ util.func public @linalg_with_dynamic_dims(%arg0: tensor<?x?xf32>) -> tensor<?x?
   util.return %result : tensor<?x?xf32>
 }
 // CHECK-LABEL: util.func public @linalg_with_dynamic_dims
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :

--- a/compiler/src/iree/compiler/DispatchCreation/test/insert_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/insert_tensor_barriers.mlir
@@ -14,10 +14,10 @@ util.func public @simple_linalg(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
 }
 // CHECK-LABEL: util.func public @simple_linalg
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[GENERIC]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 //       CHECK:   util.return %[[END]]
 
 // -----
@@ -45,13 +45,13 @@ util.func public @multiple_compute_ops(%arg0: tensor<4xf32>) -> tensor<4xf32> {
 }
 // CHECK-LABEL: util.func public @multiple_compute_ops
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC0:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
 //       CHECK:   %[[GENERIC1:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[GENERIC0]] :
-//   CHECK-NOT:   barrier.start
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[GENERIC1]]
+//   CHECK-NOT:   compute_barrier.start
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[GENERIC1]]
 //       CHECK:   util.return %[[END]]
 
 // -----
@@ -73,13 +73,13 @@ util.func public @with_reshapes(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
 }
 // CHECK-LABEL: util.func public @with_reshapes
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<32xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[START]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[EXPANDED]] :
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[GENERIC]]
 //       CHECK:   %[[RESULT:.+]] = tensor.expand_shape %[[COLLAPSED]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[RESULT]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[RESULT]]
 //       CHECK:   util.return %[[END]]
 
 // -----
@@ -90,9 +90,9 @@ util.func public @tensor_reshape_only(%arg0: tensor<32xf32>) -> tensor<4x8xf32> 
 }
 // CHECK-LABEL: util.func public @tensor_reshape_only
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<32xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[START]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[EXPANDED]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[EXPANDED]]
 //       CHECK:   util.return %[[END]]
 
 // -----
@@ -115,10 +115,10 @@ util.func public @with_hal_ops(%arg0: !hal.buffer_view, %arg1: !hal.fence) -> !h
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: !hal.buffer_view
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !hal.fence
 //       CHECK:   %[[IMPORT:.+]] = hal.tensor.import wait(%[[ARG1]]) => %[[ARG0]]
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[IMPORT]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[IMPORT]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[GENERIC]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 //       CHECK:   %[[EXPORT:.+]] = hal.tensor.export %[[END]]
 //       CHECK:   util.return %[[EXPORT]]
 
@@ -137,13 +137,13 @@ util.func public @with_hal_barrier_dynamic(%arg0: tensor<?xf32>, %arg1: !hal.fen
 // CHECK-LABEL: util.func public @with_hal_barrier_dynamic
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !hal.fence
-//   CHECK-NOT:   barrier.start
+//   CHECK-NOT:   compute_barrier.start
 //       CHECK:   %[[BARRIER:.+]]:2 = hal.tensor.barrier join(%[[ARG0]], %[[ARG0]]
 //       CHECK:   %[[DIM0:.+]] = tensor.dim %[[BARRIER]]#0
 //       CHECK:   %[[DIM1:.+]] = tensor.dim %[[BARRIER]]#1
 //       CHECK:   %[[EXPORT0:.+]] = hal.tensor.export %[[BARRIER]]#0
 //       CHECK:   %[[EXPORT1:.+]] = hal.tensor.export %[[BARRIER]]#1
-//   CHECK-NOT:   barrier.end
+//   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[EXPORT0]], %[[EXPORT1]]
 
 // -----
@@ -166,8 +166,8 @@ util.func public @linalg_with_dynamic_dims(%arg0: tensor<?x?xf32>) -> tensor<?x?
 }
 // CHECK-LABEL: util.func public @linalg_with_dynamic_dims
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[START]] :
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[GENERIC]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 //       CHECK:   util.return %[[END]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
@@ -6,7 +6,7 @@ util.func public @simple_barrier(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
   util.return %1 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @simple_barrier
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //   CHECK-NOT:   compute_barrier.start
 //   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]]
@@ -28,7 +28,7 @@ util.func public @barrier_with_compute(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32
   util.return %2 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_compute
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //   CHECK-NOT:   compute_barrier.start
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
@@ -46,8 +46,8 @@ util.func public @multiple_barriers(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) 
   util.return %2, %3 : tensor<4xf32>, tensor<4xf32>
 }
 // CHECK-LABEL: util.func public @multiple_barriers
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<4xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]
 //   CHECK-NOT:   compute_barrier.start
 //   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]], %[[ARG1]]
@@ -60,7 +60,7 @@ util.func public @barrier_with_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index
   util.return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_dynamic_dims
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //   CHECK-NOT:   compute_barrier.start
 //   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
@@ -1,20 +1,20 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-remove-tensor-barriers))" %s | FileCheck %s
 
 util.func public @simple_barrier(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
-  %1 = iree_tensor_ext.barrier.end %0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %1 = iree_tensor_ext.compute_barrier.end %0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %1 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @simple_barrier
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
-//   CHECK-NOT:   barrier.start
-//   CHECK-NOT:   barrier.end
+//   CHECK-NOT:   compute_barrier.start
+//   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]]
 
 // -----
 
 util.func public @barrier_with_compute(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   %empty = tensor.empty() : tensor<4x8xf32>
   %1 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
@@ -24,43 +24,43 @@ util.func public @barrier_with_compute(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
   } -> tensor<4x8xf32>
-  %2 = iree_tensor_ext.barrier.end %1 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %2 = iree_tensor_ext.compute_barrier.end %1 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %2 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_compute
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4x8xf32>
-//   CHECK-NOT:   barrier.start
+//   CHECK-NOT:   compute_barrier.start
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[ARG0]] :
-//   CHECK-NOT:   barrier.end
+//   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[GENERIC]]
 
 // -----
 
 util.func public @multiple_barriers(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<4xf32> -> tensor<4xf32>
-  %1 = iree_tensor_ext.barrier.start %arg1 : tensor<4xf32> -> tensor<4xf32>
-  %2 = iree_tensor_ext.barrier.end %0 : tensor<4xf32> -> tensor<4xf32>
-  %3 = iree_tensor_ext.barrier.end %1 : tensor<4xf32> -> tensor<4xf32>
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4xf32> -> tensor<4xf32>
+  %1 = iree_tensor_ext.compute_barrier.start %arg1 : tensor<4xf32> -> tensor<4xf32>
+  %2 = iree_tensor_ext.compute_barrier.end %0 : tensor<4xf32> -> tensor<4xf32>
+  %3 = iree_tensor_ext.compute_barrier.end %1 : tensor<4xf32> -> tensor<4xf32>
   util.return %2, %3 : tensor<4xf32>, tensor<4xf32>
 }
 // CHECK-LABEL: util.func public @multiple_barriers
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4xf32>
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<4xf32>
-//   CHECK-NOT:   barrier.start
-//   CHECK-NOT:   barrier.end
+//   CHECK-NOT:   compute_barrier.start
+//   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]], %[[ARG1]]
 
 // -----
 
 util.func public @barrier_with_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  %0 = iree_tensor_ext.barrier.start %arg0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
-  %1 = iree_tensor_ext.barrier.end %0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
+  %1 = iree_tensor_ext.compute_barrier.end %0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
   util.return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_dynamic_dims
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
-//   CHECK-NOT:   barrier.start
-//   CHECK-NOT:   barrier.end
+//   CHECK-NOT:   compute_barrier.start
+//   CHECK-NOT:   compute_barrier.end
 //       CHECK:   util.return %[[ARG0]]

--- a/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
@@ -49,8 +49,8 @@ util.func public @transpose_with_strided_conv(%arg0: tensor<40x1x1x32xbf16>, %ar
 // CHECK-LABEL: util.func public @transpose_with_strided_conv
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<40x1x1x32xbf16>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x192x128x32xbf16>
-//       CHECK:   %[[START0:.+]] = iree_tensor_ext.barrier.start %[[ARG1]]
-//       CHECK:   %[[START1:.+]] = iree_tensor_ext.barrier.start %[[ARG0]]
+//       CHECK:   %[[START0:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG1]]
+//       CHECK:   %[[START1:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[START1]]
 //       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[START0]][0, 0, 0, 0] [16, 96, 64, 32] [1, 2, 2, 1]
 //  CHECK-SAME:     tensor<16x192x128x32xbf16> to tensor<16x96x64x32xbf16>
@@ -59,5 +59,5 @@ util.func public @transpose_with_strided_conv(%arg0: tensor<40x1x1x32xbf16>, %ar
 //  CHECK-SAME:     ins(%[[SLICE]], %[[COLLAPSED]] : tensor<16x96x64x32xbf16>, tensor<40x32xbf16>)
 //       CHECK:   %[[TRUNC:.+]] = linalg.generic
 //  CHECK-SAME:     ins(%[[CONTRACT]] : tensor<16x96x64x40xf32>)
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.barrier.end %[[TRUNC]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[TRUNC]]
 //       CHECK:   util.return %[[END]]


### PR DESCRIPTION
Renames `iree_tensor_ext.barrier.*` ops to `iree_tensor_ext.compute_barrier.*` to signal that they are not real barriers. Also, addresses the comments that were missed before merging https://github.com/iree-org/iree/pull/22566.