### PR TITLE
[NFC] Switch to dyn_cast_if_present for consistency.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeControlFlow.cpp
@@ -90,7 +90,7 @@ std::optional<ScfForBounds> extractForBounds(mlir::stablehlo::WhileOp op) {
   if (!iterArg)
     return std::nullopt;
 
-  auto add = dyn_cast_or_null<mlir::stablehlo::AddOp>(
+  auto add = dyn_cast_if_present<mlir::stablehlo::AddOp>(
       body.getTerminator()->getOperand(*iterArg).getDefiningOp());
   if (!add || matchBbArg(add.getLhs(), body) != iterArg ||
       add.getRhs().getParentBlock() == &body) {

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
@@ -305,8 +305,8 @@ struct GeneralDotConvert final
         rhs, loc, rhsContractingDims, /*outerDimsFirst=*/false, rewriter));
 
     // Accept only static shaped types.
-    auto lhsShapeType = dyn_cast_or_null<ShapedType>(lhs.getType());
-    auto rhsShapeType = dyn_cast_or_null<ShapedType>(rhs.getType());
+    auto lhsShapeType = dyn_cast_if_present<ShapedType>(lhs.getType());
+    auto rhsShapeType = dyn_cast_if_present<ShapedType>(rhs.getType());
     if (!lhsShapeType || !rhsShapeType)
       return failure();
 

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1215,8 +1215,8 @@ struct FuseWidenOperands final : OpRewritePattern<Op> {
                                 PatternRewriter &rewriter) const override {
     llvm::SmallVector<Value> operands;
     for (Value operand : op->getOperands()) {
-      auto convertOp =
-          dyn_cast_or_null<mlir::stablehlo::ConvertOp>(operand.getDefiningOp());
+      auto convertOp = dyn_cast_if_present<mlir::stablehlo::ConvertOp>(
+          operand.getDefiningOp());
       if (convertOp) {
         auto inputType = getElementTypeOrSelf(convertOp.getOperand().getType());
         auto castedType = getElementTypeOrSelf(convertOp.getResult().getType());
@@ -1659,7 +1659,7 @@ struct CustomCallIsTopK final
 // broadcasts where the last dimension of the iota is preserved throughout.
 bool isIotaOrIotaBroadcast(PatternRewriter &rewriter, Value input) {
   if (auto iotaOp =
-          dyn_cast_or_null<mlir::stablehlo::IotaOp>(input.getDefiningOp())) {
+          dyn_cast_if_present<mlir::stablehlo::IotaOp>(input.getDefiningOp())) {
     int64_t iotaDim = iotaOp.getIotaDimension();
     auto iotaLastDim = cast<ShapedType>(iotaOp.getType()).getRank() - 1;
     if (iotaDim == iotaLastDim) {
@@ -1670,7 +1670,7 @@ bool isIotaOrIotaBroadcast(PatternRewriter &rewriter, Value input) {
     return false;
   }
 
-  if (auto broadcastOp = dyn_cast_or_null<mlir::stablehlo::BroadcastInDimOp>(
+  if (auto broadcastOp = dyn_cast_if_present<mlir::stablehlo::BroadcastInDimOp>(
           input.getDefiningOp())) {
     auto broadcastLastDim =
         cast<ShapedType>(broadcastOp.getType()).getRank() - 1;
@@ -1794,8 +1794,8 @@ struct ApproxTopK final : OpRewritePattern<mlir::stablehlo::CustomCallOp> {
     auto input = op.getOperand(0);
     auto iota = op.getOperand(1);
 
-    if (auto iotaOp =
-            dyn_cast_or_null<mlir::stablehlo::IotaOp>(iota.getDefiningOp())) {
+    if (auto iotaOp = dyn_cast_if_present<mlir::stablehlo::IotaOp>(
+            iota.getDefiningOp())) {
       int64_t iotaDim = iotaOp.getIotaDimension();
       auto iotaLastDim = cast<ShapedType>(iotaOp.getType()).getRank() - 1;
       if (iotaDim != iotaLastDim) {

--- a/compiler/plugins/input/Torch/InputConversion/BindSymbolicShapes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BindSymbolicShapes.cpp
@@ -416,7 +416,7 @@ class BindSymbolicShapesPass final
           return;
         auto torchType =
             cast<Torch::ValueTensorType>(bindOp.getOperand().getType());
-        auto builtinType = dyn_cast_or_null<RankedTensorType>(
+        auto builtinType = dyn_cast_if_present<RankedTensorType>(
             typeConverter.convertType(torchType));
         if (!builtinType) {
           emitError(childOp->getLoc())

--- a/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/FuncConversion.cpp
@@ -102,7 +102,7 @@ Value convertToBuiltinTensor(OpBuilder &builder, Value possibleTorchTensor) {
   if (isa<TensorType>(ty))
     return possibleTorchTensor;
 
-  if (auto defining = dyn_cast_or_null<TorchConversion::FromBuiltinTensorOp>(
+  if (auto defining = dyn_cast_if_present<TorchConversion::FromBuiltinTensorOp>(
           possibleTorchTensor.getDefiningOp())) {
     return defining.getOperand();
   }

--- a/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/Transforms/ApplyBuiltinPDLPatterns.cpp
@@ -392,7 +392,7 @@ public:
     llvm::SmallDenseSet<StringRef> ukernelSymbols;
     auto res = moduleOp.walk([&](Operation *op) {
       auto builtinName =
-          dyn_cast_or_null<StringAttr>(op->getAttr(kBuiltinName));
+          dyn_cast_if_present<StringAttr>(op->getAttr(kBuiltinName));
       auto ukernelDesc = getUKernelDescriptor(op);
       if (!builtinName || !ukernelDesc) {
         return WalkResult::advance();

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -59,7 +59,7 @@ struct ConcretizePadResultShape final : public OpRewritePattern<tensor::PadOp> {
     SmallVector<int64_t> staticShape;
     staticShape.reserve(rank);
 
-    auto sourceIfxOp = dyn_cast_or_null<OffsetSizeAndStrideOpInterface>(
+    auto sourceIfxOp = dyn_cast_if_present<OffsetSizeAndStrideOpInterface>(
         padOp.getSource().getDefiningOp());
     if (!sourceIfxOp)
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -224,7 +224,7 @@ struct FlattenGetGlobal final
     if (!oldType || !oldType.getLayout().isIdentity())
       return failure();
 
-    auto globalOp = dyn_cast_or_null<memref::GlobalOp>(
+    auto globalOp = dyn_cast_if_present<memref::GlobalOp>(
         SymbolTable::lookupNearestSymbolFrom(getOp, getOp.getNameAttr()));
     if (!globalOp)
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -984,7 +984,8 @@ struct DistributeMultiReduction final
     auto accVector = dyn_cast<VectorValue>(acc);
     auto resVector = dyn_cast<VectorValue>(res);
 
-    auto srcLayout = dyn_cast_or_null<NestedLayoutAttr>(signature[srcVector]);
+    auto srcLayout =
+        dyn_cast_if_present<NestedLayoutAttr>(signature[srcVector]);
     if (!srcLayout) {
       return rewriter.notifyMatchFailure(multiReduceOp,
                                          "expected nested layout attr");
@@ -1012,7 +1013,7 @@ struct DistributeMultiReduction final
 
     VectorValue mask = nullptr;
     if (maskOp) {
-      auto maskLayout = dyn_cast_or_null<NestedLayoutAttr>(
+      auto maskLayout = dyn_cast_if_present<NestedLayoutAttr>(
           maskSignature.value()[maskOp.getMask()]);
       if (!maskLayout) {
         return rewriter.notifyMatchFailure(maskOp,
@@ -1454,7 +1455,7 @@ struct DistributeContract final
 
     VectorValue mask = nullptr;
     if (maskOp) {
-      auto maskLayout = dyn_cast_or_null<NestedLayoutAttr>(
+      auto maskLayout = dyn_cast_if_present<NestedLayoutAttr>(
           maskSignature.value()[maskOp.getMask()]);
       if (!maskLayout) {
         return rewriter.notifyMatchFailure(maskOp,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -172,7 +172,7 @@ struct WarpOpBarrier final : OpRewritePattern<gpu::WarpExecuteOnLane0Op> {
     auto yield = cast<gpu::YieldOp>(
         warpOp.getBodyRegion().getBlocks().begin()->getTerminator());
     Operation *lastNode = yield->getPrevNode();
-    auto barrierOp = dyn_cast_or_null<gpu::BarrierOp>(lastNode);
+    auto barrierOp = dyn_cast_if_present<gpu::BarrierOp>(lastNode);
     if (!barrierOp)
       return failure();
 

--- a/compiler/src/iree/compiler/Codegen/Common/LoweringConfigInterpreter.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LoweringConfigInterpreter.cpp
@@ -85,10 +85,10 @@ public:
         return WalkResult::advance();
       }
 
-      auto strategy = dyn_cast_or_null<transform::NamedSequenceOp>(
+      auto strategy = dyn_cast_if_present<transform::NamedSequenceOp>(
           SymbolTable::lookupSymbolIn(symbolTableOp, *maybeSymName));
       if (!strategy && parsedLibrary) {
-        strategy = dyn_cast_or_null<transform::NamedSequenceOp>(
+        strategy = dyn_cast_if_present<transform::NamedSequenceOp>(
             SymbolTable::lookupSymbolIn(parsedLibrary->getOperation(),
                                         *maybeSymName));
       }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -117,7 +117,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
                   IREE::Encoding::kEncodingResolverAttrName)
             : nullptr;
     auto resolverAttr =
-        dyn_cast_or_null<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
+        dyn_cast_if_present<IREE::Encoding::LayoutResolverAttr>(layoutAttr);
 
     IREE::Encoding::LayoutMaterializerAttr layoutAttrWithTargetInfo =
         layoutAttr && resolverAttr

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -292,8 +292,8 @@ struct FoldMaskedTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     }
 
     // Try to get the producing write op.
-    auto writeOp =
-        dyn_cast_or_null<vector::TransferWriteOp>(op.getBase().getDefiningOp());
+    auto writeOp = dyn_cast_if_present<vector::TransferWriteOp>(
+        op.getBase().getDefiningOp());
     // Fail to match if the write doesn't have pure tensor semantics.
     if (!writeOp || !writeOp.hasPureTensorSemantics()) {
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -235,7 +235,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   if (failed(tilingInfo)) {
     return signalPassFailure();
   }
-  auto tilableOp = dyn_cast_or_null<TilingInterface>(tilingInfo->tilableOp);
+  auto tilableOp = dyn_cast_if_present<TilingInterface>(tilingInfo->tilableOp);
   if (!tilableOp) {
     // Did not find a tileable op. So do nothing.
     return;

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -456,7 +456,7 @@ static SmallVector<Operation *> getAllFusableProducers(TilingInterface op) {
     for (OpOperand &operand : currOp->getOpOperands()) {
       Operation *definingOp = operand.get().getDefiningOp();
       auto tilingInterfaceProducer =
-          dyn_cast_or_null<TilingInterface>(definingOp);
+          dyn_cast_if_present<TilingInterface>(definingOp);
       if (!tilingInterfaceProducer || isa<tensor::PadOp>(definingOp) ||
           producers.count(tilingInterfaceProducer)) {
         continue;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -547,7 +547,7 @@ transform_dialect::GpuDistributeSharedMemoryCopyOp::applyToOne(
       return;
 
     auto destSpace =
-        dyn_cast_or_null<gpu::AddressSpaceAttr>(destType.getMemorySpace());
+        dyn_cast_if_present<gpu::AddressSpaceAttr>(destType.getMemorySpace());
     if (!destSpace)
       return;
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -416,7 +416,7 @@ LogicalResult WorkgroupMappingAttr::verifyAttrList(MLIRContext *context,
   auto emitError = mlir::detail::getDefaultDiagnosticEmitFn(loc);
   for (auto attr : attrs) {
     auto typedAttr =
-        dyn_cast_or_null<IREE::Codegen::WorkgroupMappingAttr>(attr);
+        dyn_cast_if_present<IREE::Codegen::WorkgroupMappingAttr>(attr);
     if (!typedAttr) {
       return emitError() << "expected all the mapping attribute to be of "
                             "`WorkgroupMappingAttr` type";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -42,7 +42,7 @@ createFunctionCall(RewriterBase &rewriter, Operation *op, StringRef fnName,
   Location loc = op->getLoc();
   auto moduleOp = SymbolTable::getNearestSymbolTable(op);
   // Check for duplicates.
-  auto fnDecl = dyn_cast_or_null<func::FuncOp>(
+  auto fnDecl = dyn_cast_if_present<func::FuncOp>(
       SymbolTable::lookupSymbolIn(moduleOp, fnName));
   if (!fnDecl) {
     OpBuilder::InsertionGuard g(rewriter);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -57,7 +57,7 @@ void setBasis(MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
 
 FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
                           IREE::GPU::TilingLevel level) {
-  auto basisAttr = dyn_cast_or_null<ArrayAttr>(
+  auto basisAttr = dyn_cast_if_present<ArrayAttr>(
       config.getAttributes().get(getBasisLevelName(level)));
   if (!basisAttr) {
     return failure();
@@ -69,9 +69,9 @@ FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
   }
 
   std::optional<SmallVector<int64_t>> maybeCounts =
-      getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[0]));
+      getIntegerVector(dyn_cast_if_present<ArrayAttr>(attrs[0]));
   std::optional<SmallVector<int64_t>> maybeMapping =
-      getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[1]));
+      getIntegerVector(dyn_cast_if_present<ArrayAttr>(attrs[1]));
 
   if (!maybeCounts.has_value() || !maybeMapping.has_value()) {
     return failure();

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -687,7 +687,7 @@ struct CPUEncodingPackedLayoutMaterializerAttr
     auto layoutAttr = cast<CPUEncodingResolverAttr>(attr);
 
     auto encoding =
-        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
+        dyn_cast_if_present<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {
@@ -846,7 +846,7 @@ struct VMVXEncodingPackedLayoutMaterializerAttr final
     auto layoutAttr = cast<VMVXEncodingResolverAttr>(attr);
 
     auto encoding =
-        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
+        dyn_cast_if_present<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -514,7 +514,7 @@ struct GPUEncodingPackedLayoutMaterializerAttr
     DictionaryAttr config = resolver.getConfiguration();
 
     auto encoding =
-        dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
+        dyn_cast_if_present<IREE::Encoding::EncodingAttr>(type.getEncoding());
 
     MaterializeEncodingInfo info;
     if (!encoding) {
@@ -638,7 +638,7 @@ getPadLayout(IREE::Encoding::LayoutResolverAttr layoutAttr,
     return nullptr;
   }
   auto encoding =
-      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
+      dyn_cast_if_present<IREE::Encoding::LayoutAttr>(type.getEncoding());
   if (encoding) {
     ArrayAttr layouts = encoding.getLayouts();
     if (layouts.size() != 1) {
@@ -759,7 +759,7 @@ struct GPUPadLayoutResolverAttr final
     }
 
     auto paddingEncodingAttr =
-        dyn_cast_or_null<IREE::Encoding::PaddingAttr>(type.getEncoding());
+        dyn_cast_if_present<IREE::Encoding::PaddingAttr>(type.getEncoding());
     if (!paddingEncodingAttr) {
       return nullptr;
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -49,7 +49,7 @@ static bool isValidInterchange(ArrayRef<int64_t> interchange, int numLoops) {
 static LogicalResult verifyMultiTilingExpertPassPipelineConfig(
     Operation *op, IREE::CPU::LoweringConfigAttr loweringConfig) {
 
-  auto interfaceOp = dyn_cast_or_null<TilingInterface>(op);
+  auto interfaceOp = dyn_cast_if_present<TilingInterface>(op);
   if (!interfaceOp) {
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
@@ -62,7 +62,7 @@ struct LLVMGPUCastAddressSpaceFunctionPass final
       rewriter.setInsertionPoint(callOp);
       if (castOperands(callOp->getOperands(), newOperands)) {
         callOp.getArgOperandsMutable().assign(newOperands);
-        auto fnDecl = dyn_cast_or_null<mlir::FunctionOpInterface>(
+        auto fnDecl = dyn_cast_if_present<mlir::FunctionOpInterface>(
             SymbolTable::lookupSymbolIn(moduleOp, callee));
         if (fnDecl) {
           SmallVector<Type> callArgumentTypes;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -102,8 +102,9 @@ static void inferMmaKind(vector::ContractionOp contract) {
     return;
   }
 
-  auto intrinsic = dyn_cast_or_null<IREE::Codegen::InnerTileDescAttrInterface>(
-      toLayout.getMmaKindAttr());
+  auto intrinsic =
+      dyn_cast_if_present<IREE::Codegen::InnerTileDescAttrInterface>(
+          toLayout.getMmaKindAttr());
   if (!intrinsic) {
     return;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -737,9 +737,9 @@ struct LLVMGPUConfigureTensorLayoutsPass final
       return signalPassFailure();
     }
 
-    auto attentionQKMatmul = dyn_cast_or_null<linalg::LinalgOp>(
+    auto attentionQKMatmul = dyn_cast_if_present<linalg::LinalgOp>(
         getOpWithAttr(funcOp, "attention_qk_matmul"));
-    auto attentionPVMatmul = dyn_cast_or_null<linalg::LinalgOp>(
+    auto attentionPVMatmul = dyn_cast_if_present<linalg::LinalgOp>(
         getOpWithAttr(funcOp, "attention_pv_matmul"));
 
     if (attentionQKMatmul && !attentionPVMatmul) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -492,7 +492,7 @@ static bool hasSharedMemory(Value val) {
   if (!memrefType)
     return false;
   auto addrSpace =
-      dyn_cast_or_null<gpu::AddressSpaceAttr>(memrefType.getMemorySpace());
+      dyn_cast_if_present<gpu::AddressSpaceAttr>(memrefType.getMemorySpace());
   return addrSpace && addrSpace.getValue() == gpu::AddressSpace::Workgroup;
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -132,9 +132,9 @@ bool mayExtI8ToI32(Value op) {
   Operation *def = stripElementBitPatternPreservingParents(op);
   Type inTy;
 
-  if (auto ext = dyn_cast_or_null<arith::ExtSIOp>(def)) {
+  if (auto ext = dyn_cast_if_present<arith::ExtSIOp>(def)) {
     inTy = getElementTypeOrSelf(ext.getIn().getType());
-  } else if (auto ext = dyn_cast_or_null<arith::ExtUIOp>(def)) {
+  } else if (auto ext = dyn_cast_if_present<arith::ExtUIOp>(def)) {
     inTy = getElementTypeOrSelf(ext.getIn().getType());
   } else {
     return false;

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -43,7 +43,7 @@ static bool affineMinOpDivisible(affine::AffineMinOp minOp, int64_t dividend) {
     if (!ivArg)
       continue;
     Operation *containingOp = ivArg.getOwner()->getParentOp();
-    auto forOp = dyn_cast_or_null<scf::ForOp>(containingOp);
+    auto forOp = dyn_cast_if_present<scf::ForOp>(containingOp);
     if (forOp && forOp.getInductionVar() == dim) {
       iv = dim;
       ub = forOp.getUpperBound();
@@ -51,7 +51,7 @@ static bool affineMinOpDivisible(affine::AffineMinOp minOp, int64_t dividend) {
       step = forOp.getStep();
       break;
     }
-    auto parallelOp = dyn_cast_or_null<scf::ParallelOp>(containingOp);
+    auto parallelOp = dyn_cast_if_present<scf::ParallelOp>(containingOp);
     if (!parallelOp)
       continue;
     for (auto [index, inductionVar] :

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -1256,12 +1256,13 @@ struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
                                 PatternRewriter &rewriter) const final {
     Operation *currentOp = padOp.getSource().getDefiningOp();
     auto maybeExtractSlice =
-        dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+        dyn_cast_if_present<tensor::ExtractSliceOp>(currentOp);
     while (currentOp && maybeExtractSlice) {
       currentOp = maybeExtractSlice.getSource().getDefiningOp();
-      maybeExtractSlice = dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+      maybeExtractSlice =
+          dyn_cast_if_present<tensor::ExtractSliceOp>(currentOp);
     }
-    auto fillOp = dyn_cast_or_null<linalg::FillOp>(currentOp);
+    auto fillOp = dyn_cast_if_present<linalg::FillOp>(currentOp);
     if (!fillOp) {
       return rewriter.notifyMatchFailure(
           padOp, "not coming from a linalg.fill op via tensor.extract_slice*");

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -20,7 +20,7 @@ namespace mlir::iree_compiler {
 static std::optional<IREE::Codegen::MaterializeEncodingInfo>
 getEncodingInfoFromType(RankedTensorType type) {
   auto layoutAttr =
-      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
+      dyn_cast_if_present<IREE::Encoding::LayoutAttr>(type.getEncoding());
   if (!layoutAttr) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -996,7 +996,7 @@ IREE::GPU::TargetAttr getCLGPUTarget(MLIRContext *context) {
 }
 
 IREE::GPU::TargetAttr getGPUTargetAttr(DictionaryAttr attr) {
-  return dyn_cast_or_null<IREE::GPU::TargetAttr>(getConfigTargetInfo(attr));
+  return dyn_cast_if_present<IREE::GPU::TargetAttr>(getConfigTargetInfo(attr));
 }
 
 IREE::GPU::TargetAttr getGPUTargetAttr(MLIRContext *context,

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -876,13 +876,13 @@ isTiledAndDistributedLoop(scf::ForOp forOp) {
     // Try to see if this is a specical case where we have:
     //   scf.for %iv = %id to %ub step %count
     std::optional<unsigned> idDim;
-    if (auto ifx = dyn_cast_or_null<ProcessorIDInterface>(
+    if (auto ifx = dyn_cast_if_present<ProcessorIDInterface>(
             forOp.getLowerBound().getDefiningOp())) {
       idDim = ifx.getDimIndex();
     }
 
     std::optional<unsigned> countDim;
-    if (auto ifx = dyn_cast_or_null<ProcessorCountInterface>(
+    if (auto ifx = dyn_cast_if_present<ProcessorCountInterface>(
             forOp.getStep().getDefiningOp())) {
       countDim = ifx.getDimIndex();
     }
@@ -1573,7 +1573,7 @@ SmallVector<int64_t> getStaticNumWorkgroups(mlir::FunctionOpInterface funcOp) {
 
   for (unsigned i = 0; i < 3; ++i) {
     Operation *defOp = returnOp.getOperand(i).getDefiningOp();
-    if (auto indexOp = dyn_cast_or_null<arith::ConstantIndexOp>(defOp)) {
+    if (auto indexOp = dyn_cast_if_present<arith::ConstantIndexOp>(defOp)) {
       result.push_back(indexOp.value());
     } else {
       result.push_back(ShapedType::kDynamic);

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -506,7 +506,7 @@ private:
 
     // Find immutable loads.
     for (auto loadOp : funcOp.getOps<IREE::Util::GlobalLoadOpInterface>()) {
-      auto globalOp = dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
+      auto globalOp = dyn_cast_if_present<IREE::Util::GlobalOpInterface>(
           sourceSymbolTable.lookup(loadOp.getGlobalAttr().getAttr()));
       if (!globalOp || globalOp.isGlobalMutable()) {
         emitDebugWarning(loadOp.getLoc(), [&](InFlightDiagnostic &diagnostic) {
@@ -556,7 +556,7 @@ private:
     // Find immutable stores, early exiting if not supported.
     // The consumers must come after rewrites of the producers above.
     for (auto storeOp : funcOp.getOps<IREE::Util::GlobalStoreOpInterface>()) {
-      auto globalOp = dyn_cast_or_null<IREE::Util::GlobalOpInterface>(
+      auto globalOp = dyn_cast_if_present<IREE::Util::GlobalOpInterface>(
           sourceSymbolTable.lookup(storeOp.getGlobalAttr().getAttr()));
       assert(globalOp && "should have been checked in isConstExpr");
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -163,7 +163,7 @@ def IREEEncoding_SerializableAttr :
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         auto attr =
-          llvm::dyn_cast_or_null<SerializableAttr>($_attr);
+          dyn_cast_if_present<SerializableAttr>($_attr);
         if (!attr) {
           return false;
         }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -21,8 +21,8 @@ bool SerializableAttr::areCompatible(Attribute lhs, Attribute rhs) {
   if (lhs == rhs) {
     return true;
   }
-  auto lhsEncoding = dyn_cast_or_null<SerializableAttr>(lhs);
-  auto rhsEncoding = dyn_cast_or_null<SerializableAttr>(rhs);
+  auto lhsEncoding = dyn_cast_if_present<SerializableAttr>(lhs);
+  auto rhsEncoding = dyn_cast_if_present<SerializableAttr>(rhs);
   if (!lhsEncoding || !rhsEncoding) {
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/Utils/Utils.cpp
@@ -15,15 +15,15 @@
 namespace mlir::iree_compiler::IREE::Encoding {
 
 SerializableAttr getSerializableAttr(RankedTensorType type) {
-  return dyn_cast_or_null<SerializableAttr>(type.getEncoding());
+  return dyn_cast_if_present<SerializableAttr>(type.getEncoding());
 }
 
 EncodingAttr getEncodingAttr(RankedTensorType type) {
-  return dyn_cast_or_null<EncodingAttr>(type.getEncoding());
+  return dyn_cast_if_present<EncodingAttr>(type.getEncoding());
 }
 
 bool hasPackedStorageAttr(RankedTensorType type) {
-  return dyn_cast_or_null<PackedStorageAttr>(type.getEncoding()) != nullptr;
+  return dyn_cast_if_present<PackedStorageAttr>(type.getEncoding()) != nullptr;
 }
 
 FailureOr<linalg::ContractionDimensions>

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -121,7 +121,7 @@ struct ReplaceOpIfTensorOperandEmpty : public OpRewritePattern<Op> {
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
     auto operand = op->getOperand(OperandIdx);
-    auto emptyOp = dyn_cast_or_null<TensorEmptyOp>(operand.getDefiningOp());
+    auto emptyOp = dyn_cast_if_present<TensorEmptyOp>(operand.getDefiningOp());
     if (!emptyOp)
       return failure();
     auto result = op->getResult(ResultIdx);
@@ -532,11 +532,11 @@ struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
     // intermediate reshapes.
     Value source;
     ValueRange sourceDims;
-    if (auto sourceOp = dyn_cast_or_null<TensorReshapeOp>(
+    if (auto sourceOp = dyn_cast_if_present<TensorReshapeOp>(
             reshapeOp.getSource().getDefiningOp())) {
       source = sourceOp.getSource();
       sourceDims = sourceOp.getSourceDims();
-    } else if (auto sourceOp = dyn_cast_or_null<TensorBitCastOp>(
+    } else if (auto sourceOp = dyn_cast_if_present<TensorBitCastOp>(
                    reshapeOp.getSource().getDefiningOp())) {
       source = sourceOp.getSource();
       sourceDims = sourceOp.getSourceDims();
@@ -678,7 +678,7 @@ struct FoldSplatLoadIntoPrimitive : public OpRewritePattern<TensorLoadOp> {
   LogicalResult matchAndRewrite(TensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     auto sourceOp =
-        dyn_cast_or_null<TensorSplatOp>(loadOp.getSource().getDefiningOp());
+        dyn_cast_if_present<TensorSplatOp>(loadOp.getSource().getDefiningOp());
     if (!sourceOp)
       return failure();
     rewriter.replaceOp(loadOp, sourceOp.getValue());

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -60,7 +60,7 @@ static LogicalResult populateWorkgroupCountComputingRegion(
   // For now, this assumes that we only pull in constants.
   // TODO: Iteratively pull operations that are only consuming IndexType.
   for (Value v : forallOp.getUpperBound(rewriter)) {
-    auto op = dyn_cast_or_null<arith::ConstantIndexOp>(v.getDefiningOp());
+    auto op = dyn_cast_if_present<arith::ConstantIndexOp>(v.getDefiningOp());
     if (!op)
       return failure();
     results.push_back(

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
@@ -63,7 +63,7 @@ HALTypeConverter::HALTypeConverter(
       // Look for the buffer view this buffer came from, if any.
       // If we don't have the origin buffer view then we can't know the shape
       // and can't materialize one here - it's too late.
-      if (auto bvbOp = dyn_cast_or_null<IREE::HAL::BufferViewBufferOp>(
+      if (auto bvbOp = dyn_cast_if_present<IREE::HAL::BufferViewBufferOp>(
               inputValue.getDefiningOp())) {
         return bvbOp.getBufferView();
       }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -182,7 +182,7 @@ struct FoldBufferViewCreateSubspan
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
     auto newSourceOffset = cast<Value>(op.getSourceOffset());
-    if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<IREE::HAL::BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
       newSourceOffset = rewriter.createOrFold<arith::AddIOp>(
@@ -240,7 +240,7 @@ struct SkipCommandBufferDeviceOp
 
   LogicalResult matchAndRewrite(CommandBufferDeviceOp op,
                                 PatternRewriter &rewriter) const override {
-    if (auto createOp = dyn_cast_or_null<CommandBufferCreateOp>(
+    if (auto createOp = dyn_cast_if_present<CommandBufferCreateOp>(
             op.getCommandBuffer().getDefiningOp())) {
       rewriter.replaceOp(op, createOp.getDevice());
       return success();
@@ -270,7 +270,7 @@ struct FoldCommandBufferFillBufferSubspans
     bool needsUpdate = false;
     auto newTargetBuffer = op.getTargetBuffer();
     auto newTargetOffset = cast<Value>(op.getTargetOffset());
-    if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
       newTargetOffset = rewriter.createOrFold<arith::AddIOp>(
@@ -310,7 +310,7 @@ struct FoldCommandBufferUpdateBufferSubspans
     bool needsUpdate = false;
     auto newTargetBuffer = op.getTargetBuffer();
     auto newTargetOffset = cast<Value>(op.getTargetOffset());
-    if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
       newTargetOffset = rewriter.createOrFold<arith::AddIOp>(
@@ -350,7 +350,7 @@ struct FoldCommandBufferCopyBufferSubspans
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
     auto newSourceOffset = cast<Value>(op.getSourceOffset());
-    if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<IREE::HAL::BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
       newSourceOffset = rewriter.createOrFold<arith::AddIOp>(
@@ -360,7 +360,7 @@ struct FoldCommandBufferCopyBufferSubspans
     }
     auto newTargetBuffer = op.getTargetBuffer();
     auto newTargetOffset = cast<Value>(op.getTargetOffset());
-    if (auto subspanOp = dyn_cast_or_null<IREE::HAL::BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<IREE::HAL::BufferSubspanOp>(
             op.getTargetBuffer().getDefiningOp())) {
       newTargetBuffer = subspanOp.getSourceBuffer();
       newTargetOffset = rewriter.createOrFold<arith::AddIOp>(
@@ -565,8 +565,8 @@ struct HoistDeviceQueueBarrierChain
                                 PatternRewriter &rewriter) const override {
     // See if we can observe the original fence creation in the local scope.
     auto waitFence = barrierOp.getWaitFence();
-    auto createOp =
-        dyn_cast_or_null<IREE::HAL::FenceCreateOp>(waitFence.getDefiningOp());
+    auto createOp = dyn_cast_if_present<IREE::HAL::FenceCreateOp>(
+        waitFence.getDefiningOp());
     if (!createOp) {
       return rewriter.notifyMatchFailure(barrierOp,
                                          "cannot analyze wait fence creation");
@@ -1103,7 +1103,7 @@ struct ElideSignaledFence : public OpRewritePattern<FenceSignalOp> {
                                 PatternRewriter &rewriter) const override {
     auto fence = signalOp.getFence();
     auto createOp =
-        dyn_cast_or_null<IREE::HAL::FenceCreateOp>(fence.getDefiningOp());
+        dyn_cast_if_present<IREE::HAL::FenceCreateOp>(fence.getDefiningOp());
     if (!createOp)
       return failure();
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -580,7 +580,7 @@ LogicalResult ReturnOp::verify() {
   ReturnOp op = *this;
 
   auto parentFuncOp =
-      dyn_cast_or_null<mlir::FunctionOpInterface>(op->getParentOp());
+      dyn_cast_if_present<mlir::FunctionOpInterface>(op->getParentOp());
   if (parentFuncOp) {
     auto expectedTypes = parentFuncOp.getResultTypes();
     if (op.getNumOperands() != expectedTypes.size()) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/SubstituteExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/SubstituteExecutables.cpp
@@ -110,7 +110,7 @@ replaceExecutableOpWithMLIR(IREE::HAL::ExecutableOp executableOp,
   if (auto moduleOp = dyn_cast<mlir::ModuleOp>(rootOpRef.get())) {
     // We expect a `hal.executable` with the same name as the one we are
     // replacing.
-    replacementOp = dyn_cast_or_null<IREE::HAL::ExecutableOp>(
+    replacementOp = dyn_cast_if_present<IREE::HAL::ExecutableOp>(
         SymbolTable::lookupSymbolIn(moduleOp, executableOp.getNameAttr()));
   } else {
     // Verify the name matches.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -128,7 +128,7 @@ SplitReductionMappingAttr::verifyAttrList(MLIRContext *context, Location loc,
   SmallVector<SplitReductionMappingAttr> mappingAttrs;
   llvm::SmallDenseSet<SplitReductionMappingAttr> attrSet;
   for (auto attr : attrs) {
-    auto typedAttr = dyn_cast_or_null<SplitReductionMappingAttr>(attr);
+    auto typedAttr = dyn_cast_if_present<SplitReductionMappingAttr>(attr);
     if (!typedAttr) {
       return emitError("expected all the mapping attribute to be of "
                        "`SplitReductionMappingAttr` type");

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -51,7 +51,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 //===----------------------------------------------------------------------===//
 
 static Type getComplexElementTypeOrSelf(Type ty) {
-  if (auto complex = dyn_cast_or_null<ComplexType>(ty)) {
+  if (auto complex = dyn_cast_if_present<ComplexType>(ty)) {
     return complex.getElementType();
   }
   return ty;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -765,9 +765,9 @@ isContractionOpSequence(Value yielded,
     return std::nullopt;
   }
 
-  auto elementwiseLHS = dyn_cast_or_null<BlockArgument>(
+  auto elementwiseLHS = dyn_cast_if_present<BlockArgument>(
       getSourceSkipUnary(elementwiseOp->getOperand(0)));
-  auto elementwiseRHS = dyn_cast_or_null<BlockArgument>(
+  auto elementwiseRHS = dyn_cast_if_present<BlockArgument>(
       getSourceSkipUnary(elementwiseOp->getOperand(1)));
   if (!elementwiseLHS || !elementwiseRHS) {
     return std::nullopt;
@@ -803,7 +803,7 @@ isContractionOpSequence(Value yielded) {
 /// TODO: The logic below is quite convoluted. Might be better
 /// off having a dedicated operation for this.
 bool isaHorizontallyFusedContraction(Operation *op) {
-  auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op);
+  auto linalgOp = dyn_cast_if_present<linalg::LinalgOp>(op);
   if (!linalgOp) {
     return false;
   }
@@ -1019,13 +1019,13 @@ bool hasOnlyScalarInputs(linalg::GenericOp linalgOp) {
 }
 
 bool isPureMatmul(Operation *op) {
-  auto matmulOp = dyn_cast_or_null<linalg::MatmulOp>(op);
+  auto matmulOp = dyn_cast_if_present<linalg::MatmulOp>(op);
   return matmulOp &&
          linalg::MatmulOp::isDefaultIndexingMaps(matmulOp.getIndexingMaps());
 }
 
 bool isPureBatchMatmul(Operation *op) {
-  auto batchMatmulOp = dyn_cast_or_null<linalg::BatchMatmulOp>(op);
+  auto batchMatmulOp = dyn_cast_if_present<linalg::BatchMatmulOp>(op);
   return batchMatmulOp && linalg::BatchMatmulOp::isDefaultIndexingMaps(
                               batchMatmulOp.getIndexingMaps());
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -508,7 +508,7 @@ TraversalResult ValueConsumerAffinityPVS::updateFromUse(Value value,
             DFX::Resolution::REQUIRED);
         newState ^= parentUsage.getState();
         if (auto whileOp =
-                dyn_cast_or_null<mlir::scf::WhileOp>(op->getParentOp())) {
+                dyn_cast_if_present<mlir::scf::WhileOp>(op->getParentOp())) {
           auto value = Position::forValue(
               whileOp.getAfter().getArgument(operand.getOperandNumber() - 1));
           auto &valueUsage = solver.getElementFor<ValueConsumerAffinityPVS>(

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -195,7 +195,7 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
         dyn_cast<IREE::Stream::AsyncTransferOp>(op)) {
       auto producer = op.getOperand(0).getDefiningOp();
       auto streamable =
-          dyn_cast_or_null<IREE::Stream::StreamableOpInterface>(producer);
+          dyn_cast_if_present<IREE::Stream::StreamableOpInterface>(producer);
       if (streamable) {
         if (!syncOps.contains(producer)) {
           syncOps[producer] = llvm::SmallVector<Operation *>();

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -573,7 +573,7 @@ private:
               DFX::Resolution::REQUIRED);
           getState() ^= parentUsage.getState();
           if (auto whileOp =
-                  dyn_cast_or_null<scf::WhileOp>(op->getParentOp())) {
+                  dyn_cast_if_present<scf::WhileOp>(op->getParentOp())) {
             auto value = Position::forValue(
                 whileOp.getAfter().getArgument(operandIdx - 1));
             auto &valueUsage = solver.getElementFor<ValueResourceUsage>(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -184,7 +184,7 @@ def Stream_AffinityOp : Stream_OpInterface<"AffinityOpInterface"> {
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return dyn_cast_or_null<IREE::Stream::AffinityAttr>($_op->getAttr("affinity"));
+        return dyn_cast_if_present<IREE::Stream::AffinityAttr>($_op->getAttr("affinity"));
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -101,7 +101,7 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp,
     Operation *userOp = *result.user_begin();
 
     // Check if the user is an update op we can merge.
-    auto updateOp = dyn_cast_or_null<IREE::Stream::AsyncUpdateOp>(userOp);
+    auto updateOp = dyn_cast_if_present<IREE::Stream::AsyncUpdateOp>(userOp);
     if (!updateOp || updateOp.getUpdate() != result) {
       continue; // not relevant
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -85,7 +85,7 @@ static void convertAndDecomposeToI32s(
   // If the value complex from a complex::BitcastOp we should grab the
   // real / complex values instead.
   if (auto bitcast =
-          dyn_cast_or_null<complex::BitcastOp>(operand.getDefiningOp())) {
+          dyn_cast_if_present<complex::BitcastOp>(operand.getDefiningOp())) {
     auto complexOperand = bitcast.getOperand();
     auto complexTy = cast<ComplexType>(complexOperand.getType());
     auto real = builder.createOrFold<complex::ReOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -137,7 +137,7 @@ static std::pair<Value, Value> consumeTimepoint(Location loc, Value value,
     return std::make_pair(timepoint, value);
   }
 
-  if (auto awaitOp = dyn_cast_or_null<IREE::Stream::TimepointAwaitOp>(
+  if (auto awaitOp = dyn_cast_if_present<IREE::Stream::TimepointAwaitOp>(
           value.getDefiningOp())) {
     // We can only consume asynchronous timepoints. If the await is a sync point
     // then we know that know result can be used without the host synchronizing
@@ -150,7 +150,7 @@ static std::pair<Value, Value> consumeTimepoint(Location loc, Value value,
       return std::make_pair(awaitOp.getAwaitTimepoint(),
                             awaitOp.getTiedResultOperand(value));
     }
-  } else if (auto executeOp = dyn_cast_or_null<IREE::Stream::AsyncExecuteOp>(
+  } else if (auto executeOp = dyn_cast_if_present<IREE::Stream::AsyncExecuteOp>(
                  value.getDefiningOp())) {
     return std::make_pair(executeOp.getResultTimepoint(), value);
   } else {
@@ -195,7 +195,7 @@ static void expandTimepoints(Operation *op, SymbolTable &symbolTable,
 static Value makeBlockArgResourceSize(Location loc, Value resourceValue,
                                       OpBuilder &builder) {
   // We can take any implicitly captured SSA values.
-  if (auto sizeAwareOp = dyn_cast_or_null<IREE::Util::SizeAwareOpInterface>(
+  if (auto sizeAwareOp = dyn_cast_if_present<IREE::Util::SizeAwareOpInterface>(
           resourceValue.getDefiningOp())) {
     auto sizeValue = sizeAwareOp.getResultSizeFromValue(resourceValue);
     if (sizeValue)

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1549,7 +1549,7 @@ static SmallVector<IREE::Util::SubrangeOperand>
 gatherSubranges(Value derivedValue) {
   SmallVector<IREE::Util::SubrangeOperand> subrangeStack;
   Value baseValue = derivedValue;
-  while (auto definingOp = dyn_cast_or_null<IREE::Util::TiedOpInterface>(
+  while (auto definingOp = dyn_cast_if_present<IREE::Util::TiedOpInterface>(
              baseValue.getDefiningOp())) {
     auto tiedValue = definingOp.getTiedResultOperand(baseValue);
     if (!tiedValue)

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -21,7 +21,7 @@ struct ReplaceBitCastIfTensorOperandEmpty final : OpRewritePattern<BitCastOp> {
   LogicalResult matchAndRewrite(BitCastOp op,
                                 PatternRewriter &rewriter) const override {
     auto emptyOp =
-        dyn_cast_or_null<tensor::EmptyOp>(op.getSource().getDefiningOp());
+        dyn_cast_if_present<tensor::EmptyOp>(op.getSource().getDefiningOp());
     if (!emptyOp)
       return failure();
     rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, op.getResult().getType(),
@@ -436,7 +436,7 @@ OpFoldResult DispatchWorkloadOrdinalOp::fold(FoldAdaptor operands) {
   //   %2 = iree_tensor_ext.dispatch.workload.ordinal %1, 2
   //
   // This can happen when the operands get deduped.
-  if (auto producerOrdinalOp = dyn_cast_or_null<DispatchWorkloadOrdinalOp>(
+  if (auto producerOrdinalOp = dyn_cast_if_present<DispatchWorkloadOrdinalOp>(
           getOperand().getDefiningOp())) {
     if (producerOrdinalOp.getOrdinal() == getOrdinal()) {
       return producerOrdinalOp.getOperand();

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
@@ -133,7 +133,7 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
   if (auto valueBlockArg = dyn_cast<BlockArgument>(value)) {
     Block *ownerBlock = valueBlockArg.getOwner();
     if (auto linalgParent =
-            dyn_cast_or_null<linalg::LinalgOp>(ownerBlock->getParentOp())) {
+            dyn_cast_if_present<linalg::LinalgOp>(ownerBlock->getParentOp())) {
       value = linalgParent->getOperand(valueBlockArg.getArgNumber());
       LLVM_DEBUG(dbgs() << "  ++ REMAP LINALG BLOCK ARG TO: " << value << "\n");
     }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.cpp
@@ -158,7 +158,7 @@ struct FoldDimOp : public OpRewritePattern<DimOp> {
       source = assumeAlignmentOp.getViewSource();
     }
     auto shapeAwareOp =
-        dyn_cast_or_null<ShapeAwareOpInterface>(source.getDefiningOp());
+        dyn_cast_if_present<ShapeAwareOpInterface>(source.getDefiningOp());
     if (!shapeAwareOp)
       return failure();
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -332,7 +332,7 @@ OpFoldResult NullOp::fold(FoldAdaptor operands) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult CastOp::fold(FoldAdaptor operands) {
-  if (auto castOp = dyn_cast_or_null<CastOp>(getOperand().getDefiningOp())) {
+  if (auto castOp = dyn_cast_if_present<CastOp>(getOperand().getDefiningOp())) {
     if (castOp.getOperand().getType() == getResult().getType()) {
       return castOp.getOperand();
     }
@@ -348,7 +348,8 @@ struct FoldCastIntoNullOp : public OpRewritePattern<CastOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(CastOp castOp,
                                 PatternRewriter &rewriter) const override {
-    auto nullOp = dyn_cast_or_null<NullOp>(castOp.getOperand().getDefiningOp());
+    auto nullOp =
+        dyn_cast_if_present<NullOp>(castOp.getOperand().getDefiningOp());
     if (!nullOp)
       return failure();
     rewriter.replaceOpWithNewOp<NullOp>(castOp, castOp.getResult().getType());
@@ -1022,7 +1023,7 @@ struct PropagateGlobalLoadAddress : public OpRewritePattern<IndirectOpT> {
   using OpRewritePattern<IndirectOpT>::OpRewritePattern;
   LogicalResult matchAndRewrite(IndirectOpT op,
                                 PatternRewriter &rewriter) const override {
-    if (auto addressOp = dyn_cast_or_null<GlobalAddressOpInterface>(
+    if (auto addressOp = dyn_cast_if_present<GlobalAddressOpInterface>(
             op.getGlobal().getDefiningOp())) {
       rewriter.replaceOpWithNewOp<DirectOpT>(
           op, op.getResult().getType(), addressOp.getGlobalAttr(),
@@ -1052,7 +1053,7 @@ struct EraseUnusedGlobalStoreOp : public OpRewritePattern<GlobalStoreOp> {
 
   LogicalResult matchAndRewrite(GlobalStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    if (auto loadOp = dyn_cast_or_null<GlobalLoadOpInterface>(
+    if (auto loadOp = dyn_cast_if_present<GlobalLoadOpInterface>(
             op.getValue().getDefiningOp())) {
       if (loadOp.getGlobalName() == op.getGlobal()) {
         rewriter.eraseOp(op);
@@ -1080,7 +1081,7 @@ class PropagateGlobalStoreAddress
 public:
   LogicalResult matchAndRewrite(GlobalStoreIndirectOp op,
                                 PatternRewriter &rewriter) const override {
-    if (auto addressOp = dyn_cast_or_null<GlobalAddressOpInterface>(
+    if (auto addressOp = dyn_cast_if_present<GlobalAddressOpInterface>(
             op.getGlobal().getDefiningOp())) {
       rewriter.replaceOpWithNewOp<GlobalStoreOp>(op, op.getValue(),
                                                  addressOp.getGlobalAttr());
@@ -1194,9 +1195,9 @@ struct SinkSubspanAcrossSelectOps
                                 PatternRewriter &rewriter) const override {
     if (!isa<IREE::Util::BufferType>(op.getType()))
       return failure();
-    auto trueSubspan = dyn_cast_or_null<IREE::Util::BufferSubspanOp>(
+    auto trueSubspan = dyn_cast_if_present<IREE::Util::BufferSubspanOp>(
         op.getTrueValue().getDefiningOp());
-    auto falseSubspan = dyn_cast_or_null<IREE::Util::BufferSubspanOp>(
+    auto falseSubspan = dyn_cast_if_present<IREE::Util::BufferSubspanOp>(
         op.getFalseValue().getDefiningOp());
     if (!trueSubspan || !falseSubspan)
       return failure();
@@ -1244,7 +1245,7 @@ OpFoldResult BufferSizeOp::fold(FoldAdaptor operands) {
   }
 
   // If the source is a constant then we can calculate that immediately.
-  if (auto constantOp = dyn_cast_or_null<IREE::Util::BufferConstantOp>(
+  if (auto constantOp = dyn_cast_if_present<IREE::Util::BufferConstantOp>(
           operand.getDefiningOp())) {
     if (auto storageAttr = dyn_cast_if_present<IREE::Util::SizedStorageAttr>(
             constantOp.getValue())) {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -471,7 +471,7 @@ SmallVector<int64_t> detail::getTiedResultOperandIndices(Operation *op) {
 // static
 Value TiedOpInterface::findTiedBaseValue(Value derivedValue) {
   Value baseValue = derivedValue;
-  while (auto definingOp = dyn_cast_or_null<IREE::Util::TiedOpInterface>(
+  while (auto definingOp = dyn_cast_if_present<IREE::Util::TiedOpInterface>(
              baseValue.getDefiningOp())) {
     auto tiedValue = definingOp.getTiedResultOperand(baseValue);
     if (!tiedValue)
@@ -796,8 +796,9 @@ SmallVector<Value> buildDynamicDimsForValue(Location loc, Value value,
 
   // Slower path that materializes the entire shape for a result. Some
   // implementations may only support this (vs the fast find above).
-  if (auto shapeAwareOp = dyn_cast_or_null<IREE::Util::ShapeAwareOpInterface>(
-          value.getDefiningOp())) {
+  if (auto shapeAwareOp =
+          dyn_cast_if_present<IREE::Util::ShapeAwareOpInterface>(
+              value.getDefiningOp())) {
     return shapeAwareOp.buildResultValueShape(value, builder);
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -120,8 +120,8 @@ static bool renameChainedGlobals(GlobalTable &globalTable) {
     for (auto storeOp : global.storeOps) {
       // Check to see if the stored value comes from another global.
       auto *definingOp = storeOp.getStoredGlobalValue().getDefiningOp();
-      if (auto loadOp =
-              dyn_cast_or_null<IREE::Util::GlobalLoadOpInterface>(definingOp)) {
+      if (auto loadOp = dyn_cast_if_present<IREE::Util::GlobalLoadOpInterface>(
+              definingOp)) {
         if (!aliasName) {
           aliasName = loadOp.getGlobalAttr();
         } else if (aliasName != loadOp.getGlobalAttr()) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/LinkModules.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/LinkModules.cpp
@@ -792,7 +792,7 @@ LogicalResult ModuleLinker::link(ModuleOp targetModule) {
     // Check if external declaration exists in target.
     Operation *existingDecl = targetSymbolTable.lookup(info->qualifiedName);
     if (auto existingFunc =
-            dyn_cast_or_null<FunctionOpInterface>(existingDecl)) {
+            dyn_cast_if_present<FunctionOpInterface>(existingDecl)) {
       if (auto sourceFunc = dyn_cast<FunctionOpInterface>(info->op)) {
         // Verify types match.
         if (existingFunc.getFunctionType() != sourceFunc.getFunctionType()) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Patterns.cpp
@@ -470,7 +470,8 @@ struct MergeIndexSwitchPattern : public OpRewritePattern<scf::IndexSwitchOp> {
   LogicalResult matchAndRewrite(scf::IndexSwitchOp nextOp,
                                 PatternRewriter &rewriter) const override {
     // Inspect the previous op to see if it's also a switch.
-    auto prevOp = dyn_cast_or_null<scf::IndexSwitchOp>(nextOp->getPrevNode());
+    auto prevOp =
+        dyn_cast_if_present<scf::IndexSwitchOp>(nextOp->getPrevNode());
     if (!prevOp)
       return failure();
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/PropagateSubranges.cpp
@@ -162,7 +162,7 @@ static Subrange consumeSubrange(Location loc, Value value,
     return mapIt->second;
   }
 
-  if (auto subrangeOp = dyn_cast_or_null<IREE::Util::SubrangeOpInterface>(
+  if (auto subrangeOp = dyn_cast_if_present<IREE::Util::SubrangeOpInterface>(
           value.getDefiningOp())) {
     Subrange subrange;
     subrange.resource = subrangeOp.getSubrangeResource();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
@@ -621,8 +621,8 @@ struct ExtendFOpConversion : public OpConversionPattern<arith::ExtFOp> {
   LogicalResult
   matchAndRewrite(arith::ExtFOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto srcType = dyn_cast_or_null<FloatType>(srcOp.getIn().getType());
-    auto resultType = dyn_cast_or_null<FloatType>(srcOp.getType());
+    auto srcType = dyn_cast_if_present<FloatType>(srcOp.getIn().getType());
+    auto resultType = dyn_cast_if_present<FloatType>(srcOp.getType());
     if (!srcType || !resultType)
       return failure();
     auto dstType = getTypeConverter()->convertType(resultType);

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -1424,7 +1424,7 @@ SuccessorOperands BranchTableOp::getSuccessorOperands(unsigned index) {
 
 Block *BranchTableOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
   SuccessorRange caseDestinations = getCaseDestinations();
-  if (auto valueAttr = dyn_cast_or_null<IntegerAttr>(operands.front())) {
+  if (auto valueAttr = dyn_cast_if_present<IntegerAttr>(operands.front())) {
     int64_t value = valueAttr.getValue().getSExtValue();
     if (value < 0 || value >= caseDestinations.size())
       return getDefaultDestination();

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -682,7 +682,7 @@ findRootOps(IREE::Flow::DispatchRegionOp regionOp) {
       continue;
     }
 
-    if (auto forallOp = dyn_cast_or_null<scf::ForallOp>(collapsibleOp)) {
+    if (auto forallOp = dyn_cast_if_present<scf::ForallOp>(collapsibleOp)) {
       mlir::visitUsedValuesDefinedAbove(
           MutableArrayRef<Region>{forallOp.getTerminator().getRegion()},
           [&](OpOperand *operand) {

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -62,7 +62,7 @@ struct GatherFusionPattern final : public OpRewritePattern<tensor::ExtractOp> {
                                 PatternRewriter &rewriter) const override {
     // Check if extractOp is inside a generic op
     auto consumerOp =
-        dyn_cast_or_null<linalg::GenericOp>(extractOp->getParentOp());
+        dyn_cast_if_present<linalg::GenericOp>(extractOp->getParentOp());
     if (!consumerOp) {
       return rewriter.notifyMatchFailure(
           extractOp, "expected extract op to be inside a generic op");

--- a/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
@@ -168,7 +168,7 @@ static FailureOr<unsigned> fuseMultiUseProducers(
         for (OpOperand &operand : genericOp->getOpOperands()) {
           // 2. Only fuse with `linalg.generic` producers that arent
           //    already part of another fusion group.
-          auto producer = dyn_cast_or_null<linalg::GenericOp>(
+          auto producer = dyn_cast_if_present<linalg::GenericOp>(
               operand.get().getDefiningOp());
           if (!producer || opToRootMap.count(producer)) {
             continue;

--- a/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
@@ -175,7 +175,7 @@ void SinkReshapesPass::runOnOperation() {
 
   auto collapsingControlFn = [](OpOperand *opOperand) {
     auto collapseOp =
-        dyn_cast_or_null<tensor::CollapseShapeOp>(opOperand->getOwner());
+        dyn_cast_if_present<tensor::CollapseShapeOp>(opOperand->getOwner());
     if (collapseOp) {
       return shouldBubbleCollapseShapeOp(collapseOp, opOperand);
     }

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -54,7 +54,7 @@ struct ArithConstantInferIntDivisibilityOpInterface
       Operation *op, ArrayRef<IREE::Util::IntegerDivisibility> argDivs,
       IREE::Util::SetIntDivisibilityFn setResultDivs) const {
     auto constOp = cast<arith::ConstantOp>(op);
-    auto constAttr = dyn_cast_or_null<IntegerAttr>(constOp.getValue());
+    auto constAttr = dyn_cast_if_present<IntegerAttr>(constOp.getValue());
     if (constAttr) {
       const APInt &value = constAttr.getValue();
       uint64_t udiv = value.getZExtValue();

--- a/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/ExpandTensorShapes.cpp
@@ -153,7 +153,7 @@ static ExpandedValue consumeExpandedValue(Location loc, Value value,
   // If the value comes from a tie shape we can bypass the slower checks.
   // This happens a lot during expansion as we'll expand function and block args
   // and insert ties before processing nested ops that consume them.
-  if (auto tieShapeOp = dyn_cast_or_null<IREE::Flow::TensorTieShapeOp>(
+  if (auto tieShapeOp = dyn_cast_if_present<IREE::Flow::TensorTieShapeOp>(
           value.getDefiningOp())) {
     ExpandedValue expandedValue;
     expandedValue.tensor = tieShapeOp.getOperand();

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -71,8 +71,9 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
 
 struct NarrowParams {
   static std::optional<NarrowParams> forValue(Value value) {
-    if (auto narrowOp = dyn_cast_or_null<IREE::Util::NumericOptionalNarrowOp>(
-            value.getDefiningOp())) {
+    if (auto narrowOp =
+            dyn_cast_if_present<IREE::Util::NumericOptionalNarrowOp>(
+                value.getDefiningOp())) {
       NarrowParams params;
       params.producer = narrowOp.getOperand();
       params.fromType = value.getType();

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -105,10 +105,10 @@ OpFoldResult BufferStorageOp::fold(FoldAdaptor operands) {
   auto *definingOp = getBuffer().getDefiningOp();
   if (!definingOp)
     return {};
-  if (auto sourceOp =
-          dyn_cast_or_null<IREE::HAL::Inline::BufferAllocateOp>(definingOp)) {
+  if (auto sourceOp = dyn_cast_if_present<IREE::HAL::Inline::BufferAllocateOp>(
+          definingOp)) {
     return sourceOp.getStorage();
-  } else if (auto sourceOp = dyn_cast_or_null<
+  } else if (auto sourceOp = dyn_cast_if_present<
                  IREE::HAL::Inline::BufferAllocateInitializedOp>(definingOp)) {
     return sourceOp.getStorage();
   }
@@ -159,7 +159,7 @@ struct FoldBufferViewCreateSubspan
     bool needsUpdate = false;
     auto newSourceBuffer = op.getSourceBuffer();
     auto newSourceOffset = cast<Value>(op.getSourceOffset());
-    if (auto subspanOp = dyn_cast_or_null<BufferSubspanOp>(
+    if (auto subspanOp = dyn_cast_if_present<BufferSubspanOp>(
             op.getSourceBuffer().getDefiningOp())) {
       newSourceBuffer = subspanOp.getSourceBuffer();
       newSourceOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
@@ -202,7 +202,7 @@ struct SkipBufferViewBufferOp : public OpRewritePattern<BufferViewBufferOp> {
   using Base::Base;
   LogicalResult matchAndRewrite(BufferViewBufferOp op,
                                 PatternRewriter &rewriter) const override {
-    if (auto createOp = dyn_cast_or_null<BufferViewCreateOp>(
+    if (auto createOp = dyn_cast_if_present<BufferViewCreateOp>(
             op.getBufferView().getDefiningOp())) {
       rewriter.replaceOp(op, createOp.getSourceBuffer());
       return success();


### PR DESCRIPTION
dyn_cast_or_null has been marked that it will be deprecated for three years, so we choose `dyn_cast_if_present` for the use.

https://github.com/llvm/llvm-project/blame/a9a4515b0a442ea58826047b7efb9aa2bfe48749/llvm/include/llvm/Support/Casting.h#L750-L763