### PR TITLE
Relax assert in task_worker_deinitialize in case thread creation failed

### DIFF
--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -120,8 +120,9 @@ void iree_task_worker_await_exit(iree_task_worker_t* worker) {
 void iree_task_worker_deinitialize(iree_task_worker_t* worker) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Must have called request_exit/await_exit.
-  IREE_ASSERT_TRUE(iree_task_worker_is_zombie(worker));
+  // Must have called request_exit/await_exit, OR thread creation failed during
+  // initialization.
+  IREE_ASSERT_TRUE(!worker->thread || iree_task_worker_is_zombie(worker));
 
   iree_thread_release(worker->thread);
   worker->thread = NULL;


### PR DESCRIPTION
Currently if thread creation fails, NULL thread causes await_exit to pass through without updating the thread status, causing us to hit an assert for a non-zombie thread on deinitialize.
iree_task_worker_initialize notes that failures to init are intended to go through deinitialize, but the assert leads to confusing error output. Relaxing the assert produces the expected status failure, e.g.

```
RuntimeError: Error creating driver: ../iree/runtime/src/iree/base/internal/threading_pthreads.c:176: INTERNAL; thread creation failed with 22
```