### PR TITLE
[Codegen] Fold bitcast into bufferized tensor load

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -1298,15 +1298,15 @@ void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns) {
                   FoldExpandShapeIntoInterfaceTensorLoad,
                   FoldExpandShapeIntoInterfaceTensorStore,
                   FoldInnerBitcastIntoInterfaceTensorLoad,
-                  FoldInnerBitcastIntoInterfaceTensorStore,
-                  FoldInnerBitcastIntoLoadFromBuffer>(patterns.getContext());
+                  FoldInnerBitcastIntoInterfaceTensorStore>(
+      patterns.getContext());
 }
 
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns) {
   patterns.insert<
       FoldCollapseShapeIntoLoadFromBuffer, FoldExpandShapeIntoLoadFromBuffer,
-      FoldCollapseShapeIntoStoreToBuffer, FoldExpandShapeIntoStoreToBuffer>(
-      patterns.getContext());
+      FoldCollapseShapeIntoStoreToBuffer, FoldExpandShapeIntoStoreToBuffer,
+      FoldInnerBitcastIntoLoadFromBuffer>(patterns.getContext());
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -1003,6 +1003,9 @@ struct FoldInnerBitcastIntoLoadFromBuffer
                                 PatternRewriter &rewriter) const override {
     Value bitcastSrc = bitcastOp.getSource();
 
+    // TODO(#22712): This pattern matching is fragile. Simplify this by using
+    // a memref.bitcast or similar operation once available.
+
     // Step 1: Check for iree_codegen.load_from_buffer.
     auto loadOp = bitcastSrc.getDefiningOp<IREE::Codegen::LoadFromBufferOp>();
     if (!loadOp) {

--- a/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReshapePatterns.cpp
@@ -10,8 +10,10 @@
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -825,8 +827,29 @@ struct FoldCollapseShapeIntoInterfaceTensorStore
   }
 };
 
-/// Folds iree_tensor_ext.bitcast that only change the inner most dimension into
-/// the source hal.interface.binding.subspan
+/// Folds iree_tensor_ext.bitcast that only changes the innermost dimension
+/// into the source hal.interface.binding.subspan.
+///
+/// This pattern matches the following:
+///   %subspan = hal.interface.binding.subspan ... :
+///       !dispatch_tensor<readonly:tensor<MxNx(2K)xf4E2M1FN>>
+///   %tensor = dispatch.tensor.load %subspan :
+///       !dispatch_tensor<readonly:tensor<MxNx(2K)xf4E2M1FN>> ->
+///       tensor<MxNx(2K)xf4E2M1FN>
+///   %bitcast = iree_tensor_ext.bitcast %tensor :
+///       tensor<MxNx(2K)xf4E2M1FN> -> tensor<MxNxKxi8>
+///
+/// And transforms it into:
+///   %subspan = hal.interface.binding.subspan ... :
+///       !dispatch_tensor<readonly:tensor<MxNxKxi8>>
+///   %tensor = dispatch.tensor.load %subspan :
+///       !dispatch_tensor<readonly:tensor<MxNxKxi8>> -> tensor<MxNxKxi8>
+///
+/// This is valid when:
+/// - Only the innermost dimension size and element type change
+/// - The bitcast represents a reinterpretation (e.g., f4E2M1FN -> i8)
+/// - The total byte size of the innermost dimension remains constant
+/// - The tensor has no encoding and the load is a full slice
 struct FoldInnerBitcastIntoInterfaceTensorLoad
     : OpRewritePattern<IREE::TensorExt::BitCastOp> {
   using Base::Base;
@@ -964,6 +987,105 @@ struct FoldInnerBitcastIntoInterfaceTensorStore
         storeOp, TypeRange{}, bitcastSrc, newSubspanOp, storeOp.getTargetDims(),
         storeOp.getOffsets(), storeOp.getSizes(), storeOp.getStrides(),
         storeOp.getStaticOffsets(), newSizes, storeOp.getStaticStrides());
+    return success();
+  }
+};
+
+/// Similar to FoldInnerBitcastIntoInterfaceTensorLoad, but handles the
+/// bufferized load instead:
+///   hal.interface.binding.subspan -> amdgpu.fat_raw_buffer_cast ->
+///   iree_codegen.load_from_buffer -> iree_tensor_ext.bitcast
+struct FoldInnerBitcastIntoLoadFromBuffer
+    : OpRewritePattern<IREE::TensorExt::BitCastOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(IREE::TensorExt::BitCastOp bitcastOp,
+                                PatternRewriter &rewriter) const override {
+    Value bitcastSrc = bitcastOp.getSource();
+
+    // Step 1: Check for iree_codegen.load_from_buffer.
+    auto loadOp = bitcastSrc.getDefiningOp<IREE::Codegen::LoadFromBufferOp>();
+    if (!loadOp) {
+      return failure();
+    }
+    Value loadBuffer = loadOp.getBuffer();
+
+    // Step 2: Check for amdgpu.fat_raw_buffer_cast.
+    auto bufferCastOp = loadBuffer.getDefiningOp<amdgpu::FatRawBufferCastOp>();
+    if (!bufferCastOp) {
+      return failure();
+    }
+    Value bufferCastSource = bufferCastOp.getSource();
+
+    // Step 3: Check for hal.interface.binding.subspan.
+    auto subspanOp =
+        bufferCastSource.getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
+    if (!subspanOp) {
+      return failure();
+    }
+
+    // Now we have the full bufferized load chain verified.
+    auto subspanType = cast<MemRefType>(subspanOp.getType());
+    auto bitcastSrcType = cast<RankedTensorType>(bitcastSrc.getType());
+    auto bitcastResType = cast<RankedTensorType>(bitcastOp.getType());
+
+    // Verify that only the inner most dimension is changed by the bitcast by
+    // comparing dynamic and static sizes for equality.
+    if (bitcastOp.getSourceDims() != bitcastOp.getResultDims() ||
+        bitcastSrcType.getShape().drop_back() !=
+            bitcastResType.getShape().drop_back() ||
+        ShapedType::isDynamic(bitcastSrcType.getShape().back())) {
+      return failure();
+    }
+
+    // Fail if the inner most dim doesn't match between subspan and tensor.
+    if (subspanType.getShape().back() != bitcastSrcType.getShape().back()) {
+      return failure();
+    }
+
+    int64_t newInnerSize = bitcastResType.getShape().back();
+    int64_t oldInnerSize = bitcastSrcType.getShape().back();
+
+    // Adjust the innermost dimension size.
+    MemRefLayoutAttrInterface newSubspanLayout;
+    SmallVector<int64_t> newSubspanShape(subspanType.getShape());
+    newSubspanShape.back() = newInnerSize;
+    // Scale offset and strides by (newInnerSize / oldInnerSize).
+    if (auto stridedLayout =
+            dyn_cast_or_null<StridedLayoutAttr>(subspanType.getLayout())) {
+      int64_t newOffset = stridedLayout.getOffset();
+      if (!ShapedType::isDynamic(newOffset)) {
+        newOffset = (newOffset * newInnerSize) / oldInnerSize;
+      }
+      SmallVector<int64_t> newStrides(stridedLayout.getStrides());
+      for (size_t i = 0; i + 1 < newStrides.size(); ++i) {
+        if (!ShapedType::isDynamic(newStrides[i])) {
+          newStrides[i] = (newStrides[i] * newInnerSize) / oldInnerSize;
+        }
+      }
+      newSubspanLayout =
+          StridedLayoutAttr::get(rewriter.getContext(), newOffset, newStrides);
+    }
+    // Use the bitcast's result element type.
+    auto newSubspanType =
+        MemRefType::get(newSubspanShape, bitcastResType.getElementType(),
+                        newSubspanLayout, subspanType.getMemorySpace());
+
+    rewriter.setInsertionPoint(subspanOp);
+    Value newSubspanOp = IREE::HAL::InterfaceBindingSubspanOp::create(
+        rewriter, subspanOp.getLoc(), newSubspanType, subspanOp.getLayout(),
+        subspanOp.getBinding(), subspanOp.getByteOffset(),
+        subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
+        subspanOp.getDescriptorFlagsAttr());
+
+    rewriter.setInsertionPoint(bufferCastOp);
+    Value newBufferCastOp = amdgpu::FatRawBufferCastOp::create(
+        rewriter, bufferCastOp.getLoc(), newSubspanOp,
+        bufferCastOp.getValidBytes(), bufferCastOp.getCacheSwizzleStride(),
+        bufferCastOp.getBoundsCheck(), bufferCastOp.getResetOffset());
+
+    rewriter.replaceOpWithNewOp<IREE::Codegen::LoadFromBufferOp>(
+        loadOp, bitcastResType, newBufferCastOp);
     return success();
   }
 };
@@ -1171,8 +1293,8 @@ void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns) {
                   FoldExpandShapeIntoInterfaceTensorLoad,
                   FoldExpandShapeIntoInterfaceTensorStore,
                   FoldInnerBitcastIntoInterfaceTensorLoad,
-                  FoldInnerBitcastIntoInterfaceTensorStore>(
-      patterns.getContext());
+                  FoldInnerBitcastIntoInterfaceTensorStore,
+                  FoldInnerBitcastIntoLoadFromBuffer>(patterns.getContext());
 }
 
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -55,6 +55,7 @@ iree_lit_test_suite(
             "fold_affine_min_in_distributed_loops.mlir",
             "fold_affine_min_of_block_id.mlir",
             "fold_bitcast_into_interface_tensor.mlir",
+            "fold_bitcast_into_load_from_buffer.mlir",
             "fold_reshape_into_interface_tensor.mlir",
             "fold_split_reduction_workgroup_mapping_loops.mlir",
             "fold_tensor_extract_op.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_lit_test_suite(
     "fold_affine_min_in_distributed_loops.mlir"
     "fold_affine_min_of_block_id.mlir"
     "fold_bitcast_into_interface_tensor.mlir"
+    "fold_bitcast_into_load_from_buffer.mlir"
     "fold_reshape_into_interface_tensor.mlir"
     "fold_split_reduction_workgroup_mapping_loops.mlir"
     "fold_tensor_extract_op.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
@@ -45,27 +45,3 @@ func.func @fold_store_of_bitcast_dynamic(%arg0 : tensor<?x32xf4E2M1FN>) {
 //  CHECK-SAME:       offsets = [0, 0], sizes = [%[[SHAPE]], 32], strides = [1, 1]
 //  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
 //   CHECK-NOT:   iree_tensor_ext.bitcast
-
-// -----
-
-#pipeline_layout_bufferized = #hal.pipeline.layout<bindings = [
-    #hal.pipeline.binding<storage_buffer, "ReadOnly">]>
-func.func @fold_bitcast_into_buffer_load() -> tensor<4x8x128xi8> {
-  %c0 = arith.constant 0 : index
-  %subspan = hal.interface.binding.subspan layout(#pipeline_layout_bufferized) binding(0) alignment(64) offset(%c0)
-      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>>
-  %buffer = amdgpu.fat_raw_buffer_cast %subspan resetOffset
-      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>> to memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
-  %tensor = iree_codegen.load_from_buffer %buffer : memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x256xf4E2M1FN>
-  %bitcast = iree_tensor_ext.bitcast %tensor : tensor<4x8x256xf4E2M1FN> -> tensor<4x8x128xi8>
-  return %bitcast : tensor<4x8x128xi8>
-}
-// CHECK-LABEL: func @fold_bitcast_into_buffer_load()
-//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
-//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>>
-//       CHECK:   %[[BUFFER:.+]] = amdgpu.fat_raw_buffer_cast %[[SUBSPAN]] resetOffset
-//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>> to memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>>
-//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
-//  CHECK-SAME:       memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x128xi8>
-//   CHECK-NOT:   iree_tensor_ext.bitcast
-//       CHECK:   return %[[LOAD]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_interface_tensor.mlir
@@ -45,3 +45,27 @@ func.func @fold_store_of_bitcast_dynamic(%arg0 : tensor<?x32xf4E2M1FN>) {
 //  CHECK-SAME:       offsets = [0, 0], sizes = [%[[SHAPE]], 32], strides = [1, 1]
 //  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x32xf4E2M1FN>>{%[[SHAPE]]}
 //   CHECK-NOT:   iree_tensor_ext.bitcast
+
+// -----
+
+#pipeline_layout_bufferized = #hal.pipeline.layout<bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">]>
+func.func @fold_bitcast_into_buffer_load() -> tensor<4x8x128xi8> {
+  %c0 = arith.constant 0 : index
+  %subspan = hal.interface.binding.subspan layout(#pipeline_layout_bufferized) binding(0) alignment(64) offset(%c0)
+      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>>
+  %buffer = amdgpu.fat_raw_buffer_cast %subspan resetOffset
+      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>> to memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+  %tensor = iree_codegen.load_from_buffer %buffer : memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x256xf4E2M1FN>
+  %bitcast = iree_tensor_ext.bitcast %tensor : tensor<4x8x256xf4E2M1FN> -> tensor<4x8x128xi8>
+  return %bitcast : tensor<4x8x128xi8>
+}
+// CHECK-LABEL: func @fold_bitcast_into_buffer_load()
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
+//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>>
+//       CHECK:   %[[BUFFER:.+]] = amdgpu.fat_raw_buffer_cast %[[SUBSPAN]] resetOffset
+//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>> to memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>>
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//  CHECK-SAME:       memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x128xi8>
+//   CHECK-NOT:   iree_tensor_ext.bitcast
+//       CHECK:   return %[[LOAD]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_load_from_buffer.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fold_bitcast_into_load_from_buffer.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-propagate-reshapes-by-expansion))" %s | FileCheck %s
+
+#pipeline_layout_bufferized = #hal.pipeline.layout<bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly">]>
+func.func @fold_bitcast_into_buffer_load() -> tensor<4x8x128xi8> {
+  %c0 = arith.constant 0 : index
+  %subspan = hal.interface.binding.subspan layout(#pipeline_layout_bufferized) binding(0) alignment(64) offset(%c0)
+      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>>
+  %buffer = amdgpu.fat_raw_buffer_cast %subspan resetOffset
+      : memref<4x8x256xf4E2M1FN, strided<[2048, 256, 1]>> to memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>>
+  %tensor = iree_codegen.load_from_buffer %buffer : memref<4x8x256xf4E2M1FN, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x256xf4E2M1FN>
+  %bitcast = iree_tensor_ext.bitcast %tensor : tensor<4x8x256xf4E2M1FN> -> tensor<4x8x128xi8>
+  return %bitcast : tensor<4x8x128xi8>
+}
+// CHECK-LABEL: func @fold_bitcast_into_buffer_load()
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
+//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>>
+//       CHECK:   %[[BUFFER:.+]] = amdgpu.fat_raw_buffer_cast %[[SUBSPAN]] resetOffset
+//  CHECK-SAME:       memref<4x8x128xi8, strided<[1024, 128, 1]>> to memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>>
+//       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//  CHECK-SAME:       memref<4x8x128xi8, #amdgpu.address_space<fat_raw_buffer>> -> tensor<4x8x128xi8>
+//   CHECK-NOT:   iree_tensor_ext.bitcast
+//       CHECK:   return %[[LOAD]]


### PR DESCRIPTION
We already support folding bitcast operations into `iree_tensor_ext.dispatch.tensor.load`. However, when `--iree-llvmgpu-combine-layout-transformation` is enabled, these tensor loads are bufferized before the folding pattern can be applied. Therefore, this PR extends the folding support.

One use case is the FP4 pingpong ukernel, which requires bitcasting FP4 data to `i8` to use `amdgpu.gather_to_lds` operations. Without this folding, `ComprehensiveBufferize` would fail.

Closes: #22601
