### PR TITLE
[Preprocessing] Add compute_barrier in ConvertConvFilterToChannelsLast pass

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -67,6 +67,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/Analysis",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -74,6 +74,7 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Stream::Analysis
     iree::compiler::Dialect::Stream::IR
+    iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::Util::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -250,17 +250,6 @@ struct ConvertGenericChwfToFhwc : public OpRewritePattern<linalg::GenericOp> {
       return failure();
 
     rewriter.replaceOp(linalgOp, reorderOp->getResults());
-
-    // Insert compute_barrier.end after the compute op and replace its uses.
-    Value genericVal = genericOp.getResult(0);
-    auto barrierEndOp =
-        IREE::TensorExt::ComputeBarrierEndOp::create(rewriter, loc, genericVal);
-    rewriter.replaceUsesWithIf(genericVal, barrierEndOp.getResult(),
-                               [&](OpOperand &use) {
-                                 return use.getOwner() != genericOp &&
-                                        use.getOwner() != barrierEndOp &&
-                                        !isa<tensor::DimOp>(use.getOwner());
-                               });
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -59,6 +59,7 @@ def ConvertConvFilterToChannelsLastPass:
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "mlir::tensor::TensorDialect",
+    "IREE::TensorExt::IREETensorExtDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -97,7 +97,6 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
 // CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
-// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 
 // -----
 
@@ -125,7 +124,6 @@ util.func public @conv_2d_nhwgc_gchwf(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
 // CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
-// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -90,14 +90,14 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
 
 // CHECK-FHWC-LABEL:  @conv_2d_nhwc_chwf
-// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xf32>
-// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins(%[[START]] : tensor<4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [3, 1, 2, 0]
-// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
-// CHECK-FHWC-SAME:   ins({{.*}}, %[[END]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
+// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 
 // -----
 
@@ -118,14 +118,14 @@ util.func public @conv_2d_nhwgc_gchwf(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d4, d5, d6, d7)>
 
 // CHECK-FHWC-LABEL:  @conv_2d_nhwgc_gchwf
-// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xf32>
-// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins(%[[START]] : tensor<7x4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [0, 4, 2, 3, 1]
-// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
-// CHECK-FHWC-SAME:   ins({{.*}}, %[[END]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[GENERIC]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -90,12 +90,14 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
 
 // CHECK-FHWC-LABEL:  @conv_2d_nhwc_chwf
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xf32>
-// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins(%[[START]] : tensor<4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [3, 1, 2, 0]
+// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
-// CHECK-FHWC-SAME:   ins({{.*}}, %[[TRANSPOSE]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[END]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
 
 // -----
 
@@ -116,12 +118,14 @@ util.func public @conv_2d_nhwgc_gchwf(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d4, d5, d6, d7)>
 
 // CHECK-FHWC-LABEL:  @conv_2d_nhwgc_gchwf
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xf32>
-// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins(%[[START]] : tensor<7x4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [0, 4, 2, 3, 1]
+// CHECK-FHWC:        %[[END:.*]] = iree_tensor_ext.compute_barrier.end %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
-// CHECK-FHWC-SAME:   ins({{.*}}, %[[TRANSPOSE]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[END]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
 
 // -----
 


### PR DESCRIPTION
This PR adds `iree_tensor_ext.compute_barrier` around transpose ops to avoid reshape operations being propagated and thus block undesirable fusion.