### PR TITLE
[Codegen][GPU] Add configurable num-stages option to prefetch pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -96,6 +96,11 @@ def ROCDLPrefetchSharedMemoryPass :
       let summary = "Rotate scf.for loops to prefetch shared memory with distance 1. This pass is only applicable"
           "to ROCDL targets because its effectiveness on non-AMD GPUs lacks testing and evaluation.";
   let dependentDialects = ["amdgpu::AMDGPUDialect"];
+  let options = [
+    Option<"numStages", "num-stages", "unsigned",
+           /*default=*/"2",
+           "Number of pipeline stages (1, 2, or 3+)">,
+  ];
 }
 
 def LLVMGPUSelectLoweringStrategyPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -185,7 +185,7 @@ static LogicalResult computeBackwardSlice(ArrayRef<Operation *> roots,
     (void)getBackwardSlice(root, &rootSlice, options);
     // getBackwardSlice doesn't include the root itself, so add it explicitly
     slice.insert(root);
-    slice.insert(rootSlice.begin(), rootSlice.end());
+    slice.insert_range(rootSlice);
 
     // Also add any parent scf.if operations that contain this root
     // This is necessary because roots inside scf.if need the if to be scheduled
@@ -199,7 +199,7 @@ static LogicalResult computeBackwardSlice(ArrayRef<Operation *> roots,
         // Compute backward slice OF the scf.if itself to capture its condition
         SetVector<Operation *> ifSlice;
         (void)getBackwardSlice(ifOp.getOperation(), &ifSlice, options);
-        slice.insert(ifSlice.begin(), ifSlice.end());
+        slice.insert_range(ifSlice);
 
         // Compute backward slices of all nested operations to get dependencies
         // This approach ensures correctness by capturing all transitive
@@ -208,7 +208,7 @@ static LogicalResult computeBackwardSlice(ArrayRef<Operation *> roots,
           if (nestedOp != ifOp.getOperation()) {
             SetVector<Operation *> nestedSlice;
             (void)getBackwardSlice(nestedOp, &nestedSlice, options);
-            slice.insert(nestedSlice.begin(), nestedSlice.end());
+            slice.insert_range(nestedSlice);
           }
         });
       } else if (parent->getNumRegions() > 0) {


### PR DESCRIPTION
Adds a `--num-stages` option to the `iree-llvmgpu-prefetch-shared-memory` pass, allowing configuration of pipeline stages.

**Options:**
- `num-stages=1`: Disable pipelining (no prefetch)
- `num-stages=2`: 2-stage pipeline with distance-1 prefetch (default)

This PR is mostly trivial changes and aim to get the code base ready to plumb through 3 stage pipelining. 