### PR TITLE
Drop unnecessary namespaces from cast functions in dialect stream. NFC. 9/10

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -238,7 +238,7 @@ private:
 
   // Starts analysis of the |value| with known bits based on its resource type.
   void initializeValue(Value value, DFX::Solver &solver) override {
-    auto resourceType = llvm::cast<IREE::Stream::ResourceType>(value.getType());
+    auto resourceType = cast<IREE::Stream::ResourceType>(value.getType());
     initializeFromType(resourceType);
   }
 
@@ -247,7 +247,7 @@ private:
   // itself is under analysis.
   void updateFromDefiningOp(Value value, OpResult result, DFX::Solver &solver) {
     // Some tied uses route through ops that change types - ignore those.
-    if (!llvm::isa<IREE::Stream::ResourceType>(result.getType()))
+    if (!isa<IREE::Stream::ResourceType>(result.getType()))
       return;
 
     TypeSwitch<Operation *, void>(result.getOwner())
@@ -300,7 +300,7 @@ private:
         })
         .Case([&](IREE::Stream::TensorImportOp op) {
           auto targetType =
-              llvm::cast<IREE::Stream::ResourceType>(op.getResult().getType());
+              cast<IREE::Stream::ResourceType>(op.getResult().getType());
           switch (targetType.getLifetime()) {
           default:
           case IREE::Stream::Lifetime::External:
@@ -513,7 +513,7 @@ private:
   // This walks through tied uses as well.
   void updateFromUse(Value value, OpOperand &operand, DFX::Solver &solver) {
     // Some tied uses route through ops that change types - ignore those.
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.get().getType()))
+    if (!isa<IREE::Stream::ResourceType>(operand.get().getType()))
       return;
 
     auto *userOp = operand.getOwner();
@@ -654,7 +654,7 @@ private:
         })
         .Case([&](IREE::Stream::TensorExportOp op) {
           auto sourceType =
-              llvm::cast<IREE::Stream::ResourceType>(op.getSource().getType());
+              cast<IREE::Stream::ResourceType>(op.getSource().getType());
           switch (sourceType.getLifetime()) {
           default:
           case IREE::Stream::Lifetime::External:

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -816,7 +816,7 @@ struct ConvertDispatchOp
     for (auto [oldOperand, convertedOperands] :
          llvm::zip_equal(op.getArguments(), adaptor.getArguments())) {
       Value newOperand;
-      if (llvm::isa<ShapedType>(oldOperand.getType())) {
+      if (isa<ShapedType>(oldOperand.getType())) {
         auto newOperandCast =
             transferTensorOperands(op.getLoc(), oldOperand, convertedOperands,
                                    executionAffinityAttr, rewriter);
@@ -840,7 +840,7 @@ struct ConvertDispatchOp
     auto tiedOperandBase = op.getTiedOperandsIndexAndLength().first;
     for (auto result : llvm::enumerate(op.getResults())) {
       auto oldResultType = result.value().getType();
-      if (!llvm::isa<ShapedType>(oldResultType)) {
+      if (!isa<ShapedType>(oldResultType)) {
         resultTypes.push_back(getTypeConverter()->convertType(oldResultType));
         resultEncodings.push_back(rewriter.getType<IREE::Util::UnusedType>());
         continue;
@@ -890,7 +890,7 @@ struct ConvertFuncOp : public OpConversionPattern<IREE::Flow::FuncOp> {
   matchAndRewrite(IREE::Flow::FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto convertType = [&](Type type) -> Type {
-      if (llvm::isa<TensorType>(type)) {
+      if (isa<TensorType>(type)) {
         // Tensors become resources without sizes. The default type converter
         // adds the size so we bypass that here. We may want to allow the user
         // to override the lifetime with attributes, too.
@@ -938,7 +938,7 @@ struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
     for (auto [oldOperand, convertedOperand] :
          llvm::zip_equal(op.getArguments(), adaptor.getArguments())) {
       Value newOperand;
-      if (llvm::isa<ShapedType>(oldOperand.getType())) {
+      if (isa<ShapedType>(oldOperand.getType())) {
         auto newOperandCast =
             transferTensorOperands(op.getLoc(), oldOperand, convertedOperand,
                                    executionAffinityAttr, rewriter);
@@ -962,7 +962,7 @@ struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
     auto tiedOperandBase = op.getTiedOperandsIndexAndLength().first;
     for (auto result : llvm::enumerate(op.getResults())) {
       auto oldResultType = result.value().getType();
-      if (!llvm::isa<ShapedType>(oldResultType)) {
+      if (!isa<ShapedType>(oldResultType)) {
         resultTypes.push_back(getTypeConverter()->convertType(oldResultType));
         resultSizes.push_back(nullptr);
         continue;
@@ -1139,8 +1139,7 @@ struct ConvertExecutableOp
         for (auto arg : funcOp.front().getArguments()) {
           auto oldType = arg.getType();
           if (auto tensorType =
-                  llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
-                      oldType)) {
+                  dyn_cast<IREE::TensorExt::DispatchTensorType>(oldType)) {
             // Now a binding - insert the stream.binding.subspan op to slice it.
             auto newType = rewriter.getType<IREE::Stream::BindingType>();
             newTypes.push_back(newType);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -38,19 +38,19 @@ struct ConvertTensorImportOp
       ConversionPatternRewriter &rewriter) const override {
     auto sourceType = op.getSource().getType();
     auto targetType = op.getTargetEncoding();
-    if (!llvm::isa<IREE::HAL::BufferType>(sourceType) &&
-        !llvm::isa<IREE::HAL::BufferViewType>(sourceType)) {
+    if (!isa<IREE::HAL::BufferType>(sourceType) &&
+        !isa<IREE::HAL::BufferViewType>(sourceType)) {
       return rewriter.notifyMatchFailure(op, "unsupported HAL cast conversion");
     }
 
     // Assert the shape of the buffer view matches the expected encoding
     // shape. We can only do this when we are importing a buffer view as that's
     // what carries the information we need to validate.
-    if (llvm::isa<IREE::HAL::BufferViewType>(sourceType)) {
+    if (isa<IREE::HAL::BufferViewType>(sourceType)) {
       // NOTE: we do this before the other checks as it's the most likely
       // mistake and it's better to know of a shape mismatch than just buffer
       // byte length difference.
-      if (auto tensorType = llvm::dyn_cast<RankedTensorType>(targetType)) {
+      if (auto tensorType = dyn_cast<RankedTensorType>(targetType)) {
         if (failed(buildEncodingAssertions(
                 op.getLoc(), adaptor.getSource().front(), op.getNameAttr(),
                 tensorType, op.getTargetDims(), rewriter))) {
@@ -149,8 +149,8 @@ struct ConvertTensorExportOp
       ConversionPatternRewriter &rewriter) const override {
     auto sourceType = op.getSourceEncoding();
     auto targetType = op.getTarget().getType();
-    if (!llvm::isa<IREE::HAL::BufferType>(targetType) &&
-        !llvm::isa<IREE::HAL::BufferViewType>(targetType)) {
+    if (!isa<IREE::HAL::BufferType>(targetType) &&
+        !isa<IREE::HAL::BufferViewType>(targetType)) {
       return rewriter.notifyMatchFailure(op, "unsupported HAL cast conversion");
     }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -33,7 +33,7 @@ tryLookupGlobalAffinity(Operation *op,
 IREE::Stream::AffinityAttr
 tryLookupExecutionAffinity(Operation *op,
                            IREE::Stream::AffinityAnalysis *affinityAnalysis) {
-  assert(llvm::isa<IREE::Stream::AffinityOpInterface>(op) &&
+  assert(isa<IREE::Stream::AffinityOpInterface>(op) &&
          "must be an affinity op");
   return affinityAnalysis->lookupExecutionAffinity(op);
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
@@ -46,7 +46,7 @@ struct ConvertTensorConstantOp
       ConversionPatternRewriter &rewriter) const override {
     // Only handle tensor types - other arith.constant types (like i32) are
     // ignored.
-    if (!llvm::isa<TensorType>(constantOp.getType())) {
+    if (!isa<TensorType>(constantOp.getType())) {
       return failure();
     }
 
@@ -130,7 +130,7 @@ struct SelectOpConversion
   matchAndRewrite(mlir::arith::SelectOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Only handle selects where the operands are tensors (resources).
-    if (!llvm::isa<TensorType>(op.getTrueValue().getType()))
+    if (!isa<TensorType>(op.getTrueValue().getType()))
       return failure();
     auto trueOperand = resolveTensorOperands(op.getLoc(), op.getTrueValue(),
                                              adaptor.getTrueValue(), rewriter);
@@ -193,7 +193,7 @@ struct ScfIfOpConversion
     SmallVector<Value> results;
     SmallVector<Value> resultSizes;
     for (auto result : resultMap) {
-      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+      if (isa<IREE::Stream::ResourceType>(result.newType)) {
         auto resource = ifOp.getResult(result.newIndex + 0);
         auto resourceSize = ifOp.getResult(result.newIndex + 1);
         results.push_back(resource);
@@ -270,7 +270,7 @@ struct ScfForOpConversion
     SmallVector<Value> results;
     SmallVector<Value> resultSizes;
     for (auto result : resultMap) {
-      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+      if (isa<IREE::Stream::ResourceType>(result.newType)) {
         auto resource = forOp.getResult(result.newIndex + 0);
         auto resourceSize = forOp.getResult(result.newIndex + 1);
         results.push_back(resource);
@@ -353,7 +353,7 @@ struct ScfWhileOpConversion
     SmallVector<Value> results;
     SmallVector<Value> resultSizes;
     for (auto result : resultMap) {
-      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+      if (isa<IREE::Stream::ResourceType>(result.newType)) {
         auto resource = whileOp.getResult(result.newIndex + 0);
         auto resourceSize = whileOp.getResult(result.newIndex + 1);
         results.push_back(resource);
@@ -425,9 +425,7 @@ void populateStandardToStreamConversionPatterns(
                                 tensor::RankOp>();
 
   conversionTarget.addDynamicallyLegalOp<arith::ConstantOp>(
-      [](arith::ConstantOp op) {
-        return !llvm::isa<TensorType>(op.getType());
-      });
+      [](arith::ConstantOp op) { return !isa<TensorType>(op.getType()); });
   patterns.insert<ConvertTensorConstantOp>(typeConverter, context,
                                            affinityAnalysis);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -113,7 +113,7 @@ struct CallOpConversion
     SmallVector<Value> results;
     SmallVector<Value> resourceSizes;
     for (auto result : resultMap) {
-      if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
+      if (isa<IREE::Stream::ResourceType>(result.newType)) {
         auto resource = callOp.getResult(result.newIndex + 0);
         auto resourceSize = callOp.getResult(result.newIndex + 1);
         results.push_back(resource);
@@ -158,9 +158,9 @@ struct GlobalExpansionState {
 };
 
 static bool isExpandedType(Type type) {
-  if (llvm::isa<TensorType>(type))
+  if (isa<TensorType>(type))
     return true;
-  if (auto ptrType = llvm::dyn_cast<IREE::Util::PtrType>(type)) {
+  if (auto ptrType = dyn_cast<IREE::Util::PtrType>(type)) {
     return isExpandedType(ptrType);
   }
   return false;
@@ -216,8 +216,7 @@ struct GlobalOpExpansion
     // current conversion to pick up the expanded initialization ops.
     auto initialValueAttr = globalOp.getInitialValueAttr();
     bool tensorInitializerRequired =
-        initialValueAttr ? llvm::isa<TensorType>(initialValueAttr.getType())
-                         : false;
+        initialValueAttr ? isa<TensorType>(initialValueAttr.getType()) : false;
 
     // New global holding the initial value only if it is not a tensor type.
     auto resourceOp = rewriter.replaceOpWithNewOp<IREE::Util::GlobalOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -69,7 +69,7 @@ struct StripResourceConversionCastPattern
   LogicalResult matchAndRewrite(UnrealizedConversionCastOp castOp,
                                 PatternRewriter &rewriter) const override {
     auto result = castOp.getResult(0);
-    if (!llvm::isa<IREE::Stream::ResourceType>(result.getType()))
+    if (!isa<IREE::Stream::ResourceType>(result.getType()))
       return failure();
     assert(castOp.getNumOperands() == 2 &&
            "expect resource, index -> resource");
@@ -118,11 +118,11 @@ Operation *StreamDialect::materializeConstant(OpBuilder &builder,
                                               Location loc) {
   if (mlir::func::ConstantOp::isBuildableWith(value, type)) {
     return mlir::func::ConstantOp::create(builder, loc, type,
-                                          llvm::cast<FlatSymbolRefAttr>(value));
+                                          cast<FlatSymbolRefAttr>(value));
   } else if (arith::ConstantOp::isBuildableWith(value, type)) {
     return arith::ConstantOp::create(builder, loc, type,
                                      cast<TypedAttr>(value));
-  } else if (llvm::isa<IREE::Stream::TimepointAttr>(value)) {
+  } else if (isa<IREE::Stream::TimepointAttr>(value)) {
     return IREE::Stream::TimepointImmediateOp::create(builder, loc);
   }
   return nullptr;

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -395,7 +395,7 @@ struct TieRegionResults : public OpRewritePattern<Op> {
         }
         auto baseValue =
             IREE::Util::TiedOpInterface::findTiedBaseValue(result.value());
-        if (auto blockArg = llvm::dyn_cast<BlockArgument>(baseValue)) {
+        if (auto blockArg = dyn_cast<BlockArgument>(baseValue)) {
           unsigned operandIndex = blockArg.getArgNumber();
           rewriter.modifyOpInPlace(op, [&]() {
             op.setTiedResultOperandIndex(result.index(), operandIndex);
@@ -685,7 +685,7 @@ void ResourceDeallocaOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 OpFoldResult ResourceSizeOp::fold(FoldAdaptor operands) {
   auto sizeAwareType =
-      llvm::cast<IREE::Util::SizeAwareTypeInterface>(getOperand().getType());
+      cast<IREE::Util::SizeAwareTypeInterface>(getOperand().getType());
   Operation *op = this->getOperation();
   return sizeAwareType.findSizeValue(getOperand(), op->getBlock(),
                                      Block::iterator(op));
@@ -1018,7 +1018,7 @@ struct SinkSubviewAcrossSelectOps
   using Base::Base;
   LogicalResult matchAndRewrite(mlir::arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::Stream::ResourceType>(op.getType()))
+    if (!isa<IREE::Stream::ResourceType>(op.getType()))
       return failure();
     auto trueSubview = dyn_cast_or_null<IREE::Stream::ResourceSubviewOp>(
         op.getTrueValue().getDefiningOp());
@@ -1130,8 +1130,7 @@ struct TensorConstantToEmpty : public OpRewritePattern<TensorConstantOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(TensorConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
-    auto shapedType =
-        llvm::dyn_cast<ShapedType>(constantOp.getResultEncoding());
+    auto shapedType = dyn_cast<ShapedType>(constantOp.getResultEncoding());
     if (!shapedType)
       return failure();
 
@@ -1173,7 +1172,7 @@ struct TensorConstantToSplat : public OpRewritePattern<TensorConstantOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(TensorConstantOp constantOp,
                                 PatternRewriter &rewriter) const override {
-    auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(constantOp.getValue());
+    auto splatAttr = dyn_cast<SplatElementsAttr>(constantOp.getValue());
     if (!splatAttr || !splatAttr.isSplat()) {
       return rewriter.notifyMatchFailure(
           constantOp,
@@ -1493,7 +1492,7 @@ struct ConvertSplatConstantsIntoSplats
       return failure();
     }
     auto splatElementAttr =
-        llvm::dyn_cast<SplatElementsAttr>(value).getSplatValue<TypedAttr>();
+        dyn_cast<SplatElementsAttr>(value).getSplatValue<TypedAttr>();
     auto splatValue =
         arith::ConstantOp::create(rewriter, constantOp.getLoc(),
                                   splatElementAttr.getType(), splatElementAttr);
@@ -2268,7 +2267,7 @@ struct ElideNoOpAsyncExecuteOp : public OpRewritePattern<AsyncExecuteOp> {
     }
     SmallVector<Value> newResults;
     for (auto operand : yieldOp->getResourceOperands()) {
-      auto arg = llvm::cast<BlockArgument>(operand);
+      auto arg = cast<BlockArgument>(operand);
       auto capture = op.getResourceOperands()[arg.getArgNumber()];
       assert(arg.getType() == capture.getType() &&
              "expect 1:1 types on captures to results");
@@ -2645,7 +2644,7 @@ struct FoldSubviewsIntoCmdCallOp : public OpRewritePattern<CmdCallOp> {
     bool anySubviewOps = false;
     for (auto [operandIndex, operand] :
          llvm::enumerate(op.getResourceOperands())) {
-      if (llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
+      if (isa<IREE::Stream::ResourceType>(operand.getType())) {
         auto subviewOp = ResourceSubviewOp::findSubviewOp(operand);
         if (subviewOp)
           anySubviewOps = true;
@@ -2907,10 +2906,10 @@ struct FoldParameterReadTargetSubview
     auto ip = rewriter.saveInsertionPoint();
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
-    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
+    auto newSourceOffset = cast<Value>(op.getSourceOffset());
     auto newTargetResource = op.getTarget();
     auto newTargetSize = op.getTargetSize();
-    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
+    auto newTargetOffset = cast<Value>(op.getTargetOffset());
     if (auto subviewOp = dyn_cast_or_null<IREE::Stream::ResourceSubviewOp>(
             newTargetResource.getDefiningOp())) {
       newSourceOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
@@ -2962,8 +2961,8 @@ struct FoldParameterWriteSourceSubview
     bool needsUpdate = false;
     auto newSourceResource = op.getSource();
     auto newSourceSize = op.getSourceSize();
-    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
-    auto newTargetOffset = llvm::cast<Value>(op.getTargetOffset());
+    auto newSourceOffset = cast<Value>(op.getSourceOffset());
+    auto newTargetOffset = cast<Value>(op.getTargetOffset());
     if (auto subviewOp = dyn_cast_or_null<IREE::Stream::ResourceSubviewOp>(
             newSourceResource.getDefiningOp())) {
       newSourceResource = subviewOp.getSource();

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -102,7 +102,7 @@ static LogicalResult verifyOpDynamicDims(Operation *op, TypeRange types,
                                          ValueRange dynamicDims) {
   unsigned requiredCount = 0;
   for (auto type : types) {
-    if (auto shapedType = llvm::dyn_cast_if_present<ShapedType>(type)) {
+    if (auto shapedType = dyn_cast_if_present<ShapedType>(type)) {
       requiredCount += shapedType.getNumDynamicDims();
     }
   }
@@ -123,7 +123,7 @@ static LogicalResult verifyOpDynamicDimsRange(Operation *op,
   unsigned requiredCount = 0;
   for (auto attr : typesAttr) {
     if (auto typeAttr = dyn_cast_if_present<TypeAttr>(attr)) {
-      if (auto shapedType = llvm::dyn_cast<ShapedType>(typeAttr.getValue())) {
+      if (auto shapedType = dyn_cast<ShapedType>(typeAttr.getValue())) {
         requiredCount += shapedType.getNumDynamicDims();
       }
     }
@@ -143,7 +143,7 @@ static LogicalResult verifyOpValueSizes(Operation *op, ValueRange values,
                                         ValueRange sizes) {
   unsigned requiredCount = 0;
   for (auto value : values) {
-    if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(value.getType())) {
+    if (isa<IREE::Util::SizeAwareTypeInterface>(value.getType())) {
       ++requiredCount;
     }
   }
@@ -169,7 +169,7 @@ static LogicalResult verifyAllResourcesCaptured(Region &region) {
     for (auto operand : op.getOperands()) {
       if (!operand)
         continue;
-      if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType()))
+      if (!isa<IREE::Stream::ResourceType>(operand.getType()))
         continue;
       if (!availableResources.contains(operand)) {
         return op.emitOpError() << "used resource not listed in explicit "
@@ -1131,7 +1131,7 @@ static void printResourceRegion(OpAsmPrinter &p, Operation *op,
         p << arg;
         p << ": ";
         p << arg.getType();
-        if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(arg.getType())) {
+        if (isa<IREE::Util::SizeAwareTypeInterface>(arg.getType())) {
           p << "{" << operandSizes.front() << "}";
           operandSizes = operandSizes.drop_front(1);
         }
@@ -1214,7 +1214,7 @@ static void printExplicitResourceRegion(OpAsmPrinter &p, Operation *op,
         p << arg;
         p << ": ";
         p << arg.getType();
-        if (llvm::isa<IREE::Util::SizeAwareTypeInterface>(arg.getType())) {
+        if (isa<IREE::Util::SizeAwareTypeInterface>(arg.getType())) {
           p << "{" << operandSizes.front() << "}";
           operandSizes = operandSizes.drop_front(1);
         }
@@ -1612,8 +1612,8 @@ SmallVector<ResourcePackOp::Slice> ResourcePackOp::getSlices() {
   auto offsets = getPackedOffsets();
   SmallVector<ResourcePackOp::Slice> slices(offsets.size());
   for (size_t i = 0; i < offsets.size(); ++i) {
-    int64_t start = llvm::cast<IntegerAttr>(intervalPairs[i * 2 + 0]).getInt();
-    int64_t end = llvm::cast<IntegerAttr>(intervalPairs[i * 2 + 1]).getInt();
+    int64_t start = cast<IntegerAttr>(intervalPairs[i * 2 + 0]).getInt();
+    int64_t end = cast<IntegerAttr>(intervalPairs[i * 2 + 1]).getInt();
     slices[i] = {start, end, sizes[i], offsets[i]};
   }
   return slices;
@@ -1874,8 +1874,8 @@ LogicalResult TensorCloneOp::verify() {
   TensorCloneOp op = *this;
   // Clones can't change encodings but they can change shape and element type
   // information.
-  auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
-  auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
+  auto sourceEncoding = cast<RankedTensorType>(op.getSourceEncoding());
+  auto resultEncoding = cast<RankedTensorType>(op.getResultEncoding());
   if (!IREE::Encoding::SerializableAttr::areCompatible(
           sourceEncoding.getEncoding(), resultEncoding.getEncoding())) {
     return op.emitOpError() << "clones changing tensor encoding from "
@@ -1926,7 +1926,7 @@ LogicalResult TensorSliceOp::verify() {
       failed(verifyOpValueSizes(op, op.getResult(), op.getResultSize()))) {
     return failure();
   }
-  auto sourceType = llvm::cast<ShapedType>(op.getSourceEncoding());
+  auto sourceType = cast<ShapedType>(op.getSourceEncoding());
   if (op.getStartIndices().size() != sourceType.getRank() ||
       op.getLengths().size() != sourceType.getRank()) {
     return op.emitOpError() << "start_indices/lengths rank mismatch";
@@ -2002,7 +2002,7 @@ LogicalResult TensorLoadOp::verify() {
       failed(verifyOpValueSizes(op, op.getSource(), op.getSourceSize()))) {
     return failure();
   }
-  auto sourceType = llvm::cast<ShapedType>(op.getSourceEncoding());
+  auto sourceType = cast<ShapedType>(op.getSourceEncoding());
   if (op.getIndices().size() != sourceType.getRank()) {
     return op.emitOpError() << "indices rank mismatch";
   }
@@ -2020,7 +2020,7 @@ LogicalResult TensorStoreOp::verify() {
       failed(verifyOpValueSizes(op, op.getTarget(), op.getTargetSize()))) {
     return failure();
   }
-  auto targetType = llvm::cast<ShapedType>(op.getTargetEncoding());
+  auto targetType = cast<ShapedType>(op.getTargetEncoding());
   if (op.getIndices().size() != targetType.getRank()) {
     return op.emitOpError() << "indices rank mismatch";
   }
@@ -2365,7 +2365,7 @@ void AsyncCopyOp::getAsyncAccessRanges(
 //===----------------------------------------------------------------------===//
 
 static const char *getCollectiveParamKeyword(Attribute opAttr) {
-  auto attr = llvm::cast<IREE::Stream::CollectiveAttr>(opAttr);
+  auto attr = cast<IREE::Stream::CollectiveAttr>(opAttr);
   switch (attr.getKind()) {
   case IREE::Stream::CollectiveKind::Broadcast:
     return "source";
@@ -2667,7 +2667,7 @@ static void printDispatchOperands(OpAsmPrinter &p, Operation *op,
   unsigned resourceIndex = 0;
   llvm::interleaveComma(resourceOperands, p, [&](Value operand) {
     p.printOperand(operand);
-    if (llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
+    if (isa<IREE::Stream::ResourceType>(operand.getType())) {
       p << "[";
       p.printOperand(resourceOffsets[resourceIndex]);
       p << " to ";
@@ -2690,7 +2690,7 @@ LogicalResult AsyncDispatchOp::verify() {
   }
   unsigned requiredRangeCount = 0;
   for (auto value : op.getResourceOperands()) {
-    if (llvm::isa<IREE::Stream::ResourceType>(value.getType())) {
+    if (isa<IREE::Stream::ResourceType>(value.getType())) {
       ++requiredRangeCount;
     }
   }
@@ -2723,7 +2723,7 @@ void AsyncDispatchOp::getAsyncAccessRanges(
   unsigned rangeIndex = 0;
   unsigned tiedOperandBase = getTiedOperandsIndexAndLength().first;
   for (auto [operandIndex, operand] : llvm::enumerate(getResourceOperands())) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType()))
+    if (!isa<IREE::Stream::ResourceType>(operand.getType()))
       continue;
     ResourceAccessBitfield access = ResourceAccessBitfield::Read;
     auto tiedResults = getOperandTiedResults(tiedOperandBase + operandIndex);
@@ -2806,7 +2806,7 @@ bool AsyncFuncOp::isResultTied(int resultIndex) {
   auto tiedOperandsAttr = getTiedOperandsAttr();
   if (!tiedOperandsAttr)
     return false;
-  auto indexAttr = llvm::dyn_cast_if_present<IntegerAttr>(
+  auto indexAttr = dyn_cast_if_present<IntegerAttr>(
       tiedOperandsAttr.getValue()[resultIndex]);
   if (!indexAttr)
     return false;
@@ -2828,7 +2828,7 @@ LogicalResult AsyncCallOp::verify() {
 
   unsigned requiredRangeCount = 0;
   for (auto value : op.getResourceOperands()) {
-    if (llvm::isa<IREE::Stream::ResourceType>(value.getType())) {
+    if (isa<IREE::Stream::ResourceType>(value.getType())) {
       ++requiredRangeCount;
     }
   }
@@ -2850,7 +2850,7 @@ LogicalResult AsyncCallOp::verify() {
   // to be able to return non-resource types as well and adjust partitioning
   // to set them up as return values. For now we just avoid this.
   for (auto resultType : op.getResultTypes()) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(resultType)) {
+    if (!isa<IREE::Stream::ResourceType>(resultType)) {
       return op->emitOpError() << "non-resource return values are not yet "
                                   "supported on async calls";
     }
@@ -2881,8 +2881,8 @@ AsyncCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto typesCompatible = [](Type callee, Type call) {
     if (callee == call)
       return true;
-    auto calleeResource = llvm::dyn_cast<IREE::Stream::ResourceType>(callee);
-    auto callResource = llvm::dyn_cast<IREE::Stream::ResourceType>(call);
+    auto calleeResource = dyn_cast<IREE::Stream::ResourceType>(callee);
+    auto callResource = dyn_cast<IREE::Stream::ResourceType>(call);
     if (calleeResource && callResource) {
       if (calleeResource.getLifetime() == IREE::Stream::Lifetime::Unknown) {
         // Allow anything to match with an unknown lifetime on the async.func.
@@ -2926,7 +2926,7 @@ void AsyncCallOp::getAsyncAccessRanges(
   unsigned rangeIndex = 0;
   unsigned tiedOperandBase = getTiedOperandsIndexAndLength().first;
   for (auto [operandIndex, operand] : llvm::enumerate(getResourceOperands())) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType()))
+    if (!isa<IREE::Stream::ResourceType>(operand.getType()))
       continue;
     ResourceAccessBitfield access = ResourceAccessBitfield::Read;
     auto tiedResults = getOperandTiedResults(tiedOperandBase + operandIndex);
@@ -3033,7 +3033,7 @@ getExecutionAsyncAccessRanges(Op op,
   for (auto [i, operand, operandSize] : llvm::zip_equal(
            llvm::seq<unsigned>(0, op.getResourceOperands().size()),
            op.getResourceOperands(), op.getResourceOperandSizes())) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType()))
+    if (!isa<IREE::Stream::ResourceType>(operand.getType()))
       continue;
     ResourceAccessBitfield access = ResourceAccessBitfield::Read;
     auto tiedResults = op.getOperandTiedResults(tiedOperandBase + i);
@@ -3339,7 +3339,7 @@ LogicalResult CmdCollectiveOp::verify() {
            << " provided";
   }
   for (size_t i = 0; i < requiredCount; ++i) {
-    auto declaredAccess = llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+    auto declaredAccess = cast<IREE::Stream::ResourceAccessBitfieldAttr>(
                               op.getResourceAccesses()[i])
                               .getValue();
     if (!bitEnumContainsAll(declaredAccess, requiredAccess[i])) {
@@ -3495,9 +3495,9 @@ printDispatchResources(OpAsmPrinter &p, Operation *op, ValueRange resources,
     auto resourceSize = resourceSizes[i];
     auto resourceOffset = resourceOffsets[i];
     auto resourceLength = resourceLengths[i];
-    auto resourceAccess = llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
-                              resourceAccesses[i])
-                              .getValue();
+    auto resourceAccess =
+        cast<IREE::Stream::ResourceAccessBitfieldAttr>(resourceAccesses[i])
+            .getValue();
     p.printNewline();
     p << "  ";
     if (bitEnumContainsAll(resourceAccess,
@@ -3532,14 +3532,14 @@ SmallVector<unsigned>
 CmdDispatchOp::makeOperandToArgMap(mlir::FunctionOpInterface funcOp) {
   unsigned operandCount =
       llvm::count_if(funcOp.getArgumentTypes(), [](Type type) {
-        return !llvm::isa<IREE::Stream::BindingType>(type);
+        return !isa<IREE::Stream::BindingType>(type);
       });
   SmallVector<unsigned> map(operandCount);
   unsigned operandIdx = 0;
   for (auto it : llvm::enumerate(funcOp.getArgumentTypes())) {
     unsigned argIdx = it.index();
     auto argType = it.value();
-    if (!llvm::isa<IREE::Stream::BindingType>(argType)) {
+    if (!isa<IREE::Stream::BindingType>(argType)) {
       map[operandIdx++] = argIdx;
     }
   }
@@ -3678,7 +3678,7 @@ static void printDispatchFunctionResultList(OpAsmPrinter &p, Operation *op,
     p.printType(resultType);
     if (resultAttrs) {
       auto attrs =
-          llvm::dyn_cast_if_present<DictionaryAttr>(resultAttrs.getValue()[i]);
+          dyn_cast_if_present<DictionaryAttr>(resultAttrs.getValue()[i]);
       if (attrs && !attrs.empty()) {
         p.printOptionalAttrDict(attrs.getValue());
       }
@@ -3726,7 +3726,7 @@ ParseResult parseDispatchFunctionSignature(OpAsmParser &parser,
 void printDispatchFunctionSignature(OpAsmPrinter &p, Operation *op,
                                     TypeAttr functionTypeAttr,
                                     ArrayAttr argAttrs, ArrayAttr resultAttrs) {
-  auto functionType = llvm::cast<FunctionType>(functionTypeAttr.getValue());
+  auto functionType = cast<FunctionType>(functionTypeAttr.getValue());
   p << "(";
   for (size_t argIndex = 0; argIndex < functionType.getNumInputs();) {
     if (argIndex)
@@ -3735,7 +3735,7 @@ void printDispatchFunctionSignature(OpAsmPrinter &p, Operation *op,
     auto type = functionType.getInput(baseArgIndex);
     p << "%arg";
     p << (baseArgIndex + 0);
-    if (llvm::isa<IREE::Stream::ResourceType>(type)) {
+    if (isa<IREE::Stream::ResourceType>(type)) {
       p << "[%arg" << (baseArgIndex + 1) << " for %arg" << (baseArgIndex + 2)
         << "]";
       argIndex += 3; // <resource, offset, length>
@@ -3745,7 +3745,7 @@ void printDispatchFunctionSignature(OpAsmPrinter &p, Operation *op,
     p << ": ";
     p.printType(type);
     if (argAttrs) {
-      auto attrs = llvm::dyn_cast_if_present<DictionaryAttr>(
+      auto attrs = dyn_cast_if_present<DictionaryAttr>(
           argAttrs.getValue()[baseArgIndex]);
       if (attrs && !attrs.empty()) {
         p.printOptionalAttrDict(attrs.getValue());
@@ -3779,7 +3779,7 @@ LogicalResult CmdCallOp::verify() {
 
   unsigned resourceCount = 0;
   for (auto value : op.getResourceOperands()) {
-    if (llvm::isa<IREE::Stream::ResourceType>(value.getType())) {
+    if (isa<IREE::Stream::ResourceType>(value.getType())) {
       ++resourceCount;
     }
   }
@@ -3879,14 +3879,13 @@ static void printCmdCallOperands(OpAsmPrinter &p, Operation *op,
   size_t resourceIndex = 0;
   for (size_t i = 0; i < resourceOperands.size(); ++i) {
     auto operand = resourceOperands[i];
-    if (llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
+    if (isa<IREE::Stream::ResourceType>(operand.getType())) {
       // Resource type.
       auto resourceOffset = resourceOffsets[resourceIndex];
       auto resourceLength = resourceLengths[resourceIndex];
-      auto resourceAccess =
-          llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
-              resourceAccesses[resourceIndex])
-              .getValue();
+      auto resourceAccess = cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+                                resourceAccesses[resourceIndex])
+                                .getValue();
       if (bitEnumContainsAll(resourceAccess,
                              IREE::Stream::ResourceAccessBitfield::Read |
                                  IREE::Stream::ResourceAccessBitfield::Write)) {
@@ -4363,7 +4362,7 @@ mlir::FunctionOpInterface ExecutableExportOp::lookupFunctionRef() {
 
 LogicalResult BindingSubspanOp::verify() {
   BindingSubspanOp op = *this;
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(op.getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(op.getType())) {
     if (failed(verifyOpDynamicDims(op, shapedType, op.getDynamicDims()))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -273,7 +273,7 @@ ResourceConfigAttr ResourceConfigAttr::lookup(Operation *op) {
     if (attr)
       return attr;
     // See if the affinity specified provides a resource configuration.
-    if (auto affinityOp = llvm::dyn_cast<AffinityOpInterface>(op)) {
+    if (auto affinityOp = dyn_cast<AffinityOpInterface>(op)) {
       auto affinityAttr = affinityOp.getAffinityAttr();
       if (affinityAttr) {
         auto attr = affinityAttr.getResourceConfigAttr();
@@ -297,7 +297,7 @@ int64_t NamedParameterAttr::getStorageSize() const {
       return lengthAttr.getInt();
     }
   }
-  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
+  if (auto shapedType = dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());
@@ -339,7 +339,7 @@ void TimepointAttr::print(AsmPrinter &p) const {
 AffinityAttr AffinityAttr::lookup(Operation *fromOp) {
   auto attrId = StringAttr::get(fromOp->getContext(), "stream.affinity");
   while (fromOp) {
-    if (auto affinityOp = llvm::dyn_cast<AffinityOpInterface>(fromOp)) {
+    if (auto affinityOp = dyn_cast<AffinityOpInterface>(fromOp)) {
       if (auto affinity = affinityOp.getAffinityAttr()) {
         return affinity;
       }
@@ -508,12 +508,12 @@ void ResourceType::print(AsmPrinter &p) const {
 }
 
 bool ResourceType::isAccessStorageCompatible(Type accessType) const {
-  if (auto resourceType = llvm::dyn_cast<ResourceType>(accessType)) {
+  if (auto resourceType = dyn_cast<ResourceType>(accessType)) {
     // We could allow widening loads or stores here but today we require
     // transfers to accomplish that.
     return accessType == resourceType;
   }
-  return llvm::isa<ShapedType>(accessType);
+  return isa<ShapedType>(accessType);
 }
 
 Value ResourceType::inferSizeFromValue(Location loc, Value value,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
@@ -201,8 +201,8 @@ void GlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
     // Cannot perform analysis.
     indicatePessimisticFixpoint();
   } else if (globalInfo) {
-    if (auto initialValue = llvm::dyn_cast_if_present<IntegerAttr>(
-            globalOp.getInitialValueAttr())) {
+    if (auto initialValue =
+            dyn_cast_if_present<IntegerAttr>(globalOp.getInitialValueAttr())) {
       // Initial value is available for use; stored values from the rest of the
       // program will come during iteration.
       unionAssumed(initialValue.getValue());
@@ -504,8 +504,8 @@ static void annotateExport(IREE::Stream::ExecutableOp executableOp,
         potentialValues.push_back(IntegerAttr::get(argType, value));
       }
       llvm::sort(potentialValues, [](Attribute lhs, Attribute rhs) {
-        auto lhsInt = llvm::dyn_cast<IntegerAttr>(lhs);
-        auto rhsInt = llvm::dyn_cast<IntegerAttr>(rhs);
+        auto lhsInt = dyn_cast<IntegerAttr>(lhs);
+        auto rhsInt = dyn_cast<IntegerAttr>(rhs);
         if (!lhsInt || !rhsInt)
           return false;
         return lhsInt.getValue().ult(rhsInt.getValue());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -45,7 +45,7 @@ namespace {
 static bool doesOperationNeedWrapping(Operation *op) {
   return llvm::any_of(op->getOperands(),
                       [](Value operand) {
-                        if (!llvm::isa<TensorType>(operand.getType()))
+                        if (!isa<TensorType>(operand.getType()))
                           return false;
                         return !isa_and_nonnull<TensorExportOp>(
                             operand.getDefiningOp());
@@ -244,10 +244,10 @@ struct ConvertToStreamPass final
     // Allow unknown types to pass through; these come from custom dialects that
     // may be mixed into the IR we are converting.
     typeConverter.addConversion([=](Type type) -> Type {
-      if (llvm::isa<IREE::Flow::ChannelType>(type)) {
+      if (isa<IREE::Flow::ChannelType>(type)) {
         return IREE::Stream::ChannelType::get(context);
       }
-      return !llvm::isa<TensorType>(type) ? type : Type{};
+      return !isa<TensorType>(type) ? type : Type{};
     });
 
     // Disallow tensor dialects; the goal here is to remove all tensors and

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -60,7 +60,7 @@ struct UsageInfo {
   void analyze(mlir::ModuleOp moduleOp) {
     SymbolTable symbolTable(moduleOp);
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOp>()) {
-      if (llvm::isa<IREE::Stream::ResourceType>(globalOp.getType())) {
+      if (isa<IREE::Stream::ResourceType>(globalOp.getType())) {
         resourceGlobalOps[globalOp.getName()] = globalOp;
       }
     }
@@ -126,7 +126,7 @@ struct Statistics {
     // Globals:
     for (auto [name, globalOp] : usageInfo.resourceGlobalOps) {
       auto globalType =
-          llvm::dyn_cast<IREE::Stream::ResourceType>(globalOp.getType());
+          dyn_cast<IREE::Stream::ResourceType>(globalOp.getType());
       if (!globalType)
         continue;
       // TODO(benvanik): analyze size in UsageInfo where possible.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -216,7 +216,7 @@ private:
     // If the operand is a block argument then we need to ask for the argument
     // semantics first - if it's by reference then it's definitely not the last
     // use and we can short-circuit this.
-    if (auto arg = llvm::dyn_cast<BlockArgument>(operand.get())) {
+    if (auto arg = dyn_cast<BlockArgument>(operand.get())) {
       auto &argumentSemantics = solver.getElementFor<ArgumentSemantics>(
           *this, Position::forValue(operand.get()), DFX::Resolution::REQUIRED);
       LLVM_DEBUG(llvm::dbgs()
@@ -243,7 +243,7 @@ private:
     auto assumedBits = getAssumed();
     auto traversalResult = TraversalResult::COMPLETE;
 
-    auto arg = llvm::cast<BlockArgument>(value);
+    auto arg = cast<BlockArgument>(value);
     bool isEntryArg = arg.getParentBlock()->isEntryBlock();
     if (isEntryArg) {
       // Call argument.
@@ -318,7 +318,7 @@ public:
         continue;
       for (auto &block : *region) {
         for (auto arg : block.getArguments()) {
-          if (llvm::isa<IREE::Stream::ResourceType>(arg.getType())) {
+          if (isa<IREE::Stream::ResourceType>(arg.getType())) {
             solver.getOrCreateElementFor<ArgumentSemantics>(
                 Position::forValue(arg));
           }
@@ -402,9 +402,9 @@ static bool isSafeToElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
   // values as "eventually constant" to allow us to promote to constant
   // lifetime.
   auto sourceType =
-      llvm::cast<IREE::Stream::ResourceType>(cloneOp.getSource().getType());
+      cast<IREE::Stream::ResourceType>(cloneOp.getSource().getType());
   auto targetType =
-      llvm::cast<IREE::Stream::ResourceType>(cloneOp.getResult().getType());
+      cast<IREE::Stream::ResourceType>(cloneOp.getResult().getType());
   if (sourceType != targetType &&
       sourceType.getLifetime() == IREE::Stream::Lifetime::Constant) {
     LLVM_DEBUG(llvm::dbgs()
@@ -417,7 +417,7 @@ static bool isSafeToElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
   // to see if it's been classified as a last use/by-value move. If it isn't
   // then we cannot mutate it in-place as it could be used by the caller/another
   // branch and we need to respect the forking of the value.
-  if (auto arg = llvm::dyn_cast<BlockArgument>(cloneOp.getSource())) {
+  if (auto arg = dyn_cast<BlockArgument>(cloneOp.getSource())) {
     if (!analysis.isArgMoved(arg)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "  - clone source is a by-ref arg; cannot elide\n");
@@ -605,7 +605,7 @@ static void foldSliceIntoDispatch(IREE::Stream::AsyncSliceOp sliceOp,
   unsigned resourceIndex = llvm::count_if(
       dispatchOp.getResourceOperands().slice(0, operandIndex),
       [](Value operand) {
-        return llvm::isa<IREE::Stream::ResourceType>(operand.getType());
+        return isa<IREE::Stream::ResourceType>(operand.getType());
       });
   OpBuilder builder(dispatchOp);
   dispatchOp.getResourceOperandOffsetsMutable()[resourceIndex].set(addOffset(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
@@ -439,7 +439,7 @@ private:
     };
 
     auto *definingOp = value.getDefiningOp();
-    if (auto blockArg = llvm::dyn_cast<BlockArgument>(value)) {
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
       // Block arguments need an intersection of all incoming branch/call edges.
       gatherBlockOperands(blockArg);
       return DFX::clampStateAndIndicateChange(getState(), newState);
@@ -476,13 +476,13 @@ private:
           // sites.
           auto callableOp = callOp.resolveCallableInTable(
               &solver.getExplorer().getSymbolTables());
-          unsigned resultIndex = llvm::cast<OpResult>(value).getResultNumber();
+          unsigned resultIndex = cast<OpResult>(value).getResultNumber();
           gatherRegionReturns(callableOp, resultIndex);
         })
         .Case([&](RegionBranchOpInterface regionOp) {
           // Step into regions and get a coverage intersection of all return
           // sites.
-          unsigned resultIndex = llvm::cast<OpResult>(value).getResultNumber();
+          unsigned resultIndex = cast<OpResult>(value).getResultNumber();
           gatherRegionReturns(regionOp, resultIndex);
         })
         .Case([&](arith::SelectOp op) {
@@ -552,7 +552,7 @@ public:
       for (auto &block : region) {
         // Seed all block arguments.
         for (auto arg : block.getArguments()) {
-          if (llvm::isa<IREE::Stream::TimepointType>(arg.getType())) {
+          if (isa<IREE::Stream::TimepointType>(arg.getType())) {
             solver.getOrCreateElementFor<IsImmediate>(Position::forValue(arg));
           }
         }
@@ -576,7 +576,7 @@ public:
         // Seed all terminator operands.
         if (auto *terminatorOp = block.getTerminator()) {
           for (auto operand : terminatorOp->getOperands()) {
-            if (llvm::isa<IREE::Stream::TimepointType>(operand.getType())) {
+            if (isa<IREE::Stream::TimepointType>(operand.getType())) {
               solver.getOrCreateElementFor<TimepointCoverage>(
                   Position::forValue(operand));
               solver.getOrCreateElementFor<IsImmediate>(
@@ -722,7 +722,7 @@ static bool tryElideTimepointsInRegion(Region &region,
   // Elides all timepoint operands of |op| that are immediately resolved.
   auto elideTimepointOperands = [&](Operation *op) {
     for (auto operand : llvm::make_early_inc_range(op->getOperands())) {
-      if (!llvm::isa<IREE::Stream::TimepointType>(operand.getType()))
+      if (!isa<IREE::Stream::TimepointType>(operand.getType()))
         continue;
       if (isDefinedImmediate(operand))
         continue;
@@ -761,7 +761,7 @@ static bool tryElideTimepointsInRegion(Region &region,
     //  %imm0 = immediate
     //  %imm1 = immediate
     for (auto result : llvm::reverse(op->getResults())) {
-      if (!llvm::isa<IREE::Stream::TimepointType>(result.getType()))
+      if (!isa<IREE::Stream::TimepointType>(result.getType()))
         continue;
       if (isDefinedImmediate(result))
         continue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -47,7 +47,7 @@ namespace {
 static LogicalResult checkEncoding(Operation *op, RankedTensorType encodingType,
                                    ValueRange encodingDims,
                                    PatternRewriter &rewriter) {
-  if (llvm::isa_and_nonnull<IREE::Encoding::PackedStorageAttr>(
+  if (isa_and_nonnull<IREE::Encoding::PackedStorageAttr>(
           encodingType.getEncoding())) {
     return success();
   }
@@ -205,7 +205,7 @@ struct EncodeTensorImportOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorImportOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -228,7 +228,7 @@ struct EncodeTensorExportOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorExportOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+    auto sourceType = cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
@@ -251,7 +251,7 @@ struct EncodeTensorSizeOfOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSizeOfOp op,
                                 PatternRewriter &rewriter) const override {
-    auto encodingType = llvm::cast<RankedTensorType>(op.getEncoding());
+    auto encodingType = cast<RankedTensorType>(op.getEncoding());
     auto encodingDims = op.getEncodingDims();
     if (failed(checkEncoding(op, encodingType, encodingDims, rewriter))) {
       return failure();
@@ -279,7 +279,7 @@ struct EncodeTensorEmptyOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorEmptyOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -302,7 +302,7 @@ struct EncodeTensorConstantOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorConstantOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -327,7 +327,7 @@ struct EncodeTensorConstantOp
     RankedTensorType alignedType = alignTensorType(resultType);
     Attribute encodedAttr = op.getValue();
     if (alignedType != resultType) {
-      if (auto sourceAttr = llvm::dyn_cast<DenseIntElementsAttr>(encodedAttr)) {
+      if (auto sourceAttr = dyn_cast<DenseIntElementsAttr>(encodedAttr)) {
         auto alignedBitWidth = alignedType.getElementTypeBitWidth();
         encodedAttr = sourceAttr.mapValues(
             alignedType.getElementType(), [=](APInt sourceValue) {
@@ -363,7 +363,7 @@ struct EncodeTensorSplatOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSplatOp op,
                                 PatternRewriter &rewriter) const override {
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -396,12 +396,12 @@ struct EncodeTensorCloneOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorCloneOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+    auto sourceType = cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
     }
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -425,12 +425,12 @@ struct EncodeTensorSliceOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorSliceOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+    auto sourceType = cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     if (failed(checkEncoding(op, sourceType, sourceDims, rewriter))) {
       return failure();
     }
-    auto resultType = llvm::cast<RankedTensorType>(op.getResultEncoding());
+    auto resultType = cast<RankedTensorType>(op.getResultEncoding());
     auto resultDims = op.getResultEncodingDims();
     if (failed(checkEncoding(op, resultType, resultDims, rewriter))) {
       return failure();
@@ -458,7 +458,7 @@ struct EncodeTensorFillOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorFillOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
+    auto targetType = cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -497,12 +497,12 @@ struct EncodeTensorUpdateOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorUpdateOp op,
                                 PatternRewriter &rewriter) const override {
-    auto updateType = llvm::cast<RankedTensorType>(op.getUpdateEncoding());
+    auto updateType = cast<RankedTensorType>(op.getUpdateEncoding());
     auto updateDims = op.getUpdateEncodingDims();
     if (failed(checkEncoding(op, updateType, updateDims, rewriter))) {
       return failure();
     }
-    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
+    auto targetType = cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -531,7 +531,7 @@ struct EncodeTensorLoadOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+    auto sourceType = cast<RankedTensorType>(op.getSourceEncoding());
     auto sourceDims = op.getSourceEncodingDims();
     auto loadType = op.getResult().getType();
     if (auto complexTy = dyn_cast<ComplexType>(loadType)) {
@@ -574,7 +574,7 @@ struct EncodeTensorStoreOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::TensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = llvm::cast<RankedTensorType>(op.getTargetEncoding());
+    auto targetType = cast<RankedTensorType>(op.getTargetEncoding());
     auto targetDims = op.getTargetEncodingDims();
     if (failed(checkEncoding(op, targetType, targetDims, rewriter))) {
       return failure();
@@ -680,8 +680,8 @@ struct EncodeBindingSubspanOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::Stream::BindingSubspanOp op,
                                 PatternRewriter &rewriter) const override {
-    auto originalType = llvm::dyn_cast<IREE::TensorExt::DispatchTensorType>(
-        op.getResult().getType());
+    auto originalType =
+        dyn_cast<IREE::TensorExt::DispatchTensorType>(op.getResult().getType());
     if (!originalType) {
       return rewriter.notifyMatchFailure(op, "binding type not supported");
     }
@@ -710,7 +710,7 @@ struct EncodeDispatchTensorLoadOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    auto targetType = llvm::cast<RankedTensorType>(op.getResult().getType());
+    auto targetType = cast<RankedTensorType>(op.getResult().getType());
 
     // Align the element type, if needed.
     RankedTensorType alignedType = alignTensorType(targetType);
@@ -744,7 +744,7 @@ struct EncodeDispatchTensorStoreOp
   using Base::Base;
   LogicalResult matchAndRewrite(IREE::TensorExt::DispatchTensorStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    auto sourceType = llvm::cast<RankedTensorType>(op.getValue().getType());
+    auto sourceType = cast<RankedTensorType>(op.getValue().getType());
 
     // Align the element type, if needed.
     RankedTensorType alignedType = alignTensorType(sourceType);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -39,7 +39,7 @@ namespace {
 struct BindingRange {
   BindingRange() = default;
   BindingRange(IREE::Stream::CmdDispatchOp dispatchOp, unsigned idx)
-      : idx(idx), access(llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
+      : idx(idx), access(cast<IREE::Stream::ResourceAccessBitfieldAttr>(
                              dispatchOp.getResourceAccesses()[idx])
                              .getValue()),
         resource(dispatchOp.getResources()[idx]),
@@ -92,8 +92,7 @@ findCorrelatedBindings(unsigned bindingCount,
       // If the resource is mutable and we were told not to alias mutable
       // bindings we always put the resource into its own class.
       auto resourceAccess =
-          llvm::cast<IREE::Stream::ResourceAccessBitfieldAttr>(
-              resourceAccessAttr);
+          cast<IREE::Stream::ResourceAccessBitfieldAttr>(resourceAccessAttr);
       if (!aliasMutableBindings &&
           bitEnumContainsAll(resourceAccess.getValue(),
                              IREE::Stream::ResourceAccessBitfield::Write)) {
@@ -180,7 +179,7 @@ static void updateExecutableSignature(IREE::Stream::ExecutableOp executableOp,
   // Gather old bindings (in order).
   SmallVector<BlockArgument> oldBindingArgs;
   for (auto arg : entryBlock.getArguments()) {
-    if (llvm::isa<IREE::Stream::BindingType>(arg.getType())) {
+    if (isa<IREE::Stream::BindingType>(arg.getType())) {
       oldBindingArgs.push_back(arg);
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -41,7 +41,7 @@ namespace {
 static bool isSafeToElideCOW(Value operand, IREE::Stream::ResourceType type) {
   // Can't do anything with block args without analysis - we don't know if the
   // value they carry is the last user (move semantics).
-  if (llvm::isa<BlockArgument>(operand))
+  if (isa<BlockArgument>(operand))
     return false;
 
   // If our value is a constant then we need to ensure that we aren't
@@ -86,8 +86,7 @@ static Value materializeOperandCOW(Location loc, OpOperand &operand,
     return nullptr;
 
   // Materialize a clone operation just for the operand provided.
-  auto sizeAwareType =
-      llvm::cast<IREE::Util::SizeAwareTypeInterface>(resourceType);
+  auto sizeAwareType = cast<IREE::Util::SizeAwareTypeInterface>(resourceType);
   auto size = sizeAwareType.queryValueSize(loc, operand.get(), builder);
   return IREE::Stream::AsyncCloneOp::create(
       builder, loc, resourceType, operand.get(), size, size, affinity);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -167,7 +167,7 @@ createExportOp(RewriterBase &rewriter, Location loc,
   SmallVector<Location> workloadLocs;
   for (auto argument : encodeOp.getSourceEncodingDims()) {
     Type argumentType = argument.getType();
-    if (!llvm::isa<IndexType>(argumentType)) {
+    if (!isa<IndexType>(argumentType)) {
       continue;
     }
     workloadTypes.push_back(argumentType);
@@ -175,7 +175,7 @@ createExportOp(RewriterBase &rewriter, Location loc,
   }
   for (auto argument : encodeOp.getResultEncodingDims()) {
     Type argumentType = argument.getType();
-    if (!llvm::isa<IndexType>(argumentType)) {
+    if (!isa<IndexType>(argumentType)) {
       continue;
     }
     workloadTypes.push_back(argumentType);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
@@ -472,8 +472,7 @@ static Value generateSerializedUpload(
   // subrange it so that we don't need so many files.
 
   auto anyResult = slices.front().result;
-  auto resourceType =
-      llvm::cast<IREE::Stream::ResourceType>(anyResult.getType());
+  auto resourceType = cast<IREE::Stream::ResourceType>(anyResult.getType());
 
   // Emit rodata storage for the constant values.
   // As our upload paths may vary this ensures that we are only emitting
@@ -524,8 +523,7 @@ static Value generateParameterUpload(
     ArrayRef<ConstantSlice> slices, IntegerSet<int64_t> &i64Set,
     IndexSet &indexSet, OpBuilder &builder) {
   auto anyResult = slices.front().result;
-  auto resourceType =
-      llvm::cast<IREE::Stream::ResourceType>(anyResult.getType());
+  auto resourceType = cast<IREE::Stream::ResourceType>(anyResult.getType());
 
   // Perform the packing of dense values to compute the storage resources we
   // will need and where each value will be placed unless we have a chance to

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -244,7 +244,7 @@ static Value recomposeFromI32sAndConvert(
   }
 
   // i16 -> bf16, i32 -> f32, i64 -> f64 ...
-  if (auto floatType = llvm::dyn_cast<FloatType>(oldArgType)) {
+  if (auto floatType = dyn_cast<FloatType>(oldArgType)) {
     value = arith::BitcastOp::create(builder, loc, oldArgType, value);
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -63,7 +63,7 @@ static ExpandedGlobalMap expandResourceGlobals(Operation *rootOp,
   // Gather all of the resource globals in the root.
   for (auto &region : rootOp->getRegions()) {
     for (auto globalOp : region.getOps<IREE::Util::GlobalOp>()) {
-      if (!llvm::isa<IREE::Stream::ResourceType>(globalOp.getType()))
+      if (!isa<IREE::Stream::ResourceType>(globalOp.getType()))
         continue;
       expandedGlobals[globalOp.getName()].resourceOp = globalOp;
     }
@@ -93,7 +93,7 @@ static ExpandedGlobalMap expandResourceGlobals(Operation *rootOp,
 //===----------------------------------------------------------------------===//
 
 static bool isResourceType(Type type) {
-  return llvm::isa<IREE::Stream::ResourceType>(type);
+  return isa<IREE::Stream::ResourceType>(type);
 }
 
 // Returns true if an operands or results of |op| use !stream.resources.
@@ -217,7 +217,7 @@ static Value makeBlockArgResourceSize(Location loc, Value resourceValue,
       // Size value found and implicitly captured; we can reuse (could be
       // a parent block argument, a constant, computed, etc).
       return sizeValue;
-    } else if (auto blockArg = llvm::dyn_cast<BlockArgument>(sizeValue)) {
+    } else if (auto blockArg = dyn_cast<BlockArgument>(sizeValue)) {
       if (blockArg.getParentBlock()->isEntryBlock()) {
         // Dynamic dimension passed in to the entry block; safe to use.
         return sizeValue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -100,7 +100,7 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
   // Updates the |arg| type to the lifetime derived by analysis, if needed.
   // Returns true if a change was made.
   bool applyArgTransition(BlockArgument arg, PatternRewriter &rewriter) const {
-    auto oldType = llvm::dyn_cast<IREE::Stream::ResourceType>(arg.getType());
+    auto oldType = dyn_cast<IREE::Stream::ResourceType>(arg.getType());
     if (!oldType)
       return false;
     auto newUsage = analysis.lookupResourceUsage(arg);
@@ -123,7 +123,7 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
   // Returns true if a change was made.
   bool applyResultTransition(Operation *op, Value result,
                              PatternRewriter &rewriter) const {
-    auto oldType = llvm::dyn_cast<IREE::Stream::ResourceType>(result.getType());
+    auto oldType = dyn_cast<IREE::Stream::ResourceType>(result.getType());
     if (!oldType)
       return false;
     auto newUsage = analysis.lookupResourceUsage(result);
@@ -161,7 +161,7 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
   bool applyResultTransition(Value result, Value resultSize,
                              IREE::Stream::AffinityAttr affinityAttr,
                              PatternRewriter &rewriter) const {
-    auto oldType = llvm::dyn_cast<IREE::Stream::ResourceType>(result.getType());
+    auto oldType = dyn_cast<IREE::Stream::ResourceType>(result.getType());
     if (!oldType)
       return false;
     auto newUsage = analysis.lookupResourceUsage(result);
@@ -179,7 +179,7 @@ struct UsageRefinementPattern : public OpRewritePattern<OpT> {
         auto consumerOp =
             dyn_cast<IREE::Stream::AsyncTransferOp>(*result.getUsers().begin());
         if (consumerOp) {
-          auto finalType = llvm::cast<IREE::Stream::ResourceType>(
+          auto finalType = cast<IREE::Stream::ResourceType>(
               consumerOp.getResult().getType());
           if (finalType.getLifetime() != IREE::Stream::Lifetime::Unknown) {
             // Already have a transfer to the new lifetime.
@@ -254,8 +254,7 @@ struct ApplyFuncOp : public UsageRefinementPattern<IREE::Util::FuncOp> {
     // Arguments:
     SmallVector<Type> newInputs;
     for (auto inputType : llvm::enumerate(op.getFunctionType().getInputs())) {
-      auto oldType =
-          llvm::dyn_cast<IREE::Stream::ResourceType>(inputType.value());
+      auto oldType = dyn_cast<IREE::Stream::ResourceType>(inputType.value());
       if (!oldType) {
         newInputs.push_back(inputType.value());
       } else if (oldType.getLifetime() == IREE::Stream::Lifetime::Unknown) {
@@ -274,8 +273,7 @@ struct ApplyFuncOp : public UsageRefinementPattern<IREE::Util::FuncOp> {
     SmallVector<Type> newOutputs;
     auto anyReturnOp = getAnyReturnLikeOp(op);
     for (auto outputType : llvm::enumerate(op.getFunctionType().getResults())) {
-      auto oldType =
-          llvm::dyn_cast<IREE::Stream::ResourceType>(outputType.value());
+      auto oldType = dyn_cast<IREE::Stream::ResourceType>(outputType.value());
       if (!oldType) {
         newOutputs.push_back(outputType.value());
       } else if (oldType.getLifetime() == IREE::Stream::Lifetime::Unknown) {
@@ -320,7 +318,7 @@ struct ApplyScfIfOp : public UsageRefinementPattern<mlir::scf::IfOp> {
     bool didChange = this->applyRegionTransitions(op, rewriter);
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
       auto result = op->getResult(i);
-      if (llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+      if (isa<IREE::Stream::ResourceType>(result.getType())) {
         if (this->applyResultTransition(op, result, rewriter))
           didChange |= true;
       }
@@ -337,7 +335,7 @@ struct ApplyScfForOp : public UsageRefinementPattern<mlir::scf::ForOp> {
     bool didChange = this->applyRegionTransitions(op, rewriter);
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
       auto result = op->getResult(i);
-      if (llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+      if (isa<IREE::Stream::ResourceType>(result.getType())) {
         if (this->applyResultTransition(op, result, rewriter))
           didChange |= true;
       }
@@ -353,7 +351,7 @@ struct ApplyScfWhileOp : public UsageRefinementPattern<mlir::scf::WhileOp> {
     bool didChange = this->applyRegionTransitions(op, rewriter);
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
       auto result = op->getResult(i);
-      if (llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+      if (isa<IREE::Stream::ResourceType>(result.getType())) {
         if (this->applyResultTransition(op, result, rewriter))
           didChange |= true;
       }
@@ -376,7 +374,7 @@ struct ApplyGenericOp : public UsageRefinementPattern<Op> {
     rewriter.setInsertionPointAfter(op);
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
       auto result = op->getResult(i);
-      if (llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+      if (isa<IREE::Stream::ResourceType>(result.getType())) {
         if (this->applyResultTransition(op, result, rewriter))
           didChange = true;
       }
@@ -410,7 +408,7 @@ struct ApplyStreamableOp : public UsageRefinementPattern<Op> {
         cast<IREE::Util::SizeAwareOpInterface>(op.getOperation());
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
       auto result = op->getResult(i);
-      if (!llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+      if (!isa<IREE::Stream::ResourceType>(result.getType())) {
         continue;
       }
       auto resultSize = sizeAwareOp.getResultSize(i);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -80,7 +80,7 @@ static void computeRegionValueAliases(Operation *regionOp,
   // things like stream.async.execute returning a timepoint.
   auto resourceResults =
       llvm::filter_to_vector(regionOp->getResults(), [](OpResult result) {
-        return llvm::isa<IREE::Stream::ResourceType>(result.getType());
+        return isa<IREE::Stream::ResourceType>(result.getType());
       });
 
   // Start with outputs so that we handle tied values that may lead all the way
@@ -110,7 +110,7 @@ static void computeRegionValueAliases(Operation *regionOp,
     // Tied results reuse their operand buffer.
     auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(op);
     for (auto result : op.getResults()) {
-      if (!llvm::isa<IREE::Stream::ResourceType>(result.getType()))
+      if (!isa<IREE::Stream::ResourceType>(result.getType()))
         continue;
       if (tiedOp) {
         auto tiedOperand = tiedOp.getTiedResultOperand(result);
@@ -181,7 +181,7 @@ computeExecutionRegionLivenessIntervals(IREE::Stream::AsyncExecuteOp executeOp,
   SmallPtrSet<Value, 16> liveOuts;
   auto yieldOp = cast<IREE::Stream::YieldOp>(streamBlock->back());
   for (auto returnValue : yieldOp.getResourceOperands()) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(returnValue.getType()))
+    if (!isa<IREE::Stream::ResourceType>(returnValue.getType()))
       continue;
     liveOuts.insert(returnValue);
   }
@@ -191,7 +191,7 @@ computeExecutionRegionLivenessIntervals(IREE::Stream::AsyncExecuteOp executeOp,
   LivenessIntervalMap valueIntervals;
   int ordinal = 0;
   for (Value value : streamBlock->getArguments()) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(value.getType()))
+    if (!isa<IREE::Stream::ResourceType>(value.getType()))
       continue;
     LivenessInterval interval;
     interval.start = LIVE_IN;
@@ -218,7 +218,7 @@ computeExecutionRegionLivenessIntervals(IREE::Stream::AsyncExecuteOp executeOp,
       // the duration of the region.
       concurrentOp.walk([&](Operation *op) {
         for (auto value : op->getResults()) {
-          if (!llvm::isa<IREE::Stream::ResourceType>(value.getType()))
+          if (!isa<IREE::Stream::ResourceType>(value.getType()))
             continue;
           if (auto tiedOp = dyn_cast<Util::TiedOpInterface>(op)) {
             // Skip tied results as their liveness is determined by the tied
@@ -238,7 +238,7 @@ computeExecutionRegionLivenessIntervals(IREE::Stream::AsyncExecuteOp executeOp,
       });
     }
     for (auto value : op.getResults()) {
-      if (!llvm::isa<IREE::Stream::ResourceType>(value.getType()))
+      if (!isa<IREE::Stream::ResourceType>(value.getType()))
         continue;
       LivenessInterval interval;
       interval.start = start;
@@ -666,8 +666,8 @@ applyAsyncTransferOp(IREE::Stream::AffinityAttr executionAffinityAttr,
   // Lookup the affinity for where we are executing. This lets us determine if
   // this transfer is incoming or outgoing.
   auto isStaging = [](Value value) {
-    return llvm::cast<IREE::Stream::ResourceType>(value.getType())
-               .getLifetime() == IREE::Stream::Lifetime::Staging;
+    return cast<IREE::Stream::ResourceType>(value.getType()).getLifetime() ==
+           IREE::Stream::Lifetime::Staging;
   };
   auto sourceAffinityAttr = asyncOp.getSourceAffinityAttr();
   auto resultAffinityAttr = asyncOp.getResultAffinityAttr();
@@ -720,7 +720,7 @@ static LogicalResult applyAsyncDispatchOp(IREE::Stream::AsyncDispatchOp asyncOp,
   unsigned resourceIndex = 0;
   for (auto it : llvm::enumerate(asyncOp.getResourceOperands())) {
     auto operand = it.value();
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
+    if (!isa<IREE::Stream::ResourceType>(operand.getType())) {
       // Primitive operand.
       newOperands.push_back(operand);
       continue;
@@ -788,7 +788,7 @@ static void convertAsyncFuncOp(IREE::Stream::AsyncFuncOp asyncOp) {
   SmallVector<DictionaryAttr> newArgAttrs;
   for (auto [i, oldInput] : llvm::enumerate(oldFunctionType.getInputs())) {
     auto oldArgAttr = asyncOp.getArgAttrDict(i);
-    if (llvm::isa<IREE::Stream::ResourceType>(oldInput)) {
+    if (isa<IREE::Stream::ResourceType>(oldInput)) {
       newInputs.push_back(oldInput); // resource
       newArgAttrs.push_back(oldArgAttr);
       newInputs.push_back(indexType); // offset
@@ -805,7 +805,7 @@ static void convertAsyncFuncOp(IREE::Stream::AsyncFuncOp asyncOp) {
   SmallVector<DictionaryAttr> newResultAttrs;
   for (auto [i, oldResult] : llvm::enumerate(oldFunctionType.getResults())) {
     auto oldResultAttr = asyncOp.getResultAttrDict(i);
-    if (llvm::isa<IREE::Stream::ResourceType>(oldResult)) {
+    if (isa<IREE::Stream::ResourceType>(oldResult)) {
       if (asyncOp.isResultTied(i)) {
         // Tied results reuse the operands they are tied to.
         continue;
@@ -845,7 +845,7 @@ static LogicalResult applyAsyncCallOp(IREE::Stream::AsyncCallOp asyncOp,
 
   unsigned resourceIndex = 0;
   for (auto [i, operand] : llvm::enumerate(asyncOp.getResourceOperands())) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(operand.getType())) {
+    if (!isa<IREE::Stream::ResourceType>(operand.getType())) {
       // Primitive operand.
       newResourceOperands.push_back(operand);
       continue;
@@ -874,7 +874,7 @@ static LogicalResult applyAsyncCallOp(IREE::Stream::AsyncCallOp asyncOp,
   }
 
   for (auto result : asyncOp.getResults()) {
-    if (!llvm::isa<IREE::Stream::ResourceType>(result.getType())) {
+    if (!isa<IREE::Stream::ResourceType>(result.getType())) {
       // Primitive result.
       newResultTypes.push_back(result.getType());
       continue;
@@ -1052,8 +1052,7 @@ allocateLocalTransients(IREE::Stream::AsyncExecuteOp executeOp,
   for (auto valueInterval : livenessIntervals) {
     auto value = valueInterval.value;
     assert(value && "must have value for interval");
-    auto valueType =
-        llvm::dyn_cast<IREE::Stream::ResourceType>(value.getType());
+    auto valueType = dyn_cast<IREE::Stream::ResourceType>(value.getType());
     if (!valueType)
       continue;
 
@@ -1755,8 +1754,7 @@ allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
   ResultAllocationMap resultReservations;
   for (auto [resultValue, resultSize] :
        llvm::zip_equal(executeOp.getResults(), executeOp.getResultSizes())) {
-    auto resultType =
-        llvm::cast<IREE::Stream::ResourceType>(resultValue.getType());
+    auto resultType = cast<IREE::Stream::ResourceType>(resultValue.getType());
     if (handledResults.contains(resultValue)) {
       resultReplacements.push_back(std::make_pair(resultValue, Value{}));
       continue;
@@ -1820,7 +1818,7 @@ allocateExecutionRegion(IREE::Stream::AsyncExecuteOp executeOp,
     if (!definingOp) {
       // Directly returning an operand; this usually gets canonicalized away but
       // may be introduced by intermediate transformations.
-      auto arg = llvm::cast<BlockArgument>(definingValue);
+      auto arg = cast<BlockArgument>(definingValue);
       auto operand = newOperands[arg.getArgNumber()];
       LLVM_DEBUG({
         AsmState asmState(executeOp->getParentOp());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
@@ -93,7 +93,7 @@ struct WavePartitionBuilder {
     operandTypes.reserve(partition->ins.size());
     operandSizes.reserve(partition->ins.size());
     for (auto in : partition->ins) {
-      if (!llvm::isa<IREE::Stream::ResourceType>(in.getType()))
+      if (!isa<IREE::Stream::ResourceType>(in.getType()))
         continue;
       operands.push_back(in);
       operandTypes.push_back(in.getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -93,7 +93,7 @@ struct ExecutePartitionBuilder {
     operandTypes.reserve(partition->ins.size());
     operandSizes.reserve(partition->ins.size());
     for (auto in : partition->ins) {
-      if (!llvm::isa<IREE::Stream::ResourceType>(in.getType()))
+      if (!isa<IREE::Stream::ResourceType>(in.getType()))
         continue;
       operands.push_back(in);
       operandTypes.push_back(in.getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -135,8 +135,8 @@ static TypedAttr buildConstantSetAttr(ConstantSet &set, OpBuilder &builder) {
     for (int64_t value = 0; value < valueCount; ++value) {
       auto valueAttr = set.values[value].second[site];
       if (storageType != valueAttr.getType()) {
-        valueAttr = IntegerAttr::get(
-            storageType, llvm::cast<IntegerAttr>(valueAttr).getInt());
+        valueAttr = IntegerAttr::get(storageType,
+                                     cast<IntegerAttr>(valueAttr).getInt());
       }
       flattenedAttrs.push_back(valueAttr);
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -189,7 +189,7 @@ getBindingLayoutAttrs(IREE::Stream::TensorDispatchOp dispatchOp) {
           dispatchOp.getTiedOperands()) {
     tiedOperands =
         llvm::map_to_vector(tiedOperandsAttr.value(), [](Attribute intAttr) {
-          return llvm::cast<IntegerAttr>(intAttr).getInt();
+          return cast<IntegerAttr>(intAttr).getInt();
         });
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -91,9 +91,7 @@ public:
 
   template <typename TypeT>
   void addTypeVerifier(std::function<Legality(TypeT)> fn) {
-    auto wrapperFn = [=](Type baseType) {
-      return fn(llvm::cast<TypeT>(baseType));
-    };
+    auto wrapperFn = [=](Type baseType) { return fn(cast<TypeT>(baseType)); };
     if (typeVerifiers.insert({TypeID::get<TypeT>(), wrapperFn}).second ==
         false) {
       assert(false && "already registered for this type");


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.