### PR TITLE
[HAL] fix IREE_HAL_MAX_QUEUES to be number of bits in queue affinity type

### DIFF
--- a/runtime/src/iree/hal/queue.h
+++ b/runtime/src/iree/hal/queue.h
@@ -34,7 +34,7 @@ typedef uint64_t iree_hal_queue_affinity_t;
 
 // Specifies that any queue may be selected.
 #define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
-#define IREE_HAL_MAX_QUEUES (sizeof(iree_hal_queue_affinity_t) / 8)
+#define IREE_HAL_MAX_QUEUES (sizeof(iree_hal_queue_affinity_t) * 8)
 
 // Returns true if the |queue_affinity| is empty (none specified).
 #define iree_hal_queue_affinity_is_empty(queue_affinity) ((queue_affinity) == 0)


### PR DESCRIPTION
The computation of the number of bits in the queue affinity type iree_hal_queue_affinity_t needs to use a multiplication by 8 to get from the number of bytes to the number of bits. Before, it incorrectly used a divison by 8. This resulted in IREE_HAL_MAX_QUEUES having an incorrect value of 1 instead of 64.