### PR TITLE
Drop prefetches in AVX512 ukernels

### DIFF
--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -85,6 +85,7 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
     char* out_tile = out_tile_row;
     const char* rhs_panel = rhs_panel_start;
     // Prefetches needed on ARM Cortex-X2, Issue #13332.
+    // Reevaluated 2025-11 on AMD Zen5 (x86), also slightly beneficial there.
     IREE_UK_PREFETCH_RW(out_tile_row, IREE_UK_PREFETCH_LOCALITY_L3);
     IREE_UK_PREFETCH_RO(lhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);
     IREE_UK_PREFETCH_RO(rhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);


### PR DESCRIPTION
This is a 1.3x speedup on 4096x4096xf32 matmuls on Zen5, single-thread.

The other prefetches in `mmt4d.c` are kept after benchmarks show that they are still slightly beneficial there. Comment added.

Test CPU: `AMD EPYC 9575F`.

Test code:
```mlir
util.func @matmul_f32(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %acc: tensor<?x?xf32>) -> tensor<?x?xf32> {
  %result = linalg.matmul   ins(%lhs, %rhs: tensor<?x?xf32>, tensor<?x?xf32>) outs(%acc: tensor<?x?xf32>) -> tensor<?x?xf32>
  util.return %result: tensor<?x?xf32>
}
```

Test command:
```
ninja iree-compile && tools/iree-compile --iree-llvmcpu-target-cpu=znver5 --iree-hal-target-backends=llvm-cpu --iree-dispatch-creation-data-tiling=true ~/matmul_f32.mlir -o ~/matmul_f32.vmfb && tools/iree-benchmark-module --module=$HOME/matmul_f32.vmfb --function=matmul_f32 --input=4096x4096xf32 --input=4096x4096xf32 --input=4096x4096xf32 --device_allocator=caching --device=local-task --task_topology_group_count=1 --benchmark_min_warmup_time=1 --benchmark_repetitions=10
```

Result:
* Before: `items_per_second=0.98333/s`
* After: `items_per_second=1.29521/s`


