### PR TITLE
Drop unnecessary namespaces from cast functions in codegen backends. NFC. 4/10

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -57,10 +57,10 @@ namespace mlir::iree_compiler {
 
 // Returns the size, in bits, of |typeAttr|.
 static unsigned getDITypeSizeInBits(LLVM::DITypeAttr typeAttr) {
-  if (auto basicTypeAttr = llvm::dyn_cast<LLVM::DIBasicTypeAttr>(typeAttr)) {
+  if (auto basicTypeAttr = dyn_cast<LLVM::DIBasicTypeAttr>(typeAttr)) {
     return basicTypeAttr.getSizeInBits();
   } else if (auto derivedTypeAttr =
-                 llvm::dyn_cast<LLVM::DIDerivedTypeAttr>(typeAttr)) {
+                 dyn_cast<LLVM::DIDerivedTypeAttr>(typeAttr)) {
     if (unsigned derivedSize = derivedTypeAttr.getSizeInBits()) {
       return derivedSize;
     } else {
@@ -513,7 +513,7 @@ HALDispatchABI::buildScopeAttr(mlir::ModuleOp moduleOp,
   Builder builder(context);
 
   std::string inputFilePath("-");
-  if (auto fileLoc = llvm::dyn_cast<mlir::FileLineColLoc>(moduleOp.getLoc())) {
+  if (auto fileLoc = dyn_cast<mlir::FileLineColLoc>(moduleOp.getLoc())) {
     inputFilePath = fileLoc.getFilename().getValue();
   }
 
@@ -583,20 +583,20 @@ static StringRef getDimName(int32_t dim) {
 // the ops if MLIR or LLVM is likely to reject them.
 static bool isLocationValidForDI(Location loc) {
   // Unknown locations are passed as null and DI doesn't like that.
-  if (llvm::isa<UnknownLoc>(loc))
+  if (isa<UnknownLoc>(loc))
     return false;
   // MLIR currently can't handle name-only locations. We do this check to ensure
   // there's at least one real location MLIR can pass along.
-  if (auto callLoc = llvm::dyn_cast<CallSiteLoc>(loc)) {
+  if (auto callLoc = dyn_cast<CallSiteLoc>(loc)) {
     return isLocationValidForDI(callLoc.getCaller()) &&
            isLocationValidForDI(callLoc.getCallee());
-  } else if (auto fileLoc = llvm::dyn_cast<FileLineColLoc>(loc)) {
+  } else if (auto fileLoc = dyn_cast<FileLineColLoc>(loc)) {
     return true;
-  } else if (auto fusedLoc = llvm::dyn_cast<FusedLoc>(loc)) {
+  } else if (auto fusedLoc = dyn_cast<FusedLoc>(loc)) {
     return llvm::all_of(fusedLoc.getLocations(), isLocationValidForDI);
-  } else if (auto namedLoc = llvm::dyn_cast<NameLoc>(loc)) {
+  } else if (auto namedLoc = dyn_cast<NameLoc>(loc)) {
     return isLocationValidForDI(namedLoc.getChildLoc());
-  } else if (auto opaqueLoc = llvm::dyn_cast<OpaqueLoc>(loc)) {
+  } else if (auto opaqueLoc = dyn_cast<OpaqueLoc>(loc)) {
     return isLocationValidForDI(opaqueLoc.getFallbackLocation());
   }
   return false;
@@ -1216,8 +1216,8 @@ FailureOr<LLVM::LLVMFunctionType> HALDispatchABI::getABIFunctionType(
                      [](auto it) {
                        auto lhsType = std::get<0>(it);
                        auto rhsType = std::get<1>(it);
-                       return (llvm::isa<LLVM::LLVMPointerType>(lhsType) &&
-                               llvm::isa<LLVM::LLVMPointerType>(rhsType)) ||
+                       return (isa<LLVM::LLVMPointerType>(lhsType) &&
+                               isa<LLVM::LLVMPointerType>(rhsType)) ||
                               std::get<0>(it) == std::get<1>(it);
                      })) {
       // Extra fields already added. Drop them.
@@ -1255,8 +1255,8 @@ bool HALDispatchABI::hasCompatibleFunctionSignature(
   if (!llvm::all_of(llvm::zip(funcParamTypes, paramTypes), [](auto it) {
         auto lhsType = std::get<0>(it);
         auto rhsType = std::get<1>(it);
-        return (llvm::isa<LLVM::LLVMPointerType>(lhsType) &&
-                llvm::isa<LLVM::LLVMPointerType>(rhsType)) ||
+        return (isa<LLVM::LLVMPointerType>(lhsType) &&
+                isa<LLVM::LLVMPointerType>(rhsType)) ||
                std::get<0>(it) == std::get<1>(it);
       })) {
     return false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -392,7 +392,7 @@ getMinTilingSizesForEachDim(mlir::FunctionOpInterface entryPointFn,
 
     // If the indexing map has result it has to be a shaped type.
     auto operandType =
-        llvm::cast<ShapedType>(inputOutputOpOperands[index].get().getType());
+        cast<ShapedType>(inputOutputOpOperands[index].get().getType());
     int64_t tileSize = getVectorSize(entryPointFn, operandType);
 
     minTileSizes[fastestVaryingDim] =
@@ -3149,7 +3149,7 @@ void MultiLoweringConfigGenerator::loadRootLoweringConfig() {
       flags.resize(sizes.size(), false);
     } else if (level == IREE::CPU::TilingLevel::VectorCommonParallelTiles) {
       if (rootLoweringConfig.hasTilingLevel(llvm::to_underlying(level))) {
-        auto attr = llvm::cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        auto attr = cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
             rootLoweringConfig.getTilingLevelAttr(llvm::to_underlying(level)));
         sizes.assign(attr.getSizes());
         // Only `VectorCommonParallel` has scalable flags.
@@ -3279,7 +3279,7 @@ void MultiLoweringConfigGenerator::adjustTileSizesForRootOp() {
   if (!resultTypes.empty()) {
     Type elementType = getElementTypeOrSelf(resultTypes[0]);
     unsigned int elementTypeSize;
-    if (auto complexType = llvm::dyn_cast<ComplexType>(elementType)) {
+    if (auto complexType = dyn_cast<ComplexType>(elementType)) {
       elementTypeSize =
           2 * complexType.getElementType().getIntOrFloatBitWidth();
     } else {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -71,7 +71,7 @@ checkStackAllocationSize(mlir::FunctionOpInterface funcOp) {
           "function");
     }
     int allocaSize = 1;
-    auto allocaType = llvm::cast<ShapedType>(allocaOp.getType());
+    auto allocaType = cast<ShapedType>(allocaOp.getType());
     for (auto dimSize : allocaType.getShape()) {
       if (ShapedType::isDynamic(dimSize))
         continue;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -43,7 +43,7 @@ void collectLoopsToPeel(Operation *op,
                               .Default([](auto) { return 0; });
   for (int i = 0; i < maxNumLoopsToPeel; ++i) {
     op = op->getParentOfType<scf::ForOp>();
-    auto loop = llvm::cast_or_null<scf::ForOp>(op);
+    auto loop = cast_or_null<scf::ForOp>(op);
     if (!loop || iree_compiler::isTiledAndDistributedLoop(loop))
       break;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileToVectorSize.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileToVectorSize.cpp
@@ -73,8 +73,8 @@ getTileSizesForEachDims(linalg::LinalgOp op) {
     unsigned firstOperandDim = operandDimPairs[0].second;
 
     // Trivial case: `dim` size is available in the operand type.
-    int64_t dimSize = llvm::cast<ShapedType>(firstOperand.getType())
-                          .getShape()[firstOperandDim];
+    int64_t dimSize =
+        cast<ShapedType>(firstOperand.getType()).getShape()[firstOperandDim];
     int64_t vectorDimSize = vectorSizes.value()[dim];
     if (ShapedType::isStatic(dimSize) && dimSize > vectorDimSize) {
       LDBG() << "set dim #" << dim << " size (" << dimSize

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -115,8 +115,8 @@ static bool matchMMT(vector::ContractionOp contractionOp, int64_t mSize,
   if (!isMatrixTimesMatrixTransposed(contractionOp)) {
     return false;
   }
-  VectorType lhsType = llvm::cast<VectorType>(contractionOp.getLhs().getType());
-  VectorType rhsType = llvm::cast<VectorType>(contractionOp.getRhs().getType());
+  VectorType lhsType = cast<VectorType>(contractionOp.getLhs().getType());
+  VectorType rhsType = cast<VectorType>(contractionOp.getRhs().getType());
   auto lhsShape = lhsType.getShape();
   auto rhsShape = rhsType.getShape();
   if (lhsShape[1] != kSize || rhsShape[1] != kSize) {
@@ -146,7 +146,7 @@ static bool matchMMT(vector::ContractionOp contractionOp, int64_t mSize,
 static Value getUnpromotedInput(Type unpromotedType, Type promotedType,
                                 Value promotedResult) {
   VectorType promotedResultVectorType =
-      llvm::cast<VectorType>(promotedResult.getType());
+      cast<VectorType>(promotedResult.getType());
   if (promotedResultVectorType.getElementType() != promotedType) {
     return nullptr;
   }
@@ -160,8 +160,7 @@ static Value getUnpromotedInput(Type unpromotedType, Type promotedType,
     return nullptr;
   }
   Value extInput = extSIOp.getIn();
-  if (llvm::cast<VectorType>(extInput.getType()).getElementType() !=
-      unpromotedType) {
+  if (cast<VectorType>(extInput.getType()).getElementType() != unpromotedType) {
     return nullptr;
   }
   return extInput;
@@ -181,7 +180,7 @@ static Value extract1DSlice(PatternRewriter &rewriter, Location loc,
 // Helper to extract an element of a 1D vector.
 static Value extract(PatternRewriter &rewriter, Location loc, Value input,
                      int position) {
-  VectorType vectorType = llvm::cast<VectorType>(input.getType());
+  VectorType vectorType = cast<VectorType>(input.getType());
   assert(vectorType.getRank() == 1);
   (void)vectorType;
   std::array<int64_t, 1> offsets{position};
@@ -190,7 +189,7 @@ static Value extract(PatternRewriter &rewriter, Location loc, Value input,
 
 // Helper to flatten a N-dimensional vector to a 1D vector.
 static Value flatten(PatternRewriter &rewriter, Location loc, Value vector) {
-  VectorType inputVecType = llvm::cast<VectorType>(vector.getType());
+  VectorType inputVecType = cast<VectorType>(vector.getType());
   VectorType dstType = VectorType::get(inputVecType.getNumElements(),
                                        inputVecType.getElementType());
   return vector::ShapeCastOp::create(rewriter, loc, dstType, vector);
@@ -854,7 +853,7 @@ private:
     // the constraints string. Not confusing at all!
     inputs.append(lhs.begin(), lhs.end());
     for (const auto &v : rhs) {
-      if (llvm::cast<VectorType>(v.getType()).getNumElements() == 1)
+      if (cast<VectorType>(v.getType()).getNumElements() == 1)
         inputs.push_back(extract(rewriter, loc, v, 0));
       else
         inputs.push_back(v);
@@ -924,8 +923,7 @@ public:
     Type lhsElemType = generator.getLhsType();
     Type rhsElemType = generator.getRhsType();
     Type accElemType = generator.getAccType();
-    VectorType accType =
-        llvm::cast<VectorType>(contractionOp.getAcc().getType());
+    VectorType accType = cast<VectorType>(contractionOp.getAcc().getType());
     if (accType.getElementType() != accElemType) {
       return failure();
     }
@@ -1034,7 +1032,7 @@ public:
     auto acc = contractionOp.getAcc();
     auto lhs = contractionOp.getLhs();
     auto rhs = contractionOp.getRhs();
-    if (llvm::cast<VectorType>(acc.getType()).getElementType() != I32Type) {
+    if (cast<VectorType>(acc.getType()).getElementType() != I32Type) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -117,7 +117,7 @@ struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
 
   LogicalResult matchAndRewrite(MathOpTy mathOp,
                                 PatternRewriter &rewriter) const override {
-    auto vecType = llvm::dyn_cast<VectorType>(mathOp.getType());
+    auto vecType = dyn_cast<VectorType>(mathOp.getType());
     if (!vecType)
       return failure();
     Location loc = mathOp.getLoc();
@@ -164,7 +164,7 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
     } else {
       // If no alignment specified align at least to the size of an element.
       Type elType = allocOp.getType().getElementType();
-      if (auto shapeType = llvm::dyn_cast<ShapedType>(elType))
+      if (auto shapeType = dyn_cast<ShapedType>(elType))
         alignement =
             shapeType.getNumElements() * shapeType.getElementTypeBitWidth() / 8;
       else if (elType.isIndex()) {
@@ -391,7 +391,7 @@ struct ConvertIREEBindingSubspanOp final
     Location loc = op->getLoc();
     auto subspanOp = cast<IREE::HAL::InterfaceBindingSubspanOp>(op);
     MemRefType memrefType =
-        llvm::dyn_cast<MemRefType>(subspanOp.getResult().getType());
+        dyn_cast<MemRefType>(subspanOp.getResult().getType());
     mlir::BlockArgument llvmBufferArg =
         llvmFuncOp.getArgument(subspanOp.getBinding().getZExtValue());
     // Add the byte offset.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -140,7 +140,7 @@ static void populateSwapSetPrioWithMFMAPatterns(RewritePatternSet &patterns) {
 template <typename... Floats>
 static bool containsAPred(Type type) {
   type = getElementTypeOrSelf(type);
-  return llvm::isa<Floats...>(type);
+  return isa<Floats...>(type);
 }
 
 // Function to check valid data types on the ROCm backend.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -568,11 +568,9 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // Infer if lhs or rhs is transposed to help generate better schedule.
   SmallVector<AffineMap> maps = op.getIndexingMapsArray();
   bool transposedLhs =
-      kDim !=
-      llvm::cast<AffineDimExpr>(maps[0].getResults().back()).getPosition();
+      kDim != cast<AffineDimExpr>(maps[0].getResults().back()).getPosition();
   bool transposedRhs =
-      nDim !=
-      llvm::cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
+      nDim != cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
 
   std::optional<int64_t> wgpCount = std::nullopt;
   if (IREE::GPU::TargetChipAttr chip = target.getChip()) {
@@ -823,15 +821,15 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   LDBG() << "Attention Vector Distribution Config";
 
   // Infer if Q, K and V are transposed to help generate better schedule.
-  bool transposedQ = k1Dims.back() != llvm::cast<AffineDimExpr>(
-                                          op.getQueryMap().getResults().back())
-                                          .getPosition();
-  bool transposedK = k1Dims.back() != llvm::cast<AffineDimExpr>(
-                                          op.getKeyMap().getResults().back())
-                                          .getPosition();
-  bool transposedV = k2Dims.back() != llvm::cast<AffineDimExpr>(
-                                          op.getValueMap().getResults().back())
-                                          .getPosition();
+  bool transposedQ =
+      k1Dims.back() !=
+      cast<AffineDimExpr>(op.getQueryMap().getResults().back()).getPosition();
+  bool transposedK =
+      k1Dims.back() !=
+      cast<AffineDimExpr>(op.getKeyMap().getResults().back()).getPosition();
+  bool transposedV =
+      k2Dims.back() !=
+      cast<AffineDimExpr>(op.getValueMap().getResults().back()).getPosition();
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
   // First try to find a schedule with an exactly matching intrinsic.
@@ -1521,11 +1519,9 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
   };
   // Infer the MxN size of the matmul based on operands and indexing maps.
   auto lhsShape =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType())
-          .getShape();
+      cast<ShapedType>(op.getDpsInputOperand(0)->get().getType()).getShape();
   auto rhsShape =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(1)->get().getType())
-          .getShape();
+      cast<ShapedType>(op.getDpsInputOperand(1)->get().getType()).getShape();
   int64_t sizeM = ShapedType::kDynamic;
   int64_t sizeN = ShapedType::kDynamic;
   int64_t sizeK = ShapedType::kDynamic;
@@ -1762,7 +1758,7 @@ static LogicalResult setRootDefaultConfig(IREE::GPU::TargetAttr target,
         break;
       }
       ArrayRef<int64_t> shape =
-          llvm::cast<ShapedType>(outputOperand.get().getType()).getShape();
+          cast<ShapedType>(outputOperand.get().getType()).getShape();
       if (ShapedType::isDynamicShape(shape)) {
         vectorSize = 1;
         break;
@@ -2114,9 +2110,9 @@ static LogicalResult setConvolutionConfig(
   const int ocIndex = isNHWC ? 3 : 1;
 
   Type inputType = linalgOp.getDpsInputOperand(0)->get().getType();
-  ArrayRef<int64_t> inputShape = llvm::cast<ShapedType>(inputType).getShape();
+  ArrayRef<int64_t> inputShape = cast<ShapedType>(inputType).getShape();
   Type outputType = linalgOp.getDpsInitOperand(0)->get().getType();
-  ArrayRef<int64_t> outputShape = llvm::cast<ShapedType>(outputType).getShape();
+  ArrayRef<int64_t> outputShape = cast<ShapedType>(outputType).getShape();
   if (ShapedType::isDynamic(inputShape[3]) ||
       ShapedType::isDynamicShape(outputShape.drop_front())) {
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -69,9 +69,9 @@ struct LLVMGPUVectorDistributePass final
     std::array<int64_t, 3> workgroupSize;
     if (funcOp->hasAttr("workgroup_size")) {
       auto tmpSizes =
-          llvm::cast<ArrayAttr>(funcOp->getAttr("workgroup_size")).getValue();
+          cast<ArrayAttr>(funcOp->getAttr("workgroup_size")).getValue();
       for (auto [i, size] : llvm::enumerate(tmpSizes)) {
-        workgroupSize[i] = llvm::cast<IntegerAttr>(size).getInt();
+        workgroupSize[i] = cast<IntegerAttr>(size).getInt();
       }
     } else {
       std::optional<SmallVector<int64_t>> maybeWorkgroupSize =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -165,10 +165,10 @@ static FailureOr<Value> gpuAllocationFn(OpBuilder &builder, Location loc,
 static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
                                Value to) {
   bool needsBarrier = false;
-  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(from.getType()))) {
+  if (hasSharedMemoryAddressSpace(cast<MemRefType>(from.getType()))) {
     needsBarrier = true;
   }
-  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(to.getType()))) {
+  if (hasSharedMemoryAddressSpace(cast<MemRefType>(to.getType()))) {
     needsBarrier = true;
   }
   if (needsBarrier)
@@ -335,8 +335,7 @@ static FailureOr<Value> gpuRequireMemSpaceAllocationFn(OpBuilder &builder,
   // Bail out if the memref type specifies a nonnull memory space that is not
   // #gpu.address_space.
   if (memorySpace &&
-      !llvm::isa<gpu::AddressSpaceAttr, amdgpu::AddressSpaceAttr>(
-          memorySpace)) {
+      !isa<gpu::AddressSpaceAttr, amdgpu::AddressSpaceAttr>(memorySpace)) {
     return failure();
   }
 
@@ -725,11 +724,11 @@ void addGPUTransposePassPipeline(OpPassManager &funcPassManager,
 static LogicalResult gpuVectorCopyFn(OpBuilder &builder, Location loc,
                                      Value from, Value to) {
   bool needsBarrier = false;
-  MemRefType fromType = llvm::cast<MemRefType>(from.getType());
+  MemRefType fromType = cast<MemRefType>(from.getType());
   if (hasSharedMemoryAddressSpace(fromType)) {
     needsBarrier = true;
   }
-  if (hasSharedMemoryAddressSpace(llvm::cast<MemRefType>(to.getType()))) {
+  if (hasSharedMemoryAddressSpace(cast<MemRefType>(to.getType()))) {
     needsBarrier = true;
   }
   if (needsBarrier)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -363,7 +363,7 @@ static Value allocateGlobalSharedMemory(Location loc, OpBuilder &builder,
   MemRefType memrefType;
   auto addressSpaceAttr = gpu::AddressSpaceAttr::get(
       builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
-  if (auto vectorType = llvm::dyn_cast<VectorType>(type)) {
+  if (auto vectorType = dyn_cast<VectorType>(type)) {
     memrefType =
         MemRefType::get(vectorType.getShape(), vectorType.getElementType(),
                         MemRefLayoutAttrInterface{}, addressSpaceAttr);
@@ -487,7 +487,7 @@ static void populateMultiReductionLoweringPatterns(Operation *target,
 
 static AffineMap simpleDistributionFunction(Value val) {
   AffineMap map = AffineMap::get(val.getContext());
-  auto vecType = llvm::dyn_cast<VectorType>(val.getType());
+  auto vecType = dyn_cast<VectorType>(val.getType());
   if (!vecType)
     return map;
   // Create a map (d0, d1) -> (d1) to distribute along the inner
@@ -1484,7 +1484,7 @@ transform_dialect::CreateMatmulMfmaTileSizesOp::apply(
   auto payload = state.getPayloadOps(getTarget());
   Operation *target = *payload.begin();
   ArrayRef<int64_t> shape =
-      llvm::cast<ShapedType>(target->getResult(0).getType()).getShape();
+      cast<ShapedType>(target->getResult(0).getType()).getShape();
   if (shape.size() != 2) {
     return emitDefiniteFailure() << "matmul shape size should be 2";
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -93,7 +93,7 @@ static MaskResult getMask(Operation *op) {
           : transferRead.getMask().getDefiningOp<vector::CreateMaskOp>();
   if (maybeExtractOp) {
     if (maybeExtractOp.getStaticPosition().size() + 1 !=
-        llvm::cast<VectorType>(maskOp->getResultTypes().front()).getRank()) {
+        cast<VectorType>(maskOp->getResultTypes().front()).getRank()) {
       LDBG() << "----mask through extract unexpected position size -> Skip: "
              << maybeExtractOp;
       return MaskResult{};
@@ -200,13 +200,13 @@ void createAsyncGroups(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
       return WalkResult::advance();
     LDBG() << "--candidate writeOp: " << *writeOp;
     Value vectorVal = getValueStored(writeOp);
-    if (llvm::cast<VectorType>(vectorVal.getType()).getRank() != 1) {
+    if (cast<VectorType>(vectorVal.getType()).getRank() != 1) {
       LDBG() << "----writeOp is not an inbounds 1-D minor identity -> Skip";
       return WalkResult::advance();
     }
     Value memrefOperand = getMemrefOperand(writeOp);
     if (!hasSharedMemoryAddressSpace(
-            llvm::cast<MemRefType>(memrefOperand.getType()))) {
+            cast<MemRefType>(memrefOperand.getType()))) {
       LDBG() << "----address space is not workgroup -> Skip";
       return WalkResult::advance();
     }
@@ -236,7 +236,7 @@ void createAsyncGroups(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
 
     // Check whether both accesses are supported before we emit: this is
     // necessary to ensure the correctness of DeviceAsyncCopyOp.
-    VectorType vecType = llvm::cast<VectorType>(vectorVal.getType());
+    VectorType vecType = cast<VectorType>(vectorVal.getType());
     Value storeBase = getMemrefOperand(writeOp);
     Value loadBase = getMemrefOperand(readOp);
     if (!resultsInSupportedAsyncCopy(cast<MemRefType>(loadBase.getType()),
@@ -270,7 +270,7 @@ void createAsyncGroups(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
         Operation *readOp = nextNode;
         Value memrefOperand = getMemrefOperand(readOp);
         if (!hasSharedMemoryAddressSpace(
-                llvm::cast<MemRefType>(memrefOperand.getType()))) {
+                cast<MemRefType>(memrefOperand.getType()))) {
           continue;
         }
       }
@@ -289,13 +289,13 @@ void createAsyncGroups(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
     for (Operation *writeOp : group) {
       rewriter.setInsertionPoint(writeOp);
       Value vectorVal = getValueStored(writeOp);
-      auto vectorType = llvm::cast<VectorType>(vectorVal.getType());
+      auto vectorType = cast<VectorType>(vectorVal.getType());
       int64_t numElements = vectorType.getNumElements();
       Operation *readOp = vectorVal.getDefiningOp();
       Value storeBase = getMemrefOperand(writeOp);
       Value loadBase = getMemrefOperand(readOp);
       Value mask = getMaskValue(rewriter, readOp);
-      auto dstMemref = llvm::cast<MemRefType>(storeBase.getType());
+      auto dstMemref = cast<MemRefType>(storeBase.getType());
       int64_t sizeInBytes =
           (dstMemref.getElementTypeBitWidth() * numElements) / 8;
       UnitAttr bypassL1 =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -23,7 +23,7 @@ LogicalResult verifyLLVMGPUVectorDistributePipeline(
   }
 
   unsigned reduction = static_cast<uint32_t>(IREE::GPU::TilingLevel::Reduction);
-  unsigned numLoops = llvm::cast<linalg::LinalgOp>(op).getNumLoops();
+  unsigned numLoops = cast<linalg::LinalgOp>(op).getNumLoops();
   size_t size = 0;
 
   SmallVector<int64_t> reductionTileSizes =
@@ -37,7 +37,7 @@ LogicalResult verifyLLVMGPUVectorDistributePipeline(
   }
   for (size_t i = 0; i < size; ++i) {
     if (reductionTileSizes[i] > 0 &&
-        llvm::cast<linalg::LinalgOp>(op).getIteratorTypesArray()[i] !=
+        cast<linalg::LinalgOp>(op).getIteratorTypesArray()[i] !=
             utils::IteratorType::reduction) {
       return op->emitOpError(
           "expected to non-zero reduction tile has reduction iterator");
@@ -49,7 +49,7 @@ LogicalResult verifyLLVMGPUVectorDistributePipeline(
   size = workgroupTileSizes.size();
   for (size_t i = 0; i < size; ++i) {
     if (workgroupTileSizes[i] > 0 &&
-        llvm::cast<linalg::LinalgOp>(op).getIteratorTypesArray()[i] !=
+        cast<linalg::LinalgOp>(op).getIteratorTypesArray()[i] !=
             utils::IteratorType::parallel) {
       return op->emitOpError(
           "expected to non-zero workgroup tile has parallel iterator");

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -40,8 +40,7 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
   int subgroupSize = target.getPreferredSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 8};
   std::array<int64_t, 3> threadMNK;
-  auto inputType =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
+  auto inputType = cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {8, 8, 32};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -23,8 +23,7 @@ static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
   const int subgroupSize = target.getPreferredSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
-  auto inputType =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
+  auto inputType = cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {16, 8, 8};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -22,8 +22,7 @@ static LogicalResult setAppleMatmulConfig(linalg::LinalgOp op,
                                           IREE::GPU::TargetAttr target) {
   const std::array<int64_t, 2> workgroupXY = {256, 1};
   std::array<int64_t, 3> threadMNK;
-  auto inputType =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
+  auto inputType = cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {4, 8, 8};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -491,8 +491,8 @@ struct RemoveStaticDynamicCast final : OpRewritePattern<memref::CastOp> {
 
   LogicalResult matchAndRewrite(memref::CastOp castOp,
                                 PatternRewriter &rewriter) const override {
-    auto srcType = llvm::cast<MemRefType>(castOp.getSource().getType());
-    auto dstType = llvm::cast<MemRefType>(castOp.getType());
+    auto srcType = cast<MemRefType>(castOp.getSource().getType());
+    auto dstType = cast<MemRefType>(castOp.getType());
     if (srcType.getRank() == 1 && dstType.getRank() == 1 &&
         srcType.hasStaticShape() != dstType.hasStaticShape()) {
       rewriter.replaceOp(castOp, castOp.getSource());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -25,7 +25,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
   Type inputType = op.getDpsInputOperand(0)->get().getType();
-  Type elementType = llvm::cast<ShapedType>(inputType).getElementType();
+  Type elementType = cast<ShapedType>(inputType).getElementType();
   if (IREE::Util::getTypeBitWidth(elementType) == 16) {
     threadMNK = {2, 8, 8};
   } else if (elementType.isInteger(8)) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -36,8 +36,7 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
   const int subgroupSize = target.getPreferredSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize, 8};
   std::array<int64_t, 3> threadMNK;
-  auto inputType =
-      llvm::cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
+  auto inputType = cast<ShapedType>(op.getDpsInputOperand(0)->get().getType());
   if (IREE::Util::getTypeBitWidth(inputType.getElementType()) == 16) {
     threadMNK = {8, 8, 32};
   } else {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -89,8 +89,8 @@ static FailureOr<Value> gpuAllocateFunctionMemoryFn(OpBuilder &builder,
 
 static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
                                Value to) {
-  auto fromType = llvm::cast<MemRefType>(from.getType());
-  auto toType = llvm::cast<MemRefType>(to.getType());
+  auto fromType = cast<MemRefType>(from.getType());
+  auto toType = cast<MemRefType>(to.getType());
 
   bool needsBarrier = hasSharedMemoryAddressSpace(fromType) ||
                       hasSharedMemoryAddressSpace(toType);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -137,7 +137,7 @@ struct ConvertUtilAssumeIntOp final
 
 // Tries to flatten `type` to a 1-D vector type. Returns `nullptr` on failure.
 static VectorType flattenVectorType(Type type) {
-  auto vecTy = llvm::dyn_cast<VectorType>(type);
+  auto vecTy = dyn_cast<VectorType>(type);
   if (!vecTy)
     return nullptr;
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -35,11 +35,11 @@ class EraseStorageBufferStaticShapePass final
 /// buffer.
 bool is1DStaticShapedStorageBuffer(
     IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
-  auto type = llvm::dyn_cast<MemRefType>(subspanOp.getType());
+  auto type = dyn_cast<MemRefType>(subspanOp.getType());
   if (!type)
     return false;
-  auto attr = llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(
-      type.getMemorySpace());
+  auto attr =
+      dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(type.getMemorySpace());
   if (!attr)
     return false;
   return type.hasStaticShape() && type.getRank() == 1 &&
@@ -75,7 +75,7 @@ rewriteStorageBufferSubspanOp(RewriterBase &rewriter,
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(subspanOp);
 
-  auto oldType = llvm::cast<MemRefType>(subspanOp.getType());
+  auto oldType = cast<MemRefType>(subspanOp.getType());
   auto newType =
       MemRefType::get({ShapedType::kDynamic}, oldType.getElementType(),
                       oldType.getLayout(), oldType.getMemorySpace());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -232,7 +232,7 @@ SmallVector<int64_t> getNativeVectorShapeImpl(vector::GatherOp op) {
 std::optional<SmallVector<int64_t>>
 getNativeVectorShape(Operation *op, bool targetSupportsDotProd) {
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
-    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0])) {
+    if (auto vecType = dyn_cast<VectorType>(op->getResultTypes()[0])) {
       SmallVector<int64_t> nativeSize(vecType.getRank(), 1);
       nativeSize.back() = getComputeVectorSize(vecType.getShape().back());
       return nativeSize;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
@@ -30,8 +30,7 @@ namespace {
 template <bool UseIndirectBindings>
 std::optional<spirv::StorageClass>
 mapHALDescriptorTypeForVulkan(Attribute attr) {
-  if (auto dtAttr =
-          llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
+  if (auto dtAttr = dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
     switch (dtAttr.getValue()) {
     case IREE::HAL::DescriptorType::UniformBuffer:
       return spirv::StorageClass::Uniform;
@@ -42,7 +41,7 @@ mapHALDescriptorTypeForVulkan(Attribute attr) {
       return std::nullopt;
     }
   }
-  if (auto gpuAttr = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
+  if (auto gpuAttr = dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
     switch (gpuAttr.getValue()) {
     case gpu::AddressSpace::Workgroup:
       return spirv::StorageClass::Workgroup;
@@ -55,8 +54,7 @@ mapHALDescriptorTypeForVulkan(Attribute attr) {
 
 std::optional<spirv::StorageClass>
 mapHALDescriptorTypeForOpenCL(Attribute attr) {
-  if (auto dtAttr =
-          llvm::dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
+  if (auto dtAttr = dyn_cast_if_present<IREE::HAL::DescriptorTypeAttr>(attr)) {
     switch (dtAttr.getValue()) {
     case IREE::HAL::DescriptorType::UniformBuffer:
       return spirv::StorageClass::Uniform;
@@ -64,7 +62,7 @@ mapHALDescriptorTypeForOpenCL(Attribute attr) {
       return spirv::StorageClass::CrossWorkgroup;
     }
   }
-  if (auto gpuAttr = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
+  if (auto gpuAttr = dyn_cast_if_present<gpu::AddressSpaceAttr>(attr)) {
     switch (gpuAttr.getValue()) {
     case gpu::AddressSpace::Workgroup:
       return spirv::StorageClass::Workgroup;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -298,7 +298,7 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
   auto genericOp = cast<linalg::GenericOp>(*linalgOps.back());
 
   auto matmulType =
-      llvm::cast<MemRefType>(matmulOp.getDpsInitOperand(0)->get().getType());
+      cast<MemRefType>(matmulOp.getDpsInitOperand(0)->get().getType());
   if (hasSharedMemoryAddressSpace(matmulType)) {
     // The matmul output is already in shared memory. This can happen when
     // bufferization decides an allocation is needed, e.g., matmul + arith.extf,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -182,7 +182,7 @@ getExtOpVectorShape(ExtOpTy op, ArrayRef<int64_t> nativeShape) {
     auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
     if (!extract)
       return std::nullopt;
-    auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
+    auto vecType = cast<VectorType>(extract.getResult().getType());
     if (!llvm::equal(sliceType.getShape(), vecType.getShape()))
       return std::nullopt;
   }
@@ -201,7 +201,7 @@ getCooperativeOpVectorShape(Operation *op, ArrayRef<int64_t> nativeShape) {
 
   // Unroll elementwise ops according to native cooperative matrix size.
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
-    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0]))
+    if (auto vecType = dyn_cast<VectorType>(op->getResultTypes()[0]))
       return llvm::to_vector(nativeShape.drop_back()); // Drop K dim size
   }
 
@@ -240,7 +240,7 @@ getCooperativeOpVectorShape(Operation *op, ArrayRef<int64_t> nativeShape) {
       auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
       if (!extract)
         return std::nullopt;
-      auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
+      auto vecType = cast<VectorType>(extract.getResult().getType());
       if (sliceType && sliceType != vecType)
         return std::nullopt;
       sliceType = vecType;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -160,8 +160,8 @@ static unsigned isMemRefVectorizable(Value value,
   auto memrefType = dyn_cast<MemRefType>(value.getType());
 
   // Require scalar element type
-  if (!memrefType || (!llvm::isa<IntegerType>(memrefType.getElementType()) &&
-                      !llvm::isa<FloatType>(memrefType.getElementType()))) {
+  if (!memrefType || (!isa<IntegerType>(memrefType.getElementType()) &&
+                      !isa<FloatType>(memrefType.getElementType()))) {
     LLVM_DEBUG(llvm::dbgs() << "failed: not (scalar) memref\n");
     return 0;
   }
@@ -554,7 +554,7 @@ MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
   // If the vector we need to generate is bigger than the the max vector size
   // allowed for loads use a larger element type.
   if (vectorNumElements > kMaxVectorNumElements) {
-    scalarType = llvm::isa<IntegerType>(scalarType)
+    scalarType = isa<IntegerType>(scalarType)
                      ? cast<Type>(rewriter.getI32Type())
                      : cast<Type>(rewriter.getF32Type());
     scalarNumBits = scalarType.getIntOrFloatBitWidth();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -100,9 +100,9 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> lhsShape =
-      llvm::cast<ShapedType>(op->getOperand(0).getType()).getShape();
+      cast<ShapedType>(op->getOperand(0).getType()).getShape();
   ArrayRef<int64_t> rhsShape =
-      llvm::cast<ShapedType>(op->getOperand(1).getType()).getShape();
+      cast<ShapedType>(op->getOperand(1).getType()).getShape();
 
   if (loweringConfig.getTilingLevels().size() != 1) {
     return op->emitOpError("expected 1 levels of tiling sizes, got ")
@@ -209,9 +209,9 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> lhsShape =
-      llvm::cast<ShapedType>(op->getOperand(0).getType()).getShape();
+      cast<ShapedType>(op->getOperand(0).getType()).getShape();
   ArrayRef<int64_t> rhsShape =
-      llvm::cast<ShapedType>(op->getOperand(1).getType()).getShape();
+      cast<ShapedType>(op->getOperand(1).getType()).getShape();
 
   SmallVector<int64_t> workgroupTileSizes =
       loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
@@ -233,7 +233,7 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   }
 
   auto getElementType = [](Value v) {
-    return llvm::cast<ShapedType>(v.getType()).getElementType();
+    return cast<ShapedType>(v.getType()).getElementType();
   };
 
   Type lhsType = getElementType(op->getOperand(0));
@@ -324,7 +324,7 @@ LogicalResult verifySPIRVBaseVectorizePassPipeline(
   }
 
   ArrayRef<int64_t> outputShape =
-      llvm::cast<ShapedType>(op->getOperand(2).getType()).getShape();
+      cast<ShapedType>(op->getOperand(2).getType()).getShape();
   const int64_t oh = outputShape[1], ow = outputShape[2], oc = outputShape[3];
 
   // Verify the first level tile size divides the Convolution

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
@@ -166,7 +166,7 @@ public:
   bool isValid() { return true; }
 
   // Gets the type of the buffer being analyzed.
-  MemRefType getType() { return llvm::cast<MemRefType>(buffer.getType()); }
+  MemRefType getType() { return cast<MemRefType>(buffer.getType()); }
 
   // Gets the rank of the buffer being analyzed.
   unsigned getRank() { return getType().getRank(); }
@@ -186,7 +186,7 @@ public:
     builder.setInsertionPointAfterValue(buffer);
 
     Location loc = buffer.getLoc();
-    desc = StridedBufferDescriptor(llvm::cast<MemRefType>(buffer.getType()));
+    desc = StridedBufferDescriptor(cast<MemRefType>(buffer.getType()));
 
     int rank = getType().getRank();
     SmallVector<Type> sizeStrideTypes;
@@ -545,9 +545,9 @@ struct LinalgBinaryGenericConversion
       return failure();
     }
     BlockArgument operandScalar0 =
-        llvm::dyn_cast<BlockArgument>(binaryOp->getOperands()[0]);
+        dyn_cast<BlockArgument>(binaryOp->getOperands()[0]);
     BlockArgument operandScalar1 =
-        llvm::dyn_cast<BlockArgument>(binaryOp->getOperands()[1]);
+        dyn_cast<BlockArgument>(binaryOp->getOperands()[1]);
     if (!operandScalar0 || !operandScalar1)
       return failure();
 
@@ -725,7 +725,7 @@ struct LinalgUnaryGenericConversion
       return failure();
     }
     BlockArgument operandScalar0 =
-        llvm::dyn_cast<BlockArgument>(unaryOp->getOperands()[0]);
+        dyn_cast<BlockArgument>(unaryOp->getOperands()[0]);
     if (!operandScalar0)
       return failure();
 
@@ -843,7 +843,7 @@ struct LinalgTrivialGenericConversion
     Operation &yieldOp = children.front();
     for (auto [outputIndex, yieldOperand] :
          llvm::enumerate(yieldOp.getOperands())) {
-      if (auto blockArg = llvm::dyn_cast<BlockArgument>(yieldOperand)) {
+      if (auto blockArg = dyn_cast<BlockArgument>(yieldOperand)) {
         unsigned inputIndex = blockArg.getArgNumber();
         OpOperand *input = op.getDpsInputOperand(inputIndex);
         OpOperand *output = op.getDpsInitOperand(outputIndex);
@@ -941,7 +941,7 @@ class VMVXLowerLinalgMicrokernelsPass
 
     if (warnOnUnconverted) {
       getOperation()->walk([](Operation *op) {
-        if (llvm::isa<linalg::LinalgOp>(op)) {
+        if (isa<linalg::LinalgOp>(op)) {
           auto diag = op->emitWarning(
               "Linalg op not converted to microkernel and will be implemented "
               "with fallback scalar loops");


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.