### PR TITLE
Drop unnecessary namespaces from cast functions in dialect util. NFC. 8/10

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
@@ -106,7 +106,7 @@ const char FloatRangeValueElement::ID = 0;
 // of fp types.
 // TODO: getElementTypeOrSelf?
 static bool isFpType(Type type) {
-  return llvm::isa<FloatType>(getElementTypeOrSelf(type));
+  return isa<FloatType>(getElementTypeOrSelf(type));
 }
 
 void FloatRangeValueElement::initializeValue(Value value, DFX::Solver &solver) {
@@ -130,10 +130,10 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
   // TODO: We shouldn't need to hard switch on LinalgOp here and should
   // be relying on some kind of concept/interface. It just isn't
   // clear what that would be.
-  if (auto valueBlockArg = llvm::dyn_cast<BlockArgument>(value)) {
+  if (auto valueBlockArg = dyn_cast<BlockArgument>(value)) {
     Block *ownerBlock = valueBlockArg.getOwner();
-    if (auto linalgParent = llvm::dyn_cast_or_null<linalg::LinalgOp>(
-            ownerBlock->getParentOp())) {
+    if (auto linalgParent =
+            dyn_cast_or_null<linalg::LinalgOp>(ownerBlock->getParentOp())) {
       value = linalgParent->getOperand(valueBlockArg.getArgNumber());
       LLVM_DEBUG(dbgs() << "  ++ REMAP LINALG BLOCK ARG TO: " << value << "\n");
     }
@@ -144,12 +144,12 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
       *this, Position::forValue(value), DFX::Resolution::OPTIONAL);
   if (pvs.isValidState() && !pvs.isUndefContained()) {
     for (Attribute constValue : pvs.getAssumedSet()) {
-      if (auto scalarValue = llvm::dyn_cast<FloatAttr>(constValue)) {
+      if (auto scalarValue = dyn_cast<FloatAttr>(constValue)) {
         FloatRangeStats stats;
         stats.addDomainValue(scalarValue.getValueAsDouble());
         newState.setAssumed(stats);
         newState.indicateOptimisticFixpoint();
-      } else if (auto elements = llvm::dyn_cast<ElementsAttr>(constValue)) {
+      } else if (auto elements = dyn_cast<ElementsAttr>(constValue)) {
         FloatRangeStats stats;
         for (APFloat elementValue : elements.getValues<APFloat>()) {
           stats.addDomainValue(elementValue.convertToDouble());

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -564,7 +564,7 @@ TraversalResult Explorer::walkReturnOps(Operation *parentOp,
         break;
     }
   } else if (auto parentFuncOp =
-                 llvm::dyn_cast<mlir::FunctionOpInterface>(parentOp)) {
+                 dyn_cast<mlir::FunctionOpInterface>(parentOp)) {
     if (parentFuncOp->getNumRegions() == 0 ||
         parentFuncOp->getRegion(0).empty()) {
       LLVM_DEBUG(
@@ -741,7 +741,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn,
   // Fast-path short-circuit for constants, which are like 25% of all IR.
   if (value.getDefiningOp() &&
       value.getDefiningOp()->hasTrait<OpTrait::ConstantLike>()) {
-    fn(llvm::cast<OpResult>(value));
+    fn(cast<OpResult>(value));
     return TraversalResult::COMPLETE;
   }
 
@@ -889,7 +889,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn,
     if (!definingOp) {
       // Op comes from a block argument; we need to continue walking through all
       // predecessors.
-      result |= traverseBlockArg(llvm::cast<BlockArgument>(work));
+      result |= traverseBlockArg(cast<BlockArgument>(work));
       continue;
     }
 
@@ -903,7 +903,7 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn,
     }
 
     // Op is visible in the CFG as a leaf.
-    auto resultValue = llvm::cast<OpResult>(work);
+    auto resultValue = cast<OpResult>(work);
     LLVM_DEBUG(llvm::dbgs() << "  == emitting op "
                             << definingOp->getName().getStringRef() << "\n");
     auto fnResult = fn(resultValue);
@@ -1193,12 +1193,12 @@ TraversalResult Explorer::walkTransitiveUses(Value value, UseWalkFn fn,
 
       // If op is a return then we need to walk into the caller results.
       if (ownerOp->hasTrait<OpTrait::ReturnLike>() &&
-          llvm::isa<CallableOpInterface>(ownerOp->getParentOp())) {
+          isa<CallableOpInterface>(ownerOp->getParentOp())) {
         result |= traverseReturnOp(ownerOp, use.getOperandNumber());
       }
 
       if (ownerOp->hasTrait<OpTrait::ReturnLike>() &&
-          !llvm::isa<CallableOpInterface>(ownerOp->getParentOp())) {
+          !isa<CallableOpInterface>(ownerOp->getParentOp())) {
         auto parent = ownerOp->getParentOp();
         auto result = parent->getResult(use.getOperandNumber());
         worklist.insert(result);

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.cpp
@@ -25,7 +25,7 @@ namespace {
 
 /// Returns true if the given `type` is a MemRef of rank 0 or 1.
 static bool isRankZeroOrOneMemRef(Type type) {
-  if (auto memrefType = llvm::dyn_cast<MemRefType>(type)) {
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.hasRank() && memrefType.getRank() <= 1 &&
            memrefType.getLayout().isIdentity();
   }
@@ -34,8 +34,7 @@ static bool isRankZeroOrOneMemRef(Type type) {
 
 static Value getElementTypeByteSize(OpBuilder &builder, Location loc,
                                     Value memrefValue) {
-  auto elementType =
-      llvm::cast<ShapedType>(memrefValue.getType()).getElementType();
+  auto elementType = cast<ShapedType>(memrefValue.getType()).getElementType();
   return builder.createOrFold<IREE::Util::SizeOfOp>(loc, elementType);
 }
 
@@ -47,7 +46,7 @@ static Value getElementTypeByteSize(OpBuilder &builder, Location loc,
 static Value getByteOffsetForIndices(OpBuilder &builder, Location loc,
                                      Value memrefValue, ValueRange indices,
                                      Value elementTypeByteSize) {
-  auto memrefType = llvm::cast<MemRefType>(memrefValue.getType());
+  auto memrefType = cast<MemRefType>(memrefValue.getType());
   if (memrefType.getRank() == 0) {
     // Rank 0 buffers (like memref<i32>) have only a single valid offset at 0.
     return builder.createOrFold<arith::ConstantIndexOp>(loc, 0);
@@ -71,7 +70,7 @@ static Value getByteOffsetForIndices(OpBuilder &builder, Location loc,
 
 static Value getByteLength(OpBuilder &builder, Location loc,
                            Value memrefValue) {
-  auto memrefType = llvm::cast<MemRefType>(memrefValue.getType());
+  auto memrefType = cast<MemRefType>(memrefValue.getType());
   if (memrefType.getRank() == 0) {
     return getElementTypeByteSize(builder, loc, memrefValue);
   }
@@ -196,7 +195,7 @@ struct ConvertMemRefDimOp : public OpConversionPattern<memref::DimOp> {
           dimOp, "only rank-0 and rank-1 memrefs are supported; flatten first");
     }
     auto elementType =
-        llvm::cast<MemRefType>(dimOp.getSource().getType()).getElementType();
+        cast<MemRefType>(dimOp.getSource().getType()).getElementType();
     Value elementSize = rewriter.createOrFold<IREE::Util::SizeOfOp>(
         dimOp.getLoc(), elementType);
     Value bufferSize = IREE::Util::BufferSizeOp::create(

--- a/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
@@ -47,9 +47,9 @@ void excludeClosureOperandsAndResults(
   for (auto it : llvm::enumerate(oldOperandValues)) {
     unsigned numDynamicDims = 0;
     auto type = it.value().getType();
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
       numDynamicDims = shapedType.getNumDynamicDims();
-    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
+    } else if (isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       numDynamicDims = 1;
     }
     if (!llvm::count(excludedOperandIndices, it.index())) {
@@ -69,9 +69,9 @@ void excludeClosureOperandsAndResults(
   for (auto it : llvm::enumerate(oldResultTypes)) {
     unsigned numDynamicDims = 0;
     auto type = it.value();
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(type)) {
+    if (auto shapedType = dyn_cast<ShapedType>(type)) {
       numDynamicDims = shapedType.getNumDynamicDims();
-    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(type)) {
+    } else if (isa<IREE::Util::SizeAwareTypeInterface>(type)) {
       numDynamicDims = 1;
     }
     if (!llvm::count(excludedResultIndices, it.index())) {
@@ -207,14 +207,14 @@ static bool isConstantInlinable(const ClosureOptimizationOptions &options,
 
   auto constantValueAttr = constantOp.getValue();
   auto constantType = constantOp.getType();
-  if (llvm::isa<SplatElementsAttr>(constantValueAttr)) {
+  if (isa<SplatElementsAttr>(constantValueAttr)) {
     // Splats are always small and can often have special handling when we
     // know they are a splat - which is why it's so important we inline them
     // here so we know when they are used that's the case.
     return true;
-  } else if (auto attr = llvm::dyn_cast<ElementsAttr>(constantValueAttr)) {
+  } else if (auto attr = dyn_cast<ElementsAttr>(constantValueAttr)) {
     // Smallish constants are worth moving inside.
-    auto shapedType = llvm::cast<ShapedType>(constantType);
+    auto shapedType = cast<ShapedType>(constantType);
     uint64_t estimatedByteLength =
         IREE::Util::getRoundedPhysicalStorageSize(shapedType);
     return attr.isSplat() || estimatedByteLength <= maxInlinedConstantBytes;

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -181,17 +181,17 @@ LogicalResult SerializableAttrInterface::serializeSplatValue(
     llvm::raw_ostream &os) {
   // Get the encoded byte contents of the splat element.
   SmallVector<char> elementBuffer;
-  if (auto attr = llvm::dyn_cast<SerializableAttrInterface>(elementAttr)) {
+  if (auto attr = dyn_cast<SerializableAttrInterface>(elementAttr)) {
     if (failed(attr.serializeToVector(loc, endian, elementBuffer))) {
       return failure();
     }
-  } else if (auto attr = llvm::dyn_cast<IntegerAttr>(elementAttr)) {
+  } else if (auto attr = dyn_cast<IntegerAttr>(elementAttr)) {
     if (failed(serializeAPIntRawData(loc, attr.getValue(),
                                      attr.getType().getIntOrFloatBitWidth(),
                                      endian, elementBuffer))) {
       return failure();
     }
-  } else if (auto attr = llvm::dyn_cast<FloatAttr>(elementAttr)) {
+  } else if (auto attr = dyn_cast<FloatAttr>(elementAttr)) {
     if (failed(serializeAPFloatRawData(loc, attr.getValue(),
                                        attr.getType().getIntOrFloatBitWidth(),
                                        endian, elementBuffer))) {
@@ -382,7 +382,7 @@ static LogicalResult serializeGenericElementData(Location loc,
                                                  DenseElementsAttr elementsAttr,
                                                  llvm::endianness endian,
                                                  llvm::raw_ostream &os) {
-  if (auto attr = llvm::dyn_cast<DenseIntElementsAttr>(elementsAttr)) {
+  if (auto attr = dyn_cast<DenseIntElementsAttr>(elementsAttr)) {
     // Don't hoist bitWidth given `getElementTypeBitWidth()` asserts if the
     // element type is not integer or floating-point.
     unsigned bitWidth = attr.getType().getElementTypeBitWidth();
@@ -415,7 +415,7 @@ static LogicalResult serializeGenericElementData(Location loc,
              << "unhandled integer element bit width " << bitWidth
              << " for type " << elementsAttr.getType();
     }
-  } else if (auto attr = llvm::dyn_cast<DenseFPElementsAttr>(elementsAttr)) {
+  } else if (auto attr = dyn_cast<DenseFPElementsAttr>(elementsAttr)) {
     // Don't hoist bitWidth given `getElementTypeBitWidth()` asserts if the
     // element type is not integer or floating-point.
     unsigned bitWidth = attr.getType().getElementTypeBitWidth();
@@ -450,10 +450,10 @@ static LogicalResult serializeGenericResourceElementData(
   // For complex resource types, we can just serialize based on the bit width of
   // the underlying integer or floating point type.
   Type elementType = resourceElementsAttr.getType().getElementType();
-  if (auto complexType = llvm::dyn_cast<ComplexType>(elementType)) {
+  if (auto complexType = dyn_cast<ComplexType>(elementType)) {
     elementType = complexType.getElementType();
   }
-  if (auto integerType = llvm::dyn_cast<IntegerType>(elementType)) {
+  if (auto integerType = dyn_cast<IntegerType>(elementType)) {
     // At the time of writing, DenseResourceElementsAttr byte aligned physical
     // element types only with the exception of i1, which is stored as a full
     // byte. This is in contrast to DenseElementsAttr which has an exception for
@@ -475,7 +475,7 @@ static LogicalResult serializeGenericResourceElementData(
              << "unhandled integer element bit width " << bitWidth
              << " for type " << resourceElementsAttr.getType();
     }
-  } else if (auto floatType = llvm::dyn_cast<FloatType>(elementType)) {
+  } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
     unsigned bitWidth = floatType.getIntOrFloatBitWidth();
     switch (bitWidth) {
     case 16:
@@ -498,7 +498,7 @@ static LogicalResult serializeGenericResourceElementData(
 //===----------------------------------------------------------------------===//
 
 int64_t BytePatternAttr::getStorageSize() const {
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());
@@ -602,7 +602,7 @@ CompositeAttr CompositeAttr::get(MLIRContext *context,
                                  ArrayRef<Attribute> valueAttrs) {
   int64_t calculatedLength = 0;
   for (auto valueAttr : valueAttrs) {
-    if (auto storageAttr = llvm::dyn_cast<SizedStorageAttr>(valueAttr)) {
+    if (auto storageAttr = dyn_cast<SizedStorageAttr>(valueAttr)) {
       calculatedLength += storageAttr.getStorageSize();
     } else {
       return {};
@@ -617,7 +617,7 @@ CompositeAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                       int64_t totalLength, ArrayAttr valueAttrs) {
   int64_t calculatedLength = 0;
   for (auto valueAttr : valueAttrs) {
-    if (auto storageAttr = llvm::dyn_cast<SizedStorageAttr>(valueAttr)) {
+    if (auto storageAttr = dyn_cast<SizedStorageAttr>(valueAttr)) {
       calculatedLength += storageAttr.getStorageSize();
     } else {
       return emitError() << "value is not serializable: " << valueAttr;
@@ -703,8 +703,7 @@ LogicalResult CompositeAttr::serializeToStream(Location loc,
                                                llvm::endianness endian,
                                                llvm::raw_ostream &os) const {
   for (auto valueAttr : getValues()) {
-    auto serializableAttr =
-        llvm::dyn_cast<SerializableAttrInterface>(valueAttr);
+    auto serializableAttr = dyn_cast<SerializableAttrInterface>(valueAttr);
     if (!serializableAttr) {
       return emitError(loc)
              << "unable to serialize a non-serializable attribute: "
@@ -722,7 +721,7 @@ LogicalResult CompositeAttr::serializeToStream(Location loc,
 //===----------------------------------------------------------------------===//
 
 int64_t UninitializedAttr::getStorageSize() const {
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());
@@ -737,7 +736,7 @@ struct SizedStorageDenseElementsAttrModel
     : public SizedStorageAttr::ExternalModel<SizedStorageDenseElementsAttrModel,
                                              DenseIntOrFPElementsAttr> {
   int64_t getStorageSize(Attribute baseAttr) const {
-    auto attr = llvm::cast<ElementsAttr>(baseAttr);
+    auto attr = cast<ElementsAttr>(baseAttr);
     return IREE::Util::getRoundedPhysicalStorageSize(
         attr.getNumElements(),
         cast<ShapedType>(attr.getType()).getElementType());
@@ -749,7 +748,7 @@ struct SizedStorageDenseResourceElementsAttrModel
           SizedStorageDenseResourceElementsAttrModel,
           DenseResourceElementsAttr> {
   int64_t getStorageSize(Attribute baseAttr) const {
-    auto attr = llvm::cast<DenseResourceElementsAttr>(baseAttr);
+    auto attr = cast<DenseResourceElementsAttr>(baseAttr);
     return IREE::Util::getRoundedPhysicalStorageSize(
         attr.getNumElements(), attr.getType().getElementType());
   }
@@ -760,7 +759,7 @@ struct SizedStorageStringAttrModel
     : public SizedStorageAttr::ExternalModel<SizedStorageStringAttrModel,
                                              StringAttr> {
   int64_t getStorageSize(Attribute baseAttr) const {
-    auto attr = llvm::cast<StringAttr>(baseAttr);
+    auto attr = cast<StringAttr>(baseAttr);
     return attr.getValue().size();
   }
 };
@@ -795,7 +794,7 @@ struct SerializableDenseElementsAttrModel
     // it can really help.
     os.reserveExtraSpace(cast<SizedStorageAttr>(baseAttr).getStorageSize());
 
-    auto elementsAttr = llvm::cast<DenseElementsAttr>(baseAttr);
+    auto elementsAttr = cast<DenseElementsAttr>(baseAttr);
     if (elementsAttr.isSplat()) {
       // Fast-path for splat (no need to convert the value a bunch).
       return IREE::Util::SerializableAttrInterface::serializeSplatValue(
@@ -838,7 +837,7 @@ struct SerializableDenseResourceElementsAttrModel
   LogicalResult serializeToStream(Attribute baseAttr, Location loc,
                                   llvm::endianness endian,
                                   llvm::raw_ostream &os) const {
-    auto attr = llvm::cast<DenseResourceElementsAttr>(baseAttr);
+    auto attr = cast<DenseResourceElementsAttr>(baseAttr);
     auto handle = attr.getRawHandle();
 
     // Special testing path for elided attributes. We want this to be an
@@ -888,7 +887,7 @@ struct SerializableStringAttrModel
     // NOTE: not all ostream implementations handle this but for buffering ones
     // it can really help.
     os.reserveExtraSpace(cast<SizedStorageAttr>(baseAttr).getStorageSize());
-    auto stringAttr = llvm::cast<StringAttr>(baseAttr);
+    auto stringAttr = cast<StringAttr>(baseAttr);
     os.write(stringAttr.data(), stringAttr.size());
     return success();
   }
@@ -905,8 +904,8 @@ struct SerializableStringAttrModel
 void HoistableAttrInterface::gatherHoistableAttrs(Operation *fromOp,
                                                   NamedAttrList &dialectAttrs) {
   for (auto attr : fromOp->getDialectAttrs()) {
-    if (auto hoistableAttr = llvm::dyn_cast<IREE::Util::HoistableAttrInterface>(
-            attr.getValue())) {
+    if (auto hoistableAttr =
+            dyn_cast<IREE::Util::HoistableAttrInterface>(attr.getValue())) {
       if (hoistableAttr.shouldAttachToHoistedOps() &&
           !dialectAttrs.get(attr.getName())) {
         dialectAttrs.push_back(attr);

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -36,7 +36,7 @@ struct UtilOpAsmInterface : public OpAsmDialectInterface {
   /// end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (auto compositeAttr = llvm::dyn_cast<CompositeAttr>(attr)) {
+    if (auto compositeAttr = dyn_cast<CompositeAttr>(attr)) {
       os << "composite_of_" << compositeAttr.getTotalLength() << "b";
       return AliasResult::OverridableAlias;
     }
@@ -173,7 +173,7 @@ struct FoldDimOp : public OpRewritePattern<DimOp> {
     }
 
     // If it's a static dim then just fold to that.
-    auto type = llvm::cast<ShapedType>(source.getType());
+    auto type = cast<ShapedType>(source.getType());
     int64_t staticDim = type.getDimSize(index.getZExtValue());
     if (ShapedType::isStatic(staticDim)) {
       rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(op, staticDim);

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -64,7 +64,7 @@ static LogicalResult canonicalizeAssumeIntOp(AssumeIntOp op,
 
     // Detect whether assumptions need to be normalized or can fold to a single
     // value.
-    ArrayAttr assumptionRow = llvm::cast<ArrayAttr>(assumptions[idx]);
+    ArrayAttr assumptionRow = cast<ArrayAttr>(assumptions[idx]);
     if (assumptionRow.size() > 1) {
       bool allAssumptionsSame = true;
       for (unsigned i = 1; i < assumptionRow.size(); ++i) {
@@ -86,7 +86,7 @@ static LogicalResult canonicalizeAssumeIntOp(AssumeIntOp op,
 
   // Need to rewrite the assumption.
   auto normalizeAssumptions = [](Attribute row, bool &madeChange) {
-    auto rowArray = llvm::cast<ArrayAttr>(row);
+    auto rowArray = cast<ArrayAttr>(row);
     if (rowArray.size() <= 1)
       return rowArray;
 
@@ -423,7 +423,7 @@ static OpFoldResult foldRangeOp(Type type, ValueRange operands,
   // If all operands are constant then fold into a constant.
   int64_t value = initialValue;
   for (auto operand : attrOperands) {
-    auto intValue = llvm::dyn_cast_if_present<IntegerAttr>(operand);
+    auto intValue = dyn_cast_if_present<IntegerAttr>(operand);
     if (!intValue)
       return {};
     value = expr(value, intValue.getValue().getSExtValue());
@@ -782,7 +782,7 @@ OpFoldResult AlignOp::fold(FoldAdaptor operands) {
 
 OpFoldResult SizeOfOp::fold(FoldAdaptor operands) {
   Type t = getSizedType();
-  if (llvm::isa<IntegerType>(t) || llvm::isa<FloatType>(t)) {
+  if (isa<IntegerType>(t) || isa<FloatType>(t)) {
     return IntegerAttr::get(IndexType::get(getContext()),
                             getRoundedElementByteWidth(t));
   }
@@ -1192,7 +1192,7 @@ struct SinkSubspanAcrossSelectOps
   using Base::Base;
   LogicalResult matchAndRewrite(mlir::arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::Util::BufferType>(op.getType()))
+    if (!isa<IREE::Util::BufferType>(op.getType()))
       return failure();
     auto trueSubspan = dyn_cast_or_null<IREE::Util::BufferSubspanOp>(
         op.getTrueValue().getDefiningOp());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -35,7 +35,7 @@ namespace mlir::iree_compiler::IREE::Util {
 //===----------------------------------------------------------------------===//
 
 bool BufferType::isAccessStorageCompatible(Type accessType) const {
-  return llvm::isa<IREE::Util::BufferType>(accessType);
+  return isa<IREE::Util::BufferType>(accessType);
 }
 
 Value BufferType::inferSizeFromValue(Location loc, Value value,
@@ -71,7 +71,7 @@ static LogicalResult parseListElementType(AsmParser &parser,
 }
 
 static void printListElementType(AsmPrinter &printer, Type elementType) {
-  if (llvm::isa<IREE::Util::VariantType>(elementType)) {
+  if (isa<IREE::Util::VariantType>(elementType)) {
     printer << "?";
   } else {
     printer << elementType;
@@ -83,15 +83,15 @@ bool ListType::isCompatible(Type type) { return true; }
 
 // static
 bool ListType::canImplicitlyCast(Type from, Type to) {
-  if (llvm::isa<VariantType>(from) || llvm::isa<VariantType>(to)) {
+  if (isa<VariantType>(from) || isa<VariantType>(to)) {
     return true;
-  } else if (llvm::isa<ObjectType>(from) &&
+  } else if (isa<ObjectType>(from) &&
              IREE::Util::ObjectType::isCompatible(to)) {
     return true;
   } else if (IREE::Util::ObjectType::isCompatible(from) &&
-             llvm::isa<ObjectType>(to)) {
+             isa<ObjectType>(to)) {
     return true;
-  } else if (llvm::isa<TensorType>(from) && llvm::isa<TensorType>(to)) {
+  } else if (isa<TensorType>(from) && isa<TensorType>(to)) {
     return true;
   }
   return from == to;
@@ -128,10 +128,10 @@ LogicalResult PtrType::verify(function_ref<InFlightDiagnostic()> emitError,
 
 // static
 bool ObjectType::isCompatible(Type type) {
-  if (llvm::isa<ObjectType>(type)) {
+  if (isa<ObjectType>(type)) {
     // Already an object.
     return true;
-  } else if (type.isIntOrIndexOrFloat() || llvm::isa<ComplexType>(type)) {
+  } else if (type.isIntOrIndexOrFloat() || isa<ComplexType>(type)) {
     // Ignore known primitive types.
     return false;
   }
@@ -168,7 +168,7 @@ bool isValueUsableForOp(Value value, Block *block,
   }
   if (definingBlock == block) {
     // Defined in the same block; ensure block order.
-    if (llvm::isa<BlockArgument>(value))
+    if (isa<BlockArgument>(value))
       return true;
     if (insertionPoint == block->end())
       return true;
@@ -176,8 +176,7 @@ bool isValueUsableForOp(Value value, Block *block,
       return true;
     }
   } else if (definingBlock->isEntryBlock() &&
-             llvm::isa<mlir::FunctionOpInterface>(
-                 definingBlock->getParentOp())) {
+             isa<mlir::FunctionOpInterface>(definingBlock->getParentOp())) {
     // Function entry block always dominates - fast path for constants.
     return true;
   } else {
@@ -274,12 +273,11 @@ bool isPublicOrExternal(CallableOpInterface callableOp) {
 static bool isGlobalTypeCompatible(Type globalType, Type accessType) {
   // If one is a shaped type, then they both must be and have compatible
   // shapes.
-  if (llvm::isa<ShapedType>(globalType) && llvm::isa<ShapedType>(accessType)) {
+  if (isa<ShapedType>(globalType) && isa<ShapedType>(accessType)) {
     return succeeded(mlir::verifyCompatibleShape(globalType, accessType));
   }
 
-  if (auto knownType =
-          llvm::dyn_cast<IREE::Util::GlobalTypeInterface>(globalType)) {
+  if (auto knownType = dyn_cast<IREE::Util::GlobalTypeInterface>(globalType)) {
     return knownType.isAccessStorageCompatible(accessType);
   }
 
@@ -289,8 +287,7 @@ static bool isGlobalTypeCompatible(Type globalType, Type accessType) {
 
 LogicalResult detail::verifyGlobalOp(IREE::Util::GlobalOpInterface globalOp) {
   auto initialValue = globalOp.getGlobalInitialValue();
-  if (auto typedInitialValue =
-          llvm::dyn_cast_if_present<TypedAttr>(initialValue)) {
+  if (auto typedInitialValue = dyn_cast_if_present<TypedAttr>(initialValue)) {
     // Ensure the value is something we can convert to a const.
     if (!isGlobalTypeCompatible(globalOp.getGlobalType(),
                                 typedInitialValue.getType())) {
@@ -403,7 +400,7 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
   auto valueAttrs = storageAttr.getValue();
   if (valueAttrs.empty())
     return std::nullopt;
-  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
+  if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     auto indexAndLength = tiedOp.getTiedResultsIndexAndLength();
     if (resultIndex < indexAndLength.first)
       return std::nullopt;
@@ -411,10 +408,10 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
     if (resultIndex >= indexAndLength.second)
       return std::nullopt;
   }
-  int64_t value = llvm::cast<IntegerAttr>(valueAttrs[resultIndex]).getInt();
+  int64_t value = cast<IntegerAttr>(valueAttrs[resultIndex]).getInt();
   if (value == IREE::Util::TiedOpInterface::kUntiedIndex)
     return std::nullopt;
-  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
+  if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
     return tiedOperandsOffset + static_cast<unsigned>(value);
   } else {
@@ -424,7 +421,7 @@ detail::getTiedResultOperandIndex(Operation *op, unsigned resultIndex) {
 
 void detail::setTiedResultOperandIndex(Operation *op, unsigned resultIndex,
                                        std::optional<unsigned> operandIndex) {
-  auto tiedOp = llvm::cast<IREE::Util::TiedOpInterface>(op);
+  auto tiedOp = cast<IREE::Util::TiedOpInterface>(op);
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
   resultIndex -= resultRange.first;
 
@@ -458,12 +455,12 @@ SmallVector<int64_t> detail::getTiedResultOperandIndices(Operation *op) {
   auto valueAttrs = storageAttr.getValue();
   if (valueAttrs.empty())
     return indices;
-  auto tiedOp = llvm::cast<IREE::Util::TiedOpInterface>(op);
+  auto tiedOp = cast<IREE::Util::TiedOpInterface>(op);
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
   unsigned tiedOperandsOffset = tiedOp.getTiedOperandsIndexAndLength().first;
   indices.resize(resultRange.second);
   for (unsigned i = 0; i < valueAttrs.size(); ++i) {
-    int64_t index = llvm::cast<IntegerAttr>(valueAttrs[i]).getInt();
+    int64_t index = cast<IntegerAttr>(valueAttrs[i]).getInt();
     indices[i] = index != IREE::Util::TiedOpInterface::kUntiedIndex
                      ? tiedOperandsOffset + index
                      : IREE::Util::TiedOpInterface::kUntiedIndex;
@@ -474,7 +471,7 @@ SmallVector<int64_t> detail::getTiedResultOperandIndices(Operation *op) {
 // static
 Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
   Value baseValue = derivedValue;
-  while (auto definingOp = llvm::dyn_cast_or_null<IREE::Util::TiedOpInterface>(
+  while (auto definingOp = dyn_cast_or_null<IREE::Util::TiedOpInterface>(
              baseValue.getDefiningOp())) {
     auto tiedValue = definingOp.getTiedResultOperand(baseValue);
     if (!tiedValue)
@@ -487,8 +484,7 @@ Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
 // static
 bool TiedOpInterface::hasAnyTiedUses(Value value) {
   return llvm::any_of(value.getUses(), [](auto &use) {
-    if (auto tiedOp =
-            llvm::dyn_cast<IREE::Util::TiedOpInterface>(use.getOwner())) {
+    if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(use.getOwner())) {
       return tiedOp.isOperandTied(use.getOperandNumber());
     }
     return false;
@@ -496,7 +492,7 @@ bool TiedOpInterface::hasAnyTiedUses(Value value) {
 }
 
 bool detail::isOperandTied(Operation *op, unsigned operandIndex) {
-  if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op)) {
+  if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op)) {
     auto tiedIndices = tiedOp.getTiedResultOperandIndices();
     return llvm::find(tiedIndices, operandIndex) != tiedIndices.end();
   }
@@ -505,7 +501,7 @@ bool detail::isOperandTied(Operation *op, unsigned operandIndex) {
 
 SmallVector<Value> detail::getOperandTiedResults(Operation *op,
                                                  unsigned operandIndex) {
-  auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(op);
+  auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op);
   if (!tiedOp)
     return {};
   auto resultRange = tiedOp.getTiedResultsIndexAndLength();
@@ -597,10 +593,10 @@ Value SizeAwareTypeInterface::findSizeValue(Value resourceValue, Block *block,
     if (!definingOp)
       continue;
     if (auto sizeAwareOp =
-            llvm::dyn_cast<IREE::Util::SizeAwareOpInterface>(definingOp)) {
+            dyn_cast<IREE::Util::SizeAwareOpInterface>(definingOp)) {
       return sizeAwareOp.getResultSizeFromValue(value);
     }
-    if (auto tiedOp = llvm::dyn_cast<IREE::Util::TiedOpInterface>(definingOp)) {
+    if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(definingOp)) {
       auto tiedOperand = tiedOp.getTiedResultOperand(value);
       if (tiedOperand)
         worklist.push_back(tiedOperand);
@@ -612,8 +608,8 @@ Value SizeAwareTypeInterface::findSizeValue(Value resourceValue, Block *block,
   while (!worklist.empty()) {
     auto value = worklist.pop_back_val();
     for (auto &use : value.getUses()) {
-      if (auto sizeAwareOp = llvm::dyn_cast<IREE::Util::SizeAwareOpInterface>(
-              use.getOwner())) {
+      if (auto sizeAwareOp =
+              dyn_cast<IREE::Util::SizeAwareOpInterface>(use.getOwner())) {
         auto sizeValue = sizeAwareOp.getOperandSize(use.getOperandNumber());
         if (sizeValue) {
           if (isValueUsableForOp(sizeValue, block, insertionPoint)) {
@@ -621,8 +617,7 @@ Value SizeAwareTypeInterface::findSizeValue(Value resourceValue, Block *block,
           }
         }
       }
-      if (auto tiedOp =
-              llvm::dyn_cast<IREE::Util::TiedOpInterface>(use.getOwner())) {
+      if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(use.getOwner())) {
         worklist.append(tiedOp.getOperandTiedResults(use.getOperandNumber()));
       }
     }
@@ -634,8 +629,8 @@ Value SizeAwareTypeInterface::findSizeValue(Value resourceValue, Block *block,
 // static
 Value SizeAwareTypeInterface::queryValueSize(Location loc, Value resourceValue,
                                              OpBuilder &builder) {
-  auto sizeAwareType = llvm::dyn_cast<IREE::Util::SizeAwareTypeInterface>(
-      resourceValue.getType());
+  auto sizeAwareType =
+      dyn_cast<IREE::Util::SizeAwareTypeInterface>(resourceValue.getType());
   if (!sizeAwareType) {
     return {}; // Not a sized type.
   }
@@ -649,12 +644,10 @@ Value SizeAwareTypeInterface::queryValueSize(Location loc, Value resourceValue,
   // TODO(benvanik): make this cleaner.
   auto *definingOp = resourceValue.getDefiningOp();
   if (auto sizeAwareOp =
-          llvm::dyn_cast_if_present<IREE::Util::SizeAwareOpInterface>(
-              definingOp)) {
+          dyn_cast_if_present<IREE::Util::SizeAwareOpInterface>(definingOp)) {
     return sizeAwareOp.getResultSizeFromValue(resourceValue);
-  } else if (auto inferSizeType =
-                 llvm::dyn_cast<IREE::Util::InferTypeSizeInterface>(
-                     resourceValue.getType())) {
+  } else if (auto inferSizeType = dyn_cast<IREE::Util::InferTypeSizeInterface>(
+                 resourceValue.getType())) {
     return inferSizeType.inferSizeFromValue(loc, resourceValue, builder);
   }
   return {};
@@ -672,13 +665,12 @@ std::optional<ValueRange> findDynamicDims(Value workValue) {
     if (!workOp)
       break;
     if (auto shapeAwareOp =
-            llvm::dyn_cast<IREE::Util::ShapeAwareOpInterface>(workOp)) {
+            dyn_cast<IREE::Util::ShapeAwareOpInterface>(workOp)) {
       return shapeAwareOp.getResultDynamicDimsFromValue(workValue);
     } else if (auto sizeAwareOp =
-                   llvm::dyn_cast<IREE::Util::SizeAwareOpInterface>(workOp)) {
+                   dyn_cast<IREE::Util::SizeAwareOpInterface>(workOp)) {
       return sizeAwareOp.getResultSizeFromValue(workValue);
-    } else if (auto tiedOp =
-                   llvm::dyn_cast<IREE::Util::TiedOpInterface>(workOp)) {
+    } else if (auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(workOp)) {
       workValue = tiedOp.getTiedResultOperand(workValue);
     } else {
       break;
@@ -723,8 +715,7 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
   // bit, though, as {|block|, |insertionPoint|} may be a user of |shapedValue|
   // and be able to provide the shape itself.
   for (auto &use : shapedValue.getUses()) {
-    if (auto shapeAwareOp =
-            llvm::dyn_cast<ShapeAwareOpInterface>(use.getOwner())) {
+    if (auto shapeAwareOp = dyn_cast<ShapeAwareOpInterface>(use.getOwner())) {
       auto dynamicDims =
           shapeAwareOp.getOperandDynamicDims(use.getOperandNumber());
       if (llvm::all_of(dynamicDims, [&](Value dim) {
@@ -733,7 +724,7 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
         return dynamicDims;
       }
     } else if (auto sizeAwareOp =
-                   llvm::dyn_cast<SizeAwareOpInterface>(use.getOwner())) {
+                   dyn_cast<SizeAwareOpInterface>(use.getOwner())) {
       auto size = sizeAwareOp.getOperandSize(use.getOperandNumber());
       if (isValueUsableForOp(size, block, insertionPoint)) {
         return size;
@@ -750,9 +741,9 @@ ValueRange findDynamicDimsInList(unsigned idx, ValueRange values,
   // may be 0 if all dimensions are static.
   auto value = values[idx];
   unsigned dynamicDimCount = 0;
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(value.getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(value.getType())) {
     dynamicDimCount = shapedType.getNumDynamicDims();
-  } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(value.getType())) {
+  } else if (isa<IREE::Util::SizeAwareTypeInterface>(value.getType())) {
     dynamicDimCount = 1;
   }
   if (!dynamicDimCount)
@@ -762,9 +753,9 @@ ValueRange findDynamicDimsInList(unsigned idx, ValueRange values,
   unsigned offset = 0;
   for (unsigned i = 0; i < idx; ++i) {
     auto prefixValueType = values[i].getType();
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(prefixValueType)) {
+    if (auto shapedType = dyn_cast<ShapedType>(prefixValueType)) {
       offset += shapedType.getNumDynamicDims();
-    } else if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(prefixValueType)) {
+    } else if (isa<IREE::Util::SizeAwareTypeInterface>(prefixValueType)) {
       offset += 1; // fixed 1 dynamic dim
     }
   }
@@ -782,7 +773,7 @@ Value findValueSizeInList(unsigned idx, ValueRange values,
 
 SmallVector<Value> buildDynamicDimsForValue(Location loc, Value value,
                                             OpBuilder &builder) {
-  auto valueType = llvm::dyn_cast<ShapedType>(value.getType());
+  auto valueType = dyn_cast<ShapedType>(value.getType());
   if (!valueType) {
     mlir::emitError(loc) << "cannot construct shape for non shaped value: "
                          << value.getType();
@@ -805,9 +796,8 @@ SmallVector<Value> buildDynamicDimsForValue(Location loc, Value value,
 
   // Slower path that materializes the entire shape for a result. Some
   // implementations may only support this (vs the fast find above).
-  if (auto shapeAwareOp =
-          llvm::dyn_cast_or_null<IREE::Util::ShapeAwareOpInterface>(
-              value.getDefiningOp())) {
+  if (auto shapeAwareOp = dyn_cast_or_null<IREE::Util::ShapeAwareOpInterface>(
+          value.getDefiningOp())) {
     return shapeAwareOp.buildResultValueShape(value, builder);
   }
 
@@ -857,7 +847,7 @@ static SmallVector<Value> buildShape(Location loc, ShapedType type,
 SmallVector<Value> buildOperandShape(IREE::Util::ShapeAwareOpInterface op,
                                      unsigned operandIdx, OpBuilder &builder) {
   auto operand = op->getOperand(operandIdx);
-  auto type = llvm::cast<ShapedType>(operand.getType());
+  auto type = cast<ShapedType>(operand.getType());
   auto dynamicDims = op.getOperandDynamicDims(operandIdx);
   return buildShape(op.getLoc(), type, dynamicDims, builder);
 }
@@ -865,7 +855,7 @@ SmallVector<Value> buildOperandShape(IREE::Util::ShapeAwareOpInterface op,
 SmallVector<Value> buildResultShape(IREE::Util::ShapeAwareOpInterface op,
                                     unsigned resultIdx, OpBuilder &builder) {
   auto result = op->getResult(resultIdx);
-  auto type = llvm::cast<ShapedType>(result.getType());
+  auto type = cast<ShapedType>(result.getType());
   auto dynamicDims = op.getResultDynamicDims(resultIdx);
   return buildShape(op.getLoc(), type, dynamicDims, builder);
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -190,7 +190,7 @@ static Value tryMaterializeConstant(Location loc, Type type, Attribute attr,
     return arith::ConstantOp::create(builder, loc, type, cast<TypedAttr>(attr));
   } else if (mlir::func::ConstantOp::isBuildableWith(attr, type)) {
     return mlir::func::ConstantOp::create(builder, loc, type,
-                                          llvm::cast<FlatSymbolRefAttr>(attr));
+                                          cast<FlatSymbolRefAttr>(attr));
   }
   // Fallback that asks a dialect to materialize things. This may fail!
   auto *op = attr.getDialect().materializeConstant(builder, attr, type, loc);
@@ -226,8 +226,7 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
       return GlobalAction::PRESERVE;
     }
 
-    if (llvm::isa<IREE::Util::ReferenceTypeInterface>(
-            global.op.getGlobalType())) {
+    if (isa<IREE::Util::ReferenceTypeInterface>(global.op.getGlobalType())) {
       // We only inline value types; reference types have meaning as globals.
       return GlobalAction::PRESERVE;
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -242,7 +242,7 @@ static FuncAnalysis analyzeFuncOp(IREE::Util::FuncOp funcOp,
 
       // If the result value is an argument track that here.
       // We'll only use this value if all return sites are uniform.
-      if (auto arg = llvm::dyn_cast<BlockArgument>(value)) {
+      if (auto arg = dyn_cast<BlockArgument>(value)) {
         if (arg.getParentBlock()->isEntryBlock()) {
           analysis.passthroughResultArgs[i] =
               static_cast<int>(arg.getArgNumber());

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
@@ -76,7 +76,7 @@ public:
       bool updated = false;
       SmallVector<NamedAttribute> attrs(op->getAttrs());
       for (auto &attr : attrs) {
-        if (auto elements = llvm::dyn_cast<ElementsAttr>(attr.getValue())) {
+        if (auto elements = dyn_cast<ElementsAttr>(attr.getValue())) {
           // Already seen?
           auto it = replacements.find(elements);
           if (it != replacements.end()) {
@@ -109,7 +109,7 @@ public:
   }
 
   static bool shouldConvertElements(ElementsAttr attr) {
-    if (llvm::isa<DenseElementsAttr>(attr)) {
+    if (isa<DenseElementsAttr>(attr)) {
       // DenseElementsAttr encodes arbitrary dimension
       // splats whereas DenseResourceElementsAttr does not.
       return !attr.isSplat();
@@ -119,12 +119,12 @@ public:
   }
 
   static ElementsAttr convertElementsAttr(ElementsAttr elementsAttr) {
-    auto st = llvm::cast<ShapedType>(elementsAttr.getType());
+    auto st = cast<ShapedType>(elementsAttr.getType());
     auto elementType = st.getElementType();
     auto numElements = elementsAttr.getNumElements();
     auto bitWidth = elementType.getIntOrFloatBitWidth();
     AsmResourceBlob blob;
-    if (auto attr = llvm::dyn_cast<DenseIntElementsAttr>(elementsAttr)) {
+    if (auto attr = dyn_cast<DenseIntElementsAttr>(elementsAttr)) {
       switch (bitWidth) {
       case 1:
         blob = HeapAsmResourceBlob::allocate(numElements, /*align=*/64,
@@ -159,7 +159,7 @@ public:
       default:
         return {};
       }
-    } else if (auto attr = llvm::dyn_cast<DenseFPElementsAttr>(elementsAttr)) {
+    } else if (auto attr = dyn_cast<DenseFPElementsAttr>(elementsAttr)) {
       AsmResourceBlob blob;
       switch (bitWidth) {
       case 8:

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -328,7 +328,7 @@ struct ElideBranchOperandsPattern
 
           // Operand for this source differs from previous. This is either
           // because it's non-uniform _or_ that it's a cycle.
-          if (auto sourceArg = llvm::dyn_cast<BlockArgument>(operand)) {
+          if (auto sourceArg = dyn_cast<BlockArgument>(operand)) {
             // Operand comes from a block argument. If that is the block
             // argument we are analyzing it means there's a cycle (%0 -> %0) and
             // we can ignore it for the purposes of this analysis.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -37,7 +37,7 @@ namespace {
 // This pass is paired with the subrange type. Any type implementing the
 // interface can be used.
 static bool isResourceType(Type type) {
-  return llvm::isa<IREE::Util::SubrangeTypeInterface>(type);
+  return isa<IREE::Util::SubrangeTypeInterface>(type);
 }
 
 //===----------------------------------------------------------------------===//
@@ -142,7 +142,7 @@ struct Subrange {
   Value subrangeOffset;
   Value subrangeLength;
   IREE::Util::SubrangeTypeInterface getResourceType() {
-    return llvm::cast<IREE::Util::SubrangeTypeInterface>(resource.getType());
+    return cast<IREE::Util::SubrangeTypeInterface>(resource.getType());
   }
 };
 using SubrangeMap = llvm::DenseMap<Value, Subrange>;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyGlobalAccesses.cpp
@@ -52,7 +52,7 @@ static void hoistImmutableLoads(Region &region,
     for (auto &op : ops) {
       if (!immutableGlobals.contains(op.getGlobalName()))
         continue;
-      auto globalRef = llvm::cast<Attribute>(op.getGlobalAttr());
+      auto globalRef = cast<Attribute>(op.getGlobalAttr());
       auto it = loadOps.find(globalRef);
       if (it == loadOps.end()) {
         // Move to entry block; even if it's already there (so loads are


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.