### PR TITLE
[LLVMCPU] Support tile-and-fuse anchoring on producer ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -390,6 +390,12 @@ void addMmt4dTilingExpertPassPipeline(
       createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
   funcPassManager.addPass(createLLVMCPUTileRootAndFuseInputOperandsPass(
       IREE::CPU::TilingLevel::VectorReductionTiles));
+  // `VectorInnerParallelTiles` level models the tiling and fusion for the
+  // dimensions that are not captured in root op. I.e., root op may not have the
+  // config for the level. Thus, we use the last operation that has the tiling
+  // level as anchor.
+  funcPassManager.addPass(createLLVMCPUTileLastOpAndFuseProducerConsumerPass(
+      IREE::CPU::TilingLevel::VectorInnerParallelTiles));
   funcPassManager.addPass(iree_compiler::createForallToForPass());
   funcPassManager.addPass(createLLVMCPUTileToVectorSizePass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -59,7 +59,7 @@ iree_lit_test_suite(
             "split_reduction.mlir",
             "synchronize_symbol_visibility.mlir",
             "tile.mlir",
-            "tile_and_fuse_producer_consumer_anchoring_last_op.mlir",
+            "tile_and_fuse_producer_consumer_anchoring_non_root_op.mlir",
             "tile_and_fuse_producer_consumer_anchoring_root_op.mlir",
             "tile_to_vector_size.mlir",
             "unfused_fma.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -54,7 +54,7 @@ iree_lit_test_suite(
     "split_reduction.mlir"
     "synchronize_symbol_visibility.mlir"
     "tile.mlir"
-    "tile_and_fuse_producer_consumer_anchoring_last_op.mlir"
+    "tile_and_fuse_producer_consumer_anchoring_non_root_op.mlir"
     "tile_and_fuse_producer_consumer_anchoring_root_op.mlir"
     "tile_to_vector_size.mlir"
     "unfused_fma.mlir"


### PR DESCRIPTION
This patch improves the CPU pipeline by enabling tile-and-fuse to anchor on producer operations (ops that come before the root op in the compute sequence), extending the existing support for consumer-based anchoring.

Key changes:

1. Enhanced getLastAnchorOp to support anchoring before and after the root op:
   - getLastAnchorOpAfterRootOp
   - getLastAnchorOpBeforeRootOp

2. Updated runOnOperation to handle multiple anchor points:
   - Find both consumer anchors (after root) and producer anchors (before root)
   - Process all anchor ops for tile-and-fuse transformations
   - Enables fusion of producers at vector_inner_parallel tiling level

3. Added VectorInnerParallelTiles level to Mmt4dTilingExpert pipeline:
   - Models tiling/fusion for dimensions not captured in root op config
   - Uses last operation with the tiling level as anchor
   - Runs after VectorReductionTiles and before ForallToFor conversion

4. Rename test file from anchoring_last_op to anchoring_non_root_op

Fixes https://github.com/iree-org/iree/issues/22484