### PR TITLE
[Flow] Move ReplicateGlobalsPerAffinity pass to Flow

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -56,6 +56,7 @@ iree_compiler_cc_library(
         "OutlineDispatchRegions.cpp",
         "Passes.cpp",
         "RegionOpUtils.cpp",
+        "ReplicateGlobalsPerAffinity.cpp",
         "TopLevelSCFToCFG.cpp",
         "VerifyInputLegality.cpp",
     ],

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -79,6 +79,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions:LinalgExtExtensions",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
+        "//compiler/src/iree/compiler/Dialect/Stream/Analysis",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     "OutlineDispatchRegions.cpp"
     "Passes.cpp"
     "RegionOpUtils.cpp"
+    "ReplicateGlobalsPerAffinity.cpp"
     "TopLevelSCFToCFG.cpp"
     "VerifyInputLegality.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -96,6 +96,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::TransformExtensions::LinalgExtExtensions
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils
+    iree::compiler::Dialect::Stream::Analysis
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::Analysis

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -69,6 +69,12 @@ static llvm::cl::opt<bool> clZeroFillEmptyTensors(
         "Zero fill empty tensors instead of leaving them uninitialized."),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clReplicateGlobalsPerAffinity(
+    "iree-flow-experimental-replicate-globals-per-affinity",
+    llvm::cl::desc(
+        "Replicates globals for each unique affinity they are used with."),
+    llvm::cl::init(false));
+
 namespace mlir::iree_compiler::IREE::Flow {
 
 using FunctionLikeNest =
@@ -232,6 +238,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
     auto executablePassManager = passManager.nest<IREE::Flow::ExecutableOp>();
     executablePassManager.addPass(IREE::Flow::createCanonicalizePass());
     executablePassManager.addPass(mlir::createCSEPass());
+  }
+
+  // Replicate globals per affinity if requested.
+  if (clReplicateGlobalsPerAffinity) {
+    passManager.addPass(IREE::Flow::createReplicateGlobalsPerAffinityPass());
   }
 
   // Symbol DCE any remaining variables/functions that are now no longer

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -255,6 +255,21 @@ def OutlineDispatchRegionsPass :
   ];
 }
 
+def ReplicateGlobalsPerAffinityPass :
+    Pass<"iree-flow-replicate-globals-per-affinity", "mlir::ModuleOp"> {
+  let summary = "Replicates globals for each unique affinity and rewires their uses.";
+  let description = [{
+    Replicates IREE::Util::GlobalOps that are used on multiple affinities
+    and rewires their uses to the associated global. This allows for
+    specialization of globals for each affinity instead of having unspecialized
+    and a copy each use.
+  }];
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+    "IREE::Util::UtilDialect",
+  ];
+}
+
 def TopLevelSCFToCFGPass :
     InterfacePass<"iree-top-level-scf-to-cfg", "mlir::FunctionOpInterface"> {
   let summary = "Converts non-nested SCF constructs to CFG (not traversing into opaque operations).";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ReplicateGlobalsPerAffinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ReplicateGlobalsPerAffinity.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
-#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
 #include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
@@ -18,12 +18,12 @@
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
-namespace mlir::iree_compiler::IREE::Stream {
+namespace mlir::iree_compiler::IREE::Flow {
 
-#define DEBUG_TYPE "iree-stream-replicate-globals-per-affinity"
+#define DEBUG_TYPE "iree-flow-replicate-globals-per-affinity"
 
 #define GEN_PASS_DEF_REPLICATEGLOBALSPERAFFINITYPASS
-#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
 
 namespace {
 // Helper class to manage the creation of operations per affinity.
@@ -498,7 +498,7 @@ void ReplicateGlobalsPerAffinityPass::runOnOperation() {
       continue;
     }
 
-    llvm::SmallSetVector<AffinityAttr, 4> affinityAttrs;
+    llvm::SmallSetVector<Stream::AffinityAttr, 4> affinityAttrs;
     for (auto [idx, operand] : llvm::enumerate(affinityOp->getOperands())) {
       if (!opOperandAffinityStateMap.isAvailableOperand(affinityOp, idx)) {
         continue;
@@ -554,4 +554,4 @@ void ReplicateGlobalsPerAffinityPass::runOnOperation() {
   }
 }
 
-} // namespace mlir::iree_compiler::IREE::Stream
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -31,6 +31,7 @@ iree_lit_test_suite(
             "outline_dispatch_externs.mlir",
             "outline_dispatch_regions.mlir",
             "pipeline_tests.mlir",
+            "replicate_globals_per_affinity.mlir",
             "top_level_scf_to_cfg.mlir",
             "verify_input_ir.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "outline_dispatch_externs.mlir"
     "outline_dispatch_regions.mlir"
     "pipeline_tests.mlir"
+    "replicate_globals_per_affinity.mlir"
     "top_level_scf_to_cfg.mlir"
     "verify_input_ir.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/replicate_globals_per_affinity.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/replicate_globals_per_affinity.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-stream-replicate-globals-per-affinity --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-flow-replicate-globals-per-affinity --split-input-file %s | FileCheck %s
 
 // CHECK: util.global private @[[$DEVICE_A:.+]] : !hal.device
 // CHECK: util.global private @[[$DEVICE_B:.+]] : !hal.device

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -44,7 +44,6 @@ iree_compiler_cc_library(
         "Passes.h.inc",
         "PropagateTimepoints.cpp",
         "RefineUsage.cpp",
-        "ReplicateGlobalsPerAffinity.cpp",
         "ReuseAllocations.cpp",
         "ScheduleAllocation.cpp",
         "ScheduleConcurrency.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -40,7 +40,6 @@ iree_cc_library(
     "Passes.h.inc"
     "PropagateTimepoints.cpp"
     "RefineUsage.cpp"
-    "ReplicateGlobalsPerAffinity.cpp"
     "ReuseAllocations.cpp"
     "ScheduleAllocation.cpp"
     "ScheduleConcurrency.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -22,12 +22,6 @@ static llvm::cl::opt<bool> clAnnotateInputAffinities(
                    "the pipeline for debugging."),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clReplicateGlobalsPerAffinity(
-    "iree-stream-experimental-replicate-globals-per-affinity",
-    llvm::cl::desc(
-        "Replicates globals for each unique affinity they are used with."),
-    llvm::cl::init(false));
-
 namespace mlir::iree_compiler::IREE::Stream {
 
 using FunctionLikeNest =
@@ -104,10 +98,6 @@ void buildStreamTensorPassPipeline(OpPassManager &passManager,
   // debugging of analysis errors in end-user tooling.
   if (clAnnotateInputAffinities) {
     passManager.addPass(IREE::Stream::createAnnotateAffinitiesPass());
-  }
-
-  if (clReplicateGlobalsPerAffinity) {
-    passManager.addPass(IREE::Stream::createReplicateGlobalsPerAffinityPass());
   }
 
   // Converts from all input dialects into various levels of the stream dialect.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -12,22 +12,6 @@ include "mlir/Pass/PassBase.td"
 //===----------------------------------------------------------------------===//
 // Tensor lowering and resource management
 //===----------------------------------------------------------------------===//
-
-def ReplicateGlobalsPerAffinityPass :
-    Pass<"iree-stream-replicate-globals-per-affinity", "mlir::ModuleOp"> {
-  let summary = "Replicates globals for each unique affinity and rewires their uses.";
-  let description = [{
-    Replicates IREE::Util::GlobalOps that are used on multiple affinities
-    and rewires their uses to the associated global. This allows for
-    specialization of globals for each affinity instead of having unspecialized
-    and a copy each use.
-  }];
-  let dependentDialects = [
-    "IREE::Flow::FlowDialect",
-    "IREE::Util::UtilDialect",
-  ];
-}
-
 def ConvertToStreamPass :
     Pass<"iree-stream-conversion", "mlir::ModuleOp"> {
   let summary = "Converts from flow and other input dialects into the stream dialect.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -47,7 +47,6 @@ iree_lit_test_suite(
             "propagate_subviews.mlir",
             "propagate_timepoints.mlir",
             "refine_usage.mlir",
-            "replicate_globals_per_affinity.mlir",
             "reuse_allocations.mlir",
             "schedule_allocation.mlir",
             "schedule_concurrency.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -45,7 +45,6 @@ iree_lit_test_suite(
     "propagate_subviews.mlir"
     "propagate_timepoints.mlir"
     "refine_usage.mlir"
-    "replicate_globals_per_affinity.mlir"
     "reuse_allocations.mlir"
     "schedule_allocation.mlir"
     "schedule_concurrency.mlir"


### PR DESCRIPTION
The experimental pass to replicate globals per unique device affinity lived in Stream so far, but operates on Flow dialect before conversion to Stream.

Move the pass to Flow and place it right after executable cleanup in the flow pipeline if enabled through the experimental flag.