### PR TITLE
[CI] Optimize cmake flags for debug info builds

### DIFF
--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -54,6 +54,8 @@ jobs:
             -DIREE_BUILD_PYTHON_BINDINGS=ON \
             -DIREE_ENABLE_LLD=ON \
             -DIREE_ENABLE_ASSERTIONS=ON \
+            -DIREE_ENABLE_SPLIT_DWARF=ON \
+            -DIREE_ENABLE_THIN_ARCHIVES=ON \
             -DIREE_BUILD_DOCS=ON \
             -DIREE_TARGET_BACKEND_WEBGPU_SPIRV=ON
       - name: CMake - build

--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -42,6 +42,8 @@ jobs:
             -DIREE_BUILD_PYTHON_BINDINGS=ON \
             -DIREE_ENABLE_LLD=ON \
             -DIREE_ENABLE_ASSERTIONS=ON \
+            -DIREE_ENABLE_SPLIT_DWARF=ON \
+            -DIREE_ENABLE_THIN_ARCHIVES=ON \
             -DIREE_BUILD_DOCS=ON \
             -DIREE_TARGET_BACKEND_CUDA=ON \
             -DIREE_TARGET_BACKEND_ROCM=ON \
@@ -54,8 +56,6 @@ jobs:
           sccache --show-stats
       - name: Run CTest
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
-        env:
-          CTEST_PARALLEL_LEVEL: 32
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"
 

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -56,7 +56,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DIREE_BUILD_PYTHON_BINDINGS=ON \
             -DIREE_ENABLE_LLD=ON \
-            -DIREE_ENABLE_ASSERTIONS=ON
+            -DIREE_ENABLE_ASSERTIONS=ON \
+            -DIREE_ENABLE_SPLIT_DWARF=ON \
+            -DIREE_ENABLE_THIN_ARCHIVES=ON
       - name: CMake - build
         run: |
           cmake --build ${BUILD_DIR} -- -k 0


### PR DESCRIPTION
Enable split dwarf and thin archives.

Do not reduce test parallelism in the clang job.