### PR TITLE
Drop unnecessary namespaces from cast functions in dialect hal encoding. NFC. 6/10

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -105,10 +105,10 @@ static FailureOr<AffineMap> getComposedAffineMap(Attribute attr) {
   if (!attr) {
     return AffineMap();
   }
-  if (auto mapAttr = llvm::dyn_cast<AffineMapAttr>(attr)) {
+  if (auto mapAttr = dyn_cast<AffineMapAttr>(attr)) {
     return mapAttr.getAffineMap();
   }
-  if (auto mapsAttr = llvm::dyn_cast<ArrayAttr>(attr)) {
+  if (auto mapsAttr = dyn_cast<ArrayAttr>(attr)) {
     if (mapsAttr.empty()) {
       return AffineMap();
     }
@@ -119,9 +119,9 @@ static FailureOr<AffineMap> getComposedAffineMap(Attribute attr) {
       return failure();
     }
     AffineMap map =
-        llvm::cast<AffineMapAttr>(mapsAttr[mapsAttr.size() - 1]).getAffineMap();
+        cast<AffineMapAttr>(mapsAttr[mapsAttr.size() - 1]).getAffineMap();
     for (ssize_t i = mapsAttr.size() - 2; i >= 0; i--) {
-      map = map.compose(llvm::cast<AffineMapAttr>(mapsAttr[i]).getAffineMap());
+      map = map.compose(cast<AffineMapAttr>(mapsAttr[i]).getAffineMap());
     }
     return map;
   }
@@ -254,13 +254,13 @@ AffineMap EncodingAttr::getMapForOperandIndex() const {
 SmallVector<AffineMap> EncodingAttr::getRootMaps() const {
   return llvm::map_to_vector(
       getUserIndexingMaps(), [](Attribute m) -> AffineMap {
-        if (auto mapAttr = llvm::dyn_cast<AffineMapAttr>(m)) {
-          return llvm::cast<AffineMapAttr>(m).getAffineMap();
+        if (auto mapAttr = dyn_cast<AffineMapAttr>(m)) {
+          return cast<AffineMapAttr>(m).getAffineMap();
         }
-        if (auto mapsAttr = llvm::dyn_cast<ArrayAttr>(m)) {
+        if (auto mapsAttr = dyn_cast<ArrayAttr>(m)) {
           if (mapsAttr.empty())
             return AffineMap();
-          return llvm::cast<AffineMapAttr>(mapsAttr[0]).getAffineMap();
+          return cast<AffineMapAttr>(mapsAttr[0]).getAffineMap();
         }
         return AffineMap();
       });
@@ -273,14 +273,13 @@ AffineMap EncodingAttr::getLastMapForOperandIndex() const {
     return AffineMap();
   }
   Attribute indexingMap = userIndexingMaps[index];
-  if (auto mapAttr = llvm::dyn_cast<AffineMapAttr>(indexingMap)) {
+  if (auto mapAttr = dyn_cast<AffineMapAttr>(indexingMap)) {
     return mapAttr.getAffineMap();
   }
-  if (auto mapsAttr = llvm::dyn_cast<ArrayAttr>(indexingMap)) {
+  if (auto mapsAttr = dyn_cast<ArrayAttr>(indexingMap)) {
     if (mapsAttr.empty())
       return AffineMap();
-    return llvm::cast<AffineMapAttr>(mapsAttr[mapsAttr.size() - 1])
-        .getAffineMap();
+    return cast<AffineMapAttr>(mapsAttr[mapsAttr.size() - 1]).getAffineMap();
   }
   return AffineMap();
 }
@@ -297,13 +296,13 @@ SmallVector<int64_t> EncodingAttr::getIterationSizesArray() const {
     return {};
   }
   return llvm::map_to_vector(iterationSizes, [](Attribute attr) {
-    return llvm::cast<IntegerAttr>(attr).getInt();
+    return cast<IntegerAttr>(attr).getInt();
   });
 }
 
 SmallVector<Type> EncodingAttr::getElementTypesArray() {
   return llvm::map_to_vector(getElementTypes().getValue(), [](Attribute a) {
-    return llvm::cast<TypeAttr>(a).getValue();
+    return cast<TypeAttr>(a).getValue();
   });
 }
 
@@ -317,10 +316,9 @@ EncodingAttr::cloneWithNewOperandIndexingMap(AffineMap newIndexingMap) {
                                  userIndexingMaps.end());
   unsigned operandIndex = getOperandIndex().getValue().getZExtValue();
   SmallVector<Attribute> maps;
-  if (auto mapForIndex = llvm::dyn_cast<AffineMapAttr>(newMaps[operandIndex])) {
+  if (auto mapForIndex = dyn_cast<AffineMapAttr>(newMaps[operandIndex])) {
     maps.push_back(AffineMapAttr::get(mapForIndex.getAffineMap()));
-  } else if (auto mapForIndex =
-                 llvm::dyn_cast<ArrayAttr>(newMaps[operandIndex])) {
+  } else if (auto mapForIndex = dyn_cast<ArrayAttr>(newMaps[operandIndex])) {
     maps.assign(mapForIndex.begin(), mapForIndex.end());
   }
   maps.push_back(AffineMapAttr::get(newIndexingMap));

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -36,7 +36,7 @@ struct EncodingOpAsmInterface : public OpAsmDialectInterface {
   // `.` or end with a numeric digit([0-9]+). Returns success if an alias was
   // provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<EncodingAttr, LayoutAttr, TestingAttr, UnknownAttr>(attr)) {
+    if (isa<EncodingAttr, LayoutAttr, TestingAttr, UnknownAttr>(attr)) {
       os << "encoding";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -21,8 +21,8 @@ bool SerializableAttr::areCompatible(Attribute lhs, Attribute rhs) {
   if (lhs == rhs) {
     return true;
   }
-  auto lhsEncoding = llvm::dyn_cast_or_null<SerializableAttr>(lhs);
-  auto rhsEncoding = llvm::dyn_cast_or_null<SerializableAttr>(rhs);
+  auto lhsEncoding = dyn_cast_or_null<SerializableAttr>(lhs);
+  auto rhsEncoding = dyn_cast_or_null<SerializableAttr>(rhs);
   if (!lhsEncoding || !rhsEncoding) {
     return false;
   }
@@ -50,7 +50,7 @@ MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
   linalg::ContractionDimensions cDims =
       linalg::inferContractionDims(linalgOp).value();
   AffineMap map = linalgOp.getIndexingMapsArray().back();
-  auto outType = llvm::cast<ShapedType>(linalgOp.getDpsInits()[0].getType());
+  auto outType = cast<ShapedType>(linalgOp.getDpsInits()[0].getType());
   auto getOutputSizeAtDimPos = [=](unsigned dimPos) -> int64_t {
     return outType.getDimSize(
         map.getResultPosition(getAffineDimExpr(dimPos, linalgOp->getContext()))

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
@@ -84,7 +84,7 @@ public:
     }
 
     // i32 -> f32, etc
-    if (llvm::isa<FloatType>(targetType)) {
+    if (isa<FloatType>(targetType)) {
       value =
           arith::BitcastOp::create(rewriter, op.getLoc(), targetType, value);
     }
@@ -126,7 +126,7 @@ public:
 
     // f32 -> i32, etc
     auto value = adaptor.getValue();
-    if (llvm::isa<FloatType>(elementType)) {
+    if (isa<FloatType>(elementType)) {
       value = rewriter.createOrFold<arith::BitcastOp>(
           op.getLoc(),
           rewriter.getIntegerType(value.getType().getIntOrFloatBitWidth()),

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDeviceOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertDeviceOps.cpp
@@ -39,7 +39,7 @@ public:
         rewriter, op.getLoc(), rewriter.getI1Type(), rewriter.getI64Type(),
         adaptor.getDevice(), op.getCategoryAttr(), op.getKeyAttr(),
         TypedAttr{});
-    auto ok = llvm::cast<Value>(queryOp.getOk());
+    auto ok = cast<Value>(queryOp.getOk());
     auto value = queryOp.getValue();
 
     // Truncate or extend based on the target type.

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
@@ -21,7 +21,7 @@ struct BufferViewDimPattern : public OpConversionPattern<tensor::DimOp> {
   LogicalResult
   matchAndRewrite(tensor::DimOp dimOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::HAL::BufferViewType>(adaptor.getSource().getType())) {
+    if (!isa<IREE::HAL::BufferViewType>(adaptor.getSource().getType())) {
       return failure();
     }
     std::optional<int64_t> index = dimOp.getConstantIndex();
@@ -38,7 +38,7 @@ struct BufferViewRankPattern : public OpConversionPattern<tensor::RankOp> {
   LogicalResult
   matchAndRewrite(tensor::RankOp rankOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::HAL::BufferViewType>(adaptor.getTensor().getType())) {
+    if (!isa<IREE::HAL::BufferViewType>(adaptor.getTensor().getType())) {
       return failure();
     }
     rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewRankOp>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -125,7 +125,7 @@ static Value consumeBoundFence(Value timepoint, PatternRewriter &rewriter) {
     return nullptr; // non-export use
   assert(!chainOp.getExternalValues().empty());
   auto fence = chainOp.getExternalValues().front();
-  if (!fence || !llvm::isa<IREE::HAL::FenceType>(fence.getType()))
+  if (!fence || !isa<IREE::HAL::FenceType>(fence.getType()))
     return nullptr;
 
   // Try really hard to figure out if the fence can be used. A larger analysis

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
@@ -40,9 +40,9 @@ HALTypeConverter::HALTypeConverter(
   addTargetMaterialization([](OpBuilder &builder, IREE::HAL::BufferType type,
                               ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
-    if (llvm::isa<TensorType>(inputs[0].getType())) {
+    if (isa<TensorType>(inputs[0].getType())) {
       return IREE::HAL::TensorExportOp::create(builder, loc, type, inputs[0]);
-    } else if (llvm::isa<IREE::HAL::BufferViewType>(inputs[0].getType())) {
+    } else if (isa<IREE::HAL::BufferViewType>(inputs[0].getType())) {
       return IREE::HAL::BufferViewBufferOp::create(builder, loc, type,
                                                    inputs[0]);
     } else {
@@ -57,9 +57,9 @@ HALTypeConverter::HALTypeConverter(
     assert(inputs.size() == 1);
     auto inputValue = inputs[0];
     auto inputType = inputValue.getType();
-    if (llvm::isa<TensorType>(inputType)) {
+    if (isa<TensorType>(inputType)) {
       return IREE::HAL::TensorExportOp::create(builder, loc, type, inputValue);
-    } else if (llvm::isa<IREE::HAL::BufferType>(inputType)) {
+    } else if (isa<IREE::HAL::BufferType>(inputType)) {
       // Look for the buffer view this buffer came from, if any.
       // If we don't have the origin buffer view then we can't know the shape
       // and can't materialize one here - it's too late.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -37,7 +37,7 @@ static LogicalResult parseEnumAttr(AsmParser &parser, StringRef attrName,
     return parser.emitError(loc)
            << "failed to parse '" << attrName << "' enum string value";
   }
-  auto stringAttr = llvm::dyn_cast<StringAttr>(genericAttr);
+  auto stringAttr = dyn_cast<StringAttr>(genericAttr);
   if (!stringAttr) {
     return parser.emitError(loc)
            << "expected " << attrName << " attribute specified as string";
@@ -208,7 +208,7 @@ ExecutableTargetAttr ExecutableTargetAttr::lookup(Operation *op,
   auto attrId = StringAttr::get(context, "hal.executable.target");
   while (op) {
     // Take directly from the enclosing variant.
-    if (auto variantOp = llvm::dyn_cast<IREE::HAL::ExecutableVariantOp>(op)) {
+    if (auto variantOp = dyn_cast<IREE::HAL::ExecutableVariantOp>(op)) {
       if (annotationSite) {
         *annotationSite = variantOp;
       }
@@ -242,10 +242,9 @@ Attribute ExecutableObjectAttr::parse(AsmParser &p, Type type) {
       failed(p.parseGreater())) {
     return {};
   }
-  auto pathAttr = llvm::dyn_cast_if_present<StringAttr>(dict.get("path"));
-  auto dataAttr =
-      llvm::dyn_cast_if_present<IREE::Util::SerializableAttrInterface>(
-          dict.get("data"));
+  auto pathAttr = dyn_cast_if_present<StringAttr>(dict.get("path"));
+  auto dataAttr = dyn_cast_if_present<IREE::Util::SerializableAttrInterface>(
+      dict.get("data"));
   return get(p.getContext(), pathAttr, dataAttr);
 }
 
@@ -371,13 +370,13 @@ LogicalResult ExecutableObjectsAttr::verify(
     return emitError() << "targets and objects must be 1:1";
   }
   for (auto targetAttr : targetsAttr) {
-    if (!llvm::isa<IREE::HAL::ExecutableTargetAttr>(targetAttr)) {
+    if (!isa<IREE::HAL::ExecutableTargetAttr>(targetAttr)) {
       return emitError()
              << "target keys must be #hal.executable.target attributes";
     }
   }
   for (auto objectsAttr : targetObjectsAttr) {
-    auto objectsArrayAttr = llvm::dyn_cast<ArrayAttr>(objectsAttr);
+    auto objectsArrayAttr = dyn_cast<ArrayAttr>(objectsAttr);
     if (!objectsArrayAttr) {
       return emitError() << "target objects must be an array of "
                             "#hal.executable.object attributes";
@@ -433,10 +432,9 @@ std::optional<ArrayAttr> ExecutableObjectsAttr::getApplicableObjects(
   SmallVector<Attribute> allObjectAttrs;
   for (auto [targetAttr, objectsAttr] :
        llvm::zip_equal(getTargets(), getTargetObjects())) {
-    auto genericTargetAttr =
-        llvm::cast<IREE::HAL::ExecutableTargetAttr>(targetAttr);
+    auto genericTargetAttr = cast<IREE::HAL::ExecutableTargetAttr>(targetAttr);
     if (genericTargetAttr.isGenericOf(specificTargetAttr)) {
-      auto objectsArrayAttr = llvm::cast<ArrayAttr>(objectsAttr);
+      auto objectsArrayAttr = cast<ArrayAttr>(objectsAttr);
       allObjectAttrs.append(objectsArrayAttr.begin(), objectsArrayAttr.end());
     }
   }
@@ -575,7 +573,7 @@ void DeviceTargetAttr::getExecutableTargets(
 
 void IREE::HAL::DeviceTargetAttr::printStatusDescription(
     llvm::raw_ostream &os) const {
-  mlir::cast<Attribute>(this)->print(os, /*elideType=*/true);
+  cast<Attribute>(this)->print(os, /*elideType=*/true);
 }
 
 // Produces a while-loop that enumerates each device available and tries to
@@ -752,7 +750,7 @@ Value DeviceTargetAttr::buildExecutableFormatMatch(
 
 void IREE::HAL::DeviceOrdinalAttr::printStatusDescription(
     llvm::raw_ostream &os) const {
-  mlir::cast<Attribute>(this)->print(os, /*elideType=*/true);
+  cast<Attribute>(this)->print(os, /*elideType=*/true);
 }
 
 Value IREE::HAL::DeviceOrdinalAttr::buildDeviceEnumeration(
@@ -769,7 +767,7 @@ Value IREE::HAL::DeviceOrdinalAttr::buildDeviceEnumeration(
 
 void IREE::HAL::DeviceFallbackAttr::printStatusDescription(
     llvm::raw_ostream &os) const {
-  mlir::cast<Attribute>(this)->print(os, /*elideType=*/true);
+  cast<Attribute>(this)->print(os, /*elideType=*/true);
 }
 
 Value IREE::HAL::DeviceFallbackAttr::buildDeviceEnumeration(
@@ -801,8 +799,8 @@ DeviceSelectAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
     return emitError() << "must have at least one device to select";
   }
   for (auto deviceAttr : devicesAttr) {
-    if (!mlir::isa<IREE::HAL::DeviceAliasAttr>(deviceAttr) &&
-        !mlir::isa<IREE::HAL::DeviceInitializationAttrInterface>(deviceAttr)) {
+    if (!isa<IREE::HAL::DeviceAliasAttr>(deviceAttr) &&
+        !isa<IREE::HAL::DeviceInitializationAttrInterface>(deviceAttr)) {
       return emitError() << "can only select between #hal.device.alias, "
                             "#hal.device.target, #hal.device.ordinal, "
                             "#hal.device.fallback, or other device "
@@ -817,7 +815,7 @@ DeviceSelectAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
 void IREE::HAL::DeviceSelectAttr::printStatusDescription(
     llvm::raw_ostream &os) const {
   // TODO(benvanik): print something easier to read (newline per device, etc).
-  mlir::cast<Attribute>(this)->print(os, /*elideType=*/true);
+  cast<Attribute>(this)->print(os, /*elideType=*/true);
 }
 
 // Builds a recursive nest of try-else blocks for each device specified.
@@ -914,7 +912,7 @@ bool DeviceAffinityAttr::isExecutableWith(
   // peering model to allow operations to move across devices in a peered set
   // but that may be best done at higher levels and avoided once we get to the
   // "are these the same device" stage.
-  auto otherAffinityAttr = llvm::dyn_cast_if_present<DeviceAffinityAttr>(other);
+  auto otherAffinityAttr = dyn_cast_if_present<DeviceAffinityAttr>(other);
   if (!otherAffinityAttr || getDevice() != otherAffinityAttr.getDevice()) {
     return false;
   }
@@ -1037,7 +1035,7 @@ bool DevicePromiseAttr::isExecutableWith(
   // peering model to allow operations to move across devices in a peered set
   // but that may be best done at higher levels and avoided once we get to the
   // "are these the same device" stage.
-  auto otherPromiseAttr = llvm::dyn_cast_if_present<DevicePromiseAttr>(other);
+  auto otherPromiseAttr = dyn_cast_if_present<DevicePromiseAttr>(other);
   if (!otherPromiseAttr || getDevice() != otherPromiseAttr.getDevice()) {
     return false;
   }
@@ -1169,8 +1167,8 @@ DeviceOptimalAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
     return emitError() << "must have at least one device affinity";
   }
   for (auto affinityAttr : affinityAttrs) {
-    if (!mlir::isa<IREE::HAL::DeviceAffinityAttr>(affinityAttr) &&
-        !mlir::isa<IREE::HAL::DevicePromiseAttr>(affinityAttr)) {
+    if (!isa<IREE::HAL::DeviceAffinityAttr>(affinityAttr) &&
+        !isa<IREE::HAL::DevicePromiseAttr>(affinityAttr)) {
       return emitError() << "can only select between HAL affinity attrs";
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -37,13 +37,13 @@ struct HALOpAsmInterface : public OpAsmDialectInterface {
   /// end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (auto targetAttr = llvm::dyn_cast<DeviceTargetAttr>(attr)) {
+    if (auto targetAttr = dyn_cast<DeviceTargetAttr>(attr)) {
       os << "device_target_" << targetAttr.getSymbolNameFragment();
       return AliasResult::OverridableAlias;
-    } else if (auto targetAttr = llvm::dyn_cast<ExecutableTargetAttr>(attr)) {
+    } else if (auto targetAttr = dyn_cast<ExecutableTargetAttr>(attr)) {
       os << "executable_target_" << targetAttr.getSymbolNameFragment();
       return AliasResult::OverridableAlias;
-    } else if (auto layoutAttr = llvm::dyn_cast<PipelineLayoutAttr>(attr)) {
+    } else if (auto layoutAttr = dyn_cast<PipelineLayoutAttr>(attr)) {
       os << "pipeline_layout";
       return AliasResult::OverridableAlias;
     }
@@ -99,13 +99,12 @@ public:
       const function_ref<void(Attribute elementAttr)> &fn) const override {
     MLIRContext *context = attr.getContext();
     // TODO(benvanik): remove this interface or make it an attr interface.
-    if (auto bindingAttr =
-            llvm::dyn_cast<IREE::HAL::PipelineBindingAttr>(attr)) {
+    if (auto bindingAttr = dyn_cast<IREE::HAL::PipelineBindingAttr>(attr)) {
       fn(IREE::HAL::DescriptorTypeAttr::get(context, bindingAttr.getType()));
       fn(IREE::HAL::DescriptorFlagsAttr::get(context, bindingAttr.getFlags()));
       return success();
     }
-    if (auto dtAttr = llvm::dyn_cast<IREE::HAL::DescriptorTypeAttr>(attr)) {
+    if (auto dtAttr = dyn_cast<IREE::HAL::DescriptorTypeAttr>(attr)) {
       // Repack as a normal integer attribute.
       fn(IntegerAttr::get(IntegerType::get(context, 32),
                           APInt(32, static_cast<uint32_t>(dtAttr.getValue()))));
@@ -201,11 +200,11 @@ HALDialect::HALDialect(MLIRContext *context)
 
 Operation *HALDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
-  if (llvm::isa<IndexType>(type)) {
+  if (isa<IndexType>(type)) {
     // Some folders materialize raw index types, which just become std
     // constants.
     return mlir::arith::ConstantIndexOp::create(
-        builder, loc, llvm::cast<IntegerAttr>(value).getValue().getSExtValue());
+        builder, loc, cast<IntegerAttr>(value).getValue().getSExtValue());
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -181,7 +181,7 @@ struct FoldBufferViewCreateSubspan
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
+    auto newSourceOffset = cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -269,7 +269,7 @@ struct FoldCommandBufferFillBufferSubspans
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newTargetBuffer = op.getTargetBuffer();
-    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
+    auto newTargetOffset = cast<Value>(op.getTargetOffset());
     if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
@@ -309,7 +309,7 @@ struct FoldCommandBufferUpdateBufferSubspans
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newTargetBuffer = op.getTargetBuffer();
-    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
+    auto newTargetOffset = cast<Value>(op.getTargetOffset());
     if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
@@ -349,7 +349,7 @@ struct FoldCommandBufferCopyBufferSubspans
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
+    auto newSourceOffset = cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -359,7 +359,7 @@ struct FoldCommandBufferCopyBufferSubspans
       needsUpdate = true;
     }
     auto newTargetBuffer = op.getTargetBuffer();
-    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
+    auto newTargetOffset = cast<Value>(op.getTargetOffset());
     if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -620,7 +620,7 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
                            TypeAttr targetEncoding, bool consume,
                            Value waitFence, StringAttr name,
                            Attribute affinity) {
-  auto shapedType = llvm::cast<ShapedType>(resultType);
+  auto shapedType = cast<ShapedType>(resultType);
   assert((isa<IREE::HAL::BufferViewType>(source.getType()) ||
           shapedType.hasStaticShape()) &&
          "can only use this constructor for buffer views when shape "
@@ -643,8 +643,8 @@ static LogicalResult verifyTypeStorageCompatibility(Operation *op,
                                                     Type storageType) {
   if (encodingType == storageType)
     return success();
-  auto encodingShapedType = llvm::dyn_cast<ShapedType>(encodingType);
-  auto storageShapedType = llvm::dyn_cast<ShapedType>(storageType);
+  auto encodingShapedType = dyn_cast<ShapedType>(encodingType);
+  auto storageShapedType = dyn_cast<ShapedType>(storageType);
   if (!encodingShapedType || !storageShapedType)
     return success();
 
@@ -688,7 +688,7 @@ static LogicalResult verifyTypeStorageCompatibility(Operation *op,
 
 LogicalResult TensorImportOp::verify() {
   TensorImportOp op = *this;
-  auto targetType = llvm::cast<TensorType>(op.getTarget().getType());
+  auto targetType = cast<TensorType>(op.getTarget().getType());
   if (targetType.getNumDynamicDims() != op.getTargetDims().size()) {
     return op->emitOpError() << "number of target_dims must match number of "
                                 "dynamic dims in target type";
@@ -708,7 +708,7 @@ void TensorExportOp::build(OpBuilder &builder, OperationState &result,
 
 LogicalResult TensorExportOp::verify() {
   TensorExportOp op = *this;
-  auto sourceType = llvm::cast<TensorType>(op.getSource().getType());
+  auto sourceType = cast<TensorType>(op.getSource().getType());
   if (sourceType.getNumDynamicDims() != op.getSourceDims().size()) {
     return op->emitOpError() << "number of source_dims must match number of "
                                 "dynamic dims in source type";
@@ -736,7 +736,7 @@ SmallVector<int64_t> TensorAliasOp::getTiedResultOperandIndices() {
 
 LogicalResult TensorAliasOp::verify() {
   TensorAliasOp op = *this;
-  auto type = llvm::cast<TensorType>(op.getSource().getType());
+  auto type = cast<TensorType>(op.getSource().getType());
   if (type.getNumDynamicDims() != op.getSourceDims().size()) {
     return op->emitOpError()
            << "number of dynamic dims must match the operand type";
@@ -815,7 +815,7 @@ static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
                                          ValueRange dynamicDims) {
   unsigned requiredCount = 0;
   for (auto value : values) {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
+    if (auto shapedType = dyn_cast<ShapedType>(value.getType())) {
       requiredCount += shapedType.getNumDynamicDims();
     }
   }
@@ -866,14 +866,13 @@ static LogicalResult verifyWorkgroupCountRegion(Operation *op, Region &region) {
   if (region.getNumArguments() == 0) {
     // Need at least a !hal.device.
     validArguments = false;
-  } else if (!llvm::isa<IREE::HAL::DeviceType>(
-                 region.getArgument(0).getType())) {
+  } else if (!isa<IREE::HAL::DeviceType>(region.getArgument(0).getType())) {
     // !hal.device must come first.
     validArguments = false;
   } else {
     // All remaining arguments need to be of type index (today).
     for (BlockArgument &blockArg : region.getArguments().drop_front(1)) {
-      if (!llvm::isa<IndexType>(blockArg.getType())) {
+      if (!isa<IndexType>(blockArg.getType())) {
         validArguments = false;
         break;
       }
@@ -910,7 +909,7 @@ LogicalResult DispatchExternOp::verify() {
   }
 
   auto verifyIOType = [&](Type type) -> LogicalResult {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
       if (shapedType.getElementType().isIndex()) {
         return op->emitOpError() << "I/O type " << type
                                  << " is invalid: index types must not cross "
@@ -1119,7 +1118,7 @@ constexpr inline int32_t makeElementTypeValue(NumericalType numericalType,
 
 // static
 std::optional<int32_t> ElementTypeOp::getTypeValue(Type type) {
-  if (auto intType = llvm::dyn_cast_if_present<IntegerType>(type)) {
+  if (auto intType = dyn_cast_if_present<IntegerType>(type)) {
     NumericalType numericalType;
     if (intType.isInteger(1)) {
       return makeElementTypeValue(NumericalType::kBoolean, 8);
@@ -1135,7 +1134,7 @@ std::optional<int32_t> ElementTypeOp::getTypeValue(Type type) {
       numericalType = NumericalType::kInteger;
     }
     return makeElementTypeValue(numericalType, intType.getWidth());
-  } else if (auto floatType = llvm::dyn_cast_if_present<FloatType>(type)) {
+  } else if (auto floatType = dyn_cast_if_present<FloatType>(type)) {
     switch (APFloat::SemanticsToEnum(floatType.getFloatSemantics())) {
     case APFloat::S_Float8E5M2:
       return makeElementTypeValue(NumericalType::kFloat8E5M2, 8);
@@ -1159,7 +1158,7 @@ std::optional<int32_t> ElementTypeOp::getTypeValue(Type type) {
     default:
       return std::nullopt;
     }
-  } else if (auto complexType = llvm::dyn_cast_if_present<ComplexType>(type)) {
+  } else if (auto complexType = dyn_cast_if_present<ComplexType>(type)) {
     return makeElementTypeValue(
         NumericalType::kFloatComplex,
         complexType.getElementType().getIntOrFloatBitWidth() * 2);
@@ -1650,14 +1649,13 @@ static LogicalResult verifyExportConditionRegion(Operation *op,
   if (region.getNumArguments() == 0) {
     // Need at least a !hal.device.
     validArguments = false;
-  } else if (!llvm::isa<IREE::HAL::DeviceType>(
-                 region.getArgument(0).getType())) {
+  } else if (!isa<IREE::HAL::DeviceType>(region.getArgument(0).getType())) {
     // !hal.device must come first.
     validArguments = false;
   } else {
     // All remaining arguments need to be of type index (today).
     for (BlockArgument &blockArg : region.getArguments().drop_front(1)) {
-      if (!llvm::isa<IndexType>(blockArg.getType())) {
+      if (!isa<IndexType>(blockArg.getType())) {
         validArguments = false;
         break;
       }
@@ -2132,7 +2130,7 @@ LogicalResult ExecutableConstantBlockOp::verify() {
   // Verify the function takes either nothing or a device.
   auto argTypes = op.getArgumentTypes();
   if (!argTypes.empty() &&
-      (argTypes.size() > 1 || !llvm::isa<IREE::HAL::DeviceType>(argTypes[0]))) {
+      (argTypes.size() > 1 || !isa<IREE::HAL::DeviceType>(argTypes[0]))) {
     return op->emitOpError()
            << "initializer must take a !hal.device or nothing";
   }
@@ -2245,7 +2243,7 @@ void InterfaceBindingSubspanOp::build(OpBuilder &builder,
 
 LogicalResult InterfaceBindingSubspanOp::verify() {
   InterfaceBindingSubspanOp op = *this;
-  if (ShapedType shapedType = llvm::dyn_cast<ShapedType>(op.getType())) {
+  if (ShapedType shapedType = dyn_cast<ShapedType>(op.getType())) {
     if (shapedType.getNumDynamicDims() != op.getDynamicDims().size()) {
       return op.emitOpError("result type ")
              << op.getType() << " has " << shapedType.getNumDynamicDims()
@@ -2284,7 +2282,7 @@ llvm::Align InterfaceBindingSubspanOp::calculateAlignment() {
   // 4-byte aligned).
   llvm::Align naturalAlignment(1);
   auto resultType = getType();
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(resultType)) {
+  if (auto shapedType = dyn_cast<ShapedType>(resultType)) {
     naturalAlignment = llvm::Align(
         IREE::Util::getRoundedElementByteWidth(shapedType.getElementType()));
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -130,27 +130,27 @@ Type HALDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void HALDialect::printType(Type type, DialectAsmPrinter &p) const {
-  if (llvm::isa<AllocatorType>(type)) {
+  if (isa<AllocatorType>(type)) {
     p << "allocator";
-  } else if (llvm::isa<BufferType>(type)) {
+  } else if (isa<BufferType>(type)) {
     p << "buffer";
-  } else if (llvm::isa<BufferViewType>(type)) {
+  } else if (isa<BufferViewType>(type)) {
     p << "buffer_view";
-  } else if (llvm::isa<ChannelType>(type)) {
+  } else if (isa<ChannelType>(type)) {
     p << "channel";
-  } else if (llvm::isa<CommandBufferType>(type)) {
+  } else if (isa<CommandBufferType>(type)) {
     p << "command_buffer";
-  } else if (llvm::isa<DeviceType>(type)) {
+  } else if (isa<DeviceType>(type)) {
     p << "device";
-  } else if (llvm::isa<EventType>(type)) {
+  } else if (isa<EventType>(type)) {
     p << "event";
-  } else if (llvm::isa<ExecutableType>(type)) {
+  } else if (isa<ExecutableType>(type)) {
     p << "executable";
-  } else if (llvm::isa<FenceType>(type)) {
+  } else if (isa<FenceType>(type)) {
     p << "fence";
-  } else if (llvm::isa<FileType>(type)) {
+  } else if (isa<FileType>(type)) {
     p << "file";
-  } else if (llvm::isa<SemaphoreType>(type)) {
+  } else if (isa<SemaphoreType>(type)) {
     p << "semaphore";
   } else {
     assert(false && "unknown HAL type");

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -246,7 +246,7 @@ static void materializeExecutableFromSourceOp(
 static LogicalResult
 verifyEntryPointTypes(mlir::FunctionOpInterface entryFuncOp) {
   for (auto inputType : llvm::enumerate(entryFuncOp.getArgumentTypes())) {
-    if (llvm::isa<IREE::Stream::BindingType>(inputType.value()) ||
+    if (isa<IREE::Stream::BindingType>(inputType.value()) ||
         inputType.value().isInteger(32)) {
       // OK - directly translates to a HAL interface binding.
     } else {
@@ -332,14 +332,14 @@ cloneFuncWithInterface(mlir::func::FuncOp sourceFuncOp,
   // for use by the binding accessors.
   unsigned operandIdx = 0;
   for (auto arg : entryBlock->getArguments()) {
-    if (!llvm::isa<IREE::Stream::BindingType>(arg.getType())) {
+    if (!isa<IREE::Stream::BindingType>(arg.getType())) {
       convertOperandUsage(sourceFuncOp, arg, layoutAttr, operandIdx++,
                           entryBuilder);
     }
   }
   unsigned resourceIdx = 0;
   for (auto arg : entryBlock->getArguments()) {
-    if (!llvm::isa<IREE::Stream::BindingType>(arg.getType())) {
+    if (!isa<IREE::Stream::BindingType>(arg.getType())) {
       continue; // unhandled arg type (primitive/etc)
     }
     auto binding = resourceMap[resourceIdx++];


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.