### PR TITLE
[CI] Reduce ctest parallelism in the clang job

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -56,6 +56,8 @@ jobs:
           sccache --show-stats
       - name: Run CTest
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+        env:
+          CTEST_PARALLEL_LEVEL: 32
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"
 


### PR DESCRIPTION
mlir can spawn multiple threads, so we don't want to oversubscribe github runners.