### PR TITLE
[CI] Add ubsan build and test script. Run ubsan tests in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,12 @@ jobs:
     uses: ./.github/workflows/ci_linux_x64_clang_asan.yml
     secrets: inherit
 
+  linux_x64_clang_ubsan:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_ubsan')
+    uses: ./.github/workflows/ci_linux_x64_clang_ubsan.yml
+    secrets: inherit
+
   windows_x64_msvc:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'windows_x64_msvc')
@@ -264,6 +270,7 @@ jobs:
       - linux_x64_bazel
       - linux_x64_clang
       - linux_x64_clang_asan
+      - linux_x64_clang_ubsan
       - windows_x64_msvc
     uses: ./.github/workflows/workflow_summary.yml
     secrets: inherit

--- a/.github/workflows/ci_linux_x64_clang_ubsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_ubsan.yml
@@ -1,0 +1,41 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: CI - Linux x64 clang UBSan
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  linux_x64_clang_ubsan:
+    runs-on: azure-linux-scale
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:78a558b999b230f7e1da376639e14b44f095f30f1777d6a272ba48c0bbdd4ccb
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: true
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+      - name: Build and test with UBSan
+        env:
+          # Use a modern clang explicitly.
+          CC: clang-20
+          CXX: clang++-20
+          SCCACHE_AZURE_CONNECTION_STRING: "${{ secrets.AZURE_CCACHE_CONNECTION_STRING }}"
+          SCCACHE_AZURE_BLOB_CONTAINER: ccache-container
+          SCCACHE_CACHE_ZSTD_LEVEL: 10
+          SCCACHE_AZURE_KEY_PREFIX: "ci_linux_x64_clang_ubsan"
+        run: |
+          source build_tools/cmake/setup_sccache.sh
+          ./build_tools/cmake/build_and_test_ubsan.sh
+          sccache --show-stats
+
+      # Alerting on failure is the responsibility of the calling job.

--- a/.github/workflows/ci_linux_x64_clang_ubsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_ubsan.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Build and test with UBSan
         env:
           # Use a modern clang explicitly.
-          CC: clang-20
-          CXX: clang++-20
+          CC: clang-19
+          CXX: clang++-19
           SCCACHE_AZURE_CONNECTION_STRING: "${{ secrets.AZURE_CCACHE_CONNECTION_STRING }}"
           SCCACHE_AZURE_BLOB_CONTAINER: ccache-container
           SCCACHE_CACHE_ZSTD_LEVEL: 10

--- a/build_tools/cmake/build_and_test_ubsan.sh
+++ b/build_tools/cmake/build_and_test_ubsan.sh
@@ -1,0 +1,86 @@
+#! /usr/bin/env bash
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Build and test, using CMake/CTest, with Undefined Behavior Sanitizer
+# instrumentation.
+#
+# See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html. Components
+# that don't work with UBSan are disabled.
+#
+# The desired build directory can be passed as the first argument. Otherwise, it
+# uses the environment variable IREE_UBSAN_BUILD_DIR, defaulting to
+# "build-ubsan". Designed for CI, but can be run manually. It reuses the build
+# directory if it already exists. Expects to be run from the root of the IREE
+# repository.
+
+set -xeuo pipefail
+
+BUILD_DIR="${1:-${IREE_UBSAN_BUILD_DIR:-build-ubsan}}"
+IREE_ENABLE_ASSERTIONS="${IREE_ENABLE_ASSERTIONS:-ON}"
+# Enable CUDA and HIP/ROCM compiler and runtime by default if not on Darwin.
+OFF_IF_DARWIN="$(uname | awk '{print ($1 == "Darwin") ? "OFF" : "ON"}')"
+IREE_HAL_DRIVER_CUDA="${IREE_HAL_DRIVER_CUDA:-${OFF_IF_DARWIN}}"
+IREE_HAL_DRIVER_HIP="${IREE_HAL_DRIVER_HIP:-${OFF_IF_DARWIN}}"
+IREE_TARGET_BACKEND_CUDA="${IREE_TARGET_BACKEND_CUDA:-${OFF_IF_DARWIN}}"
+IREE_TARGET_BACKEND_ROCM="${IREE_TARGET_BACKEND_ROCM:-${OFF_IF_DARWIN}}"
+
+# Build hip tests for gfx942 to exercise codegen, but we won't run them.
+# The user can override this to test other chips.
+IREE_HIP_TEST_TARGET_CHIP="${IREE_HIP_TEST_TARGET_CHIP:-gfx942}"
+
+source build_tools/cmake/setup_build.sh
+
+CMAKE_ARGS=(
+  "-G" "Ninja"
+  "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+  "-DIREE_ENABLE_UBSAN=ON"
+  "-B" "${BUILD_DIR?}"
+  "-DPython3_EXECUTABLE=${IREE_PYTHON3_EXECUTABLE}"
+
+  # Python bindings are not compatible with sanitizers yet.
+  "-DIREE_BUILD_PYTHON_BINDINGS=OFF"
+
+  "-DIREE_ENABLE_ASSERTIONS=${IREE_ENABLE_ASSERTIONS}"
+  "-DIREE_ENABLE_LLD=ON"
+  "-DIREE_ENABLE_SPLIT_DWARF=ON"
+  "-DIREE_ENABLE_THIN_ARCHIVES=ON"
+
+  "-DIREE_HAL_DRIVER_CUDA=${IREE_HAL_DRIVER_CUDA}"
+  "-DIREE_HAL_DRIVER_HIP=${IREE_HAL_DRIVER_HIP}"
+  "-DIREE_TARGET_BACKEND_CUDA=${IREE_TARGET_BACKEND_CUDA}"
+  "-DIREE_TARGET_BACKEND_ROCM=${IREE_TARGET_BACKEND_ROCM}"
+  "-DIREE_HIP_TEST_TARGET_CHIP=${IREE_HIP_TEST_TARGET_CHIP}"
+
+  "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+)
+
+echo "::group::Configuring CMake"
+cmake "${CMAKE_ARGS[@]?}"
+echo "::endgroup::"
+
+echo "::group::Building all"
+cmake --build "${BUILD_DIR?}" -- -k 0
+echo "::endgroup::"
+
+echo "::group::Building test deps"
+cmake --build "${BUILD_DIR?}" --target iree-test-deps -- -k 0
+echo "::endgroup::"
+
+# Don't run any GPU tests for the time being.
+# These are not ubsan-warning-free yet.
+export IREE_VULKAN_DISABLE=1
+export IREE_METAL_DISABLE=1
+export IREE_CUDA_DISABLE=1
+export IREE_HIP_DISABLE=1
+
+echo "::group::Running tests"
+build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+echo "::endgroup::"
+
+echo "::group::Running llvm-external-projects tests"
+cmake --build "${BUILD_DIR?}" --target check-iree-dialects -- -k 0
+echo "::endgroup::"


### PR DESCRIPTION
We could technically add ubsan to asan jobs, but I decided to separate this because asan+ubsan gets very slow, and different sets of tests may not support on or the other. If we have enough runners, having these separate will result in lower latency overall.

Issue: https://github.com/iree-org/iree/issues/22555