### PR TITLE
Drop unnecessary namespaces from cast functions in codegen dialect utils. NFC. 5/10

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -354,7 +354,7 @@ CompilationInfoAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   if (!loweringConfig) {
     return emitError() << "missing lowering config";
   }
-  if (auto defaultConfig = llvm::dyn_cast<LoweringConfigAttr>(loweringConfig)) {
+  if (auto defaultConfig = dyn_cast<LoweringConfigAttr>(loweringConfig)) {
     if (failed(LoweringConfigAttr::verify(emitError,
                                           defaultConfig.getTilingLevels()))) {
       return emitError() << "invalid lowering config: " << defaultConfig;
@@ -416,7 +416,7 @@ LogicalResult WorkgroupMappingAttr::verifyAttrList(MLIRContext *context,
   auto emitError = mlir::detail::getDefaultDiagnosticEmitFn(loc);
   for (auto attr : attrs) {
     auto typedAttr =
-        ::mlir::dyn_cast_or_null<IREE::Codegen::WorkgroupMappingAttr>(attr);
+        dyn_cast_or_null<IREE::Codegen::WorkgroupMappingAttr>(attr);
     if (!typedAttr) {
       return emitError() << "expected all the mapping attribute to be of "
                             "`WorkgroupMappingAttr` type";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -22,13 +22,13 @@ namespace mlir::iree_compiler::IREE::Codegen {
 struct IREECodegenDialectOpAsmInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<TranslationInfoAttr>(attr)) {
+    if (isa<TranslationInfoAttr>(attr)) {
       os << "translation";
       return AliasResult::OverridableAlias;
-    } else if (llvm::isa<CompilationInfoAttr>(attr)) {
+    } else if (isa<CompilationInfoAttr>(attr)) {
       os << "compilation";
       return AliasResult::OverridableAlias;
-    } else if (llvm::isa<LoweringConfigAttr>(attr)) {
+    } else if (isa<LoweringConfigAttr>(attr)) {
       os << "config";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -40,7 +40,7 @@ LogicalResult ExtractStridedMetadataOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location,
     ExtractStridedMetadataOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
-  auto sourceType = llvm::dyn_cast<MemRefType>(adaptor.getSource().getType());
+  auto sourceType = dyn_cast<MemRefType>(adaptor.getSource().getType());
   if (!sourceType)
     return failure();
 
@@ -277,7 +277,7 @@ LogicalResult InnerTiledOp::verify() {
   }
 
   SmallVector<ShapedType> opTypes = llvm::map_to_vector(
-      getOperandTypes(), [](auto t) { return llvm::cast<ShapedType>(t); });
+      getOperandTypes(), [](auto t) { return cast<ShapedType>(t); });
   SmallVector<AffineMap, 4> indexingMaps = getIndexingMapsArray();
 
   // Verify that an indexing map was specified for each operand.

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
@@ -31,8 +31,7 @@ SmallVector<Range> InnerTiledOp::getIterationDomain(OpBuilder &builder) {
   for (const auto &it : llvm::enumerate(getIteratorTypes())) {
     // Search input map results for 'targetExpr'.
     auto targetExpr = getAffineDimExpr(it.index(), builder.getContext());
-    auto iteratorType =
-        llvm::cast<linalg::IteratorTypeAttr>(it.value()).getValue();
+    auto iteratorType = cast<linalg::IteratorTypeAttr>(it.value()).getValue();
     ArrayRef<AffineMap> maps =
         iteratorType == utils::IteratorType::reduction ? inputMaps : outputMaps;
     ValueRange ops = iteratorType == utils::IteratorType::reduction

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -157,7 +157,7 @@ lowerUKernelGenericToFunctionCall(RewriterBase &rewriter,
   }
   SmallVector<Type> callResultTypes;
   for (auto [idx, resultType] : llvm::enumerate(op->getResultTypes())) {
-    if (llvm::isa<ShapedType>(resultType)) {
+    if (isa<ShapedType>(resultType)) {
       return rewriter.notifyMatchFailure(
           op, "cannot lower a `ShapedType` return value to function call");
     }
@@ -266,14 +266,14 @@ void UKernelGenericOp::getEffects(
   llvm::append_range(readOnlyOperands,
                      llvm::make_pointer_range(getOtherOperandsMutable()));
   for (OpOperand *operand : readOnlyOperands) {
-    if (!llvm::isa<MemRefType>(operand->get().getType())) {
+    if (!isa<MemRefType>(operand->get().getType())) {
       continue;
     }
     effects.emplace_back(MemoryEffects::Read::get(), operand,
                          SideEffects::DefaultResource::get());
   }
   for (OpOperand &operand : getDpsInitsMutable()) {
-    if (!llvm::isa<MemRefType>(operand.get().getType())) {
+    if (!isa<MemRefType>(operand.get().getType())) {
       continue;
     }
     effects.emplace_back(MemoryEffects::Read::get(), &operand,
@@ -310,7 +310,7 @@ struct UKernelOpsBufferizationInterface
     // Replace all `tensor` operands with corresponding `memref` operands.
     for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
       // For `tensor` type operands, replace with `memref` type operand.
-      if (llvm::isa<RankedTensorType>(operand.getType())) {
+      if (isa<RankedTensorType>(operand.getType())) {
         FailureOr<Value> memrefOperand =
             getBuffer(rewriter, operand, options, state);
         if (failed(memrefOperand)) {
@@ -329,7 +329,7 @@ struct UKernelOpsBufferizationInterface
     SmallVector<Value> nonTensorResultValues;
     for (OpResult result : op->getResults()) {
       Type resultType = result.getType();
-      if (llvm::isa<RankedTensorType>(resultType))
+      if (isa<RankedTensorType>(resultType))
         continue;
       nonTensorResultTypes.push_back(resultType);
       nonTensorResultValues.push_back(result);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -724,7 +724,7 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
                          MMAIntrinsic intrinsic, Type resultType, Value lhs,
                          Value rhs, Value acc, bool colMajor = false) {
   auto getVecOrSingleElem = [&](Value vec) -> Value {
-    bool one = llvm::cast<VectorType>(vec.getType()).getNumElements() == 1;
+    bool one = cast<VectorType>(vec.getType()).getNumElements() == 1;
     return one ? vector::ExtractOp::create(builder, loc, vec, 0) : vec;
   };
   auto layout = getOpaqueMMALayout(builder.getContext(), intrinsic);
@@ -917,7 +917,7 @@ static bool incrementIndices(MutableArrayRef<int64_t> indices,
 /// that it returns the value directly if it is a 0-D vector.
 static Value flattenVector(OpBuilder &builder, Location loc, Value value) {
   Type type = value.getType();
-  VectorType vectorType = llvm::dyn_cast<VectorType>(type);
+  VectorType vectorType = dyn_cast<VectorType>(type);
   assert(vectorType);
   if (vectorType.getRank() <= 1) {
     return value;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -60,7 +60,7 @@ LogicalResult BarrierRegionOp::verifyRegions() {
   }
 
   // Ensure that the region yields an element of the right type.
-  auto yieldOp = llvm::cast<GPU::YieldOp>(block.getTerminator());
+  auto yieldOp = cast<GPU::YieldOp>(block.getTerminator());
   if (yieldOp->getNumOperands() != getNumResults()) {
     return emitOpError(
         "expected body to yield same number of values as results");

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -622,10 +622,10 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   // TODO: Drop this. This is only a consideration for other pipelines.
   bool transposedLhs =
       kDims.back() !=
-      llvm::cast<AffineDimExpr>(maps[0].getResults().back()).getPosition();
+      cast<AffineDimExpr>(maps[0].getResults().back()).getPosition();
   bool transposedRhs =
       nDims.back() !=
-      llvm::cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
+      cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
   bool couldNeedPadding = false;
 
   // Helper to pad bounds to a preferred alignment.
@@ -868,7 +868,7 @@ LogicalResult setIGEMMConvolutionLoweringConfig(
 
   ConvToIgemmInfo convToIgemmInfo;
   if (padConv) {
-    auto inputType = llvm::cast<ShapedType>(op->getOperands()[0].getType());
+    auto inputType = cast<ShapedType>(op->getOperands()[0].getType());
     ArrayRef<int64_t> inputShape = inputType.getShape();
     AffineMap inputMap = linalgOp.getIndexingMapsArray()[0];
     SmallVector<int64_t> inputImagePos;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -101,7 +101,7 @@ struct CombineAdjacentBarrierRegions final
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::GPU::BarrierRegionOp barrierOp,
                                 PatternRewriter &rewriter) const override {
-    auto prevBarrier = llvm::dyn_cast_if_present<IREE::GPU::BarrierRegionOp>(
+    auto prevBarrier = dyn_cast_if_present<IREE::GPU::BarrierRegionOp>(
         barrierOp->getPrevNode());
     if (!prevBarrier) {
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -304,7 +304,7 @@ NestedLayoutAttr::getRecombinedLayout(ArrayRef<VectorLayoutInterface> layouts,
                                       AffineMap resultMap) {
   constexpr int64_t kInvalid = -1;
   if (llvm::any_of(layouts, [](VectorLayoutInterface layout) {
-        return !mlir::isa<NestedLayoutAttr>(layout);
+        return !isa<NestedLayoutAttr>(layout);
       })) {
     return NestedLayoutAttr();
   }
@@ -313,7 +313,7 @@ NestedLayoutAttr::getRecombinedLayout(ArrayRef<VectorLayoutInterface> layouts,
   SmallVector<NestedLayoutAttr> nestedLayouts;
   llvm::transform(layouts, std::back_inserter(nestedLayouts),
                   [&](VectorLayoutInterface layout) {
-                    return mlir::cast<NestedLayoutAttr>(layout);
+                    return cast<NestedLayoutAttr>(layout);
                   });
 
   int64_t resRank = resultMap.getNumResults();

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.cpp
@@ -25,7 +25,7 @@ namespace mlir::iree_compiler::IREE::VectorExt {
 struct IREEVectorExtDialectOpAsmInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<NestedLayoutAttr>(attr)) {
+    if (isa<NestedLayoutAttr>(attr)) {
       os << "nested";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -686,8 +686,8 @@ struct CPUEncodingPackedLayoutMaterializerAttr
                                               RankedTensorType type) const {
     auto layoutAttr = cast<CPUEncodingResolverAttr>(attr);
 
-    auto encoding = llvm::dyn_cast_or_null<IREE::Encoding::EncodingAttr>(
-        type.getEncoding());
+    auto encoding =
+        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {
@@ -737,7 +737,7 @@ struct CPUEncodingResolverMaterializerAttr final
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
     auto layoutAttr = cast<CPUEncodingResolverAttr>(attr);
-    auto linalgOp = llvm::dyn_cast<linalg::LinalgOp>(op);
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
     if (!linalgOp) {
       return nullptr;
     }
@@ -845,8 +845,8 @@ struct VMVXEncodingPackedLayoutMaterializerAttr final
                                               RankedTensorType type) const {
     auto layoutAttr = cast<VMVXEncodingResolverAttr>(attr);
 
-    auto encoding = llvm::dyn_cast_or_null<IREE::Encoding::EncodingAttr>(
-        type.getEncoding());
+    auto encoding =
+        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {
@@ -891,7 +891,7 @@ struct VMVXEncodingResolverMaterializerAttr final
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
     auto layoutAttr = cast<VMVXEncodingResolverAttr>(attr);
-    auto linalgOp = llvm::dyn_cast<linalg::LinalgOp>(op);
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
     if (!linalgOp) {
       return nullptr;
     }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -513,8 +513,8 @@ struct GPUEncodingPackedLayoutMaterializerAttr
     auto resolver = cast<GPUEncodingResolverAttr>(attr);
     DictionaryAttr config = resolver.getConfiguration();
 
-    auto encoding = llvm::dyn_cast_or_null<IREE::Encoding::EncodingAttr>(
-        type.getEncoding());
+    auto encoding =
+        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {
@@ -558,7 +558,7 @@ struct GPUEncodingResolverMaterializerAttr
                      TypeRange convertedResTypes,
                      ValueRange convertedOperands) const {
     auto resolverAttr = cast<GPUEncodingResolverAttr>(attr);
-    auto linalgOp = llvm::dyn_cast<linalg::LinalgOp>(op);
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
     if (!linalgOp) {
       return nullptr;
     }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -60,7 +60,7 @@ struct DispatchTensorLoadOpInterface
   bool isWritable(Operation *op, Value value,
                   const AnalysisState &state) const {
     auto loadOp = cast<IREE::TensorExt::DispatchTensorLoadOp>(op);
-    auto shapedType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+    auto shapedType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
         loadOp.getSource().getType());
     assert(shapedType && "unexpected source type");
     return shapedType.getAccess() != IREE::TensorExt::TensorAccess::ReadOnly;
@@ -77,7 +77,7 @@ struct DispatchTensorLoadOpInterface
     Value source = findOrCreateSubspanBuffer(rewriter, tensorSubspanOp);
 
     if (equalTensorShape(loadOp.getType(), loadOp.sizes(),
-                         llvm::cast<IREE::TensorExt::DispatchTensorType>(
+                         cast<IREE::TensorExt::DispatchTensorType>(
                              loadOp.getSource().getType()),
                          loadOp.getSourceDims())) {
       // The entire tensor is loaded.
@@ -87,11 +87,11 @@ struct DispatchTensorLoadOpInterface
 
     // Bufferize to subview.
     auto subviewMemRefType = memref::SubViewOp::inferRankReducedResultType(
-        loadOp.getType().getShape(), llvm::cast<MemRefType>(source.getType()),
+        loadOp.getType().getShape(), cast<MemRefType>(source.getType()),
         loadOp.getMixedOffsets(), loadOp.getMixedSizes(),
         loadOp.getMixedStrides());
     replaceOpWithNewBufferizedOp<memref::SubViewOp>(
-        rewriter, op, llvm::cast<MemRefType>(subviewMemRefType), source,
+        rewriter, op, cast<MemRefType>(subviewMemRefType), source,
         loadOp.getMixedOffsets(), loadOp.getMixedSizes(),
         loadOp.getMixedStrides());
 
@@ -129,15 +129,14 @@ struct DispatchTensorStoreOpInterface
     assert(tensorSubspanOp && "expected that target is a SubspanOp");
     Value target = findOrCreateSubspanBuffer(rewriter, tensorSubspanOp);
 
-    if (!equalTensorShape(
-            llvm::cast<RankedTensorType>(storeOp.getValue().getType()),
-            storeOp.getSizes(),
-            llvm::cast<IREE::TensorExt::DispatchTensorType>(
-                storeOp.getTarget().getType()),
-            storeOp.getTargetDims())) {
+    if (!equalTensorShape(cast<RankedTensorType>(storeOp.getValue().getType()),
+                          storeOp.getSizes(),
+                          cast<IREE::TensorExt::DispatchTensorType>(
+                              storeOp.getTarget().getType()),
+                          storeOp.getTargetDims())) {
       // Writing to a part of the tensor.
       auto subviewMemRefType =
-          llvm::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
+          cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
               cast<ShapedType>(storeOp.getValue().getType()).getShape(),
               cast<MemRefType>(target.getType()), storeOp.getMixedOffsets(),
               storeOp.getMixedSizes(), storeOp.getMixedStrides()));
@@ -587,8 +586,7 @@ struct DispatchTensorStoreOpSubsetInsertionInterface
                               Location loc) const {
     auto storeOp = cast<IREE::TensorExt::DispatchTensorStoreOp>(op);
     auto loadOp = IREE::TensorExt::DispatchTensorLoadOp::create(
-        builder, loc,
-        llvm::cast<RankedTensorType>(storeOp.getValue().getType()),
+        builder, loc, cast<RankedTensorType>(storeOp.getValue().getType()),
         storeOp.getTarget(), storeOp.getTargetDims(), storeOp.getMixedOffsets(),
         storeOp.getMixedSizes(), storeOp.getMixedStrides());
     return loadOp.getResult();

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -39,7 +39,7 @@ static bool affineMinOpDivisible(affine::AffineMinOp minOp, int64_t dividend) {
   Value step;
   // Check if any of the dimensions is a ForOp or ParallelOp induction variable.
   for (auto dim : minOp.getDimOperands()) {
-    auto ivArg = llvm::dyn_cast<BlockArgument>(dim);
+    auto ivArg = dyn_cast<BlockArgument>(dim);
     if (!ivArg)
       continue;
     Operation *containingOp = ivArg.getOwner()->getParentOp();

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -847,8 +847,7 @@ void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
     maxAlloc = std::max(maxAlloc, allocSize);
   }
   Attribute memorySpace =
-      llvm::cast<MemRefType>(aliasGroups[0][0]->getResultTypes()[0])
-          .getMemorySpace();
+      cast<MemRefType>(aliasGroups[0][0]->getResultTypes()[0]).getMemorySpace();
   MemRefType allocType = MemRefType::get({maxAlloc}, builder.getI8Type(),
                                          AffineMap(), memorySpace);
   Value packedAlloc =
@@ -1020,8 +1019,7 @@ struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
     int64_t numInductionVars = forallOp.getInductionVars().size();
     for (auto &yieldingOp : parallelTerminator.getYieldingOps()) {
       auto parallelInsert = cast<tensor::ParallelInsertSliceOp>(&yieldingOp);
-      BlockArgument destBbArg =
-          llvm::cast<BlockArgument>(parallelInsert.getDest());
+      BlockArgument destBbArg = cast<BlockArgument>(parallelInsert.getDest());
       tensor::ExtractSliceOp destSlice;
       for (auto user : destBbArg.getUsers()) {
         if (user == parallelInsert)

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -110,7 +110,7 @@ FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensorImpl(
     ValueRange dynamicDims, IREE::Encoding::LayoutMaterializerAttr layoutAttr,
     IREE::Codegen::MaterializeEncodingInfo encodingInfo) {
   auto boundTensorType =
-      llvm::dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
+      dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
   if (!boundTensorType) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -100,11 +100,10 @@ getSubgroupIdsAndCounts(mlir::OpBuilder &builder, mlir::Location loc,
 }
 
 bool isDescendingRelativeMappingIndices(ArrayRef<Attribute> array) {
-  int64_t prev =
-      llvm::cast<DeviceMappingAttrInterface>(array[0]).getRelativeIndex();
+  int64_t prev = cast<DeviceMappingAttrInterface>(array[0]).getRelativeIndex();
   for (Attribute attr : array.drop_front()) {
     int64_t relativeIndex =
-        llvm::cast<DeviceMappingAttrInterface>(attr).getRelativeIndex();
+        cast<DeviceMappingAttrInterface>(attr).getRelativeIndex();
     if (relativeIndex != prev - 1) {
       return false;
     }
@@ -430,7 +429,7 @@ static Value warpReduction(Location loc, OpBuilder &builder, Value input,
                            uint32_t numLaneToReduce,
                            bool expandSubgroupReduce) {
   assert(llvm::isPowerOf2_32(numLaneToReduce));
-  assert((llvm::isa<IntegerType, FloatType>(input.getType())) &&
+  assert((isa<IntegerType, FloatType>(input.getType())) &&
          "Input must be a scalar");
   IntegerType shuffleIntType = builder.getIntegerType(kShuffleBitWidth);
   Type origInputType = input.getType();
@@ -528,13 +527,13 @@ static TypedAttr getCombiningKindIdentity(OpBuilder &builder,
   case vector::CombiningKind::MINIMUMF:
   case vector::CombiningKind::MINNUMF: {
     auto posInfApFloat = APFloat::getInf(
-        llvm::cast<FloatType>(type).getFloatSemantics(), /*Negative=*/false);
+        cast<FloatType>(type).getFloatSemantics(), /*Negative=*/false);
     return builder.getFloatAttr(type, posInfApFloat);
   }
   case vector::CombiningKind::MAXIMUMF:
   case vector::CombiningKind::MAXNUMF: {
     auto negInfApFloat = APFloat::getInf(
-        llvm::cast<FloatType>(type).getFloatSemantics(), /*Negative=*/true);
+        cast<FloatType>(type).getFloatSemantics(), /*Negative=*/true);
     return builder.getFloatAttr(type, negInfApFloat);
   }
   }
@@ -544,7 +543,7 @@ static TypedAttr getCombiningKindIdentity(OpBuilder &builder,
 /// Emit identity variable.
 Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
                                 vector::CombiningKind kind, Type identityType) {
-  auto vectorType = llvm::dyn_cast<VectorType>(identityType);
+  auto vectorType = dyn_cast<VectorType>(identityType);
   Type elementType = identityType;
   if (vectorType) {
     elementType = vectorType.getElementType();
@@ -682,7 +681,7 @@ std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op) {
       auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
       if (!extract)
         return std::nullopt;
-      auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
+      auto vecType = cast<VectorType>(extract.getResult().getType());
       if (sliceType && sliceType != vecType)
         return std::nullopt;
       sliceType = vecType;
@@ -690,7 +689,7 @@ std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op) {
     return llvm::to_vector(sliceType.getShape());
   }
   if ((OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1)) {
-    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0])) {
+    if (auto vecType = dyn_cast<VectorType>(op->getResultTypes()[0])) {
       // TODO: The condition for unrolling elementwise should be restricted
       // only to operations that need unrolling (connected to the contract).
       if (vecType.getRank() < 2)
@@ -705,7 +704,7 @@ std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op) {
         auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
         if (!extract)
           return std::nullopt;
-        auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
+        auto vecType = cast<VectorType>(extract.getResult().getType());
         if (sliceType && sliceType != vecType)
           return std::nullopt;
         sliceType = vecType;
@@ -814,8 +813,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
 
   // Shape of warp-level vector read (load) operation.
   if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
-    auto resultVectorType =
-        llvm::cast<VectorType>(readOp.getVector().getType());
+    auto resultVectorType = cast<VectorType>(readOp.getVector().getType());
     Type resultElementType = resultVectorType.getElementType();
 
     std::optional<int> operandId =
@@ -896,7 +894,7 @@ std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
           auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
           if (!extract)
             return std::nullopt;
-          auto vecType = llvm::cast<VectorType>(extract.getResult().getType());
+          auto vecType = cast<VectorType>(extract.getResult().getType());
           if (sliceType && sliceType != vecType)
             return std::nullopt;
           sliceType = vecType;
@@ -915,18 +913,18 @@ bool hasGlobalMemoryAddressSpace(MemRefType memrefType) {
   Attribute addrSpace = memrefType.getMemorySpace();
   if (!addrSpace)
     return true;
-  auto intAttr = llvm::dyn_cast<IntegerAttr>(addrSpace);
+  auto intAttr = dyn_cast<IntegerAttr>(addrSpace);
   // Accept both default numeric address space and HAL descriptor type address
   // space--the former is used by LLVMGPU while the latter is used by SPIR-V.
   if (intAttr && intAttr.getInt() == 0)
     return true;
-  auto gpuAttr = llvm::dyn_cast<gpu::AddressSpaceAttr>(addrSpace);
+  auto gpuAttr = dyn_cast<gpu::AddressSpaceAttr>(addrSpace);
   if (gpuAttr && gpuAttr.getValue() == gpu::AddressSpace::Global)
     return true;
-  auto amdgpuAttr = llvm::dyn_cast<amdgpu::AddressSpaceAttr>(addrSpace);
+  auto amdgpuAttr = dyn_cast<amdgpu::AddressSpaceAttr>(addrSpace);
   if (amdgpuAttr && amdgpuAttr.getValue() == amdgpu::AddressSpace::FatRawBuffer)
     return true;
-  return llvm::isa<IREE::HAL::DescriptorTypeAttr>(addrSpace);
+  return isa<IREE::HAL::DescriptorTypeAttr>(addrSpace);
 }
 
 bool hasAMDGPUFatRawBufferAddressSpace(MemRefType memrefType) {
@@ -943,8 +941,8 @@ bool hasAMDGPUFatRawBufferAddressSpace(MemRefType memrefType) {
 }
 
 bool hasSharedMemoryAddressSpace(MemRefType memrefType) {
-  auto addrSpace = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(
-      memrefType.getMemorySpace());
+  auto addrSpace =
+      dyn_cast_if_present<gpu::AddressSpaceAttr>(memrefType.getMemorySpace());
   return addrSpace &&
          addrSpace.getValue() == gpu::GPUDialect::getWorkgroupAddressSpace();
 }

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -184,14 +184,14 @@ replaceEntryPointUses(mlir::ModuleOp moduleOp,
             if (attr == oldAttr) {
               // Found old->new replacement.
               return {newAttr, WalkResult::skip()};
-            } else if (llvm::isa<SymbolRefAttr>(attr)) {
+            } else if (isa<SymbolRefAttr>(attr)) {
               // Don't recurse into symbol refs - we only want to match roots.
               return {attr, WalkResult::skip()};
             }
             // Non-symbol ref attr.
             return {attr, WalkResult::advance()};
           });
-      use.getUser()->setAttrs(llvm::cast<DictionaryAttr>(newDict));
+      use.getUser()->setAttrs(cast<DictionaryAttr>(newDict));
     }
   };
   replaceSymbolRefs(moduleOp, symbolReplacements.exportRefs);

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -303,7 +303,7 @@ bool isReadOnly(Value v) {
           [&](auto op) { return isReadOnly(op.getSource()); })
       .Case<IREE::TensorExt::DispatchTensorLoadOp>(
           [&](IREE::TensorExt::DispatchTensorLoadOp loadOp) {
-            return llvm::cast<IREE::TensorExt::DispatchTensorType>(
+            return cast<IREE::TensorExt::DispatchTensorType>(
                        loadOp.getSource().getType())
                        .getAccess() == IREE::TensorExt::TensorAccess::ReadOnly;
           })
@@ -1062,7 +1062,7 @@ FailureOr<int64_t> getSoftwarePipelineDepth(DictionaryAttr config) {
   if (!depth) {
     return failure();
   }
-  return llvm::cast<IntegerAttr>(depth).getInt();
+  return cast<IntegerAttr>(depth).getInt();
 }
 
 FailureOr<int64_t> getSoftwarePipelineStoreStage(DictionaryAttr config) {
@@ -1073,7 +1073,7 @@ FailureOr<int64_t> getSoftwarePipelineStoreStage(DictionaryAttr config) {
   if (!stage) {
     return failure();
   }
-  return llvm::cast<IntegerAttr>(stage).getInt();
+  return cast<IntegerAttr>(stage).getInt();
 }
 
 /// Returns a small tiling factor for the given reduction `dimSize`.
@@ -1158,7 +1158,7 @@ static SmallVector<int64_t> getStridesFromShape(ArrayRef<int64_t> shape) {
 
 Value findOrCreateSubspanBuffer(
     RewriterBase &rewriter, IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
-  auto shapedType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
+  auto shapedType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
       subspanOp.getResult().getType());
   assert((shapedType && shapedType.hasRank()) &&
          "expected the result of subspanOp is DispatchTensorType");
@@ -1169,7 +1169,7 @@ Value findOrCreateSubspanBuffer(
     // Using buffer resources on AMDGPU will require buffers to be relocated to
     // offset 0, so any static offset we can compute here might change.
     // Therefore, always use a ? for the offset field unless it's known to be 0.
-    auto tensorType = llvm::cast<RankedTensorType>(shapedType.getBoundType());
+    auto tensorType = cast<RankedTensorType>(shapedType.getBoundType());
     SmallVector<int64_t> strides = getStridesFromShape(tensorType.getShape());
     layoutAttr = StridedLayoutAttr::get(rewriter.getContext(),
                                         ShapedType::kDynamic, strides);
@@ -1198,7 +1198,7 @@ Value findOrCreateSubspanBuffer(
       continue;
 
     auto bufferMemrefType =
-        llvm::dyn_cast<MemRefType>(bufferSubspanOp.getResult().getType());
+        dyn_cast<MemRefType>(bufferSubspanOp.getResult().getType());
     if (!bufferMemrefType)
       continue;
 
@@ -1212,7 +1212,7 @@ Value findOrCreateSubspanBuffer(
       continue;
 
     if (useRocdlBuffers && bufferSubspanOp->hasOneUse()) {
-      auto castOp = llvm::dyn_cast<amdgpu::FatRawBufferCastOp>(
+      auto castOp = dyn_cast<amdgpu::FatRawBufferCastOp>(
           *bufferSubspanOp->getUsers().begin());
       if (!castOp)
         continue;
@@ -1395,9 +1395,8 @@ replaceNonTrivialUse(RewriterBase &rewriter, Location loc, OpOperand &use,
 
   LDBG() << "\tReplacing in user by creating new user : " << *user;
   if (auto castOp = dyn_cast<memref::CastOp>(user)) {
-    auto replacementType = llvm::cast<MemRefType>(replacement.getType());
-    auto currentResultType =
-        llvm::cast<MemRefType>(castOp.getResult().getType());
+    auto replacementType = cast<MemRefType>(replacement.getType());
+    auto currentResultType = cast<MemRefType>(castOp.getResult().getType());
     if (replacementType == currentResultType) {
       // Cast is a no op, just return the replacement.
       return SmallVector<Value>{replacement};
@@ -1412,18 +1411,16 @@ replaceNonTrivialUse(RewriterBase &rewriter, Location loc, OpOperand &use,
                               newCastOp->result_end());
   }
   if (auto subviewOp = dyn_cast<memref::SubViewOp>(user)) {
-    auto currResultType =
-        llvm::cast<MemRefType>(subviewOp.getResult().getType());
-    auto newSourceType = llvm::cast<MemRefType>(replacement.getType());
+    auto currResultType = cast<MemRefType>(subviewOp.getResult().getType());
+    auto newSourceType = cast<MemRefType>(replacement.getType());
     SmallVector<OpFoldResult> offsets = subviewOp.getMixedOffsets();
     SmallVector<OpFoldResult> sizes = subviewOp.getMixedSizes();
     SmallVector<OpFoldResult> strides = subviewOp.getMixedStrides();
     MemRefType newResultType =
         (currResultType.getRank() != newSourceType.getRank()
-             ? llvm::cast<MemRefType>(
-                   memref::SubViewOp::inferRankReducedResultType(
-                       currResultType.getShape(), newSourceType, offsets, sizes,
-                       strides))
+             ? cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
+                   currResultType.getShape(), newSourceType, offsets, sizes,
+                   strides))
              : nullptr);
     auto newSubviewOp = memref::SubViewOp::create(
         rewriter, loc, newResultType, replacement, offsets, sizes, strides);
@@ -1432,9 +1429,8 @@ replaceNonTrivialUse(RewriterBase &rewriter, Location loc, OpOperand &use,
     return llvm::to_vector_of<Value>(newSubviewOp->getResults());
   }
   if (auto expandOp = dyn_cast<memref::ExpandShapeOp>(user)) {
-    auto currResultType =
-        llvm::cast<MemRefType>(expandOp.getResult().getType());
-    auto newSourceType = llvm::cast<MemRefType>(replacement.getType());
+    auto currResultType = cast<MemRefType>(expandOp.getResult().getType());
+    auto newSourceType = cast<MemRefType>(replacement.getType());
 
     FailureOr<MemRefType> newResultType =
         memref::ExpandShapeOp::computeExpandedType(
@@ -1451,7 +1447,7 @@ replaceNonTrivialUse(RewriterBase &rewriter, Location loc, OpOperand &use,
     return llvm::to_vector_of<Value>(newExpandOp->getResults());
   }
   if (auto collapseOp = dyn_cast<memref::CollapseShapeOp>(user)) {
-    auto newSourceType = llvm::cast<MemRefType>(replacement.getType());
+    auto newSourceType = cast<MemRefType>(replacement.getType());
     FailureOr<MemRefType> newResultType =
         memref::CollapseShapeOp::computeCollapsedType(
             newSourceType, collapseOp.getReassociationIndices());
@@ -1722,8 +1718,8 @@ inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult) {
     unsigned firstOperandDim = operandDimPairs[0].second;
 
     // Trivial case: `dim` size is available in the operand type.
-    int64_t dimSize = llvm::cast<ShapedType>(firstOperand.getType())
-                          .getShape()[firstOperandDim];
+    int64_t dimSize =
+        cast<ShapedType>(firstOperand.getType()).getShape()[firstOperandDim];
     bool dimScalable = false;
     if (ShapedType::isStatic(dimSize)) {
       result.vectorSizes.push_back(dimSize);
@@ -2089,8 +2085,8 @@ bool hasExternalCapture(linalg::GenericOp genericOp) {
 
 Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
                               ArrayRef<NamedAttribute> attributes) {
-  auto memrefTypeFrom = llvm::dyn_cast<MemRefType>(from.getType());
-  auto memrefTypeTo = llvm::dyn_cast<MemRefType>(to.getType());
+  auto memrefTypeFrom = dyn_cast<MemRefType>(from.getType());
+  auto memrefTypeTo = dyn_cast<MemRefType>(to.getType());
   if (!memrefTypeFrom || !memrefTypeTo ||
       memrefTypeFrom.getRank() != memrefTypeTo.getRank()) {
     mlir::emitError(
@@ -2121,15 +2117,15 @@ SmallVector<OpFoldResult> getCopyTileSizes(OpBuilder &b, memref::CopyOp copy) {
   }
 
   SmallVector<OpFoldResult> tileSizes(rank - 1, b.getIndexAttr(1));
-  int64_t elementBitWidth = llvm::cast<MemRefType>(copy.getTarget().getType())
-                                .getElementTypeBitWidth();
+  int64_t elementBitWidth =
+      cast<MemRefType>(copy.getTarget().getType()).getElementTypeBitWidth();
   tileSizes.push_back(b.getIndexAttr(kPreferredCopyNumBits / elementBitWidth));
   return tileSizes;
 }
 
 std::optional<SmallVector<int64_t>> getCopyTileSizes(linalg::CopyOp copyOp) {
   auto type =
-      llvm::dyn_cast<MemRefType>(copyOp.getDpsInputOperand(0)->get().getType());
+      dyn_cast<MemRefType>(copyOp.getDpsInputOperand(0)->get().getType());
   if (!type) {
     return std::nullopt;
   }


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.