### PR TITLE
Drop unnecessary namespaces from cast functions in plugins. NFC. 1/10

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/ConvertCollectives.cpp
@@ -100,7 +100,7 @@ static std::pair<Value, Value> makeSplitColorAndKey(Location loc,
   if (!groups)
     return std::make_pair(noColor, noColor);
 
-  auto groupsType = llvm::cast<RankedTensorType>(groups.getType());
+  auto groupsType = cast<RankedTensorType>(groups.getType());
   assert(groupsType.getRank() == 2);
   int64_t rows = groupsType.getShape()[0];
   int64_t cols = groupsType.getShape()[1];
@@ -152,7 +152,7 @@ convertToRankGroupsByCrossReplica(DenseIntElementsAttr replicaGroups,
     return replicaGroups;
   }
 
-  auto groupsType = llvm::cast<RankedTensorType>(replicaGroups.getType());
+  auto groupsType = cast<RankedTensorType>(replicaGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -186,7 +186,7 @@ convertToRankGroupsByCrossPartition(DenseIntElementsAttr partitionGroups,
     return partitionGroups;
   }
 
-  auto groupsType = llvm::cast<RankedTensorType>(partitionGroups.getType());
+  auto groupsType = cast<RankedTensorType>(partitionGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -224,7 +224,7 @@ static DenseIntElementsAttr convertToRankGroupsByCrossReplicaAndPartition(
     return replicaGroups;
   }
 
-  auto groupsType = llvm::cast<RankedTensorType>(replicaGroups.getType());
+  auto groupsType = cast<RankedTensorType>(replicaGroups.getType());
   assert(groupsType.getRank() == 2);
   int rows = groupsType.getShape()[0];
   int cols = groupsType.getShape()[1];
@@ -420,8 +420,7 @@ struct PartitionIdOpConversion
                                                 /*value=*/numPartitions);
       value = arith::RemUIOp::create(rewriter, loc, rank, cst);
     }
-    auto resultType =
-        llvm::cast<RankedTensorType>(op.getType()); // tensor<ui32>
+    auto resultType = cast<RankedTensorType>(op.getType()); // tensor<ui32>
     auto elemType = resultType.getElementType();
     // index -> ui32
     auto rankElem =
@@ -456,8 +455,7 @@ struct ReplicaIdOpConversion
       rank = arith::DivUIOp::create(rewriter, loc, rank, cst);
     }
 
-    auto resultType =
-        llvm::cast<RankedTensorType>(op.getType()); // tensor<ui32>
+    auto resultType = cast<RankedTensorType>(op.getType()); // tensor<ui32>
     auto elemType = resultType.getElementType();
     // index -> ui32
     auto rankElem = arith::IndexCastUIOp::create(rewriter, loc, elemType, rank);
@@ -871,7 +869,7 @@ struct CollectivePermuteOpConversion
         loc, op.getChannelHandleAttr(), numReplicas, numPartitions,
         replicaGroupsAttr, /*useGlobalDeviceIds=*/std::nullopt, rewriter);
 
-    auto inputType = llvm::cast<RankedTensorType>(op.getOperand().getType());
+    auto inputType = cast<RankedTensorType>(op.getOperand().getType());
 
     // Get the collective element type attribute.
     IREE::Flow::CollectiveElementTypeAttr elementTypeAttr =

--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
@@ -95,7 +95,7 @@ struct ConcatenateConverter final
     elements.reserve(resultTy.getNumElements());
 
     for (Value operand : op->getOperands()) {
-      ShapedType operandTy = llvm::cast<ShapedType>(operand.getType());
+      ShapedType operandTy = cast<ShapedType>(operand.getType());
       if (operandTy.getRank() == 0) {
         Value extract =
             tensor::ExtractOp::create(rewriter, loc, operand, ValueRange({}));

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
@@ -118,7 +118,7 @@ Value transposeReshape(Value arg, Location loc,
 
 Value processDotArg(Value arg, Location loc, ArrayRef<int64_t> contractDimsAttr,
                     bool outerDimsFirst, PatternRewriter &rewriter) {
-  auto shape = llvm::cast<ShapedType>(arg.getType()).getShape();
+  auto shape = cast<ShapedType>(arg.getType()).getShape();
 
   llvm::SmallVector<bool, 5> isOuterDim;
   isOuterDim.resize(shape.size(), true);
@@ -336,7 +336,7 @@ struct GeneralDotConvert final
 
     auto getDynamicDims = [&](Value arg,
                               llvm::ArrayRef<int64_t> contractingDims) {
-      RankedTensorType ty = llvm::cast<RankedTensorType>(arg.getType());
+      RankedTensorType ty = cast<RankedTensorType>(arg.getType());
       int index = 0;
       for (int64_t contractingDim : contractingDims) {
         for (; index < contractingDim; ++index) {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
@@ -60,8 +60,7 @@ struct GatherIsTorchIndexSelectPattern final
       return rewriter.notifyMatchFailure(gather, "start_index_map != [0]");
     }
 
-    auto resultTy =
-        llvm::dyn_cast<RankedTensorType>(gather.getResult().getType());
+    auto resultTy = dyn_cast<RankedTensorType>(gather.getResult().getType());
     if (!resultTy) {
       return rewriter.notifyMatchFailure(gather, "unranked result");
     }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -189,7 +189,7 @@ struct ReorderConvOpOutputDimensions final
 
   LogicalResult matchAndRewrite(mlir::stablehlo::ConvolutionOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = llvm::cast<ShapedType>(op.getType());
+    auto resultType = cast<ShapedType>(op.getType());
     auto resultShape = resultType.getShape();
     if (!resultType.hasRank()) {
       return failure();
@@ -495,7 +495,7 @@ struct ScatterImplicitIndex final
     auto dimNumbers = op.getScatterDimensionNumbers();
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
     Value indices = op.getScatterIndices();
-    auto indicesTy = llvm::cast<ShapedType>(indices.getType());
+    auto indicesTy = cast<ShapedType>(indices.getType());
 
     // Check indices vector has an implicit dim.
     if (indexVectorDim != indicesTy.getRank()) {
@@ -561,8 +561,8 @@ struct ScatterImplicitBatch final
                                 PatternRewriter &rewriter) const override {
     auto dimNumbers = op.getScatterDimensionNumbers();
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
-    auto indices = llvm::cast<Value>(op.getScatterIndices());
-    auto indicesTy = llvm::dyn_cast<RankedTensorType>(indices.getType());
+    auto indices = cast<Value>(op.getScatterIndices());
+    auto indicesTy = dyn_cast<RankedTensorType>(indices.getType());
 
     // Check whether indices has no batch dimension.
     if (!indicesTy)
@@ -649,8 +649,8 @@ struct ScatterCollapseBatch final
                                 PatternRewriter &rewriter) const override {
     auto dimNumbers = op.getScatterDimensionNumbers();
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
-    auto indices = llvm::cast<Value>(op.getScatterIndices());
-    auto indicesTy = llvm::cast<ShapedType>(indices.getType());
+    auto indices = cast<Value>(op.getScatterIndices());
+    auto indicesTy = cast<ShapedType>(indices.getType());
     auto updatedWindowDims = dimNumbers.getUpdateWindowDims();
 
     if (!indicesTy.hasRank()) {
@@ -727,7 +727,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
     // If the index vector dim is not implicitly or explicitly at the end
     // we need to transpose the batch dimensions to the start.
     Value indices = op.getScatterIndices();
-    auto indicesTy = llvm::cast<ShapedType>(indices.getType());
+    auto indicesTy = cast<ShapedType>(indices.getType());
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
     if (indexVectorDim < indicesTy.getRank() - 1) {
       llvm::SmallVector<int64_t> perm;
@@ -748,7 +748,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
       indices = mlir::stablehlo::TransposeOp::create(
           builder, indicesTy.clone(newShape), indices,
           builder.getDenseI64ArrayAttr(perm));
-      indicesTy = llvm::cast<RankedTensorType>(indices.getType());
+      indicesTy = cast<RankedTensorType>(indices.getType());
       indexVectorDim = indicesTy.getRank() - 1;
     }
 
@@ -756,7 +756,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
     // the beginning.
     auto updates = op.getUpdates();
     auto updates0 = updates.front();
-    auto updates0Ty = llvm::cast<ShapedType>(updates0.getType());
+    auto updates0Ty = cast<ShapedType>(updates0.getType());
     auto updatedWindowDims = dimNumbers.getUpdateWindowDims();
 
     // Determine which dimensions are batch dimensions.
@@ -784,7 +784,7 @@ struct ScatterBatchFirst final : OpRewritePattern<mlir::stablehlo::ScatterOp> {
     llvm::SmallVector<Value> newUpdates(updates.begin(), updates.end());
     if (updatesChanged) {
       for (Value &update : newUpdates) {
-        auto updateTy = llvm::cast<ShapedType>(update.getType());
+        auto updateTy = cast<ShapedType>(update.getType());
         llvm::SmallVector<int64_t> newShape;
         newShape.reserve(updateTy.getRank());
         for (int i = 0, s = updatePerm.size(); i < s; i++)
@@ -853,8 +853,8 @@ struct ScatterMaterializeInsertedDim final
                                 PatternRewriter &rewriter) const override {
     auto indices = op.getScatterIndices();
     auto operand = op.getInputs().front();
-    auto indicesTy = llvm::cast<ShapedType>(indices.getType());
-    auto operandTy = llvm::cast<ShapedType>(operand.getType());
+    auto indicesTy = cast<ShapedType>(indices.getType());
+    auto operandTy = cast<ShapedType>(operand.getType());
 
     if (!operandTy.hasRank() || !indicesTy.hasRank()) {
       return rewriter.notifyMatchFailure(op, "operand/indices have no rank");
@@ -917,7 +917,7 @@ struct ScatterMaterializeInsertedDim final
 
     llvm::SmallVector<Value> expandedUpdates;
     for (auto update : op.getUpdates()) {
-      auto updatesTy = llvm::cast<ShapedType>(update.getType());
+      auto updatesTy = cast<ShapedType>(update.getType());
 
       llvm::SmallVector<int64_t> newShape;
       for (int i = 0, s = reassociationMap.size(); i < s; ++i) {
@@ -966,7 +966,7 @@ bool isFromBool(Value val) {
       return false;
 
     if (auto convertOp = dyn_cast<mlir::stablehlo::ConvertOp>(op)) {
-      auto inTy = llvm::cast<ShapedType>(convertOp.getOperand().getType());
+      auto inTy = cast<ShapedType>(convertOp.getOperand().getType());
       if (inTy.getElementType().isInteger(1)) {
         return true;
       }
@@ -1462,13 +1462,13 @@ struct DotGeneralIsMul final : OpRewritePattern<mlir::stablehlo::DotGeneralOp> {
         builder,
         RankedTensorType::get(lhsTransposeShape, lhsTy.getElementType()), lhs,
         builder.getDenseI64ArrayAttr(permLhs));
-    lhsTy = llvm::cast<RankedTensorType>(lhs.getType());
+    lhsTy = cast<RankedTensorType>(lhs.getType());
 
     rhs = mlir::stablehlo::TransposeOp::create(
         builder,
         RankedTensorType::get(rhsTransposeShape, rhsTy.getElementType()), rhs,
         builder.getDenseI64ArrayAttr(permRhs));
-    rhsTy = llvm::cast<RankedTensorType>(rhs.getType());
+    rhsTy = cast<RankedTensorType>(rhs.getType());
 
     auto dimI32Ty = RankedTensorType::get({1}, builder.getI32Type());
 

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
@@ -95,7 +95,7 @@ struct UnfuseBatchNormInferencePattern final
     // which should not be subject to quantization at a higher level.
     auto inputType = dyn_cast<RankedTensorType>(bnOp.getOperand().getType());
     auto varianceType =
-        llvm::dyn_cast<RankedTensorType>(bnOp.getVariance().getType());
+        dyn_cast<RankedTensorType>(bnOp.getVariance().getType());
     if (!inputType || !varianceType) {
       return failure();
     }

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
@@ -147,7 +147,7 @@ Value createLinalgMatmulOnTensors(OpBuilder b, Location loc,
   Value zeroTensor =
       linalg::FillOp::create(b, loc, zero, emptyTensor).getResult(0);
 
-  switch (llvm::cast<RankedTensorType>(lhs.getType()).getRank()) {
+  switch (cast<RankedTensorType>(lhs.getType()).getRank()) {
   case 1:
     return linalg::VecmatOp::create(b, loc, TypeRange{resultType},
                                     ValueRange{lhs, rhs},
@@ -188,9 +188,9 @@ struct FftOpConversion final : OpConversionPattern<mlir::stablehlo::FftOp> {
     Location loc = op.getLoc();
     auto matrixType =
         RankedTensorType::get({n, fftLength}, inputType.getElementType());
-    auto resultType = RankedTensorType::get(
-        llvm::cast<RankedTensorType>(op.getType()).getShape(),
-        inputType.getElementType());
+    auto resultType =
+        RankedTensorType::get(cast<RankedTensorType>(op.getType()).getShape(),
+                              inputType.getElementType());
 
     Value realMatrix =
         getDFTMatmulCoeff(rewriter, loc, matrixType, /*isRealPart=*/true);
@@ -271,7 +271,7 @@ static void rewriteFuncAttrs(func::FuncOp funcOp) {
         newAttrs.push_back({
             abiOutputName,
             IntegerAttr::get(indexType,
-                             llvm::cast<IntegerAttr>(attr.getValue()).getInt()),
+                             cast<IntegerAttr>(attr.getValue()).getInt()),
         });
       } else {
         newAttrs.push_back(attr);

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -216,7 +216,7 @@ struct ScatterOpConversion final
   /// * Update window dims order: (d + 1, ... , m)
   static bool hasCanonicalDimensionNumbers(mlir::stablehlo::ScatterOp op) {
     auto dimNumbers = op.getScatterDimensionNumbers();
-    auto indicesType = llvm::cast<ShapedType>(op.getScatterIndices().getType());
+    auto indicesType = cast<ShapedType>(op.getScatterIndices().getType());
     auto indicesRank = indicesType.getRank();
     auto indexVectorDim = dimNumbers.getIndexVectorDim();
     auto indexDepth = indicesType.getShape().back();
@@ -260,7 +260,7 @@ struct ScatterOpConversion final
     Value indices = adaptor.getScatterIndices();
     Value updates = adaptor.getUpdates().front();
 
-    auto originalType = llvm::dyn_cast<ShapedType>(original.getType());
+    auto originalType = dyn_cast<ShapedType>(original.getType());
 
     llvm::SmallVector<int64_t> scatterDimMap;
     for (auto dim :
@@ -553,11 +553,9 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
     Location loc = op.getLoc();
     Value operand = adaptor.getOperand();
 
-    auto inputValuesType = llvm::dyn_cast<ShapedType>(operand.getType());
-    auto outputValuesType =
-        llvm::dyn_cast<ShapedType>(op.getValues().getType());
-    auto outputIndicesType =
-        llvm::dyn_cast<ShapedType>(op.getIndices().getType());
+    auto inputValuesType = dyn_cast<ShapedType>(operand.getType());
+    auto outputValuesType = dyn_cast<ShapedType>(op.getValues().getType());
+    auto outputIndicesType = dyn_cast<ShapedType>(op.getIndices().getType());
     if (!inputValuesType || !outputValuesType || !outputIndicesType) {
       return rewriter.notifyMatchFailure(
           op, "Input and output must be of ShapedType");
@@ -566,7 +564,7 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
     Type valueElementType = inputValuesType.getElementType();
     Type indicesElementType = outputIndicesType.getElementType();
     // Only handle integer types for indicies. Index type is not supported.
-    if (!llvm::isa<IntegerType>(indicesElementType)) {
+    if (!isa<IntegerType>(indicesElementType)) {
       return rewriter.notifyMatchFailure(
           op, "Output indices must be of integer type.");
     }
@@ -582,13 +580,13 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
         rewriter, loc, mixedSizes, indicesElementType);
     // Initialize indices to 0 and values to negative infinity
     TypedAttr negInfAttr;
-    if (auto intType = llvm::dyn_cast<IntegerType>(valueElementType)) {
+    if (auto intType = dyn_cast<IntegerType>(valueElementType)) {
       negInfAttr = rewriter.getIntegerAttr(
           intType, APInt::getSignedMinValue(intType.getWidth()));
     } else {
-      auto negApFloat = APFloat::getInf(
-          llvm::cast<FloatType>(valueElementType).getFloatSemantics(),
-          /*Negative=*/true);
+      auto negApFloat =
+          APFloat::getInf(cast<FloatType>(valueElementType).getFloatSemantics(),
+                          /*Negative=*/true);
       negInfAttr = rewriter.getFloatAttr(valueElementType, negApFloat);
     }
     Value negInf = arith::ConstantOp::create(rewriter, loc, negInfAttr);
@@ -625,7 +623,7 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
       Value lhs = block->getArgument(0);
       Value rhs = block->getArgument(1);
       Value condition;
-      if (llvm::isa<IntegerType>(valueElementType)) {
+      if (isa<IntegerType>(valueElementType)) {
         condition = arith::CmpIOp::create(rewriter, loc,
                                           arith::CmpIPredicate::sge, lhs, rhs);
       } else {

--- a/compiler/plugins/input/TOSA/InputConversion/StripSignedness.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/StripSignedness.cpp
@@ -26,7 +26,7 @@ public:
 class IntegerTypeConverter : public TypeConverter {
 public:
   static Type convertType(Type type) {
-    if (auto iType = llvm::dyn_cast<IntegerType>(type)) {
+    if (auto iType = dyn_cast<IntegerType>(type)) {
       if (!iType.isSignless()) {
         return IntegerType::get(type.getContext(),
                                 iType.getIntOrFloatBitWidth());
@@ -78,9 +78,9 @@ public:
 };
 
 static bool isIllegalType(Type type) {
-  if (IntegerType ity = llvm::dyn_cast<IntegerType>(type))
+  if (IntegerType ity = dyn_cast<IntegerType>(type))
     return !ity.isSignless();
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return isIllegalType(shapedType.getElementType());
   }
   return false;

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -35,11 +35,11 @@ public:
   LogicalResult matchAndRewrite(tosa::ScatterOp op,
                                 PatternRewriter &rewriter) const final {
     auto values = op.getValuesIn();
-    auto indices = llvm::cast<Value>(op.getIndices());
-    auto updates = llvm::cast<Value>(op.getInput());
-    auto valuesTy = llvm::dyn_cast<RankedTensorType>(values.getType());
-    auto indicesTy = llvm::dyn_cast<RankedTensorType>(indices.getType());
-    auto updatesTy = llvm::dyn_cast<RankedTensorType>(updates.getType());
+    auto indices = cast<Value>(op.getIndices());
+    auto updates = cast<Value>(op.getInput());
+    auto valuesTy = dyn_cast<RankedTensorType>(values.getType());
+    auto indicesTy = dyn_cast<RankedTensorType>(indices.getType());
+    auto updatesTy = dyn_cast<RankedTensorType>(updates.getType());
     ImplicitLocOpBuilder builder(op.getLoc(), rewriter);
 
     if (!valuesTy || !indicesTy || !updatesTy)
@@ -63,7 +63,7 @@ public:
 
     indices = tensor::ExpandShapeOp::create(
         builder, indicesTy.clone(expandIndShape), indices, expandIndMap);
-    indicesTy = llvm::dyn_cast<RankedTensorType>(indices.getType());
+    indicesTy = dyn_cast<RankedTensorType>(indices.getType());
 
     // Materialize the batch indice as LinalgExt scatter is not batched.
     {
@@ -101,7 +101,7 @@ public:
                 .getResult(0);
       }
 
-      indicesTy = llvm::cast<RankedTensorType>(indicesTy.clone(
+      indicesTy = cast<RankedTensorType>(indicesTy.clone(
           {indicesTy.getDimSize(0), indicesTy.getDimSize(1), 2}));
       indices = tosa::ConcatOp::create(builder, indicesTy,
                                        ValueRange{batchIdx, indices},
@@ -109,7 +109,7 @@ public:
     }
 
     auto collapseBatch = [](Value value, ImplicitLocOpBuilder &b) -> Value {
-      auto valueTy = llvm::cast<ShapedType>(value.getType());
+      auto valueTy = cast<ShapedType>(value.getType());
       llvm::SmallVector<int64_t> collapseShape(valueTy.getShape().drop_front());
       llvm::SmallVector<ReassociationExprs> collapseMap(valueTy.getRank() - 1);
       collapseMap.front().push_back(b.getAffineDimExpr(0));

--- a/compiler/plugins/input/Torch/InputConversion/BindSymbolicShapes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BindSymbolicShapes.cpp
@@ -86,7 +86,7 @@ class BindSymbolicShapesPass final
     auto operand = bindOp.getOperand();
     // Torch programs are single block and use structured control flow, so
     // presume this is an entrypoint.
-    if (llvm::isa<BlockArgument>(operand))
+    if (isa<BlockArgument>(operand))
       return true;
 
     // Mutable tensors can exist at the boundary and must be "copied" to a
@@ -252,7 +252,7 @@ class BindSymbolicShapesPass final
       for (auto [index, expr] : llvm::enumerate(shapeMap.getResults())) {
         if (expr.getKind() != AffineExprKind::SymbolId)
           continue;
-        auto symbolPos = llvm::cast<AffineSymbolExpr>(expr).getPosition();
+        auto symbolPos = cast<AffineSymbolExpr>(expr).getPosition();
         Value symbol = symbols[symbolPos];
         auto symbolInfoIt = symbolInfos.find(symbol);
         assert(symbolInfoIt != symbolInfos.end() &&
@@ -265,7 +265,7 @@ class BindSymbolicShapesPass final
     Value materializeDimExpr(Location loc, OpBuilder &builder,
                              AffineExpr genericExpr,
                              llvm::DenseMap<Value, SymbolInfo> &symbolInfos) {
-      if (auto binaryExpr = llvm::dyn_cast<AffineBinaryOpExpr>(genericExpr)) {
+      if (auto binaryExpr = dyn_cast<AffineBinaryOpExpr>(genericExpr)) {
         auto lhs =
             materializeDimExpr(loc, builder, binaryExpr.getLHS(), symbolInfos);
         if (!lhs)
@@ -296,12 +296,12 @@ class BindSymbolicShapesPass final
         return arith::ConstantOp::create(
             builder, loc,
             builder.getIndexAttr(
-                llvm::cast<AffineConstantExpr>(genericExpr).getValue()));
+                cast<AffineConstantExpr>(genericExpr).getValue()));
       case AffineExprKind::DimId:
         // Unsupported.
         break;
       case AffineExprKind::SymbolId: {
-        auto symExpr = llvm::cast<AffineSymbolExpr>(genericExpr);
+        auto symExpr = cast<AffineSymbolExpr>(genericExpr);
         auto pos = symExpr.getPosition();
         if (pos >= symbols.size())
           break;
@@ -406,18 +406,17 @@ class BindSymbolicShapesPass final
 
     // Walk the ops we care about and stash for analysis.
     getOperation()->walk([&](Operation *childOp) {
-      if (auto symbolOp = llvm::dyn_cast<Torch::SymbolicIntOp>(childOp)) {
+      if (auto symbolOp = dyn_cast<Torch::SymbolicIntOp>(childOp)) {
         cleanupOpList.push_back(symbolOp);
         symbolInfos.insert_or_assign(symbolOp.getResult(),
                                      SymbolInfo(symbolOp));
-      } else if (auto bindOp =
-                     llvm::dyn_cast<Torch::BindSymbolicShapeOp>(childOp)) {
+      } else if (auto bindOp = dyn_cast<Torch::BindSymbolicShapeOp>(childOp)) {
         cleanupOpList.push_back(bindOp);
         if (!isEligibleBinding(bindOp))
           return;
         auto torchType =
-            llvm::cast<Torch::ValueTensorType>(bindOp.getOperand().getType());
-        auto builtinType = llvm::dyn_cast_or_null<RankedTensorType>(
+            cast<Torch::ValueTensorType>(bindOp.getOperand().getType());
+        auto builtinType = dyn_cast_or_null<RankedTensorType>(
             typeConverter.convertType(torchType));
         if (!builtinType) {
           emitError(childOp->getLoc())

--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -499,7 +499,7 @@ public:
       }
 
       // Read the PTX from the object file.
-      auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(
+      auto objectAttr = cast<IREE::HAL::ExecutableObjectAttr>(
           variantOp.getObjects()->getValue().front());
       if (auto data = objectAttr.loadData()) {
         targetPTX = data.value();

--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -372,8 +372,8 @@ public:
     if (auto importsAttr =
             variantOp->getAttrOfType<ArrayAttr>(importsAttrName)) {
       for (auto importAttr : importsAttr.getAsValueRange<ArrayAttr>()) {
-        auto nameAttr = llvm::cast<StringAttr>(importAttr[0]);
-        auto weakAttr = llvm::cast<BoolAttr>(importAttr[1]);
+        auto nameAttr = cast<StringAttr>(importAttr[0]);
+        auto weakAttr = cast<BoolAttr>(importAttr[1]);
         libraryBuilder.addImport(nameAttr.getValue(), weakAttr.getValue());
       }
       variantOp->removeAttr(importsAttrName);
@@ -680,7 +680,7 @@ public:
                                                    {".o", ".obj", ".a", ".lib"},
                                                    linkerObjectAttrs);
     for (auto [index, attr] : llvm::enumerate(linkerObjectAttrs)) {
-      auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(attr);
+      auto objectAttr = cast<IREE::HAL::ExecutableObjectAttr>(attr);
       if (auto dataAttr = objectAttr.getData()) {
         objectFiles.push_back(Artifact::createTemporary(
             objectFiles.front().path + "_object_" + std::to_string(index),

--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -199,7 +199,7 @@ LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
   auto getString = [&](StringRef name, StringRef fallback,
                        bool required) -> StringRef {
     Attribute attr = config.get(name);
-    if (auto sattr = llvm::dyn_cast_if_present<StringAttr>(attr)) {
+    if (auto sattr = dyn_cast_if_present<StringAttr>(attr)) {
       return sattr.strref();
     } else {
       if (required) {
@@ -212,7 +212,7 @@ LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
   };
   auto getOptionalString = [&](StringRef name) -> std::optional<StringRef> {
     Attribute attr = config.get(name);
-    if (auto sattr = llvm::dyn_cast_if_present<StringAttr>(attr)) {
+    if (auto sattr = dyn_cast_if_present<StringAttr>(attr)) {
       return sattr.strref();
     } else if (attr) {
       hasFailures = true;
@@ -223,7 +223,7 @@ LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
   };
   auto getBool = [&](StringRef name, bool fallback) -> bool {
     Attribute attr = config.get(name);
-    if (auto battr = llvm::dyn_cast_if_present<BoolAttr>(attr)) {
+    if (auto battr = dyn_cast_if_present<BoolAttr>(attr)) {
       return battr.getValue();
     } else if (attr) {
       hasFailures = true;

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -581,7 +581,7 @@ public:
       }
 
       // Read the HSACO from the object file.
-      auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(
+      auto objectAttr = cast<IREE::HAL::ExecutableObjectAttr>(
           variantOp.getObjects()->getValue().front());
       if (auto data = objectAttr.loadData()) {
         targetHSACO = data.value();

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -412,7 +412,7 @@ public:
     }
 
     // Load .spv object file.
-    auto objectAttr = llvm::cast<IREE::HAL::ExecutableObjectAttr>(
+    auto objectAttr = cast<IREE::HAL::ExecutableObjectAttr>(
         variantOp.getObjects()->getValue().front());
     std::string spirvBinary;
     if (auto data = objectAttr.loadData()) {


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.