### PR TITLE
[Dispatch Creation] Add pass to fold reshapes into barriers

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
         "ConvertEncodingToFlow.cpp",
         "ConvertTensorToFlow.cpp",
         "ElementwiseOpFusion.cpp",
+        "FoldReshapesIntoTensorBarriers.cpp",
         "FoldUnitExtentDims.cpp",
         "FormDispatchRegions.cpp",
         "FormScalarDispatches.cpp",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "ConvertEncodingToFlow.cpp"
     "ConvertTensorToFlow.cpp"
     "ElementwiseOpFusion.cpp"
+    "FoldReshapesIntoTensorBarriers.cpp"
     "FoldUnitExtentDims.cpp"
     "FormDispatchRegions.cpp"
     "FormScalarDispatches.cpp"

--- a/compiler/src/iree/compiler/DispatchCreation/FoldReshapesIntoTensorBarriers.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldReshapesIntoTensorBarriers.cpp
@@ -1,0 +1,106 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_FOLDRESHAPESINTOTENSORBARRIERSPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+namespace {
+
+// Move tensor.expand_shape/collapse_shape above compute_barrier.start
+struct MoveReshapeAboveBarrierStart : public RewritePattern {
+  MoveReshapeAboveBarrierStart(MLIRContext *context, PatternBenefit benefit = 1)
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (!isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(op)) {
+      return failure();
+    }
+
+    auto barrierStartOp =
+        op->getOperand(0)
+            .getDefiningOp<IREE::TensorExt::ComputeBarrierStartOp>();
+    if (!barrierStartOp) {
+      return failure();
+    }
+
+    // Update reshape's operand to use compute_barrier.start's input
+    rewriter.modifyOpInPlace(
+        op, [&]() { op->getOpOperand(0).set(barrierStartOp.getValue()); });
+
+    IRRewriter::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfter(op);
+    Value reshapeResult = op->getResult(0);
+    auto newBarrier = IREE::TensorExt::ComputeBarrierStartOp::create(
+        rewriter, barrierStartOp.getLoc(), reshapeResult);
+    reshapeResult.replaceUsesWithIf(
+        newBarrier.getResult(), [&](OpOperand &use) {
+          return use.getOwner() != newBarrier &&
+                 !isa<tensor::DimOp>(use.getOwner());
+        });
+    return success();
+  }
+};
+
+// Move tensor.expand_shape/collapse_shape below compute_barrier.end
+struct MoveReshapeBelowBarrierEnd
+    : public OpRewritePattern<IREE::TensorExt::ComputeBarrierEndOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(IREE::TensorExt::ComputeBarrierEndOp barrierEndOp,
+                  PatternRewriter &rewriter) const override {
+    Operation *reshapeOp = barrierEndOp.getValue().getDefiningOp();
+    if (!reshapeOp ||
+        !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(reshapeOp)) {
+      return failure();
+    }
+    Value reshapeSrc = reshapeOp->getOperand(0);
+
+    // Create a new compute_barrier.end before the reshape with the reshape's
+    // source type
+    IRRewriter::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(reshapeOp);
+    auto newBarrier = IREE::TensorExt::ComputeBarrierEndOp::create(
+        rewriter, barrierEndOp.getLoc(), reshapeSrc);
+
+    rewriter.modifyOpInPlace(reshapeOp, [&]() {
+      reshapeOp->getOpOperand(0).set(newBarrier.getResult());
+    });
+    rewriter.replaceOp(barrierEndOp, reshapeOp->getResult(0));
+    return success();
+  }
+};
+
+struct FoldReshapesIntoTensorBarriersPass final
+    : public impl::FoldReshapesIntoTensorBarriersPassBase<
+          FoldReshapesIntoTensorBarriersPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    RewritePatternSet patterns(funcOp.getContext());
+    patterns.add<MoveReshapeAboveBarrierStart, MoveReshapeBelowBarrierEnd>(
+        funcOp.getContext());
+
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      funcOp.emitError("failed to fold reshapes into tensor barriers");
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -99,6 +99,21 @@ def ElementwiseOpFusionPass :
   ];
 }
 
+def FoldReshapesIntoTensorBarriersPass :
+    InterfacePass<"iree-dispatch-creation-fold-reshapes-into-tensor-barriers",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Fold reshape operations into tensor barriers.";
+  let description = [{
+    Moves tensor.expand_shape and tensor.collapse_shape operations through
+    iree_tensor_ext.compute_barrier.start and iree_tensor_ext.compute_barrier.end operations.
+    This blocks reshapes on the edge of the program from being propagated.
+  }];
+  let dependentDialects = [
+    "IREE::TensorExt::IREETensorExtDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 def FoldUnitExtentDimsPass :
     Pass<"iree-dispatch-creation-fold-unit-extent-dims", "mlir::ModuleOp"> {
   let summary = "Fold unit extent dimension of operations.";

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "collapse_linalg_generic_on_tensors.mlir",
             "elementwise_op_fusion.mlir",
             "dispatch_region_formation_preprocessing.mlir",
+            "fold_reshapes_into_tensor_barriers.mlir",
             "fold_unit_dims.mlir",
             "form_dispatch_regions.mlir",
             "dispatch_linalg_on_tensors.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "dispatch_linalg_on_tensors_fusion_with_transpose.mlir"
     "dispatch_region_formation_preprocessing.mlir"
     "elementwise_op_fusion.mlir"
+    "fold_reshapes_into_tensor_barriers.mlir"
     "fold_unit_dims.mlir"
     "form_dispatch_regions.mlir"
     "form_dispatch_workgroups.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_reshapes_into_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_reshapes_into_tensor_barriers.mlir
@@ -1,0 +1,116 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fold-reshapes-into-tensor-barriers))" %s | FileCheck %s
+
+util.func public @move_expand_shape_above_barrier_start(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
+  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<32xf32> -> tensor<32xf32>
+  %expanded = tensor.expand_shape %start [[0, 1]] output_shape [4, 8] : tensor<32xf32> into tensor<4x8xf32>
+  util.return %expanded : tensor<4x8xf32>
+}
+// CHECK-LABEL: util.func public @move_expand_shape_above_barrier_start
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<32xf32> into tensor<4x8xf32>
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[EXPAND]]
+//  CHECK-SAME:     tensor<4x8xf32> -> tensor<4x8xf32>
+//       CHECK:   util.return %[[START]]
+
+// -----
+
+util.func public @move_collapse_shape_above_barrier_start(%arg0: tensor<4x8xf32>) -> tensor<32xf32> {
+  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %collapsed = tensor.collapse_shape %start [[0, 1]] : tensor<4x8xf32> into tensor<32xf32>
+  util.return %collapsed : tensor<32xf32>
+}
+// CHECK-LABEL: util.func public @move_collapse_shape_above_barrier_start
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<4x8xf32> into tensor<32xf32>
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[COLLAPSE]]
+//  CHECK-SAME:     tensor<32xf32> -> tensor<32xf32>
+//       CHECK:   util.return %[[START]]
+
+// -----
+
+util.func public @move_expand_shape_below_barrier_end(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : tensor<32xf32> into tensor<4x8xf32>
+  %end = iree_tensor_ext.compute_barrier.end %expanded : tensor<4x8xf32> -> tensor<4x8xf32>
+  util.return %end : tensor<4x8xf32>
+}
+// CHECK-LABEL: util.func public @move_expand_shape_below_barrier_end
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//  CHECK-SAME:     tensor<32xf32> -> tensor<32xf32>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[END]]
+//  CHECK-SAME:     tensor<32xf32> into tensor<4x8xf32>
+//       CHECK:   util.return %[[EXPAND]]
+
+// -----
+
+util.func public @move_collapse_shape_below_barrier_end(%arg0: tensor<4x8xf32>) -> tensor<32xf32> {
+  %collapsed = tensor.collapse_shape %arg0 [[0, 1]] : tensor<4x8xf32> into tensor<32xf32>
+  %end = iree_tensor_ext.compute_barrier.end %collapsed : tensor<32xf32> -> tensor<32xf32>
+  util.return %end : tensor<32xf32>
+}
+// CHECK-LABEL: util.func public @move_collapse_shape_below_barrier_end
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//  CHECK-SAME:     tensor<4x8xf32> -> tensor<4x8xf32>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[END]]
+//  CHECK-SAME:     tensor<4x8xf32> into tensor<32xf32>
+//       CHECK:   util.return %[[COLLAPSE]]
+
+// -----
+
+util.func public @move_expand_shape_above_barrier_start_dynamic(%arg0: tensor<?xf32>) -> tensor<?x8xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+  %c8 = arith.constant 8 : index
+  %div = arith.divsi %dim, %c8 : index
+  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?xf32>{%dim} -> tensor<?xf32>
+  %expanded = tensor.expand_shape %start [[0, 1]] output_shape [%div, 8] : tensor<?xf32> into tensor<?x8xf32>
+  util.return %expanded : tensor<?x8xf32>
+}
+// CHECK-LABEL: util.func public @move_expand_shape_above_barrier_start_dynamic
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<?xf32> into tensor<?x8xf32>
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[EXPAND]]
+//  CHECK-SAME:     tensor<?x8xf32>{{.*}} -> tensor<?x8xf32>
+//       CHECK:   util.return %[[START]]
+
+// -----
+
+util.func public @move_expand_shape_below_barrier_end_dynamic(%arg0: tensor<?xf32>) -> tensor<?x8xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+  %c8 = arith.constant 8 : index
+  %div = arith.divsi %dim, %c8 : index
+  %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [%div, 8] : tensor<?xf32> into tensor<?x8xf32>
+  %end = iree_tensor_ext.compute_barrier.end %expanded : tensor<?x8xf32>{%dim} -> tensor<?x8xf32>
+  util.return %end : tensor<?x8xf32>
+}
+// CHECK-LABEL: util.func public @move_expand_shape_below_barrier_end_dynamic
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//  CHECK-SAME:     tensor<?xf32>{{.*}} -> tensor<?xf32>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[END]]
+//  CHECK-SAME:     tensor<?xf32> into tensor<?x8xf32>
+//       CHECK:   util.return %[[EXPAND]]
+
+// -----
+
+util.func public @move_collapse_shape_below_barrier_end_dynamic(%arg0: tensor<?x8xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x8xf32>
+  %c8 = arith.constant 8 : index
+  %size = arith.muli %dim, %c8 : index
+  %collapsed = tensor.collapse_shape %arg0 [[0, 1]] : tensor<?x8xf32> into tensor<?xf32>
+  %end = iree_tensor_ext.compute_barrier.end %collapsed : tensor<?xf32>{%size} -> tensor<?xf32>
+  util.return %end : tensor<?xf32>
+}
+// CHECK-LABEL: util.func public @move_collapse_shape_below_barrier_end_dynamic
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//  CHECK-SAME:     tensor<?x8xf32>{{.*}} -> tensor<?x8xf32>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[END]]
+//  CHECK-SAME:     tensor<?x8xf32> into tensor<?xf32>
+//       CHECK:   util.return %[[COLLAPSE]]


### PR DESCRIPTION
Adds a new pass, `FoldReshapesIntoTensorBarriersPass`, that moves `tensor.expand_shape` and `tensor.collapse_shape` operations through compute barrier operations. Specifically, it moves the reshape ops above `iree_tensor_ext.compute_barrier.start` ops and below `iree_tensor_ext.compute_barrier.end, effectively containing them to the edges of the program.


**Note:** This pass is not currently integrated into the main pipeline, as some users depend on reshapes to block transpose fusion for performance reasons. This can be added after determining that it doesn't negatively impact these cases.