### PR TITLE
[Dispatch Creation] Add aggressive reshape movement flag

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -464,7 +464,7 @@ void BubbleUpExpandShapesPass::runOnOperation() {
           // If producer generic op is elementwise op, bubble up the expand
           // shape past this operation.
           // If bubbling across reduction ops is enabled, allow all generic ops.
-          return (enableBubbleUpExpandShapesAcrossReductionOps ||
+          return (enableReshapeMovementAcrossReductions ||
                   llvm::all_of(producerGenericOp.getIteratorTypesArray(),
                                linalg::isParallelIterator));
         }
@@ -478,7 +478,7 @@ void BubbleUpExpandShapesPass::runOnOperation() {
           // If bubbling collapse shapes down across reduction ops is enabled,
           // allow collapse shapes to bubble down through reduction ops.
           // TODO: This condition should be removed.
-          return enableBubbleDownCollapseShapesAcrossReductionOps ||
+          return enableReshapeMovementAcrossReductions ||
                  llvm::all_of(consumerGenericOp.getIteratorTypesArray(),
                               linalg::isParallelIterator);
         }

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -474,13 +474,18 @@ void BubbleUpExpandShapesPass::runOnOperation() {
           return false;
         }
 
-        // Do not push expand shapes down across operations with reduction
-        // iterator types.
-        // TODO: This condition should be removed.
-        if (auto consumerLinalgOp = dyn_cast<linalg::LinalgOp>(consumer)) {
-          return isa<linalg::GenericOp>(consumerLinalgOp) &&
-                 llvm::all_of(consumerLinalgOp.getIteratorTypesArray(),
+        if (auto consumerGenericOp = dyn_cast<linalg::GenericOp>(consumer)) {
+          // If bubbling collapse shapes down across reduction ops is enabled,
+          // allow collapse shapes to bubble down through reduction ops.
+          // TODO: This condition should be removed.
+          return enableBubbleDownCollapseShapesAcrossReductionOps ||
+                 llvm::all_of(consumerGenericOp.getIteratorTypesArray(),
                               linalg::isParallelIterator);
+        }
+
+        // Do not push expand shapes down across named ops for now.
+        if (isa<linalg::LinalgOp>(consumer)) {
+          return false;
         }
         // Fuse in all other cases.
         return true;

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -131,7 +131,14 @@ static void addDispatchRegionCreationPreprocessingPasses(
       // 2. Bubble up expand_shape ops (or sink collapse_shape ops) to get
       //    elementwise operation into higher dimensions for more fusion
       //    opportunities.
-      .addPass(DispatchCreation::createBubbleUpExpandShapesPass)
+      .addPass([&]() {
+        return DispatchCreation::createBubbleUpExpandShapesPass(
+            DispatchCreation::BubbleUpExpandShapesPassOptions{
+                /*enableBubbleUpExpandShapesAcrossReductionOps=*/
+                dispatchOptions.enableAggressiveReshapeMovement,
+                /*enableBubbleDownCollapseShapesAcrossReductionOps=*/
+                dispatchOptions.enableAggressiveReshapeMovement});
+      })
       .addPass(IREE::Flow::createCanonicalizePass)
       .addPass(mlir::createCSEPass)
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -134,9 +134,7 @@ static void addDispatchRegionCreationPreprocessingPasses(
       .addPass([&]() {
         return DispatchCreation::createBubbleUpExpandShapesPass(
             DispatchCreation::BubbleUpExpandShapesPassOptions{
-                /*enableBubbleUpExpandShapesAcrossReductionOps=*/
-                dispatchOptions.enableAggressiveReshapeMovement,
-                /*enableBubbleDownCollapseShapesAcrossReductionOps=*/
+                /*enableReshapeMovementAcrossReductions=*/
                 dispatchOptions.enableAggressiveReshapeMovement});
       })
       .addPass(IREE::Flow::createCanonicalizePass)

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -48,6 +48,14 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
       llvm::cl::desc("Enable split reduction for dispatch creation pipeline"),
       llvm::cl::init(false),
   };
+  Option<bool> enableAggressiveReshapeMovement{
+      *this,
+      "aggressive-reshape-movement",
+      llvm::cl::desc(
+          "Enable aggressive reshape movement (bubbling expand/collapse "
+          "shapes across reduction ops)"),
+      llvm::cl::init(false),
+  };
   Option<bool> constExprHoisting{
       *this,
       "const-expr-hoisting",

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -36,10 +36,8 @@ def BubbleUpExpandShapesPass :
     Pass<"iree-dispatch-creation-bubble-up-expand-shapes"> {
   let summary = "Propagate expand_shapes up the program (and collapse_shapes down).";
   let options = [
-    Option<"enableBubbleUpExpandShapesAcrossReductionOps", "enable-bubble-up-expand-shapes-across-reduction-ops", "bool",
-           /*default=*/"false", "Enables propagation of 'expand_shape's through 'linalg.generic's with reductions">,
-    Option<"enableBubbleDownCollapseShapesAcrossReductionOps", "enable-bubble-down-collapse-shapes-across-reduction-ops", "bool",
-           /*default=*/"false", "Enables propagation of 'collapse_shape's through 'linalg.generic's with reductions">
+    Option<"enableReshapeMovementAcrossReductions", "enable-reshape-movement-across-reductions", "bool",
+           /*default=*/"false", "Enables propagation of 'expand_shape's and 'collapse_shape's through 'linalg.generic's with reductions">
   ];
   let dependentDialects = [
     "mlir::affine::AffineDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -37,7 +37,9 @@ def BubbleUpExpandShapesPass :
   let summary = "Propagate expand_shapes up the program (and collapse_shapes down).";
   let options = [
     Option<"enableBubbleUpExpandShapesAcrossReductionOps", "enable-bubble-up-expand-shapes-across-reduction-ops", "bool",
-           /*default=*/"false", "Enables propagation of 'expand_shape's through 'linalg.generic's with reductions">
+           /*default=*/"false", "Enables propagation of 'expand_shape's through 'linalg.generic's with reductions">,
+    Option<"enableBubbleDownCollapseShapesAcrossReductionOps", "enable-bubble-down-collapse-shapes-across-reduction-ops", "bool",
+           /*default=*/"false", "Enables propagation of 'collapse_shape's through 'linalg.generic's with reductions">
   ];
   let dependentDialects = [
     "mlir::affine::AffineDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
-// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-bubble-up-expand-shapes-across-reduction-ops}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-bubble-up-expand-shapes-across-reduction-ops enable-bubble-down-collapse-shapes-across-reduction-ops}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
 
 util.func public @bubbble_expand_through_extract(%arg0 : tensor<2x4096x5120xf16>) -> (tensor<2x64x64x2560xf16>) {
   %extracted_slice_237 = tensor.extract_slice %arg0[0, 0, 0] [2, 4096, 2560] [1, 1, 1] : tensor<2x4096x5120xf16> to tensor<2x4096x2560xf16>
@@ -132,6 +132,32 @@ util.func @bubble_up_through_reduction(%arg0: tensor<10x?xi64>) -> tensor<2x5xi6
 // CHECK-AGGRESSIVE:   %[[EXPANDED:.+]] = tensor.expand_shape %[[ARG0]]
 // CHECK-AGGRESSIVE:   %[[EXPANDED_GENERIC:.+]] = linalg.generic {{.+}} ins(%[[EXPANDED]]
 // CHECK-AGGRESSIVE:   return %[[EXPANDED_GENERIC]]
+
+// -----
+
+// Bubbling collapse shapes down through reductions should apply when enabled via flag.
+util.func @bubble_down_through_reduction(%arg0: tensor<2x5x?xi64>) -> tensor<10xi64> {
+  %collapsed = tensor.collapse_shape %arg0 [[0, 1], [2]] : tensor<2x5x?xi64> into tensor<10x?xi64>
+  %outs = tensor.empty() : tensor<10xi64>
+  %9 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]
+  } ins(%collapsed : tensor<10x?xi64>) outs(%outs : tensor<10xi64>) {
+  ^bb0(%in: i64, %out: i64):
+    %x = arith.addi %in, %out : i64
+    linalg.yield %x : i64
+  } -> tensor<10xi64>
+  util.return %9 : tensor<10xi64>
+}
+//      CHECK-LABEL: func public @bubble_down_through_reduction
+//       CHECK-SAME:     %[[ARG0:.+]]: tensor
+//    CHECK-DEFAULT:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//    CHECK-DEFAULT:   %[[GENERIC:.+]] = linalg.generic {{.+}} ins(%[[COLLAPSED]]
+//    CHECK-DEFAULT:   return %[[GENERIC]]
+
+// CHECK-AGGRESSIVE:   %[[GENERIC:.+]] = linalg.generic {{.+}} ins(%[[ARG0]]
+// CHECK-AGGRESSIVE:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[GENERIC]]
+// CHECK-AGGRESSIVE:   return %[[COLLAPSED]]
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
-// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-bubble-up-expand-shapes-across-reduction-ops enable-bubble-down-collapse-shapes-across-reduction-ops}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-reshape-movement-across-reductions}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
 
 util.func public @bubbble_expand_through_extract(%arg0 : tensor<2x4096x5120xf16>) -> (tensor<2x64x64x2560xf16>) {
   %extracted_slice_237 = tensor.extract_slice %arg0[0, 0, 0] [2, 4096, 2560] [1, 1, 1] : tensor<2x4096x5120xf16> to tensor<2x4096x2560xf16>

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{aggressive-fusion})" --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-dispatch-creation-pipeline{aggressive-fusion aggressive-reshape-movement})" --mlir-print-local-scope %s | FileCheck %s --check-prefixes=CHECK-AGGRESSIVE-RESHAPE
 
 util.func public @truncate_fusion(%arg0: tensor<2x64x64x320xi8>, %arg1: tensor<2x66x66x640xi8>, %arg2: tensor<3x3x640x640xi8>, %arg3: tensor<640xi32>, %arg4: tensor<640xf32>, %arg5: tensor<640x320xi8>, %arg6: tensor<640xi32>, %arg7: tensor<640xf32>) -> tensor<2x640x64x64xf16> {
   %c0_i32 = arith.constant 0 : i32
@@ -182,3 +183,33 @@ util.func public @transpose_barrier_matmul(%arg0: tensor<128x64xf32>, %arg1: ten
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups
 //       CHECK:     %[[MATMUL:.+]] = linalg.matmul
 //  CHECK-SAME:       ins({{.*}}, {{.*}} : tensor<128x64xf32>, tensor<64x128xf32>)
+
+// -----
+
+// Test aggressive reshape movement: collapse shape should move through reduction so that the transpose and reduction can be fused.
+util.func public @aggressive_reshape_movement(%arg0: tensor<2x10x20xi64>) -> tensor<10xi64> {
+  %empty_transpose = tensor.empty() : tensor<2x20x10xi64>
+  %transposed = linalg.transpose ins(%arg0 : tensor<2x10x20xi64>) outs(%empty_transpose : tensor<2x20x10xi64>) permutation = [0, 2, 1]
+  %collapsed = tensor.collapse_shape %transposed [[0, 1], [2]] : tensor<2x20x10xi64> into tensor<40x10xi64>
+  %empty_reduction = tensor.empty() : tensor<10xi64>
+  %reduced = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]
+  } ins(%collapsed : tensor<40x10xi64>) outs(%empty_reduction : tensor<10xi64>) {
+  ^bb0(%in: i64, %out: i64):
+    %x = arith.addi %in, %out : i64
+    linalg.yield %x : i64
+  } -> tensor<10xi64>
+  util.return %reduced : tensor<10xi64>
+}
+// CHECK-LABEL: func public @aggressive_reshape_movement
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.workgroups(%[[ARG0]])
+//       CHECK:   %[[RESHAPED:.+]] = flow.tensor.reshape %[[DISPATCH0]]
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups(%[[RESHAPED]])
+//       CHECK:   util.return %[[DISPATCH1]]
+
+// CHECK-AGGRESSIVE-RESHAPE-LABEL: util.func public @aggressive_reshape_movement
+// CHECK-AGGRESSIVE-RESHAPE-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
+// CHECK-AGGRESSIVE-RESHAPE:   %[[DISPATCH:.+]] = flow.dispatch.workgroups(%[[ARG0]])
+// CHECK-AGGRESSIVE-RESHAPE:   util.return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -339,6 +339,13 @@ void DispatchCreationOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc(
           "Enable split-reduction for certain reduction operations."),
       llvm::cl::cat(category));
+  binder.opt<bool>(
+      "iree-dispatch-creation-enable-aggressive-reshape-movement",
+      enableAggressiveReshapeMovement,
+      llvm::cl::desc(
+          "Enable aggressive reshape movement (bubbling expand/collapse "
+          "shapes across reduction ops)."),
+      llvm::cl::cat(category));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -235,6 +235,10 @@ struct DispatchCreationOptions {
   // Enables data tiling in dispatch creation phase.
   bool dataTiling = false;
 
+  // Enables aggressive reshape movement (bubbling expand/collapse shapes
+  // across reduction ops).
+  bool enableAggressiveReshapeMovement = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<DispatchCreationOptions>;
 };

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -328,6 +328,8 @@ void buildIREEVMTransformPassPipeline(
     }
     dispatchTransformOptions.enableSplitReduction =
         dispatchCreationOptions.enableSplitReduction;
+    dispatchTransformOptions.enableAggressiveReshapeMovement =
+        dispatchCreationOptions.enableAggressiveReshapeMovement;
     dispatchTransformOptions.constExprMaxSizeIncreaseThreshold =
         pipelineOptions.constExprMaxSizeIncreaseThreshold;
     dispatchTransformOptions.constExprHoisting =

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -153,7 +153,7 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   passManager.addPass(DispatchCreation::createFusionPreprocessingPass());
   passManager.addPass(mlir::createCSEPass());
   DispatchCreation::BubbleUpExpandShapesPassOptions bubbleOptions;
-  bubbleOptions.enableBubbleUpExpandShapesAcrossReductionOps = true;
+  bubbleOptions.enableReshapeMovementAcrossReductions = true;
   passManager.addPass(
       DispatchCreation::createBubbleUpExpandShapesPass(bubbleOptions));
   passManager.addPass(DispatchCreation::createElementwiseOpFusionPass(


### PR DESCRIPTION
Adds new compiler flag `--dispatch-creation-enable-aggressive-reshape-movement` to enable moving reshapes through reduction operations. The top-level flag controls the pass option `enableReshapeMovementAcrossReductions` in BubbleUpExpandShapes.

I have been working to enable this by default on https://github.com/iree-org/iree/pull/22341; there are a few issues/regressions to fix. For now, I'm adding this under a flag because this is needed in Fusilli https://github.com/iree-org/fusilli/issues/18 https://github.com/iree-org/iree/issues/22502