### PR TITLE
Drop unnecessary namespaces from cast functions in bindings/dispatch/external. NFC. 2/10

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
@@ -94,7 +94,7 @@ convertStreamableFunc(mlir::ModuleOp moduleOp, IREE::Util::FuncOp funcOp,
   // Because streamable ops are asynchronous they must be able to declare their
   // result shapes before they execute so memory can be allocated.
   for (auto resultType : functionType.getResults()) {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+    if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
       streamableFunc.requiredResultDims += shapedType.getNumDynamicDims();
     }
   }
@@ -161,7 +161,7 @@ convertStreamableFunc(mlir::ModuleOp moduleOp, IREE::Util::FuncOp funcOp,
     // arbitrarily complex (up to and including calling a function to compute
     // dims).
     SmallVector<int64_t> dynamicDimArgs;
-    auto shapedType = llvm::dyn_cast<ShapedType>(resultType);
+    auto shapedType = dyn_cast<ShapedType>(resultType);
     if (shapedType) {
       // Initialize dynamic dim args - we'll verify that they all get covered.
       dynamicDimArgs.resize(shapedType.getNumDynamicDims(), kUnspecifiedDim);
@@ -256,7 +256,7 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
   // Capture all argument dynamic dimensions.
   SmallVector<Value> argDims;
   for (auto arg : callOp.getOperands()) {
-    if (llvm::isa<ShapedType>(arg.getType())) {
+    if (isa<ShapedType>(arg.getType())) {
       llvm::append_range(argDims, IREE::Util::buildDynamicDimsForValue(
                                       callOp.getLoc(), arg, builder));
     }
@@ -278,7 +278,7 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
   } else {
     // Get the shape dimensions from existing call arguments or tied operands.
     for (auto [i, resultType] : llvm::enumerate(callOp.getResultTypes())) {
-      if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+      if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
         const auto &resultDimArgs = streamableFunc.resultDimArgs[i];
         if (resultDimArgs.empty())
           continue;

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -40,7 +40,7 @@ getInvocationModel(Operation *op, IREE::ABI::InvocationModel defaultModel) {
 
 // Maps a source type to the native ABI type.
 static Type mapToABIType(Type type) {
-  if (llvm::isa<TensorType>(type)) {
+  if (isa<TensorType>(type)) {
     return IREE::HAL::BufferViewType::get(type.getContext());
   }
   return type;
@@ -136,7 +136,7 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   SmallVector<Value> tensorArgs;
   for (auto [argIndex, arg] : llvm::enumerate(entryArgs)) {
     auto oldType = oldImportType.getInput(argIndex);
-    if (llvm::isa<TensorType>(oldType)) {
+    if (isa<TensorType>(oldType)) {
       tensorArgIndices.push_back(argIndex);
       tensorArgs.push_back(arg);
     }
@@ -229,7 +229,7 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   for (auto [argIndex, arg] : llvm::enumerate(entryArgs)) {
     auto oldType = oldImportType.getInput(argIndex);
     auto newType = newImportType.getInput(argIndex);
-    if (llvm::isa<TensorType>(oldType)) {
+    if (isa<TensorType>(oldType)) {
       // This is where we could perform type casting or in-place storage binding
       // if the user had any attrs specifying it.
       // NOTE: we insert a barrier on this above if needed so that the wait
@@ -280,7 +280,7 @@ createImportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   SmallVector<Value> results;
   for (auto [resultIndex, result] : llvm::enumerate(callOp.getResults())) {
     auto oldType = oldImportType.getResult(resultIndex);
-    if (llvm::isa<TensorType>(oldType)) {
+    if (isa<TensorType>(oldType)) {
       // NOTE: we set the import pending on the signal fence from the import
       // indicating when the returned tensor is ready for consumption by the
       // program.
@@ -601,8 +601,8 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
     // Today all outputs need to be a !hal.buffer - we could change this
     // in the future to be something more generalized.
     auto storageArg = entryBlock->getArgument(i);
-    if (!llvm::isa<IREE::HAL::BufferType>(storageArg.getType()) &&
-        !llvm::isa<IREE::HAL::BufferViewType>(storageArg.getType())) {
+    if (!isa<IREE::HAL::BufferType>(storageArg.getType()) &&
+        !isa<IREE::HAL::BufferViewType>(storageArg.getType())) {
       exportOp.emitError() << "storage argument " << i
                            << " has an invalid type " << storageArg.getType()
                            << "; must be a !hal.buffer";
@@ -633,7 +633,7 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   for (auto [argIndex, arg] : llvm::enumerate(
            entryBlock->getArguments().slice(0, oldExportType.getNumInputs()))) {
     auto oldType = oldExportType.getInput(argIndex);
-    if (llvm::isa<TensorType>(oldType)) {
+    if (isa<TensorType>(oldType)) {
       auto encodingAttr =
           exportOp.getArgAttrOfType<TypeAttr>(argIndex, "iree.abi.encoding");
       auto consumeAttr =
@@ -680,7 +680,7 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   if (signalFence) {
     SmallVector<Value> asyncTensors;
     for (auto result : asyncResults) {
-      if (llvm::isa<TensorType>(result.getType())) {
+      if (isa<TensorType>(result.getType())) {
         asyncTensors.push_back(result);
       }
     }
@@ -701,7 +701,7 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
   for (auto [resultIndex, result] : llvm::enumerate(asyncResults)) {
     auto oldType = oldExportType.getResult(resultIndex);
     auto newType = newExportType.getResult(resultIndex);
-    if (llvm::isa<TensorType>(oldType)) {
+    if (isa<TensorType>(oldType)) {
       auto encodingAttr = exportOp.getResultAttrOfType<TypeAttr>(
           resultIndex, "iree.abi.encoding");
       auto affinityAttr =

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -157,7 +157,7 @@ private:
     for (auto [arg, inputName, inputType] : llvm::zip_equal(
              funcOp.getArguments(), inputNames, funcType.getInputs())) {
       auto fullName = (namePrefix + "_" + inputName + "_shape").str();
-      auto tensorType = llvm::dyn_cast<TensorType>(inputType);
+      auto tensorType = dyn_cast<TensorType>(inputType);
       assert(tensorType && "expecting only tensors in tflite function I/O");
       inputDynamicDims.push_back(createDynamicDimGlobals(
           arg.getLoc(), fullName, tensorType, moduleBuilder));
@@ -166,7 +166,7 @@ private:
     for (auto [outputName, outputType] :
          llvm::zip_equal(outputNames, funcType.getResults())) {
       auto fullName = (namePrefix + "_" + outputName + "_shape").str();
-      auto tensorType = llvm::dyn_cast<TensorType>(outputType);
+      auto tensorType = dyn_cast<TensorType>(outputType);
       assert(tensorType && "expecting only tensors in tflite function I/O");
       outputDynamicDims.push_back(
           createDynamicDimGlobals(loc, fullName, tensorType, moduleBuilder));

--- a/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
@@ -102,7 +102,7 @@ static bool dataTilablePreCondition(linalg::LinalgOp linalgOp) {
     return false;
   }
   auto hasEncoding = [](Value operand) -> bool {
-    auto type = llvm::dyn_cast<RankedTensorType>(operand.getType());
+    auto type = dyn_cast<RankedTensorType>(operand.getType());
     return type && type.getEncoding();
   };
   if (llvm::any_of(linalgOp.getDpsInputs(), hasEncoding) ||

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -107,8 +107,8 @@ collapseExtractSlice(tensor::ExtractSliceOp sliceOp,
 /// with "reduction" types. It is expected that the `op` has projected
 /// permutations only as indexing maps. (Checked using `isEligibleForCollapse`).
 static SmallVector<ReassociationIndices> getCollapsibleLoops(Operation *op) {
-  auto fusionInterfaceOp = llvm::cast<LinalgFusionOpInterface>(op);
-  auto tilingInterfaceOp = llvm::cast<TilingInterface>(op);
+  auto fusionInterfaceOp = cast<LinalgFusionOpInterface>(op);
+  auto tilingInterfaceOp = cast<TilingInterface>(op);
 
   SmallVector<ReassociationIndices> contiguousLoops;
   SmallVector<unsigned> pDims, rDims;

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -563,7 +563,7 @@ isFusableWithConsumer(OpOperand &fusedOperand, const FusionTracker &tracker,
       }
       return linalg::isElementwise(consumerLinalgOp) &&
              consumerLinalgOp.getNumLoops() ==
-                 llvm::cast<RankedTensorType>(producer->getResult(0).getType())
+                 cast<RankedTensorType>(producer->getResult(0).getType())
                      .getRank();
     }
     return false;
@@ -574,7 +574,7 @@ isFusableWithConsumer(OpOperand &fusedOperand, const FusionTracker &tracker,
         .Case<tensor::PadOp>([&](auto padOp) { return true; })
         .Case<linalg::LinalgOp>([&](auto linalgOp) {
           AffineMap producerIndexingMap = linalgOp.getIndexingMapMatchingResult(
-              llvm::cast<OpResult>(fusedOperand.get()));
+              cast<OpResult>(fusedOperand.get()));
           // Make sure the producer op has an identity result indexing map. As
           // CPU backend currently can't handle transpose between fused ops.
           return producerIndexingMap.isIdentity();
@@ -776,7 +776,7 @@ static bool isFusableWithProducer(OpOperand &operand,
             }
           }
           AffineMap producerIndexingMap = linalgOp.getIndexingMapMatchingResult(
-              llvm::cast<OpResult>(operand.get()));
+              cast<OpResult>(operand.get()));
           // Make sure the producer op has an identity result indexing map. As
           // CPU backend currently can't handle transpose between fused ops.
           return producerIndexingMap.isIdentity();

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -27,7 +27,7 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
   if (llvm::all_of(producerOp->getResultTypes(), [](Type t) {
         if (t.isInteger(1))
           return true;
-        if (auto shapedType = llvm::dyn_cast<ShapedType>(t)) {
+        if (auto shapedType = dyn_cast<ShapedType>(t)) {
           if (shapedType.getElementType().isInteger(1))
             return true;
         }

--- a/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/MaterializeDefaultWorkgroupCountRegion.cpp
@@ -57,7 +57,7 @@ static LogicalResult createDefaultWorkgroupCountRegion(
   SmallVector<Location> workloadLocs;
   for (auto argument : workgroupsOp.getArguments()) {
     Type argumentType = argument.getType();
-    if (!llvm::isa<IndexType>(argumentType))
+    if (!isa<IndexType>(argumentType))
       continue;
     workload.push_back(argument);
     workloadTypes.push_back(argumentType);
@@ -114,7 +114,7 @@ static LogicalResult createDefaultWorkgroupCountRegion(
     rewriter.setInsertionPointToStart(&body.front());
     int ordinalNumber = 0;
     for (auto [index, operand] : llvm::enumerate(workgroupsOp.getArguments())) {
-      if (!llvm::isa<IndexType>(operand.getType()))
+      if (!isa<IndexType>(operand.getType()))
         continue;
       BlockArgument arg = workgroupsOp.getInputBlockArgument(index);
       auto ordinalOp = IREE::TensorExt::DispatchWorkloadOrdinalOp::create(

--- a/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetSplitReductionSizes.cpp
@@ -193,11 +193,11 @@ private:
     Value outputVal = output->get();
 
     ArrayRef<int64_t> inputShape =
-        llvm::cast<ShapedType>(inputVal.getType()).getShape();
+        cast<ShapedType>(inputVal.getType()).getShape();
     ArrayRef<int64_t> filterShape =
-        llvm::cast<ShapedType>(filterVal.getType()).getShape();
+        cast<ShapedType>(filterVal.getType()).getShape();
     ArrayRef<int64_t> outputShape =
-        llvm::cast<ShapedType>(outputVal.getType()).getShape();
+        cast<ShapedType>(outputVal.getType()).getShape();
 
     if (ShapedType::isDynamicShape(inputShape) ||
         ShapedType::isDynamicShape(filterShape) ||

--- a/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
@@ -50,9 +50,9 @@ struct SinkReshapesPass final
 /// we just approximate it (and try to be optimistic)
 static bool isFusableUsingTileAndFuse(Operation *producer,
                                       Operation *consumer) {
-  return llvm::isa_and_nonnull<IREE::LinalgExt::LinalgFusionOpInterface,
-                               linalg::LinalgOp, linalg::UnPackOp,
-                               IREE::Encoding::UnsetEncodingOp>(producer);
+  return isa_and_nonnull<IREE::LinalgExt::LinalgFusionOpInterface,
+                         linalg::LinalgOp, linalg::UnPackOp,
+                         IREE::Encoding::UnsetEncodingOp>(producer);
 }
 
 /// Control function to check if a `tensor.collapse_shape` (which is the
@@ -175,7 +175,7 @@ void SinkReshapesPass::runOnOperation() {
 
   auto collapsingControlFn = [](OpOperand *opOperand) {
     auto collapseOp =
-        llvm::dyn_cast_or_null<tensor::CollapseShapeOp>(opOperand->getOwner());
+        dyn_cast_or_null<tensor::CollapseShapeOp>(opOperand->getOwner());
     if (collapseOp) {
       return shouldBubbleCollapseShapeOp(collapseOp, opOperand);
     }

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -20,43 +20,40 @@ struct LinalgFusionOpInterfaceAdapter
           LinalgFusionOpInterfaceAdapter<ConcreteType>, ConcreteType> {
 public:
   SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
-    auto maps = llvm::cast<ConcreteType>(op)
+    auto maps = cast<ConcreteType>(op)
                     .getIndexingMaps()
                     .template getAsValueRange<AffineMapAttr>();
-    return {maps.begin(),
-            maps.end() - llvm::cast<ConcreteType>(op).getNumResults()};
+    return {maps.begin(), maps.end() - cast<ConcreteType>(op).getNumResults()};
   }
 
   SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
-    auto maps = llvm::cast<ConcreteType>(op)
+    auto maps = cast<ConcreteType>(op)
                     .getIndexingMaps()
                     .template getAsValueRange<AffineMapAttr>();
-    return {maps.end() - llvm::cast<ConcreteType>(op).getNumResults(),
-            maps.end()};
+    return {maps.end() - cast<ConcreteType>(op).getNumResults(), maps.end()};
   }
 
   // Forward all the interface methods to the corresponding linalg op.
   unsigned getNumParallelLoops(mlir::Operation *op) const {
-    return (llvm::cast<ConcreteType>(op).getNumParallelLoops());
+    return (cast<ConcreteType>(op).getNumParallelLoops());
   }
 
   unsigned getNumLoops(mlir::Operation *op) const {
-    return (llvm::cast<ConcreteType>(op).getNumLoops());
+    return (cast<ConcreteType>(op).getNumLoops());
   }
 
   SmallVector<int64_t> getStaticLoopRanges(mlir::Operation *op) const {
-    return SmallVector<int64_t>(
-        llvm::cast<ConcreteType>(op).getStaticLoopRanges());
+    return SmallVector<int64_t>(cast<ConcreteType>(op).getStaticLoopRanges());
   }
 
   AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
                                          OpResult result) const {
-    return (llvm::cast<ConcreteType>(op).getIndexingMapMatchingResult(result));
+    return (cast<ConcreteType>(op).getIndexingMapMatchingResult(result));
   }
 
   AffineMap getMatchingIndexingMap(mlir::Operation *op,
                                    OpOperand *operand) const {
-    return (llvm::cast<ConcreteType>(op).getMatchingIndexingMap(operand));
+    return (cast<ConcreteType>(op).getMatchingIndexingMap(operand));
   }
 
   SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
@@ -73,7 +70,7 @@ public:
   SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
     Builder b(op->getContext());
     return llvm::to_vector(llvm::map_range(
-        llvm::cast<linalg::SoftmaxOp>(op).getDpsInputs(),
+        cast<linalg::SoftmaxOp>(op).getDpsInputs(),
         [&b](Value operand) -> AffineMap {
           auto rank = cast<ShapedType>(operand.getType()).getRank();
           return b.getMultiDimIdentityMap(rank);
@@ -83,7 +80,7 @@ public:
   SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
     Builder b(op->getContext());
     return llvm::to_vector(llvm::map_range(
-        llvm::cast<linalg::SoftmaxOp>(op).getDpsInits(),
+        cast<linalg::SoftmaxOp>(op).getDpsInits(),
         [&b](Value operand) -> AffineMap {
           auto rank = cast<ShapedType>(operand.getType()).getRank();
           return b.getMultiDimIdentityMap(rank);

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -54,7 +54,7 @@ struct ArithConstantInferIntDivisibilityOpInterface
       Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
       IREE::Util::SetIntDivisibilityFn setResultDivs) const {
     auto constOp = cast<arith::ConstantOp>(op);
-    auto constAttr = llvm::dyn_cast_or_null<IntegerAttr>(constOp.getValue());
+    auto constAttr = dyn_cast_or_null<IntegerAttr>(constOp.getValue());
     if (constAttr) {
       const APInt &value = constAttr.getValue();
       uint64_t udiv = value.getZExtValue();
@@ -341,7 +341,7 @@ struct HoistableLinalgOpInterface
 
     // Hoist all non-generic linalg ops except for fill ops which should be
     // fused with their consumers.
-    auto genericOp = llvm::dyn_cast<linalg::GenericOp>(op);
+    auto genericOp = dyn_cast<linalg::GenericOp>(op);
     if (!genericOp) {
       return !isa<linalg::FillOp>(op);
     }


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.