### PR TITLE
Simplify SPIRV test configuration files by removing HAL infrastructure

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -2,31 +2,17 @@
 
 // Conv - large OC - distribute to only one workgroup dimension.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_112x112x512() {
-  %c0 = arith.constant 0 : index
-  %c512 = arith.constant 512 : index
-  %c112 = arith.constant 112 : index
+func.func @conv_112x112x512(%arg0: tensor<1x225x225x3xf32>, %arg1: tensor<3x3x3x512xf32>) -> tensor<1x112x112x512xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x512xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 512], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x512xf32>> -> tensor<3x3x3x512xf32>
-  %5 = tensor.empty() : tensor<1x112x112x512xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x512xf32>) outs(%6 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 512], strides = [1, 1, 1, 1] : tensor<1x112x112x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x112x112x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x225x225x3xf32>, tensor<3x3x3x512xf32>) outs(%1 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  return %2 : tensor<1x112x112x512xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 256], [1, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [64, 1, 1]>
-//      CHECK: func.func @conv_112x112x512()
+//      CHECK: func.func @conv_112x112x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -35,31 +21,17 @@ func.func @conv_112x112x512() {
 
 // Conv - medium OC/OW/OH - distribute to two workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_112x112x32() {
-  %c0 = arith.constant 0 : index
-  %c32 = arith.constant 32 : index
-  %c112 = arith.constant 112 : index
+func.func @conv_112x112x32(%arg0: tensor<1x225x225x3xf32>, %arg1: tensor<3x3x3x32xf32>) -> tensor<1x112x112x32xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>> -> tensor<3x3x3x32xf32>
-  %5 = tensor.empty() : tensor<1x112x112x32xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%6 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x112x112x32xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%1 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  return %2 : tensor<1x112x112x32xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [1, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 8, 1]>
-//      CHECK: func.func @conv_112x112x32()
+//      CHECK: func.func @conv_112x112x32(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -68,29 +40,16 @@ func.func @conv_112x112x32() {
 
 // Conv - small OC/OW/OH - distribute to all three workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_16x16x16() {
-  %c0 = arith.constant 0 : index
-  %c16 = arith.constant 16 : index
+func.func @conv_16x16x16(%arg0: tensor<1x33x33x3xf32>, %arg1: tensor<3x3x3x16xf32>) -> tensor<1x16x16x16xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33x33x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 33, 33, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33x33x3xf32>> -> tensor<1x33x33x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>> -> tensor<3x3x3x16xf32>
-  %5 = tensor.empty() : tensor<1x16x16x16xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x33x33x3xf32>, tensor<3x3x3x16xf32>) outs(%6 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 16, 16, 16], strides = [1, 1, 1, 1] : tensor<1x16x16x16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x16x16x16xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x33x33x3xf32>, tensor<3x3x3x16xf32>) outs(%1 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %2 : tensor<1x16x16x16xf32>
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 8, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [4, 4, 4]>
-//      CHECK: func.func @conv_16x16x16()
+//      CHECK: func.func @conv_16x16x16(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -99,31 +58,17 @@ func.func @conv_16x16x16() {
 
 // Depthwise conv - small OC/OW/OH - distribute to all three workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @dwconv_28x28x144() {
-  %c0 = arith.constant 0 : index
-  %c144 = arith.constant 144 : index
-  %c28 = arith.constant 28 : index
+func.func @dwconv_28x28x144(%arg0: tensor<1x57x57x144xf32>, %arg1: tensor<3x3x144xf32>) -> tensor<1x28x28x144xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x57x57x144xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x144xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 57, 57, 144], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x57x57x144xf32>> -> tensor<1x57x57x144xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 144], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x144xf32>> -> tensor<3x3x144xf32>
-  %5 = tensor.empty() : tensor<1x28x28x144xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
-  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x57x57x144xf32>, tensor<3x3x144xf32>) outs(%6 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 28, 28, 144], strides = [1, 1, 1, 1] : tensor<1x28x28x144xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x28x28x144xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  %2 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x57x57x144xf32>, tensor<3x3x144xf32>) outs(%1 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  return %2 : tensor<1x28x28x144xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [4, 4, 4]>
-//      CHECK: func.func @dwconv_28x28x144()
+//      CHECK: func.func @dwconv_28x28x144(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -132,31 +77,17 @@ func.func @dwconv_28x28x144() {
 
 // Depthwise conv - tiny OC/OW/OH - starving the GPU.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @dwconv_4x4x8() {
-  %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c4 = arith.constant 4 : index
+func.func @dwconv_4x4x8(%arg0: tensor<1x9x9x8xf32>, %arg1: tensor<3x3x8xf32>) -> tensor<1x4x4x8xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x9x9x8xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x8xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4x4x8xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 9, 9, 8], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x9x9x8xf32>> -> tensor<1x9x9x8xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 8], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x8xf32>> -> tensor<3x3x8xf32>
-  %5 = tensor.empty() : tensor<1x4x4x8xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
-  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x9x9x8xf32>, tensor<3x3x8xf32>) outs(%6 : tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 4, 4, 8], strides = [1, 1, 1, 1] : tensor<1x4x4x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4x4x8xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x4x4x8xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
+  %2 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x9x9x8xf32>, tensor<3x3x8xf32>) outs(%1 : tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
+  return %2 : tensor<1x4x4x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 4, 4]>
-//      CHECK: func.func @dwconv_4x4x8()
+//      CHECK: func.func @dwconv_4x4x8(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -2,31 +2,17 @@
 
 // Large matmul that can match the best tiling scheme.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_1024x2048x512() {
-  %c0 = arith.constant 0 : index
-  %c2048 = arith.constant 2048 : index
-  %c1024 = arith.constant 1024 : index
+func.func @matmul_1024x2048x512(%arg0: tensor<1024x512xf32>, %arg1: tensor<512x2048xf32>) -> tensor<1024x2048xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xf32>> -> tensor<512x2048xf32>
-  %5 = tensor.empty() : tensor<1024x2048xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<1024x512xf32>, tensor<512x2048xf32>) outs(%6 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : tensor<1024x2048xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xf32>>
-  return
+  %0 = tensor.empty() : tensor<1024x2048xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
+  %2 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<1024x512xf32>, tensor<512x2048xf32>) outs(%1 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
+  return %2 : tensor<1024x2048xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128], [16, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 2, 1]>
-//      CHECK: func.func @matmul_1024x2048x512()
+//      CHECK: func.func @matmul_1024x2048x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -35,31 +21,17 @@ func.func @matmul_1024x2048x512() {
 
 // Small matmul N that can still tile to all threads in a workgroup.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_3136x24x96() {
-  %c0 = arith.constant 0 : index
-  %c24 = arith.constant 24 : index
-  %c3136 = arith.constant 3136 : index
+func.func @matmul_3136x24x96(%arg0: tensor<3136x96xf32>, %arg1: tensor<96x24xf32>) -> tensor<3136x24xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3136x96xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<96x24xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3136x24xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [3136, 96], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3136x96xf32>> -> tensor<3136x96xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [96, 24], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<96x24xf32>> -> tensor<96x24xf32>
-  %5 = tensor.empty() : tensor<3136x24xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<3136x96xf32>, tensor<96x24xf32>) outs(%6 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [3136, 24], strides = [1, 1] : tensor<3136x24xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3136x24xf32>>
-  return
+  %0 = tensor.empty() : tensor<3136x24xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
+  %2 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<3136x96xf32>, tensor<96x24xf32>) outs(%1 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
+  return %2 : tensor<3136x24xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[448, 8], [14, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 32, 1]>
-//      CHECK: func.func @matmul_3136x24x96()
+//      CHECK: func.func @matmul_3136x24x96(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -68,31 +40,17 @@ func.func @matmul_3136x24x96() {
 
 // Small matmul M that can still tile to all threads in a workgroup.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_196x64x192() {
-  %c0 = arith.constant 0 : index
-  %c64 = arith.constant 64 : index
-  %c196 = arith.constant 196 : index
+func.func @matmul_196x64x192(%arg0: tensor<196x192xf32>, %arg1: tensor<192x64xf32>) -> tensor<196x64xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<196x192xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<192x64xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<196x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [196, 192], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<196x192xf32>> -> tensor<196x192xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [192, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<192x64xf32>> -> tensor<192x64xf32>
-  %5 = tensor.empty() : tensor<196x64xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<196x64xf32>) -> tensor<196x64xf32>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<196x192xf32>, tensor<192x64xf32>) outs(%6 : tensor<196x64xf32>) -> tensor<196x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [196, 64], strides = [1, 1] : tensor<196x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<196x64xf32>>
-  return
+  %0 = tensor.empty() : tensor<196x64xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<196x64xf32>) -> tensor<196x64xf32>
+  %2 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<196x192xf32>, tensor<192x64xf32>) outs(%1 : tensor<196x64xf32>) -> tensor<196x64xf32>
+  return %2 : tensor<196x64xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[28, 64], [7, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 4, 1]>
-//      CHECK: func.func @matmul_196x64x192()
+//      CHECK: func.func @matmul_196x64x192(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:      lowering_config = #[[CONFIG]]
@@ -101,27 +59,16 @@ func.func @matmul_196x64x192() {
 
 // Small matmul K that can still tile to all threads in a workgroup.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_12544x96x16() {
-  %c0 = arith.constant 0 : index
-  %c96 = arith.constant 96 : index
-  %c12544 = arith.constant 12544 : index
+func.func @matmul_12544x96x16(%arg0: memref<12544x16xf32>, %arg1: memref<16x96xf32>, %arg2: memref<12544x96xf32>) {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<12544x16xf32>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<16x96xf32>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<12544x96xf32>
-  linalg.fill ins(%cst : f32) outs(%2 : memref<12544x96xf32>)
-  linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%0, %1 : memref<12544x16xf32>, memref<16x96xf32>) outs(%2 : memref<12544x96xf32>)
+  linalg.fill ins(%cst : f32) outs(%arg2 : memref<12544x96xf32>)
+  linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : memref<12544x16xf32>, memref<16x96xf32>) outs(%arg2 : memref<12544x96xf32>)
   return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 32], [16, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 8, 1]>
-//      CHECK: func.func @matmul_12544x96x16()
+//      CHECK: func.func @matmul_12544x96x16(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -130,31 +77,17 @@ func.func @matmul_12544x96x16() {
 
 // Odd matmul M and small N that cannot utilize all threads in a workgroup.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_49x160x576() {
-  %c0 = arith.constant 0 : index
-  %c160 = arith.constant 160 : index
-  %c49 = arith.constant 49 : index
+func.func @matmul_49x160x576(%arg0: tensor<49x576xf32>, %arg1: tensor<576x160xf32>) -> tensor<49x160xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<49x576xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x160xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<49x160xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [49, 576], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<49x576xf32>> -> tensor<49x576xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [576, 160], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x160xf32>> -> tensor<576x160xf32>
-  %5 = tensor.empty() : tensor<49x160xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<49x160xf32>) -> tensor<49x160xf32>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<49x576xf32>, tensor<576x160xf32>) outs(%6 : tensor<49x160xf32>) -> tensor<49x160xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [49, 160], strides = [1, 1] : tensor<49x160xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<49x160xf32>>
-  return
+  %0 = tensor.empty() : tensor<49x160xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<49x160xf32>) -> tensor<49x160xf32>
+  %2 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<49x576xf32>, tensor<576x160xf32>) outs(%1 : tensor<49x160xf32>) -> tensor<49x160xf32>
+  return %2 : tensor<49x160xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[7, 32], [7, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 1, 1]>
-//      CHECK: func.func @matmul_49x160x576()
+//      CHECK: func.func @matmul_49x160x576(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -163,31 +96,17 @@ func.func @matmul_49x160x576() {
 
 // Large batch matmul.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_4x384x384() {
-  %c0 = arith.constant 0 : index
-  %c384 = arith.constant 384 : index
-  %c4 = arith.constant 4 : index
+func.func @batch_matmul_4x384x384(%arg0: tensor<4x384x32xf32>, %arg1: tensor<4x32x384xf32>) -> tensor<4x384x384xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x384x32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x384xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x384x384xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4, 384, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x384x32xf32>> -> tensor<4x384x32xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4, 32, 384], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x384xf32>> -> tensor<4x32x384xf32>
-  %5 = tensor.empty() : tensor<4x384x384xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
-  %7 = linalg.batch_matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<4x384x32xf32>, tensor<4x32x384xf32>) outs(%6 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [4, 384, 384], strides = [1, 1, 1] : tensor<4x384x384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x384x384xf32>>
-  return
+  %0 = tensor.empty() : tensor<4x384x384xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
+  %2 = linalg.batch_matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<4x384x32xf32>, tensor<4x32x384xf32>) outs(%1 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
+  return %2 : tensor<4x384x384xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 128], [1, 16, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 2, 1]>
-//      CHECK: func.func @batch_matmul_4x384x384()
+//      CHECK: func.func @batch_matmul_4x384x384(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -196,31 +115,17 @@ func.func @batch_matmul_4x384x384() {
 
 // Small batch matmul.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_4x8x8() {
-  %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c4 = arith.constant 4 : index
+func.func @batch_matmul_4x8x8(%arg0: tensor<4x8x32xf32>, %arg1: tensor<4x32x8xf32>) -> tensor<4x8x8xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x8x32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x8xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x8x8xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4, 8, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x8x32xf32>> -> tensor<4x8x32xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4, 32, 8], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x8xf32>> -> tensor<4x32x8xf32>
-  %5 = tensor.empty() : tensor<4x8x8xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<4x8x8xf32>) -> tensor<4x8x8xf32>
-  %7 = linalg.batch_matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<4x8x32xf32>, tensor<4x32x8xf32>) outs(%6 : tensor<4x8x8xf32>) -> tensor<4x8x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [4, 8, 8], strides = [1, 1, 1] : tensor<4x8x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x8x8xf32>>
-  return
+  %0 = tensor.empty() : tensor<4x8x8xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<4x8x8xf32>) -> tensor<4x8x8xf32>
+  %2 = linalg.batch_matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<4x8x32xf32>, tensor<4x32x8xf32>) outs(%1 : tensor<4x8x8xf32>) -> tensor<4x8x8xf32>
+  return %2 : tensor<4x8x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8, 8], [1, 1, 4], [0, 0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 8, 1]>
-//      CHECK: func.func @batch_matmul_4x8x8()
+//      CHECK: func.func @batch_matmul_4x8x8(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_conv.mlir
@@ -1,22 +1,8 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna2@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @nhwc_conv_pointwise_2x64x64x320() {
-  %c0 = arith.constant 0 : index
+func.func @nhwc_conv_pointwise_2x64x64x320(%4: tensor<2x66x66x320xf16>, %5: tensor<3x3x320x320xf16>, %6: tensor<2x64x64x320xf16>) -> tensor<2x64x64x320xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x66x66x320xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x320x320xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x64x320xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 66, 66, 320], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x66x66x320xf16>> -> tensor<2x66x66x320xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 320, 320], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x320x320xf16>> -> tensor<3x3x320x320xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 64, 64, 320], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x64x64x320xf16>> -> tensor<2x64x64x320xf16>
   %7 = tensor.empty() : tensor<2x64x64x320xf16>
   %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<2x64x64x320xf16>) -> tensor<2x64x64x320xf16>
   %9 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%4, %5 : tensor<2x66x66x320xf16>, tensor<3x3x320x320xf16>) outs(%8 : tensor<2x64x64x320xf16>) -> tensor<2x64x64x320xf16>
@@ -25,13 +11,12 @@ func.func @nhwc_conv_pointwise_2x64x64x320() {
     %11 = arith.divf %in, %in_0 : f16
     linalg.yield %11 : f16
   } -> tensor<2x64x64x320xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [2, 64, 64, 320], strides = [1, 1, 1, 1] : tensor<2x64x64x320xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
-  return
+  return %10 : tensor<2x64x64x320xf16>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 64], [1, 2, 2, 8], [0, 0, 0, 0, 1, 1, 8], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 2]>
-//      CHECK: func.func @nhwc_conv_pointwise_2x64x64x320()
+//      CHECK: func.func @nhwc_conv_pointwise_2x64x64x320(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -1,26 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna2@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_f32_16x4096x40x4096() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x40xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<16x4096x40xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 4096, 4096], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf32>> -> tensor<16x4096x4096xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 4096, 40], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x40xf32>> -> tensor<16x4096x40xf32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [16, 4096, 40], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<16x4096x40xf32>> -> tensor<16x4096x40xf32>
-  %6 = linalg.batch_matmul ins(%3, %4 : tensor<16x4096x4096xf32>, tensor<16x4096x40xf32>) outs(%5 : tensor<16x4096x40xf32>) -> tensor<16x4096x40xf32>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0], sizes = [16, 4096, 40], strides = [1, 1, 1] : tensor<16x4096x40xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<16x4096x40xf32>>
-  return
+func.func @batch_matmul_f32_16x4096x40x4096(%arg0: tensor<16x4096x4096xf32>, %arg1: tensor<16x4096x40xf32>, %arg2: tensor<16x4096x40xf32>) -> tensor<16x4096x40xf32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x4096x4096xf32>, tensor<16x4096x40xf32>) outs(%arg2 : tensor<16x4096x40xf32>) -> tensor<16x4096x40xf32>
+  return %0 : tensor<16x4096x40xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 8, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [2, 32, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>
-//      CHECK: func.func @batch_matmul_f32_16x4096x40x4096()
+//      CHECK: func.func @batch_matmul_f32_16x4096x40x4096(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -28,155 +15,94 @@ func.func @batch_matmul_f32_16x4096x40x4096() {
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_f16_64x640x320() {
-  %c0 = arith.constant 0 : index
+func.func @matmul_f16_64x640x320(%arg0: tensor<64x320xf16>, %arg1: tensor<320x640xf16>) -> tensor<64x640xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x320xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<320x640xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x640xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 320], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x320xf16>> -> tensor<64x320xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 640], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<320x640xf16>> -> tensor<320x640xf16>
-  %5 = tensor.empty() : tensor<64x640xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x640xf16>) -> tensor<64x640xf16>
-  %7 = linalg.matmul ins(%3, %4 : tensor<64x320xf16>, tensor<320x640xf16>) outs(%6 : tensor<64x640xf16>) -> tensor<64x640xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 640], strides = [1, 1] : tensor<64x640xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x640xf16>>
-  return
+  %0 = tensor.empty() : tensor<64x640xf16>
+  %1 = linalg.fill ins(%cst : f16) outs(%0 : tensor<64x640xf16>) -> tensor<64x640xf16>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<64x320xf16>, tensor<320x640xf16>) outs(%1 : tensor<64x640xf16>) -> tensor<64x640xf16>
+  return %2 : tensor<64x640xf16>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [16, 8, 1], {pipeline_depth = 2 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @matmul_f16_64x640x320()
+//      CHECK: func.func @matmul_f16_64x640x320(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_f32_16x4096x40x4096() {
+func.func @batch_matmul_f32_16x4096x40x4096(%arg0: tensor<16x4096x4096xf32>, %arg1: tensor<16x4096x48xf32>) -> tensor<16x4096x48xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x48xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x4096x48xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 4096, 4096], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf32>> -> tensor<16x4096x4096xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 4096, 48], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x48xf32>> -> tensor<16x4096x48xf32>
-  %5 = tensor.empty() : tensor<16x4096x48xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<16x4096x48xf32>) -> tensor<16x4096x48xf32>
-  %7 = linalg.batch_matmul ins(%3, %4 : tensor<16x4096x4096xf32>, tensor<16x4096x48xf32>) outs(%6 : tensor<16x4096x48xf32>) -> tensor<16x4096x48xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [16, 4096, 48], strides = [1, 1, 1] : tensor<16x4096x48xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x4096x48xf32>>
-  return
+  %0 = tensor.empty() : tensor<16x4096x48xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<16x4096x48xf32>) -> tensor<16x4096x48xf32>
+  %2 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x4096x4096xf32>, tensor<16x4096x48xf32>) outs(%1 : tensor<16x4096x48xf32>) -> tensor<16x4096x48xf32>
+  return %2 : tensor<16x4096x48xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 128, 16, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [4, 16, 1], {pipeline_depth = 2 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @batch_matmul_f32_16x4096x40x4096()
+//      CHECK: func.func @batch_matmul_f32_16x4096x40x4096(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @batch_matmul_f16_1x4096x4096x512() {
-  %c0 = arith.constant 0 : index
+func.func @batch_matmul_f16_1x4096x4096x512(%arg0: tensor<1x4096x512xf16>, %arg1: tensor<1x512x4096xf16>) -> tensor<1x4096x4096xf32> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096x512xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x512x4096xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4096x4096xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1, 4096, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096x512xf16>> -> tensor<1x4096x512xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1, 512, 4096], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x512x4096xf16>> -> tensor<1x512x4096xf16>
-  %5 = tensor.empty() : tensor<1x4096x4096xf32>
-  %6 = tensor.empty() : tensor<1x4096x4096xf16>
-  %7 = linalg.fill ins(%cst : f16) outs(%6 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
-  %8 = linalg.batch_matmul ins(%3, %4 : tensor<1x4096x512xf16>, tensor<1x512x4096xf16>) outs(%7 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
-  %9 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%8 : tensor<1x4096x4096xf16>) outs(%5 : tensor<1x4096x4096xf32>) {
+  %0 = tensor.empty() : tensor<1x4096x4096xf32>
+  %1 = tensor.empty() : tensor<1x4096x4096xf16>
+  %2 = linalg.fill ins(%cst : f16) outs(%1 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
+  %3 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<1x4096x512xf16>, tensor<1x512x4096xf16>) outs(%2 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
+  %4 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%3 : tensor<1x4096x4096xf16>) outs(%0 : tensor<1x4096x4096xf32>) {
   ^bb0(%in: f16, %out: f32):
-    %10 = arith.extf %in : f16 to f32
-    linalg.yield %10 : f32
+    %5 = arith.extf %in : f16 to f32
+    linalg.yield %5 : f32
   } -> tensor<1x4096x4096xf32>
-  iree_tensor_ext.dispatch.tensor.store %9, %2, offsets = [0, 0, 0], sizes = [1, 4096, 4096], strides = [1, 1, 1] : tensor<1x4096x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4096x4096xf32>>
-  return
+  return %4 : tensor<1x4096x4096xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [16, 8, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>
-//      CHECK: func.func @batch_matmul_f16_1x4096x4096x512()
+//      CHECK: func.func @batch_matmul_f16_1x4096x4096x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 5, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
-func.func @matmul_multi_reduce_i4xf32xf32() {
+func.func @matmul_multi_reduce_i4xf32xf32(%arg0: tensor<11008x32x128xi4>, %arg1: tensor<11008x32xf32>, %arg2: tensor<11008x32xf32>, %arg3: tensor<512x32x128xf32>) -> tensor<512x11008xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
-  %3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : i32
-  %4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : i32
-  %5 = arith.index_castui %0 : i32 to index
-  %6 = arith.index_castui %1 : i32 to index
-  %7 = arith.index_castui %2 : i32 to index
-  %8 = arith.index_castui %3 : i32 to index
-  %9 = arith.index_castui %4 : i32 to index
-  %10 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%5) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32x128xi4>>
-  %11 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%6) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32xf32>>
-  %12 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%7) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32xf32>>
-  %13 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%8) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x32x128xf32>>
-  %14 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%9) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x11008xf32>>
-  %15 = iree_tensor_ext.dispatch.tensor.load %10, offsets = [0, 0, 0], sizes = [11008, 32, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32x128xi4>> -> tensor<11008x32x128xi4>
-  %16 = iree_tensor_ext.dispatch.tensor.load %11, offsets = [0, 0], sizes = [11008, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32xf32>> -> tensor<11008x32xf32>
-  %17 = iree_tensor_ext.dispatch.tensor.load %12, offsets = [0, 0], sizes = [11008, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11008x32xf32>> -> tensor<11008x32xf32>
-  %18 = iree_tensor_ext.dispatch.tensor.load %13, offsets = [0, 0, 0], sizes = [512, 32, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x32x128xf32>> -> tensor<512x32x128xf32>
-  %19 = tensor.empty() : tensor<512x11008xf32>
-  %20 = tensor.empty() : tensor<11008x32x128xf32>
-  %21 = linalg.fill ins(%cst : f32) outs(%19 : tensor<512x11008xf32>) -> tensor<512x11008xf32>
-  %22 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%15, %16, %17 : tensor<11008x32x128xi4>, tensor<11008x32xf32>, tensor<11008x32xf32>) outs(%20 : tensor<11008x32x128xf32>) {
+  %0 = tensor.empty() : tensor<512x11008xf32>
+  %1 = tensor.empty() : tensor<11008x32x128xf32>
+  %2 = linalg.fill ins(%cst : f32) outs(%0 : tensor<512x11008xf32>) -> tensor<512x11008xf32>
+  %3 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<11008x32x128xi4>, tensor<11008x32xf32>, tensor<11008x32xf32>) outs(%1 : tensor<11008x32x128xf32>) {
   ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
-    %24 = arith.extui %in : i4 to i32
-    %25 = arith.uitofp %24 : i32 to f32
-    %26 = arith.subf %25, %in_1 : f32
-    %27 = arith.mulf %26, %in_0 : f32
-    linalg.yield %27 : f32
+    %5 = arith.extui %in : i4 to i32
+    %6 = arith.uitofp %5 : i32 to f32
+    %7 = arith.subf %6, %in_1 : f32
+    %8 = arith.mulf %7, %in_0 : f32
+    linalg.yield %8 : f32
   } -> tensor<11008x32x128xf32>
-  %23 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%18, %22 : tensor<512x32x128xf32>, tensor<11008x32x128xf32>) outs(%21 : tensor<512x11008xf32>) {
+  %4 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%arg3, %3 : tensor<512x32x128xf32>, tensor<11008x32x128xf32>) outs(%2 : tensor<512x11008xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
-    %24 = arith.mulf %in, %in_0 : f32
-    %25 = arith.addf %24, %out : f32
-    linalg.yield %25 : f32
+    %5 = arith.mulf %in, %in_0 : f32
+    %6 = arith.addf %5, %out : f32
+    linalg.yield %6 : f32
   } -> tensor<512x11008xf32>
-  iree_tensor_ext.dispatch.tensor.store %23, %14, offsets = [0, 0], sizes = [512, 11008], strides = [1, 1] : tensor<512x11008xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x11008xf32>>
-  return
+  return %4 : tensor<512x11008xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 1, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [16, 8, 1], {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
-//      CHECK: func.func @matmul_multi_reduce_i4xf32xf32()
+//      CHECK: func.func @matmul_multi_reduce_i4xf32xf32(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 //      CHECK:   linalg.generic

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
@@ -1,83 +1,48 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna3@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna4@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @matmul_256x1024x128_div_add() {
-  %c0 = arith.constant 0 : index
-  %c1024 = arith.constant 1024 : index
-  %c256 = arith.constant 256 : index
+func.func @matmul_256x1024x128_div_add(%arg0: tensor<256x1024xf16>, %arg1: tensor<256x1024xf16>, %arg2: tensor<256x128xf16>, %arg3: tensor<128x1024xf16>) -> tensor<256x1024xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-  %7 = tensor.empty() : tensor<256x1024xf16>
-  %8 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>> -> tensor<256x128xf16>
-  %9 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>> -> tensor<128x1024xf16>
-  %10 = tensor.empty() : tensor<256x1024xf16>
-  %11 = linalg.fill ins(%cst : f16) outs(%10 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %12 = linalg.matmul ins(%8, %9 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%11 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %13 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%12, %5, %6 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>) outs(%7 : tensor<256x1024xf16>) {
+  %0 = tensor.empty() : tensor<256x1024xf16>
+  %1 = tensor.empty() : tensor<256x1024xf16>
+  %2 = linalg.fill ins(%cst : f16) outs(%1 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %3 = linalg.matmul ins(%arg2, %arg3 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%2 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %4 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%3, %arg0, %arg1 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>) outs(%0 : tensor<256x1024xf16>) {
   ^bb0(%in: f16, %in_0: f16, %in_1: f16, %out: f16):
-    %14 = arith.divf %in, %in_0 : f16
-    %15 = arith.addf %14, %in_1 : f16
-    linalg.yield %15 : f16
+    %5 = arith.divf %in, %in_0 : f16
+    %6 = arith.addf %5, %in_1 : f16
+    linalg.yield %6 : f16
   } -> tensor<256x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  return
+  return %4 : tensor<256x1024xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @matmul_256x1024x128_div_add()
+//      CHECK: func.func @matmul_256x1024x128_div_add(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @batch_matmul_16x128x256x512_div() {
-  %c0 = arith.constant 0 : index
+func.func @batch_matmul_16x128x256x512_div(%arg0: tensor<16x128x512xf16>, %arg1: tensor<16x512x256xf16>, %arg2: tensor<16x128x256xf16>) -> tensor<16x128x256xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 128, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>> -> tensor<16x128x512xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 512, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>> -> tensor<16x512x256xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>> -> tensor<16x128x256xf16>
-  %7 = tensor.empty() : tensor<16x128x256xf16>
-  %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-  %9 = linalg.batch_matmul ins(%4, %5 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%8 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%9, %6 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%7 : tensor<16x128x256xf16>) {
+  %0 = tensor.empty() : tensor<16x128x256xf16>
+  %1 = linalg.fill ins(%cst : f16) outs(%0 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
+  %2 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%1 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
+  %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%2, %arg2 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%0 : tensor<16x128x256xf16>) {
   ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %11 = arith.divf %in, %in_0 : f16
-    linalg.yield %11 : f16
+    %4 = arith.divf %in, %in_0 : f16
+    linalg.yield %4 : f16
   } -> tensor<16x128x256xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : tensor<16x128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-  return
+  return %3 : tensor<16x128x256xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @batch_matmul_16x128x256x512_div()
+//      CHECK: func.func @batch_matmul_16x128x256x512_div(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -86,40 +51,28 @@ func.func @batch_matmul_16x128x256x512_div() {
 
 // Linalg.generic that is a batch matmul.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d0, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map4 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map5 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @generic_batch_matmul_32x8x512x64() {
-  %c0 = arith.constant 0 : index
+func.func @generic_batch_matmul_32x8x512x64(%arg0: tensor<128x32x64xf16>, %arg1: tensor<32x64x512xf16>) -> tensor<32x128x512xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x32x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 32, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x32x64xf16>> -> tensor<128x32x64xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [32, 64, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf16>> -> tensor<32x64x512xf16>
-  %5 = tensor.empty() : tensor<32x128x512xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x128x512xf16>) -> tensor<32x128x512xf16>
-  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<128x32x64xf16>, tensor<32x64x512xf16>) outs(%6 : tensor<32x128x512xf16>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
+  %0 = tensor.empty() : tensor<32x128x512xf16>
+  %1 = linalg.fill ins(%cst : f16) outs(%0 : tensor<32x128x512xf16>) -> tensor<32x128x512xf16>
+  %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<128x32x64xf16>, tensor<32x64x512xf16>) outs(%1 : tensor<32x128x512xf16>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
   ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.mulf %in, %in_0 : f16
-    %9 = arith.addf %out, %8 : f16
-    linalg.yield %9 : f16
+    %3 = arith.mulf %in, %in_0 : f16
+    %4 = arith.addf %out, %3 : f16
+    linalg.yield %4 : f16
   } -> tensor<32x128x512xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [32, 128, 512], strides = [1, 1, 1] : tensor<32x128x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-  return
+  return %2 : tensor<32x128x512xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @generic_batch_matmul_32x8x512x64()
+//      CHECK: func.func @generic_batch_matmul_32x8x512x64(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -128,29 +81,17 @@ func.func @generic_batch_matmul_32x8x512x64() {
 
 // K dim size not divisble by 32.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_16x1024x1024x80() {
-  %c0 = arith.constant 0 : index
+func.func @batch_matmul_16x1024x1024x80(%arg0: tensor<16x1024x80xf16>, %arg1: tensor<16x80x1024xf16>) -> tensor<16x1024x1024xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x1024x80xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x80x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x1024x1024xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 1024, 80], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x1024x80xf16>> -> tensor<16x1024x80xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 80, 1024], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x80x1024xf16>> -> tensor<16x80x1024xf16>
-  %5 = tensor.empty() : tensor<16x1024x1024xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
-  %7 = linalg.batch_matmul ins(%3, %4 : tensor<16x1024x80xf16>, tensor<16x80x1024xf16>) outs(%6 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [16, 1024, 1024], strides = [1, 1, 1] : tensor<16x1024x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x1024x1024xf16>>
-  return
+  %0 = tensor.empty() : tensor<16x1024x1024xf16>
+  %1 = linalg.fill ins(%cst : f16) outs(%0 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
+  %2 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x1024x80xf16>, tensor<16x80x1024xf16>) outs(%1 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
+  return %2 : tensor<16x1024x1024xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 0 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @batch_matmul_16x1024x1024x80()
+//      CHECK: func.func @batch_matmul_16x1024x1024x80(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -159,26 +100,12 @@ func.func @batch_matmul_16x1024x1024x80() {
 
 // Small K - not supported by cooperative matrix.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_256x1024x8() {
-  %c0 = arith.constant 0 : index
-  %c1024 = arith.constant 1024 : index
-  %c256 = arith.constant 256 : index
+func.func @matmul_256x1024x8(%arg0: tensor<256x8xf16>, %arg1: tensor<8x1024xf16>) -> tensor<256x1024xf16> {
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x8xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 8], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x8xf16>> -> tensor<256x8xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [8, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x1024xf16>> -> tensor<8x1024xf16>
-  %5 = tensor.empty() : tensor<256x1024xf16>
-  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<256x8xf16>, tensor<8x1024xf16>) outs(%6 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  return
+  %0 = tensor.empty() : tensor<256x1024xf16>
+  %1 = linalg.fill ins(%cst : f16) outs(%0 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %2 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<256x8xf16>, tensor<8x1024xf16>) outs(%1 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  return %2 : tensor<256x1024xf16>
 }
 
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [16, 8, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -2,26 +2,10 @@
 
 // Convolution with consumer pointwise ops.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @nhwc_conv_pointwise_112x112x32() {
-  %c0 = arith.constant 0 : index
+func.func @nhwc_conv_pointwise_112x112x32(%4: tensor<1x112x112x32xf32>, %6: tensor<1x225x225x3xf32>, %7: tensor<3x3x3x32xf32>) -> tensor<1x112x112x32xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %c112 = arith.constant 112 : index
-  %c32 = arith.constant 32 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x112x112x32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x112x112x32xf32>> -> tensor<1x112x112x32xf32>
   %5 = tensor.empty() : tensor<1x112x112x32xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
-  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>> -> tensor<3x3x3x32xf32>
   %8 = tensor.empty() : tensor<1x112x112x32xf32>
   %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
   %10 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%6, %7 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%9 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
@@ -30,40 +14,26 @@ func.func @nhwc_conv_pointwise_112x112x32() {
     %12 = arith.subf %in, %in_0 : f32
     linalg.yield %12 : f32
   } -> tensor<1x112x112x32xf32>
-  iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  return
+  return %11 : tensor<1x112x112x32xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 2]>
-//      CHECK: func.func @nhwc_conv_pointwise_112x112x32()
+//      CHECK: func.func @nhwc_conv_pointwise_112x112x32(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @nchw_conv_2x1280x8x8() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1280x10x10xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280x3x3xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 1280, 10, 10], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1280x10x10xf32>> -> tensor<2x1280x10x10xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [1280, 1280, 3, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x1280x3x3xf32>> -> tensor<1280x1280x3x3xf32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 1280, 8, 8], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>> -> tensor<2x1280x8x8xf32>
-  %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x1280x10x10xf32>, tensor<1280x1280x3x3xf32>) outs(%5 : tensor<2x1280x8x8xf32>) -> tensor<2x1280x8x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0, 0, 0, 0], sizes = [2, 1280, 8, 8], strides = [1, 1, 1, 1] : tensor<2x1280x8x8xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2x1280x8x8xf32>>
-  return
+func.func @nchw_conv_2x1280x8x8(%arg0: tensor<2x1280x10x10xf32>, %arg1: tensor<1280x1280x3x3xf32>, %arg2: tensor<2x1280x8x8xf32>) -> tensor<2x1280x8x8xf32> {
+  %0 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %arg1 : tensor<2x1280x10x10xf32>, tensor<1280x1280x3x3xf32>) outs(%arg2 : tensor<2x1280x8x8xf32>) -> tensor<2x1280x8x8xf32>
+  return %0 : tensor<2x1280x8x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 16, 8, 8], [1, 8, 1, 4], [0, 0, 0, 0, 4, 1, 1], [0, 0, 1, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 8, 2]>
-//      CHECK: func.func @nchw_conv_2x1280x8x8()
+//      CHECK: func.func @nchw_conv_2x1280x8x8(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nchw_fchw
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -1,163 +1,108 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @static_1d_sort() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1000xi32>>
-  %1 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [1000], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1000xi32>> -> tensor<1000xi32>
-  %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<1000xi32>) {
-  ^bb0(%arg0: i32, %arg1: i32):
-    %3 = arith.cmpi slt, %arg0, %arg1 : i32
-    iree_linalg_ext.yield %3 : i1
+func.func @static_1d_sort(%arg0: tensor<1000xi32>) -> tensor<1000xi32> {
+  %0 = iree_linalg_ext.sort dimension(0) outs(%arg0 : tensor<1000xi32>) {
+  ^bb0(%arg1: i32, %arg2: i32):
+    %1 = arith.cmpi slt, %arg1, %arg2 : i32
+    iree_linalg_ext.yield %1 : i1
   } -> tensor<1000xi32>
-  iree_tensor_ext.dispatch.tensor.store %2, %0, offsets = [0], sizes = [1000], strides = [1] : tensor<1000xi32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1000xi32>>
-  return
+  return %0 : tensor<1000xi32>
 }
 
 // Check that the workgroup count and size are (1, 1, 1) for serializing the computation.
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = []>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [1, 1, 1]>
-//       CHECK: func.func @static_1d_sort()
+//       CHECK: func.func @static_1d_sort(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.sort
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @static_3d_sort() {
-  %c64 = arith.constant 64 : index
-  %c128 = arith.constant 128 : index
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<64x32x128xi32>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<64x32x128xi32>
-  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0 : memref<64x32x128xi32>) outs(%1 : memref<64x32x128xi32>) {
+func.func @static_3d_sort(%arg0: memref<64x32x128xi32>, %arg1: memref<64x32x128xi32>) {
+  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : memref<64x32x128xi32>) outs(%arg1 : memref<64x32x128xi32>) {
   ^bb0(%in: i32, %out: i32):
     linalg.yield %in : i32
   }
-  iree_linalg_ext.sort dimension(1) outs(%1 : memref<64x32x128xi32>) {
-  ^bb0(%arg0: i32, %arg1: i32):
-    %2 = arith.cmpi slt, %arg0, %arg1 : i32
-    iree_linalg_ext.yield %2 : i1
+  iree_linalg_ext.sort dimension(1) outs(%arg1 : memref<64x32x128xi32>) {
+  ^bb0(%arg2: i32, %arg3: i32):
+    %0 = arith.cmpi slt, %arg2, %arg3 : i32
+    iree_linalg_ext.yield %0 : i1
   }
   return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 64], [1, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [64, 1, 1]>
-//      CHECK: func.func @static_3d_sort()
+//      CHECK: func.func @static_3d_sort(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   iree_linalg_ext.sort
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @static_1d_fft_stage2() {
-  %c0 = arith.constant 0 : index
+func.func @static_1d_fft_stage2(%arg0: tensor<32xf32>, %arg1: tensor<32xf32>) -> (tensor<32xf32>, tensor<32xf32>) {
   %c2 = arith.constant 2 : index
   %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
   %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [32], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
-  %3 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [32], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
-  %4:2 = iree_linalg_ext.fft ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
-  iree_tensor_ext.dispatch.tensor.store %4#0, %0, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>>
-  iree_tensor_ext.dispatch.tensor.store %4#1, %1, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<32xf32>>
-  return
+  %0:2 = iree_linalg_ext.fft ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%arg0, %arg1 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
+  return %0#0, %0#1 : tensor<32xf32>, tensor<32xf32>
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [64, 1, 1]>
-//       CHECK: func.func @static_1d_fft_stage2()
+//       CHECK: func.func @static_1d_fft_stage2(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.fft
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @static_3d_fft_stage3() {
-  %c0 = arith.constant 0 : index
+func.func @static_3d_fft_stage3(%arg0: memref<64x128x32xf32>, %arg1: memref<64x128x32xf32>) {
   %c3 = arith.constant 3 : index
-  %c64 = arith.constant 64 : index
-  %c128 = arith.constant 128 : index
-  %c32 = arith.constant 32 : index
   %cst = arith.constant dense<[1.000000e+00, 0.707106769, 6.12323426E-17, -0.707106769]> : tensor<4xf32>
   %cst_0 = arith.constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
   %0 = bufferization.to_buffer %cst_0 : tensor<4xf32> to memref<4xf32>
   %1 = bufferization.to_buffer %cst : tensor<4xf32> to memref<4xf32>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<64x128x32xf32>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<64x128x32xf32>
-  iree_linalg_ext.fft ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>) outs(%2, %3 : memref<64x128x32xf32>, memref<64x128x32xf32>)
+  iree_linalg_ext.fft ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>) outs(%arg0, %arg1 : memref<64x128x32xf32>, memref<64x128x32xf32>)
   return
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 8]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [64, 1, 1]>
-//       CHECK: func.func @static_3d_fft_stage3()
+//       CHECK: func.func @static_3d_fft_stage3(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.fft
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @winograd_input_transform() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
-  %3 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
-  %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : tensor<8x8x2x6x6x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
-  return
+func.func @winograd_input_transform(%arg0: tensor<2x34x34x128xf16>) -> tensor<8x8x2x6x6x128xf16> {
+  %0 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
+  %1 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%arg0 : tensor<2x34x34x128xf16>) outs(%0 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
+  return %1 : tensor<8x8x2x6x6x128xf16>
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
-//       CHECK: func.func @winograd_input_transform()
+//       CHECK: func.func @winograd_input_transform(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.input_transform
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @winograd_output_transform() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>> -> tensor<8x8x2x6x6x128xf16>
-  %3 = tensor.empty() : tensor<2x36x36x128xf16>
-  %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
-  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
-  return
+func.func @winograd_output_transform(%arg0: tensor<8x8x2x6x6x128xf16>) -> tensor<2x36x36x128xf16> {
+  %0 = tensor.empty() : tensor<2x36x36x128xf16>
+  %1 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%arg0 : tensor<8x8x2x6x6x128xf16>) outs(%0 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+  return %1 : tensor<2x36x36x128xf16>
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
-//       CHECK: func.func @winograd_output_transform()
+//       CHECK: func.func @winograd_output_transform(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.output_transform
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -1,9 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -12,12 +8,7 @@
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @copy_as_generic() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<?x?xi32>{%0, %1}
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<?x?xi32>{%0, %1}
+func.func @copy_as_generic(%0: index, %1: index, %2: memref<?x?xi32>, %3: memref<?x?xi32>) attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%2 : memref<?x?xi32>) outs(%3 : memref<?x?xi32>) {
   ^bb0(%in: i32, %out: i32):
     linalg.yield %in : i32
@@ -26,17 +17,13 @@ func.func @copy_as_generic() attributes {hal.executable.target = #executable_tar
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16], [1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [16, 1, 1]>
-//      CHECK: func.func @copy_as_generic()
+//      CHECK: func.func @copy_as_generic(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -45,12 +32,7 @@ func.func @copy_as_generic() attributes {hal.executable.target = #executable_tar
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @copy() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c224 = arith.constant 224 : index
-  %c3 = arith.constant 3 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<1x224x224x3xf32>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<1x224x224x3xf32>
+func.func @copy(%0: memref<1x224x224x3xf32>, %1: memref<1x224x224x3xf32>) attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0 : memref<1x224x224x3xf32>) outs(%1 : memref<1x224x224x3xf32>) {
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
@@ -60,7 +42,7 @@ func.func @copy() attributes {hal.executable.target = #executable_target_vulkan_
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 32, 1], [0, 1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [1, 32, 2]>
-//      CHECK: func.func @copy()
+//      CHECK: func.func @copy(
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -69,10 +51,6 @@ func.func @copy() attributes {hal.executable.target = #executable_target_vulkan_
 
 // Average pooling op with nice tilable input.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -80,35 +58,24 @@ func.func @copy() attributes {hal.executable.target = #executable_target_vulkan_
     max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384,
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
-func.func @avg_pool() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @avg_pool(%3: tensor<1x24x24x8xf32>) -> tensor<1x2x2x8xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %c2 = arith.constant 2 : index
-  %c8 = arith.constant 8 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x24x24x8xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x2x8xf32>>
   %2 = tensor.empty() : tensor<12x12xf32>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 24, 24, 8], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x24x24x8xf32>> -> tensor<1x24x24x8xf32>
   %4 = tensor.empty() : tensor<1x2x2x8xf32>
   %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<1x2x2x8xf32>) -> tensor<1x2x2x8xf32>
   %6 = linalg.pooling_nhwc_sum {dilations = dense<1> : vector<2xi64>, strides = dense<12> : vector<2xi64>} ins(%3, %2 : tensor<1x24x24x8xf32>, tensor<12x12xf32>) outs(%5 : tensor<1x2x2x8xf32>) -> tensor<1x2x2x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %6, %1, offsets = [0, 0, 0, 0], sizes = [1, 2, 2, 8], strides = [1, 1, 1, 1] : tensor<1x2x2x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x2x2x8xf32>>
-  return
+  return %6 : tensor<1x2x2x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 2, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 2, 2]>
-//      CHECK: func.func @avg_pool()
+//      CHECK: func.func @avg_pool(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_sum
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -117,13 +84,9 @@ func.func @avg_pool() attributes {hal.executable.target = #executable_target_vul
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @avg_pool() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @avg_pool(%2: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 4.900000e+01 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x7x7x1280xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x1x1280xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 7, 7, 1280], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x7x7x1280xf32>> -> tensor<1x7x7x1280xf32>
   %3 = tensor.empty() : tensor<7x7xf32>
   %4 = tensor.empty() : tensor<1x1x1x1280xf32>
   %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<1x1x1x1280xf32>) -> tensor<1x1x1x1280xf32>
@@ -133,13 +96,12 @@ func.func @avg_pool() attributes {hal.executable.target = #executable_target_vul
     %8 = arith.divf %in, %cst_0 : f32
     linalg.yield %8 : f32
   } -> tensor<1x1x1x1280xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0, 0, 0], sizes = [1, 1, 1, 1280], strides = [1, 1, 1, 1] : tensor<1x1x1x1280xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x1x1280xf32>>
-  return
+  return %7 : tensor<1x1x1x1280xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 1, 128], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//      CHECK: func.func @avg_pool()
+//      CHECK: func.func @avg_pool(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_sum
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -148,10 +110,6 @@ func.func @avg_pool() attributes {hal.executable.target = #executable_target_vul
 
 // Max pooling op with odd size-1 dimension sizes.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -159,26 +117,18 @@ func.func @avg_pool() attributes {hal.executable.target = #executable_target_vul
     max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384,
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
-func.func @max_pool() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @max_pool(%3: tensor<1x76x1x1xf32>) -> tensor<1x38x1x1xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0xFF800000 : f32
-  %c38 = arith.constant 38 : index
-  %c1 = arith.constant 1 : index
-  %c0 = arith.constant 0 : index
-  %c320 = arith.constant 320 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x76x1x1xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x38x1x1xf32>>
   %2 = tensor.empty() : tensor<2x1xf32>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 76, 1, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x76x1x1xf32>> -> tensor<1x76x1x1xf32>
   %4 = tensor.empty() : tensor<1x38x1x1xf32>
   %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<1x38x1x1xf32>) -> tensor<1x38x1x1xf32>
   %6 = linalg.pooling_nhwc_max {dilations = dense<1> : vector<2xi64>, strides = dense<[2, 1]> : vector<2xi64>} ins(%3, %2 : tensor<1x76x1x1xf32>, tensor<2x1xf32>) outs(%5 : tensor<1x38x1x1xf32>) -> tensor<1x38x1x1xf32>
-  iree_tensor_ext.dispatch.tensor.store %6, %1, offsets = [0, 0, 0, 0], sizes = [1, 38, 1, 1], strides = [1, 1, 1, 1] : tensor<1x38x1x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x38x1x1xf32>>
-  return
+  return %6 : tensor<1x38x1x1xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 32], [0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [32, 1, 1]>
-//      CHECK: func.func @max_pool()
+//      CHECK: func.func @max_pool(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pooling_nhwc_max
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
@@ -187,11 +137,6 @@ func.func @max_pool() attributes {hal.executable.target = #executable_target_vul
 
 // Element wise op with mismatched input and output rank.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -201,37 +146,24 @@ func.func @max_pool() attributes {hal.executable.target = #executable_target_vul
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
-func.func @elementwise() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c10 = arith.constant 10 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<10xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 10], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>> -> tensor<1x10xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [10], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<10xf32>> -> tensor<10xf32>
+func.func @elementwise(%3: tensor<1x10xf32>, %4: tensor<10xf32>) -> tensor<10xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %5 = tensor.empty() : tensor<10xf32>
   %6 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%3, %4 : tensor<1x10xf32>, tensor<10xf32>) outs(%5 : tensor<10xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %7 = arith.addf %in, %in_0 : f32
     linalg.yield %7 : f32
   } -> tensor<10xf32>
-  iree_tensor_ext.dispatch.tensor.store %6, %2, offsets = [0], sizes = [10], strides = [1] : tensor<10xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<10xf32>>
-  return
+  return %6 : tensor<10xf32>
 }
 
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [32, 1, 1]>
-//      CHECK: func.func @elementwise()
+//      CHECK: func.func @elementwise(
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 
 // -----
 
 // Fused depthwise convolution and element wise ops: don't vectorize with partially active subgroups.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -240,19 +172,11 @@ func.func @elementwise() attributes {hal.executable.target = #executable_target_
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
-func.func @dwconv_elementwise() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @dwconv_elementwise(%3: tensor<1x21x20x1xf32>) -> tensor<1x19x18x1x4xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant dense_resource<__elided__> : tensor<3x3x1x4xf32>
   %cst_0 = arith.constant 1.001000e+00 : f32
   %cst_1 = arith.constant 0.000000e+00 : f32
-  %c18 = arith.constant 18 : index
-  %c1 = arith.constant 1 : index
-  %c4 = arith.constant 4 : index
-  %c4576 = arith.constant 4576 : index
-  %c6272 = arith.constant 6272 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x21x20x1xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x19x18x1x4xf32>>
   %2 = tensor.empty() : tensor<1x19x18x1x4xf32>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 21, 20, 1], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x21x20x1xf32>> -> tensor<1x21x20x1xf32>
   %4 = tensor.empty() : tensor<1x19x18x1x4xf32>
   %5 = linalg.fill ins(%cst_1 : f32) outs(%4 : tensor<1x19x18x1x4xf32>) -> tensor<1x19x18x1x4xf32>
   %6 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%3, %cst : tensor<1x21x20x1xf32>, tensor<3x3x1x4xf32>) outs(%5 : tensor<1x19x18x1x4xf32>) -> tensor<1x19x18x1x4xf32>
@@ -262,23 +186,18 @@ func.func @dwconv_elementwise() attributes {hal.executable.target = #executable_
     %9 = arith.addf %in, %cst_1 : f32
     linalg.yield %9 : f32
   } -> tensor<1x19x18x1x4xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0, 0, 0, 0], sizes = [1, 19, 18, 1, 4], strides = [1, 1, 1, 1, 1] : tensor<1x19x18x1x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x19x18x1x4xf32>>
-  return
+  return %7 : tensor<1x19x18x1x4xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 2, 0, 4], [0, 1, 1, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [4, 2, 4]>
-//      CHECK: func.func @dwconv_elementwise()
+//      CHECK: func.func @dwconv_elementwise(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwcm
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -288,12 +207,8 @@ func.func @dwconv_elementwise() attributes {hal.executable.target = #executable_
 }>
 #map = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @outermost_reduction() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @outermost_reduction(%2: tensor<4x2048x512xf32>) -> tensor<2048x512xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x2048x512xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4, 2048, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x2048x512xf32>> -> tensor<4x2048x512xf32>
   %3 = tensor.empty() : tensor<2048x512xf32>
   %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<2048x512xf32>) -> tensor<2048x512xf32>
   %5 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%2 : tensor<4x2048x512xf32>) outs(%4 : tensor<2048x512xf32>) {
@@ -301,23 +216,18 @@ func.func @outermost_reduction() attributes {hal.executable.target = #executable
     %6 = arith.addf %in, %out : f32
     linalg.yield %6 : f32
   } -> tensor<2048x512xf32>
-  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1] : tensor<2048x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-  return
+  return %5 : tensor<2048x512xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 128], [1, 4],  [0, 0, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @outermost_reduction()
+//       CHECK: func.func @outermost_reduction(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -327,19 +237,8 @@ func.func @outermost_reduction() attributes {hal.executable.target = #executable
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @innermost_reduction() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @innermost_reduction(%9: tensor<128x384xf32>, %10: tensor<128xf32>) -> tensor<128xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant -0.000000e+00 : f32
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-  %2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : i32
-  %3 = arith.index_cast %0 {stream.alignment = 512 : index, stream.values = [0 : index, 394752 : index, 984064 : index]} : i32 to index
-  %4 = arith.index_cast %1 {stream.alignment = 512 : index, stream.values = [0 : index, 196608 : index, 197120 : index]} : i32 to index
-  %5 = arith.index_cast %2 {stream.alignment = 512 : index, stream.values = [512 : index, 197120 : index, 197632 : index]} : i32 to index
-  %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x384xf32>>
-  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%4) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128xf32>>
-  %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%5) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128xf32>>
-  %9 = iree_tensor_ext.dispatch.tensor.load %6, offsets = [0, 0], sizes = [128, 384], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x384xf32>> -> tensor<128x384xf32>
-  %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0], sizes = [128], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128xf32>> -> tensor<128xf32>
   %11 = tensor.empty() : tensor<128xf32>
   %12 = linalg.fill ins(%cst : f32) outs(%11 : tensor<128xf32>) -> tensor<128xf32>
   %13 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "reduction"]} ins(%9, %10 : tensor<128x384xf32>, tensor<128xf32>) outs(%12 : tensor<128xf32>) {
@@ -349,23 +248,18 @@ func.func @innermost_reduction() attributes {hal.executable.target = #executable
     %16 = arith.addf %15, %out : f32
     linalg.yield %16 : f32
   } -> tensor<128xf32>
-  iree_tensor_ext.dispatch.tensor.store %13, %8, offsets = [0], sizes = [128], strides = [1] : tensor<128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128xf32>>
-  return
+  return %13 : tensor<128xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32], [1],  [0, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @innermost_reduction()
+//       CHECK: func.func @innermost_reduction(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -375,33 +269,24 @@ func.func @innermost_reduction() attributes {hal.executable.target = #executable
 }>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @four_dim_elementwise() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x8x256x4xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256x4x8xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [128, 8, 256, 4], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x8x256x4xf32>> -> tensor<128x8x256x4xf32>
+func.func @four_dim_elementwise(%2: tensor<128x8x256x4xf32>) -> tensor<128x256x4x8xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %3 = tensor.empty() : tensor<128x256x4x8xf32>
   %4 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<128x8x256x4xf32>) outs(%3 : tensor<128x256x4x8xf32>) {
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
   } -> tensor<128x256x4x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [128, 256, 4, 8], strides = [1, 1, 1, 1] : tensor<128x256x4x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x256x4x8xf32>>
-  return
+  return %4 : tensor<128x256x4x8xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 2, 4, 8], [0, 1, 1, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 4, 2]>
-//       CHECK: func.func @four_dim_elementwise()
+//       CHECK: func.func @four_dim_elementwise(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -411,12 +296,8 @@ func.func @four_dim_elementwise() attributes {hal.executable.target = #executabl
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @odd_reduction_dimension_size_501() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @odd_reduction_dimension_size_501(%2: tensor<512x501xf32>) -> tensor<512x501xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0xFF800000 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x501xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x501xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 501], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x501xf32>> -> tensor<512x501xf32>
   %3 = tensor.empty() : tensor<512x501xf32>
   %4 = tensor.empty() : tensor<512xf32>
   %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<512xf32>) -> tensor<512xf32>
@@ -431,23 +312,18 @@ func.func @odd_reduction_dimension_size_501() attributes {hal.executable.target 
     %9 = math.exp %8 : f32
     linalg.yield %9 : f32
   } -> tensor<512x501xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [512, 501], strides = [1, 1] : tensor<512x501xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x501xf32>>
-  return
+  return %7 : tensor<512x501xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 3]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @odd_reduction_dimension_size_501()
+//       CHECK: func.func @odd_reduction_dimension_size_501(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -457,12 +333,8 @@ func.func @odd_reduction_dimension_size_501() attributes {hal.executable.target 
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @odd_reduction_dimension_size_2809() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @odd_reduction_dimension_size_2809(%2: tensor<512x2809xf32>) -> tensor<512x2809xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0xFF800000 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2809xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x2809xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 2809], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2809xf32>> -> tensor<512x2809xf32>
   %3 = tensor.empty() : tensor<512x2809xf32>
   %4 = tensor.empty() : tensor<512xf32>
   %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<512xf32>) -> tensor<512xf32>
@@ -477,23 +349,18 @@ func.func @odd_reduction_dimension_size_2809() attributes {hal.executable.target
     %9 = math.exp %8 : f32
     linalg.yield %9 : f32
   } -> tensor<512x2809xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [512, 2809], strides = [1, 1] : tensor<512x2809xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<512x2809xf32>>
-  return
+  return %7 : tensor<512x2809xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @odd_reduction_dimension_size_2809()
+//       CHECK: func.func @odd_reduction_dimension_size_2809(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -503,13 +370,9 @@ func.func @odd_reduction_dimension_size_2809() attributes {hal.executable.target
 }>
 #map = affine_map<(d0, d1, d2, d3) -> ()>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @broadcast() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @broadcast(%2: tensor<f32>) -> tensor<2048x1x1x1xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 1.000000e-10 : f32
   %cst_0 = arith.constant -1.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<f32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x1x1x1xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<f32>> -> tensor<f32>
   %3 = tensor.empty() : tensor<2048x1x1x1xf32>
   %4 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<f32>) outs(%3 : tensor<2048x1x1x1xf32>) {
   ^bb0(%in: f32, %out: f32):
@@ -517,13 +380,12 @@ func.func @broadcast() attributes {hal.executable.target = #executable_target_vu
     %6 = arith.divf %cst_0, %5 : f32
     linalg.yield %6 : f32
   } -> tensor<2048x1x1x1xf32>
-  iree_tensor_ext.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2048, 1, 1, 1], strides = [1, 1, 1, 1] : tensor<2048x1x1x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x1x1x1xf32>>
-  return
+  return %4 : tensor<2048x1x1x1xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128], [4],  [0, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @broadcast()
+//       CHECK: func.func @broadcast(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -2,11 +2,6 @@
 
 // Odd K that forbids vectorization.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -14,27 +9,17 @@
     max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384,
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
-func.func @batch_matmul_1x3x32() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c32 = arith.constant 32 : index
-  %c3 = arith.constant 3 : index
-  %c1 = arith.constant 1 : index
+func.func @batch_matmul_1x3x32(%3: tensor<1x3x3xf32>, %4: tensor<1x3x32xf32>) -> tensor<1x3x32xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x32xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x3x32xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1, 3, 3], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x3xf32>> -> tensor<1x3x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1, 3, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x32xf32>> -> tensor<1x3x32xf32>
   %5 = tensor.empty() : tensor<1x3x32xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x3x32xf32>) -> tensor<1x3x32xf32>
   %7 = linalg.batch_matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<1x3x3xf32>, tensor<1x3x32xf32>) outs(%6 : tensor<1x3x32xf32>) -> tensor<1x3x32xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [1, 3, 32], strides = [1, 1, 1] : tensor<1x3x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x3x32xf32>>
-  return
+  return %7 : tensor<1x3x32xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 32], [0, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [32, 1, 1]>
-//       CHECK: func.func @batch_matmul_1x3x32()
+//       CHECK: func.func @batch_matmul_1x3x32(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -43,11 +28,6 @@ func.func @batch_matmul_1x3x32() attributes {hal.executable.target = #executable
 
 // 8-bit integers can be vectorized.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -55,26 +35,17 @@ func.func @batch_matmul_1x3x32() attributes {hal.executable.target = #executable
     max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384,
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
-func.func @matmul_64x16xi8() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c16 = arith.constant 16 : index
-  %c64 = arith.constant 64 : index
+func.func @matmul_64x16xi8(%3: tensor<64x32xi8>, %4: tensor<32x16xi8>) -> tensor<64x16xi32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %c0_i32 = arith.constant 0 : i32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x32xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x16xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x16xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x32xi8>> -> tensor<64x32xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32, 16], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x16xi8>> -> tensor<32x16xi8>
   %5 = tensor.empty() : tensor<64x16xi32>
   %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<64x16xi32>) -> tensor<64x16xi32>
   %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<64x32xi8>, tensor<32x16xi8>) outs(%6 : tensor<64x16xi32>) -> tensor<64x16xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 16], strides = [1, 1] : tensor<64x16xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x16xi32>>
-  return
+  return %7 : tensor<64x16xi32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 16], [2, 8], [0, 0, 8]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 32, 1]>
-//       CHECK: func.func @matmul_64x16xi8()
+//       CHECK: func.func @matmul_64x16xi8(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -83,11 +54,6 @@ func.func @matmul_64x16xi8() attributes {hal.executable.target = #executable_tar
 
 // Vectorize non-32 bit types.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int64|int32, storage = b32, subgroup = none,
@@ -95,26 +61,17 @@ func.func @matmul_64x16xi8() attributes {hal.executable.target = #executable_tar
     max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384,
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
-func.func @matmul_64x16xi64() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c16 = arith.constant 16 : index
-  %c64 = arith.constant 64 : index
+func.func @matmul_64x16xi64(%3: tensor<64x32xi64>, %4: tensor<32x16xi64>) -> tensor<64x16xi64> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %c0_i32 = arith.constant 0 : i32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x32xi64>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x16xi64>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x16xi64>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 32], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x32xi64>> -> tensor<64x32xi64>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32, 16], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x16xi64>> -> tensor<32x16xi64>
   %5 = tensor.empty() : tensor<64x16xi64>
   %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<64x16xi64>) -> tensor<64x16xi64>
   %7 = linalg.matmul ins(%3, %4 : tensor<64x32xi64>, tensor<32x16xi64>) outs(%6 : tensor<64x16xi64>) -> tensor<64x16xi64>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 16], strides = [1, 1] : tensor<64x16xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x16xi64>>
-  return
+  return %7 : tensor<64x16xi64>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16], [1, 4], [0, 0, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [4, 16, 1]>
-//       CHECK: func.func @matmul_64x16xi64()
+//       CHECK: func.func @matmul_64x16xi64(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -123,11 +80,6 @@ func.func @matmul_64x16xi64() attributes {hal.executable.target = #executable_ta
 
 // Odd N that forbids vectorization.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -137,20 +89,9 @@ func.func @matmul_64x16xi64() attributes {hal.executable.target = #executable_ta
 }>
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-func.func @matmul_400x273() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c11775744 = arith.constant 11775744 : index
+func.func @matmul_400x273(%4: tensor<273xf32>, %6: tensor<400x576xf32>, %7: tensor<576x273xf32>) -> tensor<400x273xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %c400 = arith.constant 400 : index
-  %c273 = arith.constant 273 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c11775744) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<273xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<400x576xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x273xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<400x273xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [273], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<273xf32>> -> tensor<273xf32>
   %5 = tensor.empty() : tensor<400x273xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [400, 576], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<400x576xf32>> -> tensor<400x576xf32>
-  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [576, 273], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x273xf32>> -> tensor<576x273xf32>
   %8 = tensor.empty() : tensor<400x273xf32>
   %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<400x273xf32>) -> tensor<400x273xf32>
   %10 = linalg.matmul ins(%6, %7 : tensor<400x576xf32>, tensor<576x273xf32>) outs(%9 : tensor<400x273xf32>) -> tensor<400x273xf32>
@@ -159,13 +100,12 @@ func.func @matmul_400x273() attributes {hal.executable.target = #executable_targ
     %12 = arith.addf %in, %in_0 : f32
     linalg.yield %12 : f32
   } -> tensor<400x273xf32>
-  iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [400, 273], strides = [1, 1] : tensor<400x273xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<400x273xf32>>
-  return
+  return %11 : tensor<400x273xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 32], [1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [32, 2, 1]>
-//       CHECK: func.func @matmul_400x273()
+//       CHECK: func.func @matmul_400x273(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -175,11 +115,6 @@ func.func @matmul_400x273() attributes {hal.executable.target = #executable_targ
 
 // Odd M and non-4-multiplier N
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -189,20 +124,9 @@ func.func @matmul_400x273() attributes {hal.executable.target = #executable_targ
 }>
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-func.func @matmul_25x546() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
-  %c15842560 = arith.constant 15842560 : index
+func.func @matmul_25x546(%4: tensor<546xf32>, %6: tensor<25x512xf32>, %7: tensor<512x546xf32>) -> tensor<25x546xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %c25 = arith.constant 25 : index
-  %c546 = arith.constant 546 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%c15842560) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<546xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<25x512xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x546xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<25x546xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [546], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<546xf32>> -> tensor<546xf32>
   %5 = tensor.empty() : tensor<25x546xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [25, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<25x512xf32>> -> tensor<25x512xf32>
-  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [512, 546], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x546xf32>> -> tensor<512x546xf32>
   %8 = tensor.empty() : tensor<25x546xf32>
   %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<25x546xf32>) -> tensor<25x546xf32>
   %10 = linalg.matmul ins(%6, %7 : tensor<25x512xf32>, tensor<512x546xf32>) outs(%9 : tensor<25x546xf32>) -> tensor<25x546xf32>
@@ -211,13 +135,12 @@ func.func @matmul_25x546() attributes {hal.executable.target = #executable_targe
     %12 = arith.addf %in, %in_0 : f32
     linalg.yield %12 : f32
   } -> tensor<25x546xf32>
-  iree_tensor_ext.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [25, 546], strides = [1, 1] : tensor<25x546xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<25x546xf32>>
-  return
+  return %11 : tensor<25x546xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 2], [1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [2, 32, 1]>
-//       CHECK: func.func @matmul_25x546()
+//       CHECK: func.func @matmul_25x546(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -227,13 +150,6 @@ func.func @matmul_25x546() attributes {hal.executable.target = #executable_targe
 
 // Matmul with consumer pointwise ops
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = none,
@@ -242,21 +158,9 @@ func.func @matmul_25x546() attributes {hal.executable.target = #executable_targe
     max_workgroup_counts = [65535, 65535, 65535]>>
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @matmul_pointwise_256x1024() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @matmul_pointwise_256x1024(%5: tensor<256x1024xf16>, %6: tensor<256x1024xf16>, %8: tensor<256x128xf16>, %9: tensor<128x1024xf16>) -> tensor<256x1024xf16> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f16
-  %c256 = arith.constant 256 : index
-  %c1024 = arith.constant 1024 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
   %7 = tensor.empty() : tensor<256x1024xf16>
-  %8 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>> -> tensor<256x128xf16>
-  %9 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>> -> tensor<128x1024xf16>
   %10 = tensor.empty() : tensor<256x1024xf16>
   %11 = linalg.fill ins(%cst : f16) outs(%10 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
   %12 = linalg.matmul ins(%8, %9 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%11 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
@@ -266,13 +170,12 @@ func.func @matmul_pointwise_256x1024() attributes {hal.executable.target = #exec
     %15 = arith.subf %14, %in_1 : f16
     linalg.yield %15 : f16
   } -> tensor<256x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  return
+  return %13 : tensor<256x1024xf16>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 8]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 2, 1]>
-//       CHECK: func.func @matmul_pointwise_256x1024()
+//       CHECK: func.func @matmul_pointwise_256x1024(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_misc.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_misc.mlir
@@ -1,27 +1,11 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @complex_view_as_real() {
+func.func @complex_view_as_real(%4: tensor<1xi32>, %5: tensor<1x1x32x50x2xf32>, %9: tensor<50xcomplex<f32>>) -> tensor<32x50x2xf32> {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1xi32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x50xcomplex<f32>>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x32x50x2xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x50x2xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [1], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1xi32>> -> tensor<1xi32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0, 0, 0], sizes = [1, 1, 32, 50, 2], strides = [1, 1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x1x32x50x2xf32>> -> tensor<1x1x32x50x2xf32>
   %6 = tensor.empty() : tensor<32x50x2xf32>
-  %extracted = tensor.extract %4[%c0] : tensor<1xi32>
-  %7 = arith.extsi %extracted : i32 to i64
-  %8 = arith.index_cast %7 : i64 to index
-  %9 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [%8, 0], sizes = [1, 50], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x50xcomplex<f32>>> -> tensor<50xcomplex<f32>>
   %10 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%9 : tensor<50xcomplex<f32>>) outs(%6 : tensor<32x50x2xf32>) {
   ^bb0(%in: complex<f32>, %out: f32):
     %11 = linalg.index 0 : index
@@ -37,13 +21,12 @@ func.func @complex_view_as_real() {
     %19 = arith.select %18, %15, %16 : f32
     linalg.yield %19 : f32
   } -> tensor<32x50x2xf32>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0], sizes = [32, 50, 2], strides = [1, 1, 1] : tensor<32x50x2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x50x2xf32>>
-  return
+  return %10 : tensor<32x50x2xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 2, 2], [1, 1, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseDistribute workgroup_size = [2, 2, 16]>
-//      CHECK: func.func @complex_view_as_real()
+//      CHECK: func.func @complex_view_as_real(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_reduction.mlir
@@ -1,9 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = shuffle,
@@ -13,36 +9,27 @@
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @subgroup_reduce_f32() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c0 = arith.constant 0 : index
+func.func @subgroup_reduce_f32(%arg0: tensor<2x512xf32>) -> tensor<2xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x512xf32>> -> tensor<2x512xf32>
-  %3 = tensor.empty() : tensor<2xf32>
-  %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<2xf32>) -> tensor<2xf32>
-  %5 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<2x512xf32>) outs(%4 : tensor<2xf32>) {
+  %0 = tensor.empty() : tensor<2xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2xf32>) -> tensor<2xf32>
+  %2 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<2x512xf32>) outs(%1 : tensor<2xf32>) {
   ^bb0(%in: f32, %out: f32):
-    %6 = arith.addf %out, %in : f32
-    linalg.yield %6 : f32
+    %3 = arith.addf %out, %in : f32
+    linalg.yield %3 : f32
   } -> tensor<2xf32>
-  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [2], strides = [1] : tensor<2xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2xf32>>
-  return
+  return %2 : tensor<2xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1], [0, 512]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVSubgroupReduce workgroup_size = [128, 1, 1]>
-//      CHECK: func.func @subgroup_reduce_f32()
+//      CHECK: func.func @subgroup_reduce_f32(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
     compute = fp32|int32, storage = b32, subgroup = shuffle,
@@ -52,42 +39,33 @@ func.func @subgroup_reduce_f32() attributes {hal.executable.target = #executable
 }>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @subgroup_reduce_f16() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
+func.func @subgroup_reduce_f16(%arg0: tensor<16x4096x4096xf16>) -> tensor<16x4096x4096xf16> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f16
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x4096x4096xf16>>
-  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 4096, 4096], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x4096x4096xf16>> -> tensor<16x4096x4096xf16>
-  %3 = tensor.empty() : tensor<16x4096x4096xf16>
-  %4 = tensor.empty() : tensor<16x4096xf16>
-  %5 = linalg.fill ins(%cst : f16) outs(%4 : tensor<16x4096xf16>) -> tensor<16x4096xf16>
-  %6 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%2 : tensor<16x4096x4096xf16>) outs(%5 : tensor<16x4096xf16>) {
+  %0 = tensor.empty() : tensor<16x4096x4096xf16>
+  %1 = tensor.empty() : tensor<16x4096xf16>
+  %2 = linalg.fill ins(%cst : f16) outs(%1 : tensor<16x4096xf16>) -> tensor<16x4096xf16>
+  %3 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0 : tensor<16x4096x4096xf16>) outs(%2 : tensor<16x4096xf16>) {
   ^bb0(%in: f16, %out: f16):
-    %8 = arith.addf %in, %out : f16
-    linalg.yield %8 : f16
+    %5 = arith.addf %in, %out : f16
+    linalg.yield %5 : f16
   } -> tensor<16x4096xf16>
-  %7 = linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%2, %6 : tensor<16x4096x4096xf16>, tensor<16x4096xf16>) outs(%3 : tensor<16x4096x4096xf16>) {
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %3 : tensor<16x4096x4096xf16>, tensor<16x4096xf16>) outs(%0 : tensor<16x4096x4096xf16>) {
   ^bb0(%in: f16, %in_0: f16, %out: f16):
-    %8 = arith.divf %in, %in_0 : f16
-    linalg.yield %8 : f16
+    %5 = arith.divf %in, %in_0 : f16
+    linalg.yield %5 : f16
   } -> tensor<16x4096x4096xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %1, offsets = [0, 0, 0], sizes = [16, 4096, 4096], strides = [1, 1, 1] : tensor<16x4096x4096xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x4096x4096xf16>>
-  return
+  return %4 : tensor<16x4096x4096xf16>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 512]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVSubgroupReduce workgroup_size = [64, 1, 1]>
-//      CHECK: func.func @subgroup_reduce_f16()
+//      CHECK: func.func @subgroup_reduce_f16(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #config = #iree_codegen.lowering_config<tile_sizes = [[1], [0, 64]]>
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
   iree_codegen.target_info = #iree_gpu.target<arch = "", features = "spirv:v1.6,cap:Shader", wgp = <
@@ -98,37 +76,23 @@ func.func @subgroup_reduce_f16() attributes {hal.executable.target = #executable
 }>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @subgroup_reduce_dynamic() attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
-  %c32_i64 = arith.constant 32 : i64
+func.func @subgroup_reduce_dynamic(%arg0: tensor<8x?xf32>) -> tensor<8xf32> attributes {hal.executable.target = #executable_target_vulkan_spirv_fb} {
   %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 2.000000e+00 : f32
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-  %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-  %2 = arith.extui %0 : i32 to i64
-  %3 = arith.extui %1 : i32 to i64
-  %4 = arith.shli %3, %c32_i64 : i64
-  %5 = arith.ori %2, %4 : i64
-  %6 = arith.index_castui %5 : i64 to index
-  %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
-  %8 = iree_tensor_ext.dispatch.workload.ordinal %6, 0 : index
-  %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x?xf32>>{%8}
-  %10 = iree_tensor_ext.dispatch.tensor.load %9, offsets = [0, 0], sizes = [8, %8], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x?xf32>>{%8} -> tensor<8x?xf32>
-  %11 = tensor.empty() : tensor<8xf32>
-  %12 = linalg.fill {lowering_config = #config} ins(%cst : f32) outs(%11 : tensor<8xf32>) -> tensor<8xf32>
-  %13 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%10 : tensor<8x?xf32>) outs(%12 : tensor<8xf32>) attrs =  {lowering_config = #config} {
+  %0 = tensor.empty() : tensor<8xf32>
+  %1 = linalg.fill {lowering_config = #config} ins(%cst : f32) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+  %2 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "reduction"]} ins(%arg0 : tensor<8x?xf32>) outs(%1 : tensor<8xf32>) attrs =  {lowering_config = #config} {
   ^bb0(%in: f32, %out: f32):
-    %14 = math.powf %in, %cst_0 : f32
-    %15 = arith.addf %14, %out : f32
-    linalg.yield %15 : f32
+    %3 = math.powf %in, %cst_0 : f32
+    %4 = arith.addf %3, %out : f32
+    linalg.yield %4 : f32
   } -> tensor<8xf32>
-  iree_tensor_ext.dispatch.tensor.store %13, %7, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
-  return
+  return %2 : tensor<8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1], [0, 64]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVSubgroupReduce workgroup_size = [64, 1, 1]>
-//      CHECK: func.func @subgroup_reduce_dynamic()
+//      CHECK: func.func @subgroup_reduce_dynamic(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_sub_byte_types.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_sub_byte_types.mlir
@@ -1,22 +1,8 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
-func.func @i4_dequant() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072x128xi4>> -> tensor<131072x128xi4>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0], sizes = [131072], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131072xf32>> -> tensor<131072xf32>
+func.func @i4_dequant(%4: tensor<131072x128xi4>, %5: tensor<131072xf32>, %6: tensor<131072xf32>) -> tensor<131072x128xf32> {
   %7 = tensor.empty() : tensor<131072x128xf32>
   %8 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %5, %6 : tensor<131072x128xi4>, tensor<131072xf32>, tensor<131072xf32>) outs(%7 : tensor<131072x128xf32>) {
   ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
@@ -26,13 +12,12 @@ func.func @i4_dequant() {
     %12 = arith.mulf %11, %in_0 : f32
     linalg.yield %12 : f32
   } -> tensor<131072x128xf32>
-  iree_tensor_ext.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [131072, 128], strides = [1, 1] : tensor<131072x128xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<131072x128xf32>>
-  return
+  return %8 : tensor<131072x128xf32>
 }
 
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 128], [2, 8]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 4, 1]>
-//       CHECK: func.func @i4_dequant()
+//       CHECK: func.func @i4_dequant(
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -2,31 +2,17 @@
 
 // Conv - large OC - distribute to only one workgroup dimension.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_112x112x512() {
-  %c0 = arith.constant 0 : index
-  %c512 = arith.constant 512 : index
-  %c112 = arith.constant 112 : index
+func.func @conv_112x112x512(%arg0: tensor<1x225x225x3xf32>, %arg1: tensor<3x3x3x512xf32>) -> tensor<1x112x112x512xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x512xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 512], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x512xf32>> -> tensor<3x3x3x512xf32>
-  %5 = tensor.empty() : tensor<1x112x112x512xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x512xf32>) outs(%6 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 512], strides = [1, 1, 1, 1] : tensor<1x112x112x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x512xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x112x112x512xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x225x225x3xf32>, tensor<3x3x3x512xf32>) outs(%1 : tensor<1x112x112x512xf32>) -> tensor<1x112x112x512xf32>
+  return %2 : tensor<1x112x112x512xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 4, 64], [1, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 1, 1]>
-//      CHECK: func.func @conv_112x112x512()
+//      CHECK: func.func @conv_112x112x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -35,31 +21,17 @@ func.func @conv_112x112x512() {
 
 // Conv - medium OC/OW/OH - distribute to two workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_112x112x32() {
-  %c0 = arith.constant 0 : index
-  %c32 = arith.constant 32 : index
-  %c112 = arith.constant 112 : index
+func.func @conv_112x112x32(%arg0: tensor<1x225x225x3xf32>, %arg1: tensor<3x3x3x32xf32>) -> tensor<1x112x112x32xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x225x225x3xf32>> -> tensor<1x225x225x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x32xf32>> -> tensor<3x3x3x32xf32>
-  %5 = tensor.empty() : tensor<1x112x112x32xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%6 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x112x112x32xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x112x112x32xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%1 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  return %2 : tensor<1x112x112x32xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 32], [1, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @conv_112x112x32()
+//      CHECK: func.func @conv_112x112x32(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -68,30 +40,17 @@ func.func @conv_112x112x32() {
 
 // Conv - small OC/OW/OH - distribute to all three workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @conv_16x16x16() {
-  %c0 = arith.constant 0 : index
-  %c16 = arith.constant 16 : index
+func.func @conv_16x16x16(%arg0: tensor<1x33x33x3xf32>, %arg1: tensor<3x3x3x16xf32>) -> tensor<1x16x16x16xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33x33x3xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 33, 33, 3], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33x33x3xf32>> -> tensor<1x33x33x3xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 16], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x3x16xf32>> -> tensor<3x3x3x16xf32>
-  %5 = tensor.empty() : tensor<1x16x16x16xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
-  %7 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x33x33x3xf32>, tensor<3x3x3x16xf32>) outs(%6 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 16, 16, 16], strides = [1, 1, 1, 1] : tensor<1x16x16x16xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x16x16x16xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x16x16x16xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  %2 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x33x33x3xf32>, tensor<3x3x3x16xf32>) outs(%1 : tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %2 : tensor<1x16x16x16xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [4, 2, 2]>
-//      CHECK: func.func @conv_16x16x16()
+//      CHECK: func.func @conv_16x16x16(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -100,31 +59,17 @@ func.func @conv_16x16x16() {
 
 // Depthwise conv - small OC/OW/OH - distribute to all three workgroup dimensions.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @dwconv_28x28x144() {
-  %c0 = arith.constant 0 : index
-  %c144 = arith.constant 144 : index
-  %c28 = arith.constant 28 : index
+func.func @dwconv_28x28x144(%arg0: tensor<1x57x57x144xf32>, %arg1: tensor<3x3x144xf32>) -> tensor<1x28x28x144xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x57x57x144xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x144xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [0, 57, 57, 144], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x57x57x144xf32>> -> tensor<1x57x57x144xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 144], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x144xf32>> -> tensor<3x3x144xf32>
-  %5 = tensor.empty() : tensor<1x28x28x144xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
-  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x57x57x144xf32>, tensor<3x3x144xf32>) outs(%6 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 28, 28, 144], strides = [1, 1, 1, 1] : tensor<1x28x28x144xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x28x28x144xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x28x28x144xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  %2 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x57x57x144xf32>, tensor<3x3x144xf32>) outs(%1 : tensor<1x28x28x144xf32>) -> tensor<1x28x28x144xf32>
+  return %2 : tensor<1x28x28x144xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [4, 2, 2]>
-//      CHECK: func.func @dwconv_28x28x144()
+//      CHECK: func.func @dwconv_28x28x144(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -133,32 +78,17 @@ func.func @dwconv_28x28x144() {
 
 // Depthwise conv - tiny OC/OW/OH - starving the GPU.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @dwconv_1x2x8() {
-  %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c2 = arith.constant 2 : index
-  %c1 = arith.constant 1 : index
+func.func @dwconv_1x2x8(%arg0: tensor<1x3x5x8xf32>, %arg1: tensor<3x3x8xf32>) -> tensor<1x1x2x8xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x5x8xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x8xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x2x8xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 3, 5, 8], strides = [1, 1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x3x5x8xf32>> -> tensor<1x3x5x8xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 8], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3x3x8xf32>> -> tensor<3x3x8xf32>
-  %5 = tensor.empty() : tensor<1x1x2x8xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
-  %7 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x3x5x8xf32>, tensor<3x3x8xf32>) outs(%6 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 1, 2, 8], strides = [1, 1, 1, 1] : tensor<1x1x2x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x1x2x8xf32>>
-  return
+  %0 = tensor.empty() : tensor<1x1x2x8xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+  %2 = linalg.depthwise_conv_2d_nhwc_hwc {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x3x5x8xf32>, tensor<3x3x8xf32>) outs(%1 : tensor<1x1x2x8xf32>) -> tensor<1x1x2x8xf32>
+  return %2 : tensor<1x1x2x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 2, 1]>
-//      CHECK: func.func @dwconv_1x2x8()
+//      CHECK: func.func @dwconv_1x2x8(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -7,26 +7,20 @@
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_1024x2048x512() {
+func.func @matmul_1024x2048x512(%arg0: tensor<1024x512xf32>, %arg1: tensor<512x2048xf32>) -> tensor<1024x2048xf32> {
   %c0 = arith.constant 0 : index
   %c2048 = arith.constant 2048 : index
   %c1024 = arith.constant 1024 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xf32>> -> tensor<512x2048xf32>
   %5 = tensor.empty() : tensor<1024x2048xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
-  %7 = linalg.matmul ins(%3, %4 : tensor<1024x512xf32>, tensor<512x2048xf32>) outs(%6 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : tensor<1024x2048xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xf32>>
-  return
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x512xf32>, tensor<512x2048xf32>) outs(%6 : tensor<1024x2048xf32>) -> tensor<1024x2048xf32>
+  return %7 : tensor<1024x2048xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @matmul_1024x2048x512()
+//      CHECK: func.func @matmul_1024x2048x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -40,26 +34,20 @@ func.func @matmul_1024x2048x512() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_3136x24x96() {
+func.func @matmul_3136x24x96(%arg0: tensor<3136x96xf32>, %arg1: tensor<96x24xf32>) -> tensor<3136x24xf32> {
   %c0 = arith.constant 0 : index
   %c24 = arith.constant 24 : index
   %c3136 = arith.constant 3136 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3136x96xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<96x24xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3136x24xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [3136, 96], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3136x96xf32>> -> tensor<3136x96xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [96, 24], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<96x24xf32>> -> tensor<96x24xf32>
   %5 = tensor.empty() : tensor<3136x24xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
-  %7 = linalg.matmul ins(%3, %4 : tensor<3136x96xf32>, tensor<96x24xf32>) outs(%6 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [3136, 24], strides = [1, 1] : tensor<3136x24xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3136x24xf32>>
-  return
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<3136x96xf32>, tensor<96x24xf32>) outs(%6 : tensor<3136x24xf32>) -> tensor<3136x24xf32>
+  return %7 : tensor<3136x24xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 8], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 8, 1]>
-//      CHECK: func.func @matmul_3136x24x96()
+//      CHECK: func.func @matmul_3136x24x96(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -73,26 +61,20 @@ func.func @matmul_3136x24x96() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_196x64x192() {
+func.func @matmul_196x64x192(%arg0: tensor<196x192xf32>, %arg1: tensor<192x64xf32>) -> tensor<196x64xf32> {
   %c0 = arith.constant 0 : index
   %c64 = arith.constant 64 : index
   %c196 = arith.constant 196 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<196x192xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<192x64xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<196x64xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [196, 192], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<196x192xf32>> -> tensor<196x192xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [192, 64], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<192x64xf32>> -> tensor<192x64xf32>
   %5 = tensor.empty() : tensor<196x64xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<196x64xf32>) -> tensor<196x64xf32>
-  %7 = linalg.matmul ins(%3, %4 : tensor<196x192xf32>, tensor<192x64xf32>) outs(%6 : tensor<196x64xf32>) -> tensor<196x64xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [196, 64], strides = [1, 1] : tensor<196x64xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<196x64xf32>>
-  return
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<196x192xf32>, tensor<192x64xf32>) outs(%6 : tensor<196x64xf32>) -> tensor<196x64xf32>
+  return %7 : tensor<196x64xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 32], [2, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @matmul_196x64x192()
+//      CHECK: func.func @matmul_196x64x192(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:        lowering_config = #[[CONFIG]]
@@ -121,7 +103,7 @@ func.func @matmul_12544x96x16() {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 32], [4, 4], [0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @matmul_12544x96x16()
+//      CHECK: func.func @matmul_12544x96x16(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -135,26 +117,20 @@ func.func @matmul_12544x96x16() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_49x160x576() {
+func.func @matmul_49x160x576(%arg0: tensor<49x576xf32>, %arg1: tensor<576x160xf32>) -> tensor<49x160xf32> {
   %c0 = arith.constant 0 : index
   %c160 = arith.constant 160 : index
   %c49 = arith.constant 49 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<49x576xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x160xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<49x160xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [49, 576], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<49x576xf32>> -> tensor<49x576xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [576, 160], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x160xf32>> -> tensor<576x160xf32>
   %5 = tensor.empty() : tensor<49x160xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<49x160xf32>) -> tensor<49x160xf32>
-  %7 = linalg.matmul ins(%3, %4 : tensor<49x576xf32>, tensor<576x160xf32>) outs(%6 : tensor<49x160xf32>) -> tensor<49x160xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [49, 160], strides = [1, 1] : tensor<49x160xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<49x160xf32>>
-  return
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<49x576xf32>, tensor<576x160xf32>) outs(%6 : tensor<49x160xf32>) -> tensor<49x160xf32>
+  return %7 : tensor<49x160xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32], [1, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 1, 1]>
-//      CHECK: func.func @matmul_49x160x576()
+//      CHECK: func.func @matmul_49x160x576(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -168,7 +144,7 @@ func.func @matmul_49x160x576() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_2x1024x576() {
+func.func @matmul_2x1024x576(%arg0: tensor<2x576xf32>, %arg1: tensor<576x1024xf32>, %arg2: tensor<2x1024xf32>) -> tensor<2x1024xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %cst_0 = arith.constant 3.000000e+00 : f32
   %cst_1 = arith.constant 6.000000e+00 : f32
@@ -177,23 +153,15 @@ func.func @matmul_2x1024x576() {
   %c3436864 = arith.constant 3436864 : index
   %c10141312 = arith.constant 10141312 : index
   %c2304 = arith.constant 2304 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x576xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c3436864) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x1024xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c10141312) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 576], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x576xf32>> -> tensor<2x576xf32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [576, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<576x1024xf32>> -> tensor<576x1024xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x1024xf32>> -> tensor<2x1024xf32>
   %7 = tensor.empty() : tensor<2x1024xf32>
   %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<2x1024xf32>) -> tensor<2x1024xf32>
-  %9 = linalg.matmul ins(%4, %5 : tensor<2x576xf32>, tensor<576x1024xf32>) outs(%8 : tensor<2x1024xf32>) -> tensor<2x1024xf32>
-  iree_tensor_ext.dispatch.tensor.store %9, %3, offsets = [0, 0], sizes = [2, 1024], strides = [1, 1] : tensor<2x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2x1024xf32>>
-  return
+  %9 = linalg.matmul ins(%arg0, %arg1 : tensor<2x576xf32>, tensor<576x1024xf32>) outs(%8 : tensor<2x1024xf32>) -> tensor<2x1024xf32>
+  return %9 : tensor<2x1024xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 128], [2, 4], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [32, 1, 1]>
-//      CHECK: func.func @matmul_2x1024x576()
+//      CHECK: func.func @matmul_2x1024x576(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -207,21 +175,15 @@ func.func @matmul_2x1024x576() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @matmul_1024x2048x512xi8() {
+func.func @matmul_1024x2048x512xi8(%arg0: tensor<1024x512xi8>, %arg1: tensor<512x2048xi8>) -> tensor<1024x2048xi32> {
   %c0 = arith.constant 0 : index
   %c2048 = arith.constant 2048 : index
   %c1024 = arith.constant 1024 : index
   %c0_i32 = arith.constant 0 : i32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xi8>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xi8>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x512xi8>> -> tensor<1024x512xi8>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 2048], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x2048xi8>> -> tensor<512x2048xi8>
   %5 = tensor.empty() : tensor<1024x2048xi32>
   %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<1024x2048xi32>) -> tensor<1024x2048xi32>
-  %7 = linalg.matmul ins(%3, %4 : tensor<1024x512xi8>, tensor<512x2048xi8>) outs(%6 : tensor<1024x2048xi32>) -> tensor<1024x2048xi32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : tensor<1024x2048xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1024x2048xi32>>
-  return
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x512xi8>, tensor<512x2048xi8>) outs(%6 : tensor<1024x2048xi32>) -> tensor<1024x2048xi32>
+  return %7 : tensor<1024x2048xi32>
 }
 
 // -----
@@ -231,26 +193,20 @@ func.func @matmul_1024x2048x512xi8() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @batch_matmul_4x384x384() {
+func.func @batch_matmul_4x384x384(%arg0: tensor<4x384x32xf32>, %arg1: tensor<4x32x384xf32>) -> tensor<4x384x384xf32> {
   %c0 = arith.constant 0 : index
   %c384 = arith.constant 384 : index
   %c4 = arith.constant 4 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x384x32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x384xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x384x384xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4, 384, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x384x32xf32>> -> tensor<4x384x32xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4, 32, 384], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x384xf32>> -> tensor<4x32x384xf32>
   %5 = tensor.empty() : tensor<4x384x384xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
-  %7 = linalg.batch_matmul ins(%3, %4 : tensor<4x384x32xf32>, tensor<4x32x384xf32>) outs(%6 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [4, 384, 384], strides = [1, 1, 1] : tensor<4x384x384xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x384x384xf32>>
-  return
+  %7 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<4x384x32xf32>, tensor<4x32x384xf32>) outs(%6 : tensor<4x384x384xf32>) -> tensor<4x384x384xf32>
+  return %7 : tensor<4x384x384xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 12, 32], [1, 6, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @batch_matmul_4x384x384()
+//      CHECK: func.func @batch_matmul_4x384x384(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -264,27 +220,21 @@ func.func @batch_matmul_4x384x384() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @batch_matmul_4x2x8() {
+func.func @batch_matmul_4x2x8(%arg0: tensor<4x2x32xf32>, %arg1: tensor<4x32x8xf32>) -> tensor<4x2x8xf32> {
   %c0 = arith.constant 0 : index
   %c8 = arith.constant 8 : index
   %c2 = arith.constant 2 : index
   %c4 = arith.constant 4 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x2x32xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x8xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x2x8xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4, 2, 32], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x2x32xf32>> -> tensor<4x2x32xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [4, 32, 8], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x32x8xf32>> -> tensor<4x32x8xf32>
   %5 = tensor.empty() : tensor<4x2x8xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<4x2x8xf32>) -> tensor<4x2x8xf32>
-  %7 = linalg.batch_matmul ins(%3, %4 : tensor<4x2x32xf32>, tensor<4x32x8xf32>) outs(%6 : tensor<4x2x8xf32>) -> tensor<4x2x8xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [4, 2, 8], strides = [1, 1, 1] : tensor<4x2x8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x2x8xf32>>
-  return
+  %7 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<4x2x32xf32>, tensor<4x32x8xf32>) outs(%6 : tensor<4x2x8xf32>) -> tensor<4x2x8xf32>
+  return %7 : tensor<4x2x8xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 2, 8], [1, 1, 4], [0, 0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [2, 2, 1]>
-//      CHECK: func.func @batch_matmul_4x2x8()
+//      CHECK: func.func @batch_matmul_4x2x8(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -304,29 +254,23 @@ func.func @batch_matmul_4x2x8() {
 #map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map4 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map5 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @generic_batch_matmul_32x2x512() {
+func.func @generic_batch_matmul_32x2x512(%arg0: tensor<8x32x64xf32>, %arg1: tensor<32x64x512xf32>) -> tensor<32x8x512xf32> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x32x64xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x8x512xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 32, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x32x64xf32>> -> tensor<8x32x64xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [32, 64, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf32>> -> tensor<32x64x512xf32>
   %5 = tensor.empty() : tensor<32x8x512xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<32x8x512xf32>) -> tensor<32x8x512xf32>
-  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<8x32x64xf32>, tensor<32x64x512xf32>) outs(%6 : tensor<32x8x512xf32>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
+  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x64xf32>, tensor<32x64x512xf32>) outs(%6 : tensor<32x8x512xf32>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %8 = arith.mulf %in, %in_0 : f32
     %9 = arith.addf %out, %8 : f32
     linalg.yield %9 : f32
   } -> tensor<32x8x512xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [32, 8, 512], strides = [1, 1, 1] : tensor<32x8x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x8x512xf32>>
-  return
+  return %7 : tensor<32x8x512xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8, 32], [1, 4, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @generic_batch_matmul_32x2x512()
+//      CHECK: func.func @generic_batch_matmul_32x2x512(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -345,41 +289,31 @@ func.func @generic_batch_matmul_32x2x512() {
 #map1 = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @generic_batch_matmul_8x2500x512x4608() {
+func.func @generic_batch_matmul_8x2500x512x4608(%arg0: tensor<8x2500x4608xf32>, %arg1: tensor<4608x512xf32>, %arg2: tensor<8x2500x512xf32>, %arg3: tensor<8x2500x512xf32>) -> tensor<8x2500x512xf32> {
   %c168607744 = arith.constant 168607744 : index
   %c537247744 = arith.constant 537247744 : index
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c168607744) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x4608xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4608x512xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c537247744) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x512xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x512xf32>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x2500x512xf32>>
-  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [8, 2500, 4608], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x4608xf32>> -> tensor<8x2500x4608xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4608, 512], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4608x512xf32>> -> tensor<4608x512xf32>
-  %7 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [8, 2500, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x512xf32>> -> tensor<8x2500x512xf32>
-  %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0, 0], sizes = [8, 2500, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x2500x512xf32>> -> tensor<8x2500x512xf32>
   %9 = tensor.empty() : tensor<8x2500x512xf32>
   %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<8x2500x512xf32>) -> tensor<8x2500x512xf32>
-  %11 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%5, %6 : tensor<8x2500x4608xf32>, tensor<4608x512xf32>) outs(%10 : tensor<8x2500x512xf32>) {
+  %11 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x2500x4608xf32>, tensor<4608x512xf32>) outs(%10 : tensor<8x2500x512xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %13 = arith.mulf %in, %in_0 : f32
     %14 = arith.addf %13, %out : f32
     linalg.yield %14 : f32
   } -> tensor<8x2500x512xf32>
-  %12 = linalg.generic {indexing_maps = [#map3, #map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel"]} ins(%11, %7, %8 : tensor<8x2500x512xf32>, tensor<8x2500x512xf32>, tensor<8x2500x512xf32>) outs(%9 : tensor<8x2500x512xf32>) {
+  %12 = linalg.generic {indexing_maps = [#map3, #map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel"]} ins(%11, %arg2, %arg3 : tensor<8x2500x512xf32>, tensor<8x2500x512xf32>, tensor<8x2500x512xf32>) outs(%9 : tensor<8x2500x512xf32>) {
   ^bb0(%in: f32, %in_0: f32, %in_1: f32, %out: f32):
     %13 = arith.addf %in, %in_0 : f32
     %14 = arith.subf %13, %in_1 : f32
     linalg.yield %14 : f32
   } -> tensor<8x2500x512xf32>
-  iree_tensor_ext.dispatch.tensor.store %12, %4, offsets = [0, 0, 0], sizes = [8, 2500, 512], strides = [1, 1, 1] : tensor<8x2500x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x2500x512xf32>>
-  return
+  return %12 : tensor<8x2500x512xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 10, 32], [1, 5, 4], [0, 0, 0, 4]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [8, 2, 1]>
-//      CHECK: func.func @generic_batch_matmul_8x2500x512x4608()
+//      CHECK: func.func @generic_batch_matmul_8x2500x512x4608(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
@@ -1,31 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=pascal@vulkan --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-generalize-named-ops),iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_4x4096x9216() {
-  %c36864 = arith.constant 36864 : index
-  %c667974912 = arith.constant 667974912 : index
-  %c209920 = arith.constant 209920 : index
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x9216xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c209920) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9216x4096xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c667974912) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c36864) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 9216], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x9216xf32>> -> tensor<4x9216xf32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [9216, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9216x4096xf32>> -> tensor<9216x4096xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x4096xf32>> -> tensor<4x4096xf32>
-  %7 = linalg.matmul ins(%4, %5 : tensor<4x9216xf32>, tensor<9216x4096xf32>) outs(%6 : tensor<4x4096xf32>) -> tensor<4x4096xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %3, offsets = [0, 0], sizes = [4, 4096], strides = [1, 1] : tensor<4x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4x4096xf32>>
-  return
+func.func @matmul_4x4096x9216(%arg0: tensor<4x9216xf32>, %arg1: tensor<9216x4096xf32>, %arg2: tensor<4x4096xf32>) -> tensor<4x4096xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<4x9216xf32>, tensor<9216x4096xf32>) outs(%arg2 : tensor<4x4096xf32>) -> tensor<4x4096xf32>
+  return %0 : tensor<4x4096xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 128, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [32, 4, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>
-//      CHECK: func.func @matmul_4x4096x9216()
+//      CHECK: func.func @matmul_4x4096x9216(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -34,32 +16,14 @@ func.func @matmul_4x4096x9216() {
 
 // Matvec does not go down matmul pipelines.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_1x4096x9216() {
-  %c36864 = arith.constant 36864 : index
-  %c667974912 = arith.constant 667974912 : index
-  %c209920 = arith.constant 209920 : index
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x9216xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c209920) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9216x4096xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c667974912) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf32>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c36864) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4096xf32>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 9216], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x9216xf32>> -> tensor<1x9216xf32>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [9216, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<9216x4096xf32>> -> tensor<9216x4096xf32>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x4096xf32>> -> tensor<1x4096xf32>
-  %7 = linalg.matmul ins(%4, %5 : tensor<1x9216xf32>, tensor<9216x4096xf32>) outs(%6 : tensor<1x4096xf32>) -> tensor<1x4096xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %3, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : tensor<1x4096xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1x4096xf32>>
-  return
+func.func @matmul_1x4096x9216(%arg0: tensor<1x9216xf32>, %arg1: tensor<9216x4096xf32>, %arg2: tensor<1x4096xf32>) -> tensor<1x4096xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<1x9216xf32>, tensor<9216x4096xf32>) outs(%arg2 : tensor<1x4096xf32>) -> tensor<1x4096xf32>
+  return %0 : tensor<1x4096xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 1024]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVSubgroupReduce workgroup_size = [256, 1, 1]>
-//      CHECK: func.func @matmul_1x4096x9216()
+//      CHECK: func.func @matmul_1x4096x9216(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
@@ -68,37 +32,25 @@ func.func @matmul_1x4096x9216() {
 
 // Multi-reduction-dimension transposed-B matmul.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
-func.func @multi_reduction_transposed_b_matmul() {
-  %c0 = arith.constant 0 : index
+func.func @multi_reduction_transposed_b_matmul(%arg0: tensor<4096x86x128xf32>, %arg1: tensor<2048x86x128xf32>) -> tensor<4096x2048xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x86x128xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x2048xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [4096, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096x86x128xf32>> -> tensor<4096x86x128xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [2048, 86, 128], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x86x128xf32>> -> tensor<2048x86x128xf32>
-  %5 = tensor.empty() : tensor<4096x2048xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<4096x2048xf32>) -> tensor<4096x2048xf32>
-  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%3, %4 : tensor<4096x86x128xf32>, tensor<2048x86x128xf32>) outs(%6 : tensor<4096x2048xf32>) {
+  %0 = tensor.empty() : tensor<4096x2048xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<4096x2048xf32>) -> tensor<4096x2048xf32>
+  %2 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<4096x86x128xf32>, tensor<2048x86x128xf32>) outs(%1 : tensor<4096x2048xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
-    %8 = arith.mulf %in, %in_0 : f32
-    %9 = arith.addf %out, %8 : f32
-    linalg.yield %9 : f32
+    %3 = arith.mulf %in, %in_0 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
   } -> tensor<4096x2048xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [4096, 2048], strides = [1, 1] : tensor<4096x2048xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4096x2048xf32>>
-  return
+  return %2 : tensor<4096x2048xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 128, 1, 32]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [32, 8, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>
-//      CHECK: func.func @multi_reduction_transposed_b_matmul()
+//      CHECK: func.func @multi_reduction_transposed_b_matmul(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -2,83 +2,52 @@
 // RUN:   --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s |  \
 // RUN:   FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @matmul_256x1024x128_div_add() {
+func.func @matmul_256x1024x128_div_add(%arg0: tensor<256x1024xf16>, %arg1: tensor<256x1024xf16>, %arg2: tensor<256x128xf16>, %arg3: tensor<128x1024xf16>) -> tensor<256x1024xf16> {
   %c0 = arith.constant 0 : index
   %c1024 = arith.constant 1024 : index
   %c256 = arith.constant 256 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(4) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  %5 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf16>> -> tensor<256x1024xf16>
   %7 = tensor.empty() : tensor<256x1024xf16>
-  %8 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x128xf16>> -> tensor<256x128xf16>
-  %9 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x1024xf16>> -> tensor<128x1024xf16>
   %10 = tensor.empty() : tensor<256x1024xf16>
   %11 = linalg.fill ins(%cst : f16) outs(%10 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %12 = linalg.matmul ins(%8, %9 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%11 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %13 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%12, %5, %6 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>) outs(%7 : tensor<256x1024xf16>) {
+  %12 = linalg.matmul ins(%arg2, %arg3 : tensor<256x128xf16>, tensor<128x1024xf16>) outs(%11 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  %13 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%12, %arg0, %arg1 : tensor<256x1024xf16>, tensor<256x1024xf16>, tensor<256x1024xf16>) outs(%7 : tensor<256x1024xf16>) {
   ^bb0(%in: f16, %in_0: f16, %in_1: f16, %out: f16):
     %14 = arith.divf %in, %in_0 : f16
     %15 = arith.addf %14, %in_1 : f16
     linalg.yield %15 : f16
   } -> tensor<256x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %13, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  return
+  return %13 : tensor<256x1024xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 32], [0, 0, 32], [16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @matmul_256x1024x128_div_add()
+//      CHECK: func.func @matmul_256x1024x128_div_add(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[$CONFIG]]
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-func.func @batch_matmul_16x128x256x512_div() {
+func.func @batch_matmul_16x128x256x512_div(%arg0: tensor<16x128x512xf16>, %arg1: tensor<16x512x256xf16>, %arg2: tensor<16x128x256xf16>) -> tensor<16x128x256xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>>
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-  %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 128, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x512xf16>> -> tensor<16x128x512xf16>
-  %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 512, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x512x256xf16>> -> tensor<16x512x256xf16>
-  %6 = iree_tensor_ext.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x128x256xf16>> -> tensor<16x128x256xf16>
   %7 = tensor.empty() : tensor<16x128x256xf16>
   %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-  %9 = linalg.batch_matmul ins(%4, %5 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%8 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
-  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%9, %6 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%7 : tensor<16x128x256xf16>) {
+  %9 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x128x512xf16>, tensor<16x512x256xf16>) outs(%8 : tensor<16x128x256xf16>) -> tensor<16x128x256xf16>
+  %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%9, %arg2 : tensor<16x128x256xf16>, tensor<16x128x256xf16>) outs(%7 : tensor<16x128x256xf16>) {
   ^bb0(%in: f16, %in_0: f16, %out: f16):
     %11 = arith.divf %in, %in_0 : f16
     linalg.yield %11 : f16
   } -> tensor<16x128x256xf16>
-  iree_tensor_ext.dispatch.tensor.store %10, %3, offsets = [0, 0, 0], sizes = [16, 128, 256], strides = [1, 1, 1] : tensor<16x128x256xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x128x256xf16>>
-  return
+  return %10 : tensor<16x128x256xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @batch_matmul_16x128x256x512_div()
+//      CHECK: func.func @batch_matmul_16x128x256x512_div(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -87,40 +56,29 @@ func.func @batch_matmul_16x128x256x512_div() {
 
 // Linalg.generic that is a batch matmul.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d0, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map4 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map5 = affine_map<(d0, d1, d2) -> (d0, d1)>
-func.func @generic_batch_matmul_32x8x512x64() {
+func.func @generic_batch_matmul_32x8x512x64(%arg0: tensor<128x32x64xf16>, %arg1: tensor<32x64x512xf16>) -> tensor<32x128x512xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x32x64xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 32, 64], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x32x64xf16>> -> tensor<128x32x64xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [32, 64, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x64x512xf16>> -> tensor<32x64x512xf16>
   %5 = tensor.empty() : tensor<32x128x512xf16>
   %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<32x128x512xf16>) -> tensor<32x128x512xf16>
-  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<128x32x64xf16>, tensor<32x64x512xf16>) outs(%6 : tensor<32x128x512xf16>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
+  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<128x32x64xf16>, tensor<32x64x512xf16>) outs(%6 : tensor<32x128x512xf16>) attrs =  {linalg.memoized_indexing_maps = [#map3, #map4, #map5]} {
   ^bb0(%in: f16, %in_0: f16, %out: f16):
     %8 = arith.mulf %in, %in_0 : f16
     %9 = arith.addf %out, %8 : f16
     linalg.yield %9 : f16
   } -> tensor<32x128x512xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [32, 128, 512], strides = [1, 1, 1] : tensor<32x128x512xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x128x512xf16>>
-  return
+  return %7 : tensor<32x128x512xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 1 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @generic_batch_matmul_32x8x512x64()
+//      CHECK: func.func @generic_batch_matmul_32x8x512x64(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -129,29 +87,18 @@ func.func @generic_batch_matmul_32x8x512x64() {
 
 // K dim size not divisble by 32.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @batch_matmul_16x1024x1024x80() {
+func.func @batch_matmul_16x1024x1024x80(%arg0: tensor<16x1024x80xf16>, %arg1: tensor<16x80x1024xf16>) -> tensor<16x1024x1024xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x1024x80xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x80x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x1024x1024xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [16, 1024, 80], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x1024x80xf16>> -> tensor<16x1024x80xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [16, 80, 1024], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16x80x1024xf16>> -> tensor<16x80x1024xf16>
   %5 = tensor.empty() : tensor<16x1024x1024xf16>
   %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
-  %7 = linalg.batch_matmul ins(%3, %4 : tensor<16x1024x80xf16>, tensor<16x80x1024xf16>) outs(%6 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [16, 1024, 1024], strides = [1, 1, 1] : tensor<16x1024x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x1024x1024xf16>>
-  return
+  %7 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<16x1024x80xf16>, tensor<16x80x1024xf16>) outs(%6 : tensor<16x1024x1024xf16>) -> tensor<16x1024x1024xf16>
+  return %7 : tensor<16x1024x1024xf16>
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVCooperativeMatrixVectorize workgroup_size = [64, 2, 1] subgroup_size = 32, {pipeline_depth = 0 : i64, store_stage = 0 : i64}>
-//      CHECK: func.func @batch_matmul_16x1024x1024x80()
+//      CHECK: func.func @batch_matmul_16x1024x1024x80(
 // CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:       lowering_config = #[[$CONFIG]]
@@ -160,26 +107,15 @@ func.func @batch_matmul_16x1024x1024x80() {
 
 // Small K - not supported by cooperative matrix.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-func.func @matmul_256x1024x8() {
+func.func @matmul_256x1024x8(%arg0: tensor<256x8xf16>, %arg1: tensor<8x1024xf16>) -> tensor<256x1024xf16> {
   %c0 = arith.constant 0 : index
   %c1024 = arith.constant 1024 : index
   %c256 = arith.constant 256 : index
   %cst = arith.constant 0.000000e+00 : f16
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x8xf16>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x1024xf16>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 8], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x8xf16>> -> tensor<256x8xf16>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [8, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x1024xf16>> -> tensor<8x1024xf16>
   %5 = tensor.empty() : tensor<256x1024xf16>
   %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%3, %4 : tensor<256x8xf16>, tensor<8x1024xf16>) outs(%6 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x1024xf16>>
-  return
+  %7 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%arg0, %arg1 : tensor<256x8xf16>, tensor<8x1024xf16>) outs(%6 : tensor<256x1024xf16>) -> tensor<256x1024xf16>
+  return %7 : tensor<256x1024xf16>
 }
 
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [32, 8, 1], {pipeline_depth = 1 : i64, store_stage = 1 : i64}>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
@@ -1,33 +1,19 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-codegen-materialize-user-configs, iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 #config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
 #translation = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 8, 1] subgroup_size = 64>
 #compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
-func.func @matmul_128x1024x256() {
+func.func @matmul_128x1024x256(%3: tensor<128x256xf32>, %4: tensor<256x1024xf32>) -> tensor<128x1024xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %c128 = arith.constant 128 : index
-  %c1024 = arith.constant 1024 : index
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x1024xf32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
-  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x1024xf32>> -> tensor<256x1024xf32>
   %5 = tensor.empty() : tensor<128x1024xf32>
   %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
   %7 = linalg.matmul {compilation_info = #compilation} ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%6 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
-  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<128x1024xf32>>
-  return
+  return %7 : tensor<128x1024xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 256], [16, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 8, 1] subgroup_size = 64>
-//      CHECK: func.func @matmul_128x1024x256()
+//      CHECK: func.func @matmul_128x1024x256(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.matmul
 // CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
@@ -3,12 +3,12 @@
 #config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
 #translation = #iree_codegen.translation_info<pipeline = SPIRVBaseVectorize workgroup_size = [16, 8, 1] subgroup_size = 64>
 #compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
-func.func @matmul_128x1024x256(%3: tensor<128x256xf32>, %4: tensor<256x1024xf32>) -> tensor<128x1024xf32> {
+func.func @matmul_128x1024x256(%arg0: tensor<128x256xf32>, %arg1: tensor<256x1024xf32>) -> tensor<128x1024xf32> {
   %cst = arith.constant 0.000000e+00 : f32
-  %5 = tensor.empty() : tensor<128x1024xf32>
-  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
-  %7 = linalg.matmul {compilation_info = #compilation} ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%6 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
-  return %7 : tensor<128x1024xf32>
+  %0 = tensor.empty() : tensor<128x1024xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  %2 = linalg.matmul {compilation_info = #compilation} ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%1 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+  return %2 : tensor<128x1024xf32>
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 256], [16, 16]{{\]}}>


### PR DESCRIPTION
## Summary

Simplify 18 SPIRV test configuration files by removing Hardware Abstraction Layer (HAL) infrastructure dependencies. This enables cleaner, more focused test cases for the SPIRV lowering strategy selection pass.

### Changes

- **Transform 84 functions across 18 config files** to remove HAL-specific operations
- Convert HAL interface-based signatures to clean tensor/memref function arguments
- Remove dispatch infrastructure: `hal.interface.binding.subspan`, `iree_tensor_ext.dispatch.tensor.load/store`
- Preserve all CHECK patterns and test verification logic

### Files Modified

- `config_adreno_conv.mlir` (6 functions)
- `config_adreno_matmul.mlir` (14 functions)
- `config_amd_conv.mlir` (1 function)
- `config_amd_matmul.mlir` (10 functions)
- `config_amd_matmul_cooperative_ops.mlir` (9 functions)
- `config_amd_matvec.mlir` (14 functions)
- `config_default_conv.mlir` (2 functions)
- `config_default_linalg_ext_ops.mlir` (5 functions)
- `config_default_linalg_ops.mlir` (13 functions)
- `config_default_matmul.mlir` (6 functions)
- `config_default_misc.mlir` (1 function)
- `config_default_reduction.mlir` (3 functions)
- `config_default_sub_byte_types.mlir` (1 function)
- `config_mali_conv.mlir` (6 functions)
- `config_mali_matmul.mlir` (21 functions)
- `config_nvidia_matmul.mlir` (3 functions)
- `config_nvidia_matmul_cooperative_ops.mlir` (9 functions)
- `config_user.mlir` (1 function)