### PR TITLE
[DispatchCreation] Move RemoveTensorBarriers to end of pipeline

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -152,11 +152,6 @@ static void addDispatchRegionCreationPreprocessingPasses(
       //    producer-consumer fusion.
       .addPass(DispatchCreation::createSinkReshapesPass)
       .addPass(IREE::Flow::createCanonicalizePass)
-      .addPass(mlir::createCSEPass)
-
-      // 5. Remove tensor barriers after the preprocessing passes.
-      .addPass(DispatchCreation::createRemoveTensorBarriersPass)
-      .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass);
 
   if (clEnableFuseHorizontalContractions) {
@@ -313,6 +308,10 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager,
     passManager.addPass(
         IREE::Util::createHoistIntoGlobalsPass(hoistingOptions));
   }
+
+  // Remove tensor compute_barriers at the end of dispatch region creation.
+  FunctionLikeNest(passManager)
+      .addPass(DispatchCreation::createRemoveTensorBarriersPass);
 }
 
 // Apply preprocessing and form dispatch regions


### PR DESCRIPTION
`RemoveTensorBarriersPass` was being run too early in the pipeline, which prevented the barriers from blocking fusion. Barriers should be removed at the very end of the pipeline.