### PR TITLE
Drop unnecessary namespaces from cast functions in dialect vm vmvx etc. NFC. 10/10

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -506,7 +506,7 @@ private:
 
     // Find immutable loads.
     for (auto loadOp : funcOp.getOps<IREE::Util::GlobalLoadOpInterface>()) {
-      auto globalOp = llvm::dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
+      auto globalOp = dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
           sourceSymbolTable.lookup(loadOp.getGlobalAttr().getAttr()));
       if (!globalOp || globalOp.isGlobalMutable()) {
         emitDebugWarning(loadOp.getLoc(), [&](InFlightDiagnostic &diagnostic) {
@@ -556,7 +556,7 @@ private:
     // Find immutable stores, early exiting if not supported.
     // The consumers must come after rewrites of the producers above.
     for (auto storeOp : funcOp.getOps<IREE::Util::GlobalStoreOpInterface>()) {
-      auto globalOp = llvm::dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
+      auto globalOp = dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
           sourceSymbolTable.lookup(storeOp.getGlobalAttr().getAttr()));
       assert(globalOp && "should have been checked in isConstExpr");
 

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -34,7 +34,7 @@ LogicalResult handleRuntimeError(Location loc, iree_status_t status,
 LogicalResult convertToElementType(Location loc, Type baseType,
                                    iree_hal_element_type_t *outElementType) {
   Builder builder(loc.getContext());
-  if (auto t = llvm::dyn_cast<IntegerType>(baseType)) {
+  if (auto t = dyn_cast<IntegerType>(baseType)) {
     switch (t.getWidth()) {
     case 32:
       *outElementType = IREE_HAL_ELEMENT_TYPE_INT_32;
@@ -253,8 +253,8 @@ LogicalResult FunctionCall::addBufferViewArgumentAttr(
 }
 
 static ShapedType getAttrShapedType(Attribute attr) {
-  if (auto typedAttr = llvm::dyn_cast<TypedAttr>(attr)) {
-    if (auto shapedType = llvm::dyn_cast<ShapedType>(typedAttr.getType())) {
+  if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (auto shapedType = dyn_cast<ShapedType>(typedAttr.getType())) {
       return shapedType;
     }
   }
@@ -262,18 +262,18 @@ static ShapedType getAttrShapedType(Attribute attr) {
 }
 
 LogicalResult FunctionCall::addArgument(Location loc, Attribute attr) {
-  if (auto elementsAttr = llvm::dyn_cast<ElementsAttr>(attr)) {
+  if (auto elementsAttr = dyn_cast<ElementsAttr>(attr)) {
     return addBufferViewArgumentAttr(
         loc, elementsAttr.getShapedType(),
         cast<IREE::Util::SerializableAttrInterface>(attr));
   } else if (auto serializableAttr =
-                 llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(attr)) {
+                 dyn_cast<IREE::Util::SerializableAttrInterface>(attr)) {
     if (auto shapedType = getAttrShapedType(attr)) {
       return addBufferViewArgumentAttr(loc, shapedType, serializableAttr);
     } else {
       return addBufferArgumentAttr(loc, serializableAttr);
     }
-  } else if (auto integerAttr = llvm::dyn_cast<IntegerAttr>(attr)) {
+  } else if (auto integerAttr = dyn_cast<IntegerAttr>(attr)) {
     iree_vm_value_t value;
     APInt apValue = integerAttr.getValue();
     switch (apValue.getBitWidth()) {
@@ -300,7 +300,7 @@ LogicalResult FunctionCall::addArgument(Location loc, Attribute attr) {
     }
     return handleRuntimeError(loc,
                               iree_vm_list_push_value(inputs.get(), &value));
-  } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(attr)) {
+  } else if (auto floatAttr = dyn_cast<FloatAttr>(attr)) {
     iree_vm_value_t value;
     APFloat apValue = floatAttr.getValue();
     // Note that there are many floating point semantics that LLVM knows

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -304,9 +304,8 @@ LogicalResult RegisterAllocation::recalculate(IREE::VM::FuncOp funcOp) {
       for (auto result : op.getResults()) {
         auto reg = registerUsage.allocateRegister(result.getType());
         if (!reg.has_value()) {
-          return op.emitError()
-                 << "register allocation failed for result "
-                 << llvm::cast<OpResult>(result).getResultNumber();
+          return op.emitError() << "register allocation failed for result "
+                                << cast<OpResult>(result).getResultNumber();
         }
         map_[result] = reg.value();
         if (result.use_empty()) {

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -65,7 +65,7 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
     SmallVector<StringAttr, 8> valueNames;
     for (auto value : values) {
       std::string str;
-      if (auto blockArg = llvm::dyn_cast<BlockArgument>(value)) {
+      if (auto blockArg = dyn_cast<BlockArgument>(value)) {
         if (blockArg.getOwner()->isEntryBlock()) {
           str = llvm::formatv("%arg{}", blockArg.getArgNumber());
         } else {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
@@ -36,8 +36,8 @@ struct ConstantOpConversion : public OpConversionPattern<arith::ConstantOp> {
       return srcOp.emitError() << "could not convert type: " << srcOp.getType()
                                << " (check -iree-vm-target-* options)";
     }
-    if (llvm::isa<IntegerType>(targetType)) {
-      auto integerAttr = llvm::dyn_cast<IntegerAttr>(srcOp.getValue());
+    if (isa<IntegerType>(targetType)) {
+      auto integerAttr = dyn_cast<IntegerAttr>(srcOp.getValue());
       if (!integerAttr) {
         return srcOp.emitRemark() << "unsupported const type for dialect";
       }
@@ -64,8 +64,8 @@ struct ConstantOpConversion : public OpConversionPattern<arith::ConstantOp> {
         return srcOp.emitRemark()
                << "unsupported const integer bit width for dialect";
       }
-    } else if (llvm::isa<FloatType>(targetType)) {
-      auto floatAttr = llvm::dyn_cast<FloatAttr>(srcOp.getValue());
+    } else if (isa<FloatType>(targetType)) {
+      auto floatAttr = dyn_cast<FloatAttr>(srcOp.getValue());
       if (!floatAttr) {
         return srcOp.emitRemark() << "unsupported const type for dialect";
       }
@@ -835,7 +835,7 @@ struct SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
           srcOp, valueType, adaptor.getCondition(), adaptor.getTrueValue(),
           adaptor.getFalseValue());
       return success();
-    } else if (llvm::isa<IREE::VM::RefType>(valueType)) {
+    } else if (isa<IREE::VM::RefType>(valueType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::SelectRefOp>(
           srcOp, valueType, adaptor.getCondition(), adaptor.getTrueValue(),
           adaptor.getFalseValue());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/Patterns.cpp
@@ -30,7 +30,7 @@ class UnaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
   matchAndRewrite(SrcOpTy srcOp, typename SrcOpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // TODO(benvanik): support vectors.
-    if (llvm::isa<VectorType>(srcOp.getResult().getType()))
+    if (isa<VectorType>(srcOp.getResult().getType()))
       return failure();
 
     switch (adaptor.getOperand().getType().getIntOrFloatBitWidth()) {
@@ -57,7 +57,7 @@ class BinaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
   matchAndRewrite(SrcOpTy srcOp, typename SrcOpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // TODO(benvanik): support vectors.
-    if (llvm::isa<VectorType>(srcOp.getResult().getType()))
+    if (isa<VectorType>(srcOp.getResult().getType()))
       return failure();
 
     switch (adaptor.getLhs().getType().getIntOrFloatBitWidth()) {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/Patterns.cpp
@@ -200,7 +200,7 @@ struct ExternalFuncOpConversion : public OpConversionPattern<func::FuncOp> {
     auto signatureAttr = srcOp->getAttrOfType<TypeAttr>("vm.signature");
     if (signatureAttr) {
       // Directly use the signature from the user.
-      newSignature = llvm::dyn_cast<FunctionType>(signatureAttr.getValue());
+      newSignature = dyn_cast<FunctionType>(signatureAttr.getValue());
       if (!newSignature) {
         return rewriter.notifyMatchFailure(srcOp, "invalid vm.signature");
       }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
@@ -105,8 +105,7 @@ TypeConverter::TypeConverter(TargetOptions targetOptions)
 
   addSourceMaterialization([](OpBuilder &builder, IndexType type,
                               ValueRange inputs, Location loc) -> Value {
-    if (inputs.size() != 1 ||
-        !llvm::isa<IntegerType>(inputs.front().getType())) {
+    if (inputs.size() != 1 || !isa<IntegerType>(inputs.front().getType())) {
       return nullptr;
     }
     return arith::IndexCastOp::create(builder, loc, type, inputs.front());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
@@ -86,7 +86,7 @@ struct FixateIndexSizeofConversion
   matchAndRewrite(IREE::Util::SizeOfOp sizeofOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type sizedType = sizeofOp.getSizedType();
-    if (llvm::isa<IndexType>(sizedType)) {
+    if (isa<IndexType>(sizedType)) {
       Type converted = getTypeConverter()->convertType(sizedType);
       if (converted) {
         Value newSizeof = rewriter.createOrFold<IREE::Util::SizeOfOp>(

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertBufferOps.cpp
@@ -176,7 +176,7 @@ struct BufferFillOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto oldType = fillOp.getPattern().getType();
     auto newType = adaptor.getPattern().getType();
-    if (llvm::isa<IndexType>(oldType)) {
+    if (isa<IndexType>(oldType)) {
       // Use the actual converted type for IndexType.
       oldType = newType;
     }
@@ -188,7 +188,7 @@ struct BufferFillOpConversion
     auto elementLength =
         unscaleOffset(fillOp.getLoc(), byteLength, elementSize, rewriter);
     auto pattern = adaptor.getPattern();
-    if (auto integerType = llvm::dyn_cast<IntegerType>(oldType)) {
+    if (auto integerType = dyn_cast<IntegerType>(oldType)) {
       if (integerType.isInteger(1) || integerType.isInteger(8)) {
         rewriter.replaceOpWithNewOp<IREE::VM::BufferFillI8Op>(
             fillOp, adaptor.getTarget(), byteOffset, byteLength, pattern);
@@ -227,14 +227,14 @@ struct BufferLoadOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto oldType = loadOp.getResult().getType();
     auto newType = getTypeConverter()->convertType(oldType);
-    if (llvm::isa<IndexType>(oldType)) {
+    if (isa<IndexType>(oldType)) {
       oldType = newType;
     }
     auto byteOffset = castToI64(adaptor.getSourceOffset(), rewriter);
     int64_t elementSize = IREE::Util::getRoundedElementByteWidth(oldType);
     auto elementOffset =
         unscaleOffset(loadOp.getLoc(), byteOffset, elementSize, rewriter);
-    if (auto integerType = llvm::dyn_cast<IntegerType>(oldType)) {
+    if (auto integerType = dyn_cast<IntegerType>(oldType)) {
       if (integerType.isInteger(1) || integerType.isInteger(8)) {
         if (integerType.isSigned() || integerType.isSignless()) {
           rewriter.replaceOpWithNewOp<IREE::VM::BufferLoadI8SOp>(
@@ -283,7 +283,7 @@ struct BufferStoreOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto oldType = storeOp.getSource().getType();
     auto newType = adaptor.getSource().getType();
-    if (llvm::isa<IndexType>(oldType)) {
+    if (isa<IndexType>(oldType)) {
       oldType = newType;
     }
     auto byteOffset = castToI64(adaptor.getTargetOffset(), rewriter);

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertGlobalOps.cpp
@@ -26,7 +26,7 @@ struct GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
     const bool isInitialized =
         op.getInitialValueAttr() &&
         !isa<IREE::Util::UninitializedAttr>(op.getInitialValueAttr());
-    if (llvm::isa<IREE::VM::RefType>(convertedType) ||
+    if (isa<IREE::VM::RefType>(convertedType) ||
         IREE::VM::RefType::isCompatible(convertedType)) {
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalRefOp>(
           op, op.getSymName(), op.getIsMutable(), convertedType,
@@ -35,7 +35,7 @@ struct GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (isInitialized) {
         convertedValue = rewriter.getI32IntegerAttr(static_cast<int32_t>(
-            llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt()));
+            cast<IntegerAttr>(op.getInitialValue().value()).getInt()));
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI32Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -44,7 +44,7 @@ struct GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (isInitialized) {
         convertedValue = rewriter.getI64IntegerAttr(
-            llvm::cast<IntegerAttr>(op.getInitialValue().value()).getInt());
+            cast<IntegerAttr>(op.getInitialValue().value()).getInt());
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI64Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -53,8 +53,7 @@ struct GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (isInitialized) {
         convertedValue = rewriter.getF32FloatAttr(static_cast<float>(
-            llvm::cast<FloatAttr>(op.getInitialValue().value())
-                .getValueAsDouble()));
+            cast<FloatAttr>(op.getInitialValue().value()).getValueAsDouble()));
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF32Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -63,8 +62,7 @@ struct GlobalOpConversion : public OpConversionPattern<IREE::Util::GlobalOp> {
       std::optional<TypedAttr> convertedValue = std::nullopt;
       if (isInitialized) {
         convertedValue = rewriter.getF64FloatAttr(
-            llvm::cast<FloatAttr>(op.getInitialValue().value())
-                .getValueAsDouble());
+            cast<FloatAttr>(op.getInitialValue().value()).getValueAsDouble());
       }
       newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF64Op>(
           op, op.getSymName(), op.getIsMutable(), convertedType, convertedValue,
@@ -168,7 +166,7 @@ struct GlobalStoreOpConversion
   matchAndRewrite(IREE::Util::GlobalStoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getValue().getType();
-    if (llvm::isa<IREE::VM::RefType>(operandType)) {
+    if (isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::GlobalStoreRefOp>(
           op, adaptor.getValue(), op.getGlobal());
     } else if (operandType.isInteger(32)) {
@@ -199,7 +197,7 @@ struct GlobalStoreIndirectOpConversion
   matchAndRewrite(IREE::Util::GlobalStoreIndirectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getValue().getType();
-    if (llvm::isa<IREE::VM::RefType>(operandType)) {
+    if (isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::GlobalStoreIndirectRefOp>(
           op, adaptor.getValue(), adaptor.getGlobal());
     } else if (operandType.isInteger(32)) {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
@@ -194,8 +194,8 @@ void populateUtilListToVMPatterns(MLIRContext *context,
   typeConverter.addConversion(
       [&typeConverter](IREE::Util::ListType type) -> std::optional<Type> {
         Type elementType;
-        if (llvm::isa<IREE::Util::ObjectType>(type.getElementType()) ||
-            llvm::isa<IREE::Util::VariantType>(type.getElementType())) {
+        if (isa<IREE::Util::ObjectType>(type.getElementType()) ||
+            isa<IREE::Util::VariantType>(type.getElementType())) {
           elementType = IREE::VM::OpaqueType::get(type.getContext());
         } else {
           elementType = typeConverter.convertType(type.getElementType());

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertStructuralOps.cpp
@@ -176,7 +176,7 @@ class ExternalFuncOpConversion
     auto signatureAttr = srcOp->getAttrOfType<TypeAttr>("vm.signature");
     if (signatureAttr) {
       // Directly use the signature from the user.
-      newSignature = llvm::dyn_cast<FunctionType>(signatureAttr.getValue());
+      newSignature = dyn_cast<FunctionType>(signatureAttr.getValue());
       if (!newSignature) {
         return rewriter.notifyMatchFailure(srcOp, "invalid vm.signature");
       }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/Patterns.cpp
@@ -75,7 +75,7 @@ struct CmpEQOpConversion : public OpConversionPattern<IREE::Util::CmpEQOp> {
   matchAndRewrite(IREE::Util::CmpEQOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getLhs().getType();
-    if (llvm::isa<IREE::VM::RefType>(operandType)) {
+    if (isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::CmpEQRefOp>(
           op, rewriter.getI32Type(), adaptor.getLhs(), adaptor.getRhs());
       return success();
@@ -94,7 +94,7 @@ struct CmpNEOpConversion : public OpConversionPattern<IREE::Util::CmpNEOp> {
   matchAndRewrite(IREE::Util::CmpNEOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto operandType = adaptor.getLhs().getType();
-    if (llvm::isa<IREE::VM::RefType>(operandType)) {
+    if (isa<IREE::VM::RefType>(operandType)) {
       rewriter.replaceOpWithNewOp<IREE::VM::CmpNERefOp>(
           op, rewriter.getI32Type(), adaptor.getLhs(), adaptor.getRhs());
       return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -90,7 +90,7 @@ Value asRValue(OpBuilder builder, Location loc,
 void asRValues(OpBuilder builder, Location location,
                SmallVector<Value> &values) {
   for (auto &value : values) {
-    if (auto lvalue = llvm::dyn_cast<TypedValue<emitc::LValueType>>(value)) {
+    if (auto lvalue = dyn_cast<TypedValue<emitc::LValueType>>(value)) {
       value = emitc_builders::asRValue(builder, location, lvalue);
     }
   }
@@ -122,7 +122,7 @@ Value contentsOf(OpBuilder builder, Location location, Value operand) {
   return emitc::ApplyOp::create(
              builder,
              /*location=*/location,
-             /*result=*/llvm::cast<emitc::PointerType>(type).getPointee(),
+             /*result=*/cast<emitc::PointerType>(type).getPointee(),
              /*applicableOperator=*/StringAttr::get(ctx, "*"),
              /*operand=*/operand)
       .getResult();
@@ -246,9 +246,8 @@ structMemberAddress(OpBuilder builder, Location location,
                     TypedValue<emitc::LValueType> operand) {
   auto member = emitc::MemberOp::create(builder, location, type.getPointee(),
                                         memberName, operand);
-  return addressOf(
-      builder, location,
-      llvm::cast<TypedValue<emitc::LValueType>>(member.getResult()));
+  return addressOf(builder, location,
+                   cast<TypedValue<emitc::LValueType>>(member.getResult()));
 }
 
 void structMemberAssign(OpBuilder builder, Location location,
@@ -275,9 +274,8 @@ structPtrMemberAddress(OpBuilder builder, Location location,
   auto member = emitc::MemberOfPtrOp::create(
       builder, location, emitc::LValueType::get(type.getPointee()), memberName,
       operand);
-  return addressOf(
-      builder, location,
-      llvm::cast<TypedValue<emitc::LValueType>>(member.getResult()));
+  return addressOf(builder, location,
+                   cast<TypedValue<emitc::LValueType>>(member.getResult()));
 }
 
 void structPtrMemberAssign(OpBuilder builder, Location location,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -33,7 +33,7 @@ EmitCTypeConverter::EmitCTypeConverter(ModuleOp module)
 Type EmitCTypeConverter::convertTypeAsNonPointer(Type type) const {
   Type convertedType = convertType(type);
 
-  if (auto ptrType = llvm::dyn_cast<emitc::PointerType>(convertedType)) {
+  if (auto ptrType = dyn_cast<emitc::PointerType>(convertedType)) {
     return ptrType.getPointee();
   }
 
@@ -47,11 +47,11 @@ emitc::PointerType EmitCTypeConverter::convertTypeAsPointer(Type type) const {
 emitc::OpaqueType EmitCTypeConverter::convertTypeAsCType(Type type) const {
   Type convertedType = convertTypeAsNonPointer(type);
 
-  if (auto oType = llvm::dyn_cast<emitc::OpaqueType>(convertedType)) {
+  if (auto oType = dyn_cast<emitc::OpaqueType>(convertedType)) {
     return oType;
   }
 
-  if (auto iType = llvm::dyn_cast<IntegerType>(type)) {
+  if (auto iType = dyn_cast<IntegerType>(type)) {
     std::string typeLiteral;
     switch (iType.getWidth()) {
     case 32: {
@@ -68,7 +68,7 @@ emitc::OpaqueType EmitCTypeConverter::convertTypeAsCType(Type type) const {
     return emitc::OpaqueType::get(type.getContext(), typeLiteral);
   }
 
-  if (auto fType = llvm::dyn_cast<FloatType>(type)) {
+  if (auto fType = dyn_cast<FloatType>(type)) {
     std::string typeLiteral;
     switch (fType.getWidth()) {
     case 32: {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -38,14 +38,14 @@ struct VMDialect::VMOpAsmInterface
     SmallString<32> osBuffer;
     llvm::raw_svector_ostream os(osBuffer);
 
-    if (llvm::isa<VectorType>(op->getResult(0).getType())) {
+    if (isa<VectorType>(op->getResult(0).getType())) {
       os << "v";
     }
     if (auto refType =
-            llvm::dyn_cast<IREE::VM::RefType>(op->getResult(0).getType())) {
-      if (llvm::isa<BufferType>(refType.getObjectType())) {
+            dyn_cast<IREE::VM::RefType>(op->getResult(0).getType())) {
+      if (isa<BufferType>(refType.getObjectType())) {
         os << "buffer";
-      } else if (llvm::isa<ListType>(refType.getObjectType())) {
+      } else if (isa<ListType>(refType.getObjectType())) {
         os << "list";
       } else {
         os << "ref";
@@ -224,24 +224,24 @@ Type VMDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void VMDialect::printType(Type type, DialectAsmPrinter &os) const {
-  if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
+  if (auto refType = dyn_cast<IREE::VM::RefType>(type)) {
     auto objectType = refType.getObjectType();
-    if (auto bufferType = llvm::dyn_cast<IREE::VM::BufferType>(objectType)) {
+    if (auto bufferType = dyn_cast<IREE::VM::BufferType>(objectType)) {
       printType(bufferType, os);
-    } else if (auto listType = llvm::dyn_cast<IREE::VM::ListType>(objectType)) {
+    } else if (auto listType = dyn_cast<IREE::VM::ListType>(objectType)) {
       printType(listType, os);
-    } else if (llvm::isa<IREE::VM::OpaqueType>(objectType)) {
+    } else if (isa<IREE::VM::OpaqueType>(objectType)) {
       os << "ref<?>";
     } else {
       os << "ref<" << objectType << ">";
     }
-  } else if (llvm::isa<IREE::VM::OpaqueType>(type)) {
+  } else if (isa<IREE::VM::OpaqueType>(type)) {
     os << "opaque";
-  } else if (llvm::isa<IREE::VM::BufferType>(type)) {
+  } else if (isa<IREE::VM::BufferType>(type)) {
     os << "buffer";
-  } else if (auto listType = llvm::dyn_cast<IREE::VM::ListType>(type)) {
+  } else if (auto listType = dyn_cast<IREE::VM::ListType>(type)) {
     os << "list<";
-    if (llvm::isa<OpaqueType>(listType.getElementType())) {
+    if (isa<OpaqueType>(listType.getElementType())) {
       os << "?";
     } else {
       os << listType.getElementType();
@@ -264,29 +264,29 @@ Operation *VMDialect::materializeConstant(OpBuilder &builder, Attribute value,
 
   if (ConstI32Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstI32Op::convertConstValue(typedValue);
-    if (llvm::cast<IntegerAttr>(convertedValue).getValue() == 0) {
+    if (cast<IntegerAttr>(convertedValue).getValue() == 0) {
       return VM::ConstI32ZeroOp::create(builder, loc);
     }
     return VM::ConstI32Op::create(builder, loc, convertedValue);
   } else if (ConstI64Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstI64Op::convertConstValue(typedValue);
-    if (llvm::cast<IntegerAttr>(convertedValue).getValue() == 0) {
+    if (cast<IntegerAttr>(convertedValue).getValue() == 0) {
       return VM::ConstI64ZeroOp::create(builder, loc);
     }
     return VM::ConstI64Op::create(builder, loc, convertedValue);
   } else if (ConstF32Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstF32Op::convertConstValue(typedValue);
-    if (llvm::cast<FloatAttr>(convertedValue).getValue().isZero()) {
+    if (cast<FloatAttr>(convertedValue).getValue().isZero()) {
       return VM::ConstF32ZeroOp::create(builder, loc);
     }
     return VM::ConstF32Op::create(builder, loc, convertedValue);
   } else if (ConstF64Op::isBuildableWith(typedValue, type)) {
     auto convertedValue = ConstF64Op::convertConstValue(typedValue);
-    if (llvm::cast<FloatAttr>(convertedValue).getValue().isZero()) {
+    if (cast<FloatAttr>(convertedValue).getValue().isZero()) {
       return VM::ConstF64ZeroOp::create(builder, loc);
     }
     return VM::ConstF64Op::create(builder, loc, convertedValue);
-  } else if (llvm::isa<IREE::VM::RefType>(type)) {
+  } else if (isa<IREE::VM::RefType>(type)) {
     // The only constant type we support for refs is null so we can just
     // emit that here.
     // TODO(benvanik): relace unit attr with a proper null ref attr.

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -32,7 +32,7 @@ template <typename NameTy>
 void setResultName(OpAsmSetValueNameFn &setNameFn, Value result, NameTy name) {
   SmallString<32> osBuffer;
   llvm::raw_svector_ostream os(osBuffer);
-  if (llvm::isa<VectorType>(result.getType())) {
+  if (isa<VectorType>(result.getType())) {
     os << "v";
   }
   os << name;
@@ -43,7 +43,7 @@ void setResultIntegerName(OpAsmSetValueNameFn &setNameFn, Value result,
                           IntegerAttr value) {
   SmallString<32> osBuffer;
   llvm::raw_svector_ostream os(osBuffer);
-  if (llvm::isa<VectorType>(result.getType())) {
+  if (isa<VectorType>(result.getType())) {
     os << "v";
   }
   if (!value) {
@@ -138,7 +138,7 @@ Block *FuncOp::addEntryBlock() {
 
 LogicalResult FuncOp::verifyType() {
   auto type = getFunctionTypeAttr().getValue();
-  if (!llvm::isa<FunctionType>(type))
+  if (!isa<FunctionType>(type))
     return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                        "' attribute of function type");
   return success();
@@ -370,7 +370,7 @@ void ImportOp::build(OpBuilder &builder, OperationState &result, StringRef name,
 
 LogicalResult ImportOp::verifyType() {
   auto type = getFunctionTypeAttr().getValue();
-  if (!llvm::isa<FunctionType>(type))
+  if (!isa<FunctionType>(type))
     return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
                        "' attribute of function type");
   return success();
@@ -542,18 +542,18 @@ void GlobalLoadRefOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 template <int SZ>
 static bool isConstIntegerBuildableWith(TypedAttr value, Type type) {
   // FlatSymbolRefAttr can only be used with a function type.
-  if (llvm::isa<FlatSymbolRefAttr>(value)) {
+  if (isa<FlatSymbolRefAttr>(value)) {
     return false;
   }
   // Otherwise, the attribute must have the same type as 'type'.
   if (value.getType() != type) {
     return false;
   }
-  if (llvm::isa<UnitAttr>(value)) {
+  if (isa<UnitAttr>(value)) {
     return SZ == 32; // Conditions/bools are always i32
-  } else if (auto intAttr = llvm::dyn_cast<IntegerAttr>(value)) {
+  } else if (auto intAttr = dyn_cast<IntegerAttr>(value)) {
     return intAttr.getType().isInteger(SZ);
-  } else if (auto elementsAttr = llvm::dyn_cast<ElementsAttr>(value)) {
+  } else if (auto elementsAttr = dyn_cast<ElementsAttr>(value)) {
     return elementsAttr.getShapedType().getElementType().isInteger(SZ);
   }
   return false;
@@ -562,7 +562,7 @@ static bool isConstIntegerBuildableWith(TypedAttr value, Type type) {
 template <int SZ>
 static bool isConstFloatBuildableWith(TypedAttr value, Type type) {
   // FlatSymbolRefAttr can only be used with a function type.
-  if (llvm::isa<FlatSymbolRefAttr>(value)) {
+  if (isa<FlatSymbolRefAttr>(value)) {
     return false;
   }
   // Otherwise, the attribute must have the same type as 'type'.
@@ -570,9 +570,9 @@ static bool isConstFloatBuildableWith(TypedAttr value, Type type) {
     return false;
   }
   Type elementType;
-  if (auto floatAttr = llvm::dyn_cast<FloatAttr>(value)) {
+  if (auto floatAttr = dyn_cast<FloatAttr>(value)) {
     elementType = floatAttr.getType();
-  } else if (auto elementsAttr = llvm::dyn_cast<ElementsAttr>(value)) {
+  } else if (auto elementsAttr = dyn_cast<ElementsAttr>(value)) {
     elementType = elementsAttr.getShapedType().getElementType();
   }
   if (!elementType)
@@ -586,18 +586,18 @@ static TypedAttr convertConstIntegerValue(TypedAttr value) {
   Builder builder(value.getContext());
   auto integerType = builder.getIntegerType(SZ);
   int32_t dims = 1;
-  if (llvm::isa<UnitAttr>(value)) {
+  if (isa<UnitAttr>(value)) {
     return IntegerAttr::get(integerType, APInt(SZ, 1));
-  } else if (auto v = llvm::dyn_cast<BoolAttr>(value)) {
+  } else if (auto v = dyn_cast<BoolAttr>(value)) {
     return IntegerAttr::get(integerType,
                             APInt(SZ, v.getValue() ? 1 : 0, false));
-  } else if (auto v = llvm::dyn_cast<IntegerAttr>(value)) {
+  } else if (auto v = dyn_cast<IntegerAttr>(value)) {
     return IntegerAttr::get(integerType,
                             APInt(SZ, v.getValue().getLimitedValue()));
-  } else if (auto v = llvm::dyn_cast<ElementsAttr>(value)) {
+  } else if (auto v = dyn_cast<ElementsAttr>(value)) {
     dims = v.getNumElements();
     ShapedType adjustedType = VectorType::get({dims}, integerType);
-    if (auto elements = llvm::dyn_cast<SplatElementsAttr>(v)) {
+    if (auto elements = dyn_cast<SplatElementsAttr>(v)) {
       return SplatElementsAttr::get(adjustedType,
                                     elements.getSplatValue<Attribute>());
     } else {
@@ -629,12 +629,12 @@ static TypedAttr convertConstFloatValue(TypedAttr value) {
   Builder builder(value.getContext());
   auto floatType = getFloatType(SZ, value.getContext());
   int32_t dims = 1;
-  if (auto v = llvm::dyn_cast<FloatAttr>(value)) {
+  if (auto v = dyn_cast<FloatAttr>(value)) {
     return FloatAttr::get(floatType, v.getValue());
-  } else if (auto v = llvm::dyn_cast<ElementsAttr>(value)) {
+  } else if (auto v = dyn_cast<ElementsAttr>(value)) {
     dims = v.getNumElements();
     ShapedType adjustedType = VectorType::get({dims}, floatType);
-    if (auto elements = llvm::dyn_cast<SplatElementsAttr>(v)) {
+    if (auto elements = dyn_cast<SplatElementsAttr>(v)) {
       return SplatElementsAttr::get(adjustedType,
                                     elements.getSplatValue<Attribute>());
     } else {
@@ -665,7 +665,7 @@ void ConstI32Op::build(OpBuilder &builder, OperationState &result,
 
 void ConstI32Op::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setResultIntegerName(setNameFn, getResult(),
-                       llvm::dyn_cast<IntegerAttr>(getValue()));
+                       dyn_cast<IntegerAttr>(getValue()));
 }
 
 void ConstI32Op::build(OpBuilder &builder, OperationState &result,
@@ -697,7 +697,7 @@ void ConstI64Op::build(OpBuilder &builder, OperationState &result,
 
 void ConstI64Op::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setResultIntegerName(setNameFn, getResult(),
-                       llvm::dyn_cast<IntegerAttr>(getValue()));
+                       dyn_cast<IntegerAttr>(getValue()));
 }
 
 // static
@@ -904,19 +904,19 @@ void RodataTableInlineOp::build(OpBuilder &builder, OperationState &result,
 
 LogicalResult ListGetRefOp::verify() {
   Operation *op = getOperation();
-  auto listType = llvm::cast<IREE::VM::ListType>(
+  auto listType = cast<IREE::VM::ListType>(
       cast<IREE::VM::RefType>(getList().getType()).getObjectType());
   auto elementType = listType.getElementType();
   auto resultType = getResult().getType();
-  if (!llvm::isa<IREE::VM::OpaqueType>(elementType)) {
-    if (llvm::isa<IREE::VM::RefType>(elementType) !=
-        llvm::isa<IREE::VM::RefType>(resultType)) {
+  if (!isa<IREE::VM::OpaqueType>(elementType)) {
+    if (isa<IREE::VM::RefType>(elementType) !=
+        isa<IREE::VM::RefType>(resultType)) {
       // Attempting to go between a primitive type and ref type.
       return op->emitError()
              << "cannot convert between list type " << elementType
              << " and result type " << resultType;
-    } else if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(elementType)) {
-      if (!llvm::isa<IREE::VM::OpaqueType>(refType.getObjectType()) &&
+    } else if (auto refType = dyn_cast<IREE::VM::RefType>(elementType)) {
+      if (!isa<IREE::VM::OpaqueType>(refType.getObjectType()) &&
           elementType != resultType) {
         // List has a concrete type, verify it matches.
         return op->emitError() << "list contains " << elementType
@@ -929,18 +929,18 @@ LogicalResult ListGetRefOp::verify() {
 
 LogicalResult ListSetRefOp::verify() {
   Operation *op = getOperation();
-  auto listType = llvm::cast<IREE::VM::ListType>(
+  auto listType = cast<IREE::VM::ListType>(
       cast<IREE::VM::RefType>(getList().getType()).getObjectType());
   auto elementType = listType.getElementType();
   auto valueType = getValue().getType();
-  if (!llvm::isa<IREE::VM::OpaqueType>(elementType)) {
-    if (llvm::isa<IREE::VM::RefType>(elementType) !=
-        llvm::isa<IREE::VM::RefType>(valueType)) {
+  if (!isa<IREE::VM::OpaqueType>(elementType)) {
+    if (isa<IREE::VM::RefType>(elementType) !=
+        isa<IREE::VM::RefType>(valueType)) {
       // Attempting to go between a primitive type and ref type.
       return op->emitError() << "cannot convert between list type "
                              << elementType << " and value type " << valueType;
-    } else if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(elementType)) {
-      if (!llvm::isa<IREE::VM::OpaqueType>(refType.getObjectType()) &&
+    } else if (auto refType = dyn_cast<IREE::VM::RefType>(elementType)) {
+      if (!isa<IREE::VM::OpaqueType>(refType.getObjectType()) &&
           elementType != valueType) {
         // List has a concrete type, verify it matches.
         return op->emitError() << "list contains " << elementType
@@ -1229,7 +1229,7 @@ ParseResult CallVariadicOp::parse(OpAsmParser &parser, OperationState &result) {
     bool isVariadic = succeeded(parser.parseOptionalEllipsis());
     if (isVariadic) {
       int flatSegmentSize = flatSegmentSizes[segmentIndex];
-      if (auto tupleType = llvm::dyn_cast<TupleType>(operandType)) {
+      if (auto tupleType = dyn_cast<TupleType>(operandType)) {
         for (int i = 0; i < flatSegmentSize / tupleType.size(); ++i) {
           for (auto type : tupleType) {
             flatOperandTypes.push_back(type);
@@ -1271,7 +1271,7 @@ ParseResult CallVariadicOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addAttribute("segment_types",
                       parser.getBuilder().getArrayAttr(
                           llvm::map_to_vector(segmentTypes, [&](Type type) {
-                            return llvm::cast<Attribute>(TypeAttr::get(type));
+                            return cast<Attribute>(TypeAttr::get(type));
                           })));
 
   if (failed(parser.parseOptionalArrowTypeList(result.types))) {
@@ -1291,12 +1291,12 @@ void CallVariadicOp::print(OpAsmPrinter &p) {
       [&](std::tuple<APInt, Attribute> segmentSizeType) {
         int segmentSize = std::get<0>(segmentSizeType).getSExtValue();
         Type segmentType =
-            llvm::cast<TypeAttr>(std::get<1>(segmentSizeType)).getValue();
+            cast<TypeAttr>(std::get<1>(segmentSizeType)).getValue();
         if (segmentSize == -1) {
           p.printOperand(getOperand(operand++));
         } else {
           p << '[';
-          if (auto tupleType = llvm::dyn_cast<TupleType>(segmentType)) {
+          if (auto tupleType = dyn_cast<TupleType>(segmentType)) {
             for (size_t i = 0; i < segmentSize; ++i) {
               p << '(';
               SmallVector<Value> tupleOperands;
@@ -1330,7 +1330,7 @@ void CallVariadicOp::print(OpAsmPrinter &p) {
       [&](std::tuple<APInt, Attribute> segmentSizeType) {
         int segmentSize = std::get<0>(segmentSizeType).getSExtValue();
         Type segmentType =
-            llvm::cast<TypeAttr>(std::get<1>(segmentSizeType)).getValue();
+            cast<TypeAttr>(std::get<1>(segmentSizeType)).getValue();
         if (segmentSize == -1) {
           p.printType(segmentType);
         } else {
@@ -1424,7 +1424,7 @@ SuccessorOperands BranchTableOp::getSuccessorOperands(unsigned index) {
 
 Block *BranchTableOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
   SuccessorRange caseDestinations = getCaseDestinations();
-  if (auto valueAttr = llvm::dyn_cast_or_null<IntegerAttr>(operands.front())) {
+  if (auto valueAttr = dyn_cast_or_null<IntegerAttr>(operands.front())) {
     int64_t value = valueAttr.getValue().getSExtValue();
     if (value < 0 || value >= caseDestinations.size())
       return getDefaultDestination();

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -47,10 +47,10 @@ struct ListTypeStorage : public TypeStorage {
 
 // static
 bool ListType::isCompatible(Type type) {
-  if (llvm::isa<OpaqueType>(type)) {
+  if (isa<OpaqueType>(type)) {
     // Allow all types (variant).
     return true;
-  } else if (llvm::isa<RefType>(type)) {
+  } else if (isa<RefType>(type)) {
     // Allow all ref types.
     return true;
   } else if (type.isIntOrFloat()) {
@@ -83,7 +83,7 @@ Type ListType::getElementType() { return getImpl()->elementType; }
 namespace detail {
 
 struct RefTypeStorage : public TypeStorage {
-  RefTypeStorage(Type objectType) : objectType(llvm::cast<Type>(objectType)) {}
+  RefTypeStorage(Type objectType) : objectType(cast<Type>(objectType)) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;
@@ -102,11 +102,10 @@ struct RefTypeStorage : public TypeStorage {
 
 // static
 bool RefType::isCompatible(Type type) {
-  if (llvm::isa<RefType>(type)) {
+  if (isa<RefType>(type)) {
     // Already a ref - don't double-wrap.
     return false;
-  } else if (type.isSignlessIntOrIndexOrFloat() ||
-             llvm::isa<ComplexType>(type)) {
+  } else if (type.isSignlessIntOrIndexOrFloat() || isa<ComplexType>(type)) {
     // Ignore known primitive types.
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -72,7 +72,7 @@ public:
   }
 
   LogicalResult encodeType(Value value) override {
-    auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(value.getType());
+    auto refPtrType = dyn_cast<IREE::VM::RefType>(value.getType());
     if (!refPtrType) {
       return currentOp_->emitOpError()
              << "type " << value.getType()
@@ -83,8 +83,8 @@ public:
 
   LogicalResult encodeType(Type type) override {
     // HACK: it'd be nice to remove the implicit ref wrapper hiding.
-    if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
-      if (llvm::isa<IREE::VM::ListType>(refType.getObjectType())) {
+    if (auto refType = dyn_cast<IREE::VM::RefType>(type)) {
+      if (isa<IREE::VM::ListType>(refType.getObjectType())) {
         type = refType.getObjectType();
       }
     }
@@ -100,7 +100,7 @@ public:
 
   LogicalResult encodePrimitiveAttr(TypedAttr attr) override {
     unsigned int bitWidth = attr.getType().getIntOrFloatBitWidth();
-    if (auto integerAttr = llvm::dyn_cast<IntegerAttr>(attr)) {
+    if (auto integerAttr = dyn_cast<IntegerAttr>(attr)) {
       uint64_t limitedValue =
           integerAttr.getValue().extractBitsAsZExtValue(bitWidth, 0);
       switch (bitWidth) {
@@ -116,7 +116,7 @@ public:
         return currentOp_->emitOpError()
                << "attribute of bitwidth " << bitWidth << " not supported";
       }
-    } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(attr)) {
+    } else if (auto floatAttr = dyn_cast<FloatAttr>(attr)) {
       switch (bitWidth) {
       case 32: {
         union {

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -104,7 +104,7 @@ serializeEmbeddedData(Location loc, Attribute valueAttr, uint64_t alignment,
     return {};
   }
 
-  auto value = llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(valueAttr);
+  auto value = dyn_cast<IREE::Util::SerializableAttrInterface>(valueAttr);
   assert(value && "expected a serializable rodata value");
 
   // Reserve memory in the FlatBuffer for the data.
@@ -649,8 +649,8 @@ translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
   SmallVector<RodataRef> rodataRefs;
   rodataRefs.resize(rodataOps.size());
   for (auto &rodataOp : rodataOps) {
-    auto rodataValue = llvm::dyn_cast<IREE::Util::SerializableAttrInterface>(
-        rodataOp.getValue());
+    auto rodataValue =
+        dyn_cast<IREE::Util::SerializableAttrInterface>(rodataOp.getValue());
     assert(rodataValue && "expected a serializable rodata value");
 
     // Split large rodata out of the FlatBuffer to avoid going over 2GB.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -162,7 +162,7 @@ class GlobalInitializationPass
     // Phase 1: Initialize all globals with initial values.
     // This ensures all globals reach a valid state before any initializers run.
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
-      if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
+      if (isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
         if (failed(appendRefInitialization(globalOp, initBuilder))) {
           globalOp.emitOpError() << "ref-type global unable to be initialized";
           return signalPassFailure();
@@ -232,7 +232,7 @@ class GlobalInitializationPass
   // Returns {} if the constant is zero.
   std::pair<LogicalResult, Value> createConst(Location loc, Attribute value,
                                               OpBuilder &builder) {
-    if (auto integerAttr = llvm::dyn_cast<IntegerAttr>(value)) {
+    if (auto integerAttr = dyn_cast<IntegerAttr>(value)) {
       if (integerAttr.getValue().isZero()) {
         // Globals are zero-initialized by default.
         return {success(), {}};
@@ -247,7 +247,7 @@ class GlobalInitializationPass
       default:
         return {failure(), {}};
       }
-    } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(value)) {
+    } else if (auto floatAttr = dyn_cast<FloatAttr>(value)) {
       if (floatAttr.getValue().isZero()) {
         // Globals are zero-initialized by default.
         return {success(), {}};
@@ -269,7 +269,7 @@ class GlobalInitializationPass
   // Stores a value to a global; the global must be mutable.
   LogicalResult storePrimitiveGlobal(Location loc, StringRef symName,
                                      Value value, OpBuilder &builder) {
-    if (auto integerType = llvm::dyn_cast<IntegerType>(value.getType())) {
+    if (auto integerType = dyn_cast<IntegerType>(value.getType())) {
       switch (integerType.getIntOrFloatBitWidth()) {
       case 32:
         IREE::VM::GlobalStoreI32Op::create(builder, loc, value, symName);
@@ -280,7 +280,7 @@ class GlobalInitializationPass
       default:
         return failure();
       }
-    } else if (auto floatType = llvm::dyn_cast<FloatType>(value.getType())) {
+    } else if (auto floatType = dyn_cast<FloatType>(value.getType())) {
       switch (floatType.getIntOrFloatBitWidth()) {
       case 32:
         IREE::VM::GlobalStoreF32Op::create(builder, loc, value, symName);

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -64,7 +64,7 @@ class OrdinalAllocationPass
       } else if (isa<RodataOp>(op)) {
         ordinal = nextRodataOrdinal++;
       } else if (auto globalOp = dyn_cast<IREE::Util::GlobalOpInterface>(op)) {
-        if (llvm::isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
+        if (isa<IREE::VM::RefType>(globalOp.getGlobalType())) {
           ordinal = nextGlobalRefOrdinal++;
         } else {
           // Bucket the primitive global ops (like vm.global.i32) by byte size

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ReifyRodataTables.cpp
@@ -32,8 +32,7 @@ static void reifyRodataTable(RewriterBase &rewriter,
   size_t dataAlignment =
       tableOp.getDataAlignment() ? *tableOp.getDataAlignment() : 1;
   for (auto value : tableOp.getDataArray().getValue()) {
-    auto serializableAttr =
-        llvm::cast<IREE::Util::SerializableAttrInterface>(value);
+    auto serializableAttr = cast<IREE::Util::SerializableAttrInterface>(value);
     size_t storageSize = serializableAttr.getStorageSize();
     dataAttrs.push_back(value);
 

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/ResolveRodataLoads.cpp
@@ -127,9 +127,9 @@ class ResolveRodataLoadsPass
     // loads/stores to the globals and leaves the globals for SymbolDCE.
     DenseSet<Operation *> deadOps;
     explorer.forEachGlobal([&](const Explorer::GlobalInfo *globalInfo) {
-      if (auto refType = llvm::dyn_cast<IREE::VM::RefType>(
-              globalInfo->op.getGlobalType())) {
-        if (llvm::isa<IREE::VM::BufferType>(refType.getObjectType())) {
+      if (auto refType =
+              dyn_cast<IREE::VM::RefType>(globalInfo->op.getGlobalType())) {
+        if (isa<IREE::VM::BufferType>(refType.getObjectType())) {
           processBufferGlobal(explorer, globalInfo, deadOps);
         }
       }

--- a/compiler/src/iree/compiler/Dialect/VM/Utils/CallingConvention.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Utils/CallingConvention.cpp
@@ -23,10 +23,10 @@ namespace mlir::iree_compiler::IREE::VM {
 //  tuple<i32, i64>  -> iI
 LogicalResult encodeCallingConventionType(Operation *op, Type type,
                                           SmallVectorImpl<char> &s) {
-  if (auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
+  if (auto refPtrType = dyn_cast<IREE::VM::RefType>(type)) {
     s.push_back('r');
     return success();
-  } else if (auto integerType = llvm::dyn_cast<IntegerType>(type)) {
+  } else if (auto integerType = dyn_cast<IntegerType>(type)) {
     switch (integerType.getIntOrFloatBitWidth()) {
     default:
     case 32:
@@ -36,7 +36,7 @@ LogicalResult encodeCallingConventionType(Operation *op, Type type,
       s.push_back('I');
       return success();
     }
-  } else if (auto floatType = llvm::dyn_cast<FloatType>(type)) {
+  } else if (auto floatType = dyn_cast<FloatType>(type)) {
     switch (floatType.getIntOrFloatBitWidth()) {
     default:
     case 32:
@@ -46,7 +46,7 @@ LogicalResult encodeCallingConventionType(Operation *op, Type type,
       s.push_back('F');
       return success();
     }
-  } else if (auto tupleType = llvm::dyn_cast<TupleType>(type)) {
+  } else if (auto tupleType = dyn_cast<TupleType>(type)) {
     // Flatten tuple (so tuple<i32, i64> -> `...iI...`).
     SmallVector<Type> flattenedTypes;
     tupleType.getFlattenedTypes(flattenedTypes);

--- a/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Utils/TypeTable.cpp
@@ -14,7 +14,7 @@ std::vector<TypeDef> buildTypeTable(IREE::VM::ModuleOp moduleOp) {
   llvm::DenseMap<Type, std::string> typeMap;
   std::function<void(Type)> tryInsertType;
   tryInsertType = [&](Type type) {
-    if (auto refPtrType = llvm::dyn_cast<IREE::VM::RefType>(type)) {
+    if (auto refPtrType = dyn_cast<IREE::VM::RefType>(type)) {
       type = refPtrType.getObjectType();
     }
     if (typeMap.count(type))
@@ -24,7 +24,7 @@ std::vector<TypeDef> buildTypeTable(IREE::VM::ModuleOp moduleOp) {
     type.print(sstream);
     sstream.flush();
     typeMap.try_emplace(type, str);
-    if (auto listType = llvm::dyn_cast<IREE::VM::ListType>(type)) {
+    if (auto listType = dyn_cast<IREE::VM::ListType>(type)) {
       assert(listType.getElementType());
       tryInsertType(listType.getElementType());
     }

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -218,8 +218,8 @@ struct ConvertGetRawInterfaceBindingBufferOp
            "entry point not conforming to requirements");
 
     IndexSet indexSet(op.getLoc(), rewriter);
-    auto bindingType = llvm::cast<IREE::Util::ListType>(bindingsArg.getType())
-                           .getElementType();
+    auto bindingType =
+        cast<IREE::Util::ListType>(bindingsArg.getType()).getElementType();
     rewriter
         .replaceOpWithNewOp<IREE::Util::ListGetOp>(
             op, bindingType, bindingsArg,
@@ -245,8 +245,8 @@ struct ConvertHALInterfaceBindingSubspanOp
            "entry point not conforming to requirements");
 
     IndexSet indexSet(op.getLoc(), rewriter);
-    auto bindingType = llvm::cast<IREE::Util::ListType>(bindingsArg.getType())
-                           .getElementType();
+    auto bindingType =
+        cast<IREE::Util::ListType>(bindingsArg.getType()).getElementType();
     auto sourceBuffer = IREE::Util::ListGetOp::create(
                             rewriter, op.getLoc(), bindingType, bindingsArg,
                             rewriter.createOrFold<arith::ConstantIndexOp>(
@@ -260,7 +260,7 @@ struct ConvertHALInterfaceBindingSubspanOp
 
       // Compute the dest size by multiplying the element size by all extents
       // (static and dynamic).
-      auto memRefType = llvm::cast<MemRefType>(op.getResult().getType());
+      auto memRefType = cast<MemRefType>(op.getResult().getType());
       Value destSize = rewriter.createOrFold<IREE::Util::SizeOfOp>(
           op.getLoc(), memRefType.getElementType());
       auto dynamicExtentIt = adaptor.getDynamicDims().begin();

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
@@ -91,13 +91,13 @@ protected:
 
   std::string getTypedTypeStr(Type type, bool forceUnsigned = false) const {
     Type elementType = type;
-    auto shapedType = llvm::dyn_cast<ShapedType>(type);
+    auto shapedType = dyn_cast<ShapedType>(type);
     if (shapedType) {
       elementType = shapedType.getElementType();
     }
 
     std::string typePrefix = "x";
-    if (llvm::isa<FloatType>(elementType)) {
+    if (isa<FloatType>(elementType)) {
       typePrefix = "f";
     } else if (elementType.isSignlessInteger()) {
       typePrefix = forceUnsigned ? "u" : "i";

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
@@ -76,9 +76,9 @@ public:
                                 return loadOp.getLoc();
                               }));
       auto globalType = loadOps.front().getType();
-      auto globalName = (kConstantBlockGlobalPrefix +
-                         llvm::cast<StringAttr>(keyAttr).getValue())
-                            .str();
+      auto globalName =
+          (kConstantBlockGlobalPrefix + cast<StringAttr>(keyAttr).getValue())
+              .str();
 
       // Placeholder ordinal that'll be updated during linking.
       auto ordinalGlobalOp = IREE::Util::GlobalOp::create(

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -100,7 +100,7 @@ getStridesFromSizes(RewriterBase &rewriter, Location loc,
 static FailureOr<DescriptorInfo> resolveBufferDescriptorForInterfaceBinding(
     IREE::HAL::InterfaceBindingSubspanOp binding, RewriterBase &rewriter,
     Location loc) {
-  auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
+  auto memRefType = cast<MemRefType>(binding.getResult().getType());
   int rank = memRefType.getRank();
   DescriptorInfo resultDescriptor;
 
@@ -135,7 +135,7 @@ resolveBufferDescriptorForAllocation(memref::AllocaOp alloca,
   //   offset: byte offset from subspan divided by element type size
   //   sizes: static and dynamic sizes from the subspan
   //   strides: identity strides
-  auto memRefType = llvm::cast<MemRefType>(alloca.getResult().getType());
+  auto memRefType = cast<MemRefType>(alloca.getResult().getType());
   int rank = memRefType.getRank();
 
   // Compute sizes.
@@ -169,7 +169,7 @@ resolveBufferDescriptorForGetGlobalOp(memref::GetGlobalOp global,
   //   offset: byte offset from subspan divided by element type size
   //   sizes: static and dynamic sizes from the subspan
   //   strides: identity strides
-  auto memRefType = llvm::cast<MemRefType>(global.getResult().getType());
+  auto memRefType = cast<MemRefType>(global.getResult().getType());
   int rank = memRefType.getRank();
 
   // Compute sizes.
@@ -236,9 +236,9 @@ struct FromMemRefSubView : public OpRewritePattern<GetBufferDescriptorOp> {
     IndexSet indexSet(loc, rewriter);
 
     // Get types.
-    auto subType = llvm::cast<MemRefType>(subview.getResult().getType());
+    auto subType = cast<MemRefType>(subview.getResult().getType());
     Value source = subview.getSource();
-    auto sourceType = llvm::cast<MemRefType>(source.getType());
+    auto sourceType = cast<MemRefType>(source.getType());
     int sourceRank = sourceType.getRank();
     int subRank = subType.getRank();
     (void)subRank;
@@ -381,7 +381,7 @@ struct FromAllocation : public OpRewritePattern<GetBufferDescriptorOp> {
     auto alloca = op.getSource().template getDefiningOp<memref::AllocaOp>();
     if (!alloca)
       return failure();
-    auto memRefType = llvm::cast<MemRefType>(alloca.getResult().getType());
+    auto memRefType = cast<MemRefType>(alloca.getResult().getType());
     if (!memRefType.getLayout().isIdentity()) {
       return rewriter.notifyMatchFailure(op, "not identity allocation");
     }
@@ -415,7 +415,7 @@ struct FromGlobal : public OpRewritePattern<GetBufferDescriptorOp> {
     auto global = op.getSource().template getDefiningOp<memref::GetGlobalOp>();
     if (!global)
       return failure();
-    auto memRefType = llvm::cast<MemRefType>(global.getResult().getType());
+    auto memRefType = cast<MemRefType>(global.getResult().getType());
     if (!memRefType.getLayout().isIdentity()) {
       return rewriter.notifyMatchFailure(op, "not identity allocation");
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/Convert1X1FilterConv2DToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Convert1X1FilterConv2DToMatmul.cpp
@@ -27,7 +27,7 @@ public:
 
   LogicalResult matchAndRewrite(Conv2DOpType convOp,
                                 PatternRewriter &rewriter) const override {
-    auto filterShapeType = llvm::dyn_cast<RankedTensorType>(
+    auto filterShapeType = dyn_cast<RankedTensorType>(
         convOp.getDpsInputOperand(1)->get().getType());
     if (!filterShapeType)
       return failure();

--- a/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
@@ -61,7 +61,7 @@ struct DetachElementwisePattern
       // If not linalg op, or is a fill op, do nothing.
       return failure();
     }
-    auto outputType = llvm::cast<RankedTensorType>(outputOperand.getType());
+    auto outputType = cast<RankedTensorType>(outputOperand.getType());
     if (!outputType.getElementType().isIntOrFloat())
       return failure();
     auto elementType = outputType.getElementType();
@@ -102,7 +102,7 @@ struct DetachElementwisePattern
         ValueRange{linalgOp->getResult(0), outputOperand}, fill, maps,
         iterators, [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
           Value result;
-          if (llvm::isa<FloatType>(elementType)) {
+          if (isa<FloatType>(elementType)) {
             result = arith::AddFOp::create(b, nestedLoc, args[0], args[1]);
           } else {
             result = arith::AddIOp::create(b, nestedLoc, args[0], args[1]);
@@ -143,11 +143,11 @@ struct DetachSplatConstantOutsOperands
         continue;
 
       auto resultType =
-          llvm::dyn_cast<RankedTensorType>(constOp.getResult().getType());
+          dyn_cast<RankedTensorType>(constOp.getResult().getType());
       if (!resultType || !resultType.getElementType().isIntOrFloat())
         continue;
 
-      auto attr = llvm::dyn_cast<ElementsAttr>(constOp.getValue());
+      auto attr = dyn_cast<ElementsAttr>(constOp.getValue());
       if (!attr || !attr.isSplat())
         continue;
 
@@ -156,7 +156,7 @@ struct DetachSplatConstantOutsOperands
       Value emptyTensorOp = tensor::EmptyOp::create(
           rewriter, loc, resultType.getShape(), elementType);
       TypedAttr constValue;
-      if (llvm::isa<IntegerType>(elementType)) {
+      if (isa<IntegerType>(elementType)) {
         constValue = rewriter.getIntegerAttr(
             elementType, attr.template getSplatValue<APInt>());
       } else {

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -50,7 +50,7 @@ struct ExpandedGlobal {
 using ExpandedGlobalMap = DenseMap<StringRef, ExpandedGlobal>;
 
 static bool isDynamicTensor(Type type) {
-  if (auto tensorType = llvm::dyn_cast<RankedTensorType>(type)) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
     return !tensorType.hasStaticShape();
   }
   return false;
@@ -81,7 +81,7 @@ static ExpandedGlobalMap expandGlobalTensorDims(Operation *rootOp,
     OpBuilder builder(global.tensorOp);
     builder.setInsertionPointAfter(global.tensorOp);
 
-    auto tensorType = llvm::cast<RankedTensorType>(global.tensorOp.getType());
+    auto tensorType = cast<RankedTensorType>(global.tensorOp.getType());
     for (auto it : llvm::enumerate(tensorType.getShape())) {
       if (ShapedType::isDynamic(it.value())) {
         auto dimName =
@@ -112,7 +112,7 @@ static bool usesDynamicTensors(Operation *op) {
 
 static void expandType(Type type, SmallVectorImpl<Type> &newTypes) {
   newTypes.push_back(type);
-  if (auto tensorType = llvm::dyn_cast<RankedTensorType>(type)) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
     newTypes.append(tensorType.getNumDynamicDims(),
                     IndexType::get(type.getContext()));
   }
@@ -218,7 +218,7 @@ static void expandRegion(Region &region, SymbolTable &symbolTable,
     SmallVector<ExpandedValue> expansions;
     for (int i = block.getNumArguments() - 1; i >= 0; --i) {
       auto arg = block.getArgument(i);
-      auto tensorType = llvm::dyn_cast<RankedTensorType>(arg.getType());
+      auto tensorType = dyn_cast<RankedTensorType>(arg.getType());
       if (!tensorType || tensorType.hasStaticShape())
         continue;
       ExpandedValue expandedValue;
@@ -271,7 +271,7 @@ static void retieResults(Operation *op, Operation *newOp,
   unsigned newIdx = 0;
   for (unsigned oldIdx = 0; oldIdx < op->getNumResults(); ++oldIdx) {
     auto oldResult = op->getResult(oldIdx);
-    auto tensorType = llvm::dyn_cast<RankedTensorType>(oldResult.getType());
+    auto tensorType = dyn_cast<RankedTensorType>(oldResult.getType());
     if (!tensorType || tensorType.hasStaticShape()) {
       auto newResult = newOp->getResult(newIdx++);
       oldResult.replaceAllUsesWith(newResult);

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
@@ -140,15 +140,13 @@ static LogicalResult isGroupedDequantizationOp(linalg::GenericOp genericOp) {
   // Ensure that the dequantization increases the
   // bitwidth from the input to the output
   auto elementTypeOut =
-      llvm::cast<ShapedType>(genericOp.getOutputs()[0].getType())
-          .getElementType();
+      cast<ShapedType>(genericOp.getOutputs()[0].getType()).getElementType();
   if (!elementTypeOut.isIntOrFloat()) {
     return failure();
   }
   unsigned bitWidthOut = elementTypeOut.getIntOrFloatBitWidth();
   auto elementTypeIn =
-      llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-          .getElementType();
+      cast<ShapedType>(genericOp.getInputs()[0].getType()).getElementType();
   if (!elementTypeIn.isIntOrFloat()) {
     return failure();
   }
@@ -286,7 +284,7 @@ LogicalResult QuantizedMatmulRewriter::precondition() {
   OpOperand *unquantizedInputOperand = ins[1];
   Value unquantizedInput = ins[1]->get();
   RankedTensorType unquantizedInputType =
-      llvm::cast<RankedTensorType>(unquantizedInput.getType());
+      cast<RankedTensorType>(unquantizedInput.getType());
   SmallVector<int64_t> unquantizedInputShape(unquantizedInputType.getShape());
   AffineMap indexingMap =
       matmul.getMatchingIndexingMap(unquantizedInputOperand);
@@ -322,8 +320,8 @@ LogicalResult QuantizedMatmulRewriter::precondition() {
   OpOperand *matmulDequantizedOperand = ins[4];
   auto matmulDequantizedInputExprs =
       matmul.getMatchingIndexingMap(matmulDequantizedOperand).getResults();
-  auto scalesType = llvm::dyn_cast<RankedTensorType>(scales.getType());
-  auto zpsType = llvm::dyn_cast<RankedTensorType>(zps.getType());
+  auto scalesType = dyn_cast<RankedTensorType>(scales.getType());
+  auto zpsType = dyn_cast<RankedTensorType>(zps.getType());
   if (!scalesType || !zpsType) {
     return rewriter.notifyMatchFailure(
         dequant, "expected scales and zero points to have RankedTensorType");
@@ -348,7 +346,7 @@ std::pair<SmallVector<AffineMap>, SmallVector<utils::IteratorType>>
 QuantizedMatmulRewriter::getGroupReductionMapsAndIterators(
     OpOperand *inputOperand) {
   Value input = inputOperand->get();
-  RankedTensorType inputType = llvm::cast<RankedTensorType>(input.getType());
+  RankedTensorType inputType = cast<RankedTensorType>(input.getType());
   SmallVector<int64_t> inputShape(inputType.getShape());
   AffineMap indexingMap = matmul.getMatchingIndexingMap(inputOperand);
   SmallVector<utils::IteratorType> matmulIteratorTypes =
@@ -382,7 +380,7 @@ QuantizedMatmulRewriter::getGroupReductionMapsAndIterators(
 
 // Helper to create an init Value for reductions along the group dimension.
 Value QuantizedMatmulRewriter::getGroupReductionInit(Value input) {
-  RankedTensorType inputType = llvm::cast<RankedTensorType>(input.getType());
+  RankedTensorType inputType = cast<RankedTensorType>(input.getType());
   assert(isa<FloatType>(inputType.getElementType()) && "expected float type");
   Value zero = arith::ConstantOp::create(
       rewriter, loc, rewriter.getFloatAttr(inputType.getElementType(), 0.0));
@@ -419,7 +417,7 @@ Value QuantizedMatmulRewriter::generateGroupMaxGeneric() {
 // Creates a generic that computes the scales for each group, and
 // returns the result.
 Value QuantizedMatmulRewriter::generateScalesGeneric(Value groupMax) {
-  auto groupMaxType = llvm::cast<RankedTensorType>(groupMax.getType());
+  auto groupMaxType = cast<RankedTensorType>(groupMax.getType());
   assert(isa<FloatType>(groupMaxType.getElementType()) &&
          "expected float type");
   Value cst = arith::ConstantOp::create(
@@ -468,8 +466,7 @@ SmallVector<Value> QuantizedMatmulRewriter::generateQuantizationGenerics() {
   OpOperand *unquantizedInputOperand = ins[1];
   Value unquantizedInput = unquantizedInputOperand->get();
 
-  auto unquantizedType =
-      llvm::cast<RankedTensorType>(unquantizedInput.getType());
+  auto unquantizedType = cast<RankedTensorType>(unquantizedInput.getType());
   SmallVector<int64_t> unquantizedShape(unquantizedType.getShape());
 
   IntegerType quantizedElementType = rewriter.getIntegerType(quantizedBitWidth);
@@ -529,12 +526,11 @@ linalg::GenericOp QuantizedMatmulRewriter::generateQuantizedMatmulGeneric(
                                 outputExprs.front().getContext()));
 
   SmallVector<int64_t> newQuantizedInputShape(
-      llvm::cast<RankedTensorType>(newQuantizedInput.getType()).getShape());
+      cast<RankedTensorType>(newQuantizedInput.getType()).getShape());
   assert(newQuantizedInputShape.size() >= 2 &&
          "expected new quantized input to have a rank of at least 2");
   SmallVector<int64_t> outputShape(
-      llvm::cast<RankedTensorType>(matmulOutputOperand->get().getType())
-          .getShape());
+      cast<RankedTensorType>(matmulOutputOperand->get().getType()).getShape());
   outputShape.push_back(
       newQuantizedInputShape[newQuantizedInputShape.size() - 2]);
   Value zero = arith::ConstantOp::create(rewriter, loc,
@@ -602,9 +598,8 @@ QuantizedMatmulRewriter::generateReassociatedDequantizationGeneric(
     auto exprsRef =
         matmul.getMatchingIndexingMap(matmulDequantizedOperand).getResults();
     SmallVector<AffineExpr> exprs(exprsRef.slice(0, exprsRef.size() - 1));
-    RankedTensorType scalesType =
-        llvm::cast<RankedTensorType>(scales.getType());
-    RankedTensorType zpsType = llvm::cast<RankedTensorType>(zps.getType());
+    RankedTensorType scalesType = cast<RankedTensorType>(scales.getType());
+    RankedTensorType zpsType = cast<RankedTensorType>(zps.getType());
     if (exprs.size() < scalesType.getShape().size() &&
         scalesType.getShape().back() == 1 && zpsType.getShape().back() == 1) {
       exprs.push_back(rewriter.getAffineConstantExpr(0));
@@ -797,11 +792,11 @@ void FuseDequantizationMatmulPass::runOnOperation() {
     OpOperand *rhs = genericOp.getDpsInputOperand(1);
     auto lhsOp = lhs->get().getDefiningOp<linalg::GenericOp>();
     auto rhsOp = rhs->get().getDefiningOp<linalg::GenericOp>();
-    if (!llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
+    if (!cast<ShapedType>(genericOp.getInputs()[0].getType())
              .hasStaticShape() ||
-        !llvm::cast<ShapedType>(genericOp.getInputs()[1].getType())
+        !cast<ShapedType>(genericOp.getInputs()[1].getType())
              .hasStaticShape() ||
-        !llvm::cast<ShapedType>(genericOp.getResults()[0].getType())
+        !cast<ShapedType>(genericOp.getResults()[0].getType())
              .hasStaticShape()) {
       // Codegen can't handle the dynamic case yet.
       continue;

--- a/compiler/src/iree/compiler/GlobalOptimization/InferNumericNarrowing.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/InferNumericNarrowing.cpp
@@ -88,7 +88,7 @@ class InferNumericNarrowingPass
   SmallPtrSet<Value, 8> collectProbePoints() {
     SmallPtrSet<Value, 8> probePoints;
     getOperation()->walk([&](Operation *op) {
-      if (auto linalgOp = llvm::dyn_cast<linalg::LinalgOp>(op)) {
+      if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
         for (Value input : linalgOp.getDpsInputs()) {
           probePoints.insert(input);
         }

--- a/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Interfaces/HoistableTypeInterface.cpp
@@ -32,13 +32,13 @@ struct HoistableTensorTypeInterface
     : public IREE::Util::HoistableTypeInterface::ExternalModel<
           HoistableTensorTypeInterface, RankedTensorType> {
   bool isHoistableType(Type type) const {
-    auto tensorType = llvm::cast<RankedTensorType>(type);
+    auto tensorType = cast<RankedTensorType>(type);
     unsigned bitWidth =
         IREE::Util::getTypeBitWidth(tensorType.getElementType());
     return llvm::isPowerOf2_32(bitWidth) && bitWidth <= 64;
   }
   bool isHoistableLeafType(Type type) const {
-    auto tensorType = llvm::cast<RankedTensorType>(type);
+    auto tensorType = cast<RankedTensorType>(type);
     unsigned bitWidth =
         IREE::Util::getTypeBitWidth(tensorType.getElementType());
     // Never hoist boolean values; IREE still does implicit extension of
@@ -46,7 +46,7 @@ struct HoistableTensorTypeInterface
     return bitWidth != 1;
   }
   Type getPreferredStorageType(Type type) const {
-    auto tensorType = llvm::cast<RankedTensorType>(type);
+    auto tensorType = cast<RankedTensorType>(type);
     // Constant data should be statically shaped.
     if (!tensorType.hasStaticShape()) {
       return type;

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -28,7 +28,7 @@ int getNextPotBitWidth(int bitWidth, int minBitWidth = 8) {
 }
 
 Type withNewElementType(Type originalType, Type elementType) {
-  if (auto st = llvm::dyn_cast<ShapedType>(originalType)) {
+  if (auto st = dyn_cast<ShapedType>(originalType)) {
     return st.clone(elementType);
   } else {
     return elementType;
@@ -47,15 +47,14 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
   Type origElementType = getElementTypeOrSelf(origValue.getType());
   Type toElementType = getElementTypeOrSelf(toType);
 
-  if (llvm::isa<FloatType>(origElementType) &&
-      llvm::isa<IntegerType>(toElementType)) {
+  if (isa<FloatType>(origElementType) && isa<IntegerType>(toElementType)) {
     if (isSigned) {
       return arith::FPToSIOp::create(builder, loc, toType, origValue);
     } else {
       return arith::FPToUIOp::create(builder, loc, toType, origValue);
     }
-  } else if (llvm::isa<IntegerType>(origElementType) &&
-             llvm::isa<FloatType>(toElementType)) {
+  } else if (isa<IntegerType>(origElementType) &&
+             isa<FloatType>(toElementType)) {
     if (isSigned) {
       return arith::SIToFPOp::create(builder, loc, toType, origValue);
     } else {
@@ -72,9 +71,8 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
 
 struct NarrowParams {
   static std::optional<NarrowParams> forValue(Value value) {
-    if (auto narrowOp =
-            llvm::dyn_cast_or_null<IREE::Util::NumericOptionalNarrowOp>(
-                value.getDefiningOp())) {
+    if (auto narrowOp = dyn_cast_or_null<IREE::Util::NumericOptionalNarrowOp>(
+            value.getDefiningOp())) {
       NarrowParams params;
       params.producer = narrowOp.getOperand();
       params.fromType = value.getType();
@@ -86,19 +84,13 @@ struct NarrowParams {
     return {};
   }
 
-  bool isFromFloat() {
-    return llvm::isa<FloatType>(getElementTypeOrSelf(fromType));
-  }
+  bool isFromFloat() { return isa<FloatType>(getElementTypeOrSelf(fromType)); }
 
-  bool isToInteger() { return llvm::isa<IntegerType>(toElementType); }
+  bool isToInteger() { return isa<IntegerType>(toElementType); }
 
-  bool isToSigned() {
-    return llvm::cast<IntegerType>(toElementType).isSigned();
-  }
+  bool isToSigned() { return cast<IntegerType>(toElementType).isSigned(); }
 
-  int getToBitWidth() {
-    return llvm::cast<IntegerType>(toElementType).getWidth();
-  }
+  int getToBitWidth() { return cast<IntegerType>(toElementType).getWidth(); }
 
   Value producer;
   Type fromType;

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -280,7 +280,7 @@ public:
       for (int i = 0, e = transposedMap.getNumDims(); i < e; ++i) {
         if (transposedMap.isFunctionOfDim(i)) {
           interchange.push_back(
-              llvm::cast<AffineDimExpr>(transposedMap.getResult(permIdx))
+              cast<AffineDimExpr>(transposedMap.getResult(permIdx))
                   .getPosition());
           permIdx++;
           continue;
@@ -1146,7 +1146,7 @@ void PropagateLinalgTransposePass::runOnOperation() {
           // Only propagate if the immediate consumer of the reshape is a
           // transpose.
           return consumer->hasOneUse() &&
-                 llvm::isa<linalg::TransposeOp>(*(consumer->user_begin()));
+                 isa<linalg::TransposeOp>(*(consumer->user_begin()));
         };
     RewritePatternSet bubblingPatterns(context);
     linalg::populateFoldReshapeOpsByExpansionPatterns(bubblingPatterns,

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -53,7 +53,7 @@ Value emptyZero(ImplicitLocOpBuilder &builder, RankedTensorType ty,
 Value applyZeroPoint(ImplicitLocOpBuilder &builder, Value conv, Value sum,
                      Value zp, ArrayRef<int> affine_map) {
   auto context = builder.getContext();
-  auto convTy = llvm::cast<RankedTensorType>(conv.getType());
+  auto convTy = cast<RankedTensorType>(conv.getType());
 
   llvm::SmallVector<AffineExpr> sumExprs;
   for (auto i : affine_map) {
@@ -82,7 +82,7 @@ Value applyZeroPoint(ImplicitLocOpBuilder &builder, Value conv, Value sum,
 
 // Add the scalar value to the tensor.
 Value addScalar(ImplicitLocOpBuilder &builder, Value value, Value scalar) {
-  auto ty = llvm::cast<RankedTensorType>(value.getType());
+  auto ty = cast<RankedTensorType>(value.getType());
   SmallVector<utils::IteratorType> iterators(ty.getRank(),
                                              utils::IteratorType::parallel);
   auto map = builder.getMultiDimIdentityMap(ty.getRank());
@@ -101,7 +101,7 @@ void GetDynamicDym(ImplicitLocOpBuilder &builder,
                    llvm::SmallVector<int64_t> &dims,
                    llvm::SmallVector<Value> &dynDims, Value value,
                    int64_t dim) {
-  ShapedType ty = llvm::cast<ShapedType>(value.getType());
+  ShapedType ty = cast<ShapedType>(value.getType());
   dims.push_back(ty.getDimSize(dim));
   if (ty && ty.isDynamicDim(dim))
     dynDims.push_back(tensor::DimOp::create(builder, value, dim));
@@ -134,8 +134,8 @@ struct QuantizedConvToConv
     auto filter = op.getInputs()[1];
     auto iZp = op.getInputs()[2];
     auto fZp = op.getInputs()[3];
-    auto inputTy = llvm::cast<RankedTensorType>(input.getType());
-    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
+    auto inputTy = cast<RankedTensorType>(input.getType());
+    auto resultTy = cast<ShapedType>(op.getType(0));
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();
@@ -253,7 +253,7 @@ struct QuantizedDepthwiseConvToDepthwiseConv
     auto filter = op.getInputs()[1];
     auto iZp = op.getInputs()[2];
     auto fZp = op.getInputs()[3];
-    auto resultTy = llvm::cast<ShapedType>(op.getType(0));
+    auto resultTy = cast<ShapedType>(op.getType(0));
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
@@ -75,7 +75,7 @@ struct QuantizedMatmulToMatmul
       // return matmul;
     }
     // Create the result. No need to zero-fill it as we will overwrite it.
-    ShapedType accType = llvm::cast<ShapedType>(acc.getType());
+    ShapedType accType = cast<ShapedType>(acc.getType());
     Value initResult = tensor::EmptyOp::create(
         builder, tensor::getMixedSizes(builder, loc, acc),
         accType.getElementType());

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -319,19 +319,19 @@ public:
         // preferred to fuse those with producers (and the consumer fusion is
         // arguably the less canonical form).
         auto canFoldCast = [&]() {
-          if (llvm::isa<arith::ExtFOp>(*castOp))
+          if (isa<arith::ExtFOp>(*castOp))
             return true;
           // Signed operations can only be folded with (implicitly) signed
           // linalg named ops
-          if (llvm::isa<arith::ExtSIOp>(*castOp)) {
+          if (isa<arith::ExtSIOp>(*castOp)) {
             if (auto matmul =
-                    llvm::dyn_cast<linalg::MatmulOp>(namedOp.getOperation())) {
+                    dyn_cast<linalg::MatmulOp>(namedOp.getOperation())) {
               return matmul.getCast() != linalg::TypeFn::cast_unsigned;
             }
-            return !llvm::isa<linalg::PoolingNhwcMaxUnsignedOp,
-                              linalg::PoolingNhwcMinUnsignedOp,
-                              linalg::PoolingNwcMaxUnsignedOp,
-                              linalg::PoolingNwcMinUnsignedOp>(namedOp);
+            return !isa<linalg::PoolingNhwcMaxUnsignedOp,
+                        linalg::PoolingNhwcMinUnsignedOp,
+                        linalg::PoolingNwcMaxUnsignedOp,
+                        linalg::PoolingNwcMinUnsignedOp>(namedOp);
           }
           return false;
         };

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -107,7 +107,7 @@ Value createGenericElementwiseCastOp(
 Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
                                Type accETy, ArrayRef<bool> is_reduction) {
   auto context = val.getContext();
-  RankedTensorType ty = llvm::cast<RankedTensorType>(val.getType());
+  RankedTensorType ty = cast<RankedTensorType>(val.getType());
 
   llvm::SmallVector<int64_t> staticSizes;
   SmallVector<Value> dynSizes;

--- a/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ConvertPrimitiveType.cpp
@@ -43,7 +43,7 @@ Value convertRankedFloat(OpBuilder &builder, Type type, ValueRange inputs,
                          Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
-  if (!llvm::isa<FloatType>(getElementTypeOrSelf(type)))
+  if (!isa<FloatType>(getElementTypeOrSelf(type)))
     return nullptr;
 
   if (inputETy.getIntOrFloatBitWidth() > eTy.getIntOrFloatBitWidth()) {
@@ -61,7 +61,7 @@ Value convertRankedInteger(OpBuilder &builder, Type type, ValueRange inputs,
                            Location loc) {
   Type eTy = getElementTypeOrSelf(type);
   Type inputETy = getElementTypeOrSelf(inputs[0].getType());
-  if (!llvm::isa<FloatType>(getElementTypeOrSelf(type)))
+  if (!isa<FloatType>(getElementTypeOrSelf(type)))
     return nullptr;
   bool isUnsigned = eTy.isUnsignedInteger();
 

--- a/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
@@ -104,7 +104,7 @@ public:
     bool isExtern = srcOpAttr && isa<ml_program::ExternAttr>(*srcOpAttr);
     auto srcOpTypedAttr =
         (srcOpAttr && !isExtern)
-            ? std::optional<TypedAttr>(llvm::cast<TypedAttr>(srcOpAttr.value()))
+            ? std::optional<TypedAttr>(cast<TypedAttr>(srcOpAttr.value()))
             : std::nullopt;
     const SymbolTable::Visibility visibility = srcOp.getVisibility();
     // Create util Global which is mutable if the ML program global was or if
@@ -154,15 +154,14 @@ public:
         "ml_program.public_global_accessors");
     // TODO(jpienaar): The attribute should be verified before here.
     StringAttr get =
-        v ? llvm::dyn_cast_if_present<StringAttr>(v.get("get")) : nullptr;
+        v ? dyn_cast_if_present<StringAttr>(v.get("get")) : nullptr;
     {
       const std::string getFormat = get ? get.str() : "global${0}$get";
       if (failed(verifyFormat(getFormat)))
         return failure();
       getterName = llvm::formatv(getFormat.c_str(), globalOp.getSymName());
     }
-    auto set =
-        v ? llvm::dyn_cast_if_present<StringAttr>(v.get("set")) : nullptr;
+    auto set = v ? dyn_cast_if_present<StringAttr>(v.get("set")) : nullptr;
     {
       const std::string setFormat = set ? set.str() : "global${0}$set";
       if (failed(verifyFormat(setFormat)))

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/HALToHALInline/Patterns.cpp
@@ -257,7 +257,7 @@ void populateHALToHALInlinePatterns(MLIRContext *context,
       [](OpBuilder &builder, IREE::Util::BufferType type, ValueRange inputs,
          Location loc) -> Value {
         assert(inputs.size() == 1);
-        if (llvm::isa<IREE::HAL::BufferType>(inputs[0].getType())) {
+        if (isa<IREE::HAL::BufferType>(inputs[0].getType())) {
           return builder.createOrFold<IREE::HAL::Inline::BufferStorageOp>(
               loc, inputs[0]);
         } else {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -22,7 +22,7 @@ namespace mlir::iree_compiler {
 namespace {
 
 static Value getResourceSize(Location loc, Value resource, OpBuilder &builder) {
-  if (llvm::isa<IREE::HAL::BufferType>(resource.getType())) {
+  if (isa<IREE::HAL::BufferType>(resource.getType())) {
     return builder.createOrFold<IREE::HAL::Inline::BufferLengthOp>(
         loc, builder.getIndexType(), resource);
   }
@@ -39,7 +39,7 @@ struct Storage {
 
 static Storage getResourceStorage(Location loc, Value resource,
                                   Value resourceSize, OpBuilder &builder) {
-  if (llvm::isa<IREE::HAL::BufferType>(resource.getType())) {
+  if (isa<IREE::HAL::BufferType>(resource.getType())) {
     // Get the storage of the buffer; the returned buffer is already a subspan.
     auto storageBuffer =
         builder.createOrFold<IREE::HAL::Inline::BufferStorageOp>(loc, resource);
@@ -232,7 +232,7 @@ struct ResourceSubviewOpPattern
   LogicalResult
   matchAndRewrite(IREE::Stream::ResourceSubviewOp subviewOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (llvm::isa<IREE::HAL::BufferType>(adaptor.getSource().getType())) {
+    if (isa<IREE::HAL::BufferType>(adaptor.getSource().getType())) {
       auto bufferType = rewriter.getType<IREE::HAL::BufferType>();
       // NOTE: this aliases! We assume at this point all useful alias analysis
       // has been performed and it's fine to lose the tie information here.
@@ -314,7 +314,7 @@ struct TensorImportBufferOpPattern
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::HAL::BufferType>(importOp.getSource().getType())) {
+    if (!isa<IREE::HAL::BufferType>(importOp.getSource().getType())) {
       return failure();
     }
 
@@ -332,8 +332,8 @@ struct TensorImportBufferViewOpPattern
   matchAndRewrite(IREE::Stream::TensorImportOp importOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto sourceType = importOp.getSource().getType();
-    if (!llvm::isa<IREE::HAL::BufferViewType>(sourceType) &&
-        !llvm::isa<TensorType>(sourceType)) {
+    if (!isa<IREE::HAL::BufferViewType>(sourceType) &&
+        !isa<TensorType>(sourceType)) {
       return failure();
     }
 
@@ -351,7 +351,7 @@ struct TensorExportBufferOpPattern
   LogicalResult
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!llvm::isa<IREE::HAL::BufferType>(exportOp.getResult().getType())) {
+    if (!isa<IREE::HAL::BufferType>(exportOp.getResult().getType())) {
       return failure();
     }
     rewriter.replaceOp(exportOp, adaptor.getSource());
@@ -366,13 +366,13 @@ struct TensorExportBufferViewOpPattern
   matchAndRewrite(IREE::Stream::TensorExportOp exportOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto targetType = exportOp.getResult().getType();
-    if (!llvm::isa<IREE::HAL::BufferViewType>(targetType) &&
-        !llvm::isa<TensorType>(targetType)) {
+    if (!isa<IREE::HAL::BufferViewType>(targetType) &&
+        !isa<TensorType>(targetType)) {
       return failure();
     }
 
     auto loc = exportOp.getLoc();
-    auto tensorType = llvm::cast<RankedTensorType>(adaptor.getSourceEncoding());
+    auto tensorType = cast<RankedTensorType>(adaptor.getSourceEncoding());
     auto dynamicDims = adaptor.getSourceEncodingDims();
 
     // NOTE: we should have verified supported encodings/types at entry into the
@@ -577,7 +577,7 @@ struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
     size_t resourceIndex = 0;
     for (auto [originalOperand, convertedOperand] : llvm::zip_equal(
              callOp.getResourceOperands(), adaptor.getResourceOperands())) {
-      if (llvm::isa<IREE::Stream::ResourceType>(originalOperand.getType())) {
+      if (isa<IREE::Stream::ResourceType>(originalOperand.getType())) {
         // Resource type, add offset/length.
         auto resourceSize = adaptor.getResourceOperandSizes()[resourceIndex];
         auto storage = getResourceStorage(callOp.getLoc(), convertedOperand,
@@ -666,7 +666,7 @@ struct GlobalTimepointConversionPattern
     auto initialValue = op.getInitialValue();
     if (!initialValue.has_value())
       return failure();
-    if (!llvm::isa<IREE::Stream::TimepointAttr>(*initialValue))
+    if (!isa<IREE::Stream::TimepointAttr>(*initialValue))
       return failure();
     rewriter.modifyOpInPlace(
         op, [&]() { op.setInitialValueAttr(rewriter.getI64IntegerAttr(0)); });

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -158,7 +158,7 @@ struct FoldBufferViewCreateSubspan
     rewriter.setInsertionPoint(op);
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
-    auto newSourceOffset = llvm::cast<Value>(op.getSourceOffset());
+    auto newSourceOffset = cast<Value>(op.getSourceOffset());
     if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
@@ -225,8 +225,7 @@ void BufferViewBufferOp::getCanonicalizationPatterns(RewritePatternSet &results,
 LogicalResult DeviceQueryOp::verify() {
   DeviceQueryOp op = *this;
   if (op.getDefaultValue().has_value()) {
-    if (auto typedDefaultValue =
-            llvm::dyn_cast<TypedAttr>(*op.getDefaultValue())) {
+    if (auto typedDefaultValue = dyn_cast<TypedAttr>(*op.getDefaultValue())) {
       if (typedDefaultValue.getType() != op.getValue().getType()) {
         return op.emitOpError()
                << "type mismatch between result and default value";

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -71,7 +71,7 @@ public:
           return WalkResult::interrupt();
         }
         auto targetFuncName =
-            llvm::cast<StringAttr>(exportToFuncMap[entryPointAttrs.front()]);
+            cast<StringAttr>(exportToFuncMap[entryPointAttrs.front()]);
         assert(targetFuncName && "missing mapping");
         dispatchOp->setAttr("hal_inline.target",
                             FlatSymbolRefAttr::get(targetFuncName));

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
@@ -27,7 +27,7 @@ namespace {
 // either a !util.buffer or an external !hal.buffer.
 static Value getResourceBuffer(Location loc, Value resource,
                                OpBuilder &builder) {
-  if (llvm::isa<IREE::HAL::BufferType>(resource.getType())) {
+  if (isa<IREE::HAL::BufferType>(resource.getType())) {
     // Get the storage of the buffer; the returned buffer is already a subspan.
     return builder.createOrFold<IREE::HAL::Inline::BufferStorageOp>(loc,
                                                                     resource);
@@ -55,7 +55,7 @@ struct CmdDispatchOpPattern
                                          "multiple variant targets not yet "
                                          "supported in the inline HAL loader");
     }
-    auto entryPointAttr = llvm::cast<SymbolRefAttr>(entryPointAttrs.front());
+    auto entryPointAttr = cast<SymbolRefAttr>(entryPointAttrs.front());
 
     // Get the handle to the executable that is compatible with our device.
     auto executableOp =

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -84,9 +84,9 @@ public:
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
-    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
-    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
+    auto inputType = cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
@@ -209,7 +209,7 @@ public:
       auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
       SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
                                                            parallel, reduction};
-      bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
+      bool isInt = isa<IntegerType>(outputType.getElementType());
       auto genericOp = linalg::GenericOp::create(
           rewriter, loc, reshapedOutputType,
           /*inputs=*/ValueRange{reshapedImg2ColTensor, reshapedFilter},
@@ -243,12 +243,9 @@ public:
 
   LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType =
-        llvm::cast<RankedTensorType>(convOp.getInputs()[0].getType());
-    auto filterType =
-        llvm::cast<RankedTensorType>(convOp.getInputs()[1].getType());
-    auto outputType =
-        llvm::cast<RankedTensorType>(convOp.getOutputs()[0].getType());
+    auto inputType = cast<RankedTensorType>(convOp.getInputs()[0].getType());
+    auto filterType = cast<RankedTensorType>(convOp.getInputs()[1].getType());
+    auto outputType = cast<RankedTensorType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
@@ -267,7 +264,7 @@ public:
     auto loc = convOp.getLoc();
 
     auto transposeOperand = [&](Value operand, ArrayRef<int64_t> indices) {
-      auto operandTensorType = llvm::cast<RankedTensorType>(operand.getType());
+      auto operandTensorType = cast<RankedTensorType>(operand.getType());
       auto nloops = indices.size();
       auto inputShape = operandTensorType.getShape();
 
@@ -308,8 +305,7 @@ public:
     // Transpose input, filter so channels are outermost
     auto inputT = transposeOperand(input, {0, 3, 1, 2});
     auto filterT = transposeOperand(filter, {2, 0, 1});
-    auto filterTShape =
-        llvm::cast<RankedTensorType>(filterT.getType()).getShape();
+    auto filterTShape = cast<RankedTensorType>(filterT.getType()).getShape();
     auto outputShape = outputType.getShape();
 
     const int n = outputShape[0];
@@ -407,9 +403,9 @@ public:
 
   LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp convOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
-    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
-    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
+    auto inputType = cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = cast<ShapedType>(convOp.getOutputs()[0].getType());
 
     if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
@@ -530,7 +526,7 @@ public:
       auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
       SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
                                                            parallel, reduction};
-      bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
+      bool isInt = isa<IntegerType>(outputType.getElementType());
       auto genericOp = linalg::GenericOp::create(
           rewriter, loc, reshapedOutputType,
           /*inputs=*/ValueRange{reshapedFilter, reshapedImg2ColTensor},

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -133,11 +133,11 @@ struct ConvertGenericChwfToFhwc : public OpRewritePattern<linalg::GenericOp> {
     Value outputVal = output->get();
 
     ArrayRef<int64_t> inputShape =
-        llvm::cast<ShapedType>(inputVal.getType()).getShape();
+        cast<ShapedType>(inputVal.getType()).getShape();
     ArrayRef<int64_t> filterShape =
-        llvm::cast<ShapedType>(filterVal.getType()).getShape();
+        cast<ShapedType>(filterVal.getType()).getShape();
     ArrayRef<int64_t> outputShape =
-        llvm::cast<ShapedType>(outputVal.getType()).getShape();
+        cast<ShapedType>(outputVal.getType()).getShape();
 
     // TODO(vivian): Once the matmul shape check below is dropped, the
     // dynamic-shape check can also be removed.

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
@@ -38,9 +38,9 @@ public:
     Value rhs = linalgOp.getDpsInputOperand(1)->get();
     Value result = linalgOp.getDpsInitOperand(0)->get();
 
-    auto lhsType = llvm::dyn_cast<RankedTensorType>(lhs.getType());
-    auto rhsType = llvm::dyn_cast<RankedTensorType>(rhs.getType());
-    auto resultType = llvm::dyn_cast<RankedTensorType>(result.getType());
+    auto lhsType = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultType = dyn_cast<RankedTensorType>(result.getType());
 
     if (!lhsType || !rhsType)
       return failure();

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
@@ -19,18 +19,18 @@
 namespace mlir::iree_compiler {
 
 std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc) {
-  if (auto loc = llvm::dyn_cast<FileLineColLoc>(baseLoc)) {
+  if (auto loc = dyn_cast<FileLineColLoc>(baseLoc)) {
     return loc;
   }
 
-  if (auto loc = llvm::dyn_cast<FusedLoc>(baseLoc)) {
+  if (auto loc = dyn_cast<FusedLoc>(baseLoc)) {
     // Recurse through fused locations.
     for (auto &childLoc : loc.getLocations()) {
       auto childResult = findFirstFileLoc(childLoc);
       if (childResult)
         return childResult;
     }
-  } else if (auto loc = llvm::dyn_cast<CallSiteLoc>(baseLoc)) {
+  } else if (auto loc = dyn_cast<CallSiteLoc>(baseLoc)) {
     // First check caller...
     auto callerResult = findFirstFileLoc(loc.getCaller());
     if (callerResult)
@@ -39,13 +39,13 @@ std::optional<FileLineColLoc> findFirstFileLoc(Location baseLoc) {
     auto calleeResult = findFirstFileLoc(loc.getCallee());
     if (calleeResult)
       return calleeResult;
-  } else if (auto loc = llvm::dyn_cast<NameLoc>(baseLoc)) {
+  } else if (auto loc = dyn_cast<NameLoc>(baseLoc)) {
     auto childResult = findFirstFileLoc(loc.getChildLoc());
     if (childResult)
       return childResult;
-  } else if (auto loc = llvm::dyn_cast<OpaqueLoc>(baseLoc)) {
+  } else if (auto loc = dyn_cast<OpaqueLoc>(baseLoc)) {
     // TODO(scotttodd): Use loc.fallbackLocation()?
-  } else if (auto loc = llvm::dyn_cast<UnknownLoc>(baseLoc)) {
+  } else if (auto loc = dyn_cast<UnknownLoc>(baseLoc)) {
     // ¯\_(ツ)_/¯
   }
 


### PR DESCRIPTION
This removes llvm:: and mlir:: namespace prefixes from casting functions (isa, cast, dyn_cast, cast_or_null, dyn_cast_or_null, isa_and_nonnull, dyn_cast_if_present, cast_if_present, isa_and_present) where they are unnecessary due to 'using' declarations in mlir/Support/LLVM.h.

These functions are brought into scope by headers like mlir/Support/LLVM.h which is included (directly or transitively) by most MLIR-based code.