### PR TITLE
Drop unnecessary namespaces from cast functions in codegen common. NFC. 3/10

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -134,7 +134,7 @@ static Type getElementTypeForUKernel(Value input) {
   auto genericOp = input.getDefiningOp<linalg::GenericOp>();
   std::optional<CastOpInterface> castOp = getCastOpOfElementWiseCast(genericOp);
   if (!castOp) {
-    return llvm::cast<ShapedType>(input.getType()).getElementType();
+    return cast<ShapedType>(input.getType()).getElementType();
   }
   Type castOpSrcType = castOp.value()->getOperand(0).getType();
   if (isa<arith::ExtUIOp>(*castOp)) {
@@ -172,7 +172,7 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::Mmt4DOp op,
   Value lhs = getInputForUKernel(op.getDpsInputOperand(0)->get());
   Value rhs = getInputForUKernel(op.getDpsInputOperand(1)->get());
   Value out = op.getDpsInitOperand(0)->get();
-  auto outType = llvm::cast<ShapedType>(out.getType());
+  auto outType = cast<ShapedType>(out.getType());
   Type lhsElemType = getElementTypeForUKernel(op.getDpsInputOperand(0)->get());
   Type rhsElemType = getElementTypeForUKernel(op.getDpsInputOperand(1)->get());
   Type outElemType = outType.getElementType();
@@ -275,8 +275,8 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::PackOp op,
   }
   Value in = op.getSource();
   Value out = op.getDest();
-  auto inType = llvm::cast<ShapedType>(in.getType());
-  auto outType = llvm::cast<ShapedType>(out.getType());
+  auto inType = cast<ShapedType>(in.getType());
+  auto outType = cast<ShapedType>(out.getType());
   Type inElemType = inType.getElementType();
   Type outElemType = outType.getElementType();
   uint32_t flags = 0;
@@ -398,8 +398,8 @@ matchDAGForUKernel(RewriterBase &rewriter, linalg::UnPackOp op,
   }
   Value in = op.getSource();
   Value out = op.getDest();
-  auto inType = llvm::cast<ShapedType>(in.getType());
-  auto outType = llvm::cast<ShapedType>(out.getType());
+  auto inType = cast<ShapedType>(in.getType());
+  auto outType = cast<ShapedType>(out.getType());
   Type inElemType = inType.getElementType();
   Type outElemType = outType.getElementType();
   uint32_t flags = 0;

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -519,8 +519,7 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
     // Only sink reshape ops, so bail if the consumer operation is a reshape.
     auto controlSinkReshapesFn = [](OpOperand *operand) -> bool {
       Operation *consumer = operand->getOwner();
-      return !llvm::isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(
-          consumer);
+      return !isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(consumer);
     };
     linalg::populateFoldReshapeOpsByExpansionPatterns(propagationPatterns,
                                                       controlSinkReshapesFn);

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -36,7 +36,7 @@ static Value getAsIndexValue(OpFoldResult attrOrValue, OpBuilder &builder,
       return val;
     matchPattern(val, m_Constant(&attr));
   } else {
-    attr = llvm::cast<IntegerAttr>(cast<Attribute>(attrOrValue));
+    attr = cast<IntegerAttr>(cast<Attribute>(attrOrValue));
   }
   return builder.createOrFold<arith::ConstantIndexOp>(
       loc, attr.getValue().getSExtValue());

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertAccGEMMToGEMMPass.cpp
@@ -98,7 +98,7 @@ static void convertAccGemmToGemm(RewriterBase &rewriter,
       ValueRange{initOp}, maps, iterators,
       [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
         Value result;
-        if (llvm::isa<FloatType>(elementType)) {
+        if (isa<FloatType>(elementType)) {
           result = arith::AddFOp::create(b, nestedLoc, args[0], args[1]);
         } else {
           result = arith::AddIOp::create(b, nestedLoc, args[0], args[1]);

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -46,7 +46,7 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
                          Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
-  if (!llvm::isa<FloatType>(getElementTypeOrSelf(type)))
+  if (!isa<FloatType>(getElementTypeOrSelf(type)))
     return nullptr;
 
   if (inputETy.getIntOrFloatBitWidth() > eTy.getIntOrFloatBitWidth()) {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -79,8 +79,7 @@ static Value getTensorLoadOpForTensorStoreOp(
   // Clone the offset, size and stride values. They will be CSE-ed later.
   SliceAndDynamicDims clonedVals = cloneOffsetsSizesAndStrides(b, storeOp);
   Value tensorLoadOp = IREE::TensorExt::DispatchTensorLoadOp::create(
-      b, storeOp.getLoc(),
-      llvm::cast<RankedTensorType>(storeOp.getValue().getType()),
+      b, storeOp.getLoc(), cast<RankedTensorType>(storeOp.getValue().getType()),
       storeOp.getTarget(), clonedVals.dynamicDims, clonedVals.offsets,
       clonedVals.sizes, clonedVals.strides);
   return tensorLoadOp;
@@ -272,7 +271,7 @@ convertToDestinationPassingStyle(OpBuilder &b,
   auto walkResult = funcOp.walk<WalkOrder::PreOrder>(
       [&](tensor::EmptyOp emptyOp) -> WalkResult {
         for (auto result : emptyOp->getResults()) {
-          if (!llvm::isa<RankedTensorType>(result.getType()))
+          if (!isa<RankedTensorType>(result.getType()))
             continue;
           if (plan.isInStoreSet(result) && !processed.count(result)) {
             return modifyResultToUseStoreBuffer(b, result, plan, processed);
@@ -516,7 +515,7 @@ struct RemoveCstOutsDependency
         continue;
       if (!attr.isSplat())
         continue;
-      auto type = llvm::dyn_cast<RankedTensorType>(attr.getType());
+      auto type = dyn_cast<RankedTensorType>(attr.getType());
       if (!type)
         continue;
       TypedAttr scalarAttr = attr.getValues<TypedAttr>()[0];
@@ -574,8 +573,7 @@ struct SwitchStoreOfIfResultValue
                                          "store source is not an if statement");
     }
 
-    auto resultNumber =
-        llvm::cast<OpResult>(storeOp.getValue()).getResultNumber();
+    auto resultNumber = cast<OpResult>(storeOp.getValue()).getResultNumber();
     auto moveStoreInsideBody = [&](Block *body) {
       OpBuilder::InsertionGuard guard(rewriter);
       auto yieldOp = cast<scf::YieldOp>(body->getTerminator());

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -78,7 +78,7 @@ MaterializeEncodingTypeConverter::getPackedDimsForDispatchTensor(
     ValueRange dynamicDims) const {
 
   auto boundTensorType =
-      llvm::dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
+      dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
   if (!boundTensorType) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseHALDescriptorTypeFromMemRef.cpp
@@ -32,9 +32,9 @@ namespace {
 
 /// Returns true if the given `type` is considered as legal.
 static bool isLegalType(Type type) {
-  if (auto memRefType = llvm::dyn_cast<BaseMemRefType>(type)) {
+  if (auto memRefType = dyn_cast<BaseMemRefType>(type)) {
     Attribute spaceAttr = memRefType.getMemorySpace();
-    return !spaceAttr || !llvm::isa<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
+    return !spaceAttr || !isa<IREE::HAL::DescriptorTypeAttr>(spaceAttr);
   }
   return true;
 }
@@ -50,7 +50,7 @@ struct EraseHALDescriptorTypeFromMemRefPass final
             return std::nullopt;
 
           // Erase the #hal.descriptor_type memory space.
-          if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
+          if (auto rankedType = dyn_cast<MemRefType>(memRefType)) {
             return MemRefType::get(memRefType.getShape(),
                                    memRefType.getElementType(),
                                    rankedType.getLayout());
@@ -80,7 +80,7 @@ struct ConvertHALDescriptorTypeToGPUAddressSpacePass final
           Attribute globalSpace = gpu::AddressSpaceAttr::get(
               memRefType.getContext(), gpu::AddressSpace::Global);
           // Erase the #hal.descriptor_type memory space.
-          if (auto rankedType = llvm::dyn_cast<MemRefType>(memRefType)) {
+          if (auto rankedType = dyn_cast<MemRefType>(memRefType)) {
             return MemRefType::get(memRefType.getShape(),
                                    memRefType.getElementType(),
                                    rankedType.getLayout(), globalSpace);

--- a/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FastMathPatterns.cpp
@@ -39,7 +39,7 @@ struct FastErfPattern : public OpRewritePattern<math::ErfOp> {
     Value input = op.getOperand();
     Type resultType = op.getType();
 
-    VectorType resVecType = llvm::dyn_cast<VectorType>(resultType);
+    VectorType resVecType = dyn_cast<VectorType>(resultType);
     if (!(resultType.isF32() ||
           (resVecType && resVecType.getElementType().isF32()))) {
       return rewriter.notifyMatchFailure(

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -74,7 +74,7 @@ namespace {
 
 /// Returns true if the given `type` is a 0-D MemRef.
 static bool isRankZeroMemRef(Type type) {
-  if (auto memrefType = llvm::dyn_cast<MemRefType>(type)) {
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.hasRank() && memrefType.getRank() == 0;
   }
   return false;
@@ -82,7 +82,7 @@ static bool isRankZeroMemRef(Type type) {
 
 /// Returns true if the given `type` is a 0-D or 1-D MemRef.
 static bool isRankZeroOrOneMemRef(Type type) {
-  if (auto memrefType = llvm::dyn_cast<MemRefType>(type)) {
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.hasRank() && memrefType.getRank() <= 1;
   }
   return false;
@@ -156,7 +156,7 @@ struct FlattenAlloc final : public OpConversionPattern<AllocOpTy> {
   LogicalResult
   matchAndRewrite(AllocOpTy allocOp, typename AllocOpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto oldType = llvm::dyn_cast<MemRefType>(allocOp.getType());
+    auto oldType = dyn_cast<MemRefType>(allocOp.getType());
     if (!oldType || !oldType.getLayout().isIdentity())
       return failure();
 
@@ -164,8 +164,8 @@ struct FlattenAlloc final : public OpConversionPattern<AllocOpTy> {
         oldType, allocOp.getDynamicSizes(), allocOp.getLoc(), rewriter);
     Type newType = this->getTypeConverter()->convertType(oldType);
 
-    rewriter.replaceOpWithNewOp<AllocOpTy>(
-        allocOp, llvm::cast<MemRefType>(newType), ValueRange{dynamicDim});
+    rewriter.replaceOpWithNewOp<AllocOpTy>(allocOp, cast<MemRefType>(newType),
+                                           ValueRange{dynamicDim});
 
     return success();
   }
@@ -178,12 +178,12 @@ struct FlattenGlobal final : public OpConversionPattern<memref::GlobalOp> {
   static Attribute flattenAttribute(Attribute value, ShapedType newType) {
     if (!value)
       return value;
-    if (auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(value)) {
+    if (auto splatAttr = dyn_cast<SplatElementsAttr>(value)) {
       return splatAttr.reshape(newType);
-    } else if (auto denseAttr = llvm::dyn_cast<DenseElementsAttr>(value)) {
+    } else if (auto denseAttr = dyn_cast<DenseElementsAttr>(value)) {
       return denseAttr.reshape(newType);
     } else if (auto denseResourceAttr =
-                   llvm::dyn_cast<DenseResourceElementsAttr>(value)) {
+                   dyn_cast<DenseResourceElementsAttr>(value)) {
       return DenseResourceElementsAttr::get(newType,
                                             denseResourceAttr.getRawHandle());
     }
@@ -193,7 +193,7 @@ struct FlattenGlobal final : public OpConversionPattern<memref::GlobalOp> {
   LogicalResult
   matchAndRewrite(memref::GlobalOp globalOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto oldType = llvm::dyn_cast<MemRefType>(globalOp.getType());
+    auto oldType = dyn_cast<MemRefType>(globalOp.getType());
     if (!oldType || !oldType.getLayout().isIdentity())
       return failure();
 
@@ -220,7 +220,7 @@ struct FlattenGetGlobal final
   LogicalResult
   matchAndRewrite(memref::GetGlobalOp getOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto oldType = llvm::dyn_cast<MemRefType>(getOp.getType());
+    auto oldType = dyn_cast<MemRefType>(getOp.getType());
     if (!oldType || !oldType.getLayout().isIdentity())
       return failure();
 
@@ -232,8 +232,7 @@ struct FlattenGetGlobal final
     auto loadedValue = rewriter.createOrFold<memref::GetGlobalOp>(
         getOp.getLoc(), globalOp.getType(), getOp.getNameAttr());
 
-    auto newType =
-        llvm::cast<ShapedType>(getTypeConverter()->convertType(oldType));
+    auto newType = cast<ShapedType>(getTypeConverter()->convertType(oldType));
     rewriter.replaceOpWithNewOp<memref::CastOp>(getOp, newType, loadedValue);
     return success();
   }
@@ -248,7 +247,7 @@ struct FlattenBindingSubspan final
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp subspanOp,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto oldType = llvm::dyn_cast<MemRefType>(subspanOp.getType());
+    auto oldType = dyn_cast<MemRefType>(subspanOp.getType());
     // IREE subspan ops only use memref types with the default identity
     // layout maps.
     if (!oldType)
@@ -299,10 +298,9 @@ struct FlattenBindingSubspan final
       OpFoldResult stride = rewriter.getIndexAttr(1);
       MemRefType returnType =
           oldType.getRank() == 0
-              ? llvm::cast<MemRefType>(
-                    memref::SubViewOp::inferRankReducedResultType(
-                        {}, newType, elementOffset, linearShapeWithoutOffset,
-                        stride))
+              ? cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
+                    {}, newType, elementOffset, linearShapeWithoutOffset,
+                    stride))
               : nullptr;
       replacement = memref::SubViewOp::create(
           rewriter, loc, returnType, newOp, elementOffset,
@@ -348,7 +346,7 @@ struct FlattenReinterpretCast
 /// indexing into the given memref `sourceValue`.
 static Value linearizeIndices(Value sourceValue, ValueRange indices,
                               Location loc, OpBuilder &builder) {
-  MemRefType sourceType = llvm::cast<MemRefType>(sourceValue.getType());
+  MemRefType sourceType = cast<MemRefType>(sourceValue.getType());
   assert(sourceType.hasRank());
 
   int64_t rank = sourceType.getRank();
@@ -658,7 +656,7 @@ struct AdjustConversionCast final
 
     Value input = adaptor.getOperands().front();
     // We only want to handle cases where the cast op handles memref types.
-    if (!llvm::isa<BaseMemRefType>(input.getType()))
+    if (!isa<BaseMemRefType>(input.getType()))
       return failure();
 
     if (!isRankZeroOrOneMemRef(input.getType())) {
@@ -732,8 +730,8 @@ struct RemoveDynamicCastOp final : public OpRewritePattern<memref::CastOp> {
 
   LogicalResult matchAndRewrite(memref::CastOp castOp,
                                 PatternRewriter &rewriter) const override {
-    auto srcType = llvm::cast<MemRefType>(castOp.getSource().getType());
-    auto dstType = llvm::cast<MemRefType>(castOp.getType());
+    auto srcType = cast<MemRefType>(castOp.getSource().getType());
+    auto dstType = cast<MemRefType>(castOp.getType());
     // Restrict to the cases we generate in this pass--1-D static shape to 1-D
     // dynamic shape.
     if (srcType.getRank() == 1 && srcType.hasStaticShape() &&
@@ -850,12 +848,12 @@ struct FlattenMemRefSubspanPass final
     target.addDynamicallyLegalOp<vector::TransferReadOp>(
         [](vector::TransferReadOp readOp) {
           return isRankZeroOrOneMemRef(
-              llvm::cast<MemRefType>(readOp.getBase().getType()));
+              cast<MemRefType>(readOp.getBase().getType()));
         });
     target.addDynamicallyLegalOp<vector::TransferWriteOp>(
         [](vector::TransferWriteOp writeOp) {
           return isRankZeroOrOneMemRef(
-              llvm::cast<MemRefType>(writeOp.getBase().getType()));
+              cast<MemRefType>(writeOp.getBase().getType()));
         });
     target.addDynamicallyLegalOp<UnrealizedConversionCastOp>(
         [](UnrealizedConversionCastOp castOp) {
@@ -863,7 +861,7 @@ struct FlattenMemRefSubspanPass final
             return false;
 
           Type inputType = castOp->getOperandTypes().front();
-          return !llvm::isa<BaseMemRefType>(inputType) ||
+          return !isa<BaseMemRefType>(inputType) ||
                  isRankZeroOrOneMemRef(inputType);
         });
     target.addDynamicallyLegalOp<memref::SubViewOp>([](memref::SubViewOp op) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -33,8 +33,7 @@ static int shapedTypeStaticSize(
       continue;
     allocSize *= dimSize;
   }
-  if (auto elementType =
-          llvm::dyn_cast<ShapedType>(shapedType.getElementType())) {
+  if (auto elementType = dyn_cast<ShapedType>(shapedType.getElementType())) {
     allocSize *= shapedTypeStaticSize(allocOp, elementType, getIndexBitwidth);
   } else {
     auto eltTy = shapedType.getElementType();
@@ -64,7 +63,7 @@ static LogicalResult checkGPUAllocationSize(
 
   int cumSize = 0;
   for (auto allocOp : allocOps) {
-    auto allocType = llvm::cast<MemRefType>(allocOp.getType());
+    auto allocType = cast<MemRefType>(allocOp.getType());
     if (!hasSharedMemoryAddressSpace(allocType))
       continue;
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -63,10 +63,10 @@ static LogicalResult tileCopyToWorkgroupMem(mlir::FunctionOpInterface funcOp,
         // distribution.
         SmallVector<Value> tileSizesVal;
         MemRefType dstMemRefType =
-            llvm::cast<MemRefType>(cast<linalg::GenericOp>(operation)
-                                       .getDpsInitOperand(0)
-                                       ->get()
-                                       .getType());
+            cast<MemRefType>(cast<linalg::GenericOp>(operation)
+                                 .getDpsInitOperand(0)
+                                 ->get()
+                                 .getType());
 
         unsigned rank = dstMemRefType.getRank();
         // Return empty tile size for zero dim tensor.
@@ -109,7 +109,7 @@ static LogicalResult tileCopyToWorkgroupMem(mlir::FunctionOpInterface funcOp,
 static int getBaseVectorSize(linalg::GenericOp genericOp) {
   assert(genericOp.getNumDpsInits() == 1);
   unsigned resultBW =
-      llvm::cast<MemRefType>(genericOp.getDpsInitOperand(0)->get().getType())
+      cast<MemRefType>(genericOp.getDpsInitOperand(0)->get().getType())
           .getElementTypeBitWidth();
   // Check the operand element types. If we have some sub-byte types there, make
   // sure we at least read a full byte for the sub-byte-element operands.
@@ -195,9 +195,9 @@ SmallVector<linalg::ProcInfo> getIds(OpBuilder &b, Location loc,
     auto stride = dyn_cast<Attribute>(r.stride);
     auto size = dyn_cast<Attribute>(r.size);
     assert(offset && stride && size);
-    int64_t numThreadsDim = (llvm::cast<IntegerAttr>(size).getInt() -
-                             llvm::cast<IntegerAttr>(offset).getInt()) /
-                            llvm::cast<IntegerAttr>(stride).getInt();
+    int64_t numThreadsDim = (cast<IntegerAttr>(size).getInt() -
+                             cast<IntegerAttr>(offset).getInt()) /
+                            cast<IntegerAttr>(stride).getInt();
     delinSizes.push_back(numThreadsDim);
   }
   ValueRange dims =
@@ -392,8 +392,8 @@ LogicalResult gpuDistributeSharedMemoryCopy(mlir::FunctionOpInterface funcOp) {
       workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
   bool isAligned = llvm::all_of(
       copiesToWorkgroupMem, [flatWorkgroupSize](linalg::GenericOp copyOp) {
-        MemRefType dstMemRefType = llvm::cast<MemRefType>(
-            copyOp.getDpsInitOperand(0)->get().getType());
+        MemRefType dstMemRefType =
+            cast<MemRefType>(copyOp.getDpsInitOperand(0)->get().getType());
         auto shape = dstMemRefType.getShape();
         int targetVectorSize =
             copyVectorNumBits / dstMemRefType.getElementTypeBitWidth();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -203,8 +203,7 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
 
   LogicalResult distributeYield(PatternRewriter &rewriter,
                                 scf::ForOp forOp) const {
-    scf::YieldOp yieldOp =
-        llvm::cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    scf::YieldOp yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
     std::optional<DistributionSignature> maybeSignature =
         getOpSignature(yieldOp);
     if (!maybeSignature) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1137,7 +1137,7 @@ struct DistributeMultiReduction final
 
     auto constOp = arith::ConstantOp::create(rewriter, loc,
                                              rewriter.getZeroAttr(flatVecType));
-    auto res = llvm::cast<VectorValue>(constOp.getResult());
+    auto res = cast<VectorValue>(constOp.getResult());
 
     for (unsigned i = 0; i < numElements; ++i) {
       Value extracted = vector::ExtractOp::create(rewriter, loc, flat, i);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPatterns.cpp
@@ -50,9 +50,9 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
                                 PatternRewriter &rewriter) const override {
     auto loc = transferReadOp.getLoc();
     Value vector = transferReadOp.getVector();
-    VectorType vectorType = llvm::cast<VectorType>(vector.getType());
+    VectorType vectorType = cast<VectorType>(vector.getType());
     Value source = transferReadOp.getBase();
-    MemRefType sourceType = llvm::dyn_cast<MemRefType>(source.getType());
+    MemRefType sourceType = dyn_cast<MemRefType>(source.getType());
     // Contiguity check is valid on tensors only.
     if (!sourceType)
       return failure();
@@ -120,7 +120,7 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
       subViewStrides.push_back(rewriter.getIndexAttr(1));
     }
     MemRefType resultType =
-        llvm::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
+        cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
             vectorShapeCollapse, sourceType, subViewOffsets, subViewSizes,
             subViewStrides));
     Value subView =
@@ -206,7 +206,7 @@ struct DropSharedMemoryDeallocOp : public OpRewritePattern<memref::DeallocOp> {
   LogicalResult matchAndRewrite(memref::DeallocOp op,
                                 PatternRewriter &rewriter) const override {
     if (!hasSharedMemoryAddressSpace(
-            llvm::cast<MemRefType>(op.getMemref().getType())))
+            cast<MemRefType>(op.getMemref().getType())))
       return failure();
     rewriter.eraseOp(op);
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -56,7 +56,7 @@ static Operation *replaceOpWithPredicatedOp(RewriterBase &rewriter,
       return op;
     // Return/execute the op if it is a shared memory load.
     if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
-      auto loadBaseType = llvm::cast<MemRefType>(loadOp.getBase().getType());
+      auto loadBaseType = cast<MemRefType>(loadOp.getBase().getType());
       if (hasSharedMemoryAddressSpace(loadBaseType))
         return op;
     }
@@ -214,13 +214,13 @@ static bool setPipeliningMarkers(scf::ForOp forOp, bool pipelineStoreStage) {
     auto ld = dyn_cast<vector::TransferReadOp>(op);
     if (!ld)
       continue;
-    auto ldSrcType = llvm::cast<MemRefType>(ld.getBase().getType());
+    auto ldSrcType = cast<MemRefType>(ld.getBase().getType());
     if (!hasGlobalMemoryAddressSpace(ldSrcType) || !ld->hasOneUse())
       continue;
     auto st = dyn_cast<vector::TransferWriteOp>(ld->use_begin()->getOwner());
     if (!st)
       continue;
-    auto stSrcType = llvm::cast<MemRefType>(st.getBase().getType());
+    auto stSrcType = cast<MemRefType>(st.getBase().getType());
     if (!hasSharedMemoryAddressSpace(stSrcType))
       continue;
     copyToWorkgroupMemory = true;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -87,7 +87,7 @@ static int64_t computeSharedMemoryUsage(mlir::FunctionOpInterface funcOp) {
       return WalkResult::interrupt();
     }
 
-    MemRefType allocType = llvm::cast<MemRefType>(allocOp.getType());
+    MemRefType allocType = cast<MemRefType>(allocOp.getType());
     unsigned byteWidth =
         allocType.getElementType().isIndex()
             ? 8 // IREE's default byteWidth for indexes
@@ -122,7 +122,7 @@ static unsigned computeEffectiveExtraBytes(mlir::FunctionOpInterface funcOp,
   funcOp.walk([&](memref::AllocOp allocOp) {
     if (hasSharedMemoryAddressSpace(allocOp.getType()) &&
         allocOp.getType().hasStaticShape()) {
-      MemRefType allocType = llvm::cast<MemRefType>(allocOp.getType());
+      MemRefType allocType = cast<MemRefType>(allocOp.getType());
 
       ArrayRef<int64_t> shape = allocType.getShape();
       if (shape.empty())

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -45,7 +45,7 @@ static bool contractOpFilter(Operation *op) {
   // Check if the shape is tile-distributable. The leading dimension must be a
   // multiple of the target vector size, which is 128b / the element bit width.
   auto isTileDistributable = [&](Value v) {
-    ShapedType ty = llvm::cast<ShapedType>(v.getType());
+    ShapedType ty = cast<ShapedType>(v.getType());
     unsigned bitWidth = ty.getElementTypeBitWidth();
     int targetVectorSize = copyVectorNumBits / bitWidth;
     return ty.getShape().back() % targetVectorSize == 0;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
@@ -65,7 +65,7 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
   // Check that all filter loop dimensions are unit and then make them zero.
   DenseMap<AffineExpr, AffineExpr> dimMap;
   Value filter = linalgOp.getDpsInputs()[1];
-  auto filterType = llvm::cast<ShapedType>(filter.getType());
+  auto filterType = cast<ShapedType>(filter.getType());
   ArrayRef<int64_t> filterShape = filterType.getShape();
   for (auto filterLoop : convDims.filterLoop) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -60,7 +60,7 @@ static bool contractOpFilter(Operation *op) {
 // where this is used.
 static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
                                                 Value vector) {
-  VectorType vectorType = llvm::cast<VectorType>(vector.getType());
+  VectorType vectorType = cast<VectorType>(vector.getType());
   if (vectorType.isScalable()) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -45,7 +45,7 @@ static Value allocateGlobalSharedMemory(Location loc, OpBuilder &builder,
   MemRefType memrefType;
   auto addressSpaceAttr = gpu::AddressSpaceAttr::get(
       builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
-  if (auto vectorType = llvm::dyn_cast<VectorType>(type)) {
+  if (auto vectorType = dyn_cast<VectorType>(type)) {
     memrefType =
         MemRefType::get(vectorType.getShape(), vectorType.getElementType(),
                         MemRefLayoutAttrInterface{}, addressSpaceAttr);
@@ -67,7 +67,7 @@ static bool isUniformLoad(Operation *op) {
   if (!hasGlobalMemoryAddressSpace(loadOp.getMemRefType()))
     return false;
   auto space = loadOp.getMemRefType().getMemorySpace();
-  auto descTypeAttr = llvm::dyn_cast_if_present<DescriptorTypeAttr>(space);
+  auto descTypeAttr = dyn_cast_if_present<DescriptorTypeAttr>(space);
   if (descTypeAttr && descTypeAttr.getValue() == DescriptorType::UniformBuffer)
     return true;
 
@@ -135,7 +135,7 @@ static void moveScalarAndBindingUniformCode(gpu::WarpExecuteOnLane0Op warpOp) {
   // operations from there.
   for (auto &op : body->without_terminator()) {
     bool hasVectorResult = llvm::any_of(op.getResults(), [](Value result) {
-      return llvm::isa<VectorType>(result.getType());
+      return isa<VectorType>(result.getType());
     });
     if ((!hasVectorResult || isUniformLoad(&op)) &&
         canBeHoisted(&op, isDefinedOutsideOfBody)) {
@@ -273,7 +273,7 @@ struct VectorReductionToGPUPass final
                                      *subgroupSize, expandSubgroupReduction);
       };
       auto distributionFn = [](Value val) {
-        auto vecType = llvm::dyn_cast<VectorType>(val.getType());
+        auto vecType = dyn_cast<VectorType>(val.getType());
         if (!vecType)
           return AffineMap::get(val.getContext());
         // Create an identity dim map of rank |vecRank|. This greedily divides

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -120,7 +120,7 @@ static LogicalResult isWithinVectorSizeLimit(linalg::LinalgOp linalgOp,
                                              int64_t maxVectorSize) {
   int64_t maxFlatVecSize = 1;
   for (OpOperand &operand : linalgOp->getOpOperands()) {
-    auto type = llvm::dyn_cast<ShapedType>(operand.get().getType());
+    auto type = dyn_cast<ShapedType>(operand.get().getType());
     if (!type)
       continue;
     if (!type.hasStaticShape())

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -62,7 +62,7 @@ static FailureOr<Value> defaultAllocationFn(OpBuilder &builder, Location loc,
     // type memory space; that's runtime allocations. So erase and fallback to
     // the default 0 memory space. It is fine given this is just the default
     // allocator; backends are expected to control by themselves.
-    if (llvm::isa<IREE::HAL::DescriptorTypeAttr>(storage))
+    if (isa<IREE::HAL::DescriptorTypeAttr>(storage))
       type = MemRefType::get(type.getShape(), type.getElementType(),
                              type.getLayout());
   }

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -90,7 +90,7 @@ getStridesFromSizes(RewriterBase &rewriter, Location loc,
 static FailureOr<DescriptorInfo> resolveBufferDescriptorForInterfaceBinding(
     IREE::HAL::InterfaceBindingSubspanOp binding, RewriterBase &rewriter,
     Location loc) {
-  auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
+  auto memRefType = cast<MemRefType>(binding.getResult().getType());
   int rank = memRefType.getRank();
   DescriptorInfo resultDescriptor;
 
@@ -175,7 +175,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     auto binding = getSourceInterfaceBinding(op.getSource());
     if (!binding)
       return failure();
-    auto memRefType = llvm::cast<MemRefType>(binding->getResult().getType());
+    auto memRefType = cast<MemRefType>(binding->getResult().getType());
 
     auto loc = op.getLoc();
     OpBuilder::InsertionGuard g(rewriter);
@@ -246,7 +246,7 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     }
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() * 2 + 2);
-    auto baseBufferType = llvm::cast<MemRefType>(op.getBaseBuffer().getType());
+    auto baseBufferType = cast<MemRefType>(op.getBaseBuffer().getType());
     if (!op.getBaseBuffer().use_empty()) {
       if (newBufferType == baseBufferType) {
         results.push_back(newBinding);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -117,7 +117,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                   IREE::Encoding::kEncodingResolverAttrName)
             : nullptr;
     auto resolverAttr =
-        llvm::dyn_cast_or_null<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
+        dyn_cast_or_null<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
 
     IREE::Encoding::LayoutMaterializerAttr layoutAttrWithTargetInfo =
         layoutAttr && resolverAttr

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -701,7 +701,7 @@ void populateMaterializeEncodingPatterns(
   MLIRContext *context = patterns.getContext();
   target.addDynamicallyLegalOp<IREE::HAL::InterfaceBindingSubspanOp>(
       [&typeConverter](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
-        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+        auto resultType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
             subspanOp.getResult().getType());
         // For types that are not `TensorExt::DispatchTensorType` mark as legal.
         if (!resultType)
@@ -712,7 +712,7 @@ void populateMaterializeEncodingPatterns(
                       IREE::Encoding::UnsetEncodingOp>();
   target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorStoreOp>(
       [&typeConverter](IREE::TensorExt::DispatchTensorStoreOp storeOp) {
-        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+        auto resultType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
             storeOp.getTargetType());
         // For types that are not `TensorExt::DispatchTensorType` mark as legal.
         if (!resultType)
@@ -721,7 +721,7 @@ void populateMaterializeEncodingPatterns(
       });
   target.addDynamicallyLegalOp<IREE::TensorExt::DispatchTensorLoadOp>(
       [&typeConverter](IREE::TensorExt::DispatchTensorLoadOp loadOp) {
-        auto resultType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+        auto resultType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
             loadOp.getSourceType());
         // For types that are not `TensorExt::DispatchTensorType` mark as legal.
         if (!resultType)

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -740,7 +740,7 @@ void ReconcileTranslationInfoPass::runOnOperation() {
 
   for (auto exportOp : exportOps) {
     SmallVector<IREE::Codegen::TranslationInfoAttr> translationInfos;
-    auto rootFuncOp = llvm::dyn_cast_if_present<FunctionOpInterface>(
+    auto rootFuncOp = dyn_cast_if_present<FunctionOpInterface>(
         symbolTable.lookup(exportOp.getSymNameAttr()));
     if (!rootFuncOp || rootFuncOp.isExternal()) {
       // Skip external functions.

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -122,7 +122,7 @@ struct FoldCollapseShapeIntoInterfaceTensorLoad
                                collapsedStaticShape);
 
     auto tensorAccess =
-        llvm::cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
+        cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
             .getAccess();
     auto newSubspanType = IREE::TensorExt::DispatchTensorType::get(
         tensorAccess, reshapeOp.getResultType());
@@ -227,7 +227,7 @@ struct FoldExpandShapeIntoInterfaceTensorLoad
     }
 
     auto tensorAccess =
-        llvm::cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
+        cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
             .getAccess();
     auto newSubspanType = IREE::TensorExt::DispatchTensorType::get(
         tensorAccess, reshapeOp.getResultType());
@@ -317,7 +317,7 @@ struct FoldExpandShapeIntoInterfaceTensorStore
                                collapsedStaticShape);
 
     auto tensorAccess =
-        llvm::cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
+        cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType())
             .getAccess();
     auto newSubspanType = IREE::TensorExt::DispatchTensorType::get(
         tensorAccess, reshapeSrc.getType());
@@ -634,7 +634,7 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
     }
 
     auto subspanType =
-        llvm::cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType());
+        cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType());
     SmallVector<Value> dynamicDims = subspanOp.getDynamicDims();
 
     // Verify the subspan shape against the shape of the slice being inserted.
@@ -933,7 +933,7 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
     }
 
     auto subspanType =
-        llvm::cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType());
+        cast<IREE::TensorExt::DispatchTensorType>(subspanOp.getType());
     auto subspanTensorType = cast<RankedTensorType>(subspanType.getBoundType());
     if (subspanTensorType.getEncoding() ||
         subspanTensorType.getShape().back() !=

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -189,7 +189,7 @@ static void specializeExportedFunction(
         requiresSpecialization = true;
 
         // Infer the range/divisor of the dim based on the tied assumption.
-        if (auto assumeOp = llvm::dyn_cast<IREE::Util::AssumeIntOp>(
+        if (auto assumeOp = dyn_cast<IREE::Util::AssumeIntOp>(
                 assumedSize.assumptionOrOrdinal.getOwner())) {
           std::pair<std::optional<int64_t>, std::optional<int64_t>>
               dynamicRange = assumeOp.getUnionedUnsignedRange(
@@ -328,7 +328,7 @@ static void specializeExportedFunction(
               arith::AndIOp::create(builder, loc, cmp, exportCondition);
         }
 
-        if (auto originalAssumeOp = llvm::dyn_cast<IREE::Util::AssumeIntOp>(
+        if (auto originalAssumeOp = dyn_cast<IREE::Util::AssumeIntOp>(
                 assumedSize.assumptionOrOrdinal.getOwner())) {
           auto clonedAssumeOp =
               cast<IREE::Util::AssumeIntOp>(mapping.lookup(originalAssumeOp));
@@ -448,7 +448,7 @@ public:
     }
 
     for (auto exportOp : exports) {
-      auto exportedFunc = llvm::dyn_cast_if_present<func::FuncOp>(
+      auto exportedFunc = dyn_cast_if_present<func::FuncOp>(
           SymbolTable::lookupNearestSymbolFrom(innerModule,
                                                exportOp.getSymNameAttr()));
       if (!exportedFunc || exportedFunc.isExternal()) {

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -224,7 +224,7 @@ fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
       for (auto operand : tiledOp->getOperands()) {
         if (auto sliceProducer =
                 operand.getDefiningOp<tensor::ExtractSliceOp>()) {
-          if (llvm::isa_and_present<TilingInterface>(
+          if (isa_and_present<TilingInterface>(
                   sliceProducer.getSource().getDefiningOp())) {
             newFusionOpportunities.push(sliceProducer);
           }

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -70,7 +70,7 @@ getDistributeLBAndStep(OpBuilder &b, Location loc, OpFoldResult lb,
 static void changeArithCstToI64Attr(OpBuilder &b,
                                     MutableArrayRef<OpFoldResult> constants) {
   for (OpFoldResult &val : constants) {
-    if (auto dyn_cast = llvm::dyn_cast_if_present<Value>(val)) {
+    if (auto dyn_cast = dyn_cast_if_present<Value>(val)) {
       APInt intVal;
       if (matchPattern(dyn_cast, m_ConstantInt(&intVal))) {
         val = b.getI64IntegerAttr(intVal.getSExtValue());
@@ -256,9 +256,9 @@ static LogicalResult replaceAllStoresWithTiledVersion(
       return rewriter.notifyMatchFailure(
           untiledOp, "failed to rewrite destructive update");
     }
-    if (failed(replaceStoresWithTiledVersion(
-            rewriter, llvm::cast<OpResult>(result), tiledValues[index],
-            resultOffsets, resultSizes, innerLoopBody))) {
+    if (failed(replaceStoresWithTiledVersion(rewriter, cast<OpResult>(result),
+                                             tiledValues[index], resultOffsets,
+                                             resultSizes, innerLoopBody))) {
       return failure();
     }
   }
@@ -525,7 +525,7 @@ tileAndFuseDispatchUsingSCFForOp(RewriterBase &rewriter, TilingInterface op,
       rewriter.setInsertionPoint(sliceOp);
 
       // Generate the tiled implementation of the producer.
-      OpResult untiledValue = llvm::cast<OpResult>(sliceOp.getSource());
+      OpResult untiledValue = cast<OpResult>(sliceOp.getSource());
       FailureOr<TilingResult> swapSliceResult =
           tensor::replaceExtractSliceWithTiledProducer(rewriter, sliceOp,
                                                        untiledValue);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -415,7 +415,7 @@ static LogicalResult rewriteForallToWorkgroup(RewriterBase &rewriter,
   SmallVector<Attribute> blockMapping =
       llvm::to_vector(forallOp.getMapping()->getValue());
   if (llvm::any_of(blockMapping, [](Attribute map) {
-        return !llvm::isa<gpu::GPUBlockMappingAttr>(map);
+        return !isa<gpu::GPUBlockMappingAttr>(map);
       })) {
     return forallOp->emitError("mapping must be #gpu.block<x/y/z/>");
   }
@@ -435,10 +435,8 @@ static LogicalResult rewriteForallToWorkgroup(RewriterBase &rewriter,
   }
   // Step 2. sort the values by the corresponding GPUBlockMappingAttr.
   auto comparator = [](Attribute a, Attribute b) -> bool {
-    return static_cast<int64_t>(
-               llvm::cast<gpu::GPUBlockMappingAttr>(a).getBlock()) <
-           static_cast<int64_t>(
-               llvm::cast<gpu::GPUBlockMappingAttr>(b).getBlock());
+    return static_cast<int64_t>(cast<gpu::GPUBlockMappingAttr>(a).getBlock()) <
+           static_cast<int64_t>(cast<gpu::GPUBlockMappingAttr>(b).getBlock());
   };
   SmallVector<Value> gridDimValues =
       getValuesSortedByKey(blockMapping, numBlocks, comparator);
@@ -447,8 +445,8 @@ static LogicalResult rewriteForallToWorkgroup(RewriterBase &rewriter,
   IRMapping bvm;
   SmallVector<Value> workgroupIdOps, workgroupCountOps;
   for (Attribute attr : blockMapping) {
-    auto idx = static_cast<int64_t>(
-        llvm::cast<gpu::GPUBlockMappingAttr>(attr).getBlock());
+    auto idx =
+        static_cast<int64_t>(cast<gpu::GPUBlockMappingAttr>(attr).getBlock());
     workgroupIdOps.push_back(
         HAL::InterfaceWorkgroupIDOp::create(rewriter, loc, idx));
     workgroupCountOps.push_back(
@@ -643,8 +641,7 @@ transform_dialect::PopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
     // Get the mapping IDs.
     auto mappingIds = llvm::map_to_vector(
         blockMapping.value(), [](Attribute mappingAttr) -> int {
-          return llvm::cast<DeviceMappingAttrInterface>(mappingAttr)
-              .getMappingId();
+          return cast<DeviceMappingAttrInterface>(mappingAttr).getMappingId();
         });
     int maxId = 0;
     for (auto id : mappingIds) {
@@ -802,8 +799,8 @@ static LogicalResult gpuComprehensiveBufferizeCopyFn(OpBuilder &builder,
                                                      Value to) {
   // Insert barriers for copies from and to shared memory.
   bool needsBarrier = false;
-  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(from.getType())) !=
-      hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(to.getType()))) {
+  if (hasSharedMemoryAddressSpace(cast<MemRefType>(from.getType())) !=
+      hasSharedMemoryAddressSpace(cast<MemRefType>(to.getType()))) {
     needsBarrier = true;
   }
   if (needsBarrier)

--- a/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -45,8 +45,7 @@ static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
   Type sourceType = source.getType();
   if (sourceType == targetType)
     return source;
-  if (llvm::isa<IntegerType>(sourceType) &&
-      llvm::isa<IntegerType>(targetType)) {
+  if (isa<IntegerType>(sourceType) && isa<IntegerType>(targetType)) {
     unsigned sourceBitWidth = sourceType.getIntOrFloatBitWidth();
     unsigned destBitWidth = targetType.getIntOrFloatBitWidth();
     if (sourceBitWidth > destBitWidth) {
@@ -61,7 +60,7 @@ static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
 /// Legalizes the given type. If the type is already legal, returns
 /// std::nullopt.
 static std::optional<Type> getLegalizedType(Type t) {
-  if (auto shapedType = llvm::dyn_cast<RankedTensorType>(t)) {
+  if (auto shapedType = dyn_cast<RankedTensorType>(t)) {
     Type elementType = shapedType.getElementType();
     std::optional<Type> legalizedElementType =
         legalizeStorageElementType(elementType);
@@ -111,8 +110,8 @@ struct ConstantOpTypeConversion
   LogicalResult
   matchAndRewrite(arith::ConstantOp constantOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto attr = llvm::cast<ElementsAttr>(constantOp.getValue());
-    auto attrType = llvm::dyn_cast<ShapedType>(attr.getType());
+    auto attr = cast<ElementsAttr>(constantOp.getValue());
+    auto attrType = dyn_cast<ShapedType>(attr.getType());
     if (!attrType) {
       return rewriter.notifyMatchFailure(
           constantOp, "expected attribute type to be shaped type");


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.