### PR TITLE
Drop unnecessary namespaces from cast functions in dialect flow *ext. NFC. 7/10

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -139,9 +139,9 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
 
     auto loc = op.getLoc();
     Value input = op.getOperand();
-    ShapedType inputType = llvm::dyn_cast<ShapedType>(input.getType());
+    ShapedType inputType = dyn_cast<ShapedType>(input.getType());
     ShapedType resultType =
-        llvm::dyn_cast_if_present<ShapedType>(op.getResult().getType());
+        dyn_cast_if_present<ShapedType>(op.getResult().getType());
     if (!inputType || !resultType || !inputType.hasRank() ||
         !resultType.hasRank()) {
       return rewriter.notifyMatchFailure(op, "not ranked shaped types");

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -32,7 +32,7 @@ getShapeFromSizes(ArrayRef<OpFoldResult> valueOrAttrList) {
   return llvm::map_to_vector(
       valueOrAttrList, [&](OpFoldResult valueOrAttr) -> int64_t {
         if (auto attr = dyn_cast<Attribute>(valueOrAttr)) {
-          return llvm::cast<IntegerAttr>(attr).getInt();
+          return cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
       });
@@ -77,7 +77,7 @@ bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
   }
   auto getVal = [](OpFoldResult valueOrAttr, int64_t dynamicVal) -> int64_t {
     auto attr = dyn_cast<Attribute>(valueOrAttr);
-    return attr ? llvm::cast<IntegerAttr>(attr).getInt() : dynamicVal;
+    return attr ? cast<IntegerAttr>(attr).getInt() : dynamicVal;
   };
   /// To ensure contiguity, start from the least significant dimension. As long
   /// as the inner slices are "full slices", the current slice can be any offset

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -58,7 +58,7 @@ struct ElideUnusedOp : public OpRewritePattern<Op> {
 
 // Returns true if |value| is definitely empty at runtime.
 static bool isTensorZeroElements(Value value) {
-  auto type = llvm::dyn_cast<ShapedType>(value.getType());
+  auto type = dyn_cast<ShapedType>(value.getType());
   if (!type)
     return false;
   // Any static dimension being zero is definitely empty.
@@ -145,7 +145,7 @@ static SmallVector<Value> refreshDimsOnTypeChange(Operation *op, Type oldType,
   // Build an expanded list of all the dims - constants will be nullptr.
   // This lets us map back the new types without worrying about whether some
   // subset become static or dynamic.
-  auto oldShapedType = llvm::cast<ShapedType>(oldType);
+  auto oldShapedType = cast<ShapedType>(oldType);
   SmallVector<Value> allOldDims(oldShapedType.getRank());
   for (unsigned i = 0; i < oldShapedType.getRank(); ++i) {
     if (oldShapedType.isDynamicDim(i)) {
@@ -154,7 +154,7 @@ static SmallVector<Value> refreshDimsOnTypeChange(Operation *op, Type oldType,
     }
   }
 
-  auto newShapedType = llvm::cast<ShapedType>(newType);
+  auto newShapedType = cast<ShapedType>(newType);
   SmallVector<Value> newDims;
   for (unsigned i = 0; i < newShapedType.getRank(); ++i) {
     if (newShapedType.isDynamicDim(i)) {
@@ -502,8 +502,8 @@ void TensorTieShapeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 //===----------------------------------------------------------------------===//
 
 OpFoldResult TensorReshapeOp::fold(FoldAdaptor operands) {
-  auto sourceType = llvm::cast<ShapedType>(getSource().getType());
-  auto resultType = llvm::cast<ShapedType>(getResult().getType());
+  auto sourceType = cast<ShapedType>(getSource().getType());
+  auto resultType = cast<ShapedType>(getResult().getType());
   if (sourceType.getElementType() != resultType.getElementType()) {
     // Element type mismatch, this is a bitcast.
     return {};
@@ -545,8 +545,8 @@ struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
       return failure();
     }
 
-    auto sourceType = llvm::cast<ShapedType>(source.getType());
-    auto resultType = llvm::cast<ShapedType>(reshapeOp.getResult().getType());
+    auto sourceType = cast<ShapedType>(source.getType());
+    auto resultType = cast<ShapedType>(reshapeOp.getResult().getType());
 
     // If the element types don't match, this is a bitcast, else we can use
     // reshape.
@@ -567,7 +567,7 @@ struct ResolveShapedRank : public OpRewritePattern<tensor::RankOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(tensor::RankOp op,
                                 PatternRewriter &rewriter) const override {
-    auto shapedType = llvm::cast<ShapedType>(op.getTensor().getType());
+    auto shapedType = cast<ShapedType>(op.getTensor().getType());
     rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(op,
                                                         shapedType.getRank());
     return success();
@@ -585,7 +585,7 @@ struct ResolveShapedDim : public OpRewritePattern<tensor::DimOp> {
     auto idx = op.getConstantIndex().value();
 
     // Fold static dims from the type.
-    auto shapedType = llvm::cast<ShapedType>(op.getSource().getType());
+    auto shapedType = cast<ShapedType>(op.getSource().getType());
     if (!shapedType.isDynamicDim(idx)) {
       rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(
           op, shapedType.getDimSize(idx));
@@ -628,8 +628,8 @@ void TensorReshapeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 //===----------------------------------------------------------------------===//
 
 OpFoldResult TensorBitCastOp::fold(FoldAdaptor operands) {
-  auto sourceType = llvm::cast<ShapedType>(getSource().getType());
-  auto resultType = llvm::cast<ShapedType>(getResult().getType());
+  auto sourceType = cast<ShapedType>(getSource().getType());
+  auto resultType = cast<ShapedType>(getResult().getType());
   if (sourceType.getElementType() != resultType.getElementType()) {
     // Element type mismatch, this is a bitcast.
     return {};
@@ -657,13 +657,12 @@ void TensorBitCastOp::getCanonicalizationPatterns(RewritePatternSet &results,
 //===----------------------------------------------------------------------===//
 
 OpFoldResult TensorLoadOp::fold(FoldAdaptor operands) {
-  if (auto source =
-          llvm::dyn_cast_if_present<ElementsAttr>(operands.getSource())) {
+  if (auto source = dyn_cast_if_present<ElementsAttr>(operands.getSource())) {
     // Load directly from the constant source tensor.
     if (llvm::count(operands.getIndices(), nullptr) == 0) {
       return source.getValues<Attribute>()[llvm::map_to_vector(
           operands.getIndices(), [](Attribute value) {
-            return llvm::cast<IntegerAttr>(value).getValue().getZExtValue();
+            return cast<IntegerAttr>(value).getValue().getZExtValue();
           })];
     }
   }
@@ -702,8 +701,7 @@ OpFoldResult TensorStoreOp::fold(FoldAdaptor operands) {
   auto value = operands.getValue();
   if (!value)
     return {};
-  if (auto target =
-          llvm::dyn_cast_if_present<ElementsAttr>(operands.getTarget())) {
+  if (auto target = dyn_cast_if_present<ElementsAttr>(operands.getTarget())) {
     // Store into the constant target tensor.
     auto targetType = cast<ShapedType>(target.getType());
     if (targetType.getRank() == 0) {
@@ -713,7 +711,7 @@ OpFoldResult TensorStoreOp::fold(FoldAdaptor operands) {
       uint64_t offset = getFlattenedIndex(
           targetType,
           llvm::map_to_vector(operands.getIndices(), [](Attribute value) {
-            return llvm::cast<IntegerAttr>(value).getValue().getZExtValue();
+            return cast<IntegerAttr>(value).getValue().getZExtValue();
           }));
       SmallVector<Attribute, 16> newContents(target.getValues<Attribute>());
       newContents[offset] = value;
@@ -962,15 +960,15 @@ OpFoldResult TensorSliceOp::fold(FoldAdaptor operands) {
       return {};
     }
     // Fully constant arguments so we can perform the slice here.
-    auto tensor = llvm::cast<ElementsAttr>(operands.getSource());
-    int64_t rank = llvm::cast<ShapedType>(getSource().getType()).getRank();
+    auto tensor = cast<ElementsAttr>(operands.getSource());
+    int64_t rank = cast<ShapedType>(getSource().getType()).getRank();
     auto start =
         llvm::map_to_vector(operands.getStartIndices(), [](Attribute value) {
-          return llvm::cast<IntegerAttr>(value).getValue().getZExtValue();
+          return cast<IntegerAttr>(value).getValue().getZExtValue();
         });
     auto length =
         llvm::map_to_vector(operands.getLengths(), [](Attribute value) {
-          return llvm::cast<IntegerAttr>(value).getValue().getZExtValue();
+          return cast<IntegerAttr>(value).getValue().getZExtValue();
         });
     for (int64_t dim = 0; dim < rank; ++dim) {
       tensor = tensorSlice(tensor, dim, start[dim], length[dim]);
@@ -996,8 +994,8 @@ void TensorSliceOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
                                  ArrayRef<Attribute> startIndicesAttrs) {
-  auto updateType = llvm::cast<ShapedType>(update.getType());
-  auto targetType = llvm::cast<ShapedType>(target.getType());
+  auto updateType = cast<ShapedType>(update.getType());
+  auto targetType = cast<ShapedType>(target.getType());
   // If either target or update has zero element, then no update happens.
   if (updateType.getNumElements() == 0 || targetType.getNumElements() == 0) {
     return target;
@@ -1010,7 +1008,7 @@ static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
   }
 
   auto startIndex = llvm::map_to_vector(startIndicesAttrs, [](Attribute value) {
-    return llvm::cast<IntegerAttr>(value).getValue().getZExtValue();
+    return cast<IntegerAttr>(value).getValue().getZExtValue();
   });
   auto targetValues = llvm::to_vector(target.getValues<Attribute>());
   // target indices start from startIndicesAttrs and update indices start from
@@ -1044,13 +1042,13 @@ OpFoldResult TensorUpdateOp::fold(FoldAdaptor operands) {
       llvm::count(operands.getStartIndices(), nullptr) == 0;
   if (operands.getUpdate() && operands.getTarget() && allIndicesConstant) {
     // Fully constant arguments so we can perform the update here.
-    return tensorUpdate(llvm::cast<ElementsAttr>(operands.getUpdate()),
-                        llvm::cast<ElementsAttr>(operands.getTarget()),
+    return tensorUpdate(cast<ElementsAttr>(operands.getUpdate()),
+                        cast<ElementsAttr>(operands.getTarget()),
                         operands.getStartIndices());
   } else {
     // Replace the entire tensor when the sizes match.
-    auto updateType = llvm::cast<ShapedType>(getUpdate().getType());
-    auto targetType = llvm::cast<ShapedType>(getTarget().getType());
+    auto updateType = cast<ShapedType>(getUpdate().getType());
+    auto targetType = cast<ShapedType>(getTarget().getType());
     if (updateType.hasStaticShape() && targetType.hasStaticShape() &&
         updateType == targetType) {
       return getUpdate();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -166,7 +166,7 @@ int64_t NamedParameterAttr::getStorageSize() const {
       return lengthAttr.getInt();
     }
   }
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -94,8 +94,7 @@ static void rewriteParallelInsertSlices(RewriterBase &rewriter,
     rewriter.setInsertionPoint(block.getTerminator());
     auto dynamicDims = IREE::Util::findDynamicDimsInList(
         resultIndex, resultTensorOperands, resultTensorsDynamicDims);
-    BlockArgument destBbArg =
-        llvm::cast<BlockArgument>(parallelInsertOp.getDest());
+    BlockArgument destBbArg = cast<BlockArgument>(parallelInsertOp.getDest());
     assert(destBbArg.getOwner()->getParentOp() == forallOp &&
            "expected that dest is an output bbArg");
     Value dest = forallOp.getTiedOpOperand(destBbArg)->get();
@@ -125,7 +124,7 @@ static void rewriteExtractSlices(RewriterBase &rewriter, scf::ForallOp forallOp,
                                  IRMapping tensorToFlowBvm) {
   dispatchOp->walk([&](tensor::ExtractSliceOp extractSliceOp) {
     Value source = extractSliceOp.getSource();
-    if (auto sourceBbArg = llvm::dyn_cast<BlockArgument>(source))
+    if (auto sourceBbArg = dyn_cast<BlockArgument>(source))
       if (sourceBbArg.getOwner()->getParentOp() == forallOp.getOperation())
         source = forallOp.getTiedOpOperand(sourceBbArg)->get();
 
@@ -211,7 +210,7 @@ static void cloneOpsIntoForallOp(RewriterBase &rewriter,
       if (forallOp->isProperAncestor(use.getOwner()))
         uses.push_back(&use);
     for (OpOperand *use : uses) {
-      unsigned resultNum = llvm::cast<OpResult>(use->get()).getResultNumber();
+      unsigned resultNum = cast<OpResult>(use->get()).getResultNumber();
       rewriter.modifyOpInPlace(
           use->getOwner(), [&]() { use->set(cloned->getOpResult(resultNum)); });
     }
@@ -262,14 +261,13 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   llvm::SetVector<Value> resultTensorOperands, resultTensorsDynamicDims;
   for (const Operation &yieldingOp : InParallelOp.getYieldingOps()) {
     auto parallelInsertOp = cast<tensor::ParallelInsertSliceOp>(&yieldingOp);
-    BlockArgument destBbArg =
-        llvm::cast<BlockArgument>(parallelInsertOp.getDest());
+    BlockArgument destBbArg = cast<BlockArgument>(parallelInsertOp.getDest());
     Value dest = forallOp.getTiedOpOperand(destBbArg)->get();
     bool inserted = resultTensorOperands.insert(dest);
     if (!inserted)
       continue;
     auto dynamicDims =
-        getIndicesOfDynamicDims(llvm::cast<ShapedType>(dest.getType()));
+        getIndicesOfDynamicDims(cast<ShapedType>(dest.getType()));
     for (int64_t dim : dynamicDims)
       resultTensorsDynamicDims.insert(
           tensor::DimOp::create(rewriter, loc, dest, dim));
@@ -286,7 +284,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
 
   SmallVector<Value> nonTensorOperands, tensorOperands, tensorDynamicDims;
   for (Value v : valuesDefinedAbove) {
-    auto tensorType = llvm::dyn_cast<RankedTensorType>(v.getType());
+    auto tensorType = dyn_cast<RankedTensorType>(v.getType());
     if (!tensorType) {
       nonTensorOperands.push_back(v);
       continue;
@@ -300,7 +298,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
   // Also add shared outputs. (These are usually already added as result
   // tensor operands.)
   for (Value v : forallOp.getOutputs()) {
-    auto tensorType = llvm::cast<RankedTensorType>(v.getType());
+    auto tensorType = cast<RankedTensorType>(v.getType());
     if (resultTensorOperands.contains(v))
       continue;
     tensorOperands.push_back(v);
@@ -411,7 +409,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
     auto dynamicDims = IREE::Util::findDynamicDimsInList(
         en.index(), allTensorOperands, allTensorDimsBBArgs);
     auto loadOp = IREE::TensorExt::DispatchTensorLoadOp::create(
-        rewriter, loc, llvm::cast<RankedTensorType>(en.value().getType()),
+        rewriter, loc, cast<RankedTensorType>(en.value().getType()),
         tensorToFlowBvm.lookup(en.value()), dynamicDims);
     // Replace the tensor -> iree_tensor_ext.dispatch.tensor entry by a
     // tensor -> iree_tensor_ext.dispatch.tensor.load entry.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -78,7 +78,7 @@ static TensorType getMainTensorForLinalgExtOp(Operation *op) {
   auto operandTypes = llvm::to_vector(op->getOperandTypes());
   auto resultTypes = llvm::to_vector(op->getResultTypes());
   for (Type t : llvm::concat<Type>(operandTypes, resultTypes)) {
-    auto tensorType = llvm::dyn_cast<TensorType>(t);
+    auto tensorType = dyn_cast<TensorType>(t);
     if (!tensorType)
       continue;
     if (!main) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDynamicDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CaptureDynamicDims.cpp
@@ -57,8 +57,8 @@ static void captureDims(IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   // SSA value pair.
   auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
   auto captureTensorDims = [&](Value externalValue, Value internalValue) {
-    auto tensorType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
-        internalValue.getType());
+    auto tensorType =
+        dyn_cast<IREE::TensorExt::DispatchTensorType>(internalValue.getType());
     if (!tensorType)
       return;
     if (tensorType.hasStaticShape())
@@ -79,7 +79,7 @@ static void captureDims(IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
     unsigned insertionPosition = entryBlock->getNumArguments();
     for (auto argType : llvm::reverse(entryBlock->getArgumentTypes())) {
       auto flowTensorType =
-          llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(argType);
+          dyn_cast<IREE::TensorExt::DispatchTensorType>(argType);
       if (!flowTensorType || flowTensorType.getAccess() !=
                                  IREE::TensorExt::TensorAccess::WriteOnly) {
         break;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -23,7 +23,7 @@ namespace {
 /// Compute the dynamic dims of the given value and add them to the vector.
 static void appendDynamicDims(OpBuilder &b, Location loc,
                               SmallVector<Value> &argumentDims, Value tensor) {
-  auto tensorType = llvm::cast<RankedTensorType>(tensor.getType());
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
 
   // Fast-path for if the value comes from ops that support our dynamic
   // shape interfaces. Otherwise we have to insert tensor.dim ops.
@@ -106,7 +106,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   // Compute dimensions of tensor args.
   SmallVector<Value> argumentDims;
   for (Value tensor : argumentsSet) {
-    auto tensorType = llvm::dyn_cast<RankedTensorType>(tensor.getType());
+    auto tensorType = dyn_cast<RankedTensorType>(tensor.getType());
     if (!tensorType)
       continue;
     appendDynamicDims(rewriter, loc, argumentDims, tensor);
@@ -184,7 +184,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   rewriter.setInsertionPointToStart(newBodyEntry);
   SmallVector<Value> argValues;
   for (const auto &it : llvm::enumerate(arguments)) {
-    auto tensorType = llvm::dyn_cast<RankedTensorType>(it.value().getType());
+    auto tensorType = dyn_cast<RankedTensorType>(it.value().getType());
     if (!tensorType) {
       argValues.push_back(it.value());
       continue;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -208,13 +208,13 @@ private:
     int64_t largeAttrLimit = getLargeAttributeSizeLimit();
 
     // Always emit splat attributes.
-    if (llvm::isa<SplatElementsAttr>(attr)) {
+    if (isa<SplatElementsAttr>(attr)) {
       attr.print(os);
       return;
     }
 
     // Elide "big" elements attributes.
-    auto elements = llvm::dyn_cast<ElementsAttr>(attr);
+    auto elements = dyn_cast<ElementsAttr>(attr);
     if (elements && elements.getNumElements() > largeAttrLimit) {
       auto type = cast<ShapedType>(elements.getType());
       os << std::string(type.getRank(), '[') << "..."
@@ -222,7 +222,7 @@ private:
       return;
     }
 
-    auto array = llvm::dyn_cast<ArrayAttr>(attr);
+    auto array = dyn_cast<ArrayAttr>(attr);
     if (array && static_cast<int64_t>(array.size()) > largeAttrLimit) {
       os << "[...]";
       return;
@@ -421,9 +421,9 @@ private:
 
       if (op && isScalarConstantOp(op)) {
         auto ty = operand.getType();
-        if (llvm::isa<IntegerType>(ty)) {
+        if (isa<IntegerType>(ty)) {
           os << cast<arith::ConstantIntOp>(op).value();
-        } else if (llvm::isa<FloatType>(ty)) {
+        } else if (isa<FloatType>(ty)) {
           cast<arith::ConstantFloatOp>(op).value().print(os);
         } else {
           os << cast<arith::ConstantIndexOp>(op).value();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -123,7 +123,7 @@ createImportBufferViewGlobalOp(std::string name, BlockArgument arg,
 
   // Extract the type, which must be a static tensor.
   auto targetType = importOp.getTarget().getType();
-  auto tensorType = llvm::dyn_cast<RankedTensorType>(targetType);
+  auto tensorType = dyn_cast<RankedTensorType>(targetType);
   if (!tensorType || !tensorType.hasStaticShape()) {
     mlir::emitError(loc) << "unsupported buffer view import tensor type on "
                          << arg << " used as " << targetType;
@@ -169,7 +169,7 @@ static IREE::Util::GlobalOp createExportBufferGlobalOp(std::string name,
   }
 
   // The type must be a static tensor for this pass to work.
-  auto tensorType = llvm::dyn_cast<RankedTensorType>(sourceType);
+  auto tensorType = dyn_cast<RankedTensorType>(sourceType);
   if (!tensorType || !tensorType.hasStaticShape()) {
     mlir::emitError(loc) << "unsupported buffer view export tensor type on "
                          << arg << " used as " << sourceType;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -67,8 +67,7 @@ LogicalResult simplifyDimOps(RewriterBase &rewriter,
     }
 
     // Only DimOps with ranked tensors are supported.
-    auto tensorType =
-        llvm::dyn_cast<RankedTensorType>(dimOp.getSource().getType());
+    auto tensorType = dyn_cast<RankedTensorType>(dimOp.getSource().getType());
     if (!tensorType)
       continue;
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -21,10 +21,10 @@ namespace mlir::iree_compiler::IREE::Flow {
 /// Returns failure, when the type is not handled.
 static FailureOr<TypedAttr> getZero(OpBuilder &builder, Location loc,
                                     Type elementType) {
-  if (auto intType = llvm::dyn_cast<IntegerType>(elementType)) {
+  if (auto intType = dyn_cast<IntegerType>(elementType)) {
     return cast<TypedAttr>(builder.getIntegerAttr(intType, 0));
   }
-  if (auto floatType = llvm::dyn_cast<FloatType>(elementType)) {
+  if (auto floatType = dyn_cast<FloatType>(elementType)) {
     return cast<TypedAttr>(builder.getFloatAttr(floatType, 0.0));
   }
   return failure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -32,7 +32,7 @@ static SmallVector<TensorValue> filterTensorValues(ValueRange &&range,
                                                    ValueRange &&dynamicDims) {
   SmallVector<TensorValue> result;
   for (auto [idx, value] : llvm::enumerate(range)) {
-    if (llvm::isa<TensorType>(value.getType())) {
+    if (isa<TensorType>(value.getType())) {
       SmallVector<Value> dims =
           IREE::Util::findDynamicDimsInList(idx, range, dynamicDims);
       result.push_back({value, dims});

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InjectTensorTracing.cpp
@@ -34,7 +34,7 @@ static std::string inferTraceKey(Operation *op) {
 static SmallVector<Value> filterTensorValues(ValueRange &&range) {
   SmallVector<Value> result;
   for (auto value : range) {
-    if (llvm::isa<TensorType>(value.getType()))
+    if (isa<TensorType>(value.getType()))
       result.push_back(value);
   }
   return result;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -29,7 +29,7 @@ namespace mlir::iree_compiler::IREE::Flow {
 static SmallVector<Value> filterNonTensorValues(ValueRange &&range) {
   SmallVector<Value> result;
   for (auto value : range) {
-    if (llvm::isa<TensorType>(value.getType()))
+    if (isa<TensorType>(value.getType()))
       result.push_back(value);
   }
   return result;
@@ -100,7 +100,7 @@ static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
   SmallVector<Value> exports;
   SmallVector<Type> newTypes;
   for (auto retVal : op->getResults()) {
-    if (llvm::isa<TensorType>(retVal.getType())) {
+    if (isa<TensorType>(retVal.getType())) {
       auto type = IREE::HAL::BufferViewType::get(context);
       auto exportOp = IREE::HAL::TensorExportOp::create(
           builder, loc, type, retVal, TypeAttr::get(retVal.getType()),
@@ -150,7 +150,7 @@ struct InsertDebugTargetAtOrdinalPass
       Operation *operation = op;
 
       // Only look for dispatches in util func ops.
-      auto funcOp = llvm::dyn_cast<IREE::Util::FuncOp>(operation);
+      auto funcOp = dyn_cast<IREE::Util::FuncOp>(operation);
       if (!funcOp)
         continue;
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineConstants.cpp
@@ -28,7 +28,7 @@ namespace {
 
 // Returns true if |value| is worth outlining (large, etc).
 static bool isOutlinableValue(Attribute value) {
-  if (auto elementsAttr = llvm::dyn_cast<ElementsAttr>(value)) {
+  if (auto elementsAttr = dyn_cast<ElementsAttr>(value)) {
     // Don't outline splats - we want those fused.
     return !elementsAttr.isSplat();
   } else if (isa<IREE::Flow::NamedParameterAttr>(value)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -220,7 +220,7 @@ static void createWorkgroupCountFromDagRootRegion(
 /// Return `true` if the given type is a ShapedType and has at least one
 /// dynamic dimension.
 static bool hasDynamicShape(Type t) {
-  auto shapedType = llvm::dyn_cast<ShapedType>(t);
+  auto shapedType = dyn_cast<ShapedType>(t);
   if (!shapedType)
     return false;
   return !shapedType.hasStaticShape();
@@ -238,7 +238,7 @@ reifyDynamicResultDimsImpl(OpBuilder &b, Value value,
     return success();
 
   // There is at least one dynamic dimension, continue...
-  ShapedType shapedType = llvm::cast<ShapedType>(value.getType());
+  ShapedType shapedType = cast<ShapedType>(value.getType());
 
   // Helper function that generates tensor.dim ops.
   auto emitTensorDimOps = [&]() {
@@ -251,7 +251,7 @@ reifyDynamicResultDimsImpl(OpBuilder &b, Value value,
   };
 
   // Case 2: Value is a block argument.
-  if (auto bbArg = llvm::dyn_cast<BlockArgument>(value)) {
+  if (auto bbArg = dyn_cast<BlockArgument>(value)) {
     if (!createTensorDimOps)
       return failure();
 
@@ -262,7 +262,7 @@ reifyDynamicResultDimsImpl(OpBuilder &b, Value value,
 
   // Value is an OpResult.
   Operation *op = value.getDefiningOp();
-  OpResult opResult = llvm::cast<OpResult>(value);
+  OpResult opResult = cast<OpResult>(value);
 
   // Case 3: Query ShapeAwareOpInterface.
   auto shapeAwareOp = dyn_cast<IREE::Util::ShapeAwareOpInterface>(op);
@@ -434,8 +434,8 @@ clonePrecedingOpIntoDispatchRegion(RewriterBase &rewriter, Operation *target,
   // Replace all uses in the dispatch region.
   for (OpOperand *use : usesInsideOfRegion) {
     rewriter.modifyOpInPlace(use->getOwner(), [&]() {
-      use->set(newTargetOp->getResult(
-          llvm::cast<OpResult>(use->get()).getResultNumber()));
+      use->set(
+          newTargetOp->getResult(cast<OpResult>(use->get()).getResultNumber()));
     });
   }
 
@@ -890,10 +890,10 @@ bool isClonableIntoDispatchOp(Operation *op,
     }
 
     auto constantType = op->getResult(0).getType();
-    if (llvm::isa<SplatElementsAttr>(constantValueAttr)) {
+    if (isa<SplatElementsAttr>(constantValueAttr)) {
       return true;
-    } else if (auto attr = llvm::dyn_cast<ElementsAttr>(constantValueAttr)) {
-      auto shapedType = llvm::cast<ShapedType>(constantType);
+    } else if (auto attr = dyn_cast<ElementsAttr>(constantValueAttr)) {
+      auto shapedType = cast<ShapedType>(constantType);
       uint64_t estimatedByteLength =
           (shapedType.getNumElements() *
            IREE::Util::getTypeBitWidth(shapedType.getElementType())) /

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -62,14 +62,14 @@ static void getEffectsImpl(
         &effects,
     ArrayRef<OpOperand *> inputOperands, MutableOperandRange outputOperands) {
   for (OpOperand *operand : inputOperands) {
-    if (!llvm::isa<MemRefType>(operand->get().getType())) {
+    if (!isa<MemRefType>(operand->get().getType())) {
       continue;
     }
     effects.emplace_back(MemoryEffects::Read::get(), operand,
                          SideEffects::DefaultResource::get());
   }
   for (OpOperand &operand : outputOperands) {
-    if (!llvm::isa<MemRefType>(operand.get().getType())) {
+    if (!isa<MemRefType>(operand.get().getType())) {
       continue;
     }
     effects.emplace_back(MemoryEffects::Read::get(), &operand,
@@ -253,7 +253,7 @@ static void populateMap(OpTy op, MutableArrayRef<OpOperand> operands,
       continue;
     }
     Value src = opOperand.get();
-    auto sourceType = llvm::cast<RankedTensorType>(src.getType());
+    auto sourceType = cast<RankedTensorType>(src.getType());
     auto sourceMap = op.getMatchingIndexingMap(&opOperand);
 
     // Get the `sourceShape` of the `sourceType`. If the operand is a result of
@@ -295,7 +295,7 @@ static void createNewOperandWithStaticSizes(
   if (op.isScalar(opOperand)) {
     return;
   }
-  auto sourceType = llvm::cast<RankedTensorType>(src.getType());
+  auto sourceType = cast<RankedTensorType>(src.getType());
   Type resultType = sourceType;
   ArrayRef<int64_t> sourceShape = sourceType.getShape();
   AffineMap sourceMap = op.getMatchingIndexingMap(opOperand);
@@ -1133,7 +1133,7 @@ LogicalResult TopkOp::verify() {
       block.getArgument(1).getType() != inputValuesType.getElementType()) {
     return op->emitOpError("region block types must match input");
   }
-  auto terminatorOp = llvm::dyn_cast<YieldOp>(block.getTerminator());
+  auto terminatorOp = dyn_cast<YieldOp>(block.getTerminator());
   if (!terminatorOp || !terminatorOp.getOperand(0).getType().isInteger(1)) {
     return op->emitOpError("region block must end with a linalg_ext.yield i1!");
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -26,14 +26,14 @@ static bool hasAllOneValues(ArrayRef<int64_t> attr) {
 }
 
 static Value createAdd(Location loc, Value x, Value y, OpBuilder &builder) {
-  bool isInt = llvm::isa<IntegerType>(x.getType());
+  bool isInt = isa<IntegerType>(x.getType());
   if (isInt)
     return arith::AddIOp::create(builder, loc, x, y);
   return arith::AddFOp::create(builder, loc, x, y);
 }
 
 static Value createMul(Location loc, Value x, Value y, OpBuilder &builder) {
-  bool isInt = llvm::isa<IntegerType>(x.getType());
+  bool isInt = isa<IntegerType>(x.getType());
   if (isInt)
     return arith::MulIOp::create(builder, loc, x, y);
   return arith::MulFOp::create(builder, loc, x, y);
@@ -173,9 +173,9 @@ public:
     Value input = linalgOp.getDpsInputs()[0];
     Value filter = linalgOp.getDpsInputs()[1];
     Value output = linalgOp.getDpsInits()[0];
-    auto inputType = llvm::cast<ShapedType>(input.getType());
-    auto filterType = llvm::cast<ShapedType>(filter.getType());
-    auto outputType = llvm::cast<ShapedType>(output.getType());
+    auto inputType = cast<ShapedType>(input.getType());
+    auto filterType = cast<ShapedType>(filter.getType());
+    auto outputType = cast<ShapedType>(output.getType());
 
     ArrayRef<int64_t> filterShape = filterType.getShape();
     ArrayRef<int64_t> outputShape = outputType.getShape();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
@@ -97,7 +97,7 @@ struct PadContractionToBlockSizePass final
 
   void runOnOperation() override {
     getOperation()->walk([&](linalg::ContractionOpInterface op) {
-      auto linalgOp = llvm::cast<linalg::LinalgOp>(op.getOperation());
+      auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
       Location loc = op.getLoc();
       OpOperand *lhs = linalgOp.getDpsInputOperand(0);
       OpOperand *rhs = linalgOp.getDpsInputOperand(1);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/RewriteFft.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/RewriteFft.cpp
@@ -19,7 +19,7 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
          "expected FFT length to be a power of two");
   Location loc = op->getLoc();
 
-  auto operandType = llvm::dyn_cast<RankedTensorType>(operand.getType());
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
   if (!operandType || !operandType.hasStaticShape()) {
     return failure();
   }
@@ -32,7 +32,7 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 
   auto getBitReversalOrder = [](ImplicitLocOpBuilder &b, Value real,
                                 int64_t fftLength) -> SmallVector<Value> {
-    ShapedType realType = llvm::cast<ShapedType>(real.getType());
+    ShapedType realType = cast<ShapedType>(real.getType());
     int64_t rank = realType.getRank();
 
     SmallVector<OpFoldResult> mixedSizes =
@@ -79,7 +79,7 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
             arith::ConstantOp::create(
                 b, realType,
                 DenseFPElementsAttr::get(
-                    realType, llvm::cast<Attribute>(b.getF32FloatAttr(0.0))))};
+                    realType, cast<Attribute>(b.getF32FloatAttr(0.0))))};
   };
 
   SmallVector<Value> results = getBitReversalOrder(b, operand, fftLength);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -483,9 +483,9 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   Value input = linalgOp.getDpsInputs()[0];
   Value filter = linalgOp.getDpsInputs()[1];
   Value output = linalgOp.getDpsInits()[0];
-  auto inputType = llvm::cast<ShapedType>(input.getType());
-  auto filterType = llvm::cast<ShapedType>(filter.getType());
-  auto outputType = llvm::cast<ShapedType>(output.getType());
+  auto inputType = cast<ShapedType>(input.getType());
+  auto filterType = cast<ShapedType>(filter.getType());
+  auto outputType = cast<ShapedType>(output.getType());
 
   if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
     LDBG() << "[unimplemented] expected 'filterType' and 'inputType' to have "

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -100,8 +100,8 @@ struct BitCastOfTensorCastStaticInfo final : OpRewritePattern<BitCastOp> {
 }; // namespace
 
 OpFoldResult BitCastOp::fold(FoldAdaptor operands) {
-  auto sourceType = llvm::cast<ShapedType>(getSource().getType());
-  auto resultType = llvm::cast<ShapedType>(getResult().getType());
+  auto sourceType = cast<ShapedType>(getSource().getType());
+  auto resultType = cast<ShapedType>(getResult().getType());
   if (sourceType.getElementType() != resultType.getElementType()) {
     // Element type mismatch, this is a bitcast.
     return {};
@@ -177,7 +177,7 @@ struct ConvertDispatchInputLoadOfTensorToSubTensor
   using Base::Base;
   LogicalResult matchAndRewrite(DispatchTensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
-    if (!llvm::isa<RankedTensorType>(loadOp.getSource().getType())) {
+    if (!isa<RankedTensorType>(loadOp.getSource().getType())) {
       return failure();
     }
     // If the offsets are empty rely on folding to take care of it.
@@ -289,8 +289,7 @@ void DispatchTensorLoadOp::getCanonicalizationPatterns(
 // verification. Fold such uses of the offsets, size and strides are emtpy.
 // i.e, flow.dispatch.input.load %v -> %v
 OpFoldResult DispatchTensorLoadOp::fold(FoldAdaptor operands) {
-  if (getSource().getType() &&
-      llvm::isa<RankedTensorType>(getSource().getType()) &&
+  if (getSource().getType() && isa<RankedTensorType>(getSource().getType()) &&
       getMixedOffsets().empty() && getMixedSizes().empty() &&
       getMixedStrides().empty()) {
     return getSource();

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -38,11 +38,10 @@ static LogicalResult verifyOpDynamicDims(Operation *op, ValueRange values,
                                          ValueRange dynamicDims) {
   unsigned requiredCount = 0;
   for (auto value : values) {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
+    if (auto shapedType = dyn_cast<ShapedType>(value.getType())) {
       requiredCount += shapedType.getNumDynamicDims();
-    } else if (auto tensorType =
-                   llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
-                       value.getType())) {
+    } else if (auto tensorType = dyn_cast<IREE::TensorExt::DispatchTensorType>(
+                   value.getType())) {
       requiredCount += tensorType.getNumDynamicDims();
     }
   }
@@ -139,7 +138,7 @@ static void processMixedOperands(ArrayRef<OpFoldResult> valueOrAttrs,
       staticValues.push_back(dynamicIndexValue);
     } else {
       auto operandValue =
-          llvm::cast<IntegerAttr>(dyn_cast<Attribute>(valueOrAttr)).getInt();
+          cast<IntegerAttr>(dyn_cast<Attribute>(valueOrAttr)).getInt();
       staticValues.push_back(operandValue);
     }
   }
@@ -178,7 +177,7 @@ RankedTensorType DispatchTensorLoadOp::inferResultType(
   auto shape =
       llvm::map_to_vector(mixedSizes, [&](OpFoldResult valueOrAttr) -> int64_t {
         if (auto attr = dyn_cast<Attribute>(valueOrAttr)) {
-          return llvm::cast<IntegerAttr>(attr).getInt();
+          return cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
       });
@@ -195,8 +194,7 @@ void DispatchTensorLoadOp::build(OpBuilder &builder, OperationState &state,
                                  ArrayRef<NamedAttribute> attributes) {
   SmallVector<OpFoldResult> offsets, strides, sizes;
   getDefaultOffsetSizeAndStrides(
-      builder,
-      llvm::cast<IREE::TensorExt::DispatchTensorType>(source.getType()),
+      builder, cast<IREE::TensorExt::DispatchTensorType>(source.getType()),
       sourceDynamicDims, offsets, sizes, strides);
   build(builder, state, returnType, source, sourceDynamicDims, offsets, sizes,
         strides, attributes);
@@ -234,8 +232,7 @@ void DispatchTensorLoadOp::build(OpBuilder &builder, OperationState &state,
                                  ArrayRef<OpFoldResult> mixedStrides,
                                  ArrayRef<NamedAttribute> attributes) {
   auto returnType = inferResultType(
-      llvm::cast<IREE::TensorExt::DispatchTensorType>(source.getType()),
-      mixedSizes);
+      cast<IREE::TensorExt::DispatchTensorType>(source.getType()), mixedSizes);
   build(builder, state, returnType, source, sourceDynamicDims, mixedOffsets,
         mixedSizes, mixedStrides);
 }
@@ -313,8 +310,7 @@ void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
                                   ArrayRef<NamedAttribute> attributes) {
   SmallVector<OpFoldResult> offsets, sizes, strides;
   getDefaultOffsetSizeAndStrides(
-      builder,
-      llvm::cast<IREE::TensorExt::DispatchTensorType>(target.getType()),
+      builder, cast<IREE::TensorExt::DispatchTensorType>(target.getType()),
       targetDynamicDims, offsets, sizes, strides);
   build(builder, state, value, target, targetDynamicDims, offsets, sizes,
         strides, attributes);
@@ -341,7 +337,7 @@ void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
 }
 
 llvm::SmallBitVector DispatchTensorStoreOp::getDroppedDims() {
-  return getDroppedDimsImpl(llvm::cast<RankedTensorType>(getValue().getType()),
+  return getDroppedDimsImpl(cast<RankedTensorType>(getValue().getType()),
                             getMixedSizes());
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.cpp
@@ -47,7 +47,7 @@ Type DispatchTensorType::getBoundElementType() const {
   if (boundType.isIntOrFloat()) {
     return boundType;
   }
-  return llvm::cast<RankedTensorType>(boundType).getElementType();
+  return cast<RankedTensorType>(boundType).getElementType();
 }
 
 unsigned DispatchTensorType::getBoundElementTypeBitWidth() const {
@@ -68,7 +68,7 @@ int64_t DispatchTensorType::getRank() const {
   if (boundType.isIntOrIndexOrFloat()) {
     return 0;
   }
-  return llvm::cast<RankedTensorType>(boundType).getRank();
+  return cast<RankedTensorType>(boundType).getRank();
 }
 
 bool DispatchTensorType::hasRank() const { return true; }
@@ -94,7 +94,7 @@ ArrayRef<int64_t> DispatchTensorType::getShape() const {
   if (boundType.isIntOrIndexOrFloat()) {
     return {};
   }
-  return llvm::cast<RankedTensorType>(boundType).getShape();
+  return cast<RankedTensorType>(boundType).getShape();
 }
 
 int64_t DispatchTensorType::getNumDynamicDims() const {
@@ -139,7 +139,7 @@ bool DispatchTensorType::doesSliceSpanWholeTensor(
 LogicalResult
 DispatchTensorType::verify(function_ref<InFlightDiagnostic()> emitError,
                            uint32_t access, Type boundType) {
-  if (!boundType.isIntOrFloat() && !llvm::isa<RankedTensorType>(boundType)) {
+  if (!boundType.isIntOrFloat() && !isa<RankedTensorType>(boundType)) {
     return emitError() << "unhandled bounded type in dispatch. Must by int, "
                           "float or ranked tensor type";
   }
@@ -207,7 +207,7 @@ Type IREETensorExtDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void IREETensorExtDialect::printType(Type type, DialectAsmPrinter &p) const {
-  if (auto inputType = llvm::dyn_cast<DispatchTensorType>(type)) {
+  if (auto inputType = dyn_cast<DispatchTensorType>(type)) {
     IREE::TensorExt::printType(inputType, p);
   } else {
     assert(false && "unknown Flow type");


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.