### PR TITLE
Initial tools/utils/ iree-* developer utilities.

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,67 @@
+# Rules for .claude/ Directory
+
+**Every token costs.** Anything checked into `.claude/` is paid for on every invocation by every developer. Guard this directory jealously.
+
+## CLAUDE.md
+
+**Bar: Benefits ALL developers on EVERY use.**
+
+We do not yet have project-wide instructions that meet this bar. Keep your instructions in:
+- `~/.claude/CLAUDE.md` (personal global)
+- `CLAUDE.local.md` (personal per-project, gitignored)
+
+`/init` is quite decent at generating a `CLAUDE.md` and you can write your own prompt based on the kind of work you do to guide it. There's some [good example init-like prompts](https://github.com/kaushikgopal/dotfiles/blob/master/.ai/commands/initialize.md) out there to use as reference.
+
+Bad example: [pytorch/CLAUDE.md](https://github.com/pytorch/pytorch/blob/2dd529df0092799f68ee7afcf52338276906706a/CLAUDE.md) - includes testing syntax that benefits a fraction of uses.
+
+## Skills
+
+**Bar: Benefits nearly all developers. Durable (useful 1 year from now). Graduated from well-honed workflows.**
+
+Skills trigger automatically and their descriptions appear in context regardless of whether they are used (context bloat). A skill is ready for inclusion in the main repository when you've explained the same approach to Claude multiple times across many sessions and it has stabilized into a reliable workflow _and_ that workflow is one adopted by several other contributors. Otherwise, keep it local or in shared plugins.
+
+**Requirements:**
+- Broadly applicable (not for a single pass, single refactoring, or single API)
+- Concise (reference style guides, don't embed them)
+- Durable (core workflow aid, not a temporary migration helper)
+
+**Anti-patterns:**
+- Triggers on common actions (docstrings, formatting) - see [pytorch docstring skill](https://github.com/pytorch/pytorch/blob/43c30f607eeca0d3e9a26911d9c2131fc250eadd/.claude/skills/docstring/SKILL.md)
+- Narrow scope (single API conversion) - see [pytorch AT_DISPATCH_V2 skill](https://github.com/pytorch/pytorch/blob/3ca216ae172e35adde34a319a1a01faaf218e7c5/.claude/skills/add-uint-support/SKILL.md)
+- Embeds reference material that belongs in `--help` or external docs
+
+**Prefer instead:**
+- `~/.claude/skills/` for personal skills
+- [Plugins](https://code.claude.com/docs/en/plugins) for sharing with small groups
+
+## Commands
+
+**Bar: Daily workflow automation. Graduated from manual processes.**
+
+Commands should encode workflows that engineers do manually today. They must be:
+- Used frequently (not one-off investigations)
+- Stable (the underlying tools/processes are mature)
+- Broadly applicable (useful to most engineers, not specialists)
+
+**Prefer instead:**
+- `~/.claude/commands/` for personal commands
+- [Plugins](https://code.claude.com/docs/en/plugins) for sharing with small groups
+
+## Hooks
+
+Hooks auto-approve or modify Claude's behavior. They must be:
+- Security-conscious (document threat model)
+- Minimal (approve specific tools, not broad categories)
+- Self-documenting (embed rationale in the script)
+
+## Summary
+
+| Location | Bar | Examples |
+|----------|-----|----------|
+| `CLAUDE.md` (checked in) | All devs, every use | None yet |
+| `.claude/skills/` | Nearly all devs, durable | `iree-lit-tools` |
+| `.claude/commands/` | Daily workflows | `/iree-ci-triage`, `/iree-lit-test` |
+| `~/.claude/` | Personal | Your preferences |
+| Plugins | Small groups | Team-specific workflows |
+
+When in doubt, keep it local. Graduate to checked-in only after proving value across the team.

--- a/.claude/commands/iree-ci-triage.md
+++ b/.claude/commands/iree-ci-triage.md
@@ -1,0 +1,31 @@
+---
+allowed-tools: Bash(iree-ci-triage:*), Bash(gh:*), Read, Grep
+description: Triage CI failures for a PR or commit
+---
+
+## Context
+
+**Target:**
+!`if [ -n "$ARGUMENTS" ]; then echo "PR/run: $ARGUMENTS"; else echo "No PR specified - showing recent failing PRs"; fi`
+
+**CI Triage Results:**
+!`if [ -n "$ARGUMENTS" ]; then PYTHONPATH=tools/utils python3 -m ci.iree_ci_triage --pr "$ARGUMENTS" --checklist 2>&1 | head -200; else gh pr list --state open --limit 10 --json number,title,headRefName --template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}{{end}}' 2>&1; fi`
+
+## Your Task
+
+Analyze the CI triage results above and help fix the failures:
+
+1. **If no PR was specified**: Ask which PR to triage from the list shown
+
+2. **For each failure category**:
+   - **Compile errors**: Read the failing file and fix the issue
+   - **Test failures**: Run `iree-lit-test` to debug, then fix CHECK patterns or code
+   - **Sanitizer issues**: Analyze the stack trace and fix memory/thread issues
+   - **Infrastructure flakes**: Note these are transient, suggest re-running
+
+3. **Priority order**: Fix errors before warnings, compile errors before test failures
+
+4. **After fixing**: Verify the fix locally before suggesting it's ready
+
+Use `iree-ci-triage --pr N --json` for machine-readable output if needed.
+Use `iree-lit-lint` and `iree-lit-test` for test-related failures and reference the `iree-lit-tools` skill for guidance on style and common workflows.

--- a/.claude/commands/iree-lit-lint.md
+++ b/.claude/commands/iree-lit-lint.md
@@ -1,0 +1,51 @@
+---
+allowed-tools: Bash(iree-lit-lint:*), Bash(iree-lit-*), Read, Edit
+description: Lint a lit test for style issues
+---
+
+## Context
+
+**Target file(s):**
+!`if [ -n "$ARGUMENTS" ]; then echo "$ARGUMENTS"; else git diff --name-only HEAD 2>/dev/null | grep '\.mlir$' | head -5 || echo "No .mlir files in diff"; fi`
+
+**Lint results:**
+!`file="$ARGUMENTS"; if [ -z "$file" ]; then files=$(git diff --name-only HEAD 2>/dev/null | grep '\.mlir$'); else files="$file"; fi; for f in $files; do if [ -f "$f" ]; then echo "=== $f ==="; PYTHONPATH=tools/utils python3 -m lit_tools.iree_lit_lint "$f" 2>&1 | head -50; fi; done`
+
+## Your Task
+
+Fix the lint issues shown above:
+
+### Common Fixes
+
+**1. Raw SSA identifiers** (`%0`, `%arg0`, `%buffer`):
+```mlir
+// BAD:  // CHECK: %5 = arith.addi %0, %arg0
+// GOOD: // CHECK: %[[LHS:.+]] = ...
+//       // CHECK: %[[RHS:.+]] = ...
+//       // CHECK: %[[RESULT:.+]] = arith.addi %[[LHS]], %[[RHS]]
+```
+
+**2. Missing CHECK lines**:
+Add CHECK patterns that verify the transformation, not just syntax.
+
+**3. Wildcards on critical values**:
+```mlir
+// BAD:  // CHECK: stream.async.execute await({{.+}})
+// GOOD: // CHECK: %[[TIMEPOINT:.+]] = stream.timepoint.join
+//       // CHECK: stream.async.execute await(%[[TIMEPOINT]])
+```
+
+**4. Incomplete multi-result captures**:
+```mlir
+// BAD:  // CHECK: %[[RESOURCE:.+]], %{{.+}} = stream.async.execute
+// GOOD: // CHECK: %[[RESOURCE:.+]], %[[TIMEPOINT:.+]] = stream.async.execute
+```
+
+### After Fixing
+
+1. Re-run lint to verify: `iree-lit-lint <file>`
+2. Run the tests to ensure they still pass: `iree-lit-test <file>`
+
+### For More Context
+
+Run `iree-lit-lint --help-style-guide` to see the full style guide with examples.

--- a/.claude/commands/iree-lit-test.md
+++ b/.claude/commands/iree-lit-test.md
@@ -1,0 +1,37 @@
+---
+allowed-tools: Bash(iree-lit-*), Bash(iree-opt:*), Read, Edit
+description: Run and debug a lit test
+---
+
+## Context
+
+**Target file(s):**
+!`if [ -n "$ARGUMENTS" ]; then echo "$ARGUMENTS"; else git diff --name-only HEAD 2>/dev/null | grep '\.mlir$' | head -5 || echo "No .mlir files in diff"; fi`
+
+**Test structure:**
+!`file="$ARGUMENTS"; if [ -z "$file" ]; then file=$(git diff --name-only HEAD 2>/dev/null | grep '\.mlir$' | head -1); fi; if [ -n "$file" ] && [ -f "$file" ]; then PYTHONPATH=tools/utils python3 -m lit_tools.iree_lit_list "$file" 2>&1; else echo "No test file found"; fi`
+
+## Your Task
+
+Run and debug the lit test(s):
+
+1. **If no file specified**: Work with the modified `.mlir` files shown above
+
+2. **Run the test**:
+   ```bash
+   iree-lit-test <file> --case N          # Run specific case
+   iree-lit-test <file> --verbose         # See full output
+   iree-lit-test <file> --dry-run         # See commands without running
+   ```
+
+3. **If a test fails**:
+   - Use `--verbose` to see the actual vs expected output
+   - Extract the case: `iree-lit-extract <file> --case N`
+   - Run the pipeline manually to see actual IR
+   - Update CHECK patterns to match actual output
+
+4. **Before finishing**:
+   - Run `iree-lit-lint <file>` to check for style issues
+   - Verify all cases pass: `iree-lit-test <file>`
+
+Use the `iree-lit-tools` skill for guidance on style and common workflows.

--- a/.claude/commands/iree-pre-commit.md
+++ b/.claude/commands/iree-pre-commit.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash(pre-commit run:*), Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(bash -c:*)
+description: Run pre-commit on modified files and fix issues
+---
+
+## Context
+
+**Modified files (staged or unstaged):**
+!`git diff --name-only HEAD`
+
+**Pre-commit results on modified files:**
+!`bash -c 'files=$(git diff --name-only HEAD); if [ -n "$files" ]; then pre-commit run --files $files --show-diff-on-failure 2>&1; else echo "No modified files to check"; fi'`
+
+**Current git status:**
+!`git status --short`
+
+## Your Task
+
+Analyze the pre-commit results above and fix all issues that were **not** auto-fixed:
+
+1. **Auto-fixed issues (IGNORE these)**: When you see "files were modified by this hook", those files were already fixed automatically (e.g., Black formatting, clang-format). No action needed.
+
+2. **Manual fixes needed (FIX these)**: When you see detailed error messages with line numbers and specific issues (e.g., Ruff linting errors, type annotation issues), these require manual fixes.
+
+For each issue requiring manual fixes:
+- Read the affected files
+- Apply the fixes following the error messages
+- Verify the fix with `pre-commit run --files <file>` after editing
+
+After fixing all issues, run `pre-commit run` again to verify everything passes.
+
+**Important**: Only fix files that have real errors. Don't touch files that were auto-formatted unless they still have errors after auto-formatting.

--- a/.claude/hooks/auto-approve-iree-tools.sh
+++ b/.claude/hooks/auto-approve-iree-tools.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# =============================================================================
+# auto-approve-iree-tools.sh - Auto-approve IREE tool invocations
+# =============================================================================
+#
+# PURPOSE:
+#   Automatically approve permission dialogs for IREE tool invocations in
+#   Claude Code, eliminating repeated permission prompts during development.
+#
+# WHEN IT ACTIVATES:
+#   When Claude Code attempts to run a `Bash` command where:
+#   1. The command basename starts with `iree-` (e.g., iree-compile, iree-opt)
+#   2. The current working directory is within the IREE project
+#      (checked via $CLAUDE_PROJECT_DIR)
+#
+# WHAT IT ENABLES:
+#   - Seamless use of IREE tools without repeated permission prompts
+#   - Heredoc syntax: `iree-lit-test << 'EOF' ... EOF`
+#   - Environment prefixes: `PYTHONPATH=foo iree-opt ...`
+#   - Flexible build directories: `../any-build-dir/tools/iree-compile`
+#
+# SCOPE AND SECURITY:
+#   - Execution context: Must be working in IREE project directory
+#   - Tool location: Binary can exist anywhere (build dirs, $PATH, submodules)
+#   - Risk: If a malicious binary named `iree-*` exists, it will be
+#     auto-approved when working in IREE
+#
+# =============================================================================
+set -euo pipefail
+
+# If python3 is not available in this shell environment, gracefully no-op.
+if ! command -v python3 >/dev/null 2>&1; then
+  # Exit 0 with no stdout => hook is treated as "no output, no decision".
+  exit 0
+fi
+
+# Capture stdin from Claude Code.
+input=$(cat)
+
+# Debug: Uncomment to log stdin to file for debugging.
+# echo "$input" > /tmp/iree-hook-debug-stdin.json
+
+# Run the JSON logic in an inline python3 block, passing JSON as argument.
+python3 -c '
+import json
+import os
+import re
+import shlex
+import sys
+from typing import Optional
+
+ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
+
+def parse_command_word(command: str) -> Optional[str]:
+    """Return first non-env-assignment token from a shell command string."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+    if not tokens:
+        return None
+
+    idx = 0
+    n = len(tokens)
+
+    # Skip leading env assignments like FOO=bar BAR=baz.
+    while idx < n and ASSIGNMENT_RE.fullmatch(tokens[idx]):
+        idx += 1
+
+    if idx >= n:
+        return None
+
+    return tokens[idx]
+
+def is_within_project() -> bool:
+    """Return True if current working directory is within IREE project."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return False
+    cwd = os.path.realpath(os.getcwd())
+    project_root = os.path.realpath(project_dir)
+    return cwd.startswith(project_root)
+
+def is_iree_tool_command(command: str) -> bool:
+    cmd_word = parse_command_word(command)
+    if not cmd_word:
+        return False
+    basename = os.path.basename(cmd_word)
+    return basename.startswith("iree-")
+
+try:
+    # Read JSON from command-line argument.
+    data = json.loads(sys.argv[1])
+except (json.JSONDecodeError, IndexError):
+    # Invalid input => no-op.
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {}) or {}
+command = tool_input.get("command", "") or ""
+
+# Only care about Bash tool permission dialogs with a non-empty command.
+if tool_name != "Bash" or not command.strip():
+    sys.exit(0)
+
+# Only match IREE tools (basename starts with "iree-").
+if not is_iree_tool_command(command):
+    sys.exit(0)
+
+# Only auto-approve when executing from within the IREE project.
+if not is_within_project():
+    sys.exit(0)
+
+# Emit PreToolUse decision JSON to auto-approve this call.
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow"
+    }
+}
+json.dump(output, sys.stdout)
+sys.stdout.write("\n")
+sys.stdout.flush()
+' "$input"

--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/auto-approve-iree-tools.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/iree-lit-tools/SKILL.md
+++ b/.claude/skills/iree-lit-tools/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: iree-lit-tools
+description: MLIR lit test authoring, linting, debugging, and manipulation for IREE
+allowed-tools: Bash, Read, Grep, Glob, Edit
+---
+
+# IREE Lit Test Tools
+
+Tools for working with MLIR lit tests: listing, extracting, replacing, running, and linting.
+
+## When to Use
+
+- **Writing or fixing lit tests**: Use `iree-lit-lint` to check for style violations, `iree-lit-test` to run isolated cases
+- **Debugging a failing test**: Use `iree-lit-list` to see test structure, `iree-lit-extract` to get a specific case, `iree-lit-test --case N` to run it
+- **Updating CHECK patterns**: Use `iree-lit-extract` to get the case, run the pipeline manually to see actual output, then `iree-lit-replace` to update
+- **Understanding test structure**: Use `iree-lit-list --names` to see what a file tests
+
+## Tool Reference
+
+### iree-lit-list
+List test cases in a file.
+```bash
+iree-lit-list test.mlir              # Show all cases with metadata
+iree-lit-list test.mlir --count      # Just the count
+iree-lit-list test.mlir --names      # Space-separated names
+iree-lit-list test.mlir --json       # Machine-readable
+```
+
+### iree-lit-extract
+Extract individual test cases.
+```bash
+iree-lit-extract test.mlir --case 3        # Extract case #3
+iree-lit-extract test.mlir --line 123      # Extract case containing line 123
+iree-lit-extract test.mlir --name "foo"    # Extract case named "foo"
+iree-lit-extract test.mlir -c 1,3,5        # Multiple cases
+```
+
+### iree-lit-replace
+Replace a test case atomically (reads new content from stdin).
+```bash
+iree-lit-replace test.mlir --case 3 < fixed_case.mlir
+
+# Heredoc for inline replacement (no temp files needed):
+iree-lit-replace test.mlir --case 3 <<'EOF'
+// RUN: iree-opt --my-pass %s | FileCheck %s
+// CHECK-LABEL: @my_test
+func.func @my_test() {
+  return
+}
+EOF
+```
+
+### iree-lit-test
+Run tests in isolation with debug capabilities.
+```bash
+iree-lit-test test.mlir                    # Run all cases
+iree-lit-test test.mlir --case 2           # Run only case #2
+iree-lit-test test.mlir -c 1-3             # Run cases 1, 2, 3
+iree-lit-test test.mlir --name "foo"       # Run case named "foo"
+iree-lit-test test.mlir --verbose          # Show full output
+iree-lit-test test.mlir --extra-flags "--debug"  # Inject flags
+iree-lit-test test.mlir --dry-run          # Show commands without running
+
+# Heredoc for rapid testing (no temp files needed):
+iree-lit-test --run 'iree-opt --my-pass %s | FileCheck %s' <<'EOF'
+// CHECK-LABEL: @test_fusion
+// CHECK: my.fused_op
+func.func @test_fusion() {
+  %0 = my.op1
+  %1 = my.op2 %0
+  return
+}
+EOF
+```
+
+### iree-lit-lint
+Lint tests against the style guide.
+```bash
+iree-lit-lint test.mlir                    # Lint all cases
+iree-lit-lint test.mlir --case 2           # Lint only case #2
+iree-lit-lint test.mlir --errors-only      # Only show errors
+iree-lit-lint test.mlir --help-style-guide # Show full style guide
+```
+
+## Core Style Principles
+
+For the full style guide, run `iree-lit-lint --help-style-guide`.
+
+**1. Verify Transformations, Not Syntax**
+Tests must prove the transformation is correct. Capture SSA values the pass touches.
+```mlir
+// BAD - wildcards the critical value:
+// CHECK: stream.async.execute await({{.+}})
+
+// GOOD - captures and verifies:
+// CHECK: %[[TIMEPOINT:.+]] = stream.timepoint.join
+// CHECK: stream.async.execute await(%[[TIMEPOINT]])
+```
+
+**2. Track Data Flow**
+Values flowing from producer to consumer must be captured at both ends.
+```mlir
+// CHECK: %[[SIZE:.+]] = stream.tensor.sizeof
+// CHECK: stream.resource.alloc ... {%[[SIZE]]}  ← Same capture
+```
+
+**3. Capture Multi-Result Operations Completely**
+If an op returns `(resource, timepoint)`, capture both.
+```mlir
+// CHECK: %[[RESOURCE:.+]], %[[TIMEPOINT:.+]] = stream.async.execute
+```
+
+**4. Use Semantic Names**
+Match IR names: `%transient_size` → `%[[TRANSIENT_SIZE:.+]]`.
+
+**5. No Raw SSA Identifiers**
+Use named captures, not `%0`, `%arg0`, `%buffer`.
+```mlir
+// BAD:  // CHECK: %5 = arith.addi %0, %arg0
+// GOOD: // CHECK: %[[LHS:.+]] = ...
+//       // CHECK: %[[RHS:.+]] = ...
+//       // CHECK: %[[RESULT:.+]] = arith.addi %[[LHS]], %[[RHS]]
+```
+
+**6. Wildcards Only for Structural IR**
+Wildcard types, affinities, and debug attrs. Capture everything the pass modifies.
+
+## Rapid Testing with Heredocs
+
+The fastest way to test transformations without temp files:
+
+```bash
+# Test a pass inline with heredoc
+iree-lit-test --run 'iree-opt --iree-util-fold-globals %s | FileCheck %s' <<'EOF'
+// CHECK-LABEL: util.func @test
+// CHECK-NOT: util.global
+util.global private @unused : i32
+util.func @test() {
+  util.return
+}
+EOF
+
+# Replace a test case inline
+iree-lit-replace test.mlir --case 2 <<'EOF'
+// CHECK-LABEL: @fixed_test
+// CHECK: %[[RESULT:.+]] = arith.addi
+func.func @fixed_test(%arg0: i32, %arg1: i32) -> i32 {
+  %0 = arith.addi %arg0, %arg1 : i32
+  return %0 : i32
+}
+EOF
+
+# Lint inline IR
+iree-lit-lint <<'EOF'
+// RUN: iree-opt %s
+// CHECK: arith.addi %arg0, %arg1
+func.func @bad_test(%arg0: i32, %arg1: i32) {
+  %0 = arith.addi %arg0, %arg1 : i32
+  return
+}
+EOF
+```
+
+## Common Workflows
+
+### Debug a Failing Test
+```bash
+# 1. See test structure
+iree-lit-list failing_test.mlir
+
+# 2. Run the failing case in isolation
+iree-lit-test failing_test.mlir --case 3 --verbose
+
+# 3. Extract and run manually to see actual output
+iree-lit-extract failing_test.mlir --case 3 > /tmp/case.mlir
+iree-opt --pass-pipeline="..." /tmp/case.mlir
+
+# 4. Compare expected vs actual, update CHECK patterns
+```
+
+### Fix Lint Errors
+```bash
+# 1. Run linter
+iree-lit-lint test.mlir
+
+# 2. See specific issues
+iree-lit-lint test.mlir --case 2 --full-json
+
+# 3. Read the style guide for context
+iree-lit-lint --help-style-guide | grep -A 20 "Raw SSA"
+```
+
+### Update a Test After Pass Changes
+```bash
+# 1. Extract the case
+iree-lit-extract test.mlir --case 2 -o /tmp/case.mlir
+
+# 2. Run pass, capture new output
+iree-opt --my-pass /tmp/case.mlir > /tmp/new_output.mlir
+
+# 3. Update CHECK patterns manually or via editor
+
+# 4. Replace the case
+cat /tmp/updated_case.mlir | iree-lit-replace test.mlir --case 2
+
+# 5. Verify
+iree-lit-test test.mlir --case 2
+```
+
+## Environment
+
+Tools auto-detect build directories. Override with:
+```bash
+export IREE_BUILD_DIR=/path/to/build
+```
+
+Add tools to PATH if not found:
+```bash
+export PATH="$PATH:$IREE_ROOT/tools/utils/bin"
+```

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,10 @@
+# direnv configuration for IREE tools/utils
+# Copy to .envrc and run `direnv allow`
+#
+# See: https://direnv.net/
+
+# Add tools to PATH
+PATH_add tools/utils/bin
+
+# Optional: Set build directory for tools that need iree-opt/FileCheck
+# export IREE_BUILD_DIR="../builds/main"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # Cursor files
 .cursor/
 
+# Claude Code user-specific settings (project-level overrides)
+.claude/settings.local.json
+
 # macOS files
 .DS_Store
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,18 @@ repos:
       - id: black
         name: Run Black to format Python files
 
+  # Optional but recommended: fast Python linting and import checks just for utils.
+  # Configuration is in tools/utils/pyproject.toml to avoid duplication.
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        name: Run Ruff on utils Python files
+        args:
+          - --config=tools/utils/pyproject.toml
+          - --fix
+        files: ^tools/utils/.*\.py$
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     # Loosely track the most recent versions in
     #   * Runner images: https://github.com/actions/runner-images/
@@ -59,9 +71,16 @@ repos:
     rev: f2d115a052860b09b2888b4f104be614bf3b4779
     hooks:
       - id: do-not-submit
+        exclude: "^tools/utils/test/"
 
   - repo: local
     hooks:
+      - id: utils-validate
+        name: IREE utils validation (scoped)
+        language: system
+        entry: python tools/utils/scripts/precommit_utils.py
+        files: ^tools/utils/.*
+        pass_filenames: false
       - id: buildifier
         name: Run buildifier
         entry: buildifier
@@ -114,5 +133,13 @@ repos:
         entry: Files should be named BUILD.bazel instead of BUILD
         language: fail
         files: "BUILD$"
+
+      - id: iree-utils-lint
+        name: IREE utils lint (console/cli/exit-codes/fs)
+        language: python
+        entry: python tools/utils/scripts/lint_hooks.py
+        pass_filenames: true
+        files: ^tools/utils/.*\.py$
+        types: [python]
 
     # TODO(scotttodd): mypy type checking for Python (https://mypy-lang.org/)

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -48,17 +48,9 @@ CMAKE_ARGS=(
   "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 )
 
-echo "::group::Configuring CMake"
 "${CMAKE_BIN?}" "${CMAKE_ARGS[@]?}"
-echo "::endgroup::"
-
-echo "::group::Building all"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" -- -k 0
-echo "::endgroup::"
-
-echo "::group::Building test deps"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-test-deps -- -k 0
-echo "::endgroup::"
 
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
@@ -116,16 +108,12 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
 pushd "${BUILD_DIR?}"
 
-echo "::group::Running main project ctests"
 ctest \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
   --label-exclude "${label_exclude_regex}"
-echo "::endgroup::"
 
-echo "::group::Running llvm-external-projects tests"
 cmake --build . --target check-iree-dialects -- -k 0
-echo "::endgroup::"
 
 popd

--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -60,17 +60,9 @@ CMAKE_ARGS=(
   "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 )
 
-echo "::group::Configuring CMake"
 "${CMAKE_BIN}" -B "${BUILD_DIR}" "${CMAKE_ARGS[@]?}"
-echo "::endgroup::"
-
-echo "::group::Building all"
 "$CMAKE_BIN" --build "${BUILD_DIR}" -- -k 0
-echo "::endgroup::"
-
-echo "::group::Building test deps"
 "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
-echo "::endgroup::"
 
 # Disable actually running GPU tests. This tends to yield TSan reports that are
 # specific to one's particular GPU driver and therefore hard to reproduce across

--- a/build_tools/cmake/build_and_test_ubsan.sh
+++ b/build_tools/cmake/build_and_test_ubsan.sh
@@ -58,17 +58,9 @@ CMAKE_ARGS=(
   "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 )
 
-echo "::group::Configuring CMake"
 cmake "${CMAKE_ARGS[@]?}"
-echo "::endgroup::"
-
-echo "::group::Building all"
 cmake --build "${BUILD_DIR?}" -- -k 0
-echo "::endgroup::"
-
-echo "::group::Building test deps"
 cmake --build "${BUILD_DIR?}" --target iree-test-deps -- -k 0
-echo "::endgroup::"
 
 # Don't run any GPU tests for the time being.
 # These are not ubsan-warning-free yet.
@@ -77,10 +69,5 @@ export IREE_METAL_DISABLE=1
 export IREE_CUDA_DISABLE=1
 export IREE_HIP_DISABLE=1
 
-echo "::group::Running tests"
 build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
-echo "::endgroup::"
-
-echo "::group::Running llvm-external-projects tests"
 cmake --build "${BUILD_DIR?}" --target check-iree-dialects -- -k 0
-echo "::endgroup::"

--- a/tools/utils/CLAUDE.md
+++ b/tools/utils/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md - Agent Rules for tools/utils/
+
+Rules for AI agents contributing to IREE developer utilities.
+
+## Critical Rules
+
+1. **Never `print()` directly** - Use `console.error/warn/note/success` for messages
+2. **Never `sys.exit(N)`** - Use `return exit_codes.SUCCESS/ERROR/NOT_FOUND`
+3. **Never raw file writes** - Use `fs.safe_write_text()` for atomic UTF-8 writes
+4. **Always add common flags** - Call `cli.add_common_output_flags(parser)`
+5. **JSON purity** - Never mix `print()` with JSON output; use `console.print_json()`
+
+## Test Command
+
+```bash
+python -m unittest discover -s tools/utils -p "test_*.py" -v
+```
+
+**Expected output**: `Ran 356 tests ... OK`
+
+Never claim tests pass without this output.
+
+## Key Files by Category
+
+### Lit Tools (`lit_tools/`)
+- `iree_lit_list.py` - List test cases
+- `iree_lit_extract.py` - Extract cases
+- `iree_lit_replace.py` - Replace cases
+- `iree_lit_test.py` - Run tests
+- `iree_lit_lint.py` - Lint tests
+- `core/parser.py` - Parse test files
+- `core/check_matcher.py` - FileCheck pattern matching
+- `STYLE_GUIDE.md` - MLIR test style rules
+
+### CI Tools (`ci/`)
+- `iree_ci_triage.py` - Triage CI failures
+- `iree_ci_garden.py` - Manage failure corpus
+- `core/patterns.py` - Error pattern definitions
+- `core/classifier.py` - Pattern matching
+
+### Common (`common/`)
+- `console.py` - Output functions (error/warn/note/success)
+- `exit_codes.py` - Standard exit codes
+- `fs.py` - Safe file operations
+- `build_detection.py` - Locate IREE build artifacts
+
+## Import Pattern
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from common import console, exit_codes, fs
+from lit_tools.core import cli
+```
+
+Do NOT use relative imports (`from .core import ...`).
+Do NOT use inline imports (always keep at the top of the module).
+
+## Full Documentation
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for complete development guidelines.

--- a/tools/utils/CONTRIBUTING.md
+++ b/tools/utils/CONTRIBUTING.md
@@ -1,0 +1,265 @@
+# Contributing to tools/utils
+
+Development guide for contributors working on IREE developer utilities.
+
+## Pre-commit Hook
+
+This subtree has a scoped pre-commit hook (`utils-validate`):
+- Permissions: only `bin/*` are executable; wrappers must have python3 shebang
+- Imports: no `from lit ...` (use `from lit_tools ...`)
+- JSON purity: never `print()` to stdout from JSON branches
+
+Run manually:
+```bash
+pre-commit run utils-validate -a
+python3 tools/utils/scripts/precommit_utils.py
+```
+
+## Code Style
+
+- **Minimal dependencies** - Only essential packages (psutil for lit timeouts); see pyproject.toml
+- **argparse for CLI** - Consistent with IREE's existing scripts
+- **Apache 2.0 + LLVM header** - Include license header in all files
+- **Docstrings with examples** - Module docstring shows usage examples
+- **Consistent output modes**:
+  - `--json` for machine-readable output
+  - `--pretty` for human-friendly formatting (opt-in)
+  - default mode should be concise and script-friendly
+
+## Authoring Guidelines (Required)
+
+- Always add common output flags with `cli.add_common_output_flags(parser)`.
+- Use `console.error/warn/note/success` for all human messages; never `print()` directly.
+- Use `console.print_json(...)` for JSON; do not mix JSON and human text on stdout.
+- Honor `--quiet`: suppress non-essential text automatically via `console.*`.
+- Return `exit_codes.SUCCESS/ERROR/NOT_FOUND` instead of magic numbers.
+- Write files via `fs.safe_write_text(...)` (UTF-8, atomic rename, normalized newlines).
+- Shebang policy: only `bin/` wrappers have shebangs.
+- **CRITICAL**: Never disable lint checks (ruff, black) with `# noqa` without explicit approval.
+
+### Token Efficiency & LLM-Friendliness
+
+- Default output is concise and stable; opt into `--pretty` for humans.
+- `--json` prints only JSON to stdout; human notes go to stderr.
+- `--quiet` suppresses notes/warnings/success to save tokens.
+- Use shared console/formatting helpers to avoid drift and noise.
+
+## JSON Schema Coordination
+
+- In-tree only: producers and consumers live together; update both in the same PR.
+- No version fields: keep payloads small; tests catch breakages.
+- For large runs, write JSON to a file (`--json-output`) and post-process with `jq`.
+
+## I/O Output Contract (lit tools)
+
+- Without `-o`:
+  - With `--json`: JSON to stdout only
+  - Without `--json`: Text to stdout only
+- With `-o <file>`:
+  - With `--json`: JSON to file; stdout quiet
+  - Without `--json`: Text to file; stdout quiet
+
+## Minimal Tool Skeleton
+
+```python
+import sys
+from pathlib import Path
+
+# Add parent directory to sys.path (required for all tools).
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from common import console, exit_codes, fs
+from lit_tools.core import cli
+
+parser = argparse.ArgumentParser(...)
+cli.add_common_output_flags(parser)
+args = parser.parse_args()
+
+try:
+    # Do work.
+    if args.json:
+        console.print_json({"ok": True}, args=args)
+    else:
+        console.note("did the thing", args=args)
+    return exit_codes.SUCCESS
+except FileNotFoundError as e:
+    console.error(str(e), args=args)
+    return exit_codes.NOT_FOUND
+except Exception as e:
+    console.error(f"failed: {e}", args=args)
+    return exit_codes.ERROR
+```
+
+## Testing Requirements
+
+**Single test command for ALL tests:**
+
+```bash
+# From IREE repo root (primary workflow):
+python -m unittest discover -s tools/utils -p "test_*.py" -v
+
+# From tools/utils directory:
+cd tools/utils
+python -m unittest discover -s . -p "test_*.py" -v
+```
+
+**Never declare "tests pass" until seeing: `Ran 356 tests ... OK`**
+
+**Key Requirements:**
+- unittest for tests (matches IREE's test infrastructure)
+- Test coverage >80% for shared libraries
+- Fixture-based tests in `test/<category>_tests/fixtures/`
+- Cross-platform (Windows, Linux, macOS)
+- Python only, no shell scripts
+
+### Fixture-based vs Real-file Testing
+
+**Fixture-based tests** (required for CI):
+- Reproducible, controlled content
+- Place fixtures in `test/<category>_tests/fixtures/`
+
+**Real-file validation** (development, not CI):
+- Manually validate on real IREE test files
+- Document in PR description
+- Don't add real-file tests to unittest
+
+## Import Strategy (REQUIRED)
+
+### For category tools (lit_tools/, ci/, etc.)
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from common import build_detection, console, exit_codes, fs
+from lit_tools.core import cli
+```
+
+### For test files
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_list
+from common import build_detection
+```
+
+### For bin/ wrappers
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lit_tools import iree_lit_list
+
+if __name__ == "__main__":
+    sys.exit(iree_lit_list.main(iree_lit_list.parse_arguments()))
+```
+
+**CRITICAL: Do NOT use relative imports** (`from .core import ...`). Use absolute imports after sys.path is set up.
+
+## Execution Model
+
+### File naming conventions
+
+- **Python modules**: Use underscores (`iree_lit_list.py`)
+- **CLI wrappers**: Use hyphens (`iree-lit-list`)
+
+### Executable permissions
+
+- Only `bin/` wrappers should be executable and have shebangs
+- Category modules should NOT have shebangs or be executable
+
+### Module structure
+
+Category modules must include:
+```python
+if __name__ == "__main__":
+    sys.exit(main(parse_arguments()))
+```
+
+## Test Organization
+
+### Directory structure
+
+```
+tools/utils/test/<category>_tests/test_<module>.py
+```
+
+### Naming conventions
+
+| Module Location | Test Location |
+|----------------|---------------|
+| `lit_tools/iree_lit_list.py` | `test/lit_tests/test_iree_lit_list.py` |
+| `lit_tools/core/parser.py` | `test/lit_tests/test_core_parser.py` |
+| `common/build_detection.py` | `test/common_tests/test_build_detection.py` |
+
+### Fixtures
+
+Place in `test/<category>_tests/fixtures/`:
+```
+test/lit_tests/fixtures/
+  ├── split_test.mlir          # Multiple cases with // -----
+  ├── single_case_test.mlir    # Single case, no delimiters
+  └── README.md                # Documents what each fixture tests
+```
+
+## Build Detection
+
+### When to use
+
+**Use build_detection when:**
+- Tool invokes IREE binaries (`iree-opt`, `iree-compile`, `FileCheck`)
+- Tool needs to know build type (Debug vs Release)
+- Tool needs to locate LLVM tools
+
+**Skip when:**
+- Tool only parses/lists/extracts text
+- Tool is a pure utility (formatting, file manipulation)
+
+### Search order
+
+1. `IREE_BUILD_DIR` environment variable (override)
+2. `./build/` (in-tree build)
+3. `../<worktree>-build/` (worktree pattern)
+4. `../iree-build/` (main repo build)
+
+### Error handling patterns
+
+**Optional tool usage:**
+```python
+try:
+    iree_opt = build_detection.find_tool("iree-opt")
+except FileNotFoundError:
+    console.warn("Skipping validation (iree-opt not found).", args=args)
+```
+
+**Required tool:**
+```python
+try:
+    iree_opt = build_detection.find_tool("iree-opt")
+except FileNotFoundError as e:
+    console.error(f"Cannot find iree-opt.\n{e}", args=args)
+    return exit_codes.NOT_FOUND
+```
+
+## Adding New Tools
+
+1. Add implementation to appropriate category directory
+2. Add comprehensive docstring with examples
+3. Write tests (unit + integration) in `test/<category>_tests/`
+4. Create a thin Python wrapper in `bin/` (not a symlink)
+5. Update category README.md
+6. Run full test suite: `python -m unittest discover -s tools/utils -p "test_*.py" -v`
+
+## Category READMEs
+
+- `lit_tools/README.md` - Lit test tools architecture
+- `ci/README.md` - CI triage tools

--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -1,0 +1,118 @@
+# IREE Developer Utilities
+
+Developer-facing utilities for IREE contributors: testing, CI triage, and analysis.
+
+Distinct from `build_tools/` (building IREE), `tests/` (test suites), and `tools/` (user-facing compiler tools like iree-compile).
+
+## Installation
+
+**1. Install dependencies:**
+```bash
+pip install -e tools/utils
+```
+
+**2. Add to PATH (choose one):**
+
+```bash
+# Option A: Export PATH
+export PATH="$PATH:$PWD/tools/utils/bin"
+
+# Option B: direnv (recommended)
+cp .envrc.example .envrc
+direnv allow
+```
+
+**3. Verify:**
+```bash
+iree-lit-list --help
+```
+
+## Tools
+
+### Lit Test Tools (`iree-lit-*`)
+
+Work with MLIR lit test files that use `// -----` delimiters.
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `iree-lit-list` | List test cases | `iree-lit-list test.mlir` |
+| `iree-lit-extract` | Extract individual cases | `iree-lit-extract test.mlir --case 3` |
+| `iree-lit-replace` | Replace case content | `echo "..." \| iree-lit-replace test.mlir --case 3` |
+| `iree-lit-test` | Run tests in isolation | `iree-lit-test test.mlir --case 2 --verbose` |
+| `iree-lit-lint` | Lint for style issues | `iree-lit-lint test.mlir` |
+
+```bash
+# Common workflow: debug a failing test
+iree-lit-list test.mlir                    # See structure
+iree-lit-test test.mlir --case 2 --verbose # Run failing case
+iree-lit-extract test.mlir --case 2        # Extract for manual debugging
+iree-lit-lint test.mlir --case 2           # Check style
+
+# Run all tests in a file
+iree-lit-test test.mlir
+
+# Lint all modified .mlir files
+git diff --name-only HEAD | grep '\.mlir$' | xargs -I{} iree-lit-lint {}
+```
+
+### CI Triage Tools (`iree-ci-*`)
+
+Analyze GitHub Actions failures.
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `iree-ci-triage` | Analyze CI failures | `iree-ci-triage --pr 12345` |
+| `iree-ci-garden` | Manage failure corpus | `iree-ci-garden --help` |
+
+```bash
+# Triage all CI failures for a PR
+iree-ci-triage --pr 12345
+
+# Triage a specific workflow run
+iree-ci-triage --run 9876543210
+
+# Get JSON output for scripting
+iree-ci-triage --pr 12345 --json
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `IREE_BUILD_DIR` | Override build directory detection (for `iree-lit-test`) |
+
+## File System Hygiene
+
+These tools never write to the source tree:
+- No temporary files in test directories
+- All temp files use system temp directories
+- Output files only where explicitly specified (`-o`, `--json-output`)
+
+## Documentation
+
+- `--help` on any tool for detailed usage
+- `iree-lit-lint --help-style-guide` for MLIR test style guide
+- `lit_tools/STYLE_GUIDE.md` for full style documentation
+
+## Claude Code Integration
+
+Claude commands are available for these tools:
+- `/iree-ci-triage {pr}` - Triage CI failures
+- `/iree-lit-test {file}` - Run and debug a lit test
+- `/iree-lit-lint {file}` - Lint a lit test
+
+The `iree-lit-tools` skill provides guidance for MLIR test authoring.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines:
+- Code style and authoring requirements
+- Testing requirements (356 tests must pass)
+- Import strategy and execution model
+- Adding new tools
+
+```bash
+# Run all tests
+python -m unittest discover -s tools/utils -p "test_*.py" -v
+# Expected: Ran 356 tests ... OK
+```

--- a/tools/utils/bin/iree-ci-garden
+++ b/tools/utils/bin/iree-ci-garden
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Wrapper script for iree-ci-garden tool."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for development.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ci.iree_ci_garden import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/utils/bin/iree-ci-triage
+++ b/tools/utils/bin/iree-ci-triage
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for ci/iree_ci_triage.py."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to sys.path.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ci import iree_ci_triage
+
+if __name__ == "__main__":
+    sys.exit(iree_ci_triage.main(iree_ci_triage.parse_arguments()))

--- a/tools/utils/bin/iree-lit-extract
+++ b/tools/utils/bin/iree-lit-extract
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for iree-lit-extract tool."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Import and run the actual tool
+from lit_tools import iree_lit_extract
+
+if __name__ == "__main__":
+    sys.exit(iree_lit_extract.main(iree_lit_extract.parse_arguments()))

--- a/tools/utils/bin/iree-lit-lint
+++ b/tools/utils/bin/iree-lit-lint
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for lit_tools/iree_lit_lint.py."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to sys.path.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lit_tools import iree_lit_lint
+
+if __name__ == "__main__":
+    sys.exit(iree_lit_lint.main(iree_lit_lint.parse_arguments()))

--- a/tools/utils/bin/iree-lit-list
+++ b/tools/utils/bin/iree-lit-list
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for iree-lit-list tool."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Import and run the actual tool
+from lit_tools import iree_lit_list
+
+if __name__ == "__main__":
+    # Parse args and run main
+    sys.exit(iree_lit_list.main(iree_lit_list.parse_arguments()))

--- a/tools/utils/bin/iree-lit-replace
+++ b/tools/utils/bin/iree-lit-replace
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for iree-lit-replace tool."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Import and run the actual tool
+from lit_tools import iree_lit_replace
+
+if __name__ == "__main__":
+    sys.exit(iree_lit_replace.main(iree_lit_replace.parse_arguments()))

--- a/tools/utils/bin/iree-lit-test
+++ b/tools/utils/bin/iree-lit-test
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for lit/iree_lit_test.py."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to sys.path.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lit_tools import iree_lit_test
+
+if __name__ == "__main__":
+    sys.exit(iree_lit_test.main(iree_lit_test.parse_arguments()))

--- a/tools/utils/ci/PATTERN_GUIDE.md
+++ b/tools/utils/ci/PATTERN_GUIDE.md
@@ -1,0 +1,668 @@
+# CI Error Pattern Authoring Guide
+
+This guide explains how to add, modify, and test error patterns for the IREE CI triage system.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Pattern Structure](#pattern-structure)
+- [Writing Effective Patterns](#writing-effective-patterns)
+- [Field Reference](#field-reference)
+- [Extraction Rules](#extraction-rules)
+- [Testing Patterns](#testing-patterns)
+- [Common Pitfalls](#common-pitfalls)
+- [Examples](#examples)
+
+---
+
+## Overview
+
+The CI triage system uses **patterns.yaml** to define error signatures. Each pattern:
+- Has a regex that matches error text in logs
+- Includes metadata (severity, whether it's actionable, description)
+- Optionally extracts structured data (file paths, error codes, etc.)
+
+Patterns are used to:
+1. **Identify** errors in CI logs
+2. **Classify** them by type and severity
+3. **Extract** actionable information for fixing
+4. **Group** co-occurring errors into root causes
+
+---
+
+## Pattern Structure
+
+### Basic Pattern
+
+```yaml
+pattern_name:
+  pattern: 'regex pattern here'
+  severity: critical|high|medium|low
+  actionable: true|false
+  context_lines: 5
+  description: "Human-readable description"
+```
+
+### Pattern with Extraction
+
+```yaml
+compile_error:
+  pattern: 'error: .*|compilation terminated'
+  severity: critical
+  actionable: true
+  context_lines: 5
+  description: "C++ compilation error"
+  extract:
+    - name: file_path
+      regex: '(\S+\.\w+):(\d+):(\d+):'
+    - name: error_message
+      regex: 'error: (.+)'
+```
+
+---
+
+## Writing Effective Patterns
+
+### 1. **Be Specific, Not Generic**
+
+❌ **Bad**: Matches too broadly
+```yaml
+error_pattern:
+  pattern: 'error'  # Matches "error", "errors", "error-free", etc.
+```
+
+✅ **Good**: Matches specific error signatures
+```yaml
+compile_error:
+  pattern: 'error: .*|compilation terminated|fatal error:'
+  # Matches C++ compiler errors specifically
+```
+
+### 2. **Use Anchors When Possible**
+
+❌ **Bad**: Matches anywhere in the line
+```yaml
+test_pattern:
+  pattern: 'failed'  # Matches "prefailed", "failed test", etc.
+```
+
+✅ **Good**: Uses word boundaries or specific context
+```yaml
+test_failed:
+  pattern: 'FAILED.*tests?|Test.*failed'
+  # Matches "FAILED 3 tests" or "Test foo failed"
+```
+
+### 3. **Match Case-Insensitively**
+
+The pattern engine uses `re.IGNORECASE` by default, so you don't need to write:
+```yaml
+pattern: 'ERROR|Error|error'  # Unnecessary
+```
+
+Just write:
+```yaml
+pattern: 'error:'  # Matches ERROR:, Error:, error:
+```
+
+### 4. **Handle Variations**
+
+❌ **Bad**: Only matches one variant
+```yaml
+rocm_error:
+  pattern: 'rocm error'  # Misses "ROCm runtime error"
+```
+
+✅ **Good**: Matches all variants
+```yaml
+rocm_error:
+  pattern: 'ROCm error|rocm.*error'
+```
+
+### 5. **Escape Special Regex Characters**
+
+Special characters need escaping:
+- `.` → `\.` (literal dot)
+- `*` → `\*` (literal asterisk)
+- `+` → `\+` (literal plus)
+- `?` → `\?` (literal question mark)
+- `(` → `\(` (literal parenthesis)
+- `[` → `\[` (literal bracket)
+
+Example:
+```yaml
+vk_error:
+  pattern: 'VK_ERROR_\w+'  # \w+ matches alphanumeric
+```
+
+---
+
+## Field Reference
+
+### `pattern` (required)
+
+**Type**: String (regex)
+**Description**: Regular expression to match in log content
+
+**Regex Flags Enabled**:
+- `re.IGNORECASE` - Case-insensitive matching
+- `re.MULTILINE` - `^` and `$` match line boundaries
+
+**Examples**:
+```yaml
+# Simple literal match
+pattern: 'Segmentation fault'
+
+# Alternation (OR)
+pattern: 'error: .*|compilation terminated'
+
+# Character classes
+pattern: 'VK_ERROR_\w+'  # Matches VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_MEMORY, etc.
+
+# Wildcards
+pattern: 'rocm.*error'  # Matches "rocm error", "rocm runtime error", etc.
+```
+
+### `severity` (required)
+
+**Type**: String
+**Values**: `critical`, `high`, `medium`, `low`
+**Description**: How severe is this error?
+
+**Guidelines**:
+- `critical`: Crash, corruption, security issue (segfault, device lost)
+- `high`: Compilation error, test failure, assertion
+- `medium`: Timeout, OOM, infrastructure issue
+- `low`: Network error, download failure
+
+### `actionable` (required)
+
+**Type**: Boolean
+**Description**: Can a developer fix this by changing code?
+
+**Guidelines**:
+- `true`: Code bug, test failure, compilation error
+- `false`: Infrastructure flake, driver crash, network timeout
+
+**Examples**:
+```yaml
+# actionable: true - fix the undefined reference
+undefined_reference:
+  pattern: 'undefined reference to'
+  actionable: true
+
+# actionable: false - can't fix GPU driver crash in code
+cuda_device_lost:
+  pattern: 'CUDA.*device.*lost'
+  actionable: false
+```
+
+### `context_lines` (required)
+
+**Type**: Integer
+**Description**: Number of lines to capture before/after match
+
+**Guidelines**:
+- Use `3` for simple errors with clear messages
+- Use `5-10` for errors needing stack traces or build context
+- Use `10+` for segfaults, core dumps (need full stack)
+
+**Example**:
+```yaml
+compile_error:
+  context_lines: 5
+  # Captures:
+  # - 5 lines before error (may show build commands)
+  # - The error line
+  # - 5 lines after (may show additional errors)
+```
+
+### `description` (required)
+
+**Type**: String
+**Description**: Human-readable explanation of what this pattern detects
+
+**Guidelines**:
+- Be specific about error type
+- Mention the technology if relevant (Vulkan, HIP, Python, etc.)
+- Keep it concise (1-2 sentences)
+
+**Examples**:
+```yaml
+rocclr_memobj:
+  description: "ROCm memory object cleanup crash (false CI failure)"
+
+filecheck_failed:
+  description: "LLVM FileCheck test failure"
+
+hip_file_not_found:
+  description: "HIP file not found (missing device libraries)"
+```
+
+### `extract` (optional)
+
+**Type**: List of extraction rules
+**Description**: Extract structured data from matches
+
+See [Extraction Rules](#extraction-rules) below for details.
+
+---
+
+## Extraction Rules
+
+Extraction rules pull structured data from error messages for actionable triage.
+
+### Structure
+
+```yaml
+extract:
+  - name: field_name        # Name for the extracted field
+    regex: 'capture pattern' # Regex with capture groups
+```
+
+### How It Works
+
+1. The `regex` is matched against the **matched error text** (not the entire log)
+2. If the regex has **capture groups** `()`, the groups are extracted
+3. Extracted data is stored in `PatternMatch.extracted_fields[field_name]`
+
+### Example: Extract File Path and Line Number
+
+```yaml
+compile_error:
+  pattern: 'error: .*'
+  extract:
+    - name: file_path
+      regex: '(\S+\.\w+):(\d+):(\d+):'
+      # Captures: ('path/to/file.cpp', '145', '12')
+    - name: error_message
+      regex: 'error: (.+)'
+      # Captures: ('use of undeclared identifier')
+```
+
+**Input Log**:
+```
+/home/user/code.cpp:145:12: error: use of undeclared identifier 'foo'
+```
+
+**Extracted Fields**:
+```python
+{
+  "file_path": ("/home/user/code.cpp", "145", "12"),
+  "error_message": ("use of undeclared identifier 'foo'",)
+}
+```
+
+### Example: Extract Error Codes
+
+```yaml
+hip_error:
+  pattern: 'hipError\w+|HIP error'
+  extract:
+    - name: hip_error_code
+      regex: '(hipError\w+)'
+      # Captures: ('hipErrorFileNotFound',)
+```
+
+### Example: Extract Python Exception Type
+
+```yaml
+python_exception:
+  pattern: 'Traceback \(most recent call last\)|(?:Error|Exception):'
+  extract:
+    - name: exception_type
+      regex: '(\w+Error|\w+Exception):'
+      # Captures: ('ValueError', 'RuntimeError', etc.)
+    - name: exception_file
+      regex: 'File "([^"]+)", line (\d+)'
+      # Captures: ('test.py', '42')
+```
+
+---
+
+## Testing Patterns
+
+### 1. **Unit Testing** (Recommended)
+
+Create a test case in `tools/utils/test/ci_tests/test_patterns.py`:
+
+```python
+def test_compile_error_pattern():
+    """Test that compile_error pattern matches C++ errors."""
+    loader = load_default_patterns()
+    matcher = PatternMatcher(loader)
+
+    # Test log content
+    log_content = """
+/home/user/code.cpp:145:12: error: use of undeclared identifier 'foo'
+  int x = foo;
+          ^
+    """
+
+    # Analyze
+    results = matcher.analyze_log(log_content)
+
+    # Assertions
+    assert 'compile_error' in results
+    assert len(results['compile_error']) == 1
+
+    match = results['compile_error'][0]
+    assert 'file_path' in match.extracted_fields
+    assert match.extracted_fields['file_path'] == ('/home/user/code.cpp', '145', '12')
+```
+
+### 2. **Interactive Testing** (Quick Iteration)
+
+```python
+# In Python REPL
+from ci.core.patterns import load_default_patterns, PatternMatcher
+
+loader = load_default_patterns()
+matcher = PatternMatcher(loader)
+
+# Test your pattern
+log = "hipErrorFileNotFound: /opt/rocm/amdgcn/lib/bitcode.bc"
+results = matcher.analyze_log(log)
+print(results)
+```
+
+### 3. **Real-World Testing**
+
+```bash
+# Analyze actual CI log
+iree-ci-triage --run 12345678 --job 987654321
+```
+
+---
+
+## Common Pitfalls
+
+### ❌ **Pitfall 1: Pattern Too Broad**
+
+```yaml
+# BAD: Matches configuration text, not errors
+vulkan_error:
+  pattern: 'vulkan'
+  # Matches "IREE_VULKAN_DISABLE=1" (false positive)
+```
+
+**Fix**: Be specific about error context
+```yaml
+# GOOD: Matches actual Vulkan API errors
+vk_error:
+  pattern: 'VK_ERROR_\w+'
+  # Only matches VK_ERROR_* codes
+```
+
+### ❌ **Pitfall 2: Not Escaping Special Characters**
+
+```yaml
+# BAD: . matches any character, not literal dot
+file_not_found:
+  pattern: 'file.cpp'
+  # Matches "file-cpp", "filexcpp", etc.
+```
+
+**Fix**: Escape the dot
+```yaml
+# GOOD: Literal dot
+file_not_found:
+  pattern: 'file\.cpp'
+```
+
+### ❌ **Pitfall 3: Overlapping Patterns**
+
+```yaml
+# BAD: Both patterns match the same errors
+rocm_error:
+  pattern: 'rocm.*error'
+
+rocclr_error:
+  pattern: 'rocclr.*error'
+  # rocclr errors also match rocm_error!
+```
+
+**Fix**: Make patterns mutually exclusive or handle co-occurrence in rules
+```yaml
+# GOOD: Specific pattern first, generic second
+rocclr_memobj:
+  pattern: 'Memobj map does not have ptr'
+  # Very specific signature
+
+rocm_error:
+  pattern: 'ROCm error|rocm.*error'
+  # General ROCm errors
+```
+
+### ❌ **Pitfall 4: Not Testing Extraction**
+
+```yaml
+# Extraction regex doesn't match the pattern context
+pattern: 'error occurred'
+extract:
+  - name: file_path
+    regex: '(\S+):(\d+):'
+    # Will fail if error message doesn't have "file:line:"
+```
+
+**Fix**: Test extraction with realistic error messages
+
+---
+
+## Examples
+
+### Example 1: Simple Error Pattern
+
+**Goal**: Detect Python import errors
+
+```yaml
+python_import_error:
+  pattern: 'ImportError:|ModuleNotFoundError:'
+  severity: high
+  actionable: true
+  context_lines: 3
+  description: "Python import error"
+```
+
+**Matches**:
+```
+ImportError: No module named 'torch'
+ModuleNotFoundError: No module named 'iree.runtime'
+```
+
+### Example 2: Pattern with Extraction
+
+**Goal**: Detect CUDA errors and extract error codes
+
+```yaml
+cuda_error:
+  pattern: 'CUDA error|cudaError|CUDA_ERROR'
+  severity: high
+  actionable: true
+  context_lines: 5
+  description: "CUDA runtime error"
+  extract:
+    - name: cuda_error_code
+      regex: '(cudaError\w+|CUDA_ERROR_\w+)'
+```
+
+**Matches**:
+```
+CUDA error: cudaErrorMemoryAllocation
+CUDA_ERROR_OUT_OF_MEMORY
+```
+
+**Extracted**:
+```python
+{
+  "cuda_error_code": ("cudaErrorMemoryAllocation",)
+}
+```
+
+### Example 3: Complex Pattern with Multiple Extractors
+
+**Goal**: Detect FileCheck failures and extract test file and failed line
+
+```yaml
+filecheck_failed:
+  pattern: 'FileCheck.*failed'
+  severity: high
+  actionable: true
+  context_lines: 10
+  description: "LLVM FileCheck test failure"
+  extract:
+    - name: check_file
+      regex: 'FileCheck.*--check-prefix[es]*=(\S+)'
+    - name: failed_line
+      regex: '(\S+):(\d+):\d+: error:'
+```
+
+**Matches**:
+```
+FileCheck --check-prefixes=CHECK test.mlir failed
+test.mlir:42:10: error: CHECK: expected string not found in input
+```
+
+**Extracted**:
+```python
+{
+  "check_file": ("CHECK",),
+  "failed_line": ("test.mlir", "42")
+}
+```
+
+---
+
+## Adding a New Pattern: Step-by-Step
+
+### Step 1: Identify the Error Signature
+
+Find a representative error in a CI log:
+```
+hipErrorFileNotFound: code object file not found
+/opt/rocm-6.0.0/amdgcn/bitcode/oclc.amdgcn.bc
+```
+
+### Step 2: Write the Pattern Regex
+
+Start simple:
+```yaml
+pattern: 'hipErrorFileNotFound'
+```
+
+Test if it's too specific or too broad. Adjust:
+```yaml
+pattern: 'hipErrorFileNotFound'  # Specific to this error code
+```
+
+### Step 3: Determine Severity and Actionability
+
+- Is this a code bug or infrastructure? → `actionable: true` (config issue)
+- How severe? → `high` (blocks GPU tests)
+
+### Step 4: Choose Context Lines
+
+HIP errors usually need file paths, so capture more context:
+```yaml
+context_lines: 5
+```
+
+### Step 5: Write Extraction Rules (if needed)
+
+Extract the error code:
+```yaml
+extract:
+  - name: hip_error_code
+    regex: '(hipError\w+)'
+```
+
+### Step 6: Add to patterns.yaml
+
+```yaml
+hip_file_not_found:
+  pattern: 'hipErrorFileNotFound'
+  severity: high
+  actionable: true
+  context_lines: 5
+  description: "HIP file not found (missing device libraries)"
+  extract:
+    - name: hip_error_code
+      regex: '(hipError\w+)'
+```
+
+### Step 7: Test It
+
+```python
+from ci.core.patterns import load_default_patterns, PatternMatcher
+
+loader = load_default_patterns()
+matcher = PatternMatcher(loader)
+
+log = """
+hipErrorFileNotFound: code object file not found
+/opt/rocm-6.0.0/amdgcn/bitcode/oclc.amdgcn.bc
+"""
+
+results = matcher.analyze_log(log)
+assert 'hip_file_not_found' in results
+print(results['hip_file_not_found'][0].extracted_fields)
+# {'hip_error_code': ('hipErrorFileNotFound',)}
+```
+
+---
+
+## Pattern Organization
+
+### Group Related Patterns
+
+Organize patterns.yaml by technology/category:
+
+```yaml
+patterns:
+  # ========================================================================
+  # Build and Compilation Errors
+  # ========================================================================
+  compile_error: ...
+  linker_error: ...
+
+  # ========================================================================
+  # HIP/ROCm Errors (AMD GPU)
+  # ========================================================================
+  hip_error: ...
+  rocm_error: ...
+  rocclr_memobj: ...
+
+  # ========================================================================
+  # CUDA Errors (NVIDIA GPU)
+  # ========================================================================
+  cuda_error: ...
+  cuda_oom: ...
+```
+
+### Use Descriptive Names
+
+- ✅ `rocclr_memobj` - Specific error type
+- ❌ `rocm_error_3` - Meaningless number
+
+### Document Special Cases
+
+```yaml
+rocclr_memobj:
+  pattern: 'Memobj map does not have ptr'
+  severity: critical
+  actionable: false  # Infrastructure/driver issue, not code bug
+  context_lines: 10
+  description: "ROCm memory object cleanup crash (false CI failure)"
+  # IMPORTANT: Tests often PASS before this crash during cleanup
+  # Creates false negatives - DO NOT fail PRs on this pattern alone
+```
+
+---
+
+## Questions?
+
+- Check existing patterns in `patterns.yaml` for examples
+- Run pattern tests: `python -m pytest tools/utils/test/ci_tests/test_patterns.py`
+- Analyze real logs: `iree-ci-triage --run <run-id>`

--- a/tools/utils/ci/README.md
+++ b/tools/utils/ci/README.md
@@ -1,0 +1,150 @@
+# IREE CI Tools
+
+Quick start guide for IREE's CI health management tools.
+
+## Available Tools
+
+### iree-ci-triage
+Analyzes CI failures and identifies root causes from GitHub Actions runs.
+
+**Quick Start:**
+```bash
+# Triage a specific run
+iree-ci-triage --run 12345678
+
+# Triage latest failure from PR
+iree-ci-triage --pr 22625
+
+# JSON output for automation
+iree-ci-triage --run 12345678 --json
+```
+
+**[Full documentation →](iree_ci_triage.md)**
+
+### iree-ci-garden
+Manages a corpus of CI failures for pattern development and health tracking. Tracks commit hashes, PR numbers, re-runs, and recognition rates.
+
+**Quick Start:**
+```bash
+# Fetch failures (last 24 hours by default)
+iree-ci-garden fetch
+
+# Classify logs using iree-ci-triage
+iree-ci-garden classify
+
+# Check corpus health metrics
+iree-ci-garden status
+
+# Search for specific error patterns
+iree-ci-garden search "undefined reference"
+```
+
+**[Full documentation →](iree_ci_garden.md)**
+
+## Installation
+
+These tools are part of IREE's Python utilities:
+```bash
+cd tools/utils
+pip install -e .
+```
+
+## Common Workflows
+
+### Daily CI Health Check
+```bash
+# 1. Fetch overnight failures (includes commit hashes, PR numbers, re-run attempts)
+iree-ci-garden fetch
+
+# 2. Classify new failures
+iree-ci-garden classify
+
+# 3. Review corpus health and unrecognized patterns
+iree-ci-garden status
+cat ~/.iree-ci-corpus/unrecognized/TODO.md
+
+# 4. Investigate specific failures
+iree-ci-triage --run <run_id>
+```
+
+### Investigating a PR Failure
+```bash
+# Quick triage of PR
+iree-ci-triage --pr 22625
+
+# Get detailed breakdown
+iree-ci-triage --pr 22625 --checklist
+
+# Add PR failures to corpus for tracking
+iree-ci-garden fetch --pr 22625
+
+# Find all failures from this PR
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.pr_number == 22625)'
+```
+
+### Analyzing Flaky Tests
+```bash
+# Fetch recent failures
+iree-ci-garden fetch --since 2025-11-01
+
+# Find tests that passed on retry (attempt > 1)
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.attempt > 1)'
+
+# Check which jobs are flaky
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.attempt > 1) | {url, attempt, workflow}'
+```
+
+### Commit-Based Failure Analysis
+```bash
+# Fetch failures from last week
+iree-ci-garden fetch --since 2025-11-10
+
+# Find all failures for specific commit
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.head_sha == "abc123...")'
+
+# Track failures by branch
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.branch == "main") | .head_sha' | sort | uniq -c
+```
+
+### Testing New Error Patterns
+```bash
+# 1. Add pattern to patterns.yaml
+vim tools/utils/ci/patterns.yaml
+
+# 2. Test against entire corpus
+iree-ci-garden classify --force
+
+# 3. Check recognition rate improvement
+iree-ci-garden status
+
+# 4. Review remaining unrecognized failures
+cat ~/.iree-ci-corpus/unrecognized/TODO.md
+```
+
+## Configuration
+
+Both tools use GitHub CLI (`gh`) for API access:
+```bash
+# Check authentication
+gh auth status
+
+# Login if needed
+gh auth login
+```
+
+## Environment Variables
+
+- `IREE_CI_CORPUS_DIR` - CI garden corpus location (default: `~/.iree-ci-corpus`)
+- `GH_TOKEN` - GitHub authentication token (usually managed by `gh auth`)
+
+## Getting Help
+
+For detailed usage and options:
+```bash
+iree-ci-triage --help
+iree-ci-garden --help
+```
+
+For troubleshooting and development:
+- [iree-ci-triage documentation](iree_ci_triage.md)
+- [iree-ci-garden documentation](iree_ci_garden.md)

--- a/tools/utils/ci/__init__.py
+++ b/tools/utils/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI/CD utilities for continuous integration workflows."""

--- a/tools/utils/ci/cooccurrence_rules.yaml
+++ b/tools/utils/ci/cooccurrence_rules.yaml
@@ -1,0 +1,378 @@
+# IREE CI Error Pattern Co-occurrence Rules
+#
+# This file defines rules for grouping co-occurring error patterns into
+# single root causes. When multiple patterns appear together in a log,
+# these rules determine if they should be treated as a single fixable issue.
+#
+# Rule structure:
+#   - name: Human-readable name for this root cause
+#   - primary_pattern: The pattern that indicates the actual error
+#   - secondary_patterns: Patterns that commonly co-occur but are symptoms
+#   - description: Explanation of why these patterns appear together
+#   - priority: When multiple rules match, higher priority wins
+#
+# Data based on co-occurrence analysis of 563 CI failure logs.
+
+root_cause_rules:
+  # ==========================================================================
+  # ROCm Runtime Issues
+  # ==========================================================================
+
+  - name: "rocm_cleanup_crash"
+    primary_pattern: "rocclr_memobj"
+    secondary_patterns:
+      - "aborted"
+      - "core_dumped"
+      - "process_exit_error"  # Exit code 134 (SIGABRT)
+    description: >
+      ROCm memory object cleanup crash in rocclr/device/device.cpp.
+      Tests often PASS before this crash occurs during teardown.
+      This creates false CI failures and should not fail PRs.
+    priority: 100
+    actionable: false  # Infrastructure/driver issue
+    category: "infrastructure"
+
+  - name: "hip_device_enumeration_failure"
+    primary_pattern: "hip_file_not_found"
+    secondary_patterns:
+      - "hip_error"
+      - "python_exception"
+    description: >
+      HIP runtime cannot find device libraries or bitcode files.
+      Usually indicates missing ROCm installation or incorrect paths.
+    priority: 90
+    actionable: true
+    category: "configuration"
+
+  - name: "rocm_driver_crash"
+    primary_pattern: "hip_device_lost"
+    secondary_patterns:
+      - "rocm_error"
+      - "aborted"
+      - "core_dumped"
+      - "timeout"
+    description: >
+      AMD GPU driver lost device during execution.
+      Hardware or driver issue, not code bug.
+    priority: 95
+    actionable: false
+    category: "infrastructure"
+
+  # ==========================================================================
+  # Build Failures
+  # ==========================================================================
+
+  - name: "compilation_failure"
+    primary_pattern: "compile_error"
+    secondary_patterns:
+      - "process_exit_error"
+      - "fatal_error"
+    description: >
+      C++ compilation error. The primary error is the compile_error,
+      other patterns are just consequences of the build failing.
+    priority: 80
+    actionable: true
+    category: "code"
+
+  - name: "linker_failure"
+    primary_pattern: "undefined_reference"
+    secondary_patterns:
+      - "linker_error"
+      - "process_exit_error"
+    description: >
+      Undefined symbol during linking. Need to add missing library
+      or fix symbol visibility.
+    priority: 80
+    actionable: true
+    category: "code"
+
+  - name: "cmake_configuration_failure"
+    primary_pattern: "cmake_error"
+    secondary_patterns:
+      - "process_exit_error"
+    description: >
+      CMake failed to configure the build. Check dependencies
+      and CMakeLists.txt syntax.
+    priority: 75
+    actionable: true
+    category: "configuration"
+
+  # ==========================================================================
+  # Test Failures
+  # ==========================================================================
+
+  - name: "test_timeout"
+    primary_pattern: "timeout"
+    secondary_patterns:
+      - "test_failed"
+      - "process_exit_error"
+      - "python_exception"
+    description: >
+      Test exceeded time limit. May indicate infinite loop,
+      deadlock, or test infrastructure issue.
+    priority: 50
+    actionable: false  # Could be flake or infrastructure
+    category: "test_infrastructure"
+
+  - name: "python_test_failure"
+    primary_pattern: "python_exception"
+    secondary_patterns:
+      - "test_failed"
+      - "process_exit_error"
+    description: >
+      Python test threw an exception. The traceback in python_exception
+      contains the actual error details.
+    priority: 70
+    actionable: true
+    category: "code"
+
+  - name: "filecheck_mismatch"
+    primary_pattern: "filecheck_failed"
+    secondary_patterns:
+      - "test_failed"
+      - "process_exit_error"
+    description: >
+      LLVM FileCheck found output that doesn't match CHECK patterns.
+      Usually means compiler transformation changed IR output.
+    priority: 85
+    actionable: true
+    category: "code"
+
+  - name: "assertion_failure"
+    primary_pattern: "assertion_failed"
+    secondary_patterns:
+      - "aborted"
+      - "test_failed"
+      - "core_dumped"
+    description: >
+      Assertion failed in test or runtime code.
+      The assertion message contains the actual invariant violation.
+    priority: 90
+    actionable: true
+    category: "code"
+
+  # ==========================================================================
+  # Memory Issues
+  # ==========================================================================
+
+  - name: "segmentation_fault"
+    primary_pattern: "segfault"
+    secondary_patterns:
+      - "core_dumped"
+      - "aborted"
+      - "test_failed"
+    description: >
+      Null pointer dereference or invalid memory access.
+      Core dump may provide stack trace for debugging.
+    priority: 95
+    actionable: true
+    category: "code"
+
+  - name: "out_of_memory"
+    primary_pattern: "oom"
+    secondary_patterns:
+      - "bad_alloc"
+      - "cuda_oom"
+      - "vk_oom"
+      - "aborted"
+    description: >
+      System ran out of memory (CPU or GPU).
+      May need to reduce batch size or optimize memory usage.
+    priority: 60
+    actionable: false  # Often infrastructure issue
+    category: "infrastructure"
+
+  - name: "stack_overflow_error"
+    primary_pattern: "stack_overflow"
+    secondary_patterns:
+      - "segfault"
+      - "aborted"
+    description: >
+      Stack exhausted, usually from infinite recursion or
+      very deep call stacks.
+    priority: 85
+    actionable: true
+    category: "code"
+
+  # ==========================================================================
+  # GPU Driver Issues
+  # ==========================================================================
+
+  - name: "vulkan_device_lost"
+    primary_pattern: "vk_device_lost"
+    secondary_patterns:
+      - "vulkan_error"
+      - "aborted"
+      - "test_failed"
+    description: >
+      Vulkan driver lost the device. Usually GPU hang or driver crash.
+      Not a code bug.
+    priority: 90
+    actionable: false
+    category: "infrastructure"
+
+  - name: "cuda_device_lost"
+    primary_pattern: "cuda_device_lost"
+    secondary_patterns:
+      - "cuda_error"
+      - "aborted"
+      - "test_failed"
+    description: >
+      CUDA driver lost the device. Usually GPU hang or driver crash.
+      Not a code bug.
+    priority: 90
+    actionable: false
+    category: "infrastructure"
+
+  - name: "vulkan_initialization_failure"
+    primary_pattern: "vk_initialization_failed"
+    secondary_patterns:
+      - "vulkan_error"
+      - "python_exception"
+    description: >
+      Failed to initialize Vulkan device.
+      Check driver installation and device availability.
+    priority: 75
+    actionable: true
+    category: "configuration"
+
+  # ==========================================================================
+  # Build System Issues
+  # ==========================================================================
+
+  - name: "bazel_build_failure"
+    primary_pattern: "bazel_failed"
+    secondary_patterns:
+      - "compile_error"
+      - "process_exit_error"
+    description: >
+      Bazel build failed. Check the actual compilation errors
+      in the compile_error pattern matches.
+    priority: 70
+    actionable: true
+    category: "code"
+
+  - name: "bazel_timeout_failure"
+    primary_pattern: "bazel_timeout"
+    secondary_patterns:
+      - "timeout"
+      - "process_exit_error"
+    description: >
+      Bazel build exceeded time limit.
+      May indicate infrastructure issue or very slow build.
+    priority: 50
+    actionable: false
+    category: "infrastructure"
+
+  - name: "ctest_failure"
+    primary_pattern: "ctest_failed"
+    secondary_patterns:
+      - "test_failed"
+      - "process_exit_error"
+    description: >
+      CTest reported test failures. Look at individual test
+      failure patterns for root cause.
+    priority: 60
+    actionable: true
+    category: "code"
+
+  # ==========================================================================
+  # Infrastructure Issues
+  # ==========================================================================
+
+  - name: "network_download_failure"
+    primary_pattern: "download_failed"
+    secondary_patterns:
+      - "network_error"
+      - "process_exit_error"
+    description: >
+      Failed to download artifact or dependency.
+      Network or repository availability issue.
+    priority: 30
+    actionable: false
+    category: "infrastructure"
+
+  - name: "docker_container_failure"
+    primary_pattern: "docker_error"
+    secondary_patterns:
+      - "process_exit_error"
+    description: >
+      Docker container failed to start or execute.
+      Container infrastructure issue.
+    priority: 40
+    actionable: false
+    category: "infrastructure"
+
+  - name: "git_operation_failure"
+    primary_pattern: "git_error"
+    secondary_patterns:
+      - "process_exit_error"
+    description: >
+      Git command failed. May be network issue, authentication,
+      or repository state problem.
+    priority: 40
+    actionable: true
+    category: "configuration"
+
+  - name: "permission_error"
+    primary_pattern: "permission_denied"
+    secondary_patterns:
+      - "file_not_found"
+      - "process_exit_error"
+    description: >
+      File system permission issue.
+      Check file permissions or runner configuration.
+    priority: 50
+    actionable: true
+    category: "configuration"
+
+  # ==========================================================================
+  # Performance Issues
+  # ==========================================================================
+
+  - name: "benchmark_regression_failure"
+    primary_pattern: "benchmark_regression"
+    secondary_patterns:
+      - "test_failed"
+    description: >
+      Performance benchmark exceeded golden time.
+      May indicate performance regression or infrastructure variance.
+    priority: 60
+    actionable: true
+    category: "performance"
+
+# Pattern groups that should NOT be merged into a single root cause.
+# These patterns co-occur but represent independent issues.
+independent_patterns:
+  - patterns:
+      - "compile_error"
+      - "python_exception"
+    reason: "Build failures trigger Python test exceptions, but both need fixing"
+
+  - patterns:
+      - "python_exception"
+      - "timeout"
+    reason: "Python exception may cause timeout, but exception is the root cause"
+
+  - patterns:
+      - "compile_error"
+      - "timeout"
+    reason: "Build may timeout while failing, but compile error is primary"
+
+# Pattern prioritization when multiple primary patterns match.
+# Higher priority patterns take precedence for root cause assignment.
+pattern_priorities:
+  rocclr_memobj: 100  # Always prioritize - creates false failures
+  segfault: 95
+  hip_device_lost: 95
+  vk_device_lost: 95
+  cuda_device_lost: 95
+  assertion_failed: 90
+  filecheck_failed: 85
+  stack_overflow: 85
+  compile_error: 80
+  undefined_reference: 80
+  python_exception: 70
+  cmake_error: 75
+  test_failed: 60
+  timeout: 50

--- a/tools/utils/ci/core/__init__.py
+++ b/tools/utils/ci/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core CI utilities including pattern matching and GitHub integration."""

--- a/tools/utils/ci/core/classifier.py
+++ b/tools/utils/ci/core/classifier.py
@@ -1,0 +1,337 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Classification system for CI failures.
+
+Uses TriageEngine library directly to extract issues from corpus logs.
+Results are cached to avoid re-analyzing unchanged logs.
+"""
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from common import console
+from common.extractors.infrastructure_flake import InfrastructureFlakeExtractor
+from common.log_buffer import LogBuffer
+
+from ci.core.corpus import Corpus
+from ci.iree_ci_triage import create_ci_triage_engine
+
+
+@dataclass
+class ClassificationResult:
+    """Results from classifying a single log."""
+
+    run_id: str
+    job_id: str
+    extracted_issues: list[dict[str, Any]]
+    categories: list[str]
+    recognized: bool  # True if at least one issue extracted.
+    cached: bool
+
+
+@dataclass
+class ClassificationReport:
+    """Report from classifying multiple logs."""
+
+    total_logs: int
+    classified: int
+    recognized: int
+    unrecognized: int
+    recognition_rate: float
+    categories: dict[str, int]  # Category name -> count.
+    errors: list[str]
+    results: list[ClassificationResult]
+
+
+class Classifier:
+    """Classifies CI failures using TriageEngine library."""
+
+    def __init__(self, corpus: Corpus) -> None:
+        """Initialize classifier.
+
+        Args:
+            corpus: Corpus instance
+        """
+        self.corpus = corpus
+        self.cache_dir = corpus.classification_dir / "cache"
+        self.triage_engine = create_ci_triage_engine()
+
+    def classify_run(
+        self, run_id: str, force_reclassify: bool = False
+    ) -> list[ClassificationResult]:
+        """Classify all logs in a run.
+
+        Args:
+            run_id: Run ID to classify
+            force_reclassify: If True, ignore cache and reclassify
+
+        Returns:
+            List of ClassificationResult for each job log
+        """
+        # Find all logs for this run.
+        run_dir = self.corpus.logs_dir / run_id
+        if not run_dir.exists():
+            return []
+
+        log_files = list(run_dir.glob("*.log"))
+
+        # Parallelize log classification (embarrassingly parallel workload).
+        # Thread-safe: extractors are stateless, file reads independent.
+        # max_workers=None uses all available cores.
+        with ThreadPoolExecutor(max_workers=None) as executor:
+            futures = [
+                executor.submit(
+                    self.classify_log, run_id, log_file.stem, force_reclassify
+                )
+                for log_file in log_files
+            ]
+            results = [f.result() for f in futures]
+
+        # Filter out None results.
+        results = [r for r in results if r]
+
+        # Update run metadata to mark as classified.
+        run_meta = self.corpus.get_run_metadata(run_id)
+        if run_meta:
+            run_meta["classified"] = True
+            run_meta["classified_at"] = datetime.now().isoformat()
+            self.corpus.save_run_metadata(run_id, run_meta)
+
+        return results
+
+    def classify_log(
+        self, run_id: str, job_id: str, force_reclassify: bool = False
+    ) -> ClassificationResult | None:
+        """Classify a single log file.
+
+        Args:
+            run_id: Run ID
+            job_id: Job ID
+            force_reclassify: If True, ignore cache
+
+        Returns:
+            ClassificationResult, or None if log doesn't exist
+        """
+        log_path = self.corpus.get_log_path(run_id, job_id)
+        if not log_path:
+            return None
+
+        # Check cache first.
+        cache_path = self.cache_dir / f"{run_id}_{job_id}.json"
+        if not force_reclassify and cache_path.exists():
+            # Check if cache is still valid (TTL check).
+            cache_age = datetime.now() - datetime.fromtimestamp(
+                cache_path.stat().st_mtime
+            )
+            config = json.loads(self.corpus.config_path.read_text())
+            ttl_days = config.get("classification_settings", {}).get(
+                "cache_ttl_days", 30
+            )
+
+            if cache_age < timedelta(days=ttl_days):
+                # Load from cache.
+                cached_data = json.loads(cache_path.read_text())
+                extracted_issues = cached_data.get("extracted_issues", [])
+                return ClassificationResult(
+                    run_id=run_id,
+                    job_id=job_id,
+                    extracted_issues=extracted_issues,
+                    categories=cached_data.get("categories", []),
+                    recognized=len(extracted_issues) > 0,
+                    cached=True,
+                )
+
+        # Run triage engine directly.
+        try:
+            # Check for annotations first.
+            annotation_issues = []
+            annotations = self.corpus.get_annotations(run_id, job_id)
+            if annotations:
+                # Extract issues from annotations using infrastructure_flake extractor.
+                infra_extractor = InfrastructureFlakeExtractor()
+                annotation_issues = infra_extractor.extract_from_annotations(
+                    annotations, run_id, job_id
+                )
+
+            # Read log content (only if it exists).
+            log_content = log_path.read_text()
+
+            # Create log buffer and analyze.
+            log_buffer = LogBuffer(log_content, auto_detect_format=True)
+            triage_result = self.triage_engine.analyze(log_buffer)
+
+            # Combine issues from annotations and log analysis.
+            all_issues = annotation_issues + triage_result.issues
+
+            # Serialize issues to dictionaries.
+            extracted_issues = [
+                {
+                    "title": issue.message[:100],
+                    "message": issue.message,
+                    "severity": issue.severity.name,
+                    "extractor": issue.source_extractor,
+                }
+                for issue in all_issues
+            ]
+
+            # Extract unique categories (extractor names).
+            categories = list(set(issue["extractor"] for issue in extracted_issues))
+
+            # Determine extraction status.
+            extraction_status = "success" if extracted_issues else "incomplete"
+
+            # Cache the result.
+            cache_data = {
+                "run_id": run_id,
+                "job_id": job_id,
+                "extracted_issues": extracted_issues,
+                "categories": categories,
+                "extraction_status": extraction_status,
+                "classified_at": datetime.now().isoformat(),
+            }
+            cache_path.write_text(json.dumps(cache_data, indent=2))
+
+            return ClassificationResult(
+                run_id=run_id,
+                job_id=job_id,
+                extracted_issues=extracted_issues,
+                categories=categories,
+                recognized=len(extracted_issues) > 0,
+                cached=False,
+            )
+
+        except Exception as e:  # noqa: BLE001
+            # Classification failed - catch all exceptions to prevent single log from blocking entire corpus.
+            console.warn(f"Triage failed for {run_id}/{job_id}: {e}")
+            return ClassificationResult(
+                run_id=run_id,
+                job_id=job_id,
+                extracted_issues=[],
+                categories=["error"],
+                recognized=False,
+                cached=False,
+            )
+
+    def _classify_runs(
+        self, runs: list, force_reclassify: bool, action: str = "Classifying"
+    ) -> ClassificationReport:
+        """Classify a list of runs.
+
+        Args:
+            runs: List of run metadata dicts to classify
+            force_reclassify: If True, ignore cache and reclassify
+            action: Action verb for progress messages (e.g., "Classifying", "Reclassifying")
+
+        Returns:
+            ClassificationReport with statistics
+        """
+        report = ClassificationReport(
+            total_logs=0,
+            classified=0,
+            recognized=0,
+            unrecognized=0,
+            recognition_rate=0.0,
+            categories={},
+            errors=[],
+            results=[],
+        )
+
+        # Gather ALL logs across ALL runs first.
+        all_log_tasks = []
+        for run in runs:
+            run_id = run["run_id"]
+            run_dir = self.corpus.logs_dir / run_id
+            if not run_dir.exists():
+                continue
+
+            for log_file in run_dir.glob("*.log"):
+                all_log_tasks.append((run_id, log_file.stem))
+
+        total_logs = len(all_log_tasks)
+        console.note(f"{action} {total_logs} logs across {len(runs)} runs...")
+
+        # Parallelize ALL logs at once (not per-run).
+        # Thread-safe: extractors are stateless, file reads independent.
+        # max_workers=None uses all available cores.
+        results = []
+        with ThreadPoolExecutor(max_workers=None) as executor:
+            # Submit all tasks.
+            future_to_task = {
+                executor.submit(self.classify_log, run_id, job_id, force_reclassify): (
+                    run_id,
+                    job_id,
+                )
+                for (run_id, job_id) in all_log_tasks
+            }
+
+            # Process results as they complete (for progress reporting).
+            for completed, future in enumerate(as_completed(future_to_task), start=1):
+                run_id, job_id = future_to_task[future]
+                result = future.result()
+                if result:
+                    results.append(result)
+
+                # Print progress with log file path.
+                console.note(
+                    f"  [{completed}/{total_logs}] processed log: {run_id}/{job_id}.log"
+                )
+
+        # Filter out None results and build report.
+        results = [r for r in results if r]
+        report.results = results
+
+        for result in results:
+            report.total_logs += 1
+            report.classified += 1
+            if result.recognized:
+                report.recognized += 1
+            else:
+                report.unrecognized += 1
+
+            # Count categories.
+            for category in result.categories:
+                report.categories[category] = report.categories.get(category, 0) + 1
+
+        # Update run metadata for all processed runs.
+        for run in runs:
+            run_id = run["run_id"]
+            run_meta = self.corpus.get_run_metadata(run_id)
+            if run_meta:
+                run_meta["classified"] = True
+                run_meta["classified_at"] = datetime.now().isoformat()
+                self.corpus.save_run_metadata(run_id, run_meta)
+
+        # Calculate recognition rate.
+        if report.total_logs > 0:
+            report.recognition_rate = report.recognized / report.total_logs
+
+        return report
+
+    def classify_all_unclassified(self) -> ClassificationReport:
+        """Classify all unclassified runs in corpus.
+
+        Returns:
+            ClassificationReport with statistics
+        """
+        unclassified_runs = list(self.corpus.get_unclassified())
+        return self._classify_runs(
+            unclassified_runs, force_reclassify=False, action="Classifying"
+        )
+
+    def reclassify_all(self) -> ClassificationReport:
+        """Force reclassification of entire corpus.
+
+        Returns:
+            ClassificationReport with statistics
+        """
+        all_runs = list(self.corpus.get_runs())
+        return self._classify_runs(
+            all_runs, force_reclassify=True, action="Reclassifying"
+        )

--- a/tools/utils/ci/core/corpus.py
+++ b/tools/utils/ci/core/corpus.py
@@ -1,0 +1,391 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Corpus management for CI failures.
+
+The corpus stores CI failure logs and metadata in a structured directory:
+- corpus.jsonl: Main index (streaming JSONL format)
+- daily/: Daily fetch manifests
+- runs/: Per-run metadata files
+- logs/: Raw log files organized by run
+- classification/: Classification results and cache
+- unrecognized/: Failures needing attention
+
+This design allows incremental updates and reclassification without re-fetching.
+"""
+
+import json
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class Corpus:
+    """Manages the CI failure corpus with JSONL index."""
+
+    def __init__(self, corpus_dir: Path) -> None:
+        """Initialize corpus at given directory.
+
+        Args:
+            corpus_dir: Root directory for corpus storage
+        """
+        self.corpus_dir = Path(corpus_dir)
+        self.index_path = self.corpus_dir / "corpus.jsonl"
+        self.daily_dir = self.corpus_dir / "daily"
+        self.runs_dir = self.corpus_dir / "runs"
+        self.logs_dir = self.corpus_dir / "logs"
+        self.classification_dir = self.corpus_dir / "classification"
+        self.unrecognized_dir = self.corpus_dir / "unrecognized"
+        self.config_path = self.corpus_dir / "config.json"
+
+        # Ensure directories exist.
+        self._ensure_directories()
+
+    def _ensure_directories(self):
+        """Ensure corpus directory structure exists."""
+        self.corpus_dir.mkdir(parents=True, exist_ok=True)
+        self.daily_dir.mkdir(exist_ok=True)
+        self.runs_dir.mkdir(exist_ok=True)
+        self.logs_dir.mkdir(exist_ok=True)
+        self.classification_dir.mkdir(exist_ok=True)
+        (self.classification_dir / "cache").mkdir(exist_ok=True)
+        (self.classification_dir / "history").mkdir(exist_ok=True)
+        self.unrecognized_dir.mkdir(exist_ok=True)
+        (self.unrecognized_dir / "samples").mkdir(exist_ok=True)
+
+        # Create default config if doesn't exist.
+        if not self.config_path.exists():
+            default_config = {
+                "corpus_version": "2.0",
+                "created_at": datetime.now().isoformat(),
+                "github_repo": "iree-org/iree",
+                "fetch_settings": {
+                    "default_limit": 100,
+                    "include_branches": ["*"],  # All branches by default.
+                },
+                "classification_settings": {
+                    "iree_ci_triage_args": ["--json", "--no-context"],
+                    "cache_results": True,
+                    "cache_ttl_days": 30,
+                },
+            }
+            self.config_path.write_text(json.dumps(default_config, indent=2))
+
+    def add_run(self, run_data: dict[str, Any]) -> bool:
+        """Add a run to the corpus (deduped).
+
+        Args:
+            run_data: Run metadata dict with at minimum:
+                - run_id: str
+                - created_at: ISO 8601 timestamp
+                - branch: str
+                - workflow: str
+                - conclusion: str
+
+        Returns:
+            True if new run added, False if duplicate.
+        """
+        run_id = str(run_data["run_id"])
+
+        # Check for duplicate.
+        if self.has_run(run_id):
+            return False
+
+        # Append to corpus.jsonl.
+        with open(self.index_path, "a", encoding="utf-8") as f:
+            json.dump(run_data, f)
+            f.write("\n")
+
+        # Store full run metadata in runs/ directory.
+        run_path = self.runs_dir / f"{run_id}.json"
+        run_path.write_text(json.dumps(run_data, indent=2))
+
+        # Update daily manifest.
+        date = datetime.fromisoformat(
+            run_data["created_at"].replace("Z", "+00:00")
+        ).date()
+        daily_path = self.daily_dir / f"{date}.json"
+
+        daily_data = {"date": str(date), "runs": []}
+        if daily_path.exists():
+            daily_data = json.loads(daily_path.read_text())
+
+        if run_id not in daily_data["runs"]:
+            daily_data["runs"].append(run_id)
+
+        daily_path.write_text(json.dumps(daily_data, indent=2))
+
+        return True
+
+    def has_run(self, run_id: str) -> bool:
+        """Check if run already in corpus.
+
+        Args:
+            run_id: Run ID to check
+
+        Returns:
+            True if run exists, False otherwise
+        """
+        run_id = str(run_id)
+
+        # Quick check: does the run metadata file exist?
+        if (self.runs_dir / f"{run_id}.json").exists():
+            return True
+
+        # Fallback: scan corpus.jsonl (slower).
+        if not self.index_path.exists():
+            return False
+
+        with open(self.index_path) as f:
+            for line in f:
+                data = json.loads(line)
+                if str(data.get("run_id")) == run_id:
+                    return True
+        return False
+
+    def get_runs(
+        self,
+        since: datetime | None = None,
+        branch: str | None = None,
+        status: str | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Query runs from corpus with filters.
+
+        Args:
+            since: Only return runs created after this datetime
+            branch: Filter by branch name
+            status: Filter by conclusion (e.g., 'failure', 'success')
+
+        Yields:
+            Run metadata dicts
+        """
+        if not self.index_path.exists():
+            return
+
+        with open(self.index_path) as f:
+            for line in f:
+                data = json.loads(line)
+
+                # Apply filters.
+                if since:
+                    created = datetime.fromisoformat(
+                        data["created_at"].replace("Z", "+00:00")
+                    )
+                    if created < since:
+                        continue
+
+                if branch and data.get("branch") != branch:
+                    continue
+
+                if status and data.get("conclusion") != status:
+                    continue
+
+                yield data
+
+    def get_unclassified(self) -> Iterator[dict[str, Any]]:
+        """Get runs that haven't been classified yet.
+
+        Yields:
+            Run metadata dicts for unclassified runs
+        """
+        for run in self.get_runs():
+            if not run.get("classified", False):
+                yield run
+
+    def get_last_fetched_at(self) -> datetime | None:
+        """Get the most recent fetch attempt timestamp.
+
+        Returns:
+            Last fetch attempt as datetime (timezone-aware), or None if never fetched
+        """
+        # First check config for last_fetch_at (updated after each fetch attempt).
+        if self.config_path.exists():
+            config = json.loads(self.config_path.read_text())
+            last_fetch_str = config.get("last_fetch_at")
+            if last_fetch_str:
+                last_fetch = datetime.fromisoformat(last_fetch_str)
+                # Ensure timezone-aware.
+                if last_fetch.tzinfo is None:
+                    last_fetch = last_fetch.replace(tzinfo=timezone.utc)
+                return last_fetch
+
+        # Fallback: find most recent fetched_at from runs (for backwards compat).
+        if not self.index_path.exists():
+            return None
+
+        last_fetched = None
+        for run in self.get_runs():
+            fetched_at_str = run.get("fetched_at")
+            if fetched_at_str:
+                fetched_at = datetime.fromisoformat(fetched_at_str)
+                # Ensure timezone-aware.
+                if fetched_at.tzinfo is None:
+                    fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+                if last_fetched is None or fetched_at > last_fetched:
+                    last_fetched = fetched_at
+
+        return last_fetched
+
+    def save_log(self, run_id: str, job_id: str, content: str) -> Path:
+        """Save raw log to disk.
+
+        Args:
+            run_id: Run ID
+            job_id: Job ID
+            content: Log content
+
+        Returns:
+            Path to saved log file
+        """
+        run_id = str(run_id)
+        job_id = str(job_id)
+
+        run_dir = self.logs_dir / run_id
+        run_dir.mkdir(exist_ok=True)
+
+        log_path = run_dir / f"{job_id}.log"
+        log_path.write_text(content)
+
+        return log_path
+
+    def get_log_path(self, run_id: str, job_id: str) -> Path | None:
+        """Get path to a log file if it exists.
+
+        Args:
+            run_id: Run ID
+            job_id: Job ID
+
+        Returns:
+            Path to log file, or None if doesn't exist
+        """
+        run_id = str(run_id)
+        job_id = str(job_id)
+
+        log_path = self.logs_dir / run_id / f"{job_id}.log"
+        return log_path if log_path.exists() else None
+
+    def save_annotations(
+        self, run_id: str, job_id: str, annotations: list[dict[str, Any]]
+    ) -> Path:
+        """Save job annotations to disk.
+
+        Args:
+            run_id: Run ID
+            job_id: Job ID
+            annotations: List of annotation dictionaries from GitHub API
+
+        Returns:
+            Path to saved annotations file
+        """
+        run_id = str(run_id)
+        job_id = str(job_id)
+
+        run_dir = self.logs_dir / run_id
+        run_dir.mkdir(exist_ok=True)
+
+        annotations_path = run_dir / f"{job_id}.annotations.json"
+        annotations_path.write_text(json.dumps(annotations, indent=2))
+
+        return annotations_path
+
+    def get_annotations(self, run_id: str, job_id: str) -> list[dict[str, Any]] | None:
+        """Get annotations for a job if they exist.
+
+        Args:
+            run_id: Run ID
+            job_id: Job ID
+
+        Returns:
+            List of annotation dictionaries, or None if file doesn't exist
+        """
+        run_id = str(run_id)
+        job_id = str(job_id)
+
+        annotations_path = self.logs_dir / run_id / f"{job_id}.annotations.json"
+        if not annotations_path.exists():
+            return None
+
+        return json.loads(annotations_path.read_text())
+
+    def get_run_metadata(self, run_id: str) -> dict[str, Any] | None:
+        """Get full metadata for a run.
+
+        Args:
+            run_id: Run ID
+
+        Returns:
+            Run metadata dict, or None if not found
+        """
+        run_id = str(run_id)
+        run_path = self.runs_dir / f"{run_id}.json"
+
+        if not run_path.exists():
+            return None
+
+        return json.loads(run_path.read_text())
+
+    def save_run_metadata(self, run_id: str, metadata: dict[str, Any]) -> None:
+        """Save or update run metadata.
+
+        Args:
+            run_id: Run ID
+            metadata: Run metadata dict
+        """
+        run_id = str(run_id)
+        run_path = self.runs_dir / f"{run_id}.json"
+        run_path.write_text(json.dumps(metadata, indent=2))
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get corpus statistics.
+
+        Returns:
+            Dict with corpus stats:
+            - total_runs: int
+            - total_logs: int
+            - size_bytes: int
+            - time_span: dict with start/end dates
+            - by_branch: dict of run counts per branch
+        """
+        stats = {
+            "total_runs": 0,
+            "total_logs": 0,
+            "size_bytes": 0,
+            "time_span": {"start": None, "end": None},
+            "by_branch": {},
+        }
+
+        if not self.index_path.exists():
+            return stats
+
+        # Count runs and analyze.
+        with open(self.index_path) as f:
+            for line in f:
+                run = json.loads(line)
+                stats["total_runs"] += 1
+
+                # Track time span.
+                created = run.get("created_at", "")
+                if (
+                    not stats["time_span"]["start"]
+                    or created < stats["time_span"]["start"]
+                ):
+                    stats["time_span"]["start"] = created
+                if not stats["time_span"]["end"] or created > stats["time_span"]["end"]:
+                    stats["time_span"]["end"] = created
+
+                # Count by branch.
+                branch = run.get("branch", "unknown")
+                stats["by_branch"][branch] = stats["by_branch"].get(branch, 0) + 1
+
+        # Count logs and total size.
+        for run_dir in self.logs_dir.iterdir():
+            if run_dir.is_dir():
+                for log_file in run_dir.glob("*.log"):
+                    stats["total_logs"] += 1
+                    stats["size_bytes"] += log_file.stat().st_size
+
+        return stats

--- a/tools/utils/ci/core/extractors.py
+++ b/tools/utils/ci/core/extractors.py
@@ -1,0 +1,335 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Output formatters for CI triage results.
+
+This module provides formatters for:
+- Human-readable markdown output with checklists
+- JSON output for automation and LLM consumption
+- Summary statistics
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from ci.core.patterns import PatternMatch, RootCause
+
+
+@dataclass
+class TriageResult:
+    """Complete triage analysis result."""
+
+    run_id: str
+    job_id: str
+    job_name: str
+    root_causes: list[RootCause]
+    unmatched_patterns: list[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "run_id": self.run_id,
+            "job_id": self.job_id,
+            "job_name": self.job_name,
+            "root_causes": [
+                {
+                    "name": rc.rule.name,
+                    "category": rc.rule.category,
+                    "priority": rc.rule.priority,
+                    "actionable": rc.rule.actionable,
+                    "description": rc.rule.description,
+                    "primary_pattern": rc.rule.primary_pattern,
+                    "secondary_patterns": rc.rule.secondary_patterns,
+                    "matches": [
+                        {
+                            "pattern_name": m.pattern_name,
+                            "match_text": m.match_text,
+                            "line_number": m.line_number,
+                            "context_before": m.context_before,
+                            "context_after": m.context_after,
+                            "extracted_fields": m.extracted_fields,
+                        }
+                        for m in rc.all_matches
+                    ],
+                }
+                for rc in self.root_causes
+            ],
+            "unmatched_patterns": self.unmatched_patterns or [],
+        }
+
+
+class MarkdownFormatter:
+    """Formats triage results as human-readable markdown."""
+
+    def format(self, result: TriageResult, include_context: bool = True) -> str:
+        """Generate markdown triage report.
+
+        Args:
+            result: TriageResult to format
+            include_context: Whether to include error context lines
+
+        Returns:
+            Formatted markdown string
+        """
+        lines = []
+
+        # Header.
+        lines.append("# CI Failure Triage Report")
+        lines.append("")
+        lines.append(f"**Run ID**: {result.run_id}")
+        lines.append(f"**Job ID**: {result.job_id}")
+        lines.append(f"**Job**: {result.job_name}")
+        lines.append("")
+
+        # Brief summary.
+        actionable = [rc for rc in result.root_causes if rc.rule.actionable]
+        infrastructure = self._filter_infrastructure(result.root_causes)
+
+        lines.extend(self._format_summary(actionable, infrastructure))
+        lines.extend(self._format_actionable_checklist(actionable, include_context))
+        lines.extend(self._format_infrastructure_section(infrastructure))
+        lines.extend(self._format_tldr_summary(actionable, infrastructure))
+
+        return "\n".join(lines)
+
+    def _filter_infrastructure(self, root_causes: list[RootCause]) -> list[RootCause]:
+        """Filter infrastructure issues (high/critical severity only)."""
+        return [
+            rc
+            for rc in root_causes
+            if not rc.rule.actionable and self._get_severity(rc) in ["high", "critical"]
+        ]
+
+    def _format_summary(
+        self, actionable: list[RootCause], infrastructure: list[RootCause]
+    ) -> list[str]:
+        """Format the brief summary section."""
+        summary_parts = []
+        if actionable:
+            summary_parts.append(f"{len(actionable)} actionable")
+        if infrastructure:
+            summary_parts.append(f"{len(infrastructure)} infrastructure")
+
+        return [
+            f"**Summary**: {', '.join(summary_parts) if summary_parts else '0 issues found'}",
+            "",
+        ]
+
+    def _format_actionable_checklist(
+        self, actionable: list[RootCause], include_context: bool
+    ) -> list[str]:
+        """Format the actionable issues checklist."""
+        if not actionable:
+            return []
+
+        lines = ["## Fix Checklist", ""]
+
+        for _i, rc in enumerate(actionable, 1):
+            lines.extend(self._format_single_actionable_item(rc, include_context))
+            lines.append("")
+
+        return lines
+
+    def _format_single_actionable_item(
+        self, rc: RootCause, include_context: bool
+    ) -> list[str]:
+        """Format a single actionable issue item."""
+        lines = [
+            f"- [ ] **{rc.rule.name}** ({rc.rule.category})",
+            f"  - {rc.rule.description}",
+            f"  - **Severity**: {self._get_severity_icon(rc)} {self._get_severity(rc)}",
+            f"  - **Occurrences**: {len(rc.all_matches)} error(s)",
+        ]
+
+        # Show first match details.
+        if rc.primary_matches:
+            first_match = rc.primary_matches[0]
+            lines.append(f"  - **Location**: Line {first_match.line_number}")
+
+            # Show extracted fields.
+            if first_match.extracted_fields:
+                lines.append("  - **Details**:")
+                for field_name, field_value in first_match.extracted_fields.items():
+                    lines.append(f"    - {field_name}: `{field_value}`")
+
+        # Show error context.
+        if include_context and rc.primary_matches:
+            lines.extend(self._format_error_context(rc.primary_matches[0]))
+
+        return lines
+
+    def _format_error_context(self, match: PatternMatch) -> list[str]:
+        """Format error context with 2 lines before/after.
+
+        Note: Expects content to be pre-stripped by LogBuffer. Pattern matching
+        should use LogBuffer(content, auto_detect_format=True) to remove log
+        prefixes before creating PatternMatch objects.
+        """
+        lines = ["  - **Error Context**:", "    ```"]
+
+        # Show reduced context: 2 lines before, match, 2 lines after.
+        # Content should already be stripped by LogBuffer.
+        for ctx_line in match.context_before[-2:]:
+            stripped = ctx_line.strip()
+            if stripped:  # Skip empty lines.
+                lines.append(f"    {stripped}")
+
+        match_stripped = match.match_text.strip()
+        lines.append(f"    >>> {match_stripped}")
+
+        for ctx_line in match.context_after[:2]:
+            stripped = ctx_line.strip()
+            if stripped:  # Skip empty lines.
+                lines.append(f"    {stripped}")
+
+        lines.append("    ```")
+        return lines
+
+    def _format_infrastructure_section(
+        self, infrastructure: list[RootCause]
+    ) -> list[str]:
+        """Format infrastructure issues section."""
+        if not infrastructure:
+            return []
+
+        lines = [
+            "## Infrastructure Issues (Non-Actionable)",
+            "",
+            "These failures are not code bugs. They may be:",
+            "- Driver crashes or GPU hangs",
+            "- Network timeouts or download failures",
+            "- Resource exhaustion (OOM, disk full)",
+            "",
+        ]
+
+        for rc in infrastructure:
+            lines.extend(
+                [
+                    f"### {rc.rule.name}",
+                    f"- {rc.rule.description}",
+                    f"- **Category**: {rc.rule.category}",
+                    f"- **Occurrences**: {len(rc.all_matches)} match(es)",
+                    "",
+                ]
+            )
+
+        return lines
+
+    def _format_tldr_summary(
+        self, actionable: list[RootCause], infrastructure: list[RootCause]
+    ) -> list[str]:
+        """Format the TL;DR summary line."""
+        lines = ["---"]
+
+        if not actionable and infrastructure:
+            issue_names = [rc.rule.name for rc in infrastructure]
+            lines.append(
+                f"**TL;DR**: Infrastructure flake ({', '.join(issue_names)}). No code changes needed."
+            )
+        elif actionable and not infrastructure:
+            lines.append(
+                f"**TL;DR**: {len(actionable)} code bug(s) to fix. See checklist above."
+            )
+        elif actionable and infrastructure:
+            lines.append(
+                f"**TL;DR**: {len(actionable)} code bug(s) + {len(infrastructure)} infrastructure issue(s)."
+            )
+        else:
+            lines.append("**TL;DR**: No issues found.")
+
+        return lines
+
+    def _get_severity(self, root_cause: RootCause) -> str:
+        """Get severity from first primary match."""
+        if not root_cause.primary_matches:
+            return "medium"
+
+        # Severity is stored in the Pattern, not PatternMatch.
+        # We'd need to pass patterns to the formatter to access this.
+        # For now, infer from priority.
+        priority = root_cause.rule.priority
+        if priority >= 90:
+            return "critical"
+        if priority >= 75:
+            return "high"
+        if priority >= 50:
+            return "medium"
+        return "low"
+
+    def _get_severity_icon(self, root_cause: RootCause) -> str:
+        """Get severity icon emoji."""
+        severity = self._get_severity(root_cause)
+        icons = {
+            "critical": "🔴",
+            "high": "🟠",
+            "medium": "🟡",
+            "low": "🔵",
+        }
+        return icons.get(severity, "⚪")
+
+
+class JSONFormatter:
+    """Formats triage results as JSON."""
+
+    def format(self, result: TriageResult) -> dict[str, Any]:
+        """Generate JSON triage report.
+
+        Args:
+            result: TriageResult to format
+
+        Returns:
+            Dictionary suitable for JSON serialization
+        """
+        return result.to_dict()
+
+
+class ChecklistFormatter:
+    """Formats triage results as a simple checklist for LLMs."""
+
+    def format(self, result: TriageResult) -> str:
+        """Generate simple checklist for LLM consumption.
+
+        Args:
+            result: TriageResult to format
+
+        Returns:
+            Formatted checklist string
+        """
+        lines = []
+        lines.append(f"# Fix Checklist for {result.job_name}")
+        lines.append("")
+
+        # Only include actionable items.
+        actionable = [rc for rc in result.root_causes if rc.rule.actionable]
+
+        if not actionable:
+            lines.append("No actionable issues found.")
+            return "\n".join(lines)
+
+        for i, rc in enumerate(actionable, 1):
+            # Simplified checkbox item.
+            identifier = f"RC-{i}"
+            lines.append(f"- [ ] {identifier}: {rc.rule.name}")
+
+            # Show first error details.
+            if rc.primary_matches:
+                first_match = rc.primary_matches[0]
+                lines.append(
+                    f"     Line {first_match.line_number}: {first_match.match_text[:100]}"
+                )
+
+                # Show fix hint from extracted fields.
+                if first_match.extracted_fields:
+                    hints = []
+                    for field_name, field_value in first_match.extracted_fields.items():
+                        if field_name == "file_path":
+                            hints.append(f"File: {field_value[0]}")
+                        elif field_name == "error_message":
+                            hints.append(f"Error: {field_value[0]}")
+                    if hints:
+                        lines.append(f"     → Fix: {', '.join(hints)}")
+
+        return "\n".join(lines)

--- a/tools/utils/ci/core/fetcher.py
+++ b/tools/utils/ci/core/fetcher.py
@@ -1,0 +1,423 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""GitHub CI data fetcher for corpus building.
+
+Fetches workflow runs and job logs from GitHub Actions using the GitHub CLI.
+Follows the patterns established in iree-ci-triage for consistency.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from common import console
+
+from ci.core.corpus import Corpus
+from ci.core.github_client import GitHubClient, GitHubClientError
+from ci.core.utils import is_meta_job
+
+
+@dataclass
+class FetchResult:
+    """Results of a fetch operation."""
+
+    runs_fetched: int
+    runs_new: int
+    runs_duplicate: int
+    logs_fetched: int
+    logs_failed: int
+    errors: list[str]
+
+
+class GitHubFetcher:
+    """Fetches CI data from GitHub and stores in corpus."""
+
+    def __init__(
+        self, client: GitHubClient, corpus: Corpus, args: Any | None = None
+    ) -> None:
+        """Initialize fetcher.
+
+        Args:
+            client: GitHub client instance
+            corpus: Corpus instance for storage
+            args: Optional args namespace for progress reporting (uses quiet flag)
+        """
+        self.client = client
+        self.corpus = corpus
+        self.args = args
+
+    def _chunk_time_range(
+        self, since: datetime, until: datetime, chunk_days: int = 30
+    ) -> list[tuple[datetime, datetime]]:
+        """Split a time range into chunks for incremental fetching.
+
+        Args:
+            since: Start of time range (inclusive)
+            until: End of time range (exclusive)
+            chunk_days: Days per chunk (default: 30 for ~monthly chunks)
+
+        Returns:
+            List of (start, end) datetime tuples representing chunks
+        """
+        chunks = []
+        current = since
+
+        while current < until:
+            chunk_end = min(current + timedelta(days=chunk_days), until)
+            chunks.append((current, chunk_end))
+            current = chunk_end
+
+        return chunks
+
+    def fetch_since(
+        self,
+        since: datetime,
+        limit: int = 100,
+        branch: str | None = None,
+        status: str = "failure",
+    ) -> FetchResult:
+        """Fetch all failure runs since a timestamp using time-based chunking.
+
+        Args:
+            since: Fetch runs created after this datetime
+            limit: Maximum number of runs to fetch per chunk
+            branch: Filter by branch (None = all branches)
+            status: Run status filter (default: 'failure')
+
+        Returns:
+            FetchResult with statistics
+        """
+        result = FetchResult(
+            runs_fetched=0,
+            runs_new=0,
+            runs_duplicate=0,
+            logs_fetched=0,
+            logs_failed=0,
+            errors=[],
+        )
+
+        # Split time range into monthly chunks.
+        until = datetime.now(timezone.utc)
+        chunks = self._chunk_time_range(since, until, chunk_days=30)
+
+        if branch:
+            console.note(
+                f"  Fetching in {len(chunks)} time chunks from branch '{branch}'...",
+                args=self.args,
+            )
+        else:
+            console.note(
+                f"  Fetching in {len(chunks)} time chunks from ALL branches...",
+                args=self.args,
+            )
+
+        # Process each time chunk.
+        for chunk_idx, (chunk_start, chunk_end) in enumerate(chunks, 1):
+            chunk_start_str = chunk_start.strftime("%Y-%m-%d")
+            chunk_end_str = chunk_end.strftime("%Y-%m-%d")
+
+            console.note(
+                f"  Chunk {chunk_idx}/{len(chunks)}: {chunk_start_str} to {chunk_end_str}...",
+                args=self.args,
+            )
+
+            # Fetch runs for this chunk.
+            try:
+                if branch:
+                    # Fetch from specific branch.
+                    chunk_runs_raw = self.client.get_runs_for_branch(
+                        branch,
+                        status=status,
+                        limit=limit,
+                        created_since=chunk_start_str,
+                    )
+                else:
+                    # Fetch from ALL branches (no branch filter).
+                    chunk_runs_raw = self.client.get_all_runs(
+                        status=status,
+                        limit=limit,
+                        created_since=chunk_start_str,
+                    )
+
+                # Filter by time range (client-side, since gh --created only supports date-level >=).
+                chunk_runs = []
+                for run in chunk_runs_raw:
+                    created = datetime.fromisoformat(
+                        run.created_at.replace("Z", "+00:00")
+                    )
+                    # Check both bounds: chunk_start <= created < chunk_end.
+                    if chunk_start <= created < chunk_end:
+                        chunk_runs.append(run)
+
+            except GitHubClientError as e:
+                result.errors.append(
+                    f"Chunk {chunk_idx}/{len(chunks)} ({chunk_start_str} to {chunk_end_str}): "
+                    f"Failed to fetch: {e}"
+                )
+                continue
+
+            # Process runs from this chunk.
+            for run in chunk_runs:
+                result.runs_fetched += 1
+
+                # Try to add to corpus.
+                if self._fetch_and_store_run(run.run_id, result):
+                    result.runs_new += 1
+                else:
+                    result.runs_duplicate += 1
+
+            # Show chunk completion summary.
+            console.note(
+                f"    Chunk {chunk_idx}/{len(chunks)} complete: "
+                f"+{len(chunk_runs)} runs processed "
+                f"(total: {result.runs_new} new, {result.logs_fetched} logs)",
+                args=self.args,
+            )
+
+        return result
+
+    def fetch_run(self, run_id: str) -> FetchResult:
+        """Fetch a specific run and its logs.
+
+        Args:
+            run_id: Workflow run ID to fetch
+
+        Returns:
+            FetchResult with statistics
+        """
+        result = FetchResult(
+            runs_fetched=0,
+            runs_new=0,
+            runs_duplicate=0,
+            logs_fetched=0,
+            logs_failed=0,
+            errors=[],
+        )
+
+        if self._fetch_and_store_run(run_id, result):
+            result.runs_new += 1
+        else:
+            result.runs_duplicate += 1
+        return result
+
+    def fetch_pr(self, pr_number: int, status: str = "failure") -> FetchResult:
+        """Fetch failures from a PR.
+
+        Args:
+            pr_number: Pull request number
+            status: Run status filter (default: 'failure')
+
+        Returns:
+            FetchResult with statistics
+        """
+        result = FetchResult(
+            runs_fetched=0,
+            runs_new=0,
+            runs_duplicate=0,
+            logs_fetched=0,
+            logs_failed=0,
+            errors=[],
+        )
+
+        try:
+            # Get runs for this PR.
+            runs = self.client.get_runs_for_pr(pr_number, status=status, limit=10)
+
+            for run in runs:
+                result.runs_fetched += 1
+                if self._fetch_and_store_run(run.run_id, result):
+                    result.runs_new += 1
+                else:
+                    result.runs_duplicate += 1
+
+        except GitHubClientError as e:
+            result.errors.append(f"Failed to fetch PR #{pr_number}: {e}")
+
+        return result
+
+    def _check_annotation_infrastructure_flake(
+        self, annotations: list[Any]
+    ) -> tuple[bool, str]:
+        """Check if annotations indicate infrastructure flake.
+
+        Args:
+            annotations: List of annotation dictionaries from GitHub API
+
+        Returns:
+            Tuple of (is_flake, error_code) where is_flake is True if annotations
+            contain infrastructure failure patterns
+        """
+        # Infrastructure flake patterns in annotations.
+        patterns = [
+            ("No space left on device", "RUNNER_DISK_FULL"),
+            ("System.IO.IOException", "RUNNER_IO_ERROR"),
+            ("GitHub.Runner.Worker", "RUNNER_CRASH"),
+            ("Unhandled exception", "RUNNER_UNHANDLED_EXCEPTION"),
+            ("The self-hosted runner", "RUNNER_LOST"),
+            ("connection to the server was lost", "RUNNER_CONNECTION_LOST"),
+        ]
+
+        for annotation in annotations:
+            message = annotation.get("message", "")
+            for pattern, error_code in patterns:
+                if pattern in message:
+                    return (True, error_code)
+
+        return (False, "")
+
+    def _fetch_and_store_run(self, run_id: str, result: FetchResult) -> bool:
+        """Fetch and store a single run.
+
+        Args:
+            run_id: Run ID to fetch
+            result: FetchResult to update with stats
+
+        Returns:
+            True if new run added, False if duplicate
+        """
+        try:
+            # Fetch run metadata.
+            is_existing_run = self.corpus.has_run(run_id)
+            if is_existing_run:
+                console.note(
+                    f"  Checking run {run_id} for missing data...", args=self.args
+                )
+            else:
+                console.note(f"  Fetching run {run_id}...", args=self.args)
+
+            run_data = self.client.get_run(run_id)
+            if not run_data:
+                result.errors.append(f"Run {run_id} not found")
+                return False
+
+            # Get failed jobs.
+            all_failed_jobs = self.client.get_failed_jobs(run_id)
+
+            # Filter out meta/summary jobs (they just aggregate other failures).
+            failed_jobs = [job for job in all_failed_jobs if not is_meta_job(job.name)]
+
+            skipped_meta = len(all_failed_jobs) - len(failed_jobs)
+            if skipped_meta > 0:
+                console.note(
+                    f"    Skipped {skipped_meta} meta/summary jobs",
+                    args=self.args,
+                )
+
+            console.note(
+                f"    Found {len(failed_jobs)} failed jobs in run {run_id}",
+                args=self.args,
+            )
+
+            # Build run metadata for corpus.
+            run_meta = {
+                # Core identifiers.
+                "run_id": run_id,
+                "workflow": run_data.get("workflowName", ""),
+                "workflow_id": run_data.get("workflowDatabaseId", ""),
+                "name": run_data.get("name", ""),
+                # Git/commit info.
+                "head_sha": run_data.get("headSha", ""),
+                "branch": run_data.get("headBranch", ""),
+                # Trigger info.
+                "event": run_data.get("event", ""),
+                "pr_number": run_data.get("number"),  # None if not PR event.
+                # Status and timing.
+                "status": run_data.get("status", ""),
+                "conclusion": run_data.get("conclusion", ""),
+                "attempt": run_data.get("attempt", 1),
+                "created_at": run_data.get("createdAt", ""),
+                "started_at": run_data.get("startedAt", ""),
+                "updated_at": run_data.get("updatedAt", ""),
+                # Display and links.
+                "display_title": run_data.get("displayTitle", ""),
+                "url": run_data.get("url", ""),
+                # Job stats.
+                "jobs": len(run_data.get("jobs", [])),
+                "failed_jobs": len(failed_jobs),
+                # Corpus metadata.
+                "fetched_at": datetime.now().isoformat(),
+                "classified": False,
+            }
+
+            # Add to corpus (only if new run).
+            if not is_existing_run and not self.corpus.add_run(run_meta):
+                return False
+
+            # Fetch logs and annotations for failed jobs.
+            any_data_fetched = False
+            for i, job in enumerate(failed_jobs, 1):
+                try:
+                    # Check if log already exists and is non-empty.
+                    log_path = self.corpus.get_log_path(run_id, job.job_id)
+                    log_exists = (
+                        log_path and log_path.exists() and log_path.stat().st_size > 0
+                    )
+
+                    # Fetch annotations first (fast, <1s).
+                    annotations = self.client.get_job_annotations(job.job_id)
+
+                    # Always save annotations if they exist.
+                    if annotations:
+                        self.corpus.save_annotations(run_id, job.job_id, annotations)
+                        any_data_fetched = True
+
+                    # Check if annotations indicate infrastructure flake.
+                    is_flake, error_code = self._check_annotation_infrastructure_flake(
+                        annotations
+                    )
+
+                    if is_flake:
+                        # Skip log download for infrastructure flakes.
+                        console.note(
+                            f"    Skipping log {i}/{len(failed_jobs)}: {job.name} "
+                            f"(infrastructure flake: {error_code})",
+                            args=self.args,
+                        )
+                        continue
+
+                    # Skip log download if already exists and non-empty.
+                    if log_exists:
+                        console.note(
+                            f"    Skipping log {i}/{len(failed_jobs)}: {job.name} "
+                            f"(already exists, {log_path.stat().st_size} bytes)",
+                            args=self.args,
+                        )
+                        continue
+
+                    # Not an infrastructure flake and doesn't exist - download log.
+                    console.note(
+                        f"    Downloading log {i}/{len(failed_jobs)}: {job.name}",
+                        args=self.args,
+                    )
+                    log_content = self.client.get_job_log(run_id, job.job_id)
+                    if log_content:
+                        self.corpus.save_log(run_id, job.job_id, log_content)
+                        result.logs_fetched += 1
+                        any_data_fetched = True
+                    else:
+                        result.logs_failed += 1
+                        result.errors.append(f"No log available for job {job.job_id}")
+
+                except GitHubClientError as e:
+                    result.logs_failed += 1
+                    result.errors.append(str(e))
+
+            # For existing runs, only return True if we fetched new data.
+            if is_existing_run:
+                if not any_data_fetched:
+                    console.note(
+                        f"  Run {run_id} already complete (no missing data)",
+                        args=self.args,
+                    )
+                return any_data_fetched
+
+            # New run was added.
+            return True
+
+        except GitHubClientError as e:
+            result.errors.append(f"Failed to fetch run {run_id}: {e}")
+            return False

--- a/tools/utils/ci/core/gardener.py
+++ b/tools/utils/ci/core/gardener.py
@@ -1,0 +1,339 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Gardening workflows for CI corpus maintenance.
+
+Provides tools for:
+- Finding unrecognized failures
+- Generating TODO lists for pattern development
+- Testing new patterns against the corpus
+- Computing recognition rates and corpus health metrics
+"""
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ci.core.classifier import Classifier
+from ci.core.corpus import Corpus
+
+
+@dataclass
+class UnrecognizedFailure:
+    """An unrecognized failure needing investigation."""
+
+    run_id: str
+    job_id: str
+    log_path: Path
+    occurrence_count: int  # How many times this pattern appears.
+    first_seen: str  # ISO timestamp.
+    sample_lines: list[str]  # Sample error lines.
+
+
+class Gardener:
+    """Interactive gardening workflows for corpus maintenance."""
+
+    # Exclude known false positives from unrecognized/TODO.md.
+    # These are warnings/errors that appear in logs but are not root causes.
+    EXCLUSION_PATTERNS = [
+        # Pip dependency resolver warnings (appear during setup, not actual failures).
+        "ERROR: pip's dependency resolver",
+        "pip's dependency resolver does",
+        # Add more false positive patterns here as they're discovered.
+    ]
+
+    def __init__(self, corpus: Corpus, classifier: Classifier) -> None:
+        """Initialize gardener.
+
+        Args:
+            corpus: Corpus instance
+            classifier: Classifier instance
+        """
+        self.corpus = corpus
+        self.classifier = classifier
+
+    def find_unrecognized(self) -> list[UnrecognizedFailure]:
+        """Find all failures without root causes.
+
+        Returns:
+            List of UnrecognizedFailure instances
+        """
+        unrecognized = []
+
+        # Load all cached classifications.
+        cache_dir = self.corpus.classification_dir / "cache"
+        if not cache_dir.exists():
+            return unrecognized
+
+        for cache_file in cache_dir.glob("*.json"):
+            cache_data = json.loads(cache_file.read_text())
+            extracted_issues = cache_data.get("extracted_issues", [])
+
+            # Check if unrecognized.
+            if len(extracted_issues) == 0:
+                run_id = cache_data.get("run_id")
+                job_id = cache_data.get("job_id")
+                log_path = self.corpus.get_log_path(run_id, job_id)
+
+                if log_path and log_path.exists():
+                    # Extract sample error lines.
+                    sample_lines = self._extract_error_samples(log_path)
+
+                    unrecognized.append(
+                        UnrecognizedFailure(
+                            run_id=run_id,
+                            job_id=job_id,
+                            log_path=log_path,
+                            occurrence_count=1,  # Will be updated by grouping.
+                            first_seen=cache_data.get("classified_at", ""),
+                            sample_lines=sample_lines,
+                        )
+                    )
+
+        return unrecognized
+
+    def _extract_error_samples(self, log_path: Path, max_lines: int = 10) -> list[str]:
+        """Extract sample error lines from a log.
+
+        Args:
+            log_path: Path to log file
+            max_lines: Maximum number of sample lines to extract
+
+        Returns:
+            List of sample error lines
+        """
+        samples = []
+        error_keywords = ["error:", "Error:", "ERROR:", "FAILED", "fatal:", "Fatal:"]
+
+        try:
+            with open(log_path) as f:
+                for line in f:
+                    if any(keyword in line for keyword in error_keywords):
+                        samples.append(line.strip())
+                        if len(samples) >= max_lines:
+                            break
+        except (OSError, UnicodeDecodeError):
+            pass
+
+        return samples
+
+    def generate_todo(self) -> str:
+        """Generate unrecognized/TODO.md file.
+
+        Returns:
+            Markdown content for uncategorized failures list
+        """
+        unrecognized = self.find_unrecognized()
+
+        # Group by similar error patterns (simple heuristic for now).
+        pattern_groups = self._group_similar_failures(unrecognized)
+
+        # Generate markdown.
+        lines = [
+            "# Uncategorized Failures",
+            "",
+            f"Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Recognition rate: {self.compute_recognition_rate():.1%}",
+            "",
+            "These failures were not recognized by any extractor. To categorize them:",
+            "",
+            "**Available Extractors:**",
+            "- Infrastructure/network/hardware → `tools/utils/common/extractors/infrastructure_flake.py`",
+            "- Build errors (C/C++ compilation) → `tools/utils/common/extractors/build_error.py`",
+            "- CMake configuration errors → `tools/utils/common/extractors/cmake_error.py`",
+            "- Bazel build errors → `tools/utils/common/extractors/bazel_error.py`",
+            "- MLIR compiler errors → `tools/utils/common/extractors/mlir_compiler.py`",
+            "- Sanitizer failures (ASan/TSan/etc) → `tools/utils/common/extractors/sanitizer.py`",
+            "- Pre-commit hook failures → `tools/utils/common/extractors/precommit.py`",
+            "- CodeQL analysis errors → `tools/utils/common/extractors/codeql_error.py`",
+            "",
+            "**After adding patterns:** Run `iree-ci-garden reclassify` to re-process corpus.",
+            "",
+            "## Failures by Priority",
+            "",
+        ]
+
+        # Sort by occurrence count (descending).
+        sorted_groups = sorted(
+            pattern_groups.items(), key=lambda x: x[1]["count"], reverse=True
+        )
+
+        # High priority (3+ occurrences).
+        high_priority = [g for g in sorted_groups if g[1]["count"] >= 3]
+        if high_priority:
+            lines.append("### High Priority - Seen 3+ times")
+            for i, (pattern, data) in enumerate(high_priority, 1):
+                lines.append(f"{i}. **{pattern}** ({data['count']} occurrences)")
+                lines.append(f"   - First seen: {data['first_seen']}")
+                lines.append(f"   - Logs: {', '.join(data['logs'][:3])}")
+                lines.append("   - Action: Add pattern to appropriate extractor")
+                lines.append("   - [ ] Categorized")
+                lines.append("")
+
+        # Medium priority (2 occurrences).
+        med_priority = [g for g in sorted_groups if g[1]["count"] == 2]
+        if med_priority:
+            lines.append("### Medium Priority - Seen 2 times")
+            for i, (pattern, data) in enumerate(med_priority, 1):
+                lines.append(f"{i}. **{pattern}** ({data['count']} occurrences)")
+                lines.append(f"   - Logs: {', '.join(data['logs'])}")
+                lines.append("   - Action: Investigate pattern")
+                lines.append("   - [ ] Investigated")
+                lines.append("")
+
+        # Low priority (1 occurrence).
+        low_priority = [g for g in sorted_groups if g[1]["count"] == 1]
+        if low_priority and len(low_priority) <= 20:  # Only show up to 20.
+            lines.append("### Low Priority - Seen once")
+            for i, (pattern, data) in enumerate(low_priority[:20], 1):
+                lines.append(f"{i}. **{pattern}**")
+                lines.append(f"   - Log: {data['logs'][0]}")
+                lines.append("")
+
+        return "\n".join(lines)
+
+    def _group_similar_failures(
+        self, failures: list[UnrecognizedFailure]
+    ) -> dict[str, dict[str, Any]]:
+        """Group similar failures by error pattern.
+
+        Args:
+            failures: List of unrecognized failures
+
+        Returns:
+            Dict mapping pattern name to {'count', 'logs', 'first_seen'}
+        """
+        groups = {}
+
+        for failure in failures:
+            # Simple heuristic: use first error line as pattern identifier.
+            pattern = (
+                failure.sample_lines[0] if failure.sample_lines else "Unknown error"
+            )
+
+            # Skip known false positives.
+            if self._is_excluded(pattern):
+                continue
+
+            # Clean up pattern (remove timestamps, paths, etc.).
+            pattern = self._clean_pattern(pattern)
+
+            if pattern not in groups:
+                groups[pattern] = {
+                    "count": 0,
+                    "logs": [],
+                    "first_seen": failure.first_seen,
+                }
+
+            groups[pattern]["count"] += 1
+            groups[pattern]["logs"].append(f"{failure.run_id}/{failure.job_id}.log")
+
+        return groups
+
+    def _is_excluded(self, pattern: str) -> bool:
+        """Check if pattern matches exclusion list.
+
+        Args:
+            pattern: Error pattern to check
+
+        Returns:
+            True if pattern should be excluded
+        """
+        return any(exclusion in pattern for exclusion in self.EXCLUSION_PATTERNS)
+
+    def _clean_pattern(self, pattern: str) -> str:
+        """Clean up error pattern for grouping.
+
+        Args:
+            pattern: Raw error line
+
+        Returns:
+            Cleaned pattern string
+        """
+        # Remove timestamps (ISO 8601 format).
+        pattern = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z", "", pattern)
+
+        # Remove file paths (anything with /).
+        pattern = re.sub(r"/[\w/.-]+", "<path>", pattern)
+
+        # Remove numbers (line numbers, etc.).
+        pattern = re.sub(r"\b\d+\b", "<num>", pattern)
+
+        # Truncate if too long.
+        if len(pattern) > 100:
+            pattern = pattern[:97] + "..."
+
+        return pattern.strip()
+
+    def compute_recognition_rate(self) -> float:
+        """Calculate % of logs with identified root causes.
+
+        Returns:
+            Recognition rate as float (0.0 to 1.0)
+        """
+        total = 0
+        recognized = 0
+
+        cache_dir = self.corpus.classification_dir / "cache"
+        if not cache_dir.exists():
+            return 0.0
+
+        for cache_file in cache_dir.glob("*.json"):
+            total += 1
+            cache_data = json.loads(cache_file.read_text())
+            if len(cache_data.get("extracted_issues", [])) > 0:
+                recognized += 1
+
+        if total == 0:
+            return 0.0
+
+        return recognized / total
+
+    def get_category_breakdown(self) -> dict[str, int]:
+        """Get count of logs per category.
+
+        Returns:
+            Dict mapping category name to count
+        """
+        categories = Counter()
+
+        cache_dir = self.corpus.classification_dir / "cache"
+        if not cache_dir.exists():
+            return dict(categories)
+
+        for cache_file in cache_dir.glob("*.json"):
+            cache_data = json.loads(cache_file.read_text())
+            for category in cache_data.get("categories", []):
+                categories[category] += 1
+
+        return dict(categories)
+
+    def save_todo_list(self) -> None:
+        """Generate and save unrecognized/TODO.md file."""
+        todo_content = self.generate_todo()
+        todo_path = self.corpus.unrecognized_dir / "TODO.md"
+        todo_path.write_text(todo_content)
+
+    def get_corpus_health(self) -> dict[str, Any]:
+        """Get overall corpus health metrics.
+
+        Returns:
+            Dict with health metrics
+        """
+        stats = self.corpus.get_stats()
+        recognition_rate = self.compute_recognition_rate()
+        categories = self.get_category_breakdown()
+
+        return {
+            "stats": stats,
+            "recognition_rate": recognition_rate,
+            "categories": categories,
+            "health_score": recognition_rate,  # Simple score for now.
+        }

--- a/tools/utils/ci/core/github_client.py
+++ b/tools/utils/ci/core/github_client.py
@@ -1,0 +1,645 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""GitHub CLI wrapper for fetching CI workflow data.
+
+This module provides a Python interface to the GitHub CLI (gh) for:
+- Checking authentication status
+- Fetching workflow runs
+- Fetching job details and logs
+- Handling errors and rate limiting
+"""
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from common import console
+
+
+@dataclass
+class WorkflowRun:
+    """GitHub Actions workflow run."""
+
+    run_id: str
+    workflow_name: str
+    conclusion: str
+    created_at: str
+    head_branch: str
+    display_title: str
+
+
+@dataclass
+class Job:
+    """GitHub Actions job."""
+
+    job_id: str
+    name: str
+    conclusion: str
+    runner_name: str | None
+    started_at: str
+    completed_at: str
+
+
+class GitHubClientError(Exception):
+    """Exception raised for GitHub CLI errors."""
+
+    pass
+
+
+class GitHubClient:
+    """Client for interacting with GitHub via the gh CLI."""
+
+    def __init__(self, repo: str = "iree-org/iree") -> None:
+        """Initialize the GitHub client.
+
+        Args:
+            repo: GitHub repository in owner/repo format
+        """
+        self.repo = repo
+
+    def _run_gh_command_with_retry(
+        self,
+        cmd: list[str],
+        timeout: int = 120,
+        max_retries: int = 3,
+        base_delay: float = 5.0,
+    ) -> subprocess.CompletedProcess:
+        """Run a gh CLI command with retry logic on timeout.
+
+        Args:
+            cmd: Command to run (list of strings)
+            timeout: Timeout in seconds for each attempt
+            max_retries: Maximum number of retry attempts
+            base_delay: Base delay in seconds for exponential backoff
+
+        Returns:
+            CompletedProcess result from successful execution
+
+        Raises:
+            GitHubClientError: If command fails after all retries
+        """
+        last_error = None
+
+        for attempt in range(max_retries):
+            try:
+                return subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=timeout,
+                )
+
+            except subprocess.TimeoutExpired as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    # Exponential backoff: 5s, 10s, 20s.
+                    delay = base_delay * (2**attempt)
+                    console.note(
+                        f"    Retry {attempt + 1}/{max_retries - 1} after timeout "
+                        f"(waiting {delay:.0f}s before retry)..."
+                    )
+                    time.sleep(delay)
+                    continue
+                # Final attempt failed.
+                raise GitHubClientError(
+                    f"gh CLI command timed out after {max_retries} retries"
+                ) from e
+
+            except subprocess.CalledProcessError as e:
+                # Don't retry on non-timeout errors.
+                raise GitHubClientError(f"gh CLI command failed: {e.stderr}") from e
+
+        # Should not reach here, but safety fallback.
+        raise GitHubClientError(
+            f"gh CLI command failed after {max_retries} retries"
+        ) from last_error
+
+    def check_cli_available(self) -> bool:
+        """Check if gh CLI is installed.
+
+        Returns:
+            True if gh CLI is available, False otherwise
+        """
+        try:
+            subprocess.run(
+                ["gh", "--version"],
+                capture_output=True,
+                check=True,
+                timeout=5,
+            )
+            return True
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return False
+
+    def check_authenticated(self) -> bool:
+        """Check if gh CLI is authenticated.
+
+        Returns:
+            True if authenticated, False otherwise
+        """
+        try:
+            subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                check=True,
+                timeout=5,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    def get_runs_for_pr(
+        self, pr_number: int, status: str | None = None, limit: int | None = 10
+    ) -> list[WorkflowRun]:
+        """Get workflow runs for a pull request.
+
+        Args:
+            pr_number: Pull request number
+            status: Filter by run status (e.g., 'failure', 'success')
+            limit: Maximum number of runs to fetch (None = fetch all runs for commit)
+
+        Returns:
+            List of WorkflowRun objects, sorted by creation time (newest first)
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        # First, get the head SHA for the PR.
+        cmd = [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            self.repo,
+            "--json",
+            "headRefOid,headRefName",
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=10,
+            )
+            pr_data = json.loads(result.stdout)
+            head_sha = pr_data.get("headRefOid")
+
+            if not head_sha:
+                raise GitHubClientError(f"Could not get head SHA for PR #{pr_number}")
+
+            # Now fetch runs for this commit/branch.
+            return self.get_runs_for_commit(head_sha, status, limit)
+
+        except subprocess.CalledProcessError as e:
+            raise GitHubClientError(
+                f"Failed to fetch PR #{pr_number}: {e.stderr}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise GitHubClientError("gh CLI command timed out") from e
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse gh CLI output: {e}") from e
+
+    def get_runs_for_commit(
+        self, commit_sha: str, status: str | None = None, limit: int | None = 10
+    ) -> list[WorkflowRun]:
+        """Get workflow runs for a specific commit.
+
+        Args:
+            commit_sha: Git commit SHA (can be short or full)
+            status: Filter by run status (e.g., 'failure', 'success')
+            limit: Maximum number of runs to fetch (None = fetch all runs)
+
+        Returns:
+            List of WorkflowRun objects, sorted by creation time (newest first)
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        cmd = [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            self.repo,
+            "--commit",
+            commit_sha,
+            "--json",
+            "databaseId,workflowName,conclusion,createdAt,headBranch,displayTitle",
+        ]
+
+        if limit is not None:
+            cmd.extend(["--limit", str(limit)])
+
+        if status:
+            cmd.extend(["--status", status])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            runs_data = json.loads(result.stdout)
+
+            runs = []
+            for run_data in runs_data:
+                runs.append(
+                    WorkflowRun(
+                        run_id=str(run_data["databaseId"]),
+                        workflow_name=run_data.get("workflowName", ""),
+                        conclusion=run_data.get("conclusion", ""),
+                        created_at=run_data.get("createdAt", ""),
+                        head_branch=run_data.get("headBranch", ""),
+                        display_title=run_data.get("displayTitle", ""),
+                    )
+                )
+            return runs
+
+        except subprocess.CalledProcessError as e:
+            raise GitHubClientError(
+                f"Failed to fetch runs for commit {commit_sha}: {e.stderr}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise GitHubClientError("gh CLI command timed out") from e
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse gh CLI output: {e}") from e
+
+    def get_all_runs(
+        self,
+        status: str | None = None,
+        limit: int = 10,
+        created_since: str | None = None,
+    ) -> list[WorkflowRun]:
+        """Get workflow runs from ALL branches (not filtered by branch).
+
+        Args:
+            status: Filter by run status (e.g., 'failure', 'success')
+            limit: Maximum number of runs to fetch
+            created_since: Filter runs created after this date (ISO format, e.g., '2025-01-01')
+
+        Returns:
+            List of WorkflowRun objects from all branches, sorted by creation time (newest first)
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        cmd = [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            self.repo,
+            # No --branch flag = fetch from ALL branches.
+            "--json",
+            "databaseId,workflowName,conclusion,createdAt,headBranch,displayTitle",
+            "--limit",
+            str(limit),
+        ]
+
+        if status:
+            cmd.extend(["--status", status])
+
+        if created_since:
+            # Format: >=YYYY-MM-DD for server-side filtering.
+            cmd.extend(["--created", f">={created_since}"])
+
+        try:
+            # Use retry helper with 120s timeout per attempt.
+            result = self._run_gh_command_with_retry(cmd, timeout=120)
+            runs_data = json.loads(result.stdout)
+
+            runs = []
+            for run_data in runs_data:
+                runs.append(
+                    WorkflowRun(
+                        run_id=str(run_data["databaseId"]),
+                        workflow_name=run_data.get("workflowName", ""),
+                        conclusion=run_data.get("conclusion", ""),
+                        created_at=run_data.get("createdAt", ""),
+                        head_branch=run_data.get("headBranch", ""),
+                        display_title=run_data.get("displayTitle", ""),
+                    )
+                )
+            return runs
+
+        except subprocess.CalledProcessError as e:
+            raise GitHubClientError(
+                f"Failed to fetch runs: {e.stderr if e.stderr else str(e)}"
+            ) from e
+
+    def get_runs_for_branch(
+        self,
+        branch: str,
+        status: str | None = None,
+        limit: int = 10,
+        created_since: str | None = None,
+    ) -> list[WorkflowRun]:
+        """Get workflow runs for a specific branch.
+
+        Args:
+            branch: Branch name to filter by
+            status: Filter by run status (e.g., 'failure', 'success')
+            limit: Maximum number of runs to fetch
+            created_since: Filter runs created after this date (ISO format, e.g., '2025-01-01')
+
+        Returns:
+            List of WorkflowRun objects, sorted by creation time (newest first)
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        cmd = [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            self.repo,
+            "--branch",
+            branch,
+            "--json",
+            "databaseId,workflowName,conclusion,createdAt,headBranch,displayTitle",
+            "--limit",
+            str(limit),
+        ]
+
+        if status:
+            cmd.extend(["--status", status])
+
+        if created_since:
+            # Format: >=YYYY-MM-DD for server-side filtering.
+            cmd.extend(["--created", f">={created_since}"])
+
+        try:
+            # Use retry helper with 120s timeout per attempt.
+            result = self._run_gh_command_with_retry(cmd, timeout=120)
+            runs_data = json.loads(result.stdout)
+
+            runs = []
+            for run_data in runs_data:
+                runs.append(
+                    WorkflowRun(
+                        run_id=str(run_data["databaseId"]),
+                        workflow_name=run_data.get("workflowName", ""),
+                        conclusion=run_data.get("conclusion", ""),
+                        created_at=run_data.get("createdAt", ""),
+                        head_branch=run_data.get("headBranch", ""),
+                        display_title=run_data.get("displayTitle", ""),
+                    )
+                )
+            return runs
+
+        except GitHubClientError:
+            # Re-raise errors from retry helper.
+            raise
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse gh CLI output: {e}") from e
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        """Get details for a specific workflow run.
+
+        Args:
+            run_id: Workflow run ID
+
+        Returns:
+            Run data as dictionary, or None if not found
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        cmd = [
+            "gh",
+            "run",
+            "view",
+            run_id,
+            "--repo",
+            self.repo,
+            "--json",
+            "jobs,conclusion,createdAt,displayTitle,headBranch,workflowName,headSha,event,url,number,status,attempt,startedAt,updatedAt,name,workflowDatabaseId",
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            return json.loads(result.stdout)
+
+        except subprocess.CalledProcessError as e:
+            if "could not resolve to a" in e.stderr.lower():
+                return None
+            raise GitHubClientError(f"Failed to fetch run {run_id}: {e.stderr}") from e
+        except subprocess.TimeoutExpired as e:
+            raise GitHubClientError("gh CLI command timed out") from e
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse gh CLI output: {e}") from e
+
+    def get_jobs(self, run_id: str) -> list[Job]:
+        """Get all jobs for a workflow run.
+
+        Args:
+            run_id: Workflow run ID
+
+        Returns:
+            List of Job objects
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        run_data = self.get_run(run_id)
+        if not run_data:
+            return []
+
+        jobs_data = run_data.get("jobs", [])
+        jobs = []
+
+        for job_data in jobs_data:
+            jobs.append(
+                Job(
+                    job_id=str(job_data["databaseId"]),
+                    name=job_data.get("name", ""),
+                    conclusion=job_data.get("conclusion", ""),
+                    runner_name=job_data.get("runnerName"),
+                    started_at=job_data.get("startedAt", ""),
+                    completed_at=job_data.get("completedAt", ""),
+                )
+            )
+
+        return jobs
+
+    def get_failed_jobs(self, run_id: str) -> list[Job]:
+        """Get only failed jobs for a workflow run.
+
+        Args:
+            run_id: Workflow run ID
+
+        Returns:
+            List of Job objects with conclusion == 'failure'
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        all_jobs = self.get_jobs(run_id)
+        return [job for job in all_jobs if job.conclusion == "failure"]
+
+    def get_job_metadata(self, job_id: str) -> dict:
+        """Get metadata for a specific job (including run_id).
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            Dictionary with job metadata including run_id
+
+        Raises:
+            GitHubClientError: If gh CLI command fails or job not found
+        """
+        try:
+            cmd = [
+                "gh",
+                "api",
+                f"/repos/{self.repo}/actions/jobs/{job_id}",
+                "--jq",
+                "{job_id: .id, run_id: .run_id, name: .name, status: .status, conclusion: .conclusion}",
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return json.loads(result.stdout)
+
+        except subprocess.CalledProcessError as e:
+            raise GitHubClientError(f"Failed to fetch job {job_id}: {e.stderr}") from e
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse job metadata: {e}") from e
+
+    def get_job_log(self, run_id: str, job_id: str) -> str | None:
+        """Get the log for a specific job.
+
+        Args:
+            run_id: Workflow run ID
+            job_id: Job ID
+
+        Returns:
+            Log content as string, or None if not available
+
+        Raises:
+            GitHubClientError: If gh CLI command fails
+        """
+        cmd = [
+            "gh",
+            "run",
+            "view",
+            run_id,
+            "--repo",
+            self.repo,
+            "--log",
+            "--job",
+            job_id,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=60,
+            )
+            return result.stdout
+
+        except subprocess.CalledProcessError as e:
+            # Log might not be available yet or run was deleted.
+            if "no logs found" in e.stderr.lower():
+                return None
+            raise GitHubClientError(
+                f"Failed to fetch log for job {job_id}: {e.stderr}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise GitHubClientError(
+                "gh CLI command timed out while fetching log"
+            ) from e
+
+    def get_job_annotations(self, job_id: str) -> list[dict[str, Any]]:
+        """Get annotations for a specific job.
+
+        Annotations contain error messages from GitHub Actions infrastructure,
+        including runner crashes, disk full errors, and other system failures.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            List of annotation dictionaries (empty if no annotations or job not found)
+
+        Raises:
+            GitHubClientError: If gh CLI command fails (except 404)
+        """
+        cmd = [
+            "gh",
+            "api",
+            f"/repos/{self.repo}/check-runs/{job_id}/annotations",
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            annotations = json.loads(result.stdout)
+            return annotations if isinstance(annotations, list) else []
+
+        except subprocess.CalledProcessError as e:
+            # 404 means no annotations exist (normal for successful jobs).
+            if "could not resolve to" in e.stderr.lower() or "404" in e.stderr:
+                return []
+            raise GitHubClientError(
+                f"Failed to fetch annotations for job {job_id}: {e.stderr}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise GitHubClientError(
+                "gh CLI command timed out while fetching annotations"
+            ) from e
+        except json.JSONDecodeError as e:
+            raise GitHubClientError(f"Failed to parse annotations: {e}") from e
+
+
+def check_gh_cli_setup() -> tuple[bool, str]:
+    """Check if gh CLI is properly set up.
+
+    Returns:
+        Tuple of (success, error_message)
+        If success is True, error_message is empty.
+        If success is False, error_message contains helpful guidance.
+    """
+    client = GitHubClient()
+
+    # Check if gh CLI is installed.
+    if not client.check_cli_available():
+        return (
+            False,
+            "GitHub CLI (gh) not found. Install it from: https://cli.github.com",
+        )
+
+    # Check if authenticated.
+    if not client.check_authenticated():
+        return (
+            False,
+            "GitHub CLI is not authenticated. Run: gh auth login",
+        )
+
+    return (True, "")

--- a/tools/utils/ci/core/patterns.py
+++ b/tools/utils/ci/core/patterns.py
@@ -1,0 +1,353 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Pattern matching and root cause analysis for CI failures.
+
+This module provides functionality to:
+- Load error patterns from YAML configuration
+- Match patterns against log content
+- Extract structured data from matches
+- Group co-occurring patterns by root cause
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class PatternMatch:
+    """A single pattern match in a log file."""
+
+    pattern_name: str
+    match_text: str
+    line_number: int
+    context_before: list[str] = field(default_factory=list)
+    context_after: list[str] = field(default_factory=list)
+    extracted_fields: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Pattern:
+    """Error pattern definition."""
+
+    name: str
+    regex: re.Pattern
+    severity: str
+    actionable: bool
+    context_lines: int
+    description: str
+    extractors: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_yaml(cls, name: str, config: dict[str, Any]) -> "Pattern":
+        """Create a Pattern from YAML configuration."""
+        return cls(
+            name=name,
+            regex=re.compile(config["pattern"], re.IGNORECASE | re.MULTILINE),
+            severity=config.get("severity", "medium"),
+            actionable=config.get("actionable", True),
+            context_lines=config.get("context_lines", 3),
+            description=config.get("description", ""),
+            extractors=config.get("extract", []),
+        )
+
+    def match(self, content: str, lines: list[str]) -> list[PatternMatch]:
+        """Find all matches of this pattern in the content.
+
+        Args:
+            content: Full log content as a single string
+            lines: Log content split into lines
+
+        Returns:
+            List of PatternMatch objects for each match found
+        """
+        matches = []
+
+        for match_obj in self.regex.finditer(content):
+            # Find line number.
+            line_num = content[: match_obj.start()].count("\n") + 1
+
+            # Extract context.
+            context_start = max(0, line_num - self.context_lines - 1)
+            context_end = min(len(lines), line_num + self.context_lines)
+
+            # Build full context for field extraction (fields may be on adjacent lines).
+            context_before = lines[context_start : line_num - 1]
+            context_after = lines[line_num:context_end]
+            # Use full line containing match, not just matched substring.
+            matched_line = lines[line_num - 1]
+            full_context = "\n".join(context_before + [matched_line] + context_after)
+
+            # Extract fields if extractors are defined.
+            extracted = {}
+            for extractor in self.extractors:
+                field_name = extractor["name"]
+                field_regex = re.compile(extractor["regex"])
+                field_match = field_regex.search(full_context)
+                if field_match:
+                    # If regex has groups, extract them.
+                    if field_match.groups():
+                        extracted[field_name] = field_match.groups()
+                    else:
+                        extracted[field_name] = field_match.group(0)
+
+            matches.append(
+                PatternMatch(
+                    pattern_name=self.name,
+                    match_text=match_obj.group(0),
+                    line_number=line_num,
+                    context_before=context_before,
+                    context_after=context_after,
+                    extracted_fields=extracted,
+                )
+            )
+
+        return matches
+
+
+@dataclass
+class RootCauseRule:
+    """Rule for grouping co-occurring patterns into a root cause."""
+
+    name: str
+    primary_pattern: str
+    secondary_patterns: list[str]
+    description: str
+    priority: int
+    actionable: bool
+    category: str
+
+    @classmethod
+    def from_yaml(cls, config: dict[str, Any]) -> "RootCauseRule":
+        """Create a RootCauseRule from YAML configuration."""
+        return cls(
+            name=config["name"],
+            primary_pattern=config["primary_pattern"],
+            secondary_patterns=config.get("secondary_patterns", []),
+            description=config.get("description", ""),
+            priority=config.get("priority", 50),
+            actionable=config.get("actionable", True),
+            category=config.get("category", "unknown"),
+        )
+
+    def matches(self, pattern_names: list[str]) -> bool:
+        """Check if this rule matches the given set of patterns.
+
+        Args:
+            pattern_names: List of pattern names found in a log
+
+        Returns:
+            True if the primary pattern is present and at least one
+            secondary pattern (if defined) is also present
+        """
+        if self.primary_pattern not in pattern_names:
+            return False
+
+        # If no secondary patterns defined, primary is enough.
+        if not self.secondary_patterns:
+            return True
+
+        # At least one secondary pattern must be present.
+        return any(pattern in pattern_names for pattern in self.secondary_patterns)
+
+
+@dataclass
+class RootCause:
+    """A root cause grouping multiple related error patterns."""
+
+    rule: RootCauseRule
+    primary_matches: list[PatternMatch]
+    secondary_matches: list[PatternMatch]
+
+    @property
+    def all_matches(self) -> list[PatternMatch]:
+        """Get all matches (primary + secondary) for this root cause."""
+        return self.primary_matches + self.secondary_matches
+
+
+class PatternLoader:
+    """Loads error patterns and root cause rules from YAML files."""
+
+    def __init__(self, patterns_file: Path, rules_file: Path) -> None:
+        """Initialize the pattern loader.
+
+        Args:
+            patterns_file: Path to patterns.yaml
+            rules_file: Path to cooccurrence_rules.yaml
+        """
+        self.patterns_file = patterns_file
+        self.rules_file = rules_file
+        self.patterns: dict[str, Pattern] = {}
+        self.rules: list[RootCauseRule] = []
+        self.pattern_priorities: dict[str, int] = {}
+
+    def load(self) -> None:
+        """Load all patterns and rules from YAML files."""
+        self._load_patterns()
+        self._load_rules()
+
+    def _load_patterns(self) -> None:
+        """Load error patterns from YAML."""
+        with open(self.patterns_file) as f:
+            data = yaml.safe_load(f)
+
+        patterns_config = data.get("patterns", {})
+        for name, config in patterns_config.items():
+            self.patterns[name] = Pattern.from_yaml(name, config)
+
+    def _load_rules(self) -> None:
+        """Load root cause rules from YAML."""
+        with open(self.rules_file) as f:
+            data = yaml.safe_load(f)
+
+        # Load root cause grouping rules.
+        rules_config = data.get("root_cause_rules", [])
+        for rule_config in rules_config:
+            self.rules.append(RootCauseRule.from_yaml(rule_config))
+
+        # Sort rules by priority (highest first).
+        self.rules.sort(key=lambda r: r.priority, reverse=True)
+
+        # Load pattern priorities for tie-breaking.
+        self.pattern_priorities = data.get("pattern_priorities", {})
+
+
+class PatternMatcher:
+    """Matches error patterns against log content."""
+
+    def __init__(self, loader: PatternLoader) -> None:
+        """Initialize the pattern matcher.
+
+        Args:
+            loader: PatternLoader with loaded patterns and rules
+        """
+        self.loader = loader
+
+    def analyze_log(self, content: str) -> dict[str, list[PatternMatch]]:
+        """Analyze a log file and find all pattern matches.
+
+        Args:
+            content: Full log content as a string
+
+        Returns:
+            Dictionary mapping pattern names to lists of matches
+        """
+        lines = content.splitlines()
+        results = {}
+
+        for pattern_name, pattern in self.loader.patterns.items():
+            matches = pattern.match(content, lines)
+            if matches:
+                results[pattern_name] = matches
+
+        return results
+
+
+class RootCauseAnalyzer:
+    """Analyzes pattern matches to identify root causes."""
+
+    def __init__(self, loader: PatternLoader) -> None:
+        """Initialize the root cause analyzer.
+
+        Args:
+            loader: PatternLoader with loaded patterns and rules
+        """
+        self.loader = loader
+
+    def identify_root_causes(
+        self, pattern_matches: dict[str, list[PatternMatch]]
+    ) -> list[RootCause]:
+        """Group co-occurring patterns into root causes.
+
+        Args:
+            pattern_matches: Dictionary of pattern matches from PatternMatcher
+
+        Returns:
+            List of RootCause objects, sorted by priority
+        """
+        pattern_names = list(pattern_matches.keys())
+        root_causes = []
+
+        # Track which patterns have been assigned to a root cause.
+        assigned_patterns = set()
+
+        # Try to match each rule.
+        for rule in self.loader.rules:
+            # Skip rules whose patterns have already been assigned to higher-priority rules.
+            if rule.primary_pattern in assigned_patterns:
+                continue
+            if any(p in assigned_patterns for p in rule.secondary_patterns):
+                continue
+
+            if rule.matches(pattern_names):
+                # Collect primary matches.
+                primary_matches = pattern_matches.get(rule.primary_pattern, [])
+
+                # Collect secondary matches.
+                secondary_matches = []
+                for secondary_pattern in rule.secondary_patterns:
+                    if secondary_pattern in pattern_matches:
+                        secondary_matches.extend(pattern_matches[secondary_pattern])
+
+                root_cause = RootCause(
+                    rule=rule,
+                    primary_matches=primary_matches,
+                    secondary_matches=secondary_matches,
+                )
+                root_causes.append(root_cause)
+
+                # Mark these patterns as assigned.
+                assigned_patterns.add(rule.primary_pattern)
+                assigned_patterns.update(rule.secondary_patterns)
+
+        # Handle any unassigned patterns as standalone issues.
+        for pattern_name in pattern_names:
+            if pattern_name not in assigned_patterns:
+                # Create a synthetic root cause for this pattern.
+                pattern = self.loader.patterns[pattern_name]
+                synthetic_rule = RootCauseRule(
+                    name=f"{pattern_name}_standalone",
+                    primary_pattern=pattern_name,
+                    secondary_patterns=[],
+                    description=pattern.description,
+                    priority=self.loader.pattern_priorities.get(pattern_name, 50),
+                    actionable=pattern.actionable,
+                    category="uncategorized",
+                )
+                root_cause = RootCause(
+                    rule=synthetic_rule,
+                    primary_matches=pattern_matches[pattern_name],
+                    secondary_matches=[],
+                )
+                root_causes.append(root_cause)
+
+        return root_causes
+
+
+def load_default_patterns() -> PatternLoader:
+    """Load patterns from default locations in tools/utils/ci/.
+
+    Returns:
+        PatternLoader with patterns and rules loaded
+    """
+    # Find the ci directory.
+    ci_dir = Path(__file__).parent.parent
+
+    patterns_file = ci_dir / "patterns.yaml"
+    rules_file = ci_dir / "cooccurrence_rules.yaml"
+
+    if not patterns_file.exists():
+        raise FileNotFoundError(f"Patterns file not found: {patterns_file}")
+    if not rules_file.exists():
+        raise FileNotFoundError(f"Rules file not found: {rules_file}")
+
+    loader = PatternLoader(patterns_file, rules_file)
+    loader.load()
+    return loader

--- a/tools/utils/ci/core/utils.py
+++ b/tools/utils/ci/core/utils.py
@@ -1,0 +1,32 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared utility functions for CI tools."""
+
+
+def is_meta_job(job_name: str) -> bool:
+    """Check if a job is a meta/summary job.
+
+    Meta-jobs aggregate results from other jobs and should not be analyzed
+    as individual failures. They include summary jobs, aggregation jobs, etc.
+
+    Args:
+        job_name: Job name string
+
+    Returns:
+        True if job is a meta-job (aggregate, summary, etc.)
+
+    Examples:
+        >>> is_meta_job("pkgci_summary / summary")
+        True
+        >>> is_meta_job("ci_summary / summary")
+        True
+        >>> is_meta_job("Test Torch / torch_models tests")
+        False
+    """
+    meta_keywords = ["summary", "aggregate", "pkgci_summary", "job-summary"]
+    job_name_lower = job_name.lower()
+    return any(keyword in job_name_lower for keyword in meta_keywords)

--- a/tools/utils/ci/iree_ci_garden.md
+++ b/tools/utils/ci/iree_ci_garden.md
@@ -1,0 +1,401 @@
+# iree-ci-garden - CI Corpus Management Tool
+
+`iree-ci-garden` manages a corpus of CI failures for pattern development and health tracking. It fetches failures from GitHub Actions, classifies them using `iree-ci-triage`, tracks recognition rates, and generates TODO lists for unrecognized patterns.
+
+## Overview
+
+The tool separates data collection (fetch) from analysis (classify) to enable iterative improvement of error pattern detection:
+
+1. **Fetch** - Download CI failures and logs from GitHub Actions
+2. **Classify** - Run `iree-ci-triage` to identify root causes
+3. **Track** - Monitor recognition rates and pattern coverage
+4. **Garden** - Identify unrecognized failures needing new patterns
+
+**Goal**: Achieve 100% recognition rate for CI failures through continuous pattern development.
+
+## Installation
+
+```bash
+# Install IREE CI tools
+cd tools/utils
+pip install -e .
+
+# Verify installation
+iree-ci-garden --help
+
+# Authenticate with GitHub (required)
+gh auth login
+```
+
+## Quick Start
+
+```bash
+# Daily workflow: fetch and classify overnight failures
+iree-ci-garden fetch                 # Fetch last 24 hours
+iree-ci-garden classify              # Run classification
+iree-ci-garden status                # Check health metrics
+
+# Check TODO list for unrecognized patterns
+cat ~/.iree-ci-corpus/unrecognized/TODO.md
+```
+
+## Commands
+
+### fetch - Fetch CI Failures
+
+Downloads workflow run failures from GitHub Actions and stores failed job logs in the corpus.
+
+```bash
+# Fetch failures from last 24 hours (default)
+iree-ci-garden fetch
+
+# Fetch from specific date range
+iree-ci-garden fetch --since 2025-11-01
+
+# Fetch from specific PR
+iree-ci-garden fetch --pr 22625
+
+# Fetch specific run
+iree-ci-garden fetch --run 12345678
+
+# Fetch from specific branch
+iree-ci-garden fetch --branch staging
+
+# Quiet mode (no progress output)
+iree-ci-garden fetch --quiet
+
+# Limit number of runs
+iree-ci-garden fetch --limit 50
+```
+
+**Captured Metadata** (v2.0 schema):
+- Run info: `run_id`, `workflow`, `name`, `url`
+- Git info: `head_sha`, `branch`, `pr_number`
+- Trigger: `event` (push, pull_request, schedule, etc.)
+- Status: `status`, `conclusion`, `attempt` (for re-runs)
+- Timing: `created_at`, `started_at`, `updated_at`
+- Jobs: `jobs` count, `failed_jobs` count
+
+### classify - Classify Failure Logs
+
+Runs `iree-ci-triage` on corpus logs to identify root causes and categories. Results are cached with 30-day TTL.
+
+```bash
+# Classify all unclassified logs
+iree-ci-garden classify
+
+# Force reclassification (ignores cache)
+iree-ci-garden classify --force
+
+# Classify specific run
+iree-ci-garden classify --run 12345678
+
+# Quiet mode
+iree-ci-garden classify --quiet
+```
+
+**Output**:
+- Recognition rate (% of logs with identified root causes)
+- Failure categories and counts
+- Location of unrecognized failure TODO list
+
+**After classification**, check:
+```bash
+# View TODO list for unrecognized patterns
+cat ~/.iree-ci-corpus/unrecognized/TODO.md
+```
+
+### status - Show Corpus Health
+
+Displays corpus statistics and health metrics.
+
+```bash
+# Human-readable status
+iree-ci-garden status
+
+# JSON output for automation
+iree-ci-garden status --json
+
+# Quiet mode (exit code only)
+iree-ci-garden status --quiet
+```
+
+**Metrics**:
+- Total runs and logs in corpus
+- Total size on disk
+- Time span (earliest to latest failure)
+- Recognition rate (goal: >90%)
+- Top failure categories
+
+### search - Search Corpus Logs
+
+Search all corpus logs for a regex pattern (case-insensitive).
+
+```bash
+# Search for error pattern
+iree-ci-garden search "undefined reference"
+
+# Search with category filter
+iree-ci-garden search "assertion failed" --category compilation
+
+# Search date range
+iree-ci-garden search "timeout" --since 2025-11-01
+
+# Quiet mode (no output, exit code only)
+iree-ci-garden search "pattern" --quiet
+```
+
+**Output**: Shows matching log paths and line numbers for investigation.
+
+## Corpus Structure
+
+The corpus is stored in `~/.iree-ci-corpus` (configurable via `--corpus-dir`):
+
+```
+~/.iree-ci-corpus/
+├── config.json                    # Corpus configuration (v2.0 schema)
+├── corpus.jsonl                   # Main index (streaming JSONL)
+├── daily/                         # Daily fetch manifests
+│   └── 2025-11-17.json
+├── runs/                          # Per-run metadata
+│   └── 12345678.json
+├── logs/                          # Raw logs organized by run
+│   └── 12345678/
+│       ├── 55555555.log          # Job logs
+│       └── 66666666.log
+├── classification/                # Classification results
+│   ├── cache/                    # Cached triage results (30-day TTL)
+│   │   └── 12345678_55555555.json
+│   └── history/                  # Classification history
+└── unrecognized/                 # Failures needing attention
+    ├── TODO.md          # Generated TODO list
+    └── samples/                  # Sample error snippets
+```
+
+## Schema Evolution
+
+### v2.0 Schema (Current)
+
+Enhanced metadata capture for comprehensive analysis:
+
+**New fields**:
+- `head_sha` - Commit hash (enables code correlation)
+- `event` - Trigger type (push, pull_request, schedule, etc.)
+- `pr_number` - PR number for PR events
+- `url` - Direct GitHub link
+- `attempt` - Re-run count (flake detection)
+- `status` - Run status (queued, in_progress, completed)
+- `started_at`, `updated_at` - Timing info
+- `workflow_id` - Workflow database ID
+
+**Analysis capabilities enabled**:
+- Link failures to specific commits via `head_sha`
+- Track PR-specific failures via `pr_number`
+- Detect flaky tests via `attempt` count
+- Compare scheduled vs PR failures via `event`
+- Direct debugging via `url` links
+
+### Migration from v1.0
+
+Not required - the corpus can be wiped and re-fetched with the new schema:
+
+```bash
+# Backup old corpus (optional)
+mv ~/.iree-ci-corpus ~/.iree-ci-corpus.v1.0.backup
+
+# Fetch with new schema
+iree-ci-garden fetch --since 2025-11-01
+```
+
+## Advanced Usage
+
+### Analyzing Flaky Tests
+
+Find failures that passed on retry (attempt > 1):
+
+```bash
+# Fetch and classify
+iree-ci-garden fetch
+iree-ci-garden classify
+
+# Find flaky runs
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.attempt > 1)'
+```
+
+### Commit-Based Analysis
+
+Find all failures for a specific commit:
+
+```bash
+# Fetch failures
+iree-ci-garden fetch --since 2025-11-01
+
+# Find failures for commit
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.head_sha == "abc123...")'
+```
+
+### PR Failure Analysis
+
+Track failures by PR:
+
+```bash
+# Fetch PR failures
+iree-ci-garden fetch --pr 22625
+
+# Find all PR failures
+cat ~/.iree-ci-corpus/corpus.jsonl | jq 'select(.event == "pull_request")'
+```
+
+### Pattern Development Workflow
+
+1. Classify corpus to identify unrecognized failures:
+   ```bash
+   iree-ci-garden classify
+   cat ~/.iree-ci-corpus/unrecognized/TODO.md
+   ```
+
+2. Add new patterns to `patterns.yaml` (see iree-ci-triage docs)
+
+3. Test new patterns against corpus:
+   ```bash
+   iree-ci-garden classify --force
+   iree-ci-garden status  # Check recognition rate
+   ```
+
+4. Iterate until recognition rate >90%
+
+### Automation Examples
+
+**Daily cron job**:
+```bash
+#!/bin/bash
+# Daily CI health check
+iree-ci-garden fetch --quiet
+iree-ci-garden classify --quiet
+
+# Alert if recognition rate drops below 90%
+RATE=$(iree-ci-garden status --json | jq -r '.recognition.overall_rate')
+if (( $(echo "$RATE < 0.9" | bc -l) )); then
+  echo "Warning: Recognition rate dropped to $RATE"
+fi
+```
+
+**CI integration**:
+```yaml
+# GitHub Actions workflow
+- name: Check CI health
+  run: |
+    iree-ci-garden fetch --since $(date -d '7 days ago' +%Y-%m-%d)
+    iree-ci-garden classify
+    iree-ci-garden status --json > ci-health.json
+```
+
+## Configuration
+
+### Environment Variables
+
+- `GH_TOKEN` - GitHub authentication token (managed by `gh auth`)
+
+### Corpus Configuration
+
+Edit `~/.iree-ci-corpus/config.json`:
+
+```json
+{
+  "corpus_version": "2.0",
+  "github_repo": "iree-org/iree",
+  "fetch_settings": {
+    "default_limit": 100,
+    "include_branches": ["*"]
+  },
+  "classification_settings": {
+    "iree_ci_triage_args": ["--json", "--no-context"],
+    "cache_results": true,
+    "cache_ttl_days": 30
+  }
+}
+```
+
+## Troubleshooting
+
+### "GitHub CLI (gh) not found"
+
+Install GitHub CLI:
+```bash
+# macOS
+brew install gh
+
+# Linux
+sudo apt install gh  # or equivalent
+
+# Authenticate
+gh auth login
+```
+
+### "iree-ci-triage not found"
+
+Ensure iree-ci-triage is in PATH:
+```bash
+# Check installation
+which iree-ci-triage
+
+# If not found, install CI tools
+cd tools/utils
+pip install -e .
+```
+
+### Recognition Rate is Low (<50%)
+
+1. Update `iree-ci-triage` patterns (see `patterns.yaml`)
+2. Force reclassification: `iree-ci-garden classify --force`
+3. Check TODO list: `cat ~/.iree-ci-corpus/unrecognized/TODO.md`
+4. Add new patterns for high-priority failures
+
+### Corpus is Too Large
+
+Prune old failures:
+```bash
+# Keep only last 30 days
+find ~/.iree-ci-corpus/logs -mtime +30 -delete
+find ~/.iree-ci-corpus/runs -mtime +30 -delete
+
+# Rebuild index
+rm ~/.iree-ci-corpus/corpus.jsonl
+# Re-index from remaining runs metadata
+```
+
+## Development
+
+### Running Tests
+
+```bash
+# Unit tests
+pytest tools/utils/ci/
+
+# Integration test
+iree-ci-garden fetch --limit 5
+iree-ci-garden classify
+iree-ci-garden status
+```
+
+### Adding New Commands
+
+1. Add subparser in `parse_arguments()`
+2. Implement `cmd_<name>()` function
+3. Add dispatch in `main()`
+4. Update help text and documentation
+
+### Code Structure
+
+- `iree_ci_garden.py` - Main CLI with 5 commands
+- `core/corpus.py` - Corpus management (JSONL index)
+- `core/fetcher.py` - GitHub API integration
+- `core/classifier.py` - iree-ci-triage integration
+- `core/gardener.py` - Health tracking, TODO generation
+- `core/github_client.py` - GitHub CLI wrapper
+
+## See Also
+
+- [iree-ci-triage documentation](iree_ci_triage.md) - Root cause analysis tool
+- [CI Tools README](README.md) - Quick start guide
+- [GitHub CLI documentation](https://cli.github.com/manual/)

--- a/tools/utils/ci/iree_ci_garden.py
+++ b/tools/utils/ci/iree_ci_garden.py
@@ -1,0 +1,608 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""IREE CI Garden - CI Corpus Management Tool.
+
+Manages a corpus of CI failures for pattern development and health tracking.
+Fetch failures from GitHub Actions, classify them using iree-ci-triage, track
+recognition rates, and generate TODO lists for unrecognized patterns.
+
+Commands:
+    fetch       - Fetch new CI failures from GitHub Actions
+    classify    - Run classification on new/unclassified logs (incremental)
+    reclassify  - Re-run extractors on entire corpus (after pattern changes)
+    status      - Show corpus health metrics and recognition rate
+    search      - Search corpus logs for error patterns
+    garden      - Interactive gardening workflow (coming soon)
+
+Examples:
+    # Daily workflow: fetch overnight failures and classify
+    iree-ci-garden fetch
+    iree-ci-garden classify
+    iree-ci-garden status
+
+    # Fetch failures from specific PR
+    iree-ci-garden fetch --pr 22625
+
+    # Search for specific error pattern
+    iree-ci-garden search "undefined reference"
+
+    # REQUIRED after updating extractor patterns
+    iree-ci-garden reclassify
+
+See 'iree-ci-garden <command> --help' for more information on each command.
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# Import shared modules.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from common import cli, console, exit_codes
+
+from ci.core.classifier import Classifier
+from ci.core.corpus import Corpus
+from ci.core.fetcher import GitHubFetcher
+from ci.core.gardener import Gardener
+from ci.core.github_client import GitHubClient, check_gh_cli_setup
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="IREE CI corpus management tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Subcommands.
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+
+    # Fetch command.
+    fetch_parser = subparsers.add_parser(
+        "fetch",
+        help="Fetch CI failures from GitHub Actions",
+        description="""
+Fetch workflow run failures from GitHub Actions and download failed job logs.
+By default, fetches failures from the last 24 hours from main and staging branches.
+Failed job logs are stored in the corpus for later classification and analysis.
+        """,
+    )
+    fetch_parser.add_argument(
+        "--since",
+        help="Fetch since date (YYYY-MM-DD). Default: 24 hours ago. "
+        "Maximum: 90 days ago (GitHub log retention limit)",
+    )
+    fetch_parser.add_argument(
+        "--branch",
+        help="Filter by specific branch. Default: main and staging",
+    )
+    fetch_parser.add_argument(
+        "--pr",
+        type=int,
+        help="Fetch failures from specific PR number",
+    )
+    fetch_parser.add_argument(
+        "--run",
+        help="Fetch specific workflow run ID",
+    )
+    fetch_parser.add_argument(
+        "--limit",
+        type=int,
+        default=1000,
+        help="Maximum number of runs to fetch per branch (default: 1000). "
+        "Increase for large time ranges (e.g., --limit 5000 for several months)",
+    )
+    fetch_parser.add_argument(
+        "--repo",
+        default="iree-org/iree",
+        help="GitHub repository in owner/repo format (default: iree-org/iree)",
+    )
+    cli.add_common_output_flags(fetch_parser)
+
+    # Classify command.
+    classify_parser = subparsers.add_parser(
+        "classify",
+        help="Classify new/unclassified logs (incremental)",
+        description="""
+Run extractors on new or unclassified corpus logs. This is fast because it:
+- Only processes logs not yet classified
+- Uses cached results for previously classified logs
+
+Use this for daily corpus updates after fetching new failures.
+
+After classification, check ~/.iree-ci-corpus/unrecognized/TODO.md
+for failures that need new extractor patterns.
+        """,
+    )
+    classify_parser.add_argument(
+        "--run",
+        help="Classify only logs from specific run ID",
+    )
+    cli.add_common_output_flags(classify_parser)
+
+    # Reclassify command.
+    reclassify_parser = subparsers.add_parser(
+        "reclassify",
+        help="Re-run extractors on entire corpus (REQUIRED after pattern changes)",
+        description="""
+Re-run all extractors on the entire corpus, ignoring cache. This is REQUIRED after:
+- Adding new patterns to extractors (e.g., infrastructure_flake.py)
+- Modifying existing extractor logic
+- Updating extractor activation keywords
+
+This command is slower than 'classify' because it processes all logs, but ensures
+the corpus reflects your latest extractor changes.
+
+IMPORTANT: Always run this after modifying any extractor code or patterns.
+        """,
+    )
+    reclassify_parser.add_argument(
+        "--run",
+        help="Reclassify only logs from specific run ID",
+    )
+    cli.add_common_output_flags(reclassify_parser)
+
+    # Status command.
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show corpus health metrics",
+        description="""
+Display corpus statistics including total runs, logs, recognition rate, and top
+failure categories. Use --json for programmatic access to metrics.
+
+The recognition rate shows what percentage of failures are identified by existing
+patterns. A high rate (>90%) indicates good pattern coverage.
+        """,
+    )
+    cli.add_common_output_flags(status_parser)
+
+    # Search command.
+    search_parser = subparsers.add_parser(
+        "search",
+        help="Search corpus logs for patterns",
+        description="""
+Search all corpus logs for a regex pattern. Useful for finding specific errors,
+investigating common failure modes, or validating pattern coverage.
+
+Results show matching log paths and line numbers for easy investigation.
+        """,
+    )
+    search_parser.add_argument(
+        "pattern",
+        help="Regex pattern to search for (case-insensitive)",
+    )
+    search_parser.add_argument(
+        "--category",
+        help="Filter results by failure category",
+    )
+    search_parser.add_argument(
+        "--since",
+        help="Search only logs from date onwards (YYYY-MM-DD)",
+    )
+    cli.add_common_output_flags(search_parser)
+
+    # Garden command (interactive).
+    subparsers.add_parser("garden", help="Interactive gardening")
+
+    # Global options.
+    parser.add_argument(
+        "--corpus-dir",
+        type=Path,
+        help="Corpus directory (default: ~/.iree-ci-corpus)",
+    )
+
+    cli.add_common_output_flags(parser)
+
+    return parser.parse_args()
+
+
+def _get_validated_fetch_since_time(
+    args: argparse.Namespace, corpus: Corpus
+) -> datetime | None:
+    """Determine and validate the 'since' datetime for fetching.
+
+    Args:
+        args: Parsed arguments with potential --since flag
+        corpus: Corpus instance for looking up last fetch time
+
+    Returns:
+        Validated datetime (timezone-aware), or None if validation fails
+    """
+    if args.since:
+        since = datetime.fromisoformat(args.since)
+        # Ensure timezone-aware.
+        if since.tzinfo is None:
+            since = since.replace(tzinfo=timezone.utc)
+    else:
+        # Default: fetch since last fetch, or last 24 hours if corpus is empty.
+        last_fetched = corpus.get_last_fetched_at()
+        if last_fetched:
+            since = last_fetched
+            console.note(f"Using last fetch time: {since.isoformat()}", args=args)
+        else:
+            since = datetime.now(timezone.utc) - timedelta(days=1)
+            console.note("Corpus is empty, fetching last 24 hours", args=args)
+
+    # Enforce 90-day limit (GitHub log retention policy).
+    now = datetime.now(timezone.utc)
+    days_ago = (now - since).days
+    if days_ago > 90:
+        console.error(
+            f"Cannot fetch runs older than 90 days (requested: {days_ago} days ago)",
+            args=args,
+        )
+        console.error(
+            "GitHub deletes workflow logs after 90 days. "
+            f"Oldest fetchable date: {(now - timedelta(days=90)).strftime('%Y-%m-%d')}",
+            args=args,
+        )
+        return None
+
+    return since
+
+
+def _display_fetch_results(
+    result: Any, has_critical_errors: bool, corpus: Corpus, args: argparse.Namespace
+) -> None:
+    """Display fetch results summary and errors.
+
+    Args:
+        result: Fetch result object with stats
+        has_critical_errors: Whether critical errors occurred
+        corpus: Corpus instance for stats
+        args: Parsed arguments
+    """
+    console.out("\nSummary:")
+    console.out(f"  New runs added: {result.runs_new}")
+    console.out(f"  Duplicate runs: {result.runs_duplicate}")
+    console.out(f"  New logs downloaded: {result.logs_fetched}")
+    if result.logs_failed > 0:
+        console.warn(f"  Failed to fetch {result.logs_failed} logs", args=args)
+
+    stats = corpus.get_stats()
+    console.out(
+        f"  Total corpus: {stats['total_runs']} runs, {stats['total_logs']} logs"
+    )
+
+    if result.errors:
+        # Show errors as critical (error) or warnings based on severity.
+        if has_critical_errors:
+            console.out("\nCritical Errors:")
+            for error in result.errors[:10]:  # Limit to first 10.
+                console.error(f"  {error}", args=args)
+            if result.runs_new > 0:
+                console.warn("  Partial fetch completed before errors", args=args)
+        else:
+            console.out("\nWarnings:")
+            for error in result.errors[:10]:
+                console.warn(f"  {error}", args=args)
+
+
+def cmd_fetch(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute fetch command.
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    # Check gh CLI setup.
+    success, error_msg = check_gh_cli_setup()
+    if not success:
+        console.error(error_msg, args=args)
+        return exit_codes.SETUP_ERROR
+
+    # Initialize GitHub client and fetcher.
+    client = GitHubClient(repo=args.repo)
+    fetcher = GitHubFetcher(client, corpus, args=args)
+
+    # Determine fetch strategy.
+    if args.run:
+        console.note(f"Fetching run {args.run}...", args=args)
+        result = fetcher.fetch_run(args.run)
+    elif args.pr:
+        console.note(f"Fetching PR #{args.pr}...", args=args)
+        result = fetcher.fetch_pr(args.pr)
+    else:
+        # Fetch since last run or specified date.
+        since = _get_validated_fetch_since_time(args, corpus)
+        if since is None:
+            return exit_codes.ERROR
+
+        console.note(f"Fetching failures since {since.isoformat()}...", args=args)
+        result = fetcher.fetch_since(
+            since=since, limit=args.limit, branch=args.branch, status="failure"
+        )
+
+    # Check for critical errors (timeouts, gh CLI failures).
+    has_critical_errors = any(
+        "timed out" in err.lower() or "failed to fetch" in err.lower()
+        for err in result.errors
+    )
+
+    # Update last fetch time in config (even if all duplicates).
+    config = json.loads(corpus.config_path.read_text())
+    config["last_fetch_at"] = datetime.now(timezone.utc).isoformat()
+    corpus.config_path.write_text(json.dumps(config, indent=2))
+
+    # Display results.
+    if not args.quiet:
+        _display_fetch_results(result, has_critical_errors, corpus, args)
+
+    # Return error code if critical errors occurred.
+    if has_critical_errors:
+        return exit_codes.ERROR
+
+    return exit_codes.SUCCESS
+
+
+def cmd_classify(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute classify command (incremental classification).
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    classifier = Classifier(corpus)
+
+    if args.run:
+        console.note(f"Classifying run {args.run}...", args=args)
+        results = classifier.classify_run(args.run, force_reclassify=False)
+        recognized = sum(1 for r in results if r.recognized)
+
+        if not args.quiet:
+            console.out(f"\nClassified {len(results)} logs: {recognized} recognized")
+    else:
+        console.note("Classifying unclassified logs...", args=args)
+        report = classifier.classify_all_unclassified()
+
+        # Display report.
+        if not args.quiet:
+            console.out("\nResults:")
+            console.out(f"  Classified: {report.classified} logs")
+            console.out(
+                f"  Recognized: {report.recognized}/{report.total_logs} "
+                f"({report.recognition_rate:.1%})"
+            )
+
+            if report.categories:
+                console.out("\n  Categories found:")
+                for category, count in sorted(
+                    report.categories.items(), key=lambda x: x[1], reverse=True
+                )[:10]:
+                    console.out(f"    {category}: {count}")
+
+            if report.unrecognized > 0:
+                console.out(f"\n  Unrecognized: {report.unrecognized} logs")
+                console.out(f"  See {corpus.unrecognized_dir}/TODO.md for details")
+
+        # Generate TODO list.
+        gardener = Gardener(corpus, classifier)
+        gardener.save_todo_list()
+
+    return exit_codes.SUCCESS
+
+
+def cmd_reclassify(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute reclassify command (full corpus reclassification).
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    classifier = Classifier(corpus)
+
+    if args.run:
+        console.note(f"Reclassifying run {args.run}...", args=args)
+        results = classifier.classify_run(args.run, force_reclassify=True)
+        recognized = sum(1 for r in results if r.recognized)
+
+        if not args.quiet:
+            console.out(f"\nReclassified {len(results)} logs: {recognized} recognized")
+    else:
+        console.note("Reclassifying entire corpus...", args=args)
+        report = classifier.reclassify_all()
+
+        # Display report.
+        if not args.quiet:
+            console.out("\nResults:")
+            console.out(f"  Reclassified: {report.classified} logs")
+            console.out(
+                f"  Recognized: {report.recognized}/{report.total_logs} "
+                f"({report.recognition_rate:.1%})"
+            )
+
+            if report.categories:
+                console.out("\n  Categories found:")
+                for category, count in sorted(
+                    report.categories.items(), key=lambda x: x[1], reverse=True
+                )[:10]:
+                    console.out(f"    {category}: {count}")
+
+            if report.unrecognized > 0:
+                console.out(f"\n  Unrecognized: {report.unrecognized} logs")
+                console.out(f"  See {corpus.unrecognized_dir}/TODO.md for details")
+
+        # Generate TODO list.
+        gardener = Gardener(corpus, classifier)
+        gardener.save_todo_list()
+
+    return exit_codes.SUCCESS
+
+
+def cmd_status(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute status command.
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    classifier = Classifier(corpus)
+    gardener = Gardener(corpus, classifier)
+    health = gardener.get_corpus_health()
+
+    if args.json:
+        # JSON output.
+        output = {
+            "corpus_dir": str(corpus.corpus_dir),
+            "last_updated": datetime.now().isoformat(),
+            "statistics": health["stats"],
+            "recognition": {
+                "overall_rate": health["recognition_rate"],
+                "categories": health["categories"],
+            },
+        }
+        console.out(json.dumps(output, indent=2))
+    else:
+        # Human-readable output.
+        stats = health["stats"]
+        console.out("IREE CI Corpus Status")
+        console.out("=" * 50)
+        console.out(f"Location: {corpus.corpus_dir}")
+        console.out(f"Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+
+        console.out("Corpus Statistics:")
+        console.out(f"  Total runs: {stats['total_runs']}")
+        console.out(f"  Total logs: {stats['total_logs']}")
+        size_mb = stats["size_bytes"] / (1024 * 1024)
+        console.out(f"  Total size: {size_mb:.1f} MB\n")
+
+        if stats["time_span"]["start"]:
+            console.out("  Time span:")
+            console.out(f"    Start: {stats['time_span']['start']}")
+            console.out(f"    End: {stats['time_span']['end']}\n")
+
+        console.out("Recognition Health:")
+        rate = health["recognition_rate"]
+        console.out(f"  Overall rate: {rate:.1%}")
+
+        if health["categories"]:
+            console.out("\nTop Failure Categories:")
+            for i, (category, count) in enumerate(
+                sorted(health["categories"].items(), key=lambda x: x[1], reverse=True)[
+                    :5
+                ],
+                1,
+            ):
+                pct = (
+                    count / stats["total_logs"] * 100 if stats["total_logs"] > 0 else 0
+                )
+                console.out(f"  {i}. {category}: {count} ({pct:.1f}%)")
+
+    return exit_codes.SUCCESS
+
+
+def cmd_search(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute search command.
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    console.note(f"Searching corpus for '{args.pattern}'...", args=args)
+
+    pattern = re.compile(args.pattern, re.IGNORECASE)
+    matches = []
+
+    # Search all logs.
+    for run_dir in corpus.logs_dir.iterdir():
+        if not run_dir.is_dir():
+            continue
+
+        for log_file in run_dir.glob("*.log"):
+            try:
+                with open(log_file) as f:
+                    for line_num, line in enumerate(f, 1):
+                        if pattern.search(line):
+                            matches.append((log_file, line_num, line.strip()))
+                            if len(matches) >= 100:  # Limit to first 100 matches.
+                                break
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            if len(matches) >= 100:
+                break
+
+    # Display matches.
+    if not args.quiet:
+        console.out(f"\nFound {len(matches)} matches:\n")
+        for log_path, line_num, line in matches[:50]:  # Show first 50.
+            console.out(f"{log_path.relative_to(corpus.corpus_dir)}:{line_num}: {line}")
+
+        if len(matches) > 50:
+            console.out(f"\n... and {len(matches) - 50} more matches")
+
+    return exit_codes.SUCCESS
+
+
+def cmd_garden(args: argparse.Namespace, corpus: Corpus) -> int:
+    """Execute garden command (interactive).
+
+    Args:
+        args: Parsed arguments
+        corpus: Corpus instance
+
+    Returns:
+        Exit code
+    """
+    console.out("Interactive gardening mode coming soon!")
+    console.out("For now, use: iree-ci-garden status && iree-ci-garden classify")
+    return exit_codes.SUCCESS
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_arguments()
+
+    # Ensure a command was specified.
+    if not args.command:
+        console.error("No command specified. Use --help for usage.")
+        return exit_codes.ERROR
+
+    # Initialize corpus.
+    corpus_dir = args.corpus_dir or Path.home() / ".iree-ci-corpus"
+    corpus = Corpus(corpus_dir)
+
+    # Dispatch to command.
+    if args.command == "fetch":
+        return cmd_fetch(args, corpus)
+    if args.command == "classify":
+        return cmd_classify(args, corpus)
+    if args.command == "reclassify":
+        return cmd_reclassify(args, corpus)
+    if args.command == "status":
+        return cmd_status(args, corpus)
+    if args.command == "search":
+        return cmd_search(args, corpus)
+    if args.command == "garden":
+        return cmd_garden(args, corpus)
+    console.error(f"Unknown command: {args.command}")
+    return exit_codes.ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/utils/ci/iree_ci_triage.md
+++ b/tools/utils/ci/iree_ci_triage.md
@@ -1,0 +1,416 @@
+# IREE CI Triage Tools
+
+Automated error detection and triage for IREE CI failures.
+
+---
+
+## Quick Start
+
+```bash
+# Triage all failures in a workflow run
+iree-ci-triage --run 12345678
+
+# Triage latest failure from a PR
+iree-ci-triage --pr 12345
+
+# Triage latest failure from a commit
+iree-ci-triage --commit abc123def
+
+# Triage latest failure from a branch
+iree-ci-triage --branch main
+
+# Triage specific job
+iree-ci-triage --run 12345678 --job 987654321
+
+# JSON output for automation
+iree-ci-triage --run 12345678 --json | jq '.summary'
+```
+
+---
+
+## Tools
+
+### `iree-ci-triage`
+
+Fetches CI failure logs from GitHub Actions and performs automated triage.
+
+**Features**:
+- Detects 28+ error patterns (compile errors, GPU crashes, test failures, etc.)
+- Groups co-occurring errors into root causes
+- Distinguishes actionable bugs from infrastructure flakes
+- Generates fix checklists with file paths and error details
+- Supports human-readable markdown and JSON output
+
+**Usage**:
+```bash
+iree-ci-triage [INPUT] [OPTIONS]
+
+Input (mutually exclusive, one required):
+  --run RUN_ID              Workflow run ID
+  --pr PR_NUMBER            Pull request number (uses latest failed run)
+  --commit SHA              Commit SHA (uses latest failed run)
+  --branch BRANCH           Branch name (uses latest failed run)
+
+Options:
+  --job JOB_ID              Specific job to triage (default: all failed jobs)
+  --repo OWNER/REPO         Repository (default: iree-org/iree)
+  --status STATUS           Filter by run status (default: failure)
+
+  --patterns FILE           Custom patterns.yaml
+  --rules FILE              Custom cooccurrence_rules.yaml
+
+  --json                    JSON output (to stdout)
+  --checklist               Simple checklist for LLMs
+  --no-context              Don't include error context in markdown
+  --quiet                   Suppress progress messages
+```
+
+**Examples**:
+```bash
+# Human-readable triage by run ID
+iree-ci-triage --run 19394282553
+
+# Triage latest failure from a pull request
+iree-ci-triage --pr 12345
+
+# Triage latest failure from a specific commit
+iree-ci-triage --commit abc123def456
+
+# Triage latest failure from main branch
+iree-ci-triage --branch main
+
+# Find successful runs for a PR (for comparison)
+iree-ci-triage --pr 12345 --status success
+
+# JSON output for piping
+iree-ci-triage --run 19394282553 --json | jq '.jobs[0].root_causes'
+
+# Simple checklist for LLM consumption
+iree-ci-triage --pr 12345 --checklist
+
+# Custom error patterns
+iree-ci-triage --run 19394282553 --patterns my_patterns.yaml
+```
+
+---
+
+## Error Pattern System
+
+### Pattern Definitions (`patterns.yaml`)
+
+Defines error signatures to detect in logs. Each pattern includes:
+- **Regex**: Pattern to match error text
+- **Severity**: critical, high, medium, or low
+- **Actionable**: Whether developers can fix (vs infrastructure flake)
+- **Extraction rules**: Pull file paths, error codes, etc.
+
+**Example pattern**:
+```yaml
+compile_error:
+  pattern: 'error: .*|compilation terminated'
+  severity: critical
+  actionable: true
+  context_lines: 5
+  description: "C++ compilation error"
+  extract:
+    - name: file_path
+      regex: '(\S+\.\w+):(\d+):(\d+):'
+    - name: error_message
+      regex: 'error: (.+)'
+```
+
+**28 built-in patterns**:
+- Build errors: `compile_error`, `linker_error`, `cmake_error`
+- Test failures: `test_failed`, `filecheck_failed`, `assertion_failed`
+- GPU crashes: `vk_device_lost`, `cuda_device_lost`, `hip_device_lost`
+- ROCm issues: `rocclr_memobj` (cleanup crash), `hip_file_not_found`
+- Memory errors: `segfault`, `oom`, `stack_overflow`
+- Infrastructure: `timeout`, `network_error`, `docker_error`
+- ...and more
+
+### Root Cause Rules (`cooccurrence_rules.yaml`)
+
+Defines how co-occurring patterns group into single root causes.
+
+**Example rule**:
+```yaml
+- name: "rocm_cleanup_crash"
+  primary_pattern: "rocclr_memobj"
+  secondary_patterns:
+    - "aborted"
+    - "core_dumped"
+    - "process_exit_error"
+  description: >
+    ROCm memory object cleanup crash. Tests often PASS before
+    this crash during teardown. False CI failure.
+  priority: 100
+  actionable: false
+  category: "infrastructure"
+```
+
+When a log contains `rocclr_memobj` + `aborted` + `process_exit_error`, they're grouped into one "rocm_cleanup_crash" root cause instead of three separate issues.
+
+---
+
+## Adding New Patterns
+
+See [`PATTERN_GUIDE.md`](PATTERN_GUIDE.md) for detailed instructions.
+
+**Quick steps**:
+
+1. **Find the error signature** in a CI log
+2. **Write the pattern**:
+   ```yaml
+   new_pattern:
+     pattern: 'regex to match error'
+     severity: high
+     actionable: true
+     context_lines: 5
+     description: "What this error means"
+   ```
+3. **Add to `patterns.yaml`**
+4. **Test it**:
+   ```bash
+   iree-ci-triage --run <run-with-this-error>
+   ```
+5. **(Optional) Add co-occurrence rule** if it appears with other patterns
+
+---
+
+## Architecture
+
+```
+tools/utils/ci/
+├── iree_ci_triage.py        # Main tool entry point
+├── patterns.yaml             # Error pattern definitions
+├── cooccurrence_rules.yaml   # Root cause grouping rules
+├── PATTERN_GUIDE.md          # Pattern authoring guide
+├── core/
+│   ├── patterns.py           # Pattern loading & matching
+│   ├── github_client.py      # GitHub CLI wrapper
+│   └── extractors.py         # Output formatters
+└── README.md                 # This file
+
+tools/utils/bin/
+└── iree-ci-triage            # Executable wrapper
+```
+
+**Data flow**:
+1. Fetch workflow runs & job logs via GitHub CLI
+2. Match error patterns against log content
+3. Group co-occurring patterns into root causes
+4. Format output (markdown checklist or JSON)
+
+---
+
+## Output Formats
+
+### Human-Readable Markdown
+
+```bash
+iree-ci-triage --run 19394282553
+```
+
+**Output**:
+```markdown
+# CI Failure Triage Report
+
+**Run ID**: 19394282553
+**Job**: Test Sharktank / rocm_hip_w7900
+
+## Summary
+
+Found **2** root cause(s)
+- **1** actionable (code bugs)
+- **1** infrastructure (flakes/driver issues)
+
+## Fix Checklist
+
+- [ ] **compilation_failure** (code)
+  - C++ compilation error
+  - **Severity**: 🔴 critical
+  - **Occurrences**: 1 error(s)
+  - **Location**: Line 145
+  - **Details**:
+    - file_path: `/path/to/file.cpp:145:12`
+    - error_message: `use of undeclared identifier 'foo'`
+
+## Infrastructure Issues (Non-Actionable)
+
+### rocm_cleanup_crash
+- ROCm memory object cleanup crash (false CI failure)
+- **Category**: infrastructure
+- **Occurrences**: 1 error(s)
+```
+
+### JSON Output
+
+```bash
+iree-ci-triage --run 19394282553 --json
+```
+
+**Output** (to stdout):
+```json
+{
+  "jobs": [
+    {
+      "run_id": "19394282553",
+      "job_id": "52085546287",
+      "job_name": "Test Sharktank / rocm_hip_w7900",
+      "root_causes": [
+        {
+          "name": "compilation_failure",
+          "category": "code",
+          "priority": 80,
+          "actionable": true,
+          "description": "C++ compilation error...",
+          "matches": [...]
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_jobs": 1,
+    "total_root_causes": 2,
+    "actionable_issues": 1
+  }
+}
+```
+
+### Checklist Format (for LLMs)
+
+```bash
+iree-ci-triage --run 19394282553 --checklist
+```
+
+**Output**:
+```
+# Fix Checklist for Test Sharktank / rocm_hip_w7900
+
+- [ ] RC-1: compilation_failure
+     Line 145: error: use of undeclared identifier 'foo'
+     → Fix: File: /path/to/file.cpp, Error: use of undeclared identifier
+```
+
+---
+
+## Dependencies
+
+- **GitHub CLI (`gh`)**: Required for fetching workflow data
+  - Install: https://cli.github.com
+  - Auth: `gh auth login`
+- **Python 3.8+**: Standard library + PyYAML
+
+**Check dependencies**:
+```bash
+gh auth status  # Should show "Logged in to github.com"
+```
+
+---
+
+## Integration with Other Tools
+
+### Piping to jq
+
+```bash
+# Get all actionable issues
+iree-ci-triage --run 12345 --json | jq '.jobs[].root_causes[] | select(.actionable)'
+
+# Count infrastructure failures
+iree-ci-triage --run 12345 --json | jq '[.jobs[].root_causes[] | select(.actionable == false)] | length'
+
+# Extract file paths from compile errors
+iree-ci-triage --run 12345 --json | jq -r '.jobs[].root_causes[] | select(.name == "compilation_failure") | .matches[].extracted_fields.file_path'
+```
+
+### Using with lit_tools
+
+Future integration: Extract LIT test failures and structure them in JSON output automatically.
+
+---
+
+## Extending the System
+
+### Custom Patterns
+
+1. Create `my_patterns.yaml`:
+   ```yaml
+   patterns:
+     my_error:
+       pattern: 'MyError: .*'
+       severity: high
+       actionable: true
+       context_lines: 5
+       description: "My custom error type"
+   ```
+
+2. Use it:
+   ```bash
+   iree-ci-triage --run 12345 --patterns my_patterns.yaml
+   ```
+
+### Custom Root Cause Rules
+
+1. Create `my_rules.yaml`:
+   ```yaml
+   root_cause_rules:
+     - name: "my_root_cause"
+       primary_pattern: "my_error"
+       secondary_patterns: ["timeout"]
+       priority: 70
+       actionable: true
+       category: "custom"
+   ```
+
+2. Use it:
+   ```bash
+   iree-ci-triage --run 12345 --rules my_rules.yaml
+   ```
+
+---
+
+## Troubleshooting
+
+### "GitHub CLI (gh) not found"
+
+```bash
+# Install gh CLI
+# See: https://cli.github.com
+```
+
+### "GitHub CLI is not authenticated"
+
+```bash
+gh auth login
+# Follow prompts to authenticate
+```
+
+### "Pattern file not found"
+
+Make sure you're using absolute paths or paths relative to the current directory:
+```bash
+iree-ci-triage --run 12345 --patterns /full/path/to/patterns.yaml
+```
+
+### "No failed jobs found"
+
+The workflow run may have no failures, or the run ID is incorrect. Verify:
+```bash
+gh run view 12345 --repo iree-org/iree
+```
+
+---
+
+## Contributing
+
+- Add new patterns: See `PATTERN_GUIDE.md`
+- Report issues: File an issue with example run ID showing missed error
+- Submit improvements: PRs welcome
+
+---
+
+## See Also
+
+- **PATTERN_GUIDE.md** - Detailed pattern authoring guide
+- **patterns.yaml** - All error pattern definitions
+- **cooccurrence_rules.yaml** - Root cause grouping rules

--- a/tools/utils/ci/iree_ci_triage.py
+++ b/tools/utils/ci/iree_ci_triage.py
@@ -1,0 +1,887 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""IREE CI Failure Triage Tool.
+
+Fetches CI failure logs from GitHub Actions and performs automated triage:
+- Identifies errors (compile errors, test failures, GPU crashes, sanitizer issues, etc.)
+- Extracts actionable issues vs infrastructure failures
+- Generates fix checklists sorted by severity
+- Supports both human-readable and JSON output
+- Multi-workflow support: PR/commit mode fetches ALL workflows (CI, Lint, PkgCI, etc.)
+
+Usage:
+    iree-ci-triage --run 12345678                  # Triage all failed jobs in a run
+    iree-ci-triage --pr 12345                      # Triage ALL workflows for PR (CI, Lint, PkgCI, etc.)
+    iree-ci-triage --commit abc123def              # Triage ALL workflows for commit
+    iree-ci-triage --branch main                   # Triage latest workflow run from branch
+    iree-ci-triage --run 12345678 --job 987654321  # Triage specific job
+    iree-ci-triage --pr 12345 --json               # JSON output with workflow grouping
+
+Examples:
+    # Human-readable triage of all workflows in a PR (matches GitHub UI)
+    iree-ci-triage --pr 12345
+
+    # Triage all workflows for a specific commit
+    iree-ci-triage --commit abc123def
+
+    # Find successful runs for comparison
+    iree-ci-triage --pr 12345 --status success
+
+    # JSON output for piping to other tools (new schema with workflow grouping)
+    iree-ci-triage --pr 12345 --json | jq '.runs[].workflow_name'
+    iree-ci-triage --pr 12345 --json | jq '.runs[] | select(.workflow_name == "CI") | .jobs[].extracted_issues'
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Import IREE tool utilities.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+# Import extractors.
+from common import cli, console, exit_codes
+from common.extractors.bazel_error import BazelErrorExtractor
+from common.extractors.build_error import BuildErrorExtractor
+from common.extractors.cmake_error import CMakeErrorExtractor
+from common.extractors.codeql_error import CodeQLErrorExtractor
+from common.extractors.ctest_error import CTestErrorExtractor
+from common.extractors.infrastructure_flake import InfrastructureFlakeExtractor
+from common.extractors.mlir_compiler import MLIRCompilerExtractor
+from common.extractors.onnx_test import ONNXTestExtractor
+from common.extractors.precommit import PrecommitErrorExtractor
+from common.extractors.pytest_error import PytestErrorExtractor
+from common.extractors.sanitizer import SanitizerExtractor
+from common.log_buffer import LogBuffer
+from common.triage_engine import TriageEngine
+from common.triage_result import TriageResult
+
+# Import CI modules.
+from ci.core import github_client
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="IREE CI failure triage tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Input source (mutually exclusive).
+    input_group = parser.add_argument_group("Input")
+    source_group = input_group.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "--run",
+        metavar="RUN_ID",
+        help="GitHub Actions workflow run ID",
+    )
+    source_group.add_argument(
+        "--pr",
+        type=int,
+        metavar="PR_NUMBER",
+        help="Pull request number (fetches ALL workflow runs for PR's HEAD commit)",
+    )
+    source_group.add_argument(
+        "--commit",
+        metavar="SHA",
+        help="Commit SHA (fetches ALL workflow runs for this commit)",
+    )
+    source_group.add_argument(
+        "--branch",
+        metavar="BRANCH",
+        help="Branch name (uses latest failed run)",
+    )
+    source_group.add_argument(
+        "--job",
+        metavar="JOB_ID",
+        help="Specific job ID to triage (fetches run automatically)",
+    )
+    source_group.add_argument(
+        "--log-file",
+        metavar="FILE",
+        type=Path,
+        help="Analyze local log file instead of fetching from GitHub (for testing)",
+    )
+    input_group.add_argument(
+        "--job-name",
+        metavar="NAME",
+        help="Job name (optional, defaults to log filename when using --log-file)",
+    )
+    input_group.add_argument(
+        "--repo",
+        default="iree-org/iree",
+        metavar="OWNER/REPO",
+        help="GitHub repository (default: iree-org/iree)",
+    )
+    input_group.add_argument(
+        "--status",
+        default="failure",
+        metavar="STATUS",
+        help="Filter by run status (default: failure)",
+    )
+    input_group.add_argument(
+        "--save-logs",
+        metavar="DIR",
+        type=Path,
+        help="Save fetched logs to directory (for debugging/testing)",
+    )
+    input_group.add_argument(
+        "--download-all-logs",
+        action="store_true",
+        help="Download logs for all jobs (not just failed ones)",
+    )
+
+    # Output format.
+    output_group = parser.add_argument_group("Output")
+    cli.add_common_output_flags(parser)
+    output_group.add_argument(
+        "--checklist",
+        action="store_true",
+        help="Output simple checklist format (for LLMs)",
+    )
+    output_group.add_argument(
+        "--no-context",
+        action="store_true",
+        help="Don't include error context in markdown output",
+    )
+
+    return parser.parse_args()
+
+
+def check_dependencies(args: argparse.Namespace) -> int:
+    """Check that required dependencies are available.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        exit_codes.SUCCESS if all dependencies OK, error code otherwise
+    """
+    # Check gh CLI.
+    success, error_msg = github_client.check_gh_cli_setup()
+    if not success:
+        console.error(error_msg, args=args)
+        console.note(
+            "Install: https://cli.github.com",
+            args=args,
+        )
+        return exit_codes.NOT_FOUND
+
+    return exit_codes.SUCCESS
+
+
+def create_ci_triage_engine() -> TriageEngine:
+    """Create TriageEngine with all extractors for CI log analysis.
+
+    Returns:
+        TriageEngine configured with all available extractors.
+    """
+    return TriageEngine(
+        [
+            SanitizerExtractor(),
+            MLIRCompilerExtractor(),
+            BuildErrorExtractor(),
+            BazelErrorExtractor(),
+            CMakeErrorExtractor(),
+            CTestErrorExtractor(),
+            InfrastructureFlakeExtractor(),
+            ONNXTestExtractor(),
+            PrecommitErrorExtractor(),
+            PytestErrorExtractor(),
+            CodeQLErrorExtractor(),
+        ]
+    )
+
+
+def resolve_run_ids(
+    client: github_client.GitHubClient, args: argparse.Namespace
+) -> list[github_client.WorkflowRun]:
+    """Resolve --pr/--commit/--branch/--job/--run to workflow run(s).
+
+    For --pr and --commit: Returns ALL workflow runs for the commit (matching GitHub UI).
+    For --branch and --run: Returns single workflow run.
+
+    Args:
+        client: GitHubClient instance
+        args: Command line arguments
+
+    Returns:
+        List of WorkflowRun objects (may be single element for --run/--branch)
+
+    Raises:
+        SystemExit: If resolution fails
+    """
+    # If explicit run ID provided, fetch its metadata.
+    if args.run:
+        try:
+            console.note(f"Fetching workflow run {args.run}...", args=args)
+            run_data = client.get_run(args.run)
+            if not run_data:
+                console.error(f"Run {args.run} not found", args=args)
+                sys.exit(exit_codes.NOT_FOUND)
+
+            run = github_client.WorkflowRun(
+                run_id=args.run,
+                workflow_name=run_data.get("workflowName", ""),
+                conclusion=run_data.get("conclusion", ""),
+                created_at=run_data.get("createdAt", ""),
+                head_branch=run_data.get("headBranch", ""),
+                display_title=run_data.get("displayTitle", ""),
+            )
+            console.note(
+                f"Using run {run.run_id}: {run.workflow_name} ({run.conclusion})",
+                args=args,
+            )
+            return [run]
+
+        except github_client.GitHubClientError as e:
+            console.error(f"Failed to fetch run {args.run}: {e}", args=args)
+            sys.exit(exit_codes.ERROR)
+
+    # If standalone --job provided, fetch run from job metadata.
+    if args.job and not (args.pr or args.commit or args.branch):
+        try:
+            console.note(f"Fetching run ID for job {args.job}...", args=args)
+            job_metadata = client.get_job_metadata(args.job)
+            run_id = str(job_metadata["run_id"])
+
+            console.note(
+                f"Job {args.job}: {job_metadata['name']} (run {run_id})", args=args
+            )
+
+            # Fetch full run metadata.
+            run_data = client.get_run(run_id)
+            if not run_data:
+                console.error(f"Run {run_id} not found for job {args.job}", args=args)
+                sys.exit(exit_codes.NOT_FOUND)
+
+            run = github_client.WorkflowRun(
+                run_id=run_id,
+                workflow_name=run_data.get("workflowName", ""),
+                conclusion=run_data.get("conclusion", ""),
+                created_at=run_data.get("createdAt", ""),
+                head_branch=run_data.get("headBranch", ""),
+                display_title=run_data.get("displayTitle", ""),
+            )
+            return [run]
+
+        except github_client.GitHubClientError as e:
+            console.error(f"Failed to fetch job metadata: {e}", args=args)
+            sys.exit(exit_codes.ERROR)
+
+    # Otherwise, resolve PR/commit/branch to workflow run(s).
+    try:
+        if args.pr:
+            console.note(
+                f"Fetching all {args.status} workflow runs for PR #{args.pr}...",
+                args=args,
+            )
+            runs = client.get_runs_for_pr(args.pr, status=args.status, limit=None)
+
+        elif args.commit:
+            console.note(
+                f"Fetching all {args.status} workflow runs for commit {args.commit}...",
+                args=args,
+            )
+            runs = client.get_runs_for_commit(
+                args.commit, status=args.status, limit=None
+            )
+
+        elif args.branch:
+            console.note(
+                f"Fetching latest {args.status} run for branch {args.branch}...",
+                args=args,
+            )
+            runs = client.get_runs_for_branch(args.branch, status=args.status, limit=1)
+
+        else:
+            console.error("No run source specified", args=args)
+            sys.exit(exit_codes.ERROR)
+
+        if not runs:
+            source = f"PR #{args.pr}" if args.pr else args.commit or args.branch
+            console.error(
+                f"No {args.status} runs found for {source}",
+                args=args,
+            )
+            sys.exit(exit_codes.NOT_FOUND)
+
+        # Log summary of what we found.
+        if len(runs) == 1:
+            run = runs[0]
+            console.note(
+                f"Found 1 run: {run.workflow_name} ({run.conclusion})",
+                args=args,
+            )
+        else:
+            workflow_names = [r.workflow_name for r in runs]
+            console.note(
+                f"Found {len(runs)} workflow runs: {', '.join(workflow_names)}",
+                args=args,
+            )
+
+        return runs
+
+    except github_client.GitHubClientError as e:
+        console.error(f"Failed to resolve runs: {e}", args=args)
+        sys.exit(exit_codes.ERROR)
+
+
+def fetch_all_job_data(
+    client: github_client.GitHubClient,
+    workflow_runs: list[github_client.WorkflowRun],
+    job_id: str | None,
+    args: argparse.Namespace,
+) -> list[dict]:
+    """Fetch jobs and logs for multiple workflow runs.
+
+    Args:
+        client: GitHubClient instance
+        workflow_runs: List of workflow runs to fetch jobs for
+        job_id: Optional specific job ID (only used when single run)
+        args: Command line arguments
+
+    Returns:
+        List of dicts with structure:
+        {
+            "workflow_run": WorkflowRun,
+            "all_jobs": List[Job],
+            "job_logs": List[tuple[Job, str]]
+        }
+
+    Raises:
+        SystemExit: If fetch fails
+    """
+    workflow_data = []
+
+    for run_idx, run in enumerate(workflow_runs, 1):
+        run_id = run.run_id
+
+        try:
+            # Get ALL jobs to check actual GitHub API status.
+            if len(workflow_runs) > 1:
+                console.note(
+                    f"[{run_idx}/{len(workflow_runs)}] Fetching jobs for {run.workflow_name} (run {run_id})...",
+                    args=args,
+                )
+            else:
+                console.note(f"Fetching jobs for run {run_id}...", args=args)
+
+            all_jobs = client.get_jobs(run_id)
+
+            if not all_jobs:
+                console.note(
+                    f"  No jobs found in {run.workflow_name}.",
+                    args=args,
+                )
+                workflow_data.append(
+                    {
+                        "workflow_run": run,
+                        "all_jobs": [],
+                        "job_logs": [],
+                    }
+                )
+                continue
+
+            if job_id:
+                # Specific job requested (only valid for single run).
+                target_job = next((j for j in all_jobs if j.job_id == job_id), None)
+
+                if not target_job:
+                    console.error(
+                        f"Job {job_id} not found in run {run_id}",
+                        args=args,
+                    )
+                    sys.exit(exit_codes.NOT_FOUND)
+
+                console.note(f"Fetching log for job {job_id}...", args=args)
+                log_content = client.get_job_log(run_id, job_id)
+                if not log_content:
+                    console.error(
+                        f"Log not available for job {job_id}",
+                        args=args,
+                    )
+                    sys.exit(exit_codes.NOT_FOUND)
+
+                workflow_data.append(
+                    {
+                        "workflow_run": run,
+                        "all_jobs": all_jobs,
+                        "job_logs": [(target_job, log_content)],
+                    }
+                )
+                continue
+
+            # Determine which jobs to download logs for.
+            if args.download_all_logs:
+                jobs_to_download = all_jobs
+                console.note(
+                    f"  Downloading logs for all {len(all_jobs)} job(s)...",
+                    args=args,
+                )
+            else:
+                # Only download failed jobs by default (source of truth: GitHub API).
+                jobs_to_download = [j for j in all_jobs if j.conclusion == "failure"]
+                failed_count = len(jobs_to_download)
+                console.note(
+                    f"  Found {failed_count} failed job(s) in {run.workflow_name}",
+                    args=args,
+                )
+
+                if failed_count == 0:
+                    console.note(
+                        f"  No failed jobs to analyze in {run.workflow_name}.",
+                        args=args,
+                    )
+                    workflow_data.append(
+                        {
+                            "workflow_run": run,
+                            "all_jobs": all_jobs,
+                            "job_logs": [],
+                        }
+                    )
+                    continue
+
+            # Download logs.
+            job_logs = []
+            for i, job in enumerate(jobs_to_download, 1):
+                console.note(
+                    f"    [{i}/{len(jobs_to_download)}] Fetching log for: {job.name}",
+                    args=args,
+                )
+                log_content = client.get_job_log(run_id, job.job_id)
+                if log_content:
+                    job_logs.append((job, log_content))
+                else:
+                    console.warn(
+                        f"    Log not available for job {job.job_id}",
+                        args=args,
+                    )
+
+            workflow_data.append(
+                {
+                    "workflow_run": run,
+                    "all_jobs": all_jobs,
+                    "job_logs": job_logs,
+                }
+            )
+
+        except github_client.GitHubClientError as e:
+            console.error(
+                f"GitHub API error for {run.workflow_name}: {e}",
+                args=args,
+            )
+            sys.exit(exit_codes.ERROR)
+
+    return workflow_data
+
+
+def analyze_job(
+    job: github_client.Job,
+    log_content: str,
+    args: argparse.Namespace,
+) -> TriageResult:
+    """Analyze a single job log.
+
+    Args:
+        job: Job object
+        log_content: Log content string
+        args: Command line arguments
+
+    Returns:
+        TriageResult instance
+    """
+    console.note(f"Analyzing job: {job.name}", args=args)
+
+    # Create log buffer with auto-detection of format.
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+
+    # Run triage engine.
+    engine = create_ci_triage_engine()
+    result = engine.analyze(log_buffer)
+
+    console.note(
+        f"  Found {len(result.issues)} issue(s) from {len(result.extractors_run)} extractor(s)",
+        args=args,
+    )
+
+    if result.extractor_errors:
+        console.warn(
+            f"  {len(result.extractor_errors)} extractor(s) encountered errors",
+            args=args,
+        )
+
+    return result
+
+
+def save_logs_to_tmp(
+    workflow_data: list[dict],
+    args: argparse.Namespace,
+) -> dict[str, dict[str, Path]]:
+    """Save job logs to /tmp organized by workflow and return nested path mapping.
+
+    Args:
+        workflow_data: List of workflow data dicts (from fetch_all_job_data)
+        args: Command line arguments
+
+    Returns:
+        Nested dictionary: {run_id: {job_id: log_path}}
+    """
+    all_log_files = {}
+    total_saved = 0
+
+    for data in workflow_data:
+        run = data["workflow_run"]
+        job_logs = data["job_logs"]
+
+        if not job_logs:
+            continue
+
+        # Create workflow-specific subdirectory.
+        # Sanitize workflow name for directory.
+        safe_workflow_name = (
+            run.workflow_name.replace(" ", "_").replace("/", "_").replace("\\", "_")
+        )
+        output_dir = Path(f"/tmp/iree-ci-triage/run_{run.run_id}/{safe_workflow_name}")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        log_files = {}
+        for job, log_content in job_logs:
+            # Strip GitHub Actions prefixes to save tokens.
+            log_buffer = LogBuffer(log_content, auto_detect_format=True)
+            stripped_content = log_buffer.content
+
+            # Sanitize job name for filename.
+            safe_name = job.name.replace(" / ", "_").replace(" ", "_").replace("/", "_")
+            log_file = output_dir / f"job_{job.job_id}_{safe_name}.log"
+            log_file.write_text(stripped_content)
+            log_files[job.job_id] = log_file
+            total_saved += 1
+
+        all_log_files[run.run_id] = log_files
+
+        if log_files and not args.quiet:
+            console.note(
+                f"  Saved {len(log_files)} log(s) for {run.workflow_name} to: {output_dir}",
+                args=args,
+            )
+
+    if total_saved > 0 and not args.quiet:
+        base_dir = Path("/tmp/iree-ci-triage")
+        console.note(f"Total: {total_saved} log(s) saved to {base_dir}", args=args)
+
+    return all_log_files
+
+
+def output_results(
+    workflow_data: list[dict],
+    workflow_results: list[dict],
+    log_files: dict[str, dict[str, Path]],
+    args: argparse.Namespace,
+) -> None:
+    """Output triage results with GitHub status as source of truth.
+
+    Args:
+        workflow_data: List of workflow data dicts (from fetch_all_job_data)
+        workflow_results: List of workflow results with analyzed jobs
+        log_files: Nested dict {run_id: {job_id: Path}}
+        args: Command line arguments
+    """
+    # Count total jobs across all workflows.
+    total_failed = 0
+    total_passed = 0
+    total_other = 0
+    total_jobs = 0
+
+    for data in workflow_data:
+        all_jobs = data["all_jobs"]
+        total_jobs += len(all_jobs)
+        total_failed += len([j for j in all_jobs if j.conclusion == "failure"])
+        total_passed += len([j for j in all_jobs if j.conclusion == "success"])
+        total_other += len(
+            [j for j in all_jobs if j.conclusion not in ("failure", "success")]
+        )
+
+    if args.json:
+        # JSON output for automation (new multi-workflow schema).
+        runs = []
+        for data, results in zip(workflow_data, workflow_results, strict=False):
+            run = data["workflow_run"]
+            all_jobs = data["all_jobs"]
+            job_results = results["job_results"]
+            run_log_files = log_files.get(run.run_id, {})
+
+            runs.append(
+                {
+                    "run_id": run.run_id,
+                    "workflow_name": run.workflow_name,
+                    "conclusion": run.conclusion,
+                    "created_at": run.created_at,
+                    "jobs": [
+                        {
+                            "job_id": job.job_id,
+                            "name": job.name,
+                            "conclusion": job.conclusion,  # GitHub API status!
+                            "log_path": str(run_log_files.get(job.job_id, "")),
+                            "extracted_issues": (
+                                [
+                                    {
+                                        "title": issue.message[
+                                            :100
+                                        ],  # Use first 100 chars of message as title.
+                                        "message": issue.message,
+                                        "severity": issue.severity.name
+                                        if hasattr(issue.severity, "name")
+                                        else str(issue.severity),
+                                        "extractor": issue.source_extractor,
+                                    }
+                                    for issue in result.issues
+                                ]
+                                if (
+                                    result := next(
+                                        (
+                                            r
+                                            for j, r in job_results
+                                            if j.job_id == job.job_id
+                                        ),
+                                        None,
+                                    )
+                                )
+                                else []
+                            ),
+                            "extraction_status": (
+                                "success"
+                                if (
+                                    result := next(
+                                        (
+                                            r
+                                            for j, r in job_results
+                                            if j.job_id == job.job_id
+                                        ),
+                                        None,
+                                    )
+                                )
+                                and result.issues
+                                else "incomplete"
+                                if result
+                                else "not_analyzed"
+                            ),
+                        }
+                        for job in all_jobs
+                    ],
+                }
+            )
+
+        output = {
+            "runs": runs,
+            "summary": {
+                "total_workflows": len(workflow_data),
+                "total_jobs": total_jobs,
+                "failed": total_failed,
+                "passed": total_passed,
+                "other": total_other,
+                "logs_downloaded": sum(len(files) for files in log_files.values()),
+            },
+        }
+        console.print_json(output, args=args)
+        return
+
+    # Human-readable output.
+    if total_failed == 0:
+        console.out("✓ All jobs passed across all workflows")
+        console.out(f"  Total workflows: {len(workflow_data)}")
+        console.out(f"  Total jobs: {total_jobs}")
+        if log_files:
+            console.out("  Logs: /tmp/iree-ci-triage/run_*")
+        return
+
+    # Show failed jobs grouped by workflow.
+    console.out(f"\n{'=' * 80}")
+    console.out(
+        f"FAILED JOBS ({total_failed}/{total_jobs} across {len(workflow_data)} workflow(s)):"
+    )
+    console.out(f"{'=' * 80}\n")
+
+    for data, results in zip(workflow_data, workflow_results, strict=False):
+        run = data["workflow_run"]
+        all_jobs = data["all_jobs"]
+        job_results = results["job_results"]
+        run_log_files = log_files.get(run.run_id, {})
+
+        failed_jobs = [j for j in all_jobs if j.conclusion == "failure"]
+
+        if not failed_jobs:
+            continue  # Skip workflows with no failures.
+
+        console.out(f"─── {run.workflow_name} (run {run.run_id}) ───")
+        console.out(f"Failed: {len(failed_jobs)}/{len(all_jobs)} jobs\n")
+
+        for job in failed_jobs:
+            console.out(f"  ✗ Job {job.job_id}: {job.name}")
+            console.out("    Status: failure (from GitHub API)")
+
+            # Show log file path.
+            if job.job_id in run_log_files:
+                console.out(f"    Log: {run_log_files[job.job_id]}")
+
+            # Show extracted issues if available.
+            result = next((r for j, r in job_results if j.job_id == job.job_id), None)
+            if result and result.issues:
+                console.out(f"\n    Extracted Issues ({len(result.issues)}):")
+                for issue in result.issues[:5]:  # Limit to first 5.
+                    console.out(f"      • {issue.message}")
+                if len(result.issues) > 5:
+                    console.out(f"      ... and {len(result.issues) - 5} more")
+            elif result:
+                console.out(
+                    "\n    ⚠ WARNING: No issues extracted - manual review needed"
+                )
+                if job.job_id in run_log_files:
+                    console.out(f"    See full log: {run_log_files[job.job_id]}")
+            else:
+                console.out("\n    (Log not analyzed)")
+
+            console.out("")
+
+    console.out(f"{'=' * 80}")
+    console.out(
+        f"Summary: {total_failed} failed, {total_passed} passed, {total_other} other across {len(workflow_data)} workflow(s)"
+    )
+    console.out(f"{'=' * 80}\n")
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point for iree-ci-triage.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code
+    """
+    # Auto-enable quiet mode for JSON output to keep stdout clean.
+    if args.json:
+        args.quiet = True
+
+    # Handle --log-file (local testing mode).
+    if args.log_file:
+        if not args.log_file.exists():
+            console.error(f"Log file not found: {args.log_file}", args=args)
+            return exit_codes.NOT_FOUND
+
+        console.note(f"Reading log from: {args.log_file}", args=args)
+        log_content = args.log_file.read_text()
+
+        # Use provided job name or default to log filename.
+        job_name = args.job_name or args.log_file.stem
+
+        # Create synthetic job and workflow for local testing.
+        job = github_client.Job(
+            job_id=job_name,
+            name=job_name,
+            conclusion="failure",
+            runner_name=None,
+            started_at="",
+            completed_at="",
+        )
+        run = github_client.WorkflowRun(
+            run_id="local",
+            workflow_name="Local Test",
+            conclusion="failure",
+            created_at="",
+            head_branch="",
+            display_title="",
+        )
+
+        # Create workflow_data structure.
+        workflow_data = [
+            {
+                "workflow_run": run,
+                "all_jobs": [job],
+                "job_logs": [(job, log_content)],
+            }
+        ]
+
+        # Analyze the job.
+        result = analyze_job(job, log_content, args)
+        workflow_results = [{"job_results": [(job, result)]}]
+
+        # Create log files structure.
+        log_files = {"local": {job.job_id: args.log_file}}
+        any_failures = True
+
+    else:
+        # Check dependencies for GitHub mode.
+        status = check_dependencies(args)
+        if status != exit_codes.SUCCESS:
+            return status
+
+        # Create GitHub client.
+        client = github_client.GitHubClient(repo=args.repo)
+
+        # Resolve workflow runs from --pr/--commit/--branch/--run/--job.
+        workflow_runs = resolve_run_ids(client, args)
+
+        # Fetch ALL jobs and logs for failed/requested jobs across all workflows.
+        workflow_data = fetch_all_job_data(client, workflow_runs, args.job, args)
+
+        # Always save logs to /tmp.
+        log_files = save_logs_to_tmp(workflow_data, args)
+
+        # Also save to custom directory if requested.
+        if args.save_logs:
+            args.save_logs.mkdir(parents=True, exist_ok=True)
+            console.note(f"Saving logs to: {args.save_logs}", args=args)
+
+            for data in workflow_data:
+                run = data["workflow_run"]
+                job_logs = data["job_logs"]
+
+                for job, log_content in job_logs:
+                    # Strip log prefixes (GitHub Actions, etc.) to save tokens.
+                    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+                    stripped_content = log_buffer.content
+
+                    # Sanitize job name for filename.
+                    safe_name = job.name.replace(" / ", "_").replace(" ", "_")
+                    log_file = (
+                        args.save_logs / f"{run.run_id}_{job.job_id}_{safe_name}.log"
+                    )
+                    log_file.write_text(stripped_content)
+                    console.note(f"  Saved: {log_file.name}", args=args)
+
+        # Analyze downloaded logs for each workflow.
+        workflow_results = []
+        for data in workflow_data:
+            job_logs = data["job_logs"]
+
+            job_results = []
+            for job, log_content in job_logs:
+                result = analyze_job(job, log_content, args)
+                job_results.append((job, result))
+
+            workflow_results.append({"job_results": job_results})
+
+        # Determine exit code from GitHub API (source of truth).
+        any_failures = False
+        for data in workflow_data:
+            all_jobs = data["all_jobs"]
+            failed_jobs = [j for j in all_jobs if j.conclusion == "failure"]
+            if failed_jobs:
+                any_failures = True
+                break
+
+    # Output results showing GitHub status FIRST.
+    output_results(workflow_data, workflow_results, log_files, args)
+
+    # Exit code reflects ACTUAL job status from GitHub API.
+    return exit_codes.ERROR if any_failures else exit_codes.SUCCESS
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    sys.exit(main(args))

--- a/tools/utils/ci/patterns.yaml
+++ b/tools/utils/ci/patterns.yaml
@@ -1,0 +1,421 @@
+# IREE CI Error Pattern Definitions
+#
+# This file defines error patterns for automated triage of CI failures.
+# Each pattern includes:
+#   - pattern: Regular expression to match in log files
+#   - severity: critical, high, medium, or low
+#   - actionable: Whether this represents a fixable issue (vs infrastructure flake)
+#   - context_lines: Number of lines to capture before/after match
+#   - extract: Optional list of fields to extract from the match
+#   - description: Human-readable description of the error type
+#
+# Pattern definitions are based on comprehensive analysis of 563 CI failure logs
+# from the IREE project (2025-11-15).
+
+patterns:
+  # ============================================================================
+  # Build and Compilation Errors
+  # ============================================================================
+
+  compile_error:
+    pattern: '\S+\.(?:cpp|hpp|cc|cxx|h|c):\d+:\d+: error:|compilation terminated|clang.*: error:|g\+\+.*: error:|gcc.*: error:'
+    severity: critical
+    actionable: true
+    context_lines: 5
+    description: "C/C++ compilation error"
+    extract:
+      - name: file_path
+        regex: '(\S+\.\w+):(\d+):(\d+):'
+      - name: error_message
+        regex: 'error: (.+)'
+
+  undefined_reference:
+    pattern: 'undefined reference to|unresolved external symbol'
+    severity: critical
+    actionable: true
+    context_lines: 3
+    description: "Linker error: undefined symbol"
+
+  linker_error:
+    pattern: 'ld returned.*exit status|collect2: error:'
+    severity: critical
+    actionable: true
+    context_lines: 5
+    description: "Linker error"
+
+  # ============================================================================
+  # Test Failures
+  # ============================================================================
+
+  filecheck_failed:
+    pattern: 'FileCheck.*failed'
+    severity: high
+    actionable: true
+    context_lines: 10
+    description: "LLVM FileCheck test failure"
+    extract:
+      - name: check_file
+        regex: 'FileCheck.*--check-prefix[es]*=(\S+)'
+      - name: failed_line
+        regex: '(\S+):(\d+):\d+: error:'
+
+  test_failed:
+    pattern: 'FAILED.*tests?|Test.*failed'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Test suite failure"
+
+  assertion_failed:
+    pattern: 'Assertion.*failed|assert.*failed'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Assertion failure in test"
+
+  segfault:
+    pattern: 'Segmentation fault|segmentation fault|SIGSEGV'
+    severity: critical
+    actionable: true
+    context_lines: 10
+    description: "Segmentation fault"
+
+  # ============================================================================
+  # Timeouts
+  # ============================================================================
+
+  timeout:
+    pattern: '(?:timeout|TIMEOUT).*(?:exceeded|error|failed)|timed out|Test timed out after|Timeout of \d+.*exceeded'
+    severity: high
+    actionable: false
+    context_lines: 3
+    description: "Job or test timeout"
+
+  deadline_exceeded:
+    pattern: 'deadline exceeded|context deadline exceeded'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "Deadline exceeded"
+
+  # ============================================================================
+  # Python Errors
+  # ============================================================================
+
+  python_exception:
+    pattern: 'Traceback \(most recent call last\)|^\s*\w+(?:Error|Exception):\s'
+    severity: high
+    actionable: true
+    context_lines: 10
+    description: "Python runtime exception"
+    extract:
+      - name: exception_type
+        regex: '(\w+Error|\w+Exception):'
+      - name: exception_file
+        regex: 'File "([^"]+)", line (\d+)'
+
+  python_import_error:
+    pattern: 'ImportError:|ModuleNotFoundError:'
+    severity: high
+    actionable: true
+    context_lines: 3
+    description: "Python import error"
+
+  # ============================================================================
+  # CUDA Errors (NVIDIA GPU)
+  # ============================================================================
+
+  cuda_error:
+    pattern: 'CUDA error|cudaError|CUDA_ERROR'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "CUDA runtime error"
+
+  cuda_oom:
+    pattern: 'CUDA out of memory|cudaMalloc failed'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "CUDA out of memory"
+
+  cuda_device_lost:
+    pattern: 'CUDA.*device.*lost'
+    severity: critical
+    actionable: false
+    context_lines: 5
+    description: "CUDA device lost (driver issue)"
+
+  # ============================================================================
+  # HIP/ROCm Errors (AMD GPU)
+  # ============================================================================
+
+  hip_error:
+    pattern: 'hipError\w+|HIP error'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "HIP runtime error"
+    extract:
+      - name: hip_error_code
+        regex: '(hipError\w+)'
+
+  rocm_error:
+    pattern: 'ROCm error|HSA_STATUS_ERROR|hsa.*(?:error|failed)|amd.*smi.*error'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "ROCm runtime error"
+
+  rocclr_error:
+    pattern: 'rocclr/.*:\d+.*error|rocclr.*failed'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "ROCm CLR internal error"
+
+  # CRITICAL: ROCm cleanup crash - creates false CI failures
+  # Tests often PASS but crash during cleanup with exit code 134
+  rocclr_memobj:
+    pattern: 'Memobj map does not have ptr'
+    severity: critical
+    actionable: false  # Infrastructure/driver issue, not code bug
+    context_lines: 10
+    description: "ROCm memory object cleanup crash (false CI failure)"
+    extract:
+      - name: rocclr_file
+        regex: '(rocclr/\S+):(\d+)'
+
+  hip_device_lost:
+    pattern: 'HIP.*device.*lost|device.*lost.*HIP'
+    severity: critical
+    actionable: false
+    context_lines: 5
+    description: "HIP device lost (driver issue)"
+
+  hip_file_not_found:
+    pattern: 'hipErrorFileNotFound'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "HIP file not found (missing device libraries)"
+
+  # ============================================================================
+  # Vulkan Errors
+  # ============================================================================
+
+  vk_error:
+    pattern: 'VK_ERROR_\w+'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Vulkan API error"
+    extract:
+      - name: vk_error_code
+        regex: '(VK_ERROR_\w+)'
+
+  vk_device_lost:
+    pattern: 'VK_ERROR_DEVICE_LOST'
+    severity: critical
+    actionable: false
+    context_lines: 5
+    description: "Vulkan device lost (driver issue)"
+
+  vk_oom:
+    pattern: 'VK_ERROR_OUT_OF_\w+_MEMORY'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "Vulkan out of memory"
+
+  vk_initialization_failed:
+    pattern: 'VK_ERROR_INITIALIZATION_FAILED'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Vulkan initialization failed"
+
+  vulkan_error:
+    pattern: 'vulkan.*error|vkCreate.*failed'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Vulkan generic error"
+
+  # ============================================================================
+  # Metal Errors (Apple GPU)
+  # ============================================================================
+
+  metal_error:
+    pattern: 'MTL.*Error|Metal.*error'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Metal API error"
+
+  # ============================================================================
+  # Build System Errors
+  # ============================================================================
+
+  bazel_failed:
+    pattern: 'FAILED: Build did NOT complete|bazel.*failed'
+    severity: critical
+    actionable: true
+    context_lines: 5
+    description: "Bazel build failure"
+
+  bazel_timeout:
+    pattern: 'Bazel.*timeout|bazel.*timed out'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "Bazel timeout"
+
+  ctest_failed:
+    pattern: 'tests? failed out of|CTest.*failed'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "CTest failure"
+
+  cmake_error:
+    pattern: 'CMake Error|cmake.*error'
+    severity: critical
+    actionable: true
+    context_lines: 5
+    description: "CMake configuration error"
+
+  # ============================================================================
+  # Memory Errors
+  # ============================================================================
+
+  oom:
+    pattern: 'out of memory|OOM|cannot allocate memory'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "Out of memory"
+
+  bad_alloc:
+    pattern: 'std::bad_alloc|bad_alloc'
+    severity: medium
+    actionable: false
+    context_lines: 3
+    description: "Memory allocation failed"
+
+  stack_overflow:
+    pattern: 'stack overflow|STACKOVERFLOW'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "Stack overflow"
+
+  # ============================================================================
+  # Process Termination
+  # ============================================================================
+
+  aborted:
+    pattern: 'Aborted|SIGABRT|aborted'
+    severity: high
+    actionable: true
+    context_lines: 10
+    description: "Process aborted (SIGABRT)"
+
+  core_dumped:
+    pattern: 'core dumped|dumped core'
+    severity: high
+    actionable: true
+    context_lines: 10
+    description: "Process core dump"
+
+  # ============================================================================
+  # Infrastructure Errors
+  # ============================================================================
+
+  network_error:
+    pattern: 'network.*error|connection.*refused|connection.*timed out'
+    severity: low
+    actionable: false
+    context_lines: 2
+    description: "Network error"
+
+  download_failed:
+    pattern: 'download.*failed|failed to download'
+    severity: low
+    actionable: false
+    context_lines: 3
+    description: "Download failure"
+
+  permission_denied:
+    pattern: 'permission denied|access denied'
+    severity: medium
+    actionable: true
+    context_lines: 3
+    description: "Permission denied"
+
+  file_not_found:
+    pattern: 'no such file or directory|file not found'
+    severity: high
+    actionable: true
+    context_lines: 3
+    description: "File not found"
+
+  docker_error:
+    pattern: 'docker.*error|container.*failed'
+    severity: medium
+    actionable: false
+    context_lines: 5
+    description: "Docker/container error"
+
+  git_error:
+    pattern: 'git.*error|fatal: .*git'
+    severity: medium
+    actionable: true
+    context_lines: 3
+    description: "Git operation error"
+
+  # ============================================================================
+  # Performance Errors
+  # ============================================================================
+
+  benchmark_regression:
+    pattern: 'Benchmark failed|exceeds golden_time'
+    severity: medium
+    actionable: true
+    context_lines: 5
+    description: "Performance regression"
+
+  # ============================================================================
+  # General Errors
+  # ============================================================================
+
+  process_exit_error:
+    pattern: 'Process completed with exit code [1-9]'
+    severity: medium
+    actionable: true
+    context_lines: 5
+    description: "Non-zero exit code"
+    extract:
+      - name: exit_code
+        regex: 'exit code (\d+)'
+
+  fatal_error:
+    pattern: 'fatal error|FATAL ERROR'
+    severity: critical
+    actionable: true
+    context_lines: 10
+    description: "Fatal error"
+
+  internal_error:
+    pattern: 'internal error|INTERNAL ERROR'
+    severity: critical
+    actionable: true
+    context_lines: 10
+    description: "Internal error"
+
+  panic:
+    pattern: 'panic:|PANIC:'
+    severity: critical
+    actionable: true
+    context_lines: 10
+    description: "Panic"

--- a/tools/utils/common/__init__.py
+++ b/tools/utils/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities shared across tools."""

--- a/tools/utils/common/build_detection.py
+++ b/tools/utils/common/build_detection.py
@@ -1,0 +1,241 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Auto-detect IREE build directories and provide helpful build suggestions.
+
+Build directory search order:
+1. IREE_BUILD_DIR environment variable (override)
+2. ./build/ (in-tree build, standard CMake default)
+3. ../<name>-build/ (sibling pattern: main → ../main-build/)
+4. ../builds/<name>/ (builds directory: main → ../builds/main/)
+
+When tools or build directories are not found, provides helpful error messages
+suggesting how to build IREE.
+
+This module auto-detects the appropriate build directory based on the current
+working directory and provides utilities for finding build artifacts (tools, FileCheck).
+"""
+
+import os
+from pathlib import Path
+
+
+def find_repo_root(cwd: Path | None = None) -> Path | None:
+    """Finds IREE repository root by walking up to find Bazel marker file.
+
+    Args:
+        cwd: Current working directory (defaults to os.getcwd())
+
+    Returns:
+        Path to repository root, or None if marker not found
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+
+    # Walk up directory tree looking for Bazel marker files.
+    # Check MODULE.bazel (bzlmod) first, then WORKSPACE (legacy).
+    for parent in [cwd] + list(cwd.parents):
+        if (parent / "MODULE.bazel").exists() or (parent / "WORKSPACE").exists():
+            return parent
+    return None
+
+
+def _is_cmake_build_dir(path: Path) -> bool:
+    """Checks if path is a valid CMake build directory.
+
+    Validates by checking for CMakeCache.txt or tools/ subdirectory.
+    This prevents false positives from empty directories or Python packages.
+
+    Args:
+        path: Directory to check
+
+    Returns:
+        True if path appears to be a CMake build directory
+    """
+    return (path / "CMakeCache.txt").exists() or (path / "tools").is_dir()
+
+
+def detect_build_dir(cwd: Path | None = None) -> Path:
+    """Detects build directory from current working directory.
+
+    Search order:
+    1. IREE_BUILD_DIR environment variable (override)
+    2. ./build/ (in-tree build, standard CMake default)
+    3. ../<name>-build/ (sibling pattern: main → ../main-build/)
+    4. ../builds/<name>/ (builds directory: main → ../builds/main/)
+
+    Args:
+        cwd: Current working directory (defaults to os.getcwd())
+
+    Returns:
+        Path to build directory
+
+    Raises:
+        FileNotFoundError: If build directory cannot be found. Error message
+            includes helpful suggestions for building IREE.
+
+    Example:
+        >>> # From /home/ben/src/iree/main/ with ./build/
+        >>> detect_build_dir()
+        PosixPath('/home/ben/src/iree/main/build')
+
+        >>> # From /home/ben/src/iree/main/ with ../builds/main/
+        >>> detect_build_dir()
+        PosixPath('/home/ben/src/iree/builds/main')
+
+        >>> # With IREE_BUILD_DIR override
+        >>> os.environ['IREE_BUILD_DIR'] = '/custom/build'
+        >>> detect_build_dir()
+        PosixPath('/custom/build')
+    """
+    # Allow environment variable override
+    if "IREE_BUILD_DIR" in os.environ:
+        build_dir = Path(os.environ["IREE_BUILD_DIR"])
+        if not build_dir.exists():
+            raise FileNotFoundError(
+                f"IREE_BUILD_DIR points to non-existent directory: {build_dir}"
+            )
+        return build_dir
+
+    # Get current directory
+    if cwd is None:
+        cwd = Path.cwd()
+
+    # Find repository root (works from any subdirectory).
+    repo_root = find_repo_root(cwd)
+    if repo_root is None:
+        # Not in IREE repo - use cwd as fallback.
+        repo_root = cwd
+
+    parent_dir = repo_root.parent
+    worktree_name = repo_root.name
+
+    # Search order: <repo>/build/ -> ../<name>-build/ -> ../builds/<name>/
+    # Priority to <repo>/build/ for standard CMake users.
+    candidates = [
+        repo_root / "build",  # In-tree: repo/build/
+        parent_dir / f"{worktree_name}-build",  # Sibling: ../main-build/
+        parent_dir / "builds" / worktree_name,  # Builds dir: ../builds/main/
+    ]
+
+    for candidate in candidates:
+        if candidate.exists() and _is_cmake_build_dir(candidate):
+            return candidate
+
+    tried_paths = "\n".join(f"  {i + 1}. {p}" for i, p in enumerate(candidates))
+    raise FileNotFoundError(
+        f"Cannot find build directory. Tried:\n{tried_paths}\n\n"
+        f"Build IREE first:\n"
+        f"  cmake -B {candidates[0]} -S {repo_root} && "
+        f"cmake --build {candidates[0]} -j$(nproc)\n\n"
+        f"Or set IREE_BUILD_DIR to specify a custom build location."
+    )
+
+
+def find_tool(tool_name: str, build_dir: Path | None = None) -> Path:
+    """Finds IREE tool in build directory.
+
+    Args:
+        tool_name: Name of tool (e.g., 'iree-opt', 'FileCheck')
+        build_dir: Build directory (auto-detected if not provided)
+
+    Returns:
+        Path to tool executable
+
+    Raises:
+        FileNotFoundError: If tool cannot be found
+
+    Example:
+        >>> find_tool('iree-opt')
+        PosixPath('/home/ben/src/iree-loom-build/tools/iree-opt')
+
+        >>> find_tool('FileCheck')
+        PosixPath('/home/ben/src/iree-loom-build/llvm-project/bin/FileCheck')
+    """
+    if build_dir is None:
+        build_dir = detect_build_dir()
+
+    # Tool locations
+    tool_paths = [
+        build_dir / "tools" / tool_name,  # IREE tools
+        build_dir / "bin" / tool_name,  # Alternative location
+        build_dir / "llvm-project" / "bin" / tool_name,  # LLVM tools
+    ]
+
+    for tool_path in tool_paths:
+        if tool_path.exists():
+            return tool_path
+
+    # Tool not found - provide helpful error message
+    tried_paths = "\n".join(f"  - {p}" for p in tool_paths)
+    raise FileNotFoundError(
+        f"Cannot find tool '{tool_name}' in build directory {build_dir}.\n\n"
+        f"Tried:\n{tried_paths}\n\n"
+        f"Tool may not be built yet. Build IREE with:\n"
+        f"  cmake --build {build_dir} --target {tool_name}\n\n"
+        f"Or build all tools:\n"
+        f"  cmake --build {build_dir} -j$(nproc)"
+    )
+
+
+def is_debug_build(build_dir: Path | None = None) -> bool:
+    """Checks if build has LLVM assertions enabled (debug build).
+
+    Args:
+        build_dir: Build directory (auto-detected if not provided)
+
+    Returns:
+        True if LLVM_ENABLE_ASSERTIONS=ON, False otherwise
+
+    Example:
+        >>> is_debug_build()
+        True  # If built with -DLLVM_ENABLE_ASSERTIONS=ON
+    """
+    if build_dir is None:
+        build_dir = detect_build_dir()
+
+    # Check CMakeCache.txt for LLVM_ENABLE_ASSERTIONS
+    cmake_cache = build_dir / "CMakeCache.txt"
+    if not cmake_cache.exists():
+        # No CMakeCache, assume not debug
+        return False
+
+    with open(cmake_cache) as f:
+        for line in f:
+            if "LLVM_ENABLE_ASSERTIONS:BOOL=" in line:
+                return "=ON" in line
+
+    # Default to False if not found
+    return False
+
+
+def get_build_type(build_dir: Path | None = None) -> str:
+    """Gets CMAKE_BUILD_TYPE from build directory.
+
+    Args:
+        build_dir: Build directory (auto-detected if not provided)
+
+    Returns:
+        Build type string (Debug, Release, RelWithDebInfo, MinSizeRel)
+        Returns "Unknown" if cannot be determined
+
+    Example:
+        >>> get_build_type()
+        'Debug'
+    """
+    if build_dir is None:
+        build_dir = detect_build_dir()
+
+    cmake_cache = build_dir / "CMakeCache.txt"
+    if not cmake_cache.exists():
+        return "Unknown"
+
+    with open(cmake_cache) as f:
+        for line in f:
+            if "CMAKE_BUILD_TYPE:STRING=" in line:
+                return line.split("=")[1].strip()
+
+    return "Unknown"

--- a/tools/utils/common/cli.py
+++ b/tools/utils/common/cli.py
@@ -1,0 +1,190 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Common CLI helpers for all tools.
+
+Provides generic argument parsing and validation helpers.
+Lit-specific helpers are in lit_tools.core.cli.
+"""
+
+from __future__ import annotations
+
+import argparse  # noqa: TCH003
+import sys
+from typing import TYPE_CHECKING
+
+from common import console
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def add_common_output_flags(parser: argparse.ArgumentParser) -> None:
+    """Add common output flags to parser.
+
+    Auto-detects terminal color support by default. Pretty mode is enabled when:
+    - stderr is a TTY (interactive terminal)
+    - NO_COLOR environment variable is not set
+    - --no-pretty is not specified
+
+    Args:
+        parser: ArgumentParser to add flags to
+    """
+    parser.add_argument("--json", action="store_true", help="JSON output for scripting")
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        default=sys.stderr.isatty(),
+        help="Human-friendly formatting (default: auto-detect terminal)",
+    )
+    parser.add_argument(
+        "--no-pretty",
+        action="store_false",
+        dest="pretty",
+        help="Disable colored output",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress non-essential text"
+    )
+
+
+def require_exactly_one(
+    args: argparse.Namespace, names: Iterable[str], message: str | None = None
+) -> bool:
+    """Ensure exactly one of the named flags/attrs is truthy.
+
+    Args:
+        args: Parsed arguments namespace
+        names: Flag names to check
+        message: Optional error message override
+
+    Returns:
+        True if exactly one is set, False otherwise
+    """
+    count = sum(1 for n in names if getattr(args, n, None))
+    if count != 1:
+        console.error(
+            message or f"specify exactly one of: {', '.join(names)}", args=args
+        )
+        return False
+    return True
+
+
+def require_at_most_one(
+    args: argparse.Namespace, names: Iterable[str], message: str | None = None
+) -> bool:
+    """Ensures at most one of the named flags/attrs is truthy.
+
+    Useful for tools like list where multiple summary modes exist (--json, --count,
+    --names) but only one should be chosen at a time.
+
+    Args:
+        args: Parsed arguments namespace
+        names: Flag names to check
+        message: Optional error message override
+
+    Returns:
+        True if at most one is set, False otherwise
+    """
+    count = sum(1 for n in names if getattr(args, n, None))
+    if count > 1:
+        console.error(
+            message or f"choose at most one of: {', '.join(names)}", args=args
+        )
+        return False
+    return True
+
+
+def parse_case_numbers(spec: str | list[str]) -> list[int]:
+    """Parse case number specification into list of integers.
+
+    Supports:
+    - Single number: "5" -> [5]
+    - Comma-separated: "1,3,5" -> [1, 3, 5]
+    - Ranges: "1-3" -> [1, 2, 3]
+    - Mixed: "1,3-5,7" -> [1, 3, 4, 5, 7]
+    - Multiple flags: ["1", "3", "5"] -> [1, 3, 5]
+
+    Args:
+        spec: String like "1,3-5" or list like ["1", "3", "5"]
+
+    Returns:
+        Sorted list of unique case numbers
+
+    Raises:
+        ValueError: Invalid format, negative/zero numbers, or invalid range
+
+    Examples:
+        >>> parse_case_numbers("1")
+        [1]
+        >>> parse_case_numbers("1,3,5")
+        [1, 3, 5]
+        >>> parse_case_numbers("1-3")
+        [1, 2, 3]
+        >>> parse_case_numbers("1,3-5,7")
+        [1, 3, 4, 5, 7]
+        >>> parse_case_numbers(["1", "3", "5"])
+        [1, 3, 5]
+    """
+    # Convert list to comma-separated string.
+    if isinstance(spec, list):
+        spec = ",".join(spec)
+
+    if not spec or not spec.strip():
+        raise ValueError("No case numbers specified")
+
+    numbers = set()
+    parts = spec.split(",")
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        # Check if it's a range (e.g., "1-3").
+        # Must have a hyphen not at the start or end.
+        if "-" in part and not part.startswith("-") and not part.endswith("-"):
+            hyphen_index = part.index("-")
+            # Make sure there's content on both sides of the hyphen.
+            if hyphen_index > 0 and hyphen_index < len(part) - 1:
+                range_parts = part.split("-", 1)
+
+                try:
+                    start = int(range_parts[0].strip())
+                    end = int(range_parts[1].strip())
+                except ValueError:
+                    raise ValueError(
+                        f"Invalid range '{part}': both start and end must be integers"
+                    ) from None
+
+                if start <= 0 or end <= 0:
+                    raise ValueError(
+                        f"Case numbers must be positive, got range {start}-{end}"
+                    )
+
+                if start > end:
+                    raise ValueError(
+                        f"Invalid range {start}-{end}: start must be <= end"
+                    )
+
+                numbers.update(range(start, end + 1))
+                continue
+
+        # Single number (or invalid input).
+        try:
+            num = int(part)
+        except ValueError:
+            raise ValueError(f"Invalid case number: '{part}'") from None
+
+        if num <= 0:
+            raise ValueError(f"Case numbers must be positive, got {num}")
+
+        numbers.add(num)
+
+    if not numbers:
+        raise ValueError("No valid case numbers found in specification")
+
+    return sorted(numbers)

--- a/tools/utils/common/console.py
+++ b/tools/utils/common/console.py
@@ -1,0 +1,218 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Console logging helpers for lit tools.
+
+These helpers centralize printing, target stream selection, and styling. They
+pull `pretty`/`quiet` flags from an `args` object when present to keep callers
+simple and consistent.
+
+All output goes to stderr except for primary data (like extracted test cases
+or JSON output), which goes to stdout. This follows Unix conventions where
+stderr is for diagnostics and stdout is for pipeline-able data.
+
+Quiet mode behavior:
+- error() - ALWAYS prints (errors are never suppressed)
+- warn() - Suppressed when quiet=True
+- note() - Suppressed when quiet=True
+- success() - Suppressed when quiet=True
+- print_json() - Outputs compact JSON when quiet=True
+
+Pretty mode behavior:
+- When pretty=True and output is a TTY, adds ANSI color codes
+- When pretty=False or not a TTY, outputs plain text
+
+Example:
+    >>> import argparse
+    >>> from common import console
+    >>>
+    >>> # Normal mode - all messages print with color if TTY
+    >>> args = argparse.Namespace(pretty=True, quiet=False)
+    >>> console.note("Processing test cases", args=args)
+    note: Processing test cases  # (with color if TTY)
+    >>>
+    >>> console.warn("Large file detected", args=args)
+    warning: Large file detected  # (with color if TTY)
+    >>>
+    >>> # Quiet mode - only errors print
+    >>> args.quiet = True
+    >>> console.note("This will not print", args=args)
+    # (suppressed)
+    >>>
+    >>> console.warn("This warning is also suppressed", args=args)
+    # (suppressed)
+    >>>
+    >>> console.error("File not found", args=args)
+    error: File not found  # (errors ALWAYS print, even when quiet)
+    >>>
+    >>> # JSON output - compact when quiet
+    >>> console.print_json({"status": "ok", "count": 5}, args=args)
+    {"count":5,"status":"ok"}  # (compact, no whitespace)
+    >>>
+    >>> args.quiet = False
+    >>> console.print_json({"status": "ok", "count": 5}, args=args)
+    {
+      "count": 5,
+      "status": "ok"
+    }  # (pretty-printed with indentation)
+
+Integration with cli.add_common_output_flags():
+    All tools should use cli.add_common_output_flags() to get --pretty, --quiet,
+    and --json flags, then pass the args object to console functions. This ensures
+    consistent behavior across all tools without duplicating flag logic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+from common import formatting
+
+
+def _is_pretty(args: Any | None, pretty: bool | None) -> bool:
+    """Determine if color output should be used.
+
+    Checks pretty flag, TTY status, and NO_COLOR environment variable.
+    All I/O-related decisions (TTY checks) are centralized here.
+
+    Args:
+        args: Parsed arguments with pretty flag (optional)
+        pretty: Override pretty mode (optional)
+
+    Returns:
+        Whether to use color codes in output
+    """
+    # Extract the pretty flag value.
+    if pretty is not None:
+        pretty_flag = bool(pretty)
+    else:
+        pretty_flag = bool(getattr(args, "pretty", False))
+
+    # Only use color if: pretty enabled AND stderr is TTY AND NO_COLOR not set.
+    # We check stderr because that's where console output (note/warn/error) goes.
+    return bool(
+        pretty_flag and sys.stderr.isatty() and os.environ.get("NO_COLOR") is None
+    )
+
+
+def error(msg: str, *, args: Any | None = None, pretty: bool | None = None) -> None:
+    """Print error message to stderr (never suppressed, even in quiet mode).
+
+    Args:
+        msg: Error message to display
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+    """
+    sys.stderr.write(formatting.error(msg, pretty=_is_pretty(args, pretty)) + "\n")
+
+
+def warn(msg: str, *, args: Any | None = None, pretty: bool | None = None) -> None:
+    """Print warning message to stderr (suppressed in quiet mode).
+
+    Args:
+        msg: Warning message to display
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+    """
+    # Suppress non-essential noise when quiet is requested.
+    if getattr(args, "quiet", False):
+        return
+    sys.stderr.write(formatting.warn(msg, pretty=_is_pretty(args, pretty)) + "\n")
+
+
+def note(msg: str, *, args: Any | None = None, pretty: bool | None = None) -> None:
+    """Print informational note to stderr (suppressed in quiet mode).
+
+    Args:
+        msg: Note message to display
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+    """
+    if getattr(args, "quiet", False):
+        return
+    sys.stderr.write(formatting.note(msg, pretty=_is_pretty(args, pretty)) + "\n")
+
+
+def banner(case: Any, *, args: Any | None = None, pretty: bool | None = None) -> str:
+    """Format test case banner string.
+
+    Args:
+        case: Test case to format banner for
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+
+    Returns:
+        Formatted banner string
+    """
+    return formatting.case_banner(case, pretty=_is_pretty(args, pretty))
+
+
+def maybe_highlight_run(
+    line: str,
+    *,
+    args: Any | None = None,
+    pretty: bool | None = None,
+    to_file: bool = False,
+) -> str:
+    """Optionally highlight RUN lines in test output.
+
+    Args:
+        line: Line to potentially highlight
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+        to_file: If True, skip highlighting for file output
+
+    Returns:
+        Highlighted or plain line
+    """
+    if to_file:
+        return line
+    return formatting.highlight_run(line, pretty=_is_pretty(args, pretty))
+
+
+def print_json(
+    payload: Any, *, args: Any | None = None, quiet: bool | None = None
+) -> None:
+    """Print JSON to stdout (compact in quiet mode, pretty otherwise).
+
+    Args:
+        payload: Data to serialize as JSON
+        args: Parsed arguments with quiet flag (optional)
+        quiet: Override quiet mode (optional)
+    """
+    q = bool(getattr(args, "quiet", False)) if quiet is None else bool(quiet)
+    if q:
+        sys.stdout.write(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+        )
+    else:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def success(msg: str, *, args: Any | None = None, pretty: bool | None = None) -> None:
+    """Print success message to stderr (suppressed in quiet mode).
+
+    Args:
+        msg: Success message to display
+        args: Parsed arguments with pretty/quiet flags (optional)
+        pretty: Override pretty mode (optional)
+    """
+    if getattr(args, "quiet", False):
+        return
+    sys.stderr.write(formatting.success(msg, pretty=_is_pretty(args, pretty)) + "\n")
+
+
+def out(text: str) -> None:
+    """Writes a single line of primary output to stdout (adds newline)."""
+    sys.stdout.write(text + "\n")
+
+
+def write(text: str) -> None:
+    """Writes raw text to stdout without appending a newline."""
+    sys.stdout.write(text)

--- a/tools/utils/common/exit_codes.py
+++ b/tools/utils/common/exit_codes.py
@@ -1,0 +1,12 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Exit codes for lit tools."""
+
+SUCCESS = 0
+ERROR = 1
+NOT_FOUND = 2
+SETUP_ERROR = 3

--- a/tools/utils/common/extractors/__init__.py
+++ b/tools/utils/common/extractors/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Log extractors for IREE triage tools.
+
+This package provides extractor infrastructure for analyzing logs from various
+sources (CI, ctest, build logs) and extracting structured diagnostic information.
+"""
+
+from common.extractors.base import Extractor
+from common.extractors.bazel_error import BazelErrorExtractor
+from common.extractors.build_error import BuildErrorExtractor
+from common.extractors.cmake_error import CMakeErrorExtractor
+from common.extractors.codeql_error import CodeQLErrorExtractor
+from common.extractors.ctest_error import CTestErrorExtractor
+from common.extractors.infrastructure_flake import InfrastructureFlakeExtractor
+from common.extractors.mlir_compiler import MLIRCompilerExtractor
+from common.extractors.onnx_test import ONNXTestExtractor
+from common.extractors.precommit import PrecommitErrorExtractor
+from common.extractors.pytest_error import PytestErrorExtractor
+from common.extractors.sanitizer import SanitizerExtractor
+
+__all__ = [
+    "Extractor",
+    "BazelErrorExtractor",
+    "BuildErrorExtractor",
+    "CMakeErrorExtractor",
+    "CodeQLErrorExtractor",
+    "CTestErrorExtractor",
+    "InfrastructureFlakeExtractor",
+    "MLIRCompilerExtractor",
+    "ONNXTestExtractor",
+    "PrecommitErrorExtractor",
+    "PytestErrorExtractor",
+    "SanitizerExtractor",
+]

--- a/tools/utils/common/extractors/base.py
+++ b/tools/utils/common/extractors/base.py
@@ -1,0 +1,92 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Base extractor class and utilities for log analysis.
+
+This module defines the Extractor abstract base class that all log extractors
+must implement. Extractors use a single-phase approach:
+
+- **extract()** - Pattern matching and issue extraction. Returns empty list when nothing found.
+
+Example extractor implementation:
+    class SanitizerExtractor(Extractor):
+        name = "sanitizer"
+
+        def extract(self, log_buffer: LogBuffer) -> List[Issue]:
+            issues = []
+
+            # Find all TSAN warnings.
+            for line_num, match in log_buffer.find_all_matches(
+                r"WARNING: ThreadSanitizer: (.+)"
+            ):
+                # Extract detailed context, stack traces, etc.
+                issue = SanitizerIssue(
+                    severity=Severity.CRITICAL,
+                    actionable=True,
+                    message=match.group(1),
+                    sanitizer_type="TSAN",
+                    line_number=line_num,
+                    source_extractor="sanitizer",
+                )
+                issues.append(issue)
+
+            return issues  # Returns empty list if no sanitizer errors found.
+"""
+
+from abc import ABC, abstractmethod
+
+from common.issues import Issue
+from common.log_buffer import LogBuffer
+
+
+class Extractor(ABC):
+    """Abstract base class for all log extractors.
+
+    Each extractor implements pattern matching and diagnostic extraction for
+    a specific type of log failure (sanitizers, LIT tests, build errors, etc.).
+
+    Extractors use a two-level filtering architecture:
+    1. **Log-level prefilter**: TriageEngine checks activation_keywords to
+       determine if this extractor should run on a given log.
+    2. **Line-level extraction**: extract() performs pattern matching on
+       relevant logs only.
+
+    This approach avoids O(N×M) scaling where all M extractors scan all N
+    lines. Instead, only relevant extractors run on each log.
+
+    Subclasses must define:
+        - name: Unique identifier for the extractor
+        - activation_keywords: List of strings that indicate this extractor
+          should run (e.g., ["pre-commit run"]). Empty list means always run.
+        - extract(): Pattern matching and issue extraction
+    """
+
+    name: str = "unknown"  # Subclasses must override.
+    activation_keywords: list[str] = []  # Subclasses override for log-level filtering.
+
+    @abstractmethod
+    def extract(self, log_buffer: LogBuffer) -> list[Issue]:
+        """Extract diagnostic issues from log.
+
+        Performs pattern matching, context traversal, and diagnostic extraction.
+        Returns empty list when no relevant errors are found.
+
+        Args:
+            log_buffer: Log content to analyze.
+
+        Returns:
+            List of Issue objects found in the log. Empty list if nothing found.
+
+        Example:
+            def extract(self, log_buffer: LogBuffer) -> List[Issue]:
+                issues = []
+                for line_num, match in log_buffer.find_all_matches(pattern):
+                    # Parse context, extract diagnostics.
+                    issue = SanitizerIssue(...)
+                    issues.append(issue)
+                return issues  # Empty list if no matches.
+        """
+        pass

--- a/tools/utils/common/extractors/bazel_error.py
+++ b/tools/utils/common/extractors/bazel_error.py
@@ -1,0 +1,256 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Bazel build system error extractor.
+
+Extracts Bazel-specific build failures including missing targets and build
+summary errors. Uses two-phase detection to avoid false positives.
+
+Note: Compiler errors from Bazel builds (GCC/Clang format) are handled by
+BuildErrorExtractor. This extractor only handles Bazel-specific errors.
+
+Two-phase detection:
+1. Find "ERROR: Build did NOT complete successfully" marker
+2. Search backward for specific Bazel error patterns
+
+Example usage:
+    from common.extractors.bazel_error import BazelErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = BazelErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"Bazel error: {issue.error_type} in {issue.target}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import BazelErrorIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class BazelErrorExtractor(Extractor):
+    """Extracts Bazel build system errors from logs.
+
+    Only reports Bazel-specific errors when build definitively fails
+    (indicated by "ERROR: Build did NOT complete successfully"). This
+    prevents false positives from informational messages.
+    """
+
+    name = "bazel_error"
+    activation_keywords = [
+        "--bazelrc=",
+        "--noworkspace_rc",
+    ]  # Only run on Bazel logs.
+
+    # Failure markers - Bazel build or test failed.
+    # Handles ANSI escape codes: [31m[1mERROR: [0mBuild did NOT complete successfully
+    _BUILD_FAILED_RE = re.compile(
+        r"(?:\x1b\[\d+m|\s)*ERROR:(?:\x1b\[\d+m|\s)+Build did NOT complete successfully"
+    )
+
+    # Test failure patterns (can occur after successful build).
+    _TEST_NO_TARGETS_RE = re.compile(
+        r"(?:\x1b\[\d+m|\s)*ERROR:(?:\x1b\[\d+m|\s)+No test targets were found"
+    )
+
+    # Package evaluation errors (occur before build).
+    _PACKAGE_ERROR_RE = re.compile(
+        r"(?:\x1b\[\d+m|\s)*ERROR:(?:\x1b\[\d+m|\s)+package contains errors:\s+(?P<package>[^\s]+)"
+    )
+
+    # General evaluation errors.
+    _EVAL_ERROR_RE = re.compile(
+        r"(?:\x1b\[\d+m|\s)*ERROR:(?:\x1b\[\d+m|\s)+Error evaluating"
+    )
+
+    # Missing target error pattern.
+    # Example: "ERROR: /path/to/BUILD.bazel: no such target '@@workspace//package:target':"
+    # Example: "ERROR: /path/to/BUILD.bazel:123:45: no such target '@@workspace//package:target':"
+    # Handles ANSI escape codes: [31m[1mERROR: [0m/path/to/BUILD.bazel: no such target...
+    _MISSING_TARGET_RE = re.compile(
+        r"(?:\x1b\[\d+m|\s)*ERROR:(?:\x1b\[\d+m|\s)+(?P<file>[^:]+?)(?::(?P<line>\d+))?(?::(?P<col>\d+))?:\s+"
+        r"no such target\s+'(?P<target_full>@@?(?P<workspace>[^/]+)//(?P<package>[^:]+):(?P<target>[^']+))'",
+        re.IGNORECASE,
+    )
+
+    # Failed target summary line.
+    # Example: "//compiler/bindings/c:loader_test                               FAILED TO BUILD"
+    _FAILED_TARGET_SUMMARY_RE = re.compile(r"^(?P<target>//[^\s]+)\s+FAILED TO BUILD")
+
+    def extract(self, log_buffer: LogBuffer) -> list[BazelErrorIssue]:
+        """Extract Bazel build and test errors from log.
+
+        Uses multi-phase detection:
+        1. Check if Bazel build/test failed (multiple failure patterns)
+        2a. If failed, search backward for missing target errors
+        2b. Search forward for failed target summaries
+        3. Check for test-specific failures (no targets, package errors)
+
+        Args:
+            log_buffer: LogBuffer with build log content.
+
+        Returns:
+            List of BazelErrorIssue objects (empty if build/test succeeded).
+        """
+        issues = []
+
+        # Phase 1: Find any failure marker.
+        failure_info = self._find_any_failure(log_buffer)
+        if failure_info is None:
+            # Build and tests succeeded - no errors to report.
+            return []
+
+        failure_line_idx, failure_type = failure_info
+
+        # Phase 2a: Search backward from failure marker for missing target errors.
+        lines = log_buffer.get_lines()
+        seen_targets = set()  # Deduplicate by target name.
+
+        for line_idx in range(failure_line_idx, -1, -1):
+            line = lines[line_idx]
+
+            # Check for missing target error.
+            match = self._MISSING_TARGET_RE.search(line)
+            if match:
+                target_full = match.group("target_full")
+                if target_full not in seen_targets:
+                    seen_targets.add(target_full)
+                    issue = self._extract_missing_target(log_buffer, line_idx, match)
+                    issues.append(issue)
+
+        # Phase 2b: Search forward from failure marker for failed target summaries.
+        failed_targets = []
+        for line_idx in range(
+            failure_line_idx + 1, min(failure_line_idx + 50, len(lines))
+        ):
+            line = lines[line_idx]
+
+            # Check for failed target summary line.
+            match = self._FAILED_TARGET_SUMMARY_RE.match(line)
+            if match:
+                target = match.group("target")
+                failed_targets.append(target)
+
+        # If we found no specific errors, create a generic failure summary.
+        if not issues:
+            # Determine message and error type based on failure_type.
+            if failure_type == "test_no_targets":
+                message = "Bazel test failed: No test targets were found"
+                error_type = "test_no_targets"
+            elif failure_type == "package_error":
+                message = "Bazel package evaluation failed"
+                error_type = "package_error"
+            elif failure_type == "eval_error":
+                message = "Bazel evaluation failed"
+                error_type = "eval_error"
+            elif failed_targets:
+                # We have failed target summaries.
+                message = f"Bazel build failed: {len(failed_targets)} target(s)"
+                error_type = "build_failed"
+            else:
+                # Generic failure (no details available).
+                message = "Bazel build failed"
+                error_type = "build_failed"
+
+            issues.append(
+                BazelErrorIssue(
+                    severity=Severity.CRITICAL,
+                    actionable=True,
+                    message=message,
+                    line_number=failure_line_idx,
+                    error_type=error_type,
+                    failed_targets=failed_targets,
+                    context_lines=log_buffer.get_context(
+                        failure_line_idx, before=20, after=5
+                    ),
+                )
+            )
+
+        # Reverse to maintain chronological order (we searched backward).
+        issues.reverse()
+        return issues
+
+    def _find_any_failure(self, log_buffer: LogBuffer) -> tuple[int, str] | None:
+        """Find any Bazel failure marker (build or test).
+
+        Checks for multiple failure patterns in priority order:
+        1. Build did NOT complete successfully (definitive build failure)
+        2. No test targets were found (test failure)
+        3. Package contains errors (package evaluation failure)
+        4. Error evaluating (general evaluation failure)
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            Tuple of (line_index, failure_type) or None if no failures found.
+        """
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            if self._BUILD_FAILED_RE.search(line):
+                return (line_idx, "build_failed")
+            if self._TEST_NO_TARGETS_RE.search(line):
+                return (line_idx, "test_no_targets")
+            if self._PACKAGE_ERROR_RE.search(line):
+                return (line_idx, "package_error")
+            if self._EVAL_ERROR_RE.search(line):
+                return (line_idx, "eval_error")
+        return None
+
+    def _extract_missing_target(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> BazelErrorIssue:
+        """Extract missing target error.
+
+        Error format:
+            ERROR: /path/to/BUILD.bazel:123:45: no such target '@@workspace//package:target':
+              target 'TargetName' not declared in package 'package'
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with file, line, workspace, package, target groups.
+
+        Returns:
+            BazelErrorIssue instance.
+        """
+        bazel_file = match.group("file")
+        bazel_line = int(match.group("line")) if match.group("line") else 0
+        workspace = match.group("workspace")
+        package = match.group("package")
+        target = match.group("target")
+        target_full = match.group("target_full")
+
+        # Extract additional error context from next few lines.
+        error_details = []
+        lines = log_buffer.get_lines()
+        for i in range(line_idx + 1, min(line_idx + 6, len(lines))):
+            line = lines[i].strip()
+            if line.startswith("target") or line.startswith("and referenced by"):
+                error_details.append(line)
+            elif not line or line.startswith("ERROR:"):
+                # End of this error's context.
+                break
+
+        error_context = " ".join(error_details) if error_details else ""
+
+        return BazelErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"Missing Bazel target: {target_full}"
+            + (f" ({error_context})" if error_context else ""),
+            line_number=line_idx,
+            error_type="missing_target",
+            bazel_file=bazel_file,
+            bazel_line=bazel_line,
+            workspace=workspace,
+            package=package,
+            target=target,
+            context_lines=log_buffer.get_context(line_idx, before=2, after=10),
+        )

--- a/tools/utils/common/extractors/build_error.py
+++ b/tools/utils/common/extractors/build_error.py
@@ -1,0 +1,413 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+r"""Build error extractor (C/C++ compilation and linker errors).
+
+Extracts C/C++ compilation errors, linker errors, and undefined references
+from build logs. Handles GCC, Clang, and MSVC compiler output formats.
+
+Uses failure-first approach:
+1. Find "FAILED:" markers from build system (ninja/make)
+2. Extract compiler errors from context around failure
+3. Also catch linker errors (undefined reference, multiple definition)
+
+PERFORMANCE CRITICAL - BANNED TECHNIQUES:
+  ❌ DO NOT use complex regex patterns with negative character classes like:
+     r"(?P<file>[^\\s:]+):(?P<line>\\d+):(?P<col>\\d+):\\s+error:\\s+(?P<msg>.+)"
+     These cause catastrophic backtracking on non-matching lines (20x slower).
+
+  ✅ INSTEAD use fast substring checks + simple string parsing:
+     if ": error:" in line:
+         parts = line.split(": error:", 1)
+         location = parts[0].rsplit(":", 2)  # Simple, no backtracking.
+
+  This extractor processes thousands of lines per log. Every line gets checked.
+  Fast substring checks (O(n)) + simple parsing >>> regex backtracking (O(n²)).
+
+Example usage:
+    from common.extractors.build_error import BuildErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = BuildErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"{issue.file_path}:{issue.line}: {issue.compiler_message}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import BuildErrorIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class BuildErrorExtractor(Extractor):
+    """Extracts C/C++ build errors from logs.
+
+    Supports GCC, Clang, and MSVC compiler error formats.
+    Only reports errors, not warnings or build progress.
+    """
+
+    name = "build_error"
+    activation_keywords = [
+        # Build errors only happen during compilation - use precise build output markers.
+        "ninja:",  # Ninja build tool output (e.g., "ninja: build stopped").
+        "make[",  # Make recursion (e.g., "make[1]: Entering directory").
+        "FAILED:",  # Build target failure (capital F, with colon).
+        "clang++",  # C++ compiler invocation.
+        "g++",  # GCC C++ compiler.
+        "/usr/bin/c++",  # Compiler path.
+        "CMakeFiles",  # CMake build artifacts (only in build output).
+        "[1/",  # Build progress marker (e.g., "[1/100] Building").
+        "Compiling CXX",  # CMake build action.
+    ]
+
+    # Build system failure marker.
+    # Example: "FAILED: compiler/src/CMakeFiles/iree_compiler.dir/main.cpp.o"
+    _FAILED_TARGET_RE = re.compile(r"^FAILED:\s+(?P<target>.+)$")
+
+    # Linker undefined reference pattern (GCC/Clang).
+    # Example: "undefined reference to `symbol_name'"
+    _UNDEFINED_REF_RE = re.compile(r"undefined reference to [`'](?P<symbol>[^'`]+)[`']")
+
+    # MSVC linker unresolved external pattern.
+    # Example: "error LNK2019: unresolved external symbol"
+    _MSVC_UNRESOLVED_RE = re.compile(
+        r"error LNK\d+:\s+unresolved external symbol\s+(?P<symbol>\S+)"
+    )
+
+    # Multiple definition error (linker).
+    # Example: "multiple definition of `symbol_name'"
+    _MULTIPLE_DEF_RE = re.compile(r"multiple definition of [`'](?P<symbol>[^'`]+)[`']")
+
+    # Build stopped marker.
+    _BUILD_STOPPED_RE = re.compile(
+        r"ninja: build stopped|make.*Error \d+", re.IGNORECASE
+    )
+
+    def extract(self, log_buffer: LogBuffer) -> list[BuildErrorIssue]:
+        """Extract build errors from log.
+
+        Args:
+            log_buffer: LogBuffer with build log content.
+
+        Returns:
+            List of BuildErrorIssue objects.
+        """
+        issues = []
+
+        # Scan for errors.
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            # Check for build system failure marker.
+            match = self._FAILED_TARGET_RE.match(line)
+            if match:
+                # Extract compiler error from context (next 20 lines).
+                error_issue = self._extract_from_failed_target(
+                    log_buffer, line_idx, match
+                )
+                if error_issue:
+                    issues.append(error_issue)
+                continue
+
+            # Check for GCC/Clang compile errors (fast string check, then parse).
+            # Format: "file.cpp:123:45: error: message"
+            if ": error:" in line:
+                error_issue = self._try_parse_gcc_error(log_buffer, line_idx, line)
+                if error_issue:
+                    issues.append(error_issue)
+                    continue
+
+            # Check for MSVC compile errors (fast string check, then parse).
+            # Format: "file.cpp(123): error C2065: message" or "file.cpp(123,45): error ..."
+            if ") : error " in line or "): error " in line:
+                error_issue = self._try_parse_msvc_error(log_buffer, line_idx, line)
+                if error_issue:
+                    issues.append(error_issue)
+                    continue
+
+            # Check for linker errors (undefined reference).
+            match = self._UNDEFINED_REF_RE.search(line)
+            if match:
+                issues.append(self._extract_undefined_ref(log_buffer, line_idx, match))
+                continue
+
+            # Check for MSVC linker unresolved external.
+            match = self._MSVC_UNRESOLVED_RE.search(line)
+            if match:
+                issues.append(
+                    self._extract_msvc_unresolved(log_buffer, line_idx, match)
+                )
+                continue
+
+            # Check for multiple definition errors.
+            match = self._MULTIPLE_DEF_RE.search(line)
+            if match:
+                issues.append(self._extract_multiple_def(log_buffer, line_idx, match))
+                continue
+
+        return issues
+
+    def _extract_from_failed_target(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> BuildErrorIssue | None:
+        """Extract compiler error from FAILED target context.
+
+        Searches next 20 lines for compiler error (GCC/Clang/MSVC format).
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of FAILED marker.
+            match: Regex match with target group.
+
+        Returns:
+            BuildErrorIssue if found, None otherwise.
+        """
+        target = match.group("target")
+        lines = log_buffer.get_lines()
+
+        # Search next 20 lines for compiler error.
+        for i in range(line_idx + 1, min(line_idx + 21, len(lines))):
+            # Try GCC/Clang format.
+            if ": error:" in lines[i]:
+                gcc_error = self._try_parse_gcc_error(log_buffer, i, lines[i])
+                if gcc_error:
+                    return gcc_error
+
+            # Try MSVC format.
+            if ") : error " in lines[i] or "): error " in lines[i]:
+                msvc_error = self._try_parse_msvc_error(log_buffer, i, lines[i])
+                if msvc_error:
+                    return msvc_error
+
+        # No specific error found - return generic failure.
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"Build failed: {target}",
+            line_number=line_idx,
+            error_type="build_failure",
+            file_path=target,
+            line=0,
+            column=0,
+            compiler_message=f"Build target failed: {target}",
+            context_lines=log_buffer.get_context(line_idx, before=2, after=10),
+        )
+
+    def _try_parse_gcc_error(
+        self, log_buffer: LogBuffer, line_idx: int, line: str
+    ) -> BuildErrorIssue | None:
+        """Parse GCC/Clang compilation error using string operations.
+
+        Format: "file.cpp:123:45: error: message"
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            line: Line content.
+
+        Returns:
+            BuildErrorIssue if valid format, None otherwise.
+        """
+        # Split on ": error:" to separate location from message.
+        parts = line.split(": error:", 1)
+        if len(parts) != 2:
+            return None
+
+        location_str = parts[0]
+        message = parts[1].strip()
+
+        # Parse location: "file.cpp:123:45" -> ["file.cpp", "123", "45"]
+        # Use rsplit to get last 2 colons (line:col), rest is file path.
+        location_parts = location_str.rsplit(":", 2)
+        if len(location_parts) != 3:
+            return None
+
+        file_path = location_parts[0]
+        line_str = location_parts[1]
+        col_str = location_parts[2]
+
+        # Validate line and column are digits.
+        if not line_str.isdigit() or not col_str.isdigit():
+            return None
+
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=message,
+            line_number=line_idx,
+            error_type="compile",
+            file_path=file_path,
+            line=int(line_str),
+            column=int(col_str),
+            compiler_message=message,
+            compiler="gcc/clang",
+            context_lines=log_buffer.get_context(line_idx, before=3, after=5),
+        )
+
+    def _try_parse_msvc_error(
+        self, log_buffer: LogBuffer, line_idx: int, line: str
+    ) -> BuildErrorIssue | None:
+        """Parse MSVC compilation error using string operations.
+
+        Format: "file.cpp(123): error C2065: message"
+        Format: "file.cpp(123,45): error C2065: message"
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            line: Line content.
+
+        Returns:
+            BuildErrorIssue if valid format, None otherwise.
+        """
+        # Split on " error " or ": error " to separate location from error.
+        if "): error " in line:
+            parts = line.split("): error ", 1)
+        elif ") : error " in line:
+            parts = line.split(") : error ", 1)
+        else:
+            return None
+
+        if len(parts) != 2:
+            return None
+
+        location_str = parts[0]  # "file.cpp(123,45" or "file.cpp(123"
+        error_str = parts[1]  # "C2065: message"
+
+        # Parse location: split on "(" to get file and line/col.
+        if "(" not in location_str:
+            return None
+
+        file_path, line_col_str = location_str.rsplit("(", 1)
+
+        # Parse line and optional column.
+        if "," in line_col_str:
+            # Format: "123,45"
+            line_str, col_str = line_col_str.split(",", 1)
+            if not line_str.isdigit() or not col_str.isdigit():
+                return None
+            line_num = int(line_str)
+            col_num = int(col_str)
+        else:
+            # Format: "123"
+            if not line_col_str.isdigit():
+                return None
+            line_num = int(line_col_str)
+            col_num = 0
+
+        # Extract error code if present (e.g., "C2065: message").
+        error_code = ""
+        message = error_str.strip()
+        if message.startswith("C") and ":" in message:
+            code_parts = message.split(":", 1)
+            if code_parts[0][1:].isdigit():  # "C2065" -> "2065" is digits
+                error_code = code_parts[0]
+                message = code_parts[1].strip()
+
+        full_message = f"{error_code}: {message}" if error_code else message
+
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=full_message,
+            line_number=line_idx,
+            error_type="compile",
+            file_path=file_path,
+            line=line_num,
+            column=col_num,
+            compiler_message=message,
+            compiler="msvc",
+            context_lines=log_buffer.get_context(line_idx, before=3, after=5),
+        )
+
+    def _extract_undefined_ref(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> BuildErrorIssue:
+        """Extract undefined reference linker error.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with symbol group.
+
+        Returns:
+            BuildErrorIssue instance.
+        """
+        symbol = match.group("symbol")
+
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"Undefined reference to '{symbol}'",
+            line_number=line_idx,
+            error_type="undefined_reference",
+            file_path="",  # Linker errors don't have specific file.
+            line=0,
+            column=0,
+            compiler_message=f"undefined reference to `{symbol}'",
+            compiler="ld",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=3),
+        )
+
+    def _extract_msvc_unresolved(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> BuildErrorIssue:
+        """Extract MSVC unresolved external symbol linker error.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with symbol group.
+
+        Returns:
+            BuildErrorIssue instance.
+        """
+        symbol = match.group("symbol")
+
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"Unresolved external symbol '{symbol}'",
+            line_number=line_idx,
+            error_type="undefined_reference",
+            file_path="",
+            line=0,
+            column=0,
+            compiler_message=f"unresolved external symbol {symbol}",
+            compiler="link.exe",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=3),
+        )
+
+    def _extract_multiple_def(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> BuildErrorIssue:
+        """Extract multiple definition linker error.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with symbol group.
+
+        Returns:
+            BuildErrorIssue instance.
+        """
+        symbol = match.group("symbol")
+
+        return BuildErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"Multiple definition of '{symbol}'",
+            line_number=line_idx,
+            error_type="multiple_definition",
+            file_path="",
+            line=0,
+            column=0,
+            compiler_message=f"multiple definition of `{symbol}'",
+            compiler="ld",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )

--- a/tools/utils/common/extractors/cmake_error.py
+++ b/tools/utils/common/extractors/cmake_error.py
@@ -1,0 +1,219 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CMake configuration error extractor.
+
+Extracts CMake configuration failures from build logs. Uses two-phase detection:
+1. Find definitive failure marker: "-- Configuring incomplete, errors occurred!"
+2. Search backward for "CMake Error at" lines to collect all errors
+
+This approach prevents false positives from informational messages like:
+- "Could NOT find Python module pygments" (optional dependency search)
+- "-- Looking for pthread.h - not found" (feature probes)
+
+Example usage:
+    from common.extractors.cmake_error import CMakeErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = CMakeErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"CMake error at {issue.file_path}:{issue.line}: {issue.message}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import CMakeErrorIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class CMakeErrorExtractor(Extractor):
+    """Extracts CMake configuration errors from logs.
+
+    Only reports errors when CMake configuration definitively fails (indicated
+    by "-- Configuring incomplete, errors occurred!" marker). Ignores
+    informational messages about optional dependencies.
+    """
+
+    name = "cmake_error"
+    activation_keywords = ["cmake", "CMake"]  # Only run on CMake configure logs.
+
+    # Definitive failure marker - CMake configuration failed.
+    _CONFIGURE_INCOMPLETE_RE = re.compile(
+        r"--\s+Configuring incomplete, errors occurred!"
+    )
+
+    # CMake error pattern with file location.
+    # Example: "CMake Error at compiler/CMakeLists.txt:123 (find_package):"
+    _CMAKE_ERROR_RE = re.compile(
+        r"CMake Error at (?P<file>[^:]+):(?P<line>\d+)\s+\((?P<function>[^)]+)\):"
+    )
+
+    # CMake fatal error pattern (no file location).
+    # Example: "CMake Error: Could not find cmake module file: ..."
+    _CMAKE_FATAL_RE = re.compile(r"CMake Error:\s+(?P<msg>.+)")
+
+    # Patterns to IGNORE (false positives).
+    _IGNORE_PATTERNS = [
+        re.compile(r"Could NOT find", re.IGNORECASE),  # Optional dependency search.
+        re.compile(r"--\s+Looking for .+ - not found"),  # Feature probe.
+        re.compile(r"--\s+.+\s+disabled"),  # Optional feature disabled.
+    ]
+
+    def extract(self, log_buffer: LogBuffer) -> list[CMakeErrorIssue]:
+        """Extract CMake configuration errors from log.
+
+        Uses two-phase detection:
+        1. Check if configuration failed (look for "Configuring incomplete")
+        2. If failed, search backward for all "CMake Error" lines
+
+        Args:
+            log_buffer: LogBuffer with build log content.
+
+        Returns:
+            List of CMakeErrorIssue objects (empty if configuration succeeded).
+        """
+        issues = []
+
+        # Phase 1: Find definitive failure marker.
+        failure_line_idx = self._find_configuration_failure(log_buffer)
+        if failure_line_idx is None:
+            # Configuration succeeded - no errors to report.
+            return []
+
+        # Phase 2: Search backward from failure marker for all CMake errors.
+        lines = log_buffer.get_lines()
+        for line_idx in range(failure_line_idx, -1, -1):
+            line = lines[line_idx]
+
+            # Skip false positives.
+            if self._should_ignore_line(line):
+                continue
+
+            # Check for CMake Error with file location.
+            match = self._CMAKE_ERROR_RE.search(line)
+            if match:
+                issue = self._extract_cmake_error(log_buffer, line_idx, match)
+                issues.append(issue)
+                continue
+
+            # Check for CMake Fatal Error (no file location).
+            match = self._CMAKE_FATAL_RE.search(line)
+            if match:
+                issue = self._extract_cmake_fatal(log_buffer, line_idx, match)
+                issues.append(issue)
+
+        # Reverse to maintain chronological order (we searched backward).
+        issues.reverse()
+        return issues
+
+    def _find_configuration_failure(self, log_buffer: LogBuffer) -> int | None:
+        """Find the "Configuring incomplete, errors occurred!" marker.
+
+        This is the definitive indicator that CMake configuration failed.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            Line index of failure marker, or None if configuration succeeded.
+        """
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            if self._CONFIGURE_INCOMPLETE_RE.search(line):
+                return line_idx
+        return None
+
+    def _should_ignore_line(self, line: str) -> bool:
+        """Check if line should be ignored (false positive).
+
+        Args:
+            line: Log line to check.
+
+        Returns:
+            True if line should be ignored.
+        """
+        return any(pattern.search(line) for pattern in self._IGNORE_PATTERNS)
+
+    def _extract_cmake_error(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> CMakeErrorIssue:
+        """Extract CMake error with file location.
+
+        Error format:
+            CMake Error at <file>:<line> (<function>):
+              <indented error message>
+              <more error lines>
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with file, line, function groups.
+
+        Returns:
+            CMakeErrorIssue instance.
+        """
+        file_path = match.group("file")
+        line = int(match.group("line"))
+        function = match.group("function")
+
+        # Extract indented error message (next 1-10 lines that are indented).
+        error_message_lines = []
+        lines = log_buffer.get_lines()
+        for i in range(line_idx + 1, min(line_idx + 11, len(lines))):
+            if lines[i].startswith("  ") or lines[i].startswith("\t"):
+                error_message_lines.append(lines[i].strip())
+            elif lines[i].strip() == "":
+                # Blank line continues message.
+                continue
+            else:
+                # Non-indented line - end of error message.
+                break
+
+        error_message = " ".join(error_message_lines) if error_message_lines else ""
+
+        return CMakeErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"CMake error in {function}: {error_message}"
+            if error_message
+            else f"CMake error in {function}",
+            line_number=line_idx,
+            error_type="configuration",
+            cmake_file=file_path,
+            cmake_line=line,
+            cmake_command=function,
+            context_lines=log_buffer.get_context(line_idx, before=2, after=10),
+        )
+
+    def _extract_cmake_fatal(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> CMakeErrorIssue:
+        """Extract CMake fatal error (no file location).
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+            match: Regex match with msg group.
+
+        Returns:
+            CMakeErrorIssue instance.
+        """
+        error_message = match.group("msg").strip()
+
+        return CMakeErrorIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message=f"CMake fatal error: {error_message}",
+            line_number=line_idx,
+            error_type="fatal",
+            cmake_file="",
+            cmake_line=0,
+            cmake_command=None,
+            context_lines=log_buffer.get_context(line_idx, before=5, after=10),
+        )

--- a/tools/utils/common/extractors/codeql_error.py
+++ b/tools/utils/common/extractors/codeql_error.py
@@ -1,0 +1,202 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CodeQL code scanning failure extractor.
+
+Extracts failures from CodeQL/code scanning analysis, including language
+detection failures, analysis upload failures, and fatal errors.
+
+Pattern examples:
+    CodeQL detected code written in JavaScript/TypeScript, but not any written in Python.
+    ##[error]Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/..."
+    Analysis upload status is failed.
+    CodeQL job status was configuration error.
+
+Example usage:
+    from common.extractors.codeql_error import CodeQLErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = CodeQLErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"CodeQL error: {issue.message}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import CodeQLIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class CodeQLErrorExtractor(Extractor):
+    """Extracts CodeQL code scanning failures from logs.
+
+    CodeQL failures are typically infrastructure/configuration issues that
+    indicate analysis setup problems, not code bugs.
+    """
+
+    name = "codeql"
+    activation_keywords = ["codeql", "CodeQL"]  # Only run on CodeQL logs.
+
+    # CodeQL language detection failure.
+    # Pattern: "CodeQL detected code written in JavaScript/TypeScript, but not any written in Python."
+    _LANGUAGE_DETECTION_RE = re.compile(
+        r"CodeQL detected code written in (?P<found>\w+(?:/\w+)?), but not any written in (?P<expected>\w+)\."
+    )
+
+    # CodeQL fatal error in GitHub Actions.
+    # Pattern: "##[error]Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/...". Exit code was 32..."
+    _FATAL_ERROR_RE = re.compile(
+        r"##\[error\]Encountered a fatal error while running \"(?P<command>[^\"]+)\"\.\s+Exit code was (?P<exit_code>\d+)"
+    )
+
+    # Analysis upload status failure.
+    # Pattern: "Analysis upload status is failed."
+    _UPLOAD_FAILED_RE = re.compile(
+        r"Analysis upload status is (?P<status>failed|error)"
+    )
+
+    # CodeQL job status.
+    # Pattern: "CodeQL job status was configuration error."
+    _JOB_STATUS_RE = re.compile(
+        r"CodeQL job status was (?P<status>configuration error|fatal error|[\w\s]+)"
+    )
+
+    def extract(self, log_buffer: LogBuffer) -> list[CodeQLIssue]:
+        """Extract CodeQL failures from log.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            List of CodeQLIssue objects (infrastructure issues).
+        """
+        issues = []
+        lines = log_buffer.get_lines()
+
+        # Track seen errors to avoid duplicates.
+        seen_errors = set()
+
+        for line_idx, line in enumerate(lines):
+            # Check for fatal error first (most specific - has ##[error] marker).
+            # This must come before language detection because the ##[error] line
+            # may contain quoted language detection text.
+            match = self._FATAL_ERROR_RE.search(line)
+            if match:
+                command = match.group("command")
+                exit_code = match.group("exit_code")
+
+                # Extract command name for deduplication.
+                # Command format: "/path/to/codeql/codeql database finalize ..."
+                # We want "codeql" not the subcommand or path fragments.
+                command_parts = command.split()
+                if len(command_parts) > 0:
+                    # Get basename of first part (the executable).
+                    command_name = command_parts[0].split("/")[-1]
+                else:
+                    command_name = "unknown"
+                error_key = f"fatal_{command_name}_{exit_code}"
+                if error_key in seen_errors:
+                    continue
+                seen_errors.add(error_key)
+
+                issues.append(
+                    CodeQLIssue(
+                        severity=Severity.HIGH,
+                        actionable=False,  # Infrastructure issue.
+                        message=f"CodeQL fatal error: {command_name} exited with code {exit_code}",
+                        line_number=line_idx,
+                        error_category="fatal",
+                        command=command_name,
+                        exit_code=int(exit_code),
+                        context_lines=log_buffer.get_context(
+                            line_idx, before=5, after=3
+                        ),
+                    )
+                )
+                continue
+
+            # Check for upload failure.
+            match = self._UPLOAD_FAILED_RE.search(line)
+            if match:
+                status = match.group("status")
+
+                error_key = f"upload_{status}"
+                if error_key in seen_errors:
+                    continue
+                seen_errors.add(error_key)
+
+                issues.append(
+                    CodeQLIssue(
+                        severity=Severity.MEDIUM,
+                        actionable=False,  # Infrastructure issue.
+                        message=f"CodeQL analysis upload {status}",
+                        line_number=line_idx,
+                        error_category="upload",
+                        status=status,
+                        context_lines=log_buffer.get_context(
+                            line_idx, before=3, after=3
+                        ),
+                    )
+                )
+                continue
+
+            # Check for job status.
+            match = self._JOB_STATUS_RE.search(line)
+            if match:
+                status = match.group("status")
+
+                error_key = f"status_{status}"
+                if error_key in seen_errors:
+                    continue
+                seen_errors.add(error_key)
+
+                issues.append(
+                    CodeQLIssue(
+                        severity=Severity.LOW,
+                        actionable=False,  # Infrastructure issue.
+                        message=f"CodeQL job status: {status}",
+                        line_number=line_idx,
+                        error_category="status",
+                        status=status,
+                        context_lines=log_buffer.get_context(
+                            line_idx, before=2, after=2
+                        ),
+                    )
+                )
+                continue
+
+            # Check for language detection failure (least specific - matches quoted text).
+            # This comes last to avoid matching language text quoted in ##[error] lines.
+            match = self._LANGUAGE_DETECTION_RE.search(line)
+            if match:
+                found_lang = match.group("found")
+                expected_lang = match.group("expected")
+
+                error_key = f"lang_{expected_lang}_{found_lang}"
+                if error_key in seen_errors:
+                    continue
+                seen_errors.add(error_key)
+
+                issues.append(
+                    CodeQLIssue(
+                        severity=Severity.MEDIUM,
+                        actionable=False,  # Infrastructure/config issue.
+                        message=f"CodeQL language detection failure: expected {expected_lang}, found {found_lang}",
+                        line_number=line_idx,
+                        error_category="language",
+                        expected_language=expected_lang,
+                        found_language=found_lang,
+                        context_lines=log_buffer.get_context(
+                            line_idx, before=2, after=5
+                        ),
+                    )
+                )
+
+        return issues

--- a/tools/utils/common/extractors/ctest_error.py
+++ b/tools/utils/common/extractors/ctest_error.py
@@ -1,0 +1,269 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CTest test failure extractor.
+
+Extracts CTest test failures from CTest output logs using two-phase detection:
+1. Find definitive failure markers: "The following tests FAILED:" or "Errors while running CTest"
+2. Search backward for all "***Failed", "***Timeout", "***Exception" test result lines
+
+This approach ensures we only report failures when CTest actually failed, not when
+all tests passed successfully.
+
+Example usage:
+    from common.extractors.ctest_error import CTestErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = CTestErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"Test {issue.test_name} {issue.failure_reason}: {issue.message}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import CTestErrorIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class CTestErrorExtractor(Extractor):
+    """Extracts CTest test failures from logs.
+
+    Only reports test failures when CTest definitively failed (indicated by
+    "The following tests FAILED:" or "Errors while running CTest"). This prevents
+    false positives from successful test runs.
+    """
+
+    name = "ctest_error"
+    activation_keywords = ["ctest", "Test #"]  # Only run on CTest logs.
+
+    # Definitive failure markers - CTest failed.
+    _FAILED_TESTS_SUMMARY_RE = re.compile(r"The following tests? FAILED:")
+    _ERRORS_WHILE_RUNNING_RE = re.compile(r"Errors while running CTest")
+
+    # CTest test result pattern with failure indicator.
+    # Example: "123/456 Test #78: test_name ...***Failed    0.45 sec"
+    # Note the "***" before status - this distinguishes from "...Passed"
+    _TEST_FAILED_RE = re.compile(
+        r"(?P<current>\d+)/(?P<total>\d+)\s+Test\s+#(?P<num>\d+):\s+(?P<name>\S+)\s+"
+        r"\.+\*+(?P<status>Failed|Timeout|Exception)\s+(?P<time>[\d.]+)\s+sec"
+    )
+
+    # CTest summary line listing failed tests.
+    # Example: "  78 - test_name (Failed)"
+    _SUMMARY_TEST_RE = re.compile(
+        r"^\s+(?P<num>\d+)\s+-\s+(?P<name>.+?)\s+\((?P<status>Failed|Timeout|Exception)\)"
+    )
+
+    def extract(self, log_buffer: LogBuffer) -> list[CTestErrorIssue]:
+        """Extract CTest test failures from log.
+
+        Uses two-phase detection:
+        1. Check if CTest failed (look for failure summary markers)
+        2. If failed, search backward for all test failure lines
+
+        Args:
+            log_buffer: LogBuffer with CTest log content.
+
+        Returns:
+            List of CTestErrorIssue objects (empty if all tests passed).
+        """
+        issues = []
+
+        # Phase 1: Find definitive failure marker.
+        failure_line_idx = self._find_ctest_failure(log_buffer)
+        if failure_line_idx is None:
+            # All tests passed - no failures to report.
+            return []
+
+        # Phase 2: Search backward from failure marker for all test failures.
+        lines = log_buffer.get_lines()
+        seen_tests = set()  # Deduplicate by test number.
+
+        for line_idx in range(failure_line_idx, -1, -1):
+            line = lines[line_idx]
+
+            # Check for test result line with failure.
+            match = self._TEST_FAILED_RE.search(line)
+            if match:
+                test_num = int(match.group("num"))
+                if test_num not in seen_tests:
+                    seen_tests.add(test_num)
+                    issue = self._extract_test_failure(log_buffer, line_idx, match)
+                    issues.append(issue)
+                continue
+
+            # Also check summary lines (in case result line is missing).
+            match = self._SUMMARY_TEST_RE.match(line)
+            if match:
+                test_num = int(match.group("num"))
+                if test_num not in seen_tests:
+                    seen_tests.add(test_num)
+                    issue = self._extract_summary_failure(log_buffer, line_idx, match)
+                    issues.append(issue)
+
+        # Reverse to maintain chronological order (we searched backward).
+        issues.reverse()
+        return issues
+
+    def _find_ctest_failure(self, log_buffer: LogBuffer) -> int | None:
+        """Find CTest failure summary marker.
+
+        Looks for "The following tests FAILED:" or "Errors while running CTest".
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            Line index of failure marker, or None if all tests passed.
+        """
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            if self._FAILED_TESTS_SUMMARY_RE.search(line):
+                return line_idx
+            if self._ERRORS_WHILE_RUNNING_RE.search(line):
+                return line_idx
+        return None
+
+    def _extract_test_failure(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> CTestErrorIssue:
+        """Extract test failure from CTest result line.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of test result.
+            match: Regex match with test info.
+
+        Returns:
+            CTestErrorIssue instance.
+        """
+        status = match.group("status")
+        test_name = match.group("name")
+        test_num = int(match.group("num"))
+        elapsed_time = float(match.group("time"))
+
+        # Determine severity and actionability from status.
+        if status == "Timeout":
+            severity = Severity.MEDIUM  # Often infrastructure/resource issues.
+            actionable = False
+            reason = "timeout"
+        elif status == "Exception":
+            severity = Severity.HIGH  # Crashes, segfaults.
+            actionable = True
+            reason = "exception"
+        else:  # Failed
+            severity = Severity.HIGH  # Test assertion failures.
+            actionable = True
+            reason = "failed"
+
+        # Extract test output (search backward for test start).
+        test_output = self._extract_test_output(log_buffer, line_idx, test_num)
+
+        return CTestErrorIssue(
+            severity=severity,
+            actionable=actionable,
+            message=f"Test {test_name} {reason}",
+            line_number=line_idx,
+            test_name=test_name,
+            test_number=test_num,
+            failure_reason=reason,
+            elapsed_time=elapsed_time,
+            test_output_tail=test_output[-100:]
+            if test_output
+            else [],  # Last 100 lines.
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_summary_failure(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> CTestErrorIssue:
+        """Extract test failure from CTest summary line.
+
+        Used when test result line is missing but summary line exists.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of summary line.
+            match: Regex match with test info.
+
+        Returns:
+            CTestErrorIssue instance.
+        """
+        status = match.group("status")
+        test_name = match.group("name")
+        test_num = int(match.group("num"))
+
+        # Determine severity and actionability from status.
+        if status == "Timeout":
+            severity = Severity.MEDIUM
+            actionable = False
+            reason = "timeout"
+        elif status == "Exception":
+            severity = Severity.HIGH
+            actionable = True
+            reason = "exception"
+        else:  # Failed
+            severity = Severity.HIGH
+            actionable = True
+            reason = "failed"
+
+        # Try to find full test result line by searching backward.
+        test_output = self._extract_test_output(log_buffer, line_idx, test_num)
+
+        return CTestErrorIssue(
+            severity=severity,
+            actionable=actionable,
+            message=f"Test {test_name} {reason}",
+            line_number=line_idx,
+            test_name=test_name,
+            test_number=test_num,
+            failure_reason=reason,
+            elapsed_time=0.0,  # Not available from summary line.
+            test_output_tail=test_output[-100:] if test_output else [],
+            context_lines=log_buffer.get_context(line_idx, before=10, after=2),
+        )
+
+    def _extract_test_output(
+        self, log_buffer: LogBuffer, result_line_idx: int, test_num: int
+    ) -> list[str]:
+        """Extract test output by searching backward for test start.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            result_line_idx: Line index of test result.
+            test_num: Test number.
+
+        Returns:
+            List of output lines.
+        """
+        lines = log_buffer.get_lines()
+        output = []
+
+        # Search backward up to 1000 lines for test start marker.
+        # Look for "Test #N:" or "Start #N:" patterns.
+        test_start_re = re.compile(rf"(?:Test|Start)\s+#{test_num}:")
+
+        for i in range(result_line_idx - 1, max(0, result_line_idx - 1000), -1):
+            if test_start_re.search(lines[i]):
+                # Found test start - collect forward to result.
+                for j in range(i, result_line_idx):
+                    output.append(lines[j])
+                break
+
+            # Stop if we hit another test result (different test).
+            if self._TEST_FAILED_RE.search(lines[i]):
+                other_match = self._TEST_FAILED_RE.search(lines[i])
+                if other_match and int(other_match.group("num")) != test_num:
+                    break
+
+        # Fallback: if no start found, grab context.
+        if not output:
+            output = log_buffer.get_context(result_line_idx, before=50, after=0)
+
+        return output

--- a/tools/utils/common/extractors/infrastructure_flake.py
+++ b/tools/utils/common/extractors/infrastructure_flake.py
@@ -1,0 +1,624 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Infrastructure flake extractor (GPU, filesystem, permissions, etc).
+
+This extractor identifies infrastructure issues that are not code bugs.
+Most importantly, it detects the ROCm cleanup crash (rocclr_memobj) which causes
+false CI failures when tests pass but the driver crashes during teardown.
+
+To add a new flake: Add it to SUBSTRING_PATTERNS below, write a test, done!
+
+Example usage:
+    from common.extractors.infrastructure_flake import InfrastructureFlakeExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = InfrastructureFlakeExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        if issue.error_type == "cleanup_crash":
+            print(f"ROCm cleanup crash (test passed: {issue.test_passed_before_crash})")
+"""
+
+import re
+from typing import Any
+
+from common.extractors.base import Extractor
+from common.issues import GPUDriverIssue, Severity
+from common.log_buffer import LogBuffer
+
+# =============================================================================
+# Easy flake additions - just add a line here + write a test!
+# =============================================================================
+# Format: (substring, gpu_type, error_code, message, severity)
+SUBSTRING_PATTERNS = [
+    # Filesystem infrastructure flakes.
+    (
+        "Permission denied: '/shark-cache/data'",
+        "filesystem",
+        "SHARK_CACHE_PERMISSION",
+        "Permission denied on /shark-cache/data (infrastructure issue)",
+        Severity.HIGH,
+    ),
+    # Vulkan device initialization failures.
+    (
+        "physical device 0 invalid",  # From vulkan_driver.cc NOT_FOUND error.
+        "vulkan",
+        "VULKAN_DEVICE_INVALID",
+        "Vulkan physical device not found/invalid (infrastructure issue)",
+        Severity.HIGH,
+    ),
+    # Network/GitHub infrastructure flakes.
+    (
+        "##[error]fatal: unable to access 'https://",
+        "network",
+        "GIT_FETCH_ERROR",
+        "Git fetch failed (network/GitHub infrastructure issue)",
+        Severity.HIGH,
+    ),
+    (
+        "rate limit exceeded",
+        "network",
+        "RATE_LIMIT_EXCEEDED",
+        "API rate limit exceeded (infrastructure issue)",
+        Severity.HIGH,
+    ),
+    (
+        "Unable to download artifact",
+        "network",
+        "ARTIFACT_DOWNLOAD_FAILED",
+        "Artifact download failed (GitHub infrastructure issue)",
+        Severity.HIGH,
+    ),
+    (
+        "internal compiler error: Bus error",
+        "hardware",
+        "COMPILER_BUS_ERROR",
+        "Compiler crash with bus error (bad hardware/CI runner)",
+        Severity.HIGH,
+    ),
+    (
+        "git', 'lfs', 'pull",
+        "network",
+        "GIT_LFS_PULL_ERROR",
+        "Git LFS pull failed (network/GitHub LFS infrastructure issue)",
+        Severity.HIGH,
+    ),
+    # Add more simple patterns here!
+]
+
+
+class InfrastructureFlakeExtractor(Extractor):
+    """Extracts infrastructure flake errors from logs.
+
+    Handles GPU driver errors (CUDA, HIP/ROCm, Vulkan, Metal), filesystem
+    permissions, and other infrastructure issues. The most critical pattern
+    is the ROCm cleanup crash (rocclr_memobj + Aborted) which creates false
+    CI failures.
+    """
+
+    name = "infrastructure_flake"
+    activation_keywords = [
+        # GPU errors only happen during actual execution, not during builds.
+        # Use specific error patterns, not just API names (which appear in paths).
+        "CUDA error:",  # CUDA runtime error.
+        "HIP error:",  # HIP runtime error.
+        "hipError",  # HIP error code prefix.
+        "VK_ERROR_",  # Vulkan error code.
+        "HSA_STATUS_ERROR",  # HSA runtime error.
+        "rocclr",  # ROCm runtime (only in error messages, not paths).
+        "iree-run-module",  # Actual IREE execution tool.
+        "MTLCreate",  # Metal API calls (only during execution).
+        "vkQueueSubmit failed",  # Vulkan execution error.
+        "device lost",  # GPU device lost error.
+        # Filesystem/permission errors.
+        "PermissionError",  # Python permission errors.
+        "Permission denied",  # General permission errors.
+        # Network/GitHub infrastructure errors.
+        "fatal: unable to access",  # Git fetch failures.
+        "rate limit exceeded",  # GitHub API rate limits.
+        "Unable to download artifact",  # GitHub artifact download failures.
+        "internal compiler error",  # Compiler crashes (gcc/g++/clang).
+        "git', 'lfs'",  # Git LFS failures (network/GitHub LFS issues).
+    ]
+
+    # CUDA patterns.
+    _CUDA_ERROR_RE = re.compile(
+        r"CUDA error.*?:?\s*(?P<code>cuda\w+|CUDA_ERROR_\w+|device\s+lost)",
+        re.IGNORECASE,
+    )
+    _CUDA_OOM_RE = re.compile(r"CUDA out of memory", re.IGNORECASE)
+
+    # HIP/ROCm patterns.
+    _HIP_ERROR_RE = re.compile(r"hipError(?P<code>\w+)")
+    _HIP_FILE_NOT_FOUND_RE = re.compile(r"hipErrorFileNotFound")
+    _ROCM_ERROR_RE = re.compile(
+        r"ROCm error|HSA_STATUS_ERROR|hsa.*(?:error|failed)|amd.*smi.*error",
+        re.IGNORECASE,
+    )
+    # No regex needed - just substring checks for HSA queue destroy errors.
+    _ROCCLR_ERROR_RE = re.compile(r"rocclr/[^\s:]+:\d+.*error|rocclr.*failed")
+    _HIP_DEVICE_LOST_RE = re.compile(
+        r"HIP.*device.*lost|device.*lost.*HIP", re.IGNORECASE
+    )
+
+    # Vulkan patterns.
+    _VK_ERROR_RE = re.compile(r"VK_ERROR_(?P<code>\w+)")
+    _VK_INIT_FAILED_RE = re.compile(r"VK_ERROR_INITIALIZATION_FAILED")
+    _VK_GENERIC_ERROR_RE = re.compile(r"vulkan.*error|vkCreate.*failed", re.IGNORECASE)
+
+    # Metal patterns.
+    _METAL_ERROR_RE = re.compile(r"MTL.*Error|Metal.*error")
+
+    # Dispatch table: maps regex patterns to handler methods.
+    # Format: (regex, handler_method_name, needs_match_object)
+    _REGEX_HANDLERS = [
+        # CUDA patterns (most specific first).
+        (_CUDA_OOM_RE, "_extract_cuda_oom", False),
+        (_CUDA_ERROR_RE, "_extract_cuda_error", True),
+        # HIP/ROCm patterns (most specific first).
+        (_HIP_FILE_NOT_FOUND_RE, "_extract_hip_file_not_found", False),
+        (_HIP_DEVICE_LOST_RE, "_extract_hip_device_lost", False),
+        (_HIP_ERROR_RE, "_extract_hip_error", True),
+        (_ROCM_ERROR_RE, "_extract_rocm_error", False),
+        (_ROCCLR_ERROR_RE, "_extract_rocclr_error", False),
+        # Vulkan patterns (most specific first).
+        (_VK_INIT_FAILED_RE, "_extract_vk_init_failed", False),
+        (_VK_ERROR_RE, "_extract_vulkan_error", True),
+        (_VK_GENERIC_ERROR_RE, "_extract_vulkan_generic", False),
+        # Metal patterns.
+        (_METAL_ERROR_RE, "_extract_metal_error", False),
+    ]
+
+    # Known flaky CI runners (higher false positive rate).
+    _FLAKY_RUNNERS = {"shark10-ci", "amdgpu-ci"}
+
+    def extract(self, log_buffer: LogBuffer) -> list[GPUDriverIssue]:
+        """Extract GPU driver issues from log.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            List of GPUDriverIssue objects.
+        """
+        issues = []
+
+        # Check for ROCm cleanup crash (highest priority).
+        rocm_crash = self._check_rocm_cleanup_crash(log_buffer)
+        if rocm_crash:
+            issues.append(rocm_crash)
+
+        # Scan for all GPU driver errors.
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            # HSA queue destroy errors (compound condition, handle separately).
+            # Patterns: "error in hsa_queue_destroy:" or "hsa_queue_destroy threw an exception"
+            if "hsa_queue_destroy" in line.lower() and (
+                "error" in line.lower() or "threw an exception" in line.lower()
+            ):
+                issues.append(self._extract_hsa_queue_destroy(log_buffer, line_idx))
+                continue
+
+            # Check all regex patterns via dispatch table.
+            matched = False
+            for regex, handler_name, needs_match in self._REGEX_HANDLERS:
+                match = regex.search(line)
+                if match:
+                    handler = getattr(self, handler_name)
+                    if needs_match:
+                        issues.append(handler(log_buffer, line_idx, match))
+                    else:
+                        issues.append(handler(log_buffer, line_idx))
+                    matched = True
+                    break
+
+            if matched:
+                continue
+
+            # Check simple substring patterns.
+            issue = self._handle_substring_pattern(log_buffer, line_idx, line)
+            if issue:
+                issues.append(issue)
+
+        return issues
+
+    def extract_from_annotations(
+        self, annotations: list[dict[str, Any]], run_id: str, job_id: str
+    ) -> list[GPUDriverIssue]:
+        """Extract infrastructure flakes from GitHub job annotations.
+
+        Annotations contain error messages from GitHub Actions infrastructure,
+        such as runner crashes, disk full errors, and system failures.
+
+        Args:
+            annotations: List of annotation dictionaries from GitHub API
+            run_id: Run ID for context
+            job_id: Job ID for context
+
+        Returns:
+            List of GPUDriverIssue objects representing infrastructure failures
+        """
+        issues = []
+
+        # Infrastructure flake patterns in annotations.
+        patterns = [
+            ("No space left on device", "runner", "RUNNER_DISK_FULL", Severity.HIGH),
+            ("System.IO.IOException", "runner", "RUNNER_IO_ERROR", Severity.HIGH),
+            ("GitHub.Runner.Worker", "runner", "RUNNER_CRASH", Severity.HIGH),
+            (
+                "Unhandled exception",
+                "runner",
+                "RUNNER_UNHANDLED_EXCEPTION",
+                Severity.HIGH,
+            ),
+            ("The self-hosted runner", "runner", "RUNNER_LOST", Severity.HIGH),
+            (
+                "connection to the server was lost",
+                "runner",
+                "RUNNER_CONNECTION_LOST",
+                Severity.HIGH,
+            ),
+        ]
+
+        for annotation in annotations:
+            message = annotation.get("message", "")
+            title = annotation.get("title", "")
+            annotation_level = annotation.get("annotation_level", "")
+
+            # Only process error-level annotations.
+            if annotation_level != "failure":
+                continue
+
+            # Check for infrastructure flake patterns.
+            for pattern, gpu_type, error_code, severity in patterns:
+                if pattern in message or pattern in title:
+                    issues.append(
+                        GPUDriverIssue(
+                            severity=severity,
+                            actionable=False,  # Infrastructure issues not actionable.
+                            message=f"GitHub runner infrastructure failure: {pattern}",
+                            line_number=0,  # No line number for annotations.
+                            gpu_type=gpu_type,
+                            error_code=error_code,
+                            error_type="infrastructure",
+                            context_lines=[
+                                f"Annotation from run {run_id}, job {job_id}:",
+                                f"  Title: {title}",
+                                f"  Message: {message}",
+                                f"  Level: {annotation_level}",
+                            ],
+                        )
+                    )
+                    break  # Only match first pattern per annotation.
+
+        return issues
+
+    def _check_rocm_cleanup_crash(self, log_buffer: LogBuffer) -> GPUDriverIssue | None:
+        """Check for ROCm cleanup crash pattern.
+
+        This is CRITICAL: ROCm driver has a bug where it crashes during teardown
+        AFTER tests pass. This creates false CI failures. We must detect this
+        and mark as infrastructure (non-actionable).
+
+        Pattern:
+        1. Find rocclr_memobj.cpp pattern.
+        2. Check if followed by "Aborted" or "core dumped".
+        3. Check if test passed before crash.
+
+        Returns:
+            GPUDriverIssue if cleanup crash detected, None otherwise.
+        """
+        # Search for unique ROCm memobj error message.
+        rocclr_line_idx = None
+        for line_idx, line in enumerate(log_buffer.get_lines()):
+            if "Memobj map does not have ptr" in line:
+                rocclr_line_idx = line_idx
+                break
+
+        if rocclr_line_idx is None:
+            return None
+
+        # Check if followed by "Aborted" or "core dumped" within 10 lines.
+        lines = log_buffer.get_lines()
+        for i in range(
+            rocclr_line_idx, min(rocclr_line_idx + 10, log_buffer.line_count)
+        ):
+            if "Aborted" in lines[i] or "core dumped" in lines[i]:
+                # Found ROCm cleanup crash.
+
+                # Check if test passed before crash (look backward up to 200 lines).
+                test_passed = self._check_test_passed_before(
+                    log_buffer, rocclr_line_idx
+                )
+
+                return GPUDriverIssue(
+                    severity=Severity.HIGH if test_passed else Severity.CRITICAL,
+                    actionable=False,  # Infrastructure bug, not code bug!
+                    message="ROCm driver cleanup crash (known infrastructure issue)",
+                    line_number=rocclr_line_idx,
+                    gpu_type="hip",
+                    error_code="rocclr_memobj",
+                    error_type="cleanup_crash",
+                    test_passed_before_crash=test_passed,
+                    rocclr_file="rocclr_memobj.cpp",
+                    context_lines=log_buffer.get_context(
+                        rocclr_line_idx, before=10, after=10
+                    ),
+                )
+
+        return None
+
+    def _check_test_passed_before(
+        self, log_buffer: LogBuffer, crash_line_idx: int
+    ) -> bool | None:
+        """Check if test passed before crash (look backward)."""
+        lines = log_buffer.get_lines()
+        for i in range(crash_line_idx - 1, max(0, crash_line_idx - 200), -1):
+            line = lines[i]
+            if "PASSED" in line or "[       OK ]" in line:
+                return True
+            if "FAILED" in line or "[  FAILED  ]" in line:
+                return False
+        return None
+
+    def _handle_substring_pattern(
+        self, log_buffer: LogBuffer, line_idx: int, line: str
+    ) -> GPUDriverIssue | None:
+        """Handle simple substring pattern matching.
+
+        Checks line against SUBSTRING_PATTERNS and creates issue if matched.
+        Special case: COMPILER_BUS_ERROR requires system compiler verification.
+
+        Args:
+            log_buffer: LogBuffer with log content
+            line_idx: Current line index
+            line: Current line text
+
+        Returns:
+            GPUDriverIssue if pattern matched, None otherwise
+        """
+        for substring, gpu_type, error_code, message, severity in SUBSTRING_PATTERNS:
+            if substring not in line:
+                continue
+
+            # Special case: Compiler bus error requires context verification.
+            # Ensure it's /usr/bin/cc or /usr/bin/g++ (system compiler),
+            # not iree-compile (which might also say "internal compiler error").
+            if error_code == "COMPILER_BUS_ERROR":
+                # Check previous 10 lines for system compiler invocation.
+                context = log_buffer.get_context(line_idx, before=10, after=0)
+                has_system_compiler = any(
+                    "/usr/bin/cc" in ctx_line
+                    or "/usr/bin/g++" in ctx_line
+                    or "/usr/bin/c++" in ctx_line
+                    or "/usr/bin/clang" in ctx_line
+                    for ctx_line in context
+                )
+                if not has_system_compiler:
+                    continue  # Skip - might be iree-compile crash.
+
+            return GPUDriverIssue(
+                severity=severity,
+                actionable=False,  # All substring patterns are infrastructure.
+                message=message,
+                line_number=line_idx,
+                gpu_type=gpu_type,
+                error_code=error_code,
+                error_type="infrastructure",
+                context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+            )
+
+        return None
+
+    def _extract_cuda_error(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> GPUDriverIssue:
+        """Extract CUDA error."""
+        error_code = match.group("code")
+
+        # Determine if device lost (non-actionable) or other error.
+        is_device_lost = "lost" in error_code.lower()
+
+        return GPUDriverIssue(
+            severity=Severity.CRITICAL if not is_device_lost else Severity.HIGH,
+            actionable=not is_device_lost,  # Device lost is infrastructure.
+            message=f"CUDA error: {error_code}",
+            line_number=line_idx,
+            gpu_type="cuda",
+            error_code=error_code,
+            error_type="device_lost" if is_device_lost else "error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_hip_error(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> GPUDriverIssue:
+        """Extract HIP error."""
+        error_code = f"hipError{match.group('code')}"
+
+        # Common non-actionable errors.
+        is_infrastructure = error_code in [
+            "hipErrorDeviceLost",
+            "hipErrorOutOfMemory",
+        ]
+
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=not is_infrastructure,
+            message=f"HIP error: {error_code}",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code=error_code,
+            error_type="device_lost"
+            if "Lost" in error_code
+            else "oom"
+            if "Memory" in error_code
+            else "error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_vulkan_error(
+        self, log_buffer: LogBuffer, line_idx: int, match: re.Match
+    ) -> GPUDriverIssue:
+        """Extract Vulkan error."""
+        error_code = f"VK_ERROR_{match.group('code')}"
+
+        # Common non-actionable errors.
+        is_infrastructure = error_code in [
+            "VK_ERROR_DEVICE_LOST",
+            "VK_ERROR_OUT_OF_DEVICE_MEMORY",
+            "VK_ERROR_OUT_OF_HOST_MEMORY",
+        ]
+
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=not is_infrastructure,
+            message=f"Vulkan error: {error_code}",
+            line_number=line_idx,
+            gpu_type="vulkan",
+            error_code=error_code,
+            error_type="device_lost"
+            if "LOST" in error_code
+            else "oom"
+            if "MEMORY" in error_code
+            else "error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_cuda_oom(self, log_buffer: LogBuffer, line_idx: int) -> GPUDriverIssue:
+        """Extract CUDA OOM error."""
+        return GPUDriverIssue(
+            severity=Severity.MEDIUM,
+            actionable=False,  # Infrastructure - not enough GPU memory.
+            message="CUDA out of memory",
+            line_number=line_idx,
+            gpu_type="cuda",
+            error_code="CUDA_OOM",
+            error_type="oom",
+            context_lines=log_buffer.get_context(line_idx, before=3, after=3),
+        )
+
+    def _extract_hip_file_not_found(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract HIP file not found error (missing device libraries)."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=True,  # Missing device libraries - installation issue.
+            message="HIP file not found (missing device libraries)",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code="hipErrorFileNotFound",
+            error_type="missing_library",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_hip_device_lost(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract HIP device lost error."""
+        return GPUDriverIssue(
+            severity=Severity.CRITICAL,
+            actionable=False,  # Infrastructure - driver crash.
+            message="HIP device lost (driver crash)",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code="HIP_DEVICE_LOST",
+            error_type="device_lost",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_rocm_error(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract generic ROCm/HSA error."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=True,  # Could be code or infrastructure.
+            message="ROCm/HSA runtime error",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code="ROCM_ERROR",
+            error_type="error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_hsa_queue_destroy(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract HSA queue destroy error (ROCm runtime queue teardown failure)."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=False,  # ROCm runtime error.
+            message="HSA queue destroy failed (ROCm runtime error)",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code="HSA_QUEUE_DESTROY_ERROR",
+            error_type="queue_teardown",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_rocclr_error(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract ROCm CLR internal error."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=False,  # Internal ROCm runtime error.
+            message="ROCm CLR internal error",
+            line_number=line_idx,
+            gpu_type="hip",
+            error_code="ROCCLR_ERROR",
+            error_type="internal_error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_vk_init_failed(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract Vulkan initialization failed error."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=True,  # Could be config or driver issue.
+            message="Vulkan initialization failed",
+            line_number=line_idx,
+            gpu_type="vulkan",
+            error_code="VK_ERROR_INITIALIZATION_FAILED",
+            error_type="initialization",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_vulkan_generic(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract generic Vulkan error."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=True,  # Generic Vulkan API error.
+            message="Vulkan API error",
+            line_number=line_idx,
+            gpu_type="vulkan",
+            error_code="VULKAN_ERROR",
+            error_type="error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )
+
+    def _extract_metal_error(
+        self, log_buffer: LogBuffer, line_idx: int
+    ) -> GPUDriverIssue:
+        """Extract Metal API error."""
+        return GPUDriverIssue(
+            severity=Severity.HIGH,
+            actionable=True,  # Metal API error.
+            message="Metal API error",
+            line_number=line_idx,
+            gpu_type="metal",
+            error_code="METAL_ERROR",
+            error_type="error",
+            context_lines=log_buffer.get_context(line_idx, before=5, after=5),
+        )

--- a/tools/utils/common/extractors/mlir_compiler.py
+++ b/tools/utils/common/extractors/mlir_compiler.py
@@ -1,0 +1,535 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Extractor for MLIR compiler errors (iree-compile, mlir-opt, iree-opt).
+
+This extractor detects and parses MLIR compiler diagnostic messages including:
+- Compilation errors (type mismatches, invalid operations, etc.)
+- Operation-specific failures (failed to tile, out-of-bounds, etc.)
+- Multi-line diagnostics with notes and operation dumps
+
+Key features:
+- Multi-line error collection: source snippet + caret + notes
+- Operation name extraction: from message or source code
+- Graceful degradation: Extracts partial data when reports incomplete
+- FileCheck exclusion: Skips test infrastructure errors (handled separately)
+- Lit-tools compatible: File paths ready for iree-lit-test/iree-lit-extract
+
+Design philosophy:
+"Extract compiler errors that help LLMs debug MLIR code, not test infrastructure failures."
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import Issue, MLIRCompilerIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class MLIRCompilerExtractor(Extractor):
+    """Extracts MLIR compiler error diagnostics from logs."""
+
+    name = "mlir_compiler"
+    activation_keywords = [".mlir"]  # Only run on logs compiling MLIR files.
+
+    # Patterns to exclude (test infrastructure, not compiler errors).
+    # Includes both CHECK prefixes and generic FileCheck error messages.
+    FILECHECK_PATTERNS = [
+        "CHECK:",
+        "CHECK-LABEL:",
+        "CHECK-SAME:",
+        "CHECK-NOT:",
+        "CHECK-DAG:",
+        "CHECK-NEXT:",
+        # Generic FileCheck failure messages (stable upstream LLVM patterns).
+        "expected string not found in input",
+        "is not on the same line as previous match",
+        "possible intended match here",
+    ]
+
+    # Source snippet collection limit.
+    SOURCE_SNIPPET_MAX_LINES = 3  # Max lines before caret or blank.
+
+    # Compiled regex patterns (defined once, not per-line).
+    _ERROR_LINE_RE = re.compile(r"^(.+\.mlir):(\d+):(\d+): error: (.+)$")
+    _NOTE_LINE_RE = re.compile(r"^(.+\.mlir):(\d+):(\d+): note: (.+)$")
+    _DIAGNOSTIC_LINE_RE = re.compile(r"^.+\.mlir:\d+:\d+:")
+    _ERROR_WARNING_LINE_RE = re.compile(r"^.+\.mlir:\d+:\d+: (error|warning):")
+    _CARET_LINE_RE = re.compile(r"^\s*\^")
+    _OP_FROM_MESSAGE_RE = re.compile(r"'([^']+)' op")
+    _OP_FROM_SOURCE_RE = re.compile(r"%\w+(?::\d+)?\s*=\s*([a-z_][a-z0-9_.]*)\s+")
+    _TEST_TARGET_RE = re.compile(r"/(tests|compiler|artifacts)/(.+\.mlir)$")
+
+    # Compile command extraction patterns.
+    _COMPILED_WITH_RE = re.compile(r"^\s*Compiled with:\s*$")
+    _INVOKED_WITH_RE = re.compile(r"^\s*Invoked with:\s*$")
+    _CD_COMMAND_RE = re.compile(
+        r"\bcd\s+.*?\s+&&\s+.*\b(iree-compile|iree-opt|mlir-opt)\b"
+    )
+    _SHELL_XTRACE_RE = re.compile(r"^\s*\+\s+.*\b(iree-compile|iree-opt|mlir-opt)\b")
+
+    def extract(self, log_buffer: LogBuffer) -> list[Issue]:
+        """Extract all MLIR compiler errors from log.
+
+        Args:
+            log_buffer: LogBuffer with log content (may be prefix-stripped).
+
+        Returns:
+            List of MLIRCompilerIssue objects, one per detected error.
+            Returns empty list if no MLIR compiler errors found.
+            Excludes FileCheck errors (test infrastructure).
+            Never raises exceptions - all failures are graceful.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Match primary error line: FILE.mlir:LINE:COL: error: MESSAGE
+            if match := self._ERROR_LINE_RE.match(line):
+                file_path = match.group(1)
+                # Validate line/column numbers are positive (1-indexed).
+                error_line = max(1, int(match.group(2)))
+                error_column = max(1, int(match.group(3)))
+                error_message = match.group(4)
+
+                # Skip FileCheck errors (test infrastructure, not compiler).
+                if any(pattern in error_message for pattern in self.FILECHECK_PATTERNS):
+                    i += 1
+                    continue
+
+                # Parse full error context (source snippet, notes, etc.).
+                error_data = self._parse_mlir_error(
+                    log_buffer, i, file_path, error_line, error_column, error_message
+                )
+
+                # Extract compile command for reproduction.
+                compile_command = self._extract_compile_command(log_buffer, i)
+
+                # Create issue.
+                issue = MLIRCompilerIssue(
+                    severity=Severity.HIGH,
+                    actionable=True,
+                    message=f"MLIR compiler error: {error_message[:80]}",
+                    line_number=i,
+                    source_extractor=self.name,
+                    file_path=file_path,
+                    error_line=error_line,
+                    error_column=error_column,
+                    error_message=error_message,
+                    error_type=self._infer_error_type(error_message),
+                    source_snippet=error_data.get("source_snippet", ""),
+                    caret_line=error_data.get("caret_line", ""),
+                    operation=error_data.get("operation"),
+                    notes=error_data.get("notes", []),
+                    full_diagnostic=error_data.get("full_diagnostic", ""),
+                    test_target=error_data.get("test_target"),
+                    compile_command=compile_command,
+                )
+                issues.append(issue)
+
+                # Skip to end of this error.
+                i = error_data.get("next_line", i + 1)
+            else:
+                i += 1
+
+        return issues
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def _parse_mlir_error(
+        self,
+        log_buffer: LogBuffer,
+        start_line: int,
+        file_path: str,
+        error_line: int,
+        error_column: int,
+        error_message: str,
+    ) -> dict:
+        """Parse complete MLIR error with source snippet and notes.
+
+        Args:
+            log_buffer: LogBuffer to read from.
+            start_line: Line number where error starts (0-indexed).
+            file_path: Path to .mlir file with error.
+            error_line: Line number in .mlir file (1-indexed).
+            error_column: Column number in .mlir file (1-indexed).
+            error_message: Error message text.
+
+        Returns:
+            Dict with parsed error data:
+            - 'operation': str or None - MLIR operation name
+            - 'source_snippet': str - MLIR source code line(s)
+            - 'caret_line': str - Line with caret (^) marker
+            - 'notes': List[dict] - Related diagnostic notes
+            - 'full_diagnostic': str - Complete multi-line error text
+            - 'test_target': str or None - Inferred test target path
+            - 'next_line': int - Line number after this error
+        """
+        data = {}
+        i = start_line + 1
+
+        # Extract operation name from error message: 'op_name' op ...
+        if op_match := self._OP_FROM_MESSAGE_RE.search(error_message):
+            data["operation"] = op_match.group(1)
+
+        # Collect source snippet (next 1-3 lines until caret or blank).
+        source_lines = []
+        caret_line = ""
+        while (
+            i < log_buffer.line_count
+            and i < start_line + self.SOURCE_SNIPPET_MAX_LINES + 1
+        ):
+            line = log_buffer.get_line(i)
+
+            # Stop at blank line or next diagnostic.
+            if not line.strip() or self._DIAGNOSTIC_LINE_RE.match(line):
+                break
+
+            # Check for caret line (^).
+            if self._CARET_LINE_RE.match(line):
+                caret_line = line
+                i += 1
+                break
+
+            source_lines.append(line)
+            i += 1
+
+        data["source_snippet"] = "\n".join(source_lines)
+        data["caret_line"] = caret_line
+
+        # Extract operation name from source if not in message.
+        # Pattern: %result = operation_name ...
+        if (
+            not data.get("operation")
+            and source_lines
+            and (op_match := self._OP_FROM_SOURCE_RE.search(source_lines[0]))
+        ):
+            data["operation"] = op_match.group(1)
+
+        # Collect related notes (note: see current operation:, called from, etc.).
+        notes = []
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Match note diagnostic: FILE.mlir:LINE:COL: note: MESSAGE
+            if note_match := self._NOTE_LINE_RE.match(line):
+                note_file = note_match.group(1)
+                # Validate line/column numbers are positive (1-indexed).
+                note_line = max(1, int(note_match.group(2)))
+                note_col = max(1, int(note_match.group(3)))
+                note_msg = note_match.group(4)
+
+                # Collect note body (especially for "see current operation:").
+                note_body, next_i = self._collect_note_body(log_buffer, i + 1, note_msg)
+
+                notes.append(
+                    {
+                        "file": note_file,
+                        "line": note_line,
+                        "column": note_col,
+                        "type": note_msg,
+                        "body": note_body,
+                    }
+                )
+
+                i = next_i
+
+            # Stop at next error or warning.
+            elif self._ERROR_WARNING_LINE_RE.match(line):
+                break
+
+            # Stop at blank line.
+            elif not line.strip():
+                i += 1
+                break
+
+            else:
+                i += 1
+
+        data["notes"] = notes
+        data["next_line"] = i
+
+        # Collect full diagnostic text (from error line to end).
+        full_lines = []
+        for line_num in range(start_line, i):
+            full_lines.append(log_buffer.get_line(line_num))
+        data["full_diagnostic"] = "\n".join(full_lines)
+
+        # Try to infer test target from file path.
+        data["test_target"] = self._infer_test_target(file_path)
+
+        return data
+
+    def _collect_note_body(
+        self, log_buffer: LogBuffer, start_line: int, note_msg: str
+    ) -> tuple[str, int]:
+        """Collect multi-line note body (e.g., operation dump).
+
+        Args:
+            log_buffer: LogBuffer to read from.
+            start_line: Line after "note:" line (0-indexed).
+            note_msg: Note message text (e.g., "see current operation:").
+
+        Returns:
+            Tuple of (note_body_text, next_line_number):
+            - note_body_text: Collected note body (may be multi-line)
+            - next_line_number: Line number after note body
+        """
+        body_lines = []
+        i = start_line
+
+        # For "see current operation:", collect indented MLIR dump.
+        if "see current operation" in note_msg:
+            while i < log_buffer.line_count:
+                line = log_buffer.get_line(i)
+
+                # Stop at next diagnostic.
+                if self._DIAGNOSTIC_LINE_RE.match(line):
+                    break
+
+                # Stop at blank line.
+                if not line.strip():
+                    i += 1
+                    break
+
+                # Collect indented lines (operation dump).
+                body_lines.append(line)
+                i += 1
+
+        # For other notes, just collect until blank line or next diagnostic.
+        else:
+            while i < log_buffer.line_count:
+                line = log_buffer.get_line(i)
+
+                # Stop at next diagnostic or blank line.
+                if self._DIAGNOSTIC_LINE_RE.match(line) or not line.strip():
+                    break
+
+                body_lines.append(line)
+                i += 1
+
+        return "\n".join(body_lines), i
+
+    def _infer_error_type(self, error_message: str) -> str:
+        """Infer error type category from error message.
+
+        Args:
+            error_message: Error diagnostic text.
+
+        Returns:
+            Error type string (e.g., "out-of-bounds", "failed-to-tile").
+            Returns empty string if no clear category.
+        """
+        msg_lower = error_message.lower()
+
+        # Common error patterns - specific checks before general checks.
+        if "out-of-bounds" in msg_lower or "out of bounds" in msg_lower:
+            return "out-of-bounds"
+        # Specific operand dominance check before general dominance check.
+        if "operand #" in msg_lower and "does not dominate" in msg_lower:
+            return "operand-does-not-dominate"
+        if "does not dominate" in msg_lower:
+            return "does-not-dominate"
+        if "failed to tile" in msg_lower:
+            return "failed-to-tile"
+        # Note: "anaysis" typo appears in real IREE compiler output.
+        if "failed to analyze" in msg_lower or "failed to anaysis" in msg_lower:
+            return "failed-to-analyze"
+        if "type mismatch" in msg_lower:
+            return "type-mismatch"
+        if "invalid operation" in msg_lower:
+            return "invalid-operation"
+        if "expected" in msg_lower and "to have" in msg_lower:
+            return "expectation-failed"
+        # No clear category - return empty string.
+        return ""
+
+    def _infer_test_target(self, file_path: str) -> str | None:
+        """Infer test target path from file path.
+
+        Args:
+            file_path: Path to .mlir file (may be absolute or relative).
+
+        Returns:
+            Test target path if detectable, None otherwise.
+
+        Examples:
+            - "/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir"
+              → "tests/e2e/linalg/argmax.mlir"
+            - "model.mlir" → None
+        """
+        # Try to extract repository-relative path.
+        # Common patterns: /path/to/iree/tests/... or /path/to/iree/compiler/...
+        if match := self._TEST_TARGET_RE.search(file_path):
+            return f"{match.group(1)}/{match.group(2)}"
+
+        # If file path contains test-related keywords, keep as-is.
+        if any(keyword in file_path for keyword in ["test", "compiler", "artifacts"]):
+            # Try to extract just the relevant portion.
+            parts = file_path.split("/")
+            for i, part in enumerate(parts):
+                if part in ["tests", "compiler", "artifacts"]:
+                    return "/".join(parts[i:])
+
+        # Can't infer test target - return None.
+        return None
+
+    def _clean_command(self, cmd: str) -> str:
+        r"""Normalize compile command for reproduction.
+
+        Args:
+            cmd: Raw command string from log.
+
+        Returns:
+            Cleaned command with normalized whitespace and unescaped quotes.
+
+        Transformations:
+            - Strip leading/trailing whitespace
+            - Unescape quotes: \" → "
+            - Remove shell xtrace prefix: "+ " → ""
+        """
+        return cmd.strip().replace(r"\"", '"').lstrip("+ ")
+
+    def _is_in_test_framework_context(
+        self, log_buffer: LogBuffer, error_line_num: int
+    ) -> bool:
+        """Detect if error is in ONNX/pytest/Python API test context.
+
+        These contexts include large IR dumps between error and compile command,
+        so we need to scan further ahead.
+
+        Args:
+            log_buffer: LogBuffer to search.
+            error_line_num: Line number where error was found (0-indexed).
+
+        Returns:
+            True if in test framework context requiring extended forward search.
+        """
+        # Look backward up to 30 lines for test framework markers.
+        search_start = max(0, error_line_num - 30)
+        for i in range(error_line_num, search_start - 1, -1):
+            line = log_buffer.get_line(i)
+            # ONNX/pytest markers.
+            if "Error invoking iree-compile" in line:
+                return True
+            if "Stderr diagnostics:" in line:
+                return True
+            if "IREE compile and run:" in line:
+                return True
+            # Python API markers.
+            if "CompilerToolError" in line:
+                return True
+            # Pytest failure markers.
+            if "_ IREE compile" in line or "test_onnx" in line:
+                return True
+        return False
+
+    def _find_test_boundary(self, log_buffer: LogBuffer, start_line: int) -> int:
+        """Find the end of current test section for bounded forward search.
+
+        Args:
+            log_buffer: LogBuffer to search.
+            start_line: Line to start searching from (0-indexed).
+
+        Returns:
+            Line number of test boundary, or buffer end if no boundary found.
+        """
+        # Test boundary markers (indicate start of new test or section).
+        # These should be specific enough to not appear within IR dumps.
+        boundary_markers = [
+            "======",  # Pytest section divider (row of equals).
+            "------",  # Pytest test divider (row of dashes).
+            "_ IREE compile and run:",  # Next ONNX test.
+            "____ ",  # Pytest failure section (e.g., "____ test_name ____").
+        ]
+
+        # Scan forward for boundary markers (max 5000 lines to avoid infinite loops).
+        max_scan = min(log_buffer.line_count, start_line + 5000)
+        # Skip first few lines to avoid matching markers in current test's output.
+        search_start = start_line + 10
+        for i in range(search_start, max_scan):
+            line = log_buffer.get_line(i)
+            # Check if line starts with boundary marker (not just contains).
+            for marker in boundary_markers:
+                if line.startswith(marker):
+                    return i
+        return log_buffer.line_count
+
+    def _extract_compile_command(
+        self, log_buffer: LogBuffer, error_line_num: int
+    ) -> str | None:
+        """Extract compile command that triggered MLIR error.
+
+        Uses 4-strategy search based on corpus analysis:
+        1. FORWARD search (adaptive): "Compiled with:" marker (ONNX/pytest)
+           - Test framework context: Scan until test boundary or command found
+           - Other context: Scan 100 lines
+        2. FORWARD search (adaptive): "Invoked with:" marker (Python API)
+        3. BACKWARD search (20 lines): "cd ... && iree-" pattern (CMake e2e tests)
+        4. BACKWARD search (20 lines): "+ iree-" shell xtrace (lit/bazel tests)
+
+        Note: ONNX/pytest tests can have 1000+ line IR dumps between error and
+        command marker, so we detect test framework context and scan to boundary.
+
+        Args:
+            log_buffer: LogBuffer to search.
+            error_line_num: Line number where error was found (0-indexed).
+
+        Returns:
+            Compile command if found, None otherwise.
+
+        Examples of extracted commands:
+            - "cd /path && iree-compile model.mlir --target=vulkan -o output.vmfb"
+            - "iree-opt '--pass-pipeline=...' /path/test.mlir"
+            - "iree-compile /path/model.mlir --iree-hal-target-backends=llvm-cpu"
+        """
+        # Determine forward search limit based on context.
+        if self._is_in_test_framework_context(log_buffer, error_line_num):
+            # In test framework: scan until we find test boundary.
+            forward_search_limit = self._find_test_boundary(log_buffer, error_line_num)
+        else:
+            # Not in test framework: use modest forward search.
+            forward_search_limit = min(log_buffer.line_count, error_line_num + 100)
+
+        # Strategy 1: Search FORWARD for "Compiled with:" marker (ONNX/pytest tests).
+        for i in range(error_line_num, forward_search_limit):
+            line = log_buffer.get_line(i)
+            if self._COMPILED_WITH_RE.match(line):
+                # Next non-empty line contains command.
+                for j in range(i + 1, min(log_buffer.line_count, i + 5)):
+                    next_line = log_buffer.get_line(j)
+                    if next_line.strip():
+                        return self._clean_command(next_line)
+
+        # Strategy 2: Search FORWARD for "Invoked with:" marker (Python compiler API).
+        for i in range(error_line_num, forward_search_limit):
+            line = log_buffer.get_line(i)
+            if self._INVOKED_WITH_RE.match(line):
+                # Next non-empty line contains command (may start with " iree-").
+                for j in range(i + 1, min(log_buffer.line_count, i + 5)):
+                    next_line = log_buffer.get_line(j)
+                    if next_line.strip():
+                        return self._clean_command(next_line)
+
+        # Strategy 3: Search BACKWARD for "cd ... && iree-" (CMake e2e tests).
+        search_start = max(0, error_line_num - 20)
+        for i in range(error_line_num - 1, search_start - 1, -1):
+            line = log_buffer.get_line(i)
+            if self._CD_COMMAND_RE.search(line):
+                return self._clean_command(line)
+
+        # Strategy 4: Search BACKWARD for "+ iree-" shell xtrace (lit/bazel tests).
+        for i in range(error_line_num - 1, search_start - 1, -1):
+            line = log_buffer.get_line(i)
+            if self._SHELL_XTRACE_RE.match(line):
+                return self._clean_command(line)
+
+        # No compile command found.
+        return None

--- a/tools/utils/common/extractors/onnx_test.py
+++ b/tools/utils/common/extractors/onnx_test.py
@@ -1,0 +1,313 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""ONNX test suite failure extractor.
+
+Extracts rich reproduction context from ONNX test failures including:
+- Input MLIR program
+- Compilation and run commands
+- Error messages
+- Test source URLs
+
+This provides complete triage information without needing to set up ONNX.
+"""
+
+import contextlib
+
+from common.extractors.base import Extractor
+from common.issues import ONNXTestIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class ONNXTestExtractor(Extractor):
+    """Extracts ONNX test failures with reproduction context."""
+
+    name = "onnx_test"
+    activation_keywords = [
+        "Error invoking iree-run-module",
+        "Error invoking iree-compile",
+        "Input program:",
+        "IREE compile and run:",
+    ]
+
+    def extract(self, log_buffer: LogBuffer) -> list[ONNXTestIssue]:
+        """Extract ONNX test failures.
+
+        Args:
+            log_buffer: Log content to analyze
+
+        Returns:
+            List of ONNXTestIssue instances
+        """
+        issues = []
+
+        i = 0
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Look for ONNX test failure marker.
+            if "IREE compile and run:" in line:
+                issue = self._extract_onnx_test(log_buffer, i)
+                if issue:
+                    issues.append(issue)
+                    # Skip past this test (typical test is 20-30 lines).
+                    i += 20
+                    continue
+
+            i += 1
+
+        return issues
+
+    def _parse_test_name_from_header(self, header_line: str) -> str:
+        """Parse test name from ONNX test header line.
+
+        Args:
+            header_line: Header line with format "_ IREE compile and run: test_name::..."
+
+        Returns:
+            Extracted test name, or empty string if parsing fails
+        """
+        if "::" not in header_line:
+            return ""
+
+        parts = header_line.split("::")
+        if len(parts) < 2:
+            return ""
+
+        # Format: "_ IREE compile and run: test_name::..."
+        test_name_part = parts[0].split(":")
+        if len(test_name_part) >= 2:
+            return test_name_part[-1].strip()
+
+        return ""
+
+    def _find_test_block_end(self, log_buffer: LogBuffer, start_line: int) -> int:
+        """Find the boundary of ONNX test block.
+
+        Searches for next test header or end of log, whichever comes first.
+
+        Args:
+            log_buffer: LogBuffer with log content
+            start_line: Starting line index
+
+        Returns:
+            Offset from start_line where test block ends
+        """
+        max_search = min(200, log_buffer.line_count - start_line)
+        for offset in range(1, max_search):
+            line = log_buffer.get_line(start_line + offset)
+            if "IREE compile and run:" in line:
+                return offset
+        return max_search
+
+    def _extract_mlir_from_block(
+        self, log_buffer: LogBuffer, start_line: int, offset: int
+    ) -> str:
+        """Extract MLIR code from Input program block.
+
+        Looks for ``` code fence markers and extracts content between them.
+
+        Args:
+            log_buffer: LogBuffer with log content
+            start_line: Test start line index
+            offset: Offset from start_line where "Input program:" was found
+
+        Returns:
+            Extracted MLIR code, or empty string if not found
+        """
+        mlir_lines = []
+        in_code_block = False
+        for j in range(1, 100):
+            if start_line + offset + j >= log_buffer.line_count:
+                break
+            mlir_line = log_buffer.get_line(start_line + offset + j)
+            if "```" in mlir_line:
+                if in_code_block:
+                    break  # End of MLIR.
+                in_code_block = True  # Start of MLIR.
+                continue
+            if in_code_block:
+                mlir_lines.append(mlir_line)
+        return "\n".join(mlir_lines)
+
+    def _extract_error_message_after_marker(
+        self, log_buffer: LogBuffer, start_line: int, offset: int
+    ) -> str:
+        """Extract error message after "Stderr diagnostics:" marker.
+
+        Args:
+            log_buffer: LogBuffer with log content
+            start_line: Test start line index
+            offset: Offset where "Stderr diagnostics:" was found
+
+        Returns:
+            First non-empty line after marker, or empty string if not found
+        """
+        for j in range(1, 10):
+            if start_line + offset + j >= log_buffer.line_count:
+                break
+            err_line = log_buffer.get_line(start_line + offset + j)
+            if err_line.strip() and "Stdout diagnostics:" not in err_line:
+                return err_line.strip()
+        return ""
+
+    def _scan_test_block_for_data(
+        self, log_buffer: LogBuffer, start_line: int, block_end: int
+    ) -> dict:
+        """Scan ONNX test block and extract all data in single pass.
+
+        Args:
+            log_buffer: LogBuffer with log content
+            start_line: Starting line index
+            block_end: Offset where test block ends
+
+        Returns:
+            Dict with keys: error_tool, error_code, error_message, input_mlir,
+            compile_command, run_command, test_source_url
+        """
+        data = {
+            "error_tool": "",
+            "error_code": None,
+            "error_message": "",
+            "input_mlir": "",
+            "compile_command": "",
+            "run_command": "",
+            "test_source_url": "",
+        }
+
+        for offset in range(1, block_end):
+            line = log_buffer.get_line(start_line + offset)
+
+            # Extract error tool.
+            if "Error invoking iree-run-module" in line:
+                data["error_tool"] = "iree-run-module"
+            elif "Error invoking iree-compile" in line:
+                data["error_tool"] = "iree-compile"
+
+            # Extract error code.
+            if "Error code:" in line and data["error_code"] is None:
+                with contextlib.suppress(ValueError, IndexError):
+                    data["error_code"] = int(line.split("Error code:")[-1].strip())
+
+            # Extract error message (after "Stderr diagnostics:").
+            if "Stderr diagnostics:" in line and not data["error_message"]:
+                data["error_message"] = self._extract_error_message_after_marker(
+                    log_buffer, start_line, offset
+                )
+
+            # Extract test source URL.
+            if "Test case source:" in line:
+                next_line = log_buffer.get_line(start_line + offset + 1)
+                if "github.com" in next_line:
+                    data["test_source_url"] = next_line.strip()
+
+            # Extract input MLIR (between ``` markers after "Input program:").
+            if "Input program:" in line:
+                data["input_mlir"] = self._extract_mlir_from_block(
+                    log_buffer, start_line, offset
+                )
+
+            # Extract compilation command.
+            if "Compiled with:" in line:
+                next_line = log_buffer.get_line(start_line + offset + 1)
+                if "iree-compile" in next_line:
+                    data["compile_command"] = next_line.strip()
+
+            # Extract run command.
+            if "Run with:" in line:
+                next_line = log_buffer.get_line(start_line + offset + 1)
+                if "iree-run-module" in next_line:
+                    data["run_command"] = next_line.strip()
+
+        return data
+
+    def _determine_onnx_severity(self, error_message: str) -> tuple[Severity, bool]:
+        """Determine severity and actionability for ONNX test error.
+
+        Args:
+            error_message: Error message from test
+
+        Returns:
+            Tuple of (severity, actionable)
+        """
+        # Most ONNX test failures are infrastructure (GPU not available, etc.).
+        infrastructure_keywords = [
+            "physical device",
+            "device not found",
+            "vulkan",
+            "out of memory",
+            "timeout",
+        ]
+
+        if any(keyword in error_message.lower() for keyword in infrastructure_keywords):
+            return (Severity.HIGH, False)  # Infrastructure issue.
+        return (Severity.HIGH, True)  # Compilation or runtime error - actionable.
+
+    def _extract_onnx_test(
+        self, log_buffer: LogBuffer, start_line: int
+    ) -> ONNXTestIssue | None:
+        """Extract single ONNX test failure.
+
+        Pattern:
+            _ IREE compile and run: test_name::model.mlir::model.mlir::gpu_vulkan __
+            [gw2] linux -- Python ...
+            Error invoking iree-run-module  (or iree-compile)
+            Error code: 1
+            Stderr diagnostics:
+            <error message>
+
+            Stdout diagnostics:
+
+            Test case source:
+              <github url>
+
+            Input program:
+            ```
+            <mlir code>
+            ```
+
+            Compiled with:
+              <compile command>
+
+            Run with:
+              <run command>
+
+        Returns:
+            ONNXTestIssue or None if extraction fails
+        """
+        # Parse test name from header.
+        header_line = log_buffer.get_line(start_line)
+        test_name = self._parse_test_name_from_header(header_line)
+
+        # Find test block boundary.
+        block_end = self._find_test_block_end(log_buffer, start_line)
+
+        # Scan block for all data in single pass.
+        data = self._scan_test_block_for_data(log_buffer, start_line, block_end)
+
+        # Only create issue if we found error information.
+        if not data["error_tool"]:
+            return None
+
+        # Determine severity and actionability.
+        severity, actionable = self._determine_onnx_severity(data["error_message"])
+
+        return ONNXTestIssue(
+            severity=severity,
+            actionable=actionable,
+            message=f"ONNX test '{test_name}' failed: {data['error_message'][:100]}",
+            line_number=start_line,
+            source_extractor=self.name,
+            test_name=test_name,
+            error_tool=data["error_tool"],
+            error_code=data["error_code"],
+            error_message=data["error_message"],
+            input_mlir=data["input_mlir"],
+            compile_command=data["compile_command"],
+            run_command=data["run_command"],
+            test_source_url=data["test_source_url"],
+            context_lines=log_buffer.get_context(start_line, before=2, after=10),
+        )

--- a/tools/utils/common/extractors/precommit.py
+++ b/tools/utils/common/extractors/precommit.py
@@ -1,0 +1,159 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Pre-commit hook failure extractor.
+
+Extracts failures from pre-commit hooks (formatting, linting, etc.). These are
+typically infrastructure issues that can be fixed by running pre-commit locally.
+
+Pattern examples:
+    Run bazel_to_cmake.py on BUILD.bazel files......Failed
+    - hook id: bazel_to_cmake_1
+    - files were modified by this hook
+
+    Trim Trailing Whitespace.......................Failed
+    - hook id: trailing-whitespace
+
+Example usage:
+    from common.extractors.precommit import PrecommitErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = PrecommitErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"Pre-commit hook '{issue.hook_id}' failed: {issue.message}")
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import PrecommitErrorIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class PrecommitErrorExtractor(Extractor):
+    """Extracts pre-commit hook failures from logs.
+
+    Pre-commit failures are typically low-severity infrastructure issues
+    that can be fixed by running `pre-commit run --all-files` locally.
+    """
+
+    name = "precommit"
+    activation_keywords = ["pre-commit run"]  # Only run on logs with pre-commit.
+
+    # Pre-commit hook failure line.
+    # Pattern: "Run bazel_to_cmake.py on BUILD.bazel files......Failed"
+    # or: "Trim Trailing Whitespace.......................Failed"
+    # or: "Run Black to format Python filesFailed" (ANSI codes replace dots)
+    # Handles both actual ANSI escape codes (\x1b[41m) and literal bracket codes ([41m).
+    # GitHub Actions logs contain literal [41m, not escape sequences.
+    _HOOK_FAILED_RE = re.compile(
+        r"(?:(?:\x1b)?\[\d+m)*(?P<description>.+?)(?:\.{3,}|(?:(?:\x1b)?\[\d+m)+)(?:(?:\x1b)?\[\d+m)*Failed(?:(?:\x1b)?\[m)*"
+    )
+
+    # Hook ID line (follows failure line).
+    # Pattern: "- hook id: bazel_to_cmake_1"
+    # Handles both ANSI escape codes and literal brackets: [2m- hook id: bazel_to_cmake_1[m.
+    # Exclude escape chars (\x1b), brackets ([), and whitespace from hook_id.
+    _HOOK_ID_RE = re.compile(
+        r"(?:(?:\x1b)?\[\d+m)*-\s+hook id:\s+(?P<hook_id>[^\x1b\[\s]+)(?:(?:\x1b)?\[m)*"
+    )
+
+    # Files modified indicator (optional).
+    _FILES_MODIFIED_RE = re.compile(r"-\s+files were modified by this hook")
+
+    # Exit code indicator (optional).
+    _EXIT_CODE_RE = re.compile(r"-\s+exit code:\s+(?P<code>\d+)")
+
+    def extract(self, log_buffer: LogBuffer) -> list[PrecommitErrorIssue]:
+        """Extract pre-commit hook failures from log.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            List of PrecommitErrorIssue objects.
+        """
+        issues = []
+        lines = log_buffer.get_lines()
+
+        for line_idx, line in enumerate(lines):
+            # Check for hook failure line.
+            match = self._HOOK_FAILED_RE.search(line)
+            if not match:
+                continue
+
+            hook_description = match.group("description").strip()
+
+            # Look for hook ID in next few lines.
+            hook_id = None
+            files_modified = False
+            error_details_lines = []
+
+            for i in range(line_idx + 1, min(line_idx + 10, len(lines))):
+                detail_line = lines[i]
+
+                # Check for hook ID.
+                id_match = self._HOOK_ID_RE.search(detail_line)
+                if id_match:
+                    hook_id = id_match.group("hook_id")
+                    continue
+
+                # Check for files modified.
+                if self._FILES_MODIFIED_RE.search(detail_line):
+                    files_modified = True
+                    continue
+
+                # Check for exit code (captured for potential future use).
+                if self._EXIT_CODE_RE.search(detail_line):
+                    continue
+
+                # Collect other detail lines (indented with -).
+                if detail_line.strip().startswith("-"):
+                    error_details_lines.append(detail_line.strip())
+                elif not detail_line.strip():
+                    # Blank line continues.
+                    continue
+                else:
+                    # Non-detail line - end of hook failure block.
+                    break
+
+            # Determine error type and severity.
+            if files_modified:
+                error_type = "modified_files"
+                severity = (
+                    Severity.LOW
+                )  # Just needs git commit after running pre-commit.
+                message = (
+                    f"Pre-commit hook '{hook_id or hook_description}' modified files"
+                )
+            else:
+                error_type = "check_failed"
+                severity = Severity.MEDIUM  # Actual check failure, needs investigation.
+                message = f"Pre-commit hook '{hook_id or hook_description}' failed"
+
+            error_details = (
+                " ".join(error_details_lines) if error_details_lines else None
+            )
+
+            issues.append(
+                PrecommitErrorIssue(
+                    severity=severity,
+                    actionable=True,  # User can fix by running pre-commit locally.
+                    message=message,
+                    line_number=line_idx,
+                    hook_id=hook_id or "",
+                    hook_description=hook_description,
+                    error_type=error_type,
+                    files_modified=files_modified,
+                    error_details=error_details,
+                    context_lines=log_buffer.get_context(line_idx, before=2, after=8),
+                )
+            )
+
+        return issues

--- a/tools/utils/common/extractors/pytest_error.py
+++ b/tools/utils/common/extractors/pytest_error.py
@@ -1,0 +1,236 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Pytest test failure extractor.
+
+Extracts Python test failures from pytest output, including AssertionErrors,
+ValueErrors, and other exceptions. Handles both pytest error markers (E prefix)
+and test summary lines.
+
+Pattern examples:
+    E               AssertionError: Dispatch count mismatch: expected 12, got 794
+    E           ValueError: NYI floating point type: f8E4M3FNUZ
+    FAILED tests/path/test.py::test_name - AssertionError: message
+
+Example usage:
+    from common.extractors.pytest_error import PytestErrorExtractor
+    from common.log_buffer import LogBuffer
+
+    extractor = PytestErrorExtractor()
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    issues = extractor.extract(log_buffer)
+
+    for issue in issues:
+        print(f"Test '{issue.test_name}' failed: {issue.exception_message}")
+"""
+
+
+from common.extractors.base import Extractor
+from common.issues import PythonTestIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class PytestErrorExtractor(Extractor):
+    """Extracts pytest test failures from logs.
+
+    Captures Python exceptions (AssertionError, ValueError, etc.) from pytest
+    output and test summary lines.
+    """
+
+    name = "pytest"
+    activation_keywords = ["pytest", "test session starts"]  # Only run on pytest logs.
+
+    def extract(self, log_buffer: LogBuffer) -> list[PythonTestIssue]:
+        """Extract pytest test failures from log.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+
+        Returns:
+            List of PythonTestIssue objects.
+        """
+        issues = []
+        lines = log_buffer.get_lines()
+
+        # Track seen exceptions to avoid duplicates (FAILED summaries duplicate E errors).
+        seen_errors = set()
+
+        for line_idx, line in enumerate(lines):
+            # Check for FAILED summary line (fast string check, then parse).
+            # Format: "FAILED <test_path> - <exception_type>: <message>"
+            # Works with ANY exception type, not just "Error" or "Exception" suffixes.
+            if line.startswith("FAILED "):
+                result = self._try_parse_pytest_failed(log_buffer, line_idx, line)
+                if result:
+                    test_path, exception_type, exception_message = result
+
+                    # Use test path + exception type as key to avoid duplicates.
+                    error_key = (test_path, exception_type, exception_message[:50])
+                    if error_key in seen_errors:
+                        continue
+                    seen_errors.add(error_key)
+
+                    # Extract test name from path (format: file.py::test_name).
+                    test_name = (
+                        test_path.split("::")[-1] if "::" in test_path else test_path
+                    )
+
+                    issues.append(
+                        PythonTestIssue(
+                            severity=Severity.HIGH,
+                            actionable=True,
+                            message=f"Pytest test failed: {exception_type}: {exception_message}",
+                            line_number=line_idx,
+                            test_name=test_name,
+                            exception_type=exception_type,
+                            exception_message=exception_message,
+                            stack_trace=[],
+                            context_lines=log_buffer.get_context(
+                                line_idx, before=2, after=3
+                            ),
+                        )
+                    )
+                    continue
+
+            # Check for pytest E-prefixed error (fast string check, then parse).
+            # Format: "E               <ExceptionType>: <message>"
+            if line.lstrip().startswith("E ") and ": " in line:
+                result = self._try_parse_pytest_e_error(log_buffer, line_idx, line)
+                if result:
+                    exception_type, exception_message = result
+
+                    # Try to find test name by looking backward for test indicators.
+                    test_name = self._find_test_name(log_buffer, line_idx)
+
+                    # Use exception info as key (no test path for E errors).
+                    error_key = (
+                        test_name or "unknown",
+                        exception_type,
+                        exception_message[:50],
+                    )
+                    if error_key in seen_errors:
+                        continue
+                    seen_errors.add(error_key)
+
+                    issues.append(
+                        PythonTestIssue(
+                            severity=Severity.HIGH,
+                            actionable=True,
+                            message=f"Python test exception: {exception_type}: {exception_message}",
+                            line_number=line_idx,
+                            test_name=test_name or "unknown",
+                            exception_type=exception_type,
+                            exception_message=exception_message,
+                            stack_trace=[],
+                            context_lines=log_buffer.get_context(
+                                line_idx, before=5, after=3
+                            ),
+                        )
+                    )
+                    continue
+
+        return issues
+
+    def _find_test_name(self, log_buffer: LogBuffer, line_idx: int) -> str | None:
+        """Find test name by searching backward for test indicators.
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index of error.
+
+        Returns:
+            Test name if found, None otherwise.
+        """
+        lines = log_buffer.get_lines()
+
+        # Search backward up to 50 lines for test indicators.
+        for i in range(line_idx - 1, max(0, line_idx - 50), -1):
+            line = lines[i]
+
+            # Look for pytest test run line.
+            # Pattern: "tests/path/test.py::test_name PASSED" or "FAILED"
+            if "::" in line and any(
+                marker in line for marker in ["PASSED", "FAILED", "SKIPPED"]
+            ):
+                parts = line.split("::")
+                if len(parts) >= 2:
+                    return parts[-1].split()[0]  # Extract test name before status.
+
+            # Look for pytest test collection.
+            # Pattern: "tests/path/test.py::test_name"
+            if "::" in line and "test" in line.lower():
+                parts = line.split("::")
+                if len(parts) >= 2:
+                    return parts[-1].strip()
+
+        return None
+
+    def _try_parse_pytest_failed(
+        self, log_buffer: LogBuffer, line_idx: int, line: str
+    ) -> tuple | None:
+        """Parse pytest FAILED line using string operations.
+
+        Format: "FAILED <test_path> - <exception_type>: <message>"
+        Works with ANY exception type (not just Error/Exception suffixes).
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index.
+            line: Line content.
+
+        Returns:
+            (test_path, exception_type, exception_message) if valid, None otherwise.
+        """
+        # Remove "FAILED " prefix.
+        rest = line[7:]  # len("FAILED ") = 7
+
+        # Split on " - " to separate test path from error.
+        if " - " not in rest:
+            return None
+
+        test_path, error_part = rest.split(" - ", 1)
+
+        # Split error part on ": " to get exception type and message.
+        if ": " in error_part:
+            exception_type, message = error_part.split(": ", 1)
+        else:
+            # No colon - just use the whole thing as message.
+            exception_type = "UnknownError"
+            message = error_part
+
+        return (test_path.strip(), exception_type.strip(), message.strip())
+
+    def _try_parse_pytest_e_error(
+        self, log_buffer: LogBuffer, line_idx: int, line: str
+    ) -> tuple | None:
+        """Parse pytest E-prefixed error line using string operations.
+
+        Format: "E               <ExceptionType>: <message>"
+        Format: "E           ValueError: message"
+
+        Args:
+            log_buffer: LogBuffer with log content.
+            line_idx: Line index.
+            line: Line content.
+
+        Returns:
+            (exception_type, exception_message) if valid, None otherwise.
+        """
+        # Strip leading whitespace and "E ".
+        rest = line.lstrip()[2:]  # Skip "E "
+
+        # Split on ": " to get exception type and message.
+        if ": " not in rest:
+            return None
+
+        exception_type, message = rest.split(": ", 1)
+
+        # Exception type should be reasonable (not empty, not too long).
+        exception_type = exception_type.strip()
+        if not exception_type or len(exception_type) > 200:
+            return None
+
+        return (exception_type, message.strip())

--- a/tools/utils/common/extractors/sanitizer.py
+++ b/tools/utils/common/extractors/sanitizer.py
@@ -1,0 +1,921 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Extractor for sanitizer failures (ASAN, LSAN, TSAN, MSAN, UBSAN).
+
+This extractor detects and parses sanitizer reports from various formats:
+- AddressSanitizer (ASAN): heap/stack buffer overflows, use-after-free
+- LeakSanitizer (LSAN): memory leaks (direct and indirect)
+- ThreadSanitizer (TSAN): data races, deadlocks
+- MemorySanitizer (MSAN): uninitialized memory access
+- UndefinedBehaviorSanitizer (UBSAN): undefined behavior
+
+Key features:
+- Graceful degradation: Extracts partial data when reports are incomplete
+- Multiple reports: LSAN can have multiple leak blocks under one ERROR section
+- Line number preservation: Maps stripped content to original unstripped line numbers
+- Format variations: Handles ctest, LIT, and raw sanitizer output
+
+Design philosophy:
+"Better to return 80% of fields with a line number than skip entirely
+because one regex doesn't match."
+"""
+
+import re
+
+from common.extractors.base import Extractor
+from common.issues import Issue, SanitizerIssue, Severity
+from common.log_buffer import LogBuffer
+
+
+class SanitizerExtractor(Extractor):
+    """Extracts sanitizer failure reports from logs."""
+
+    name = "sanitizer"
+    activation_keywords = [
+        # Sanitizers only trigger during test execution - look for sanitizer names.
+        "AddressSanitizer",
+        "LeakSanitizer",
+        "ThreadSanitizer",
+        "MemorySanitizer",
+        "==ERROR:",  # ASAN/LSAN/TSAN error marker.
+        "runtime error:",  # UBSAN error marker.
+    ]
+
+    def extract(self, log_buffer: LogBuffer) -> list[Issue]:
+        """Extract all sanitizer reports from log.
+
+        Args:
+            log_buffer: LogBuffer with log content (may be prefix-stripped).
+
+        Returns:
+            List of SanitizerIssue objects, one per detected report.
+            Returns empty list if no sanitizer reports found.
+            Never raises exceptions - all failures are graceful.
+        """
+        issues = []
+
+        # Each sanitizer type has independent extraction.
+        # They don't interfere with each other.
+        issues.extend(self._extract_asan(log_buffer))
+        issues.extend(self._extract_lsan(log_buffer))
+        issues.extend(self._extract_tsan(log_buffer))
+        issues.extend(self._extract_msan(log_buffer))
+        issues.extend(self._extract_ubsan(log_buffer))
+
+        return issues
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def _get_original_line_number(
+        self, log_buffer: LogBuffer, stripped_line_num: int
+    ) -> int:
+        """Map stripped content line number to original content line number.
+
+        When LogBuffer strips prefixes, the line count stays the same
+        (stripping only removes prefix text, not entire lines). This means
+        line numbers have a 1:1 correspondence between stripped and original.
+
+        Args:
+            log_buffer: LogBuffer with potentially stripped content.
+            stripped_line_num: Line number in stripped content (0-indexed).
+
+        Returns:
+            Line number in original unstripped content (0-indexed).
+            Since stripping is prefix-only, this is just stripped_line_num.
+        """
+        # Prefix stripping doesn't change line count, so line numbers are 1:1.
+        # We return the same line number, but this method exists for clarity
+        # and future-proofing if we add line-removing transformations.
+        return stripped_line_num
+
+    def _parse_stack_trace(
+        self,
+        log_buffer: LogBuffer,
+        start_line: int,
+        stop_patterns: list[str] | None = None,
+    ) -> tuple[list[str], int]:
+        """Parse stack trace frames until blank line or stop pattern.
+
+        Handles various stack frame formats:
+        - Standard: #0 0xADDR in function file.c:123:45
+        - No location: #0 0xADDR in function
+        - Lambda functions: #0 ... ::operator()() const
+        - Symbol lookup errors: #0 0xADDR (<module>+0x123)
+
+        Args:
+            log_buffer: LogBuffer to read from.
+            start_line: Line number to start parsing (0-indexed).
+            stop_patterns: List of regex patterns that end the stack.
+                Examples: [r'^SUMMARY:', r'^allocated', r'^Previous']
+
+        Returns:
+            Tuple of (frames_list, next_line_number):
+            - frames_list: List of frame strings (stripped)
+            - next_line_number: Line number after last frame (0-indexed)
+        """
+        frames = []
+        i = start_line
+        stop_patterns = stop_patterns or []
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Stop on blank line.
+            if not line or not line.strip():
+                break
+
+            # Stop on any stop pattern.
+            if any(re.match(pattern, line) for pattern in stop_patterns):
+                break
+
+            # Parse frame: #NUM at start (may have whitespace before #).
+            # Collect entire frame line even if format varies.
+            if re.match(r"^\s*#(\d+)\s+", line):
+                frames.append(line.strip())
+                i += 1
+            else:
+                # Not a frame line - stop parsing stack.
+                break
+
+        return frames, i
+
+    def _find_report_end(
+        self, log_buffer: LogBuffer, start_line: int, sanitizer_type: str
+    ) -> int:
+        """Find end of sanitizer report.
+
+        Searches for report boundaries in order of preference:
+        1. SUMMARY line (most reliable)
+        2. Next ==PID==ERROR or WARNING section
+        3. Shadow bytes legend end (ASAN-specific)
+        4. EOF
+
+        Args:
+            log_buffer: LogBuffer to search.
+            start_line: Line number to start searching from.
+            sanitizer_type: Type of sanitizer ("asan", "lsan", etc.).
+
+        Returns:
+            Line number of report end (exclusive - first line after report).
+        """
+        # Search forward for SUMMARY line (skip current line to avoid matching self).
+        for i in range(start_line + 1, log_buffer.line_count):
+            line = log_buffer.get_line(i)
+
+            # SUMMARY line marks end.
+            if re.match(r"^\s*SUMMARY:", line):
+                return i + 1  # Include SUMMARY line in report.
+
+            # Next error section - don't include it.
+            if re.match(r"^==\d+==ERROR:", line):
+                return i
+
+            # TSAN uses WARNING instead of ERROR.
+            if re.match(r"^WARNING: ThreadSanitizer:", line):
+                return i
+
+        # No SUMMARY found - use EOF.
+        return log_buffer.line_count
+
+    def _extract_memory_info_asan(
+        self, log_buffer: LogBuffer, start_line: int, search_lines: int = 10
+    ) -> dict[str, any]:
+        """Extract ASAN-specific memory access details.
+
+        Parses lines like:
+        - READ/WRITE of size N at 0xADDR thread T0
+        - 0xADDR is located N bytes after/before M-byte region [START,END)
+
+        Args:
+            log_buffer: LogBuffer to search.
+            start_line: Line number to start searching.
+            search_lines: Number of lines to search forward.
+
+        Returns:
+            Dict with fields: access_type, access_size, address,
+            memory_offset, memory_region_size, etc.
+        """
+        info = {}
+
+        # Search within limited range after error header.
+        for i in range(
+            start_line, min(start_line + search_lines, log_buffer.line_count)
+        ):
+            line = log_buffer.get_line(i)
+
+            # READ/WRITE of size N at 0xADDR thread T0.
+            if match := re.search(
+                r"^\s*(READ|WRITE) of size (\d+) at (0x[0-9a-f]+)", line
+            ):
+                info["access_type"] = match.group(1)
+                info["access_size"] = int(match.group(2))
+                info["address"] = match.group(3)
+
+                # Thread info may be on same line.
+                if thread_match := re.search(r"thread (T\d+|main thread)", line):
+                    info["thread_id"] = thread_match.group(1)
+
+            # Memory location description.
+            # Example: 0xDEADBEEF is located 4 bytes after 100-byte region [0x..., 0x...)
+            if match := re.search(
+                r"(0x[0-9a-f]+) is located (\d+) bytes? (after|before) (\d+)-byte region",
+                line,
+            ):
+                info["address"] = match.group(1)
+                info["memory_offset"] = int(match.group(2))
+                # "after" = positive offset, "before" = negative.
+                if match.group(3) == "before":
+                    info["memory_offset"] = -info["memory_offset"]
+                info["memory_region_size"] = int(match.group(4))
+
+            # Region bounds: [START, END).
+            if match := re.search(r"\[(0x[0-9a-f]+),(0x[0-9a-f]+)\)", line):
+                info["memory_region_start"] = match.group(1)
+                info["memory_region_end"] = match.group(2)
+
+        return info
+
+    # =========================================================================
+    # ASAN Extraction
+    # =========================================================================
+
+    def _extract_asan(self, log_buffer: LogBuffer) -> list[SanitizerIssue]:
+        """Extract AddressSanitizer reports.
+
+        Detects errors like:
+        - heap-buffer-overflow
+        - stack-buffer-overflow
+        - use-after-free
+        - double-free
+
+        Args:
+            log_buffer: LogBuffer to search.
+
+        Returns:
+            List of SanitizerIssue objects for ASAN errors found.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Detection: ==PID==ERROR: AddressSanitizer: ERROR_TYPE.
+            if match := re.match(r"^==(\d+)==ERROR: AddressSanitizer: ([\w-]+)", line):
+                pid = int(match.group(1))
+                error_type = match.group(2)
+                report_start_line = i
+
+                # Extract report data (graceful - get whatever we can).
+                report_data = self._parse_asan_report(log_buffer, i, pid, error_type)
+
+                # Remove internal fields before passing to SanitizerIssue.
+                end_line = report_data.pop("end_line", i + 1)
+
+                # Create issue even if partial.
+                issue = SanitizerIssue(
+                    severity=Severity.CRITICAL,
+                    actionable=True,
+                    message=f"AddressSanitizer: {error_type}",
+                    line_number=self._get_original_line_number(
+                        log_buffer, report_start_line
+                    ),
+                    source_extractor=self.name,
+                    sanitizer_type="asan",
+                    error_type=error_type,
+                    pid=pid,
+                    **report_data,
+                )
+                issues.append(issue)
+
+                # Skip past this report.
+                i = end_line
+            else:
+                i += 1
+
+        return issues
+
+    def _parse_asan_report(  # noqa: C901
+        self, log_buffer: LogBuffer, start_line: int, pid: int, error_type: str
+    ) -> dict[str, any]:
+        """Parse ASAN report starting at error header.
+
+        Note: Complexity is intentional for single-pass parsing efficiency.
+
+        Extracts:
+        - Primary stack trace
+        - Allocation stack trace
+        - Memory access info (READ/WRITE, size, address)
+        - Full report text
+
+        Args:
+            log_buffer: LogBuffer containing the report.
+            start_line: Line number of ERROR header.
+            pid: Process ID from error header.
+            error_type: Error type from header (e.g., "heap-buffer-overflow").
+
+        Returns:
+            Dict with extracted fields (primary_stack, allocation_stack, etc.).
+        """
+        data = {}
+        data["primary_stack"] = []
+        data["allocation_stack"] = []
+
+        # Single-pass parsing: check each line for patterns.
+        i = start_line + 1
+        in_primary_stack = False
+        in_allocation_stack = False
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Stop at report boundaries.
+            if re.match(r"^\s*SUMMARY:|^Shadow bytes around|^==\d+==", line):
+                break
+
+            # Extract memory info patterns (READ/WRITE, location, etc.).
+            # Use separate if statements (not elif) since multiple patterns can appear on same line.
+            if match := re.search(
+                r"^\s*(READ|WRITE) of size (\d+) at (0x[0-9a-f]+)", line
+            ):
+                data["access_type"] = match.group(1)
+                data["access_size"] = int(match.group(2))
+                data["address"] = match.group(3)
+                if thread_match := re.search(r"thread (T\d+|main thread)", line):
+                    data["thread_id"] = thread_match.group(1)
+
+            if match := re.search(
+                r"(0x[0-9a-f]+) is located (\d+) bytes? (after|before) (\d+)-byte region",
+                line,
+            ):
+                data["address"] = match.group(1)
+                data["memory_offset"] = int(match.group(2)) * (
+                    1 if match.group(3) == "after" else -1
+                )
+                data["memory_region_size"] = int(match.group(4))
+
+            if match := re.search(r"\[(0x[0-9a-f]+),(0x[0-9a-f]+)\)", line):
+                data["memory_region_start"] = match.group(1)
+                data["memory_region_end"] = match.group(2)
+
+            # Check for stack frames.
+            if (
+                re.match(r"^\s*#0\s+", line)
+                and not in_primary_stack
+                and not in_allocation_stack
+            ):
+                # First frame starts primary stack.
+                in_primary_stack = True
+
+            # Check for allocation stack marker.
+            if re.search(r"allocated by thread .* here:", line):
+                in_primary_stack = False
+                in_allocation_stack = True
+                i += 1
+                continue
+
+            # Collect stack frames.
+            if re.match(r"^\s*#\d+\s+", line):
+                if in_primary_stack:
+                    data["primary_stack"].append(line.strip())
+                elif in_allocation_stack:
+                    data["allocation_stack"].append(line.strip())
+            else:
+                # Non-frame line ends current stack.
+                if (in_primary_stack or in_allocation_stack) and (
+                    data["primary_stack"] or data["allocation_stack"]
+                ):
+                    # Only stop if we've started collecting (empty line or non-frame after frames).
+                    in_primary_stack = False
+                    in_allocation_stack = False
+
+            i += 1
+
+        # Find report end.
+        end_line = self._find_report_end(log_buffer, start_line, "asan")
+        data["end_line"] = end_line
+
+        # Collect full report text.
+        report_lines = []
+        for line_num in range(start_line, end_line):
+            report_lines.append(log_buffer.get_line(line_num))
+        data["full_report"] = "\n".join(report_lines)
+
+        # Extract summary line if present.
+        for line_num in range(start_line, end_line):
+            line = log_buffer.get_line(line_num)
+            if line.startswith("SUMMARY:"):
+                data["summary_line"] = line.strip()
+                break
+
+        return data
+
+    # =========================================================================
+    # LSAN Extraction
+    # =========================================================================
+
+    def _extract_lsan(self, log_buffer: LogBuffer) -> list[SanitizerIssue]:
+        """Extract LeakSanitizer reports.
+
+        CRITICAL: LSAN can have multiple leak blocks under ONE ERROR section:
+        ==PID==ERROR: LeakSanitizer: detected memory leaks
+
+        Direct leak of 48 byte(s) in 2 object(s) allocated from:
+            #0 ...
+        Direct leak of 24 byte(s) in 1 object(s) allocated from:
+            #0 ...
+
+        SUMMARY: AddressSanitizer: 72 byte(s) leaked in 3 allocation(s).
+
+        Returns separate SanitizerIssue for EACH leak block.
+
+        Args:
+            log_buffer: LogBuffer to search.
+
+        Returns:
+            List of SanitizerIssue objects, one per leak block found.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Detection: ==PID==ERROR: LeakSanitizer: detected memory leaks.
+            if match := re.match(
+                r"^==(\d+)==ERROR: LeakSanitizer: detected memory leaks", line
+            ):
+                pid = int(match.group(1))
+                error_section_start = i
+
+                # Collect ALL leak blocks under this ERROR section.
+                leak_blocks = []
+                summary_line = ""
+                j = i + 1
+
+                while j < log_buffer.line_count:
+                    leak_line = log_buffer.get_line(j)
+
+                    # Found a leak block: Direct/Indirect leak of N byte(s) in M object(s).
+                    if leak_match := re.match(
+                        r"^(Direct|Indirect) leak of (\d+) byte\(s\) in (\d+) object\(s\)",
+                        leak_line,
+                    ):
+                        leak_data = self._parse_lsan_leak_block(
+                            log_buffer, j, leak_match
+                        )
+                        leak_blocks.append((j, leak_data))
+                        j = leak_data.get("next_line", j + 1)
+
+                    # Found SUMMARY - end of this ERROR section.
+                    elif re.match(r"^\s*SUMMARY:", leak_line):
+                        summary_line = leak_line.strip()
+                        j += 1
+                        break
+
+                    # Next ERROR section - end.
+                    elif re.match(r"^==\d+==ERROR:", leak_line):
+                        break
+
+                    else:
+                        j += 1
+
+                # Collect full report for all leaks (from ERROR to SUMMARY).
+                report_lines = []
+                for line_num in range(error_section_start, j):
+                    report_lines.append(log_buffer.get_line(line_num))
+                full_report = "\n".join(report_lines)
+
+                # Create separate issue for each leak block.
+                for leak_line_num, leak_data in leak_blocks:
+                    # Remove internal fields.
+                    leak_data.pop("next_line", None)
+
+                    issue = SanitizerIssue(
+                        severity=Severity.HIGH,
+                        actionable=True,
+                        message=f"LeakSanitizer: {leak_data['leak_type']} leak of {leak_data['leaked_bytes']} bytes",
+                        line_number=self._get_original_line_number(
+                            log_buffer, leak_line_num
+                        ),
+                        source_extractor=self.name,
+                        sanitizer_type="lsan",
+                        error_type="memory-leak",
+                        pid=pid,
+                        summary_line=summary_line,
+                        full_report=full_report,
+                        **leak_data,
+                    )
+                    issues.append(issue)
+
+                i = j
+            else:
+                i += 1
+
+        return issues
+
+    def _parse_lsan_leak_block(
+        self, log_buffer: LogBuffer, start_line: int, leak_match: re.Match
+    ) -> dict[str, any]:
+        """Parse a single LSAN leak block.
+
+        Args:
+            log_buffer: LogBuffer containing the leak.
+            start_line: Line number of "Direct/Indirect leak of..." line.
+            leak_match: Regex match object for the leak header.
+
+        Returns:
+            Dict with leak_type, leaked_bytes, leaked_objects, primary_stack, etc.
+        """
+        data = {}
+
+        # Extract leak info from header.
+        data["leak_type"] = leak_match.group(1)  # "Direct" or "Indirect"
+        data["leaked_bytes"] = int(leak_match.group(2))
+        data["leaked_objects"] = int(leak_match.group(3))
+
+        # Look for "allocated from:" on same or next line.
+        i = start_line
+        while i < min(start_line + 3, log_buffer.line_count):
+            line = log_buffer.get_line(i)
+            if "allocated from:" in line:
+                # Parse stack trace starting after "allocated from:" line.
+                stack, next_line = self._parse_stack_trace(
+                    log_buffer,
+                    i + 1,
+                    stop_patterns=[
+                        r"^Direct leak",
+                        r"^Indirect leak",
+                        r"^\s*SUMMARY:",
+                        r"^==\d+==ERROR:",
+                    ],
+                )
+                data["primary_stack"] = stack
+                data["next_line"] = next_line
+                return data
+            i += 1
+
+        # No stack found - just return what we have.
+        data["next_line"] = start_line + 1
+        return data
+
+    # =========================================================================
+    # TSAN Extraction
+    # =========================================================================
+
+    def _extract_tsan(self, log_buffer: LogBuffer) -> list[SanitizerIssue]:
+        """Extract ThreadSanitizer reports.
+
+        TSAN format uses different separator (shorter) and has dual stacks:
+        ==================
+        WARNING: ThreadSanitizer: data-race (pid=PID)
+          Write of size 8 at 0xADDR by thread T1:
+            #0 ...
+          Previous read of size 8 at 0xADDR by main thread:
+            #0 ...
+          Thread T1 created by main thread at:
+            #0 ...
+        SUMMARY: ThreadSanitizer: data-race file.c:123 in func
+        ==================
+
+        Args:
+            log_buffer: LogBuffer to search.
+
+        Returns:
+            List of SanitizerIssue objects for TSAN errors found.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Detection: WARNING: ThreadSanitizer: ERROR_TYPE (pid=PID).
+            if match := re.match(
+                r"^WARNING: ThreadSanitizer: ([\w-]+) \(pid=(\d+)\)", line
+            ):
+                error_type = match.group(1)
+                pid = int(match.group(2))
+                report_start_line = i
+
+                # Parse TSAN report (dual stacks).
+                report_data = self._parse_tsan_report(log_buffer, i, pid, error_type)
+
+                # Remove internal fields.
+                end_line = report_data.pop("end_line", i + 1)
+
+                # Create issue.
+                issue = SanitizerIssue(
+                    severity=Severity.CRITICAL,
+                    actionable=True,
+                    message=f"ThreadSanitizer: {error_type}",
+                    line_number=self._get_original_line_number(
+                        log_buffer, report_start_line
+                    ),
+                    source_extractor=self.name,
+                    sanitizer_type="tsan",
+                    error_type=error_type,
+                    pid=pid,
+                    **report_data,
+                )
+                issues.append(issue)
+
+                # Skip past this report.
+                i = end_line
+            else:
+                i += 1
+
+        return issues
+
+    def _parse_tsan_report(
+        self, log_buffer: LogBuffer, start_line: int, pid: int, error_type: str
+    ) -> dict[str, any]:
+        """Parse TSAN report with dual stack traces.
+
+        Args:
+            log_buffer: LogBuffer containing the report.
+            start_line: Line number of WARNING header.
+            pid: Process ID.
+            error_type: Error type (e.g., "data-race").
+
+        Returns:
+            Dict with primary_stack, conflicting_stack, thread info, etc.
+        """
+        data = {}
+        i = start_line + 1
+
+        # Parse primary access stack (first stack after WARNING).
+        # Look for "Write/Read of size N at 0xADDR by thread TX:".
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Primary access description.
+            if match := re.search(
+                r"^\s*(Write|Read|Atomic \w+) of size (\d+) at (0x[0-9a-f]+) by (thread \w+|main thread)",
+                line,
+            ):
+                data["access_type"] = match.group(1)
+                data["access_size"] = int(match.group(2))
+                data["address"] = match.group(3)
+                data["thread_id"] = match.group(4)
+
+                # Parse primary stack.
+                primary_stack, i = self._parse_stack_trace(
+                    log_buffer,
+                    i + 1,
+                    stop_patterns=[
+                        r"^\s*Previous",
+                        r"^\s*Thread T\d+ created",
+                        r"^\s*SUMMARY:",
+                    ],
+                )
+                data["primary_stack"] = primary_stack
+                break
+
+            i += 1
+
+        # Parse conflicting access stack ("Previous write/read...").
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            if re.match(r"^\s*Previous (write|read)", line):
+                # Parse conflicting stack.
+                conflicting_stack, i = self._parse_stack_trace(
+                    log_buffer,
+                    i + 1,
+                    stop_patterns=[
+                        r"^\s*Thread T\d+ created",
+                        r"^\s*SUMMARY:",
+                    ],
+                )
+                data["conflicting_stack"] = conflicting_stack
+                break
+
+            # Stop if we hit SUMMARY.
+            if re.match(r"^\s*SUMMARY:", line):
+                break
+
+            i += 1
+
+        # Find report end.
+        end_line = self._find_report_end(log_buffer, start_line, "tsan")
+        data["end_line"] = end_line
+
+        # Collect full report.
+        report_lines = []
+        for line_num in range(start_line, end_line):
+            report_lines.append(log_buffer.get_line(line_num))
+        data["full_report"] = "\n".join(report_lines)
+
+        # Extract SUMMARY.
+        for line_num in range(start_line, end_line):
+            line = log_buffer.get_line(line_num)
+            if line.strip().startswith("SUMMARY:"):
+                data["summary_line"] = line.strip()
+                break
+
+        return data
+
+    # =========================================================================
+    # MSAN Extraction
+    # =========================================================================
+
+    def _extract_msan(self, log_buffer: LogBuffer) -> list[SanitizerIssue]:
+        """Extract MemorySanitizer reports.
+
+        MSAN detects use of uninitialized values:
+        ==PID== WARNING: MemorySanitizer: use-of-uninitialized-value
+            #0 ...
+          Uninitialized value was created by an allocation of 'var'
+            #0 ...
+        SUMMARY: MemorySanitizer: use-of-uninitialized-value file.c:123
+
+        Args:
+            log_buffer: LogBuffer to search.
+
+        Returns:
+            List of SanitizerIssue objects for MSAN errors found.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Detection: ==PID== WARNING: MemorySanitizer: ERROR_TYPE.
+            if match := re.match(
+                r"^==(\d+)== WARNING: MemorySanitizer: ([\w-]+)", line
+            ):
+                pid = int(match.group(1))
+                error_type = match.group(2)
+                report_start_line = i
+
+                # Parse MSAN report.
+                report_data = self._parse_msan_report(log_buffer, i, pid, error_type)
+
+                # Remove internal fields.
+                end_line = report_data.pop("end_line", i + 1)
+
+                # Create issue.
+                issue = SanitizerIssue(
+                    severity=Severity.CRITICAL,
+                    actionable=True,
+                    message=f"MemorySanitizer: {error_type}",
+                    line_number=self._get_original_line_number(
+                        log_buffer, report_start_line
+                    ),
+                    source_extractor=self.name,
+                    sanitizer_type="msan",
+                    error_type=error_type,
+                    pid=pid,
+                    **report_data,
+                )
+                issues.append(issue)
+
+                # Skip past this report.
+                i = end_line
+            else:
+                i += 1
+
+        return issues
+
+    def _parse_msan_report(
+        self, log_buffer: LogBuffer, start_line: int, pid: int, error_type: str
+    ) -> dict[str, any]:
+        """Parse MSAN report.
+
+        Args:
+            log_buffer: LogBuffer containing the report.
+            start_line: Line number of WARNING header.
+            pid: Process ID.
+            error_type: Error type.
+
+        Returns:
+            Dict with primary_stack, origin_description, etc.
+        """
+        data = {}
+        i = start_line + 1
+
+        # Parse primary stack (where uninitialized value was used).
+        primary_stack, i = self._parse_stack_trace(
+            log_buffer,
+            i,
+            stop_patterns=[
+                r"^\s*Uninitialized",
+                r"^\s*SUMMARY:",
+            ],
+        )
+        data["primary_stack"] = primary_stack
+
+        # Look for origin description.
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            if re.match(r"^\s*Uninitialized value was created", line):
+                data["origin_description"] = line.strip()
+                # Parse origin stack if present.
+                origin_stack, i = self._parse_stack_trace(
+                    log_buffer,
+                    i + 1,
+                    stop_patterns=[r"^\s*SUMMARY:"],
+                )
+                data["allocation_stack"] = origin_stack
+                break
+
+            if re.match(r"^\s*SUMMARY:", line):
+                break
+
+            i += 1
+
+        # Find report end.
+        end_line = self._find_report_end(log_buffer, start_line, "msan")
+        data["end_line"] = end_line
+
+        # Collect full report.
+        report_lines = []
+        for line_num in range(start_line, end_line):
+            report_lines.append(log_buffer.get_line(line_num))
+        data["full_report"] = "\n".join(report_lines)
+
+        # Extract SUMMARY.
+        for line_num in range(start_line, end_line):
+            line = log_buffer.get_line(line_num)
+            if line.strip().startswith("SUMMARY:"):
+                data["summary_line"] = line.strip()
+                break
+
+        return data
+
+    # =========================================================================
+    # UBSAN Extraction
+    # =========================================================================
+
+    def _extract_ubsan(self, log_buffer: LogBuffer) -> list[SanitizerIssue]:
+        """Extract UndefinedBehaviorSanitizer reports.
+
+        UBSAN uses inline format (no separator):
+        file.c:123:45: runtime error: signed integer overflow
+        SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior file.c:123:45
+
+        Args:
+            log_buffer: LogBuffer to search.
+
+        Returns:
+            List of SanitizerIssue objects for UBSAN errors found.
+        """
+        issues = []
+        i = 0
+
+        while i < log_buffer.line_count:
+            line = log_buffer.get_line(i)
+
+            # Detection: FILE:LINE:COL: runtime error: DESCRIPTION.
+            # Must have absolute path or relative path with extension.
+            if match := re.match(
+                r"^([^:]+\.\w+):(\d+):(\d+): runtime error: (.+)$", line
+            ):
+                file_path = match.group(1)
+                line_num = int(match.group(2))
+                column = int(match.group(3))
+                description = match.group(4)
+                report_start_line = i
+
+                # Look for SUMMARY on next few lines.
+                summary_line = ""
+                for j in range(i + 1, min(i + 5, log_buffer.line_count)):
+                    summary_candidate = log_buffer.get_line(j)
+                    if summary_candidate.strip().startswith(
+                        "SUMMARY: UndefinedBehaviorSanitizer"
+                    ):
+                        summary_line = summary_candidate.strip()
+                        break
+
+                # Create issue.
+                issue = SanitizerIssue(
+                    severity=Severity.HIGH,
+                    actionable=True,
+                    message=f"UndefinedBehaviorSanitizer: {description}",
+                    line_number=self._get_original_line_number(
+                        log_buffer, report_start_line
+                    ),
+                    source_extractor=self.name,
+                    sanitizer_type="ubsan",
+                    error_type="undefined-behavior",
+                    pid=0,  # UBSAN doesn't show PID.
+                    ubsan_file=file_path,
+                    ubsan_line=line_num,
+                    ubsan_column=column,
+                    full_report=f"{line}\n{summary_line}" if summary_line else line,
+                    summary_line=summary_line,
+                )
+                issues.append(issue)
+
+            i += 1
+
+        return issues

--- a/tools/utils/common/formatting.py
+++ b/tools/utils/common/formatting.py
@@ -1,0 +1,195 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared formatting helpers for human-friendly output.
+
+All lit tools should use these helpers to keep banners and human output
+consistent. Tools remain concise by default; callers can opt-in to `pretty`
+styling which may add color when outputting to a TTY.
+
+Note: TTY detection and NO_COLOR checks are handled by console.py before
+calling these formatting functions. This module is pure string formatting.
+"""
+
+from __future__ import annotations
+
+
+def _use_color(pretty: bool) -> bool:
+    """Return whether to apply color codes based on pretty flag.
+
+    The pretty flag is computed by console.py which handles TTY detection
+    and NO_COLOR environment variable checks. This function just returns
+    the flag value since all I/O decisions are made in the console layer.
+
+    Args:
+        pretty: Whether color output is enabled (from console.py)
+
+    Returns:
+        The pretty flag value
+    """
+    return bool(pretty)
+
+
+def _c(code: str, text: str, pretty: bool) -> str:
+    if _use_color(pretty):
+        return f"\033[{code}m{text}\033[0m"
+    return text
+
+
+def color(code: str, text: str, pretty: bool = False) -> str:
+    """Applies an ANSI color/style ``code`` when ``pretty`` is enabled.
+
+    Prefer this for one-off emphasis in tools (headers, numbers, etc.).
+    Keep usage minimal to preserve token-efficiency and readability.
+
+    Example:
+        >>> header = color("1;33", "summary:", pretty=True)  # bold yellow
+    """
+    return _c(code, text, pretty)
+
+
+def case_banner(case: object, pretty: bool = False) -> str:
+    """Format test case as banner comment.
+
+    Args:
+        case: TestCase object with number, name, start_line, end_line attributes
+        pretty: Enable colorized output
+
+    Returns:
+        Formatted banner string
+    """
+    name = f"@{case.name}" if case.name else "(unnamed)"
+    head = f"// Test case {case.number}: {name}"
+    rng = f"(lines {case.start_line}-{case.end_line})"
+    if _use_color(pretty):
+        head = _c("1;36", head, True)  # bold cyan
+        rng = _c("2;37", rng, True)  # dim grey
+    return f"{head} {rng}"
+
+
+def use_color(pretty: bool) -> bool:
+    """Expose color decision for callers that need to branch behavior.
+
+    Args:
+        pretty: Pretty output mode enabled
+
+    Returns:
+        Whether to apply color codes
+    """
+    return _use_color(pretty)
+
+
+def warn(msg: str, pretty: bool = False) -> str:
+    """Format warning message with optional color.
+
+    Args:
+        msg: Warning message text
+        pretty: Enable colorized output
+
+    Returns:
+        Formatted warning message
+    """
+    prefix = _c("1;33", "warning:", pretty)
+    return f"{prefix} {msg}"
+
+
+def error(msg: str, pretty: bool = False) -> str:
+    """Format error message with optional color.
+
+    Args:
+        msg: Error message text
+        pretty: Enable colorized output
+
+    Returns:
+        Formatted error message
+    """
+    prefix = _c("1;31", "error:", pretty)
+    return f"{prefix} {msg}"
+
+
+def note(msg: str, pretty: bool = False) -> str:
+    """Format note message with optional color.
+
+    Args:
+        msg: Note message text
+        pretty: Enable colorized output
+
+    Returns:
+        Formatted note message
+    """
+    prefix = _c("1;34", "note:", pretty)
+    return f"{prefix} {msg}"
+
+
+def highlight_run(line: str, pretty: bool = False) -> str:
+    """Highlights a single `// RUN: ...` comment line for display.
+
+    Should only be used when writing to a terminal. Do not colorize when
+    writing to files.
+    """
+    if not _use_color(pretty):
+        return line
+    if line.lstrip().startswith("// RUN:"):
+        # Colorize RUN: label and dim the rest
+        prefix, rest = line.split("RUN:", 1)
+        return f"{prefix}{_c('1;35', 'RUN:', True)}{_c('2;37', rest, True)}"
+    return line
+
+
+def success(msg: str, pretty: bool = False) -> str:
+    """Format success message with optional color.
+
+    Args:
+        msg: Success message text
+        pretty: Enable colorized output
+
+    Returns:
+        Formatted success message
+    """
+    prefix = _c("1;32", "ok:", pretty)
+    return f"{prefix} {msg}"
+
+
+def colorize_diff(diff_text: str, pretty: bool = False) -> str:
+    """Add ANSI color codes to unified diff output.
+
+    Only adds color when pretty=True and outputting to TTY.
+
+    Args:
+        diff_text: Unified diff text
+        pretty: Whether to apply color codes
+
+    Returns:
+        Colorized diff (or original if color disabled)
+    """
+    if not _use_color(pretty):
+        return diff_text
+
+    # ANSI color codes
+    RED = "31"  # Deletions
+    GREEN = "32"  # Additions
+    CYAN = "36"  # File headers (---)
+    BOLD = "1"
+
+    lines = []
+    for line in diff_text.splitlines():
+        if line.startswith("---") or line.startswith("+++"):
+            # File headers: bold cyan
+            lines.append(_c(f"{BOLD};{CYAN}", line, True))
+        elif line.startswith("-") and not line.startswith("---"):
+            # Deletions: red
+            lines.append(_c(RED, line, True))
+        elif line.startswith("+") and not line.startswith("+++"):
+            # Additions: green
+            lines.append(_c(GREEN, line, True))
+        elif line.startswith("@@"):
+            # Hunk headers: bold cyan
+            lines.append(_c(f"{BOLD};{CYAN}", line, True))
+        else:
+            # Context lines: no color
+            lines.append(line)
+
+    return "\n".join(lines)

--- a/tools/utils/common/fs.py
+++ b/tools/utils/common/fs.py
@@ -1,0 +1,54 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Filesystem utilities for safe atomic file operations."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+
+def safe_write_text(
+    path: Path | str,
+    data: str,
+    *,
+    encoding: str = "utf-8",
+    mkdir: bool = True,
+    atomic: bool = True,
+    backup: bool = False,
+) -> None:
+    """Write text to file with optional atomic write and backup.
+
+    Args:
+        path: Destination file path.
+        data: Text content to write.
+        encoding: Text encoding (default: utf-8).
+        mkdir: Create parent directories if needed (default: True).
+        atomic: Use atomic write via temp file (default: True).
+        backup: Create .bak file before overwriting (default: False).
+    """
+    p = Path(path)
+    if mkdir:
+        p.parent.mkdir(parents=True, exist_ok=True)
+    if not atomic:
+        with open(p, "w", encoding=encoding, newline="\n") as f:
+            f.write(data)
+        return
+    # Atomic via write to a temp file in the same dir and rename
+    fd, tmp_name = tempfile.mkstemp(prefix=p.name + ".tmp-", dir=str(p.parent))
+    try:
+        with os.fdopen(fd, "w", encoding=encoding, newline="\n") as f:
+            f.write(data)
+        if backup and p.exists():
+            p.replace(p.with_suffix(p.suffix + ".bak"))
+        os.replace(tmp_name, p)
+    except Exception:
+        with suppress(Exception):
+            os.unlink(tmp_name)
+        raise

--- a/tools/utils/common/issues.py
+++ b/tools/utils/common/issues.py
@@ -1,0 +1,525 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Issue types for log analysis extractors.
+
+This module defines a type hierarchy for structured diagnostic information
+extracted from logs. Each Issue type captures specific error details for
+different failure modes (sanitizers, LIT tests, build errors, etc.).
+
+Example usage:
+    # Sanitizer error.
+    issue = SanitizerIssue(
+        severity=Severity.CRITICAL,
+        actionable=True,
+        message="Data race in Device::Submit",
+        sanitizer_type="TSAN",
+        error_type="data-race",
+        stack_trace=["#0 Device::Submit() device.cc:123", ...],
+    )
+
+    # LIT test failure.
+    issue = LITTestIssue(
+        severity=Severity.HIGH,
+        actionable=True,
+        message="FileCheck pattern mismatch",
+        test_file="test.mlir",
+        test_line=42,
+        check_type="CHECK-SAME",
+        expected="expected pattern",
+        actual="actual output",
+    )
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Severity(Enum):
+    """Issue severity levels with numeric values for sorting."""
+
+    CRITICAL = 4  # Crashes, data corruption, security issues.
+    HIGH = 3  # Functional failures, test failures.
+    MEDIUM = 2  # Warnings, deprecations.
+    LOW = 1  # Info, suggestions.
+
+
+@dataclass
+class Issue:
+    """Base class for all extracted diagnostic issues.
+
+    Line number indexing convention:
+    - line_number: 0-indexed (matches LogBuffer and Python list indexing)
+    - Source file line numbers in subclasses (e.g., LITTestIssue.test_line):
+      Should use 1-indexed to match source file conventions
+
+    Attributes:
+        severity: Issue severity level.
+        actionable: True if this requires code changes (vs infrastructure flake).
+        message: Human-readable summary of the issue.
+        context_lines: Log lines surrounding the issue (for display).
+        line_number: Line number in log where issue was found (0-indexed).
+        source_extractor: Name of extractor that found this issue.
+    """
+
+    severity: Severity
+    actionable: bool
+    message: str
+    context_lines: list[str] = field(default_factory=list)
+    line_number: int | None = None
+    source_extractor: str = "Unknown"
+
+
+@dataclass
+class SanitizerIssue(Issue):
+    """Sanitizer failure (TSAN, ASAN, LSAN, UBSAN, MSAN).
+
+    Captures comprehensive information about sanitizer-detected errors including
+    stack traces, memory details, thread/mutex state, and full reports.
+
+    Attributes:
+        sanitizer_type: Type of sanitizer ("asan", "lsan", "tsan", "msan", "ubsan").
+        error_type: Specific error ("heap-buffer-overflow", "data-race", etc.).
+        pid: Process ID from sanitizer report.
+
+        # Stack traces (list of formatted frame strings).
+        primary_stack: Main error location stack trace.
+        allocation_stack: Memory allocation stack trace (ASAN/LSAN).
+        conflicting_stack: Second access stack trace (TSAN data races).
+
+        # Memory information (ASAN).
+        access_type: Read or write access ("READ"/"WRITE").
+        access_size: Number of bytes accessed.
+        address: Memory address involved ("0xdeadbeef").
+        memory_offset: Bytes after/before region boundary.
+        memory_region_size: Size of allocated region in bytes.
+        memory_region_start: Start address of region.
+        memory_region_end: End address of region.
+
+        # Leak information (LSAN).
+        leak_type: Direct or indirect leak ("Direct"/"Indirect").
+        leaked_bytes: Total bytes leaked.
+        leaked_objects: Number of leaked objects.
+
+        # Thread/synchronization information (TSAN).
+        thread_id: Thread identifier ("T0", "main thread").
+        mutex_state: Mutex lock state during access.
+        thread_created_by: Parent thread information.
+
+        # Origin information (MSAN).
+        origin_description: Description of uninitialized value origin.
+
+        # UBSAN specific.
+        ubsan_file: Source file where UB occurred.
+        ubsan_line: Line number in source file.
+        ubsan_column: Column number in source file.
+
+        # Complete report text.
+        full_report: Complete sanitizer output from error to SUMMARY.
+        summary_line: SUMMARY line from report.
+    """
+
+    # Classification.
+    sanitizer_type: str = ""  # "asan", "lsan", "tsan", "msan", "ubsan"
+    error_type: str = ""  # "heap-buffer-overflow", "data-race", etc.
+    pid: int = 0
+
+    # Stack traces.
+    primary_stack: list[str] = field(default_factory=list)
+    allocation_stack: list[str] = field(default_factory=list)
+    conflicting_stack: list[str] = field(default_factory=list)
+
+    # Memory info (ASAN).
+    access_type: str = ""  # "READ" or "WRITE"
+    access_size: int = 0
+    address: str = ""  # "0xdeadbeef"
+    memory_offset: int = 0  # bytes after/before
+    memory_region_size: int = 0
+    memory_region_start: str = ""
+    memory_region_end: str = ""
+
+    # Leak info (LSAN).
+    leak_type: str = ""  # "Direct" or "Indirect"
+    leaked_bytes: int = 0
+    leaked_objects: int = 0
+
+    # Thread/mutex info (TSAN).
+    thread_id: str = ""  # "T0", "main thread"
+    mutex_state: str = ""
+    thread_created_by: str = ""
+
+    # Origin info (MSAN).
+    origin_description: str = ""
+
+    # UBSAN info.
+    ubsan_file: str = ""
+    ubsan_line: int = 0
+    ubsan_column: int = 0
+
+    # Full report.
+    full_report: str = ""
+    summary_line: str = ""
+
+
+@dataclass
+class LITTestIssue(Issue):
+    """LIT test failure (FileCheck, verifier, RUN command).
+
+    Captures detailed information about LIT test failures including the
+    test file, line number, check type, and expected vs actual output.
+
+    Attributes:
+        test_file: Path to the failing test file.
+        test_line: Line number in test file where failure occurred (1-indexed,
+            matching source file conventions).
+        check_type: Type of FileCheck directive (CHECK, CHECK-SAME, etc.).
+        check_pattern: The FileCheck pattern that failed.
+        expected: Expected output pattern.
+        actual: Actual output received.
+        run_command: The RUN: command that was executing.
+    """
+
+    test_file: str = ""
+    test_line: int = 0
+    check_type: str = ""  # "CHECK", "CHECK-SAME", "CHECK-NOT", etc.
+    check_pattern: str | None = None
+    expected: str | None = None
+    actual: str | None = None
+    run_command: str | None = None
+
+
+@dataclass
+class MLIRCompilerIssue(Issue):
+    """MLIR compiler error (iree-compile, mlir-opt, iree-opt).
+
+    Captures structured information about MLIR compiler failures including
+    file location, operation details, and full diagnostic context. Compatible
+    with iree-lit-test/iree-lit-extract for test file extraction.
+
+    Line number conventions:
+    - error_line: 1-indexed (matches compiler output: file.mlir:17:15)
+    - error_column: 1-indexed (matches compiler output)
+    - line_number (inherited): 0-indexed (log line where error was found)
+
+    Attributes:
+        file_path: Path to .mlir file with error (may be relative or absolute).
+        error_line: Line number where error occurred (1-indexed).
+        error_column: Column number where error occurred (1-indexed).
+        error_type: Error category inferred from message
+            (e.g., "out-of-bounds", "does-not-dominate", "failed-to-tile").
+        operation: MLIR operation name if present
+            (e.g., "linalg.generic", "stream.async.execute").
+        error_message: Primary error diagnostic text.
+        source_snippet: MLIR source code line(s) showing the error location.
+        caret_line: Line with caret (^) marker showing exact column.
+        notes: List of related diagnostic notes. Each note is a dict with:
+            - 'file': str - File path
+            - 'line': int - Line number (1-indexed)
+            - 'column': int - Column number (1-indexed)
+            - 'type': str - Note type (e.g., "see current operation:", "called from")
+            - 'body': str - Note body text (may include multi-line operation dump)
+        full_diagnostic: Complete multi-line error text including all notes.
+        test_target: Inferred test target path if detectable
+            (e.g., "compiler/.../test/foo.mlir" or Bazel target).
+        compile_command: Compilation command that triggered error if available.
+    """
+
+    # Error location.
+    file_path: str = ""  # "tests/e2e/linalg/argmax.mlir"
+    error_line: int = 0  # 17 (1-indexed, matching compiler output)
+    error_column: int = 0  # 15 (1-indexed, matching compiler output)
+
+    # Error details.
+    error_type: str = ""  # "failed-to-tile", "out-of-bounds", "does-not-dominate"
+    operation: str | None = None  # "linalg.generic", "tensor.extract_slice"
+    error_message: str = ""  # "Failed to analyze the reduction operation."
+
+    # Source context.
+    source_snippet: str = ""  # "  %result:2 = linalg.generic {"
+    caret_line: str = ""  # "              ^"
+
+    # Related diagnostics.
+    notes: list[dict] = field(
+        default_factory=list
+    )  # [{"file": ..., "line": ..., "type": "called from", "body": ...}]
+
+    # Full diagnostic.
+    full_diagnostic: str = ""  # Complete multi-line error from error to last note
+
+    # Test context (optional).
+    test_target: str | None = None  # "tests/e2e/linalg/argmax.mlir"
+    compile_command: str | None = None  # "iree-compile ... -o foo.vmfb"
+
+
+@dataclass
+class MissingDependencyIssue(Issue):
+    """Bazel/CMake missing dependency error.
+
+    Captures information about missing build dependencies including the
+    header/symbol that's missing and suggested fixes.
+
+    Attributes:
+        missing_header: Name of missing header or symbol.
+        target: Build target that needs the dependency.
+        suggested_dep: Suggested dependency to add.
+        fix_suggestion: Actionable fix instructions.
+    """
+
+    missing_header: str = ""
+    target: str | None = None
+    suggested_dep: str | None = None
+    fix_suggestion: str | None = None
+
+
+@dataclass
+class DeprecatedAPIIssue(Issue):
+    """Deprecated API usage warning.
+
+    Captures information about deprecated API usage including the symbol,
+    replacement, and location in code.
+
+    Attributes:
+        deprecated_symbol: Name of deprecated symbol.
+        replacement: Replacement API to use.
+        file_path: Source file with deprecated usage.
+        line: Line number in source file (1-indexed, matching compiler output).
+        column: Column number in source file (1-indexed, matching compiler output).
+    """
+
+    deprecated_symbol: str = ""
+    replacement: str = ""
+    file_path: str = ""
+    line: int = 0
+    column: int = 0
+
+
+@dataclass
+class PythonTestIssue(Issue):
+    """Python test failure (pytest, unittest).
+
+    Captures detailed information about Python test failures including
+    exception type, message, stack trace, and assertion details.
+
+    Attributes:
+        test_name: Name of the failing test.
+        exception_type: Type of exception raised.
+        exception_message: Exception message.
+        stack_trace: Python stack trace frames.
+        assertion_details: Details of failed assertion (if applicable).
+    """
+
+    test_name: str = ""
+    exception_type: str = ""
+    exception_message: str = ""
+    stack_trace: list[str] = field(default_factory=list)
+    assertion_details: str | None = None
+
+
+@dataclass
+class ROCmInfrastructureIssue(Issue):
+    """ROCm infrastructure failure (cleanup crash, device lost).
+
+    Captures information about ROCm/HIP infrastructure failures that are
+    typically non-actionable (driver issues, cleanup crashes, etc.).
+
+    Attributes:
+        error_pattern: Type of infrastructure error.
+        test_passed: True if tests passed before the infrastructure failure.
+    """
+
+    error_pattern: str = ""  # "cleanup_crash", "device_lost", etc.
+    test_passed: bool = False  # True if tests passed before crash.
+
+
+@dataclass
+class BuildErrorIssue(Issue):
+    """C/C++ compilation or linker error.
+
+    Attributes:
+        error_type: Type of error ("compile", "link", "undefined_reference").
+        file_path: Source file path.
+        line: Line number in source file (1-indexed).
+        column: Column number in source file (1-indexed).
+        compiler_message: Compiler/linker error message.
+        compiler: Compiler name if detected ("clang", "gcc", "msvc", "ld").
+    """
+
+    error_type: str = ""
+    file_path: str = ""
+    line: int = 0
+    column: int = 0
+    compiler_message: str = ""
+    compiler: str | None = None
+
+
+@dataclass
+class CMakeErrorIssue(Issue):
+    """CMake configuration error.
+
+    Attributes:
+        cmake_file: CMake file where error occurred.
+        cmake_line: Line number in CMake file (1-indexed).
+        error_type: Type of error ("missing_dependency", "version_mismatch", "configuration", "error").
+        cmake_command: CMake command that failed (e.g., "find_package").
+        cmake_stack: CMake call stack if available.
+        missing_dependency: Name of missing package/dependency.
+        required_version: Required version string.
+        found_version: Found version string (if any).
+    """
+
+    cmake_file: str = ""
+    cmake_line: int = 0
+    error_type: str = ""
+    cmake_command: str | None = None
+    cmake_stack: list[str] = field(default_factory=list)
+    missing_dependency: str | None = None
+    required_version: str | None = None
+    found_version: str | None = None
+
+
+@dataclass
+class CTestErrorIssue(Issue):
+    """CTest test failure.
+
+    Attributes:
+        test_name: Name of failed test.
+        test_number: CTest test number.
+        exit_code: Test exit code.
+        failure_reason: Reason for failure ("failed", "timeout", "exception", "crash").
+        test_output_tail: Last N lines of test output.
+        elapsed_time: Test execution time in seconds.
+    """
+
+    test_name: str = ""
+    test_number: int = 0
+    exit_code: int | None = None
+    failure_reason: str = "failed"
+    test_output_tail: list[str] = field(default_factory=list)
+    elapsed_time: float | None = None
+
+
+@dataclass
+class GPUDriverIssue(Issue):
+    """GPU driver error (CUDA, HIP/ROCm, Vulkan, Metal).
+
+    Attributes:
+        gpu_type: GPU API ("cuda", "hip", "vulkan", "metal").
+        error_code: Driver error code ("VK_ERROR_DEVICE_LOST", "hipErrorFileNotFound", etc.).
+        error_type: Error category ("device_lost", "oom", "initialization_failed", "cleanup_crash").
+        test_passed_before_crash: True if test passed before driver crash (for ROCm cleanup crash).
+        rocclr_file: ROCm source file for cleanup crash debugging.
+    """
+
+    gpu_type: str = ""
+    error_code: str = ""
+    error_type: str = ""
+    test_passed_before_crash: bool | None = None
+    rocclr_file: str | None = None
+
+
+@dataclass
+class BazelErrorIssue(Issue):
+    """Bazel build system error.
+
+    Captures Bazel-specific build failures including missing targets and
+    build summary errors. Note: Compiler errors from Bazel builds are
+    handled by BuildErrorExtractor.
+
+    Attributes:
+        error_type: Type of error ("missing_target", "build_failed").
+        bazel_file: BUILD.bazel file where error occurred.
+        bazel_line: Line number in BUILD.bazel file (1-indexed).
+        workspace: Workspace name for external dependencies.
+        package: Package path ("compiler/src/iree/compiler/API").
+        target: Target name that failed.
+        failed_targets: List of failed targets (for build summary).
+    """
+
+    error_type: str = ""
+    bazel_file: str = ""
+    bazel_line: int = 0
+    workspace: str | None = None
+    package: str | None = None
+    target: str | None = None
+    failed_targets: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PrecommitErrorIssue(Issue):
+    """Pre-commit hook failure.
+
+    Captures failures from pre-commit hooks (formatting, linting, etc.).
+    These are typically non-critical infrastructure issues that can be
+    fixed by running pre-commit locally.
+
+    Attributes:
+        hook_id: Pre-commit hook identifier.
+        hook_description: Human-readable hook description.
+        error_type: Type of error ("modified_files", "check_failed").
+        files_modified: True if hook modified files (needs commit).
+        error_details: Additional error details if available.
+    """
+
+    hook_id: str = ""
+    hook_description: str = ""
+    error_type: str = ""
+    files_modified: bool = False
+    error_details: str | None = None
+
+
+@dataclass
+class CodeQLIssue(Issue):
+    """CodeQL code scanning failure.
+
+    Captures failures from GitHub CodeQL code scanning, including language
+    detection failures, analysis upload failures, and fatal errors during
+    analysis. These are typically infrastructure/configuration issues.
+
+    Attributes:
+        error_category: Type of CodeQL error ("language", "upload", "fatal", "status").
+        expected_language: Expected language for analysis (if language error).
+        found_language: Actually detected language (if language error).
+        command: Command that failed (if fatal error).
+        exit_code: Exit code from failed command (if fatal error).
+        status: Job or upload status (if status error).
+    """
+
+    error_category: str = ""
+    expected_language: str | None = None
+    found_language: str | None = None
+    command: str | None = None
+    exit_code: int | None = None
+    status: str | None = None
+
+
+@dataclass
+class ONNXTestIssue(Issue):
+    """ONNX test failure with rich reproduction context.
+
+    Captures ONNX test failures from iree-test-suites with complete
+    reproduction information: input MLIR, compilation command, run command,
+    and test source URL. This provides everything needed for triage without
+    setting up the ONNX environment.
+
+    Attributes:
+        test_name: Test name (e.g., "test_mean_example").
+        error_tool: Tool that failed ("iree-compile" or "iree-run-module").
+        error_code: Exit code from failed tool.
+        error_message: Actual error message from stderr.
+        input_mlir: Complete input MLIR program.
+        compile_command: Full compilation command for reproduction.
+        run_command: Full run command for reproduction.
+        test_source_url: GitHub URL to test case source.
+    """
+
+    test_name: str = ""
+    error_tool: str = ""  # "iree-compile" or "iree-run-module"
+    error_code: int | None = None
+    error_message: str = ""
+    input_mlir: str = ""
+    compile_command: str = ""
+    run_command: str = ""
+    test_source_url: str = ""

--- a/tools/utils/common/log_buffer.py
+++ b/tools/utils/common/log_buffer.py
@@ -1,0 +1,430 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+r"""Log buffer for efficient log traversal and context extraction.
+
+This module provides LogBuffer, a utility class for efficient access to log
+content with support for:
+- Line-based access with 0-indexed line numbers
+- Context extraction (lines around a specific line)
+- Byte offset to line number conversion
+- Forward and backward pattern searching with configurable limits
+- Automatic stripping of log format prefixes (GitHub Actions, ctest, cmake, etc.)
+
+Example usage:
+    # Basic usage without prefix stripping.
+    log_buffer = LogBuffer(log_content)
+
+    # Auto-detect and strip log prefixes (GitHub Actions, etc.).
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+
+    # Explicitly strip specific formats.
+    log_buffer = LogBuffer(log_content, strip_formats=['github_actions', 'ctest'])
+
+    # Get specific line (from stripped content if stripping enabled).
+    line = log_buffer.get_line(42)
+
+    # Get context around error line.
+    context = log_buffer.get_lines_around(42, context=5)
+
+    # Search backward for RUN command.
+    match = log_buffer.find_previous_match(offset, r'^// RUN:')
+
+    # Access original unstripped content if needed.
+    original = log_buffer.get_original_content()
+"""
+
+import bisect
+import re
+from re import Match, Pattern
+
+
+class LogBuffer:
+    """Provides efficient access and traversal for log content.
+
+    This class wraps log content and provides efficient utilities for
+    extractors to navigate and extract context. All line numbers are
+    0-indexed to match Python list indexing.
+
+    Supports automatic stripping of log format prefixes (GitHub Actions
+    timestamps, ctest markers, etc.) to provide clean content for pattern
+    matching.
+
+    Attributes:
+        content: Log content as string (preprocessed if stripping enabled).
+    """
+
+    # Compiled patterns for format detection (compiled once, reused for all logs).
+    _GITHUB_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s")
+
+    def __init__(
+        self,
+        log_content: str,
+        strip_formats: list[str] | None = None,
+        auto_detect_format: bool = False,
+    ) -> None:
+        """Initialize LogBuffer with optional prefix stripping.
+
+        Args:
+            log_content: Full log content as a string.
+            strip_formats: List of format types to strip. Supported formats:
+                - 'github_actions': GitHub Actions timestamp prefix
+                - 'ctest': ctest [ctest] prefix
+                - 'cmake': cmake [cmake] or [build] prefix
+                None (default) means no stripping.
+            auto_detect_format: If True, auto-detect format from content and
+                strip automatically. Overrides strip_formats if True.
+        """
+        # Preserve original content for debugging/access.
+        self._original_content = log_content
+        self._strip_formats = strip_formats or []
+
+        # Auto-detect if requested.
+        if auto_detect_format:
+            self._strip_formats = self._detect_formats(log_content)
+
+        # Apply stripping if formats specified.
+        if self._strip_formats:
+            self.content = self._apply_stripping(log_content, self._strip_formats)
+        else:
+            self.content = log_content
+
+        # Build internal structures from preprocessed content.
+        self._lines = self.content.splitlines()
+        self._line_offsets = self._compute_line_offsets()
+
+    def _compute_line_offsets(self) -> list[int]:
+        """Compute character offset for each line start.
+
+        Note: These are character offsets (Python string indices), not byte
+        offsets. For ASCII logs these are identical, but for UTF-8 logs with
+        multi-byte characters they differ. Since we use these offsets only
+        internally for line lookups, character offsets are sufficient.
+
+        Returns:
+            List of character offsets, one per line in the log.
+        """
+        offsets = []
+        offset = 0
+        for line in self._lines:
+            offsets.append(offset)
+            offset += len(line) + 1  # +1 for newline character.
+        return offsets
+
+    def _detect_formats(self, content: str) -> list[str]:
+        """Auto-detect log format from content.
+
+        Samples first few lines to determine format type. Currently detects:
+        - GitHub Actions (ISO timestamp format)
+        - Future: ctest, cmake, ninja formats
+
+        Args:
+            content: Log content to analyze.
+
+        Returns:
+            List of detected format identifiers.
+        """
+        # Sample first 10 lines for detection.
+        sample_lines = content.split("\n", 10)[:10]
+
+        # Single-pass format detection: check each line for all patterns.
+        # Use set for efficient membership testing and to support multiple concurrent formats.
+        detected_formats = set()
+
+        for line in sample_lines:
+            stripped = line.strip()
+
+            # Check for each format type (logs can have multiple formats).
+            if self._GITHUB_PATTERN.search(line):
+                detected_formats.add("github_actions")
+
+            if stripped.startswith("[ctest]"):
+                detected_formats.add("ctest")
+
+            if stripped.startswith(
+                ("[cmake]", "[build]", "[main]", "[proc]", "[driver]")
+            ):
+                detected_formats.add("cmake")
+
+        # Return as list for consistency with API.
+        return list(detected_formats)
+
+    def _apply_stripping(self, content: str, formats: list[str]) -> str:
+        """Apply prefix stripping for specified formats.
+
+        Processes content line-by-line, applying format-specific stripping
+        functions in order. Preserves line structure (newlines).
+
+        Args:
+            content: Original log content.
+            formats: List of format types to strip (e.g., ['github_actions']).
+
+        Returns:
+            Content with prefixes stripped.
+        """
+        lines = content.splitlines()
+        stripped_lines = []
+
+        for line in lines:
+            stripped_line = line
+            for fmt in formats:
+                if fmt == "github_actions":
+                    stripped_line = self._strip_github_actions_prefix(stripped_line)
+                elif fmt == "ctest":
+                    stripped_line = self._strip_ctest_prefix(stripped_line)
+                elif fmt == "cmake":
+                    stripped_line = self._strip_cmake_prefix(stripped_line)
+            stripped_lines.append(stripped_line)
+
+        return "\n".join(stripped_lines)
+
+    @staticmethod
+    def _strip_github_actions_prefix(line: str) -> str:
+        r"""Strip GitHub Actions log prefix from a line.
+
+        GitHub Actions logs have format:
+        {job_name}\t{step_name}\t{timestamp}Z {content}
+
+        Example:
+        linux_x64_gcc\tUNKNOWN STEP\t2025-09-16T09:23:05.2141216Z Content here
+
+        The timestamp is ISO 8601 format with fractional seconds ending in Z.
+        BOM character (\\ufeff) may appear before timestamp on first line.
+
+        Args:
+            line: Log line potentially with GitHub Actions prefix.
+
+        Returns:
+            Line with prefix stripped, or original if no prefix found.
+        """
+        # Pattern: anything followed by ISO timestamp ending in Z, then space, then content.
+        # The .+? non-greedy match captures job/step tabs before timestamp.
+        match = re.match(r"^.+?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+(.*)$", line)
+        if match:
+            return match.group(1)
+        return line
+
+    @staticmethod
+    def _strip_ctest_prefix(line: str) -> str:
+        """Strip ctest log prefix from a line.
+
+        ctest logs have format: [ctest] content
+
+        Args:
+            line: Log line potentially with ctest prefix.
+
+        Returns:
+            Line with prefix stripped, or original if no prefix found.
+        """
+        # Simple prefix removal.
+        if line.startswith("[ctest] "):
+            return line[8:]  # len('[ctest] ') == 8
+        return line
+
+    @staticmethod
+    def _strip_cmake_prefix(line: str) -> str:
+        """Strip cmake/build log prefix from a line.
+
+        cmake/VSCode logs have format: [cmake] content or [build] content
+
+        Args:
+            line: Log line potentially with cmake prefix.
+
+        Returns:
+            Line with prefix stripped, or original if no prefix found.
+        """
+        if line.startswith("[cmake] "):
+            return line[8:]  # len('[cmake] ') == 8
+        if line.startswith("[build] "):
+            return line[8:]  # len('[build] ') == 8
+        return line
+
+    def get_original_content(self) -> str:
+        """Get original unprocessed log content.
+
+        Returns:
+            Original log content before any prefix stripping.
+        """
+        return self._original_content
+
+    def get_line(self, line_num: int) -> str | None:
+        """Get line by number (0-indexed).
+
+        Args:
+            line_num: Line number (0-indexed).
+
+        Returns:
+            Line content if line_num is valid, None otherwise.
+        """
+        if 0 <= line_num < len(self._lines):
+            return self._lines[line_num]
+        return None
+
+    def get_lines(self) -> list[str]:
+        """Get all lines in the log.
+
+        Returns:
+            List of all lines (after prefix stripping if enabled).
+        """
+        return self._lines
+
+    def get_lines_around(self, line_num: int, context: int = 5) -> list[str]:
+        """Get lines around a line number with context.
+
+        Args:
+            line_num: Center line number (0-indexed).
+            context: Number of lines before and after to include.
+
+        Returns:
+            List of lines including context. Always includes the center line
+            if it exists, plus up to `context` lines before and after.
+        """
+        start = max(0, line_num - context)
+        end = min(len(self._lines), line_num + context + 1)
+        return self._lines[start:end]
+
+    def get_context(self, line_num: int, before: int = 5, after: int = 5) -> list[str]:
+        """Get context lines around a line number.
+
+        Args:
+            line_num: Center line number (0-indexed).
+            before: Number of lines before to include.
+            after: Number of lines after to include.
+
+        Returns:
+            List of lines including context. Always includes the center line
+            if it exists, plus up to `before` lines before and `after` lines after.
+        """
+        start = max(0, line_num - before)
+        end = min(len(self._lines), line_num + after + 1)
+        return self._lines[start:end]
+
+    def get_line_number_from_offset(self, offset: int) -> int:
+        """Convert character offset to line number using binary search.
+
+        Args:
+            offset: Character offset into the log content.
+
+        Returns:
+            Line number (0-indexed) containing the offset. Returns -1 for
+            empty logs, or the last line number if offset is beyond the end.
+        """
+        if not self._line_offsets:
+            return -1  # Empty log.
+
+        # Binary search for the insertion point.
+        # bisect_left returns index where offset would be inserted to maintain order.
+        idx = bisect.bisect_left(self._line_offsets, offset)
+
+        if idx == len(self._line_offsets):
+            # Offset is beyond the start of the last line.
+            return len(self._lines) - 1
+        if self._line_offsets[idx] == offset:
+            # Offset exactly matches a line start.
+            return idx
+        # Offset is within a line (before idx).
+        return max(0, idx - 1)
+
+    def _get_compiled_pattern(self, pattern: str | Pattern) -> Pattern:
+        """Get compiled regex pattern from string or Pattern object.
+
+        Args:
+            pattern: Regex pattern as string or pre-compiled Pattern.
+
+        Returns:
+            Compiled re.Pattern object.
+        """
+        if isinstance(pattern, str):
+            return re.compile(pattern)
+        return pattern
+
+    def find_previous_match(
+        self, start_offset: int, pattern: str | Pattern, max_lines: int = 50
+    ) -> Match | None:
+        """Search backward from offset for regex pattern.
+
+        Searches backward from the line containing start_offset (inclusive),
+        up to max_lines away, for the first line matching the pattern.
+
+        Args:
+            start_offset: Character offset to start searching from.
+            pattern: Regex pattern (string or compiled Pattern).
+            max_lines: Maximum number of lines to search backward (including
+                start line).
+
+        Returns:
+            First regex Match object found, or None if no match within range.
+        """
+        compiled_pattern = self._get_compiled_pattern(pattern)
+        start_line = self.get_line_number_from_offset(start_offset)
+        if start_line < 0:
+            return None  # Empty log.
+
+        search_start = max(0, start_line - max_lines + 1)
+
+        # Search backwards through lines, including start_line.
+        for line_num in range(start_line, search_start - 1, -1):
+            line = self.get_line(line_num)
+            if line:
+                match = compiled_pattern.search(line)
+                if match:
+                    return match
+        return None
+
+    def find_next_match(
+        self, start_offset: int, pattern: str | Pattern, max_lines: int = 50
+    ) -> Match | None:
+        """Search forward from offset for regex pattern.
+
+        Searches forward from the line containing start_offset (inclusive),
+        up to max_lines away, for the first line matching the pattern.
+
+        Args:
+            start_offset: Character offset to start searching from.
+            pattern: Regex pattern (string or compiled Pattern).
+            max_lines: Maximum number of lines to search forward (including
+                start line).
+
+        Returns:
+            First regex Match object found, or None if no match within range.
+        """
+        compiled_pattern = self._get_compiled_pattern(pattern)
+        start_line = self.get_line_number_from_offset(start_offset)
+        if start_line < 0:
+            return None  # Empty log.
+
+        search_end = min(len(self._lines), start_line + max_lines)
+
+        for line_num in range(start_line, search_end):
+            line = self.get_line(line_num)
+            if line:
+                match = compiled_pattern.search(line)
+                if match:
+                    return match
+        return None
+
+    def find_all_matches(self, pattern: str | Pattern) -> list[tuple[int, Match]]:
+        """Find all matches of a pattern in the entire log.
+
+        Args:
+            pattern: Regex pattern (string or compiled Pattern).
+
+        Returns:
+            List of (line_number, Match) tuples for all matches found.
+            Line numbers are 0-indexed.
+        """
+        compiled_pattern = self._get_compiled_pattern(pattern)
+        matches = []
+        for line_num, line in enumerate(self._lines):
+            match = compiled_pattern.search(line)
+            if match:
+                matches.append((line_num, match))
+        return matches
+
+    @property
+    def line_count(self) -> int:
+        """Get total number of lines in the log."""
+        return len(self._lines)

--- a/tools/utils/common/triage_engine.py
+++ b/tools/utils/common/triage_engine.py
@@ -1,0 +1,174 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""TriageEngine orchestrates extractors for comprehensive log analysis.
+
+The TriageEngine runs multiple extractors in sequence, aggregates their results,
+deduplicates issues, and sorts them by severity. It provides a unified interface
+for analyzing logs regardless of the specific failure types present.
+
+Example usage:
+    from common.triage_engine import TriageEngine
+    from common.extractors.sanitizer import SanitizerExtractor
+    from common.extractors.mlir_compiler import MLIRCompilerExtractor
+    from common.log_buffer import LogBuffer
+
+    # Create engine with desired extractors.
+    engine = TriageEngine([
+        SanitizerExtractor(),
+        MLIRCompilerExtractor(),
+    ])
+
+    # Analyze log.
+    log_buffer = LogBuffer(log_content, auto_detect_format=True)
+    result = engine.analyze(log_buffer)
+
+    # Access results.
+    print(f"Found {len(result.issues)} issues")
+    for issue in result.get_actionable():
+        print(f"  {issue.severity.name}: {issue.message}")
+"""
+
+import logging
+
+from common.extractors.base import Extractor
+from common.log_buffer import LogBuffer
+from common.triage_result import TriageResult
+
+logger = logging.getLogger(__name__)
+
+
+class TriageEngine:
+    """Orchestrates extractors for comprehensive log triage.
+
+    The engine runs all registered extractors on a log and aggregates their
+    results into a single TriageResult. Issues are deduplicated (by extractor
+    name and line number) and sorted by severity, then line number.
+
+    No root cause analysis is performed - extractors return structured Issues
+    with rich diagnostic data, and the engine simply aggregates them. This
+    approach is simpler and more transparent than pattern-based co-occurrence
+    rules.
+
+    Attributes:
+        extractors: List of Extractor instances to run.
+    """
+
+    def __init__(self, extractors: list[Extractor]) -> None:
+        """Initialize TriageEngine with list of extractors.
+
+        Args:
+            extractors: List of Extractor instances to run on logs.
+        """
+        self.extractors = extractors
+
+    def _identify_relevant_extractors(self, log_buffer: LogBuffer) -> list[Extractor]:
+        """Identify which extractors should run on this log.
+
+        Performs ONE scan through log content to check for activation keywords.
+        Extractors with no activation keywords always run (e.g., sanitizer,
+        gpu_driver, build_error).
+
+        This log-level prefilter avoids O(N×M) scaling where all M extractors
+        scan all N lines. Instead, only relevant extractors run on each log.
+
+        Args:
+            log_buffer: LogBuffer containing log content.
+
+        Returns:
+            List of extractors that should run on this log.
+        """
+        log_content = log_buffer.content  # Single string for fast checking.
+        relevant = []
+
+        for extractor in self.extractors:
+            # No activation keywords = always run (e.g., sanitizer, gpu_driver).
+            if not extractor.activation_keywords:
+                relevant.append(extractor)
+                continue
+
+            # Check if ANY activation keyword present.
+            if any(keyword in log_content for keyword in extractor.activation_keywords):
+                relevant.append(extractor)
+
+        return relevant
+
+    def analyze(self, log_buffer: LogBuffer) -> TriageResult:
+        """Run relevant extractors and aggregate results.
+
+        Uses two-level filtering architecture:
+        1. Log-level prefilter: Identify which extractors are relevant
+        2. Line-level extraction: Only relevant extractors run
+
+        Each extractor is run independently. If an extractor raises an exception,
+        it is logged and the engine continues with other extractors. This ensures
+        that one broken extractor doesn't prevent analysis by other extractors.
+
+        Args:
+            log_buffer: LogBuffer containing log content with auto-detected format.
+
+        Returns:
+            TriageResult with deduplicated and sorted issues from all extractors.
+        """
+        all_issues = []
+        extractors_run = []
+        extractor_errors = []
+
+        # Log-level prefilter - identify relevant extractors.
+        relevant_extractors = self._identify_relevant_extractors(log_buffer)
+
+        # Run only relevant extractors.
+        for extractor in relevant_extractors:
+            try:
+                issues = extractor.extract(log_buffer)
+
+                # Tag each issue with its source extractor.
+                for issue in issues:
+                    issue.source_extractor = extractor.name
+
+                all_issues.extend(issues)
+                extractors_run.append(extractor.name)
+
+            except Exception as e:  # noqa: BLE001
+                # Log error but continue with other extractors.
+                # We catch all exceptions to ensure one broken extractor
+                # doesn't prevent analysis by other extractors.
+                error_msg = f"Extractor {extractor.name} failed: {e}"
+                logger.error(error_msg)
+                extractor_errors.append({"extractor": extractor.name, "error": str(e)})
+                # Still mark as run (attempted).
+                extractors_run.append(extractor.name)
+
+        # Deduplicate: same extractor + same line_number = duplicate.
+        # This prevents double-counting when multiple patterns match the same line.
+        seen = set()
+        unique_issues = []
+        for issue in all_issues:
+            key = (issue.source_extractor, issue.line_number or -1)
+            if key not in seen:
+                seen.add(key)
+                unique_issues.append(issue)
+
+        # Sort by: severity (descending) → line_number (ascending) → extractor (stable).
+        # This ensures CRITICAL issues appear first, earliest issues first within
+        # each severity level, and consistent ordering for issues at the same line.
+        sorted_issues = sorted(
+            unique_issues,
+            key=lambda issue: (
+                -issue.severity.value,  # Descending severity (CRITICAL=4 first).
+                (
+                    issue.line_number if issue.line_number is not None else float("inf")
+                ),  # Issues without line numbers at end.
+                issue.source_extractor,  # Stable sort by extractor name.
+            ),
+        )
+
+        return TriageResult(
+            issues=sorted_issues,
+            extractors_run=extractors_run,
+            extractor_errors=extractor_errors,
+            log_line_count=log_buffer.line_count,
+        )

--- a/tools/utils/common/triage_result.py
+++ b/tools/utils/common/triage_result.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""TriageResult container for aggregated triage analysis results.
+
+This module provides the TriageResult class which holds all issues found by
+the TriageEngine, along with filtering and serialization methods for different
+output formats (markdown, JSON, etc.).
+
+Example usage:
+    result = engine.analyze(log_buffer)
+
+    # Filter by severity.
+    critical = result.get_by_severity(Severity.CRITICAL)
+
+    # Filter by actionable.
+    actionable = result.get_actionable()
+
+    # Serialize to JSON.
+    json_data = result.to_dict()
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from common.issues import Issue, Severity
+
+
+@dataclass
+class TriageResult:
+    """Aggregated results from running TriageEngine on a log.
+
+    Contains all issues found by all extractors, deduplicated and sorted by
+    severity and line number. Provides filtering methods for different views
+    of the issues (by severity, by extractor, actionable vs infrastructure).
+
+    Attributes:
+        issues: All issues found, deduplicated and sorted.
+        extractors_run: Names of extractors that were executed.
+        extractor_errors: Errors encountered during extraction.
+        log_line_count: Total number of lines in the analyzed log.
+    """
+
+    issues: list[Issue]
+    extractors_run: list[str]
+    extractor_errors: list[dict[str, str]] = field(default_factory=list)
+    log_line_count: int = 0
+
+    def get_by_severity(self, severity: Severity) -> list[Issue]:
+        """Filter issues by severity level.
+
+        Args:
+            severity: Severity level to filter by.
+
+        Returns:
+            List of issues matching severity.
+        """
+        return [issue for issue in self.issues if issue.severity == severity]
+
+    def get_by_extractor(self, extractor_name: str) -> list[Issue]:
+        """Filter issues by source extractor.
+
+        Args:
+            extractor_name: Name of extractor (e.g., "sanitizer", "mlir_compiler").
+
+        Returns:
+            List of issues from that extractor.
+        """
+        return [
+            issue for issue in self.issues if issue.source_extractor == extractor_name
+        ]
+
+    def get_actionable(self) -> list[Issue]:
+        """Get only actionable issues (not infrastructure).
+
+        Actionable issues are code bugs that require fixes. Infrastructure
+        issues are flakes, driver crashes, timeouts, etc. that are outside
+        the developer's control.
+
+        Returns:
+            List of issues where actionable=True.
+        """
+        return [issue for issue in self.issues if issue.actionable]
+
+    def get_infrastructure(self) -> list[Issue]:
+        """Get only infrastructure issues (non-actionable).
+
+        Infrastructure issues are driver crashes, network flakes, timeouts,
+        and other failures not caused by code bugs.
+
+        Returns:
+            List of issues where actionable=False.
+        """
+        return [issue for issue in self.issues if not issue.actionable]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary with issues, extractors_run, and summary statistics.
+        """
+        # Convert issues to dicts (if they have to_dict method).
+        issues_dicts = []
+        for issue in self.issues:
+            if hasattr(issue, "to_dict"):
+                issues_dicts.append(issue.to_dict())
+            else:
+                # Fallback for Issue types without to_dict.
+                issues_dicts.append(
+                    {
+                        "severity": issue.severity.name,
+                        "actionable": issue.actionable,
+                        "message": issue.message,
+                        "line_number": issue.line_number,
+                        "source_extractor": issue.source_extractor,
+                    }
+                )
+
+        return {
+            "issues": issues_dicts,
+            "extractors_run": self.extractors_run,
+            "extractor_errors": self.extractor_errors,
+            "summary": {
+                "total_issues": len(self.issues),
+                "actionable_issues": len(self.get_actionable()),
+                "infrastructure_issues": len(self.get_infrastructure()),
+                "by_severity": {
+                    "critical": len(self.get_by_severity(Severity.CRITICAL)),
+                    "high": len(self.get_by_severity(Severity.HIGH)),
+                    "medium": len(self.get_by_severity(Severity.MEDIUM)),
+                    "low": len(self.get_by_severity(Severity.LOW)),
+                },
+                "log_line_count": self.log_line_count,
+            },
+        }

--- a/tools/utils/lit_tools/CONTRIBUTING.md
+++ b/tools/utils/lit_tools/CONTRIBUTING.md
@@ -1,0 +1,336 @@
+# Lit Test Utilities - Development Guide
+
+Developer documentation for contributors working on lit test tools.
+
+## Architecture
+
+**Core libraries** (`lit_tools/core/`):
+- `parser.py` - Parse test files (split by `// -----`, extract cases, RUN lines)
+- `check_pattern.py` - FileCheck pattern parsing
+- `check_matcher.py` - Pattern matching logic
+- `document.py` - Test file AST models
+- `verification.py` - IR validation
+- `suggestions.py` - Fuzzy name matching
+- `cli.py` - Common CLI utilities
+- `lit_wrapper.py` - LLVM lit integration
+
+**Tools** (`lit_tools/`):
+- `iree_lit_list.py` - List test cases
+- `iree_lit_extract.py` - Extract individual cases
+- `iree_lit_replace.py` - Replace test cases with new content
+- `iree_lit_test.py` - Run tests in isolation
+- `iree_lit_lint.py` - Lint tests against style guide
+
+All tools support `--json` for machine-readable output.
+
+## Dependencies
+
+```
+lit tools
+  ↓
+lit_tools/core/* (parser, check_matcher, etc.)
+  ↓
+common/* (build_detection, console, exit_codes, fs)
+  ↓
+Python 3 stdlib + psutil
+```
+
+## Development Workflow
+
+### Adding a New Tool
+
+1. **Create implementation** in `lit_tools/iree_<tool_name>.py` (use underscores)
+2. **Add docstring** with extensive examples (see template below)
+3. **Write tests** in `test/lit_tests/test_<tool_name>.py`
+4. **Create wrapper** in `bin/iree-<tool-name>` (use hyphens)
+5. **Validate**: Run on real IREE test files
+
+### Running Tests
+
+```bash
+# Lit-only tests
+python3 -m unittest discover -s tools/utils/test/lit_tests -v
+
+# All utils tests
+python3 -m unittest discover -s tools/utils -p "test_*.py" -v
+```
+
+## Tool Implementation Template
+
+```python
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""One-line description of what this tool does.
+
+Detailed explanation of functionality, use cases, and behavior.
+
+Usage:
+  iree-<category>-<action> input.mlir
+  iree-<category>-<action> input.mlir --option value
+
+Examples:
+  $ iree-<category>-<action> test.mlir
+  [expected output]
+
+Exit codes:
+  0 - Success
+  1 - Error (invalid input, execution failure, etc.)
+  2 - Not found (file doesn't exist, case not found, etc.)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from common import console, exit_codes, fs
+from lit_tools.core import cli
+from lit_tools.core.parser import parse_test_file
+
+
+def parse_arguments():
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="One-line description",
+        epilog="See module docstring for examples and details",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("file", help="Input test file")
+    parser.add_argument("--option", help="Option description")
+    cli.add_common_output_flags(parser)
+    return parser.parse_args()
+
+
+def main(args):
+    """Main entry point."""
+    file_path = Path(args.file)
+    if not file_path.exists():
+        console.error(f"File not found: {file_path}", args=args)
+        return exit_codes.NOT_FOUND
+
+    try:
+        result = do_work(args)
+        if args.json:
+            console.print_json({"result": result}, args=args)
+        else:
+            print(result)
+        return exit_codes.SUCCESS
+    except Exception as e:
+        console.error(f"Error: {e}", args=args)
+        return exit_codes.ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main(parse_arguments()))
+```
+
+### Binary Wrapper Pattern
+
+Create thin Python wrappers in `bin/` (not symlinks):
+
+```python
+#!/usr/bin/env python3
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Thin wrapper for iree-<tool-name> tool."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lit_tools import iree_tool_name
+
+if __name__ == "__main__":
+    sys.exit(iree_tool_name.main(iree_tool_name.parse_arguments()))
+```
+
+**Naming Convention**:
+- Python module: `iree_<tool>_<name>.py` (underscores)
+- CLI wrapper: `iree-<tool>-<name>` (hyphens)
+
+**Shebang Policy**:
+- ✅ Wrappers in `bin/` MUST have `#!/usr/bin/env python3`
+- ❌ Category modules MUST NOT have shebangs
+
+## Code Review Checklist
+
+- [ ] Docstring includes usage examples and exit codes
+- [ ] Unit tests added with >80% coverage
+- [ ] `--help` output is clear and comprehensive
+- [ ] Error messages are descriptive
+- [ ] Exit codes follow conventions (0=success, 1=error, 2=not found)
+- [ ] Binary wrapper created in `bin/`
+
+## Common Patterns
+
+### Parsing Test Files
+
+```python
+from lit_tools.core.parser import parse_test_file
+
+test_file_obj = parse_test_file(Path('test.mlir'))
+cases = list(test_file_obj.cases)
+
+case = test_file_obj.find_case_by_number(2)
+case = test_file_obj.find_case_by_name('function_name')
+case = test_file_obj.find_case_by_line(42)
+
+run_lines = test_file_obj.extract_run_lines()
+```
+
+### Build Detection
+
+**When to use**:
+- `iree-lit-list` - ❌ No build detection (only parses text)
+- `iree-lit-extract` - ⚠️ Optional (only for `--validate` flag)
+- `iree-lit-test` - ✅ Required (must run iree-opt and FileCheck)
+- `iree-lit-lint` - ❌ No build detection (only parses text)
+
+**Optional validation pattern**:
+```python
+from common import build_detection
+
+if args.validate:
+    try:
+        iree_opt = build_detection.find_tool("iree-opt")
+        # Validate IR...
+    except FileNotFoundError:
+        console.warn("Skipping validation (iree-opt not found)", args=args)
+```
+
+**Required tool pattern**:
+```python
+try:
+    iree_opt = build_detection.find_tool("iree-opt")
+    filecheck = build_detection.find_tool("FileCheck")
+except FileNotFoundError as e:
+    console.error(f"Cannot run lit tests without IREE build.\n{e}", args=args)
+    return exit_codes.NOT_FOUND
+```
+
+## Edge Cases
+
+### Multiple CHECK-LABELs in One Case
+
+Parser extracts the **first** CHECK-LABEL as the case name.
+
+### No Functions
+
+Cases without functions show as `(unnamed)`.
+
+### Mixed Named/Unnamed Cases
+
+Files can have both named and unnamed cases - this is supported.
+
+## JSON Output Conventions
+
+**Listing schema**:
+```json
+{
+  "file": "path/to/test.mlir",
+  "count": 3,
+  "cases": [
+    {"number": 1, "name": "foo", "start_line": 1, "end_line": 12, "line_count": 12, "check_count": 3}
+  ]
+}
+```
+
+**Extraction schema** (array of cases):
+```json
+[
+  {
+    "number": 2,
+    "name": "second_case",
+    "start_line": 14,
+    "end_line": 24,
+    "content": "// CHECK-LABEL: @second_case\nutil.func @second_case() { ... }"
+  }
+]
+```
+
+## Testing Philosophy
+
+- **Unit tests**: Core logic must have >80% coverage
+- **Fixture-based tests**: Use `test/lit_tests/fixtures/` for CI
+- **Development validation**: Test on real IREE files manually
+- **Edge cases**: Test unnamed cases, single case files, large files
+
+**Do NOT** add real-file tests to unittest (files change, breaking CI).
+
+## Tool-Specific Documentation
+
+### iree-lit-test Implementation
+
+Uses LLVM's lit APIs in-process:
+1. Build temporary test shard under `/tmp/iree_lit_test_$PID/`
+2. Preserve line numbers by prepending `(start_line - 1)` blanks
+3. Re-inject RUN lines from header and case body
+4. Execute with `lit.discovery` and `lit.run.Run`
+
+### iree-lit-replace Implementation
+
+**Safe atomic writes**:
+1. Read original file
+2. Parse test cases
+3. Replace specified case content
+4. Write to temporary file
+5. Move original to `.bak`
+6. Rename temporary file to original
+7. Restore from backup on failure
+
+**Validation features**:
+- Name/number consistency checking
+- Duplicate case name handling
+- Duplicate replacement entry detection
+
+## Troubleshooting
+
+### "Cannot find build directory"
+
+```bash
+# Build IREE first
+cmake -B build -S . && cmake --build build -j$(nproc)
+
+# Or set environment variable
+export IREE_BUILD_DIR=/path/to/build
+```
+
+### Test hangs forever
+
+```bash
+# Run with shorter timeout
+iree-lit-test test.mlir --case 5 --timeout 10
+
+# Or disable timeout and debug
+iree-lit-test test.mlir --case 5 --timeout 0 --verbose
+```
+
+### Wrong line numbers
+
+This shouldn't happen - iree-lit-test preserves line numbers. Report as bug if seen.
+
+### Case not found by name
+
+```bash
+# List cases to verify name
+iree-lit-list test.mlir
+
+# Use case number instead
+iree-lit-test test.mlir --case 5
+```
+
+## See Also
+
+- `STYLE_GUIDE.md` - MLIR test style rules
+- `../CONTRIBUTING.md` - Top-level development guidelines
+- `../README.md` - User documentation

--- a/tools/utils/lit_tools/README.md
+++ b/tools/utils/lit_tools/README.md
@@ -1,0 +1,83 @@
+# Lit Test Utilities
+
+Tools for working with MLIR lit test files that use `// -----` delimiters.
+
+## Tools
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `iree-lit-list` | List test cases | `iree-lit-list test.mlir` |
+| `iree-lit-extract` | Extract individual cases | `iree-lit-extract test.mlir --case 3` |
+| `iree-lit-replace` | Replace case content | `iree-lit-replace test.mlir --case 3 < new.mlir` |
+| `iree-lit-test` | Run tests in isolation | `iree-lit-test test.mlir --case 2` |
+| `iree-lit-lint` | Lint for style issues | `iree-lit-lint test.mlir` |
+
+## Quick Examples
+
+```bash
+# List test cases in a file
+iree-lit-list test.mlir
+
+# Run a specific failing case with verbose output
+iree-lit-test test.mlir --case 3 --verbose
+
+# Extract a case for manual debugging
+iree-lit-extract test.mlir --case 3 > /tmp/case.mlir
+
+# Lint tests for style violations
+iree-lit-lint test.mlir
+
+# Replace a case using heredoc (no temp files needed)
+iree-lit-replace test.mlir --case 2 <<'EOF'
+// CHECK-LABEL: @my_test
+// CHECK: %[[RESULT:.+]] = arith.addi
+func.func @my_test(%arg0: i32, %arg1: i32) -> i32 {
+  %0 = arith.addi %arg0, %arg1 : i32
+  return %0 : i32
+}
+EOF
+
+# Test inline IR with heredoc
+iree-lit-test --run 'iree-opt --my-pass %s | FileCheck %s' <<'EOF'
+// CHECK-LABEL: @test
+func.func @test() {
+  return
+}
+EOF
+```
+
+## Common Workflow: Debug a Failing Test
+
+```bash
+# 1. See test structure
+iree-lit-list failing_test.mlir
+
+# 2. Run the failing case in isolation
+iree-lit-test failing_test.mlir --case 3 --verbose
+
+# 3. Extract and run manually to see actual output
+iree-lit-extract failing_test.mlir --case 3 > /tmp/case.mlir
+iree-opt --my-pass /tmp/case.mlir
+
+# 4. Fix and replace
+iree-lit-replace failing_test.mlir --case 3 < /tmp/fixed.mlir
+
+# 5. Verify
+iree-lit-test failing_test.mlir --case 3
+```
+
+## Style Guide
+
+Run `iree-lit-lint --help-style-guide` for the full MLIR test style guide, or see `STYLE_GUIDE.md`.
+
+Key principles:
+- Capture SSA values the pass transforms (don't wildcard critical values)
+- Track data flow from producer to consumer
+- Capture all results of multi-result operations
+- Use semantic names matching IR (`%size` → `%[[SIZE:.+]]`)
+
+## Documentation
+
+- `--help` on any tool for detailed usage
+- `STYLE_GUIDE.md` - Full MLIR test style guide
+- `CONTRIBUTING.md` - Development guide for contributors

--- a/tools/utils/lit_tools/STYLE_GUIDE.md
+++ b/tools/utils/lit_tools/STYLE_GUIDE.md
@@ -1,0 +1,967 @@
+# MLIR Lit Test Style Guide
+
+This document defines best practices for authoring MLIR lit tests in IREE. These rules ensure tests are robust, maintainable, and actually verify transformations.
+
+**Automated checks** are marked with ✅ and enforced by `iree-lit-lint`.
+**Manual review guidelines** are marked with 📖 and should be verified during code review.
+
+---
+
+## Table of Contents
+
+1. [Core Principles for Transformation Verification](#core-principles-for-transformation-verification)
+2. [Automated Checks (Errors)](#automated-checks-errors)
+3. [Automated Checks (Warnings)](#automated-checks-warnings)
+4. [Manual Review Guidelines](#manual-review-guidelines)
+5. [Running the Linter](#running-the-linter)
+
+---
+
+## Core Principles for Transformation Verification
+
+This section establishes the foundational principles that inform all specific rules below. These principles answer the question: **"What makes a lit test verify correctness, not just syntax?"**
+
+Understanding these principles helps you write robust tests that catch bugs and remain maintainable as code evolves.
+
+---
+
+### 1. 📖 Transform-Aware Capture Rule
+
+**Rule**: If an SSA value is transformed by the pass under test (or intentionally NOT transformed when you'd expect it to be), that value MUST be captured and verified at all relevant sites.
+
+**Why**: The test verifies the TRANSFORMATION, not just that IR parses. Uncaptured values that the pass touches represent gaps in test coverage. When transformations fail, tests without comprehensive captures may still pass, hiding bugs.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Captures both resource and timepoint results:
+// CHECK: %[[R:.+]], %[[TP:.+]] = stream.async.execute
+// CHECK: stream.async.execute await(%[[TP]]) =>
+
+❌ BAD - Missing timepoint capture (incomplete verification):
+// CHECK: %[[R:.+]] = stream.async.execute
+// (Timepoint transformation not verified!)
+
+✅ GOOD - Verifies the specific operand after transformation:
+// CHECK: %[[JOINED:.+]] = stream.timepoint.join
+// CHECK: stream.timepoint.await %[[JOINED]]
+
+❌ BAD - Wildcards the critical operand (hides verification):
+// CHECK: stream.timepoint.await {{.+}}
+// (Which timepoint? Transformation hidden!)
+```
+
+**When to Ignore**: Never. This is the foundational principle. If you're not verifying transformations, the test provides no value.
+
+---
+
+### 2. 📖 Critical Feature Verification Rule
+
+**Rule**: If a pass's primary purpose is to transform, optimize, or analyze a specific *feature* or *property* of the IR (e.g., memory access patterns, control flow structures, dialect-specific types like timepoints, attribute propagation), then all relevant SSA values and operations related to that feature MUST be comprehensively captured and verified. Avoid wildcards for these critical elements where their specific properties are under test.
+
+**Why**: When a pass exists specifically to handle a particular IR feature, that feature IS the test. Wildcarding critical elements undermines the entire purpose of the test. This is a generalization of domain-specific requirements: timepoints for Stream dialect, memory descriptors for HAL, control flow for SCF canonicalization, etc.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Stream timepoint pass captures ALL timepoints:
+// CHECK: %[[TP1:.+]] = stream.async.execute
+// CHECK: %[[TP2:.+]] = stream.async.execute
+// CHECK: %[[JOINED:.+]] = stream.timepoint.join max(%[[TP1]], %[[TP2]])
+// CHECK: stream.async.execute await(%[[JOINED]]) =>
+
+❌ BAD - Wildcarding critical feature:
+// CHECK: stream.async.execute await({{.+}}) =>
+// (Testing timepoint elision but not verifying which timepoint!)
+
+✅ GOOD - Memory aliasing pass captures ALL buffer descriptors:
+// CHECK: %[[BUF1:.+]] = hal.buffer.subspan<%[[BASE:.+]]
+// CHECK: %[[BUF2:.+]] = hal.buffer.subspan<%[[BASE]]
+// (Proves both buffers alias the same base)
+
+❌ BAD - Missing descriptor relationships:
+// CHECK: hal.buffer.subspan<{{.+}}
+// (Can't verify aliasing without tracking base buffer)
+
+✅ GOOD - Attribute propagation pass verifies attributes:
+// CHECK: util.global @tensor {{.*}} {noinline}
+// (Verifies attribute was propagated)
+```
+
+**Domain-Specific Examples**:
+- **Stream timepoint passes**: Always capture timepoint SSA values
+- **HAL memory passes**: Always capture buffer descriptors and memory types
+- **SCF canonicalization**: Always capture control flow results and branch targets
+- **Attribute propagation**: Always verify attribute presence/changes
+
+**When to Ignore**: Never for the critical feature being tested. Wildcards are acceptable for other structural IR that the pass doesn't modify.
+
+---
+
+### 3. 📖 Data Flow Verification Rule
+
+**Rule**: If a value flows from producer to consumer across CHECK lines, both the producer's result and consumer's operand must capture/verify the same SSA name reference.
+
+**Why**: This proves data flow correctness. The test must show that value X produced here is value X consumed there. Without tracking the full data flow path, you can't verify the transformation preserved or correctly modified the value's usage.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Data flow tracked through captures:
+// CHECK: %[[CLONE:.+]], %[[TP:.+]] = stream.async.dispatch
+// CHECK: %[[JOINED:.+]] = stream.timepoint.join max(%[[TP]], %[[TP2]])
+// CHECK: stream.async.dispatch await(%[[JOINED]]) =>
+// ^^^ Proves the joined timepoint flows into the await
+
+❌ BAD - Producer captured but consumer wildcarded:
+// CHECK: %[[CLONE:.+]], %[[TP:.+]] = stream.async.dispatch
+// CHECK: stream.async.dispatch await({{.+}}) =>
+// ^^^ Lost track of what timepoint is being awaited!
+
+✅ GOOD - Multi-hop data flow:
+// CHECK: %[[BASE:.+]] = hal.buffer.allocate
+// CHECK: %[[VIEW1:.+]] = hal.buffer.subspan<%[[BASE]]
+// CHECK: %[[VIEW2:.+]] = hal.buffer.subspan<%[[BASE]]
+// CHECK: hal.device.queue.execute commands([
+// CHECK:   hal.command.copy source(%[[VIEW1]]) target(%[[VIEW2]])
+// (Proves both views alias same base, copy is from base to itself)
+
+❌ BAD - Broken data flow chain:
+// CHECK: %[[BASE:.+]] = hal.buffer.allocate
+// CHECK: hal.buffer.subspan<{{.+}}
+// CHECK: hal.command.copy source({{.+}}) target({{.+}})
+// (Can't verify aliasing or copy semantics!)
+```
+
+**When to Ignore**: When the data flow is intentionally abstracted (e.g., testing that ANY constant flows through, not a specific one), but document this clearly in comments.
+
+---
+
+### 4. 📖 Multi-Result Operation Rule
+
+**Rule**: For operations that return multiple results (e.g., `(resource, timepoint)` pairs, tuple unpacking), capture ALL results if ANY result is transformed or verified.
+
+**Why**: Partial capture suggests incomplete understanding. If you care about one result, you should verify both to ensure the operation is correct. Many MLIR operations return structured results where all components matter for correctness.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Both results captured:
+// CHECK: %[[R:.+]], %[[TP:.+]] = stream.async.dispatch
+// CHECK: stream.async.dispatch await(%[[TP]]) => with(%[[R]])
+
+❌ BAD - Only one result captured (half-verified):
+// CHECK: %[[R:.+]] = stream.async.dispatch
+// (What happened to the timepoint? Was it transformed?)
+
+✅ ACCEPTABLE - Neither captured if op is structural (not transformed):
+// CHECK: stream.async.dispatch
+// (Pass doesn't touch this dispatch, structural verification only)
+
+✅ GOOD - Tuple unpacking verified completely:
+// CHECK: %[[A:.+]], %[[B:.+]] = util.optimization_barrier %[[X]], %[[Y]]
+// CHECK: util.return %[[A]], %[[B]]
+// (Proves both values flow through correctly)
+
+❌ BAD - Partial tuple verification:
+// CHECK: %[[A:.+]] = util.optimization_barrier
+// CHECK: util.return {{.+}}, {{.+}}
+// (Missing B result, can't verify second value's flow)
+```
+
+**When to Ignore**: When the pass genuinely only transforms one result and the other is guaranteed unchanged by design, but document this assumption clearly.
+
+---
+
+### 5. 📖 Control Flow Result Rule
+
+**Rule**: Capture control flow operation results (scf.if, scf.for, scf.while) if:
+- The result is used in subsequent operations being verified, OR
+- The result type/count is transformed by the pass, OR
+- You need to verify data flow through the control flow boundary
+
+Otherwise, wildcards are acceptable for structural control flow.
+
+**Why**: Control flow results define data flow across region boundaries. If your pass modifies what flows out of a loop or conditional, you must verify this. However, if the control flow is purely structural (testing other transformations), wildcarding results reduces noise.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Result used later, so captured:
+// CHECK: %[[IF_RESULT:.+]]:2 = scf.if
+// CHECK:   scf.yield %[[A]], %[[B]]
+// CHECK: stream.async.dispatch with(%[[IF_RESULT]]#0, %[[IF_RESULT]]#1)
+
+❌ BAD - Result used but not captured:
+// CHECK: scf.if %{{.+}} -> (!stream.resource<external>, !stream.timepoint)
+// CHECK: stream.async.dispatch with({{.+}}, {{.+}})
+// ^^^ Lost provenance - which values are these?
+
+✅ GOOD - Type transformation verified:
+// CHECK: %[[LOOP:.+]] = scf.for {{.+}} -> (!stream.resource<transient>) {
+// (Pass changed result from <external> to <transient>)
+
+✅ ACCEPTABLE - Result not used later, structural verification:
+// CHECK: scf.for %{{.+}} = %c0 to %c10
+// (Testing loop structure, not what flows out)
+
+✅ GOOD - Verifying iter_args data flow:
+// CHECK: %[[INIT:.+]] = stream.async.execute
+// CHECK: %[[LOOP_RESULT:.+]] = scf.for %{{.+}} = %c0 to %c10
+// CHECK-SAME: iter_args(%[[ITER:.+]] = %[[INIT]])
+// CHECK:   scf.yield %[[ITER]]
+// CHECK: util.return %[[LOOP_RESULT]]
+// (Proves value flows: init → iter_args → yield → result → return)
+```
+
+**When to Ignore**: When control flow is purely structural scaffolding and your pass operates on the operations INSIDE the region, not the region results.
+
+---
+
+### 6. 📖 Attribute and Property Verification Rule
+
+**Rule**: If a pass transforms or propagates attributes, properties (e.g., `readonly`, `noinline`), or metadata on operations or types, those changes MUST be verified explicitly even if the SSA values themselves remain unchanged.
+
+**Why**: Many passes operate purely on attributes or properties without altering SSA values (e.g., aliasing analysis, memory effects, target-specific annotations, inlining decisions). Verifying these changes is as crucial as verifying SSA value transformations. A pass that fails to propagate an attribute correctly can cause miscompilation even if all SSA values are correct.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Verifies noinline attribute propagation:
+// RUN: iree-opt --iree-util-propagate-function-attributes %s
+// CHECK: util.func private @callee {{.*}} attributes {noinline}
+
+❌ BAD - Missing attribute verification:
+// CHECK: util.func private @callee
+// (Did the pass add noinline? Test doesn't verify!)
+
+✅ GOOD - Verifies memory effect attribute:
+// CHECK: util.global @buffer {{.*}} : !util.buffer {nosideeffect}
+
+✅ GOOD - Verifies type attributes:
+// CHECK: tensor<4x4xf32, #iree_encoding.encoding<operand_index = 0>>
+// (Pass propagated encoding attribute to tensor type)
+
+❌ BAD - Wildcards critical attributes:
+// CHECK: util.global @buffer {{.*}} : !util.buffer
+// (Missing nosideeffect verification!)
+
+✅ GOOD - Verifies target-specific annotations:
+// CHECK: hal.executable.variant @cuda target(<"cuda", ...>) {
+// CHECK:   hal.executable.export @dispatch {{.*}} {workgroup_size = [64 : index, 1 : index, 1 : index]}
+// (Verifies workgroup size attribute set by pass)
+```
+
+**When to Ignore**: When attributes are boilerplate from parsing and unrelated to the transformation (e.g., source location attributes when testing arithmetic canonicalization).
+
+---
+
+### 7. 📖 Wildcard Usage Guidelines
+
+**Rule**: Wildcards (`{{.+}}`) are acceptable ONLY for IR elements that are:
+- NOT under test by this specific pass
+- Boilerplate or structural scaffolding
+- Irrelevant to the transformation being verified
+
+Avoid wildcards for any SSA value, operation, or attribute whose specific form, type, or value is expected to change or is critical to the correctness of the transformation. **When in doubt, capture and verify.**
+
+**Why**: Wildcards hide bugs. Every wildcard is a statement: "I don't care about this value." If you DO care (because your pass touches it), wildcarding means your test won't catch bugs. Overuse of wildcards creates tests that pass for the wrong reasons.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Wildcards for structural types the pass doesn't modify:
+// RUN: iree-opt --iree-stream-pack-dispatch-operands %s
+// CHECK: stream.async.dispatch @dispatch(%[[ARG:.+]]) : ({{.+}}) -> {{.+}}
+// (Pass doesn't modify types, only packs operands - types are structural)
+
+❌ BAD - Wildcarding values the pass transforms:
+// RUN: iree-opt --iree-stream-elide-timepoints %s
+// CHECK: stream.async.execute await({{.+}}) =>
+// (Pass specifically transforms timepoint operands - MUST capture!)
+
+✅ GOOD - Wildcard for device affinity (orthogonal to transformation):
+// CHECK: stream.async.dispatch @dispatch affinity({{.+}})
+// (Testing dispatch packing, not affinity assignment)
+
+❌ BAD - Over-wildcarding masks transformation:
+// CHECK: stream.async.dispatch {{.+}}({{.+}}, {{.+}}) : ({{.+}}) -> {{.+}}
+// (What dispatch? What operands? Test verifies nothing!)
+
+✅ GOOD - Explicit captures for critical path:
+// CHECK: %[[SIZE:.+]] = stream.tensor.sizeof %[[TENSOR:.+]]
+// CHECK: %[[ALLOC:.+]] = stream.resource.alloc uninitialized : !stream.resource<*>{%[[SIZE]]}
+// CHECK: stream.async.dispatch with(%[[ALLOC]])
+// (Data flow from size → alloc → dispatch verified)
+```
+
+**General Heuristic**:
+- Capture: SSA values, critical attributes, values the pass modifies
+- Wildcard: Types (unless type transformation), device affinities, debug attributes, structural constants
+- When unsure: Capture it. The worst case is an unused capture warning, not a hidden bug.
+
+---
+
+### 8. 📖 Error and Failure Mode Verification
+
+**Rule**: If a pass is expected to diagnose or fail on specific malformed IR, the test MUST verify the expected error message or failure mode using:
+- `CHECK-NOT` for unexpected errors (ensuring pass doesn't emit spurious diagnostics)
+- `CHECK: error: <expected message>` for specific diagnostics
+
+**Why**: Compiler passes often include validation. Testing that they correctly *reject* invalid input or emit specific diagnostics is as important as testing correct transformations. A pass that accepts invalid IR can lead to downstream failures or miscompilation.
+
+**Examples**:
+
+```mlir
+✅ GOOD - Verifies expected error diagnostic:
+// RUN: iree-opt --iree-stream-verify-async-access %s -verify-diagnostics
+// expected-error @+1 {{resource used before ready}}
+%use = stream.async.dispatch with(%resource)
+
+✅ GOOD - Verifies pass rejects malformed IR:
+// RUN: not iree-opt --iree-hal-materialize-interfaces %s
+// CHECK: error: expected executable source to have public functions
+
+❌ BAD - Missing error verification:
+// RUN: not iree-opt --some-pass %s
+// (What error should occur? Test doesn't verify specific failure mode!)
+
+✅ GOOD - Verifies no spurious errors on valid input:
+// RUN: iree-opt --iree-stream-schedule-allocation %s | FileCheck %s
+// CHECK-NOT: error:
+// CHECK-NOT: warning:
+// CHECK: stream.resource.alloc
+
+✅ GOOD - Verifies specific warning message:
+// RUN: iree-opt --iree-util-optimize-ir %s | FileCheck %s --check-prefix=WARNING
+// WARNING: warning: potentially infinite loop detected
+```
+
+**When to Ignore**: For passes that don't perform validation and assume valid input (e.g., pure optimization passes with well-defined preconditions).
+
+---
+
+### 9. 📖 Semantic Naming Rule
+
+**Rule**: CHECK capture names should match the IR's SSA variable names when possible, respecting case conventions: `%foo_bar` in IR → `%[[FOO_BAR]]` in CHECK patterns.
+
+**Why**: Matched names maintain clarity and make tests easier to maintain. When IR evolves (e.g., `%size` → `%transient_size`), mismatched capture names become misleading. Semantic consistency between IR and CHECK patterns helps reviewers understand what's being tested.
+
+**Examples**:
+
+```mlir
+IR: %transient_size = stream.resource.size
+✅ GOOD: // CHECK: %[[TRANSIENT_SIZE:.+]] = stream.resource.size
+⚠️  ACCEPTABLE: // CHECK: %[[SIZE:.+]] = stream.resource.size
+❌ BAD: // CHECK: %[[FOO:.+]] = stream.resource.size (misleading name)
+
+IR: %awaited = stream.timepoint.await
+✅ GOOD: // CHECK: %[[AWAITED:.+]] = stream.timepoint.await
+❌ BAD: // CHECK: %[[READY:.+]] = stream.timepoint.await (suggests different semantics)
+
+IR: %loop_result = scf.for
+✅ GOOD: // CHECK: %[[LOOP_RESULT:.+]] = scf.for
+⚠️  ACCEPTABLE: // CHECK: %[[RESULT:.+]] = scf.for (less precise but not misleading)
+```
+
+**When Names Mismatch Acceptably**:
+- **Dialect conversions**: `%stream_resource` → `%[[TENSOR]]` during lowering
+- **Intentional abstractions**: `%0` → `%[[RESULT]]` for generic patterns
+- **Consistent abbreviations**: `%awaited_resource` → `%[[AWAITED]]` if used throughout test
+
+**When to Ignore**: When the IR uses non-semantic names like `%0`, use descriptive capture names. The goal is clarity, not blind matching.
+
+---
+
+## Summary of Core Principles
+
+These principles form a hierarchy:
+
+**Foundation**:
+1. Verify transformations (Rule 1)
+2. Comprehensive coverage for critical features (Rule 2)
+
+**Application**:
+3. Track data flow (Rule 3)
+4. Capture multi-result operations completely (Rule 4)
+5. Verify control flow results when relevant (Rule 5)
+6. Verify attribute/property changes (Rule 6)
+
+**Discipline**:
+7. Minimize wildcards (Rule 7)
+8. Test error paths (Rule 8)
+9. Use semantic names (Rule 9)
+
+**Golden Rule**: The test must prove the transformation is correct by explicitly verifying all values, attributes, and properties the pass touches. Wildcards hide bugs.
+
+---
+
+## Automated Checks (Errors)
+
+These violations will cause `iree-lit-lint` to exit with an error code. They represent CRITICAL requirements or common mistakes that break tests.
+
+### 1. ✅ Raw SSA Identifiers in CHECK Lines
+
+**Rule**: CHECK lines must use named captures for ALL SSA values, not raw identifiers like `%0`, `%arg0`, or semantic names like `%buffer`.
+
+**Why**: Raw SSA identifiers are fragile—they change when unrelated code is added or removed, arguments are reordered, or transformations rename values. Named captures verify data flow and make tests resilient to IR structure changes.
+
+**Temporary Exception - MLIR Constants (Anti-Pattern)**: Raw constants like `%c0`, `%c123`, `%c4_i32`, `%cst`, and `%cst_0` are currently exempted from this rule due to widespread usage in existing tests. However, **this is an anti-pattern**:
+
+- `%c123` tells you nothing about what the value represents
+- Is it a fill pattern? An offset? An allocation size? A tensor dimension? Which dimension?
+- When constants change, the test silently breaks or passes incorrectly
+- Prefer semantic captures like `%[[OFFSET:.+]]`, `%[[SIZE:.+]]`, or `%[[FILL_PATTERN:.+]]` that describe purpose
+
+**Examples**:
+
+```mlir
+❌ BAD:
+  %c0 = arith.constant 0 : index
+  // CHECK: %c0 = arith.constant 0
+
+✅ GOOD:
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[OFFSET:.+]] = arith.constant 0
+
+❌ BAD:
+  %0 = arith.addf %arg0, %arg0
+  // CHECK: %0 = arith.addf
+
+✅ GOOD:
+  %0 = arith.addf %arg0, %arg0
+  // CHECK: %[[RESULT:.+]] = arith.addf
+
+❌ BAD (operands need captures too):
+  // CHECK: arith.addi %arg0, %arg1
+
+✅ GOOD:
+  // CHECK: arith.addi %[[LHS:.+]], %[[RHS:.+]]
+
+❌ BAD (semantic names are still raw SSA):
+  // CHECK: call @foo(%buffer, %offset)
+
+✅ GOOD:
+  // CHECK: call @foo(%[[BUF:.+]], %[[OFF:.+]])
+```
+
+**NOLINT Escape Hatch**: For crash reproducers or special cases where raw SSA is intentional, add `// NOLINT` on a preceding line. This suppresses `raw_ssa_identifier` errors for the rest of the test case.
+
+```mlir
+// NOLINT: raw_ssa_identifier - crash reproducer needs exact SSA names
+// CHECK: %0 = crash.op
+// CHECK: return %0
+```
+
+**Capturing Function Arguments**: When capturing function arguments in CHECK-SAME lines, use the `[^:]+` pattern (matches until type specifier `:`) instead of `.+` which is greedy:
+
+```mlir
+❌ BAD (.+ is greedy - matches too much):
+  // CHECK-LABEL: util.func @test(
+  // CHECK-SAME: %[[A:.+]]: i32, %[[B:.+]]: i32
+  // (A matches "%arg0: i32, %arg1" - entire rest of signature!)
+
+✅ GOOD ([^:]+ stops at colon):
+  // CHECK-LABEL: util.func @test(
+  // CHECK-SAME: %[[A:[^:]+]]: i32
+  // CHECK-SAME: %[[B:[^:]+]]: i32
+  // CHECK-SAME: %[[C:[^:]+]]: tensor<4xf32>
+  util.func @test(%arg0: i32, %arg1: i32, %arg2: tensor<4xf32>) {
+    // CHECK: arith.addi %[[A]], %[[B]]
+    %0 = arith.addi %arg0, %arg1 : i32
+    ...
+  }
+```
+
+The `[^:]+` pattern is preferred because:
+- **Terse**: Only 5 characters vs 10 for `[a-z0-9_]+`
+- **Robust**: Naturally stops at type specifier (`:`)
+- **Works with CHECK-SAME**: Doesn't greedily consume commas or subsequent args
+
+---
+
+### 2. ✅ Zero CHECK Lines
+
+**Rule**: Test cases with IR must have CHECK lines to verify behavior.
+
+**Why**: A test with IR but no verification only confirms the IR parses, not that your pass transforms it correctly. Without CHECK lines, the test provides no value—bugs slip through undetected.
+
+**Examples**:
+
+```mlir
+❌ BAD:
+  // RUN: iree-opt --some-pass %s | FileCheck %s
+  util.func @test(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    util.return %0 : tensor<4xf32>
+  }
+  (no CHECK lines!)
+
+✅ GOOD:
+  // RUN: iree-opt --some-pass %s | FileCheck %s
+  // CHECK-LABEL: @test
+  util.func @test(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: %[[RESULT:.+]] = arith.addf
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    // CHECK: util.return %[[RESULT]]
+    util.return %0 : tensor<4xf32>
+  }
+```
+
+---
+
+### 3. ✅ TODO Without Explanation
+
+**Rule**: TODO/FIXME/NOTE comments must explain WHY and WHAT needs to be done, not just mark a location.
+
+**Why**: Bare TODO markers provide no context for future readers and will be ignored. Explain the issue, blockers, or planned work.
+
+**Examples**:
+
+```mlir
+❌ BAD:
+  // TODO
+  // TODO: fix this
+  // FIXME: broken
+
+✅ GOOD:
+  // TODO(#1234): Add support for scf.while after MutableRegionBranchOpInterface lands.
+  // NOTE: This await cannot be eliminated because public functions can't return timepoints.
+  // FIXME: Dominance check fails for block arguments in loop headers.
+```
+
+---
+
+### 4. ✅ CHECK-NOT Without Anchors
+
+**Rule**: CHECK-NOT should be bracketed by positive CHECK lines to define the scope where something shouldn't appear.
+
+**Why**: Without anchors, CHECK-NOT matches too broadly (entire file) or too narrowly (just next line), causing fragile tests.
+
+**Examples**:
+
+```mlir
+❌ BAD:
+  // CHECK-LABEL: @test
+  // CHECK-NOT: stream.timepoint.await
+  (what scope? until EOF?)
+
+✅ GOOD:
+  // CHECK-LABEL: @test
+  // CHECK: scf.if
+  // CHECK-NOT: stream.timepoint.await
+  // CHECK: scf.yield
+  (clearly checks between scf.if and scf.yield)
+```
+
+---
+
+### 5. ✅ Clean Separator Lines and Test Identification
+
+**Rule**: Separator lines (`// -----`) must contain ONLY dashes - no extra text, labels, or ordinals. Test cases are identified by CHECK-LABEL or --list ordinals, never by inline comments.
+
+**Why**: Extra text on separators confuses test identification tools and creates maintenance burden when tests are reordered. Test case ordinals change frequently as tests are added/removed, making hardcoded references immediately stale.
+
+**Examples**:
+
+```mlir
+❌ BAD (separator with extra text):
+  // ----- (Case 2: Zero CHECK lines)
+  // ===== TIER 2: WARNINGS =====
+
+✅ GOOD (clean separator):
+  // -----
+
+❌ BAD (hardcoded ordinals in comments):
+  // Case 3: Tests that TODO explanations work.
+
+✅ GOOD (no ordinals, descriptive intent):
+  // Tests that TODO explanations are required.
+```
+
+**Spacing Rule**: Add one blank line between test intent comment and first line of test code:
+
+```mlir
+✅ GOOD:
+  // Tests that raw SSA identifiers in CHECK lines trigger errors.
+
+  // CHECK-LABEL: @raw_ssa_bad
+  util.func @raw_ssa_bad() { ... }
+
+❌ BAD (no blank line):
+  // Tests that raw SSA identifiers in CHECK lines trigger errors.
+  // CHECK-LABEL: @raw_ssa_bad
+```
+
+**Test Identification**: Reference tests by:
+- **CHECK-LABEL name**: "@raw_ssa_bad"
+- **--list ordinal**: "case 3" (from `iree-lit-lint test.mlir --list`)
+- **Never**: "Case 3" in comments (ordinals change!)
+
+---
+
+## Automated Checks (Warnings)
+
+These violations generate warnings but don't block commits. They represent best practices that improve test quality.
+
+### 6. ✅ Excessive Wildcards
+
+**Rule**: Avoid more than 2 `{{.+}}` wildcards in a single CHECK line.
+
+**Why**: Wildcards are appropriate for structural IR (types, attributes) that your pass doesn't touch, but overuse masks the actual transformations being verified. Explicit captures ensure the right values flow through operations.
+
+**Examples**:
+
+```mlir
+⚠️ WARNING (5 wildcards):
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch[{{.+}}]({{.+}}, {{.+}}, {{.+}}) : ({{.+}})
+
+✅ BETTER:
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch[%[[C0:.+]]](%[[ARG0]], %[[ARG1]], %[[ARG2]]) : (!stream.resource<*>)
+```
+
+---
+
+### 7. ✅ Non-Semantic Capture Names
+
+**Rule**: Avoid capture names based on constant values (`%[[C0]]`) or argument positions (`%[[ARG0]]`). Use semantic names that describe purpose.
+
+**Why**: Names like `%[[C0]]` just copy the constant's syntactic name without conveying meaning. If the constant value changes, the capture name becomes misleading. Semantic names describe purpose and remain accurate across code changes.
+
+**Important**: This warning only fires on **capture definitions** (with `:` pattern like `%[[C0:.+]]`), not on **usages** (bare references like `%[[C0]]`). You can safely reference captures throughout your test without triggering additional warnings.
+
+**Examples**:
+
+```mlir
+⚠️ WARNING (definition):
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[C0:.+]] = arith.constant 0
+
+✅ GOOD:
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[OFFSET:.+]] = arith.constant 0
+
+OK (usage, no warning):
+  // CHECK: scf.yield %[[OFFSET]]
+
+⚠️ WARNING (definition):
+  util.func @test(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>)
+  // CHECK: arith.addf %[[ARG0:.+]], %[[ARG1:.+]]
+
+✅ GOOD:
+  util.func @test(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>)
+  // CHECK: arith.addf %[[LHS:.+]], %[[RHS:.+]]
+
+OK (usage, no warning):
+  // CHECK: util.return %[[LHS]]
+```
+
+---
+
+### 8. ✅ Mismatched Capture Names
+
+**Rule**: When IR contains semantic SSA names like `%transient_size`, CHECK captures should match: `%[[TRANSIENT_SIZE:.+]]` not `%[[SIZE:.+]]`.
+
+**Why**: Mismatched names break the connection between IR and verification, making it unclear what's being tested. Matched names maintain clarity and catch when IR changes.
+
+**Examples**:
+
+```mlir
+IR: %transient_size = arith.constant 123 : index
+
+⚠️ WARNING:
+  // CHECK: %[[SIZE:.+]] = arith.constant 123
+
+✅ GOOD:
+  // CHECK: %[[TRANSIENT_SIZE:.+]] = arith.constant 123
+
+IR: %slice_ready = stream.timepoint.await
+
+⚠️ WARNING:
+  // CHECK: %[[READY:.+]] = stream.timepoint.await
+
+✅ GOOD:
+  // CHECK: %[[SLICE_READY:.+]] = stream.timepoint.await
+```
+
+**Note**: Variance is acceptable for dialect conversion or intentional abbreviations, but exact matches are preferred.
+
+---
+
+### 9. ✅ Wildcards in Terminators
+
+**Rule**: Terminator operations (`scf.yield`, `util.return`, `func.return`, `cf.br`) should verify all operands explicitly, not use wildcards.
+
+**Why**: Terminators define data flow out of regions/blocks—their operands are what transformations modify. Wildcards here mean you're not verifying the transformation worked.
+
+**Examples**:
+
+```mlir
+⚠️ WARNING:
+  // CHECK: scf.yield {{.+}}, {{.+}}
+
+✅ GOOD:
+  // CHECK: scf.yield %[[RESULT]], %[[TP]]
+
+⚠️ WARNING:
+  // CHECK: util.return {{.+}}
+
+✅ GOOD:
+  // CHECK: util.return %[[AWAITED]]
+
+⚠️ WARNING:
+  // CHECK: cf.br ^bb1({{.+}} : i32)
+
+✅ GOOD:
+  // CHECK: cf.br ^bb1(%[[VAL]] : i32)
+```
+
+---
+
+### 10. ✅ CHECK Without LABEL Context
+
+**Rule**: CHECK lines should appear after a CHECK-LABEL that establishes which function/block is being verified.
+
+**Why**: Without CHECK-LABEL, FileCheck may match lines from the wrong function, causing tests to pass for the wrong reasons.
+
+**Examples**:
+
+```mlir
+⚠️ WARNING:
+  // CHECK: %[[FOO:.+]] = some.op
+  util.func @test() { ... }
+
+✅ GOOD:
+  // CHECK-LABEL: @test
+  util.func @test() {
+  // CHECK: %[[FOO:.+]] = some.op
+```
+
+---
+
+### 11. ✅ Unused Captures
+
+**Rule**: Captured values like `%[[FOO:.+]]` should be referenced later in CHECK lines.
+
+**Why**: A capture that's never used suggests incomplete test coverage—you intended to verify something but didn't.
+
+**Examples**:
+
+```mlir
+⚠️ WARNING:
+  // CHECK: %[[UNUSED:.+]] = stream.async.execute
+  // CHECK: util.return %[[OTHER]]
+
+✅ GOOD:
+  // CHECK: %[[RESULT:.+]] = stream.async.execute
+  // CHECK: util.return %[[RESULT]]
+
+OK (used in CHECK-SAME):
+  // CHECK: %[[TP:.+]] = stream.async.execute
+  // CHECK-SAME: await(%[[TP]]) =>
+```
+
+---
+
+## Manual Review Guidelines
+
+These patterns are too heuristic or context-dependent for reliable automation. Reviewers should verify these during code review.
+
+### 12. 📖 Missing Transformation Verification
+
+**Rule**: When RUN line invokes a transformation pass (not just parsing/printing), verify the transformation occurred.
+
+**Why**: Tests should have CHECK patterns that verify the pass's behavior, not just that IR parses. Look for pass-specific patterns: if running `--elide-timepoints`, verify awaits are removed/folded.
+
+**Examples**:
+
+```mlir
+📖 REVIEW NEEDED:
+  // RUN: iree-opt --iree-stream-elide-timepoints %s | FileCheck %s
+  // CHECK-LABEL: @test
+  util.func @test() {
+    %tp = stream.timepoint.await ...
+    ...
+  }
+  (no checks for await elimination!)
+
+✅ GOOD:
+  // RUN: iree-opt --iree-stream-elide-timepoints %s | FileCheck %s
+  // CHECK-LABEL: @test
+  // CHECK-NOT: stream.timepoint.await
+  util.func @test() { ... }
+```
+
+**Manual Review Prompt**: "Pass `X` runs, but I only see checks for unrelated ops. Does this test verify the transformation?"
+
+---
+
+### 13. 📖 Inconsistent Type Wildcards
+
+**Rule**: Type annotations in CHECK lines should be consistent: either verify types explicitly when they're relevant to the transformation, or use wildcards when types are incidental.
+
+**Why**: Mixing styles (some ops with types, some without) suggests unclear test intent. Be systematic about what you're verifying.
+
+**Examples**:
+
+```mlir
+📖 INCONSISTENT:
+  // CHECK: %[[A:.+]] = some.op : i32
+  // CHECK: %[[B:.+]] = other.op
+  // CHECK: %[[C:.+]] = third.op : f32
+
+✅ GOOD (types not relevant):
+  // CHECK: %[[A:.+]] = some.op
+  // CHECK: %[[B:.+]] = other.op
+  // CHECK: %[[C:.+]] = third.op
+
+✅ GOOD (types are relevant):
+  // CHECK: %[[A:.+]] = some.op : i32
+  // CHECK: %[[B:.+]] = other.op : i32
+  // CHECK: %[[C:.+]] = third.op : f32
+```
+
+**Manual Review Prompt**: "This test wildcards all types. Should it verify the type transformation?"
+
+---
+
+### 14. 📖 Full-Line Comment Punctuation
+
+**Rule**: Full-line comments should be complete sentences ending with proper punctuation (`.`, `!`, `?`).
+
+**Why**: Complete sentences with punctuation maintain professional code quality and make comments easier to read. This ensures comments are thoughtful explanations, not hastily written fragments.
+
+**Examples**:
+
+```mlir
+📖 REVIEW NEEDED:
+  // This await is redundant
+  // Verify that the transformation works
+
+✅ GOOD:
+  // This await is redundant and will be eliminated by the pass.
+  // Verify that the transformation correctly removes all awaits in this scope.
+
+OK (trailing comment, no punctuation required):
+  %foo = bar  // redundant await
+```
+
+**Special Considerations**:
+- **Multi-line comments**: Only the last line of a comment block needs punctuation
+- **Trailing comments**: Short comments after code don't need punctuation
+- **CHECK/RUN directives**: Excluded (not narrative comments)
+
+**Manual Review Prompt**: "Do the comments form complete sentences? Are multi-line comments properly punctuated at the end?"
+
+---
+
+### 15. 📖 "Tests that..." Pattern for Test Intent
+
+**Rule**: Test functions and test case comments should clearly state what behavior is being verified, preferably using the pattern "Tests that [behavior]."
+
+**Why**: Clear test intent makes it obvious what the test verifies and easier to debug when it fails. The "Tests that..." pattern forces you to articulate the specific behavior being tested, not just describe the test setup.
+
+**Examples**:
+
+```mlir
+📖 REVIEW NEEDED:
+  // Await elimination example
+  // CHECK-LABEL: @test
+  util.func @test() { ... }
+
+✅ GOOD:
+  // Tests that await elimination removes redundant awaits before loops.
+  // CHECK-LABEL: @test
+  util.func @test() { ... }
+
+✅ GOOD (variant):
+  // Tests that the pass preserves awaits required for correctness in public functions.
+  // CHECK-LABEL: @public_func
+  util.func public @public_func() { ... }
+```
+
+**Pattern Benefits**:
+- Forces you to think: "What am I actually testing?"
+- Makes test failures immediately clear: "Tests that X" → if X fails, debug X
+- Documents test coverage gaps: if you can't write "Tests that...", the test is unclear
+- Helps reviewers quickly understand test purpose
+
+**Manual Review Prompt**: "Can you state what this test verifies in one sentence starting with 'Tests that...'?"
+
+---
+
+## Running the Linter
+
+### Command Line
+
+```bash
+# Lint entire file
+iree-lit-lint test.mlir
+
+# Lint specific test cases
+iree-lit-lint test.mlir --case 2
+iree-lit-lint test.mlir --name fold_constants
+
+# Show only errors (suppress warnings)
+iree-lit-lint test.mlir --errors-only
+
+# JSON output for tooling
+iree-lit-lint test.mlir --json
+
+# JSON with full IR context for LLM processing
+iree-lit-lint test.mlir --json --full-json
+iree-lit-lint test.mlir --json --full-json --context-lines=10
+
+# View this style guide
+iree-lit-lint --help-style-guide
+```
+
+### Understanding Warnings
+
+Each warning includes contextual help text with:
+- **What the issue is** and why it matters
+- **How to fix it** with concrete examples
+- **When to ignore** the warning (marked with "Ignore if...")
+
+The "Ignore if..." guidance helps both humans and LLM agents make informed decisions:
+
+```
+warning: capture name based on constant value
+  // CHECK: %[[C0:.+]] = arith.constant
+  help: Use semantic name like %[[OFFSET]] or %[[SIZE]] instead...
+  (Ignore if the constant value IS the semantic meaning, e.g.,
+   %[[C0]] for zero-initialization pattern.)
+```
+
+Common valid reasons to ignore warnings:
+- **Non-semantic captures**: When testing argument forwarding or zero-init patterns
+- **Excessive wildcards**: When operation has many structural attributes the pass doesn't modify
+- **Mismatched names**: When doing dialect conversion (e.g., `%stream_resource` → `%[[TENSOR]]`)
+- **Wildcard terminators**: When terminator forwards arguments unchanged and test focuses elsewhere
+- **Unused captures**: When capture is for documentation/clarity even though not referenced
+
+### Pre-Commit Integration
+
+The linter runs automatically on modified test files during pre-commit.
+
+### Exit Codes
+
+- **0**: No errors found (warnings may exist)
+- **1**: One or more errors found
+- **2**: File not found or parse error
+
+---
+
+## Summary
+
+**Key Principles**:
+1. **Verify transformations, not syntax** - Tests should prove your pass worked
+2. **Use semantic names** - Match IR names, describe purpose
+3. **Capture data flow** - Verify operands, especially in terminators
+4. **Anchor patterns** - Use CHECK-LABEL and positive CHECKs around CHECK-NOT
+5. **Minimize wildcards** - Only wildcard structural IR you don't care about
+
+**When in doubt**:
+- Read existing well-tested files in the same directory
+- Ask in code review: "Does this test verify what the pass does?"
+- Run `iree-lit-lint` early and often

--- a/tools/utils/lit_tools/__init__.py
+++ b/tools/utils/lit_tools/__init__.py
@@ -1,0 +1,1 @@
+"""LLVM lit testing tools for MLIR/IREE test workflows."""

--- a/tools/utils/lit_tools/core/__init__.py
+++ b/tools/utils/lit_tools/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core lit tool infrastructure including test file parsing and execution."""

--- a/tools/utils/lit_tools/core/check_matcher.py
+++ b/tools/utils/lit_tools/core/check_matcher.py
@@ -1,0 +1,223 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CHECK pattern to IR line matching for MLIR lit tests.
+
+Matches CHECK directives to IR lines using content-based matching:
+operation semantics + proximity, rather than naive positional matching.
+
+This fixes false positives where CHECKs incorrectly match nearby IR lines
+with different operations.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lit_tools.core.check_pattern import CheckPattern
+    from lit_tools.core.ir_index import IRIndex, IRLine
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckMatch:
+    """A CHECK pattern matched to an IR line.
+
+    Attributes:
+        check_pattern: The CHECK directive being matched
+        ir_line: The IR line that this CHECK verifies (or None if no match)
+        confidence: Confidence score (0.0-1.0) for this match
+        match_reason: Human-readable explanation of why this match was chosen
+    """
+
+    check_pattern: CheckPattern
+    ir_line: IRLine | None
+    confidence: float
+    match_reason: str
+
+
+class CheckMatcher:
+    """Matches CHECK patterns to IR lines using content-based matching.
+
+    Uses operation semantics and proximity to match CHECK directives to the
+    IR lines they verify, avoiding false positives from naive positional matching.
+
+    Example:
+        >>> ir_index = IRIndex(ir_lines)
+        >>> check_patterns = parser.parse_file(test_lines)
+        >>> matcher = CheckMatcher(ir_index, check_patterns)
+        >>> matches = matcher.match_all()
+    """
+
+    def __init__(
+        self,
+        ir_index: IRIndex,
+        check_patterns: list[CheckPattern],
+        proximity_window: int = 50,
+    ) -> None:
+        """Initialize matcher with IR index and CHECK patterns.
+
+        Args:
+            ir_index: Index of IR lines by operation
+            check_patterns: List of CHECK patterns to match
+            proximity_window: Lines before/after CHECK to search (default: 50)
+        """
+        self.ir_index = ir_index
+        self.check_patterns = check_patterns
+        self.proximity_window = proximity_window
+
+    def match_all(self) -> list[CheckMatch]:
+        """Match all CHECK patterns to IR lines.
+
+        Processes patterns sequentially to handle CHECK-NEXT and CHECK-SAME
+        semantics, which depend on the previous CHECK's matched line.
+
+        Returns:
+            List of CheckMatch objects, one per CHECK pattern
+        """
+        matches = []
+        previous_match: CheckMatch | None = None
+
+        for check_pattern in self.check_patterns:
+            match = self.match_check(check_pattern, previous_match)
+            matches.append(match)
+
+            # Track previous match for CHECK-NEXT/SAME semantics.
+            # Only update if this was a successful match.
+            if match.ir_line is not None:
+                previous_match = match
+
+        return matches
+
+    def match_check(
+        self, check: CheckPattern, previous_match: CheckMatch | None = None
+    ) -> CheckMatch:
+        """Match a single CHECK pattern to best IR line.
+
+        Strategy:
+        1. Handle CHECK-NEXT/SAME semantics using previous match
+        2. If CHECK has no operation: return None match (can't verify)
+        3. Find all IR lines with matching operation
+        4. Score candidates by proximity and select best match
+
+        Args:
+            check: CHECK pattern to match
+            previous_match: Previous CHECK's match (for -NEXT/-SAME semantics)
+
+        Returns:
+            CheckMatch with best IR line and confidence score
+        """
+        # Handle CHECK-NEXT: must match line immediately after previous match.
+        if check.check_type.endswith("-NEXT"):
+            if previous_match is None or previous_match.ir_line is None:
+                return CheckMatch(
+                    check_pattern=check,
+                    ir_line=None,
+                    confidence=0.0,
+                    match_reason="CHECK-NEXT requires previous match",
+                )
+
+            # Get the next IR line after previous match.
+            next_line_num = previous_match.ir_line.line_num + 1
+            next_ir = self.ir_index.get_line(next_line_num)
+
+            if next_ir is None:
+                return CheckMatch(
+                    check_pattern=check,
+                    ir_line=None,
+                    confidence=0.0,
+                    match_reason=f"No IR line at {next_line_num} (after previous match)",
+                )
+
+            # TODO: Verify CHECK pattern actually matches next_ir.content.
+            # For now, assume match if line exists.
+            return CheckMatch(
+                check_pattern=check,
+                ir_line=next_ir,
+                confidence=1.0,
+                match_reason=f"CHECK-NEXT matched line {next_line_num}",
+            )
+
+        # Handle CHECK-SAME: must match same line as previous match.
+        if check.check_type.endswith("-SAME"):
+            if previous_match is None or previous_match.ir_line is None:
+                return CheckMatch(
+                    check_pattern=check,
+                    ir_line=None,
+                    confidence=0.0,
+                    match_reason="CHECK-SAME requires previous match",
+                )
+
+            # Re-use the same IR line.
+            return CheckMatch(
+                check_pattern=check,
+                ir_line=previous_match.ir_line,
+                confidence=1.0,
+                match_reason=f"CHECK-SAME matched same line as previous ({previous_match.ir_line.line_num})",
+            )
+
+        # For regular CHECK, CHECK-LABEL, CHECK-NOT: use operation-based matching.
+
+        # If CHECK has no operation, we can't do content-based matching.
+        if check.operation is None:
+            return CheckMatch(
+                check_pattern=check,
+                ir_line=None,
+                confidence=0.0,
+                match_reason="No operation found in CHECK pattern",
+            )
+
+        # Find IR lines with matching operation.
+        candidates = self.ir_index.find_by_operation(
+            check.operation, near_line=check.line_num, window=self.proximity_window
+        )
+
+        if not candidates:
+            return CheckMatch(
+                check_pattern=check,
+                ir_line=None,
+                confidence=0.0,
+                match_reason=f"No IR line with operation '{check.operation}' found within {self.proximity_window} lines",
+            )
+
+        # Select best candidate (IRIndex already sorted by proximity).
+        best_candidate = candidates[0]
+
+        # Compute confidence based on proximity.
+        distance = abs(best_candidate.line_num - check.line_num)
+        if distance == 0:
+            # CHECK on same line as IR (unusual but possible).
+            confidence = 0.5
+            reason = (
+                f"Matched '{check.operation}' on same line {best_candidate.line_num}"
+            )
+        elif len(candidates) == 1:
+            # Only one candidate, high confidence.
+            confidence = 1.0
+            reason = f"Matched '{check.operation}' at line {best_candidate.line_num} (distance: {distance}, only candidate)"
+        elif best_candidate == candidates[0] and len(candidates) > 1:
+            # Multiple candidates, this is closest.
+            confidence = 1.0
+            reason = f"Matched '{check.operation}' at line {best_candidate.line_num} (distance: {distance}, closest of {len(candidates)})"
+        else:
+            # Fallback (shouldn't reach here given current logic).
+            confidence = 0.8
+            reason = f"Matched '{check.operation}' at line {best_candidate.line_num} (distance: {distance})"
+
+        # TODO: Perform full FileCheck pattern matching (check.raw_pattern vs best_candidate.content).
+        # This would validate the CHECK regex actually matches the IR line, not just the operation.
+        # For now, operation + proximity matching is sufficient for the immediate bug fix.
+
+        return CheckMatch(
+            check_pattern=check,
+            ir_line=best_candidate,
+            confidence=confidence,
+            match_reason=reason,
+        )

--- a/tools/utils/lit_tools/core/check_pattern.py
+++ b/tools/utils/lit_tools/core/check_pattern.py
@@ -1,0 +1,222 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""FileCheck pattern parsing for MLIR lit tests.
+
+Parses CHECK directives (CHECK, CHECK-NEXT, CHECK-SAME, CHECK-LABEL, CHECK-NOT)
+to extract operation names and FileCheck variable captures.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from lit_tools.core.ir_index import IRIndex
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckCapture:
+    """A FileCheck variable capture.
+
+    Attributes:
+        name: Capture variable name (e.g., "AWAITED" from %[[AWAITED]])
+        pattern: Regex pattern if this is a definition (e.g., ".+")
+                 None if this is a reference (using previously defined capture)
+        position: Character offset in the CHECK line where capture appears
+        is_definition: True if %[[NAME:pattern]], False if %[[NAME]]
+    """
+
+    name: str
+    pattern: str | None
+    position: int
+    is_definition: bool
+
+
+@dataclass
+class CheckPattern:
+    """A parsed CHECK directive.
+
+    Attributes:
+        check_type: Type of check (CHECK, CHECK-NEXT, CHECK-SAME, CHECK-LABEL, CHECK-NOT)
+        line_num: Absolute line number in test file
+        operation: Operation name being verified (e.g., "scf.for"), or None
+        captures: List of FileCheck captures in order of appearance
+        raw_pattern: The full pattern after // CHECK: (for debugging)
+    """
+
+    check_type: str
+    line_num: int
+    operation: str | None
+    captures: list[CheckCapture]
+    raw_pattern: str
+
+
+class CheckPatternParser:
+    """Parses CHECK directives from lit test files.
+
+    Extracts operation names and FileCheck captures from CHECK patterns to
+    enable content-based matching against IR.
+
+    Example:
+        >>> parser = CheckPatternParser()
+        >>> pattern = parser.parse_check_line("// CHECK: %[[X:.+]] = arith.constant", 42)
+        >>> pattern.operation
+        'arith.constant'
+        >>> pattern.captures[0].name
+        'X'
+    """
+
+    # Pattern to match CHECK directives.
+    # Matches: CHECK, CHECK-NEXT, CHECK-SAME, CHECK-LABEL, CHECK-NOT
+    # Also supports custom prefixes via --check-prefix: FOO, FOO-NEXT, AMDGPU, etc.
+    # Group 1: Full directive (e.g., "CHECK", "FOO-NEXT", "AMDGPU")
+    # Group 2: Pattern content after the colon
+    CHECK_DIRECTIVE_PATTERN = re.compile(
+        r"^\s*//\s*([A-Z][A-Z0-9_]*(?:-NEXT|-SAME|-LABEL|-NOT)?)\s*:\s*(.*)$"
+    )
+
+    # Pattern to match FileCheck captures.
+    # Matches: %[[NAME]] (reference) or %[[NAME:pattern]] (definition)
+    # Enforces UPPER_SNAKE_CASE convention for capture names.
+    # Pattern captures everything up to the closing ]] (non-greedy).
+    CAPTURE_PATTERN = re.compile(r"%\[\[([A-Z_][A-Z0-9_]*)(?::(.+?))?\]\]")
+
+    # Placeholder used when sanitizing captures for operation extraction.
+    # Uses SSA syntax (%0) which won't match operation patterns (ops don't start with %).
+    CAPTURE_PLACEHOLDER = "%0"
+
+    def parse_check_line(self, line: str, line_num: int) -> CheckPattern | None:
+        """Parse a single CHECK line.
+
+        Args:
+            line: Line content (may or may not be a CHECK directive)
+            line_num: Absolute line number in test file
+
+        Returns:
+            CheckPattern if line is a CHECK directive, None otherwise
+        """
+        # Check if this is a CHECK directive.
+        match = self.CHECK_DIRECTIVE_PATTERN.match(line)
+        if not match:
+            return None
+
+        check_type = match.group(1)
+        raw_pattern = match.group(2)
+
+        # Extract captures from the pattern.
+        captures = self._extract_captures(raw_pattern)
+
+        # Extract operation name (if present).
+        operation = self._extract_operation(raw_pattern, captures)
+
+        return CheckPattern(
+            check_type=check_type,
+            line_num=line_num,
+            operation=operation,
+            captures=captures,
+            raw_pattern=raw_pattern,
+        )
+
+    def parse_file(self, lines: list[str]) -> list[CheckPattern]:
+        """Parse all CHECK directives from a test file.
+
+        Args:
+            lines: Test file content split by newlines
+
+        Returns:
+            List of CheckPattern objects in file order
+        """
+        patterns = []
+        for i, line in enumerate(lines):
+            pattern = self.parse_check_line(line, i)
+            if pattern:
+                patterns.append(pattern)
+        return patterns
+
+    def _extract_captures(self, pattern: str) -> list[CheckCapture]:
+        """Extract all FileCheck captures from a pattern.
+
+        Args:
+            pattern: The pattern content after // CHECK:
+
+        Returns:
+            List of CheckCapture objects in order of appearance
+        """
+        captures = []
+        for match in self.CAPTURE_PATTERN.finditer(pattern):
+            name = match.group(1)
+            regex_pattern = match.group(2)  # None if reference
+            position = match.start()
+            is_definition = regex_pattern is not None
+
+            captures.append(
+                CheckCapture(
+                    name=name,
+                    pattern=regex_pattern,
+                    position=position,
+                    is_definition=is_definition,
+                )
+            )
+
+        return captures
+
+    def _extract_operation(
+        self, pattern: str, captures: list[CheckCapture]
+    ) -> str | None:
+        """Extract operation name, avoiding FileCheck capture syntax.
+
+        Strategy:
+        1. Sanitize captures to avoid matching FileCheck syntax
+        2. Look for operations AFTER '=' (assignment pattern)
+        3. If no '=', look for namespaced operations (e.g., scf.for)
+        4. Single-word identifiers without '.' are likely not operations
+
+        Args:
+            pattern: The pattern content after // CHECK:
+            captures: Already extracted captures (for reference)
+
+        Returns:
+            Operation name if found, None otherwise
+        """
+        # Sanitize: replace all captures with placeholder to avoid confusing
+        # operation extraction with FileCheck syntax.
+        sanitized_pattern = self.CAPTURE_PATTERN.sub(self.CAPTURE_PLACEHOLDER, pattern)
+
+        # Strategy: Look for operation AFTER '=' if this is an SSA assignment.
+        # SSA assignments START with % (e.g., "%[[X]] = arith.constant", "%x = arith.constant")
+        # Operations like "scf.for %i = %c0" have % later, not at the start.
+        stripped = sanitized_pattern.lstrip()
+        if stripped.startswith("%") and "=" in stripped:
+            # This is an SSA assignment - search after the '='.
+            parts = stripped.split("=", 1)
+            search_text = parts[1] if len(parts) > 1 else stripped
+        else:
+            # Not an SSA assignment - search the whole pattern.
+            search_text = sanitized_pattern
+
+        # Search for operation using IRIndex pattern.
+        op_match = IRIndex.OPERATION_PATTERN.search(search_text)
+        if not op_match:
+            return None
+
+        operation = op_match.group(1)
+
+        # Filter out single-word identifiers that are likely not operations.
+        # Real operations are either:
+        # - Namespaced (contain '.'): scf.for, arith.constant
+        # - Known single-word operations: call, return, yield
+        if "." not in operation:
+            # Check if it's a known single-word operation.
+            known_single_word_ops = {"call", "return", "yield", "func"}
+            if operation not in known_single_word_ops:
+                # Likely not an operation (e.g., 'x', 'test', 'iter_args').
+                return None
+
+        return operation

--- a/tools/utils/lit_tools/core/cli.py
+++ b/tools/utils/lit_tools/core/cli.py
@@ -1,0 +1,351 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Lit-specific CLI helpers for lit tools.
+
+Provides test case selection and filtering specific to lit test files.
+Generic CLI helpers are in common.cli.
+"""
+
+from __future__ import annotations
+
+import argparse  # noqa: TCH003
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from lit_tools.core.parser import TestCase, TestFile
+
+from common import cli as common_cli
+from common import console, exit_codes
+
+from lit_tools.core import suggestions
+from lit_tools.core.parser import parse_test_file
+
+# Re-export generic CLI helpers from common module.
+add_common_output_flags = common_cli.add_common_output_flags
+require_exactly_one = common_cli.require_exactly_one
+require_at_most_one = common_cli.require_at_most_one
+parse_case_numbers = common_cli.parse_case_numbers
+
+
+def load_and_parse_test_file(
+    file_path: Path, args: argparse.Namespace
+) -> tuple[TestFile | None, list[TestCase], int]:
+    """Load and parse a lit test file with standardized error handling.
+
+    This helper consolidates the common pattern of parsing test files with
+    consistent error handling across all lit tools.
+
+    Args:
+        file_path: Path to the test file to parse
+        args: Parsed arguments for error reporting (uses --quiet, --json)
+
+    Returns:
+        Tuple of (test_file, cases, exit_code)
+        - test_file: Parsed TestFile object, or None if parsing failed
+        - cases: List of test cases (empty if parsing failed)
+        - exit_code: exit_codes.SUCCESS if successful, otherwise error code
+
+    Example:
+        >>> test_file, cases, exit_code = load_and_parse_test_file(file_path, args)
+        >>> if exit_code != exit_codes.SUCCESS:
+        ...     return exit_code
+        >>> # Proceed with cases...
+
+    Note:
+        This function prints error messages to stderr using console.error(),
+        so callers should not print duplicate errors.
+    """
+    try:
+        test_file = parse_test_file(file_path)
+        all_cases = list(test_file.cases)
+        return (test_file, all_cases, exit_codes.SUCCESS)
+    except FileNotFoundError:
+        console.error(f"File not found: {file_path}", args=args)
+        return (None, [], exit_codes.NOT_FOUND)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Failed to parse test file: {e}", args=args)
+        return (None, [], exit_codes.ERROR)
+
+
+def suggest_common_mistakes(argv: list[str]) -> str | None:
+    """Check for common CLI mistakes and suggest corrections.
+
+    Used by lit tools to detect when users pass case numbers or names as
+    positional arguments instead of using the proper flags (--case, --name).
+    This is integrated with run_with_argparse_suggestions() to show helpful
+    error messages.
+
+    Args:
+        argv: Command line arguments (sys.argv)
+
+    Returns:
+        Suggestion string if a common mistake is detected, None otherwise
+
+    Examples:
+        >>> suggest_common_mistakes(["iree-lit-extract", "test.mlir", "2"])
+        'Did you mean: iree-lit-extract test.mlir --case 2'
+
+        >>> suggest_common_mistakes(["iree-lit-test", "test.mlir", "my_func"])
+        'Did you mean: iree-lit-test test.mlir --name my_func'
+    """
+    if len(argv) < 2:
+        return None
+
+    # Check if last argument looks like a case number without --case flag.
+    last_arg = argv[-1]
+    if last_arg.isdigit():
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --case {last_arg}"
+
+    # Check if there's an unquoted string that looks like a name without --name flag.
+    if (
+        len(argv) >= 3
+        and not argv[-1].startswith("-")
+        and not Path(argv[-1]).exists()
+        and not argv[-1].endswith(".mlir")
+    ):
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --name {last_arg}"
+
+    return None
+
+
+def add_selection_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add standardized test case selection arguments.
+
+    Used by tools that operate on individual test cases (iree-lit-test,
+    iree-lit-extract, iree-lit-lint). Provides consistent selection interface.
+
+    Args:
+        parser: ArgumentParser to add selection arguments to
+    """
+    selection = parser.add_argument_group("Test case selection")
+    selection.add_argument(
+        "--case",
+        "-c",
+        action="append",
+        metavar="N[,N...]",
+        help="Select case number(s): --case 1, --case 1,3,5, --case 1-3",
+    )
+    selection.add_argument(
+        "--name",
+        "-n",
+        metavar="NAME",
+        help="Select case with specific function name",
+    )
+    selection.add_argument(
+        "--containing",
+        type=int,
+        metavar="LINE",
+        help="Select case containing line number",
+    )
+    selection.add_argument(
+        "--list",
+        "-l",
+        action="store_true",
+        help="List available test cases and exit",
+    )
+
+
+def add_filter_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add standardized --filter and --filter-out arguments.
+
+    Used by tools that support regex filtering of test cases by name.
+    Filters apply only when explicit selectors are not used.
+    """
+    parser.add_argument(
+        "--filter",
+        type=str,
+        metavar="REGEX",
+        help="Only include cases with name matching REGEX (when not using explicit selectors)",
+    )
+    parser.add_argument(
+        "--filter-out",
+        type=str,
+        metavar="REGEX",
+        help="Exclude cases with name matching REGEX (when not using explicit selectors)",
+    )
+
+
+def select_cases(
+    cases: list[TestCase], args: argparse.Namespace
+) -> list[TestCase] | None:
+    """Select test cases based on command-line arguments.
+
+    Handles --case, --name, --containing selection. If none specified,
+    returns all cases (for use with --filter).
+
+    Args:
+        cases: All test cases from file
+        args: Parsed arguments with selection flags
+
+    Returns:
+        Selected cases, or None if selection failed (error already printed).
+        None signals error; caller should return exit_codes.NOT_FOUND.
+
+    Note:
+        This function provides the core selection logic shared across all lit tools.
+        It handles explicit selectors (--case, --name, --containing) but not regex
+        filters (--filter, --filter-out), which should be applied afterward using
+        apply_filters().
+
+    Examples:
+        >>> cases = parse_test_file("test.mlir")
+        >>> # Select by case number
+        >>> args = Namespace(case=["2"], name=None, containing=None)
+        >>> selected = select_cases(cases, args)
+        >>>
+        >>> # Select by name
+        >>> args = Namespace(case=None, name="fold_op", containing=None)
+        >>> selected = select_cases(cases, args)
+        >>>
+        >>> # No selector - return all for filtering
+        >>> args = Namespace(case=None, name=None, containing=None)
+        >>> selected = select_cases(cases, args)  # Returns all cases
+    """
+    # --containing: select by line number.
+    if args.containing is not None:
+        for case in cases:
+            if case.start_line <= args.containing <= case.end_line:
+                return [case]
+        console.error(f"No case contains line {args.containing}", args=args)
+        return None
+
+    # --case: select by case number(s).
+    if args.case:
+        try:
+            case_numbers = parse_case_numbers(args.case)
+        except ValueError as e:
+            console.error(str(e), args=args)
+            return None
+
+        selected = []
+        for num in case_numbers:
+            found = False
+            for case in cases:
+                if case.number == num:
+                    selected.append(case)
+                    found = True
+                    break
+            if not found:
+                console.error(
+                    f"Case {num} not found (file has {len(cases)} cases)", args=args
+                )
+                return None
+        return selected
+
+    # --name: select by function name.
+    if args.name:
+        for case in cases:
+            if case.name == args.name:
+                return [case]
+        error_msg = suggestions.format_case_name_error(args.name, cases)
+        console.error(error_msg, args=args)
+        return None
+
+    # No explicit selector - return all (for --filter usage).
+    return cases
+
+
+def apply_filters(
+    cases: list[TestCase],
+    filter_pattern: str | None,
+    filter_out_pattern: str | None,
+    args: argparse.Namespace | None = None,
+) -> list[TestCase] | None:
+    """Apply regex filters to test cases by name.
+
+    Filters by case.name field (from CHECK-LABEL comments). Cases without names
+    are excluded when filters are active.
+
+    Args:
+        cases: Test cases to filter
+        filter_pattern: Regex pattern to include (or None to include all)
+        filter_out_pattern: Regex pattern to exclude (or None to exclude none)
+        args: Parsed arguments for error reporting (optional)
+
+    Returns:
+        Filtered list of cases, or None if no cases match (error already printed).
+        None signals error condition; caller should return exit_codes.NOT_FOUND.
+
+    Note:
+        Both filters can be applied together. Positive filter applied first, then
+        negative filter. This allows patterns like: --filter "op" --filter-out "gpu"
+
+    Examples:
+        >>> cases = [Case(name="fold_op"), Case(name="gpu_fold"), Case(name="add")]
+        >>> apply_filters(cases, "fold", None)
+        [Case(name="fold_op"), Case(name="gpu_fold")]
+        >>> apply_filters(cases, "fold", "gpu")
+        [Case(name="fold_op")]
+    """
+    filtered = cases
+
+    # Apply positive filter (include only matching).
+    if filter_pattern:
+        pattern = re.compile(filter_pattern)
+        filtered = [c for c in filtered if (c.name and pattern.search(c.name))]
+        if not filtered:
+            console.error("No cases matched --filter", args=args)
+            return None
+
+    # Apply negative filter (exclude matching).
+    if filter_out_pattern:
+        pattern = re.compile(filter_out_pattern)
+        filtered = [c for c in filtered if not (c.name and pattern.search(c.name))]
+        if not filtered:
+            console.error("All cases excluded by --filter-out", args=args)
+            return None
+
+    return filtered
+
+
+def run_with_argparse_suggestions(
+    parse_fn: Callable[[], argparse.Namespace],
+    main_fn: Callable[[argparse.Namespace], int],
+    suggest_fn: Callable[[list[str]], str | None],
+) -> int:
+    """Run tool with argparse error suggestion support.
+
+    This helper encapsulates the common pattern for tool entry points that want
+    to provide helpful suggestions when users make common CLI mistakes (like
+    passing positional arguments instead of using flags).
+
+    Args:
+        parse_fn: Function that parses arguments (typically parse_arguments())
+        main_fn: Main function to run with parsed args (typically main())
+        suggest_fn: Function that checks sys.argv for common mistakes and
+                    returns a suggestion string, or None if no suggestion
+
+    Returns:
+        Exit code from main_fn
+
+    Example:
+        if __name__ == "__main__":
+            sys.exit(cli.run_with_argparse_suggestions(
+                parse_arguments,
+                main,
+                _suggest_common_mistakes
+            ))
+    """
+    try:
+        args = parse_fn()
+    except SystemExit as e:
+        # Check if user made a common mistake and show helpful suggestion.
+        if e.code != 0:  # Non-zero exit means error occurred.
+            suggestion = suggest_fn(sys.argv)
+            if suggestion:
+                console.error(f"\n{suggestion}", args=None)
+        raise
+    return main_fn(args)

--- a/tools/utils/lit_tools/core/document.py
+++ b/tools/utils/lit_tools/core/document.py
@@ -1,0 +1,334 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Line-oriented document model for LLVM lit test files.
+
+This module provides the core data structures for representing lit test files
+as immutable, line-oriented documents. This enables accurate line number
+preservation, exact newline handling, and efficient span-based operations.
+
+Key classes:
+- Line: Atomic line unit with text, newline, and metadata
+- Span: Half-open range [start, end) over line indices
+- FileDoc: Immutable document as tuple of Lines
+- CheckLabelExtractor: Utility for extracting CHECK-LABEL names
+"""
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Module-level regex for CHECK-LABEL extraction
+# Matches any *-LABEL: pattern followed by optional prefix and @name
+# Group 1 captures the name after @
+_CHECK_LABEL_PATTERN = re.compile(r"//\s*[\w-]+-LABEL:\s*.*?@([\w.$-]+)")
+
+
+@dataclass(frozen=True)
+class Line:
+    r"""Represents a single line of text with preserved formatting.
+
+    Attributes:
+        text: Line content without trailing newline character
+        newline: The newline character(s): "\n", "\r\n", or "" for EOF
+        index: 0-based index of this line in the FileDoc
+        source_line: 1-based original line number (immutable diagnostic reference)
+        tags: Structural classification tags like "RUN_HEADER", "DELIMITER", "CHECK"
+    """
+
+    text: str
+    newline: str
+    index: int
+    source_line: int
+    tags: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        r"""Validate line invariants."""
+        if self.newline not in ("", "\n", "\r\n"):
+            raise ValueError(
+                f"Invalid newline character: {repr(self.newline)}. "
+                f"Must be '', '\\n', or '\\r\\n'"
+            )
+        if self.index < 0:
+            raise ValueError(f"Line index must be non-negative, got {self.index}")
+        if self.source_line < 1:
+            raise ValueError(
+                f"Source line must be >= 1 (1-based), got {self.source_line}"
+            )
+
+    def get_full_line(self) -> str:
+        """Returns the complete line including its newline character."""
+        return self.text + self.newline
+
+    def with_tags(self, tags: frozenset[str]) -> "Line":
+        r"""Returns a new Line with updated tags (immutable update)."""
+        return Line(
+            text=self.text,
+            newline=self.newline,
+            index=self.index,
+            source_line=self.source_line,
+            tags=tags,
+        )
+
+
+@dataclass(frozen=True)
+class Span:
+    """Half-open range [start, end) over line indices.
+
+    Uses Python slice semantics: start is inclusive, end is exclusive.
+    This makes slicing operations natural: lines[span.start:span.end]
+
+    Attributes:
+        start: Inclusive 0-based start index
+        end: Exclusive 0-based end index
+    """
+
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        """Validate span invariants."""
+        if self.start < 0:
+            raise ValueError(f"Span start must be non-negative, got {self.start}")
+        if self.end < self.start:
+            raise ValueError(
+                f"Invalid span [{self.start}, {self.end}): end must be >= start"
+            )
+
+    @property
+    def length(self) -> int:
+        """Number of lines in this span."""
+        return self.end - self.start
+
+    @property
+    def is_empty(self) -> bool:
+        """True if span contains no lines."""
+        return self.start == self.end
+
+    def contains(self, index: int) -> bool:
+        """Check if a line index falls within this span."""
+        return self.start <= index < self.end
+
+
+@dataclass(frozen=True)
+class FileDoc:
+    """Immutable document representation as a tuple of Lines.
+
+    This is the core data structure for representing lit test files.
+    All lines are stored in a flat tuple, and cases are represented
+    as Span indices over this tuple.
+
+    Attributes:
+        lines: Tuple of Line objects representing the file
+        path: Original file path (for error messages)
+    """
+
+    lines: tuple[Line, ...]
+    path: Path
+
+    @classmethod
+    def from_text(cls, text: str, path: Path = Path()) -> "FileDoc":
+        r"""Parse text into FileDoc with exact fidelity.
+
+        Uses splitlines(keepends=True) to preserve exact newline characters.
+        Handles LF, CRLF, and files without trailing newlines correctly.
+
+        Args:
+            text: Raw file content
+            path: File path for error messages
+
+        Returns:
+            FileDoc with all lines parsed
+
+        Example:
+            >>> doc = FileDoc.from_text("line1\\nline2\\n")
+            >>> len(doc.lines)
+            2
+            >>> doc.lines[0].text
+            'line1'
+            >>> doc.lines[0].newline
+            '\\n'
+        """
+        raw_lines = text.splitlines(keepends=True)
+        lines = []
+
+        for idx, raw in enumerate(raw_lines):
+            if raw.endswith("\r\n"):
+                lines.append(
+                    Line(
+                        text=raw[:-2],
+                        newline="\r\n",
+                        index=idx,
+                        source_line=idx + 1,
+                        tags=frozenset(),
+                    )
+                )
+            elif raw.endswith("\n"):
+                lines.append(
+                    Line(
+                        text=raw[:-1],
+                        newline="\n",
+                        index=idx,
+                        source_line=idx + 1,
+                        tags=frozenset(),
+                    )
+                )
+            else:
+                # Last line without newline
+                lines.append(
+                    Line(
+                        text=raw,
+                        newline="",
+                        index=idx,
+                        source_line=idx + 1,
+                        tags=frozenset(),
+                    )
+                )
+
+        return cls(lines=tuple(lines), path=path)
+
+    def to_text(self) -> str:
+        r"""Serialize document to string with exact fidelity.
+
+        Preserves all newline characters and content exactly as parsed.
+
+        Returns:
+            String representation of the document
+
+        Example:
+            >>> doc = FileDoc.from_text("line1\\nline2")
+            >>> doc.to_text()
+            'line1\\nline2'
+        """
+        return "".join(line.get_full_line() for line in self.lines)
+
+    def slice(self, span: Span) -> tuple[Line, ...]:
+        r"""Extract lines for a given span.
+
+        Args:
+            span: Span defining the range to extract
+
+        Returns:
+            Tuple of lines in the span
+
+        Raises:
+            IndexError: If span extends beyond document bounds
+
+        Example:
+            >>> doc = FileDoc.from_text("line1\\nline2\\nline3\\n")
+            >>> span = Span(start=1, end=3)
+            >>> lines = doc.slice(span)
+            >>> len(lines)
+            2
+        """
+        if span.end > len(self.lines):
+            raise IndexError(
+                f"Span [{span.start}, {span.end}) extends beyond document "
+                f"with {len(self.lines)} lines"
+            )
+        return self.lines[span.start : span.end]
+
+    def with_line_tags(self, line_index: int, tags: frozenset[str]) -> "FileDoc":
+        r"""Returns new FileDoc with tags updated for a specific line.
+
+        This is an immutable update operation.
+
+        Args:
+            line_index: Index of line to update
+            tags: New tags for the line
+
+        Returns:
+            New FileDoc with updated line
+        """
+        if not (0 <= line_index < len(self.lines)):
+            raise IndexError(
+                f"Line index {line_index} out of range [0, {len(self.lines)})"
+            )
+
+        updated_lines = list(self.lines)
+        updated_lines[line_index] = self.lines[line_index].with_tags(tags)
+        return FileDoc(lines=tuple(updated_lines), path=self.path)
+
+
+class CheckLabelExtractor:
+    """Utility for extracting CHECK-LABEL names from lit test lines.
+
+    IREE lit tests use CHECK-LABEL directives to name test cases.
+    This extractor handles all variations of CHECK-LABEL patterns.
+
+    Patterns matched:
+    - // CHECK-LABEL: @function_name
+    - // CHECK-LABEL: stream.executable @name
+    - // FOO-LABEL: @name (any prefix before -LABEL:)
+    - // CHECK-LABEL: func.func @name(%args)
+
+    The label is everything after '@' up to the next whitespace or '('.
+    Allowed characters: letters, digits, '.', '$', '-', '_'
+    """
+
+    @staticmethod
+    def extract_all_names(lines: Iterable[Line]) -> list[str]:
+        r"""Extract all unique CHECK-LABEL names from lines.
+
+        Returns list of unique names in order of first appearance.
+        This is useful when a case has multiple CHECK-LABEL directives
+        with different prefixes (CHECK, FOO, BAR).
+
+        Args:
+            lines: Iterable of Line objects to search
+
+        Returns:
+            List of unique label names found, in order
+
+        Example:
+            >>> lines = [
+            ...     Line("// CHECK-LABEL: @foo", "\\n", 0, 1),
+            ...     Line("// FOO-LABEL: @foo", "\\n", 1, 2),
+            ...     Line("// BAR-LABEL: @bar", "\\n", 2, 3),
+            ... ]
+            >>> CheckLabelExtractor.extract_all_names(lines)
+            ['foo', 'bar']
+        """
+        seen = set()
+        names = []
+        for line in lines:
+            for match in _CHECK_LABEL_PATTERN.finditer(line.text):
+                name = match.group(1)
+                if name and name not in seen:
+                    seen.add(name)
+                    names.append(name)
+        return names
+
+    @staticmethod
+    def extract_primary_name(
+        lines: Iterable[Line],
+    ) -> tuple[str | None, tuple[str, ...]]:
+        r"""Extract primary name (first found) and all names from CHECK-LABELs.
+
+        Args:
+            lines: Iterable of Line objects to search
+
+        Returns:
+            Tuple of (primary_name, all_names_tuple)
+            - primary_name: First CHECK-LABEL name found, or None
+            - all_names_tuple: All unique names found, or empty tuple
+
+        Example:
+            >>> lines = [
+            ...     Line("// CHECK-LABEL: @foo", "\\n", 0, 1),
+            ...     Line("// FOO-LABEL: @foo", "\\n", 1, 2),
+            ... ]
+            >>> primary, all_names = CheckLabelExtractor.extract_primary_name(lines)
+            >>> primary
+            'foo'
+            >>> all_names
+            ('foo',)
+        """
+        all_names = CheckLabelExtractor.extract_all_names(lines)
+        if not all_names:
+            return None, ()
+        return all_names[0], tuple(all_names)

--- a/tools/utils/lit_tools/core/ir_index.py
+++ b/tools/utils/lit_tools/core/ir_index.py
@@ -1,0 +1,221 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""IR line indexing for MLIR lit tests.
+
+Provides fast lookup of IR lines by operation type and proximity-based search.
+This enables content-based matching of CHECK patterns to the IR they verify.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IRLine:
+    """Represents a parsed IR line with metadata.
+
+    Attributes:
+        line_num: Absolute line number in the test case
+        content: Raw line content
+        operation: Operation name (e.g., "scf.for", "stream.timepoint.await")
+        ssa_results: SSA value names defined by this line (e.g., ["awaited"])
+        is_assignment: True if line defines SSA values (has =)
+    """
+
+    line_num: int
+    content: str
+    operation: str | None
+    ssa_results: list[str]
+    is_assignment: bool
+
+
+class IRIndex:
+    """Indexes IR lines for fast operation-based lookup.
+
+    Builds three indexes:
+    - ir_lines: All IR lines in order
+    - by_operation: Map operation → list of IRLines
+    - by_line_num: Map line number → IRLine
+
+    Example:
+        >>> lines = ['%x = arith.constant 0', 'scf.yield %x']
+        >>> index = IRIndex(lines)
+        >>> index.find_by_operation('arith.constant')
+        [IRLine(line_num=0, operation='arith.constant', ...)]
+    """
+
+    # Pattern to match assignment lines: "%result = operation" or "%a, %b = op".
+    # CRITICAL: LHS must start with % to distinguish from '=' in operation syntax.
+    ASSIGNMENT_PATTERN = re.compile(r"^(\s*%[^=]*)=")
+
+    # Pattern to extract SSA value names from LHS of assignment.
+    # Matches: %name, but not %[[CAPTURE]] (FileCheck syntax).
+    SSA_NAME_PATTERN = re.compile(r"%([a-zA-Z0-9_]+)")
+
+    # Pattern to extract operation name from IR line.
+    # Matches: namespace.operation (e.g., "scf.for", "stream.timepoint.await")
+    # or single-word operations (e.g., "call", "return").
+    # This pattern looks for the first identifier after = (for assignments)
+    # or at the start of non-assignment lines.
+    OPERATION_PATTERN = re.compile(
+        r"\b([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\b"
+    )
+
+    def __init__(self, lines: list[str], start_line: int = 0) -> None:
+        """Build index from test case content.
+
+        Args:
+            lines: Test case content split by newlines
+            start_line: Starting line number offset for the test case
+        """
+        self.ir_lines: list[IRLine] = []
+        self.by_operation: dict[str, list[IRLine]] = {}
+        self.by_line_num: dict[int, IRLine] = {}
+
+        self._build_index(lines, start_line)
+
+    def _build_index(self, lines: list[str], start_line: int) -> None:
+        """Parse lines and build indexes.
+
+        Args:
+            lines: Raw test case lines
+            start_line: Line number offset
+        """
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+
+            # Skip empty lines and comments.
+            if not stripped or stripped.startswith("//"):
+                continue
+
+            # Parse the line.
+            ir_line = self._parse_ir_line(line, start_line + i)
+            if ir_line:
+                self._add_to_indexes(ir_line)
+
+    def _parse_ir_line(self, line: str, line_num: int) -> IRLine | None:
+        """Parse a single IR line.
+
+        Args:
+            line: Raw line content
+            line_num: Absolute line number
+
+        Returns:
+            Parsed IRLine, or None if line cannot be parsed
+        """
+        stripped = line.strip()
+
+        # Extract SSA results (if assignment).
+        is_assignment = False
+        ssa_results = []
+
+        assignment_match = self.ASSIGNMENT_PATTERN.match(stripped)
+        if assignment_match:
+            is_assignment = True
+            lhs = assignment_match.group(1)
+
+            # Extract all SSA names from LHS.
+            # CRITICAL: Do NOT filter out %0, %c0, %arg0 - all are semantic!
+            for match in self.SSA_NAME_PATTERN.finditer(lhs):
+                ssa_results.append(match.group(1))
+
+        # Extract operation name.
+        # For assignments, search after the '=' to avoid matching SSA names.
+        # For non-assignments, search the whole line.
+        operation = None
+        search_text = stripped
+        if is_assignment and assignment_match:
+            # Search only in the RHS (after the '=').
+            search_text = stripped[assignment_match.end() :]
+
+        op_match = self.OPERATION_PATTERN.search(search_text)
+        if op_match:
+            operation = op_match.group(1)
+
+        # Warn if we found SSA results but no operation - indicates parsing gap.
+        if operation is None and ssa_results:
+            logger.warning(
+                f"Line {line_num}: SSA results found but no operation recognized: {stripped}"
+            )
+
+        # Create IRLine (even if operation is None - might be pure data flow line).
+        return IRLine(
+            line_num=line_num,
+            content=line,
+            operation=operation,
+            ssa_results=ssa_results,
+            is_assignment=is_assignment,
+        )
+
+    def _add_to_indexes(self, ir_line: IRLine) -> None:
+        """Add IR line to all indexes.
+
+        Args:
+            ir_line: Parsed IR line to index
+        """
+        # Add to sequential list.
+        self.ir_lines.append(ir_line)
+
+        # Add to operation index.
+        if ir_line.operation:
+            if ir_line.operation not in self.by_operation:
+                self.by_operation[ir_line.operation] = []
+            self.by_operation[ir_line.operation].append(ir_line)
+
+        # Add to line number index.
+        self.by_line_num[ir_line.line_num] = ir_line
+
+    def find_by_operation(
+        self, operation: str, near_line: int | None = None, window: int = 50
+    ) -> list[IRLine]:
+        """Find IR lines with matching operation.
+
+        Args:
+            operation: Operation name (e.g., "scf.for")
+            near_line: Optional line number for proximity filtering
+            window: Lines before/after near_line to include (default: 50)
+
+        Returns:
+            List of matching IR lines, sorted by proximity if near_line given.
+            When multiple lines are equidistant, all ties are returned.
+        """
+        # Get all lines with this operation.
+        candidates = self.by_operation.get(operation, [])
+        if not candidates:
+            return []
+
+        # If no proximity filter, return all candidates.
+        if near_line is None:
+            return list(candidates)
+
+        # Filter by proximity window.
+        in_window = [ir for ir in candidates if abs(ir.line_num - near_line) <= window]
+
+        if not in_window:
+            return []
+
+        # Sort by proximity (closest first).
+        # When ties occur (same distance), preserve original line order.
+        in_window.sort(key=lambda ir: (abs(ir.line_num - near_line), ir.line_num))
+
+        return in_window
+
+    def get_line(self, line_num: int) -> IRLine | None:
+        """Get IR line by line number.
+
+        Args:
+            line_num: Absolute line number
+
+        Returns:
+            IRLine at that number, or None if not found
+        """
+        return self.by_line_num.get(line_num)

--- a/tools/utils/lit_tools/core/lint.py
+++ b/tools/utils/lit_tools/core/lint.py
@@ -1,0 +1,2297 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Linting infrastructure for MLIR lit test files.
+
+Provides checkers to catch common test authoring mistakes before running
+the compiler. Categorizes issues into errors (must fix), warnings (should
+review), and info (suggestions).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lit_tools.core.check_matcher import CheckMatcher
+from lit_tools.core.check_pattern import CheckPatternParser
+from lit_tools.core.ir_index import IRIndex
+
+if TYPE_CHECKING:
+    from lit_tools.core.parser import TestCase, TestFile
+
+
+@dataclass
+class LintIssue:
+    """Represents a single lint issue found in a test case.
+
+    Attributes:
+        severity: Issue severity ("error", "warning", "info")
+        code: Machine-readable issue code (e.g., "raw_ssa_identifier")
+        message: Human-readable description
+        line: 1-indexed line number where issue occurs
+        column: 0-indexed column offset (optional)
+        snippet: Code snippet showing the issue
+        help: Suggested fix or explanation
+        suggestions: Alternative values (optional, for semantic naming)
+        context_lines: Surrounding IR lines for context (optional, for --full-json)
+    """
+
+    severity: str
+    code: str
+    message: str
+    line: int
+    column: int | None
+    snippet: str
+    help: str
+    suggestions: list[str] | None = None
+    context_lines: list[str] | None = None
+
+
+def get_context_lines(
+    case: TestCase, line_index: int, context_lines: int = 5
+) -> list[str]:
+    """Extract context lines around a specific line in the test case.
+
+    Args:
+        case: TestCase containing the lines
+        line_index: 0-indexed line number within the test case content
+        context_lines: Number of lines before AND after to include (default: 5)
+
+    Returns:
+        List of lines including context before and after the target line
+    """
+    lines = case.content.splitlines()
+    start = max(0, line_index - context_lines)
+    end = min(len(lines), line_index + context_lines + 1)
+    return lines[start:end]
+
+
+class LintChecker:
+    """Base class for lint checkers.
+
+    Each checker examines a test case and returns a list of issues found.
+    Checkers should be focused on a single type of problem.
+    """
+
+    def __init__(self) -> None:
+        """Initialize checker with default configuration."""
+        self.context_lines = 5  # Default context window for --full-json
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check test case for issues.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of LintIssue objects (empty if no issues found)
+        """
+        raise NotImplementedError
+
+
+class RawSSAIdentifierChecker(LintChecker):
+    """Detects raw SSA identifiers in CHECK lines that should use captures.
+
+    Examples of problems:
+    - // CHECK: %0 = op           (should be %[[RESULT:.+]] = op)
+    - // CHECK: %c123 = constant  (should be %[[SIZE:.+]] = constant)
+    - // CHECK: arith.addi %arg0  (should be %[[INPUT:.+]])
+    - // CHECK: call @foo(%buf)   (should be %[[BUFFER:.+]])
+
+    All raw SSA identifiers should be captures for robust tests. Use NOLINT
+    on a preceding line to suppress for crash reproducers or special cases.
+
+    NOTE: MLIR constants (%c0, %c123, %c4_i32) are temporarily exempted due to
+    widespread usage, but this is an ANTI-PATTERN. Constants like %c123 are not
+    semantically meaningful - they don't tell you if it's a fill pattern, offset,
+    size, or dimension. Prefer semantic captures like %[[OFFSET:.+]] or
+    %[[FILL_PATTERN:.+]] that describe purpose, not value.
+    """
+
+    # Matches the CHECK directive and extracts everything after the colon.
+    CHECK_LINE_PATTERN = re.compile(r"//\s*CHECK[^:]*:\s*(.*)")
+
+    # Matches any raw SSA value: %name, %arg0, %0, %c123, etc.
+    # Uses negative lookahead to exclude captures: %[[NAME]] or %[[NAME:.+]].
+    RAW_SSA_PATTERN = re.compile(r"%(?!\[\[)[a-zA-Z0-9_][a-zA-Z0-9_$.]*")
+
+    # MLIR constant pattern: %c0, %c123, %c4_i32, %cst, %cst_0, etc.
+    # Temporarily exempted (anti-pattern but widespread).
+    MLIR_CONSTANT_PATTERN = re.compile(r"^%c(st)?(\d+|st)(_[a-zA-Z0-9_]+)?$")
+
+    # NOLINT comment pattern (case-insensitive).
+    NOLINT_PATTERN = re.compile(r"//\s*NOLINT", re.IGNORECASE)
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for raw SSA identifiers in CHECK lines.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+        nolint_active = False
+
+        for i, line in enumerate(lines):
+            # Check for NOLINT on any line (suppresses rest of case).
+            if self.NOLINT_PATTERN.search(line):
+                nolint_active = True
+                continue
+
+            if nolint_active:
+                continue
+
+            # Only check CHECK lines.
+            check_match = self.CHECK_LINE_PATTERN.search(line)
+            if not check_match:
+                continue
+
+            # Get the content after CHECK: and find the offset where it starts.
+            check_content = check_match.group(1)
+            content_start = check_match.start(1)
+
+            # Find all raw SSA identifiers in the CHECK content.
+            for ssa_match in self.RAW_SSA_PATTERN.finditer(check_content):
+                ssa_name = ssa_match.group(0)
+
+                # Skip MLIR constants (anti-pattern but widespread).
+                # %c0, %c123, %c4_i32, %cst, %cst_0, etc.
+                if self.MLIR_CONSTANT_PATTERN.match(ssa_name):
+                    continue
+
+                # Column is relative to the line start.
+                col = content_start + ssa_match.start()
+
+                # Provide targeted help for argument patterns vs general SSA.
+                if ssa_name.startswith("%arg"):
+                    help_text = (
+                        f"Use %[[NAME:[^:]+]] instead of {ssa_name}. "
+                        "For function arguments in CHECK-SAME, use [^:]+ (not .+) "
+                        "to stop at the type specifier. Example: "
+                        "// CHECK-SAME: %[[INPUT:[^:]+]]: tensor<4xf32>"
+                    )
+                else:
+                    help_text = (
+                        f"Use %[[NAME:.+]] instead of {ssa_name}. "
+                        f"Raw SSA values like {ssa_name} are fragile - they change when "
+                        "unrelated code is added/removed. Named captures verify data flow "
+                        "and make tests resilient to IR structure changes."
+                    )
+
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="raw_ssa_identifier",
+                        message="raw SSA identifier in CHECK line",
+                        line=case.start_line + i,
+                        column=col,
+                        snippet=line.strip(),
+                        help=help_text,
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+
+class ExcessiveWildcardChecker(LintChecker):
+    """Detects excessive use of {{.+}} wildcards in CHECK lines.
+
+    Wildcards are appropriate for structural IR (device affinities, types the
+    pass doesn't touch), but excessive use masks data flow verification.
+
+    Triggers warning when:
+    - More than 2 {{.+}} wildcards in a CHECK line (default threshold)
+    - More than 5 {{.+}} wildcards in scf.for operations (special case for loop bounds/step)
+    - Suggests capturing operands explicitly to verify data flow
+    """
+
+    WILDCARD_PATTERN = re.compile(r"\{\{\.?\+\}\}")
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for excessive use of {{.+}} wildcards.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only check CHECK lines.
+            if "CHECK" not in line or "//" not in line:
+                continue
+
+            # Extract CHECK part of line.
+            check_part = line.split("//", 1)[1] if "//" in line else line
+            wildcards = self.WILDCARD_PATTERN.findall(check_part)
+
+            # Special case: scf.for operations have many structural operands.
+            # (loop bounds, step) that aren't critical to verify in tests.
+            threshold = 5 if "scf.for" in check_part else 2
+
+            if len(wildcards) > threshold:
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="excessive_wildcards",
+                        message=f"excessive wildcards ({len(wildcards)} found)",
+                        line=case.start_line + i,
+                        column=None,
+                        snippet=line.strip(),
+                        help=(
+                            "Capture operands explicitly to verify data flow. "
+                            "Wildcards {{.+}} are appropriate for structural IR (types, attributes) "
+                            "that your pass doesn't touch, but overuse masks the actual transformations "
+                            "being verified. Explicit captures ensure the right values flow through operations. "
+                            "(Ignore if operation has many structural attributes/types that the pass doesn't modify.)"
+                        ),
+                    )
+                )
+
+        return issues
+
+
+class NonSemanticCaptureChecker(LintChecker):
+    """Detects non-semantic capture names in CHECK lines.
+
+    Flags capture names that just copy the SSA value name instead of describing
+    semantic purpose. Constants and arguments have syntactic names that don't
+    convey meaning.
+
+    Examples of bad names:
+    - %[[C0]] - named after constant (use %[[OFFSET]], %[[SIZE]], etc.)
+    - %[[C123_I32]] - named after constant value and type
+    - %[[ARG0]] - named after argument (use %[[INPUT]], %[[OPERAND]], etc.)
+
+    Examples of good names:
+    - %[[BUFFER_OFFSET]] - describes semantic purpose
+    - %[[INPUT_SIZE]] - describes what the value represents
+    """
+
+    # Patterns for non-semantic names (ONLY match definitions with : pattern).
+    # Matches: %[[C0:.+]], %[[C123:.*]], %[[C0_I32:[a-z]+]], etc.
+    # Does NOT match usage/references: %[[C0]], %[[ARG1]]
+    # Use non-greedy .+? to handle character classes like [a-zA-Z0-9]+
+    CONSTANT_NAME_PATTERN = re.compile(r"%\[\[C\d+(?:_I\d+)?:.+?\]\]", re.DOTALL)
+    # Matches: %[[ARG0:.+]], %[[ARG1:.*]], %[[ARG1:[a-z]+]], etc.
+    # Does NOT match usage/references: %[[ARG0]], %[[ARG1]]
+    ARGUMENT_NAME_PATTERN = re.compile(r"%\[\[ARG\d+:.+?\]\]", re.DOTALL)
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for non-semantic capture names.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only check CHECK lines.
+            if "CHECK" not in line or "//" not in line:
+                continue
+
+            # Check for constant-based names.
+            for match in self.CONSTANT_NAME_PATTERN.finditer(line):
+                col = match.start()
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="non_semantic_capture",
+                        message="capture name based on constant value",
+                        line=case.start_line + i,
+                        column=col,
+                        snippet=line.strip(),
+                        help=(
+                            "Use semantic name like %[[OFFSET]] or %[[SIZE]] instead. "
+                            "Names like %[[C0]] just copy the constant's syntactic name without "
+                            "conveying meaning. If the constant value changes, the capture name "
+                            "becomes misleading. Semantic names describe purpose and remain accurate "
+                            "across code changes. "
+                            "(Ignore if the constant value IS the semantic meaning, e.g., %[[C0]] for zero-initialization pattern.)"
+                        ),
+                        suggestions=["OFFSET", "SIZE", "CONSTANT", "INIT_VALUE"],
+                    )
+                )
+
+            # Check for argument-based names.
+            for match in self.ARGUMENT_NAME_PATTERN.finditer(line):
+                col = match.start()
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="non_semantic_capture",
+                        message="capture name based on argument name",
+                        line=case.start_line + i,
+                        column=col,
+                        snippet=line.strip(),
+                        help=(
+                            "Use semantic name like %[[INPUT]] or %[[OPERAND]] instead. "
+                            "Names like %[[ARG0]] just copy the argument position without conveying "
+                            "what the value represents. If arguments are reordered, the name becomes "
+                            "wrong. Semantic names describe the value's role (INPUT, LHS, BUFFER) and "
+                            "remain meaningful across refactoring. "
+                            "(Ignore if testing argument forwarding where position IS the semantic meaning.)"
+                        ),
+                        suggestions=["INPUT", "OPERAND", "LHS", "RHS"],
+                    )
+                )
+
+        return issues
+
+
+class ZeroCheckLinesChecker(LintChecker):
+    """Detects test cases with IR but no CHECK lines.
+
+    A test with IR but no verification is useless - it only verifies that
+    the IR parses, not that any transformation occurred.
+    """
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for test cases with no CHECK lines.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        if case.check_count == 0:
+            # Check if there's actual IR content (not just comments/whitespace).
+            lines = case.content.splitlines()
+            has_ir = any(
+                line.strip()
+                and not line.strip().startswith("//")
+                and not line.strip().startswith("#")
+                for line in lines
+            )
+
+            if has_ir:
+                return [
+                    LintIssue(
+                        severity="error",
+                        code="zero_check_lines",
+                        message="test case has IR but no CHECK lines",
+                        line=case.start_line,
+                        column=None,
+                        snippet=f"Test case {case.number}",
+                        help=(
+                            "Add CHECK lines to verify transformation behavior. "
+                            "A test with IR but no verification only confirms the IR parses, "
+                            "not that your pass actually transforms it correctly. Without CHECK "
+                            "lines, the test provides no value - bugs slip through undetected. "
+                            "(Ignore only if this is explicitly a parse-only syntax test - add comment explaining.)"
+                        ),
+                    )
+                ]
+
+        return []
+
+
+class NonInterleavedChecksChecker(LintChecker):
+    """Detects when all CHECKs are clustered instead of interleaved with IR.
+
+    Interleaving CHECKs with IR:
+    - Proves where transformations occur
+    - Anchors checks to specific locations
+    - Makes test intent clearer
+
+    This checker triggers when >80% of CHECKs appear in first or last 20% of lines.
+    """
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for non-interleaved CHECKs.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        if case.check_count < 3 or case.line_count < 10:
+            # Too small to meaningfully check.
+            return []
+
+        lines = case.content.splitlines()
+        check_lines = []
+        for i, line in enumerate(lines):
+            if "CHECK" in line and "//" in line:
+                check_lines.append(i)
+
+        if not check_lines:
+            return []
+
+        # Calculate clustering.
+        total_lines = len(lines)
+
+        # CHECKs are non-interleaved if they're all in first or last 20%.
+        threshold = int(total_lines * 0.2)
+
+        all_at_start = all(i < threshold for i in check_lines)
+        all_at_end = all(i >= total_lines - threshold for i in check_lines)
+
+        if all_at_start or all_at_end:
+            location = "start" if all_at_start else "end"
+            return [
+                LintIssue(
+                    severity="warning",
+                    code="non_interleaved_checks",
+                    message=f"all CHECKs clustered at {location} of test",
+                    line=case.start_line,
+                    column=None,
+                    snippet=f"Lines {case.start_line}-{case.end_line}",
+                    help=(
+                        "Interleave CHECKs near corresponding IR for better verification. "
+                        "When CHECKs are clustered away from the IR they verify, it's harder to "
+                        "understand what's being tested and maintain the test. "
+                        "(Ignore if test structure requires grouped checks - e.g., all attributes at top, "
+                        "or final state verification at bottom.)"
+                    ),
+                )
+            ]
+
+        return []
+
+
+class TodoWithoutExplanationChecker(LintChecker):
+    """Detects TODO/FIXME/NOTE comments without explanation.
+
+    Bare TODO markers provide no context for future readers and will likely
+    be ignored. All TODO/FIXME/NOTE comments must explain WHY and WHAT needs
+    to be done, including relevant issue numbers or blockers.
+
+    Examples of violations:
+    - // TODO
+    - // TODO: fix this
+    - // FIXME: broken
+
+    Valid patterns:
+    - // TODO(#1234): Add support for scf.while after API lands.
+    - // NOTE: Cannot eliminate - public funcs can't return timepoints.
+    - // FIXME: Dominance check fails for block args in loop headers.
+    """
+
+    # Pattern: TODO/FIXME/NOTE with minimal or no explanation.
+    BARE_TODO_PATTERN = re.compile(
+        r"^\s*//\s*(TODO|FIXME|NOTE)\s*(:?\s*)?$", re.IGNORECASE
+    )
+    WEAK_TODO_PATTERN = re.compile(
+        r"^\s*//\s*(TODO|FIXME|NOTE)\s*:\s*(\w+\s+){0,3}\w+\s*$", re.IGNORECASE
+    )
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for TODO/FIXME comments without substantive explanation.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Check for bare TODO/FIXME/NOTE.
+            if self.BARE_TODO_PATTERN.match(line):
+                marker = self.BARE_TODO_PATTERN.match(line).group(1)
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="todo_without_explanation",
+                        message=f"{marker} comment lacks explanation",
+                        line=case.start_line + i,
+                        column=None,
+                        snippet=line.strip(),
+                        help=(
+                            f"Add explanation to {marker} comment. "
+                            f"Bare {marker} markers provide no context and will be ignored. "
+                            "Explain WHY this needs attention, WHAT needs to be done, and any "
+                            "relevant issue numbers or blockers. "
+                            f"Example: // {marker}(#1234): Add X after Y lands."
+                        ),
+                    )
+                )
+            # Check for weak explanation (1-3 words).
+            elif self.WEAK_TODO_PATTERN.match(line):
+                marker = self.WEAK_TODO_PATTERN.match(line).group(1)
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="todo_without_explanation",
+                        message=f"{marker} comment has insufficient explanation",
+                        line=case.start_line + i,
+                        column=None,
+                        snippet=line.strip(),
+                        help=(
+                            f"Expand {marker} explanation. "
+                            "Brief markers like 'fix this' or 'broken' provide no actionable "
+                            "context. Explain the issue, blockers, or planned work with enough "
+                            "detail for future readers to understand and act on it."
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+
+class CHECKNOTWithoutAnchorChecker(LintChecker):
+    """Detects CHECK-NOT without surrounding positive CHECK anchors.
+
+    CHECK-NOT should be bracketed by positive CHECK lines to define the scope
+    where something shouldn't appear. Without anchors, CHECK-NOT matches too
+    broadly (entire file) or too narrowly (just next line), causing fragile
+    tests.
+
+    Examples of violations:
+    - CHECK-LABEL: @test
+      CHECK-NOT: await
+      (no positive CHECK after - scope unclear)
+
+    Valid patterns:
+    - CHECK-LABEL: @test
+      CHECK: scf.if
+      CHECK-NOT: await
+      CHECK: scf.yield
+      (clearly checks between scf.if and scf.yield)
+    """
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for CHECK-NOT without anchoring CHECKs.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only match actual CHECK-NOT directives, not comments mentioning CHECK-NOT.
+            if not re.search(r"//\s*CHECK-NOT:", line):
+                continue
+
+            # Look backward for positive CHECK (within 10 lines).
+            has_check_before = False
+            for j in range(max(0, i - 10), i):
+                check_line = lines[j]
+                if re.search(r"//\s*CHECK(-LABEL)?:", check_line):
+                    has_check_before = True
+                    break
+
+            # Look forward for positive CHECK (within 10 lines).
+            has_check_after = False
+            for j in range(i + 1, min(len(lines), i + 11)):
+                check_line = lines[j]
+                if re.search(r"//\s*CHECK(-LABEL)?:", check_line):
+                    has_check_after = True
+                    break
+
+            if not (has_check_before and has_check_after):
+                missing = []
+                if not has_check_before:
+                    missing.append("before")
+                if not has_check_after:
+                    missing.append("after")
+
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="check_not_without_anchor",
+                        message=f"CHECK-NOT missing positive CHECK {' and '.join(missing)}",
+                        line=case.start_line + i,
+                        column=None,
+                        snippet=line.strip(),
+                        help=(
+                            "Bracket CHECK-NOT with positive CHECK lines to define scope. "
+                            "Without anchors, CHECK-NOT matches too broadly (entire file) or "
+                            "too narrowly (just next line). Add CHECK/CHECK-LABEL before and "
+                            "CHECK after to clearly define where the pattern should NOT appear. "
+                            "Example: CHECK: scf.if / CHECK-NOT: await / CHECK: scf.yield "
+                            "(Ignore if verifying file-level invariant where pattern should not appear anywhere.)"
+                        ),
+                    )
+                )
+
+        return issues
+
+
+class MatchedCaptureNameChecker(LintChecker):
+    """Detects mismatches between IR SSA names and CHECK capture names.
+
+    When IR contains semantic SSA names like %transient_size, CHECK captures
+    should match: %[[TRANSIENT_SIZE:.+]] not %[[SIZE:.+]]. Mismatched names
+    break the connection between IR and verification, making it unclear what's
+    being tested.
+
+    CRITICAL requirement per CLAUDE.md: "Keep SSA variable names and CHECK
+    capture names identical (e.g., %transient_size matches %[[TRANSIENT_SIZE:.+]])".
+
+    Note: This is a warning (not error) initially to allow variance during
+    dialect conversion or when abbreviations are intentional. Scan existing
+    tests to assess strictness before promoting to error.
+
+    Examples:
+      IR: %transient_size = ...
+      BAD:  // CHECK: %[[SIZE:.+]] =
+      GOOD: // CHECK: %[[TRANSIENT_SIZE:.+]] =
+
+      IR: %slice_ready = stream.timepoint.await
+      BAD:  // CHECK: %[[READY:.+]] = stream.timepoint.await
+      GOOD: // CHECK: %[[SLICE_READY:.+]] = stream.timepoint.await
+    """
+
+    # Extract semantic SSA names from IR (not %0, %c123, %arg0).
+    # This pattern finds individual SSA names (used for extraction from LHS).
+    SSA_NAME_PATTERN = re.compile(r"%([a-z_][a-z0-9_]+)")
+
+    # Pattern to find assignment lines (to extract LHS).
+    ASSIGNMENT_PATTERN = re.compile(r"^([^=]*)=")
+
+    # Extract CHECK capture names (handle FileCheck tuple syntax like %[[NAME:.+]]:2).
+    CHECK_CAPTURE_PATTERN = re.compile(r"%\[\[([A-Z_]+):.+?\]\](?::\d+)?")
+
+    def _extract_ir_names_from_line(self, line: str) -> list[str]:
+        """Extract SSA names from IR line in left-to-right order.
+
+        Args:
+            line: Single line of IR code
+
+        Returns:
+            List of semantic SSA names in order of appearance
+        """
+        assignment_match = self.ASSIGNMENT_PATTERN.match(line.strip())
+        if not assignment_match:
+            return []
+
+        lhs = assignment_match.group(1)
+        names = []
+        for name_match in self.SSA_NAME_PATTERN.finditer(lhs):
+            name = name_match.group(1)
+            # Skip non-semantic names (constants and arguments).
+            if not (name.startswith("c") and name[1:].isdigit()) and not (
+                name.startswith("arg") and name[3:].isdigit()
+            ):
+                names.append(name)
+        return names
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for mismatched IR SSA names and CHECK captures.
+
+        Uses content-based matching (operation + proximity) to match CHECK
+        patterns to the IR lines they verify, avoiding false positives from
+        naive positional matching.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        # Build IR index for content-based matching.
+        ir_index = IRIndex(lines)
+
+        # Parse CHECK patterns from file.
+        parser = CheckPatternParser()
+        check_patterns = parser.parse_file(lines)
+
+        if not check_patterns:
+            return []  # No CHECK patterns to validate.
+
+        # Match CHECK patterns to IR lines using content-based matching.
+        matcher = CheckMatcher(ir_index, check_patterns)
+        matches = matcher.match_all()
+
+        # Validate capture names for each successful match.
+        for match in matches:
+            # Skip if no IR line matched (no operation, or not found).
+            if match.ir_line is None:
+                continue
+
+            # Skip if CHECK has no captures.
+            check_captures = list(
+                self.CHECK_CAPTURE_PATTERN.finditer(match.check_pattern.raw_pattern)
+            )
+            if not check_captures:
+                continue
+
+            # Extract IR names from matched line.
+            target_ir_names = self._extract_ir_names_from_line(match.ir_line.content)
+
+            # Positional pairing: If capture count matches IR name count, zip them.
+            # This handles tuple assignments correctly.
+            if len(check_captures) == len(target_ir_names):
+                for capture_match, ir_name in zip(
+                    check_captures, target_ir_names, strict=False
+                ):
+                    capture_name = capture_match.group(1)
+                    capture_normalized = capture_name.lower()
+                    ir_normalized = ir_name.lower()
+                    ir_upper = ir_name.upper()
+
+                    # Exact match after case normalization - no issue.
+                    # CHECK captures use SCREAMING_SNAKE_CASE, IR uses snake_case.
+                    if capture_normalized == ir_normalized:
+                        continue
+
+                    # Check for intentional variance (semantic naming, abbreviations).
+                    if self._is_acceptable_variance(capture_normalized, ir_normalized):
+                        continue
+
+                    # Flag mismatch.
+                    issues.append(
+                        self._create_mismatch_issue(
+                            capture_name,
+                            ir_name,
+                            ir_upper,
+                            case,
+                            match.check_pattern.line_num,
+                            capture_match,
+                        )
+                    )
+
+        return issues
+
+    def _is_acceptable_variance(
+        self, capture_normalized: str, ir_normalized: str
+    ) -> bool:
+        """Check if capture/IR name difference is acceptable variance.
+
+        Args:
+            capture_normalized: CHECK capture name (lowercased)
+            ir_normalized: IR SSA name (lowercased)
+
+        Returns:
+            True if variance is intentional/acceptable, False if likely error
+        """
+        # Split both names on underscores to get word components.
+        capture_parts = set(capture_normalized.split("_"))
+        ir_parts = set(ir_normalized.split("_"))
+
+        # If all IR parts are contained in capture parts, it's likely intentional.
+        # Example: IR has "tp", CHECK has "tp_then" (adds semantic context).
+        if ir_parts.issubset(capture_parts):
+            return True  # Intentional semantic naming.
+
+        # If all capture parts are contained in IR parts, might be abbreviation.
+        # Example: IR has "transient_size", CHECK has "size" (abbreviation).
+        # Allow if missing < 2 words (minor abbreviation acceptable).
+        # Return True for minor abbreviations, False otherwise.
+        return (
+            capture_parts.issubset(ir_parts) and len(ir_parts) - len(capture_parts) < 2
+        )
+
+    def _create_mismatch_issue(
+        self,
+        capture_name: str,
+        ir_name: str,
+        ir_upper: str,
+        case: TestCase,
+        check_line_idx: int,
+        capture_match: re.Match,
+    ) -> LintIssue:
+        """Create a LintIssue for mismatched capture name.
+
+        Args:
+            capture_name: CHECK capture name (original case)
+            ir_name: IR SSA name (original case)
+            ir_upper: IR name uppercased
+            case: TestCase being checked
+            check_line_idx: Line index of CHECK comment
+            capture_match: Regex match for the capture
+
+        Returns:
+            LintIssue describing the mismatch
+        """
+        # Normalize both names for comparison.
+        capture_normalized = capture_name.lower()
+        ir_normalized = ir_name.lower()
+
+        # Calculate edit distance to detect typos.
+        def edit_distance(s1: str, s2: str) -> int:
+            """Simple Levenshtein distance for typo detection."""
+            if len(s1) < len(s2):
+                return edit_distance(s2, s1)
+            if len(s2) == 0:
+                return len(s1)
+            prev_row = range(len(s2) + 1)
+            for i, c1 in enumerate(s1):
+                curr_row = [i + 1]
+                for j, c2 in enumerate(s2):
+                    insertions = prev_row[j + 1] + 1
+                    deletions = curr_row[j] + 1
+                    substitutions = prev_row[j] + (c1 != c2)
+                    curr_row.append(min(insertions, deletions, substitutions))
+                prev_row = curr_row
+            return prev_row[-1]
+
+        distance = edit_distance(capture_normalized, ir_normalized)
+
+        # Construct message based on similarity.
+        if distance <= 2 and len(capture_normalized) > 2 and len(ir_normalized) > 2:
+            message = f"CHECK capture %[[{capture_name}]] may not match IR %{ir_name} (edit distance: {distance})"
+            help_text = (
+                f"Use %[[{ir_upper}:.+]] to match IR semantic naming. "
+                f"IR has %{ir_name} but CHECK captures %[[{capture_name}]]. "
+                f"Names are very similar (edit distance {distance}) - possible typo? "
+                "Matched names maintain clarity and catch when IR changes. "
+                "(Ignore if intentional variance for dialect conversion or abbreviation.)"
+            )
+        else:
+            message = f"CHECK capture %[[{capture_name}]] may not match IR %{ir_name}"
+            help_text = (
+                f"Use %[[{ir_upper}:.+]] to match IR semantic naming. "
+                f"IR has %{ir_name} but CHECK captures %[[{capture_name}]]. "
+                "Matched names maintain clarity and catch when IR changes. "
+                "Variance is acceptable for dialect conversion or intentional "
+                "abbreviations, but exact matches are preferred. "
+                "(Ignore if intentional - e.g., %stream_resource → %[[TENSOR]] during dialect lowering.)"
+            )
+
+        return LintIssue(
+            severity="warning",
+            code="mismatched_capture_name",
+            message=message,
+            line=case.start_line + check_line_idx,
+            column=capture_match.start(),
+            snippet=case.content.splitlines()[check_line_idx].strip(),
+            help=help_text,
+            suggestions=[ir_upper],
+            context_lines=get_context_lines(case, check_line_idx, self.context_lines),
+        )
+
+
+class WildcardInTerminatorChecker(LintChecker):
+    """Detects wildcards in terminator operations.
+
+    Terminator operations (scf.yield, util.return, func.return, cf.br) define
+    data flow out of regions/blocks - their operands are what you're testing.
+    Using wildcards here means you're not actually verifying the transformation.
+
+    Examples:
+      BAD:  // CHECK: scf.yield {{.+}}, {{.+}}
+      GOOD: // CHECK: scf.yield %[[RESULT]], %[[TP]]
+
+      BAD:  // CHECK: util.return {{.+}}
+      GOOD: // CHECK: util.return %[[AWAITED]]
+
+      BAD:  // CHECK: cf.br ^bb1({{.+}} : i32)
+      GOOD: // CHECK: cf.br ^bb1(%[[VAL]] : i32)
+    """
+
+    # Common MLIR terminator operations.
+    TERMINATORS = [
+        "scf.yield",
+        "util.return",
+        "func.return",
+        "cf.br",
+        "cf.cond_br",
+        "cf.switch",
+    ]
+
+    # Wildcard pattern.
+    WILDCARD_PATTERN = re.compile(r"\{\{\.?\+\}\}")
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for wildcards in terminator operations.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            if "//" not in line or "CHECK" not in line:
+                continue
+
+            # Check if line contains terminator and wildcard.
+            for terminator in self.TERMINATORS:
+                if terminator in line and self.WILDCARD_PATTERN.search(line):
+                    issues.append(
+                        LintIssue(
+                            severity="warning",
+                            code="wildcard_in_terminator",
+                            message=f"terminator {terminator} uses wildcards for operands",
+                            line=case.start_line + i,
+                            column=None,
+                            snippet=line.strip(),
+                            help=(
+                                f"Capture {terminator} operands explicitly to verify data flow. "
+                                "Terminators define data flow out of regions/blocks - their "
+                                "operands are what transformations modify. Wildcards here mean "
+                                "you're not verifying the transformation worked. Use named "
+                                "captures like %[[RESULT]] instead of {{.+}}. "
+                                "(Ignore if terminator forwards arguments unchanged and test focuses elsewhere.)"
+                            ),
+                            context_lines=get_context_lines(
+                                case, i, self.context_lines
+                            ),
+                        )
+                    )
+                    break  # Only report once per line.
+
+        return issues
+
+
+class CHECKWithoutLabelContextChecker(LintChecker):
+    """Detects CHECK lines appearing before any CHECK-LABEL.
+
+    CHECK lines should follow a CHECK-LABEL that establishes which function/
+    block is being verified. Without CHECK-LABEL, FileCheck may match lines
+    from the wrong function, causing tests to pass for the wrong reasons.
+
+    Example violation:
+      // CHECK: %[[FOO:.+]] = some.op
+      util.func @test() { ... }
+
+    Valid pattern:
+      // CHECK-LABEL: @test
+      util.func @test() {
+      // CHECK: %[[FOO:.+]] = some.op
+    """
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for CHECK lines before first CHECK-LABEL.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        has_label = False
+        for i, line in enumerate(lines):
+            if "//" not in line:
+                continue
+
+            # Track if we've seen a CHECK-LABEL.
+            if "CHECK-LABEL" in line:
+                has_label = True
+                continue
+
+            # Check for CHECK (not CHECK-LABEL, CHECK-NOT) before any LABEL.
+            if "CHECK:" in line and not has_label:
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="check_without_label_context",
+                        message="CHECK appears before CHECK-LABEL",
+                        line=case.start_line + i,
+                        column=None,
+                        snippet=line.strip(),
+                        help=(
+                            "Add CHECK-LABEL before CHECK lines to establish context. "
+                            "Without CHECK-LABEL, FileCheck may match from the wrong function, "
+                            "causing tests to pass incorrectly. Start each test with "
+                            "CHECK-LABEL: @functionName to anchor verification. "
+                            "(Ignore if single-case file testing module-level attributes or file-level ops.)"
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+                # Only report once (first occurrence).
+                break
+
+        return issues
+
+
+class UnusedCaptureChecker(LintChecker):
+    """Detects captured values that are never referenced.
+
+    Captured values like %[[FOO:.+]] should be referenced later in CHECK lines
+    or subsequent IR. A capture that's never used suggests incomplete test
+    coverage - you captured it intending to verify something but never did.
+
+    Note: Single-use captures for documentation are acceptable in CHECK-SAME.
+
+    Examples:
+      BAD:
+        // CHECK: %[[UNUSED:.+]] = stream.async.execute
+        // CHECK: util.return %[[OTHER]]
+
+      GOOD:
+        // CHECK: %[[RESULT:.+]] = stream.async.execute
+        // CHECK: util.return %[[RESULT]]
+
+      ACCEPTABLE (used in CHECK-SAME):
+        // CHECK: %[[TP:.+]] = stream.async.execute
+        // CHECK-SAME: await(%[[TP]]) =>
+    """
+
+    # Capture with regex definition: %[[NAME:.+]].
+    CAPTURE_DEF_PATTERN = re.compile(r"%\[\[([A-Z_]+):.+?\]\]")
+
+    # Reference to capture: %[[NAME]] (no colon).
+    CAPTURE_REF_PATTERN = re.compile(r"%\[\[([A-Z_]+)\]\]")
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for unused captures.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        # Extract all capture definitions with line numbers.
+        captures = {}  # {name: line_num}
+        for i, line in enumerate(lines):
+            if "//" not in line or "CHECK" not in line:
+                continue
+            for match in self.CAPTURE_DEF_PATTERN.finditer(line):
+                capture_name = match.group(1)
+                if capture_name not in captures:
+                    captures[capture_name] = i
+
+        if not captures:
+            return []
+
+        # Find all references to captures.
+        references = set()
+        for line in lines:
+            if "//" not in line or "CHECK" not in line:
+                continue
+            for match in self.CAPTURE_REF_PATTERN.finditer(line):
+                references.add(match.group(1))
+
+        # Report unused captures.
+        for capture_name, line_num in captures.items():
+            if capture_name not in references:
+                snippet = lines[line_num].strip()
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="unused_capture",
+                        message=f"capture %[[{capture_name}]] is never referenced",
+                        line=case.start_line + line_num,
+                        column=None,
+                        snippet=snippet,
+                        help=(
+                            f"Reference %[[{capture_name}]] in later CHECK lines or remove the capture. "
+                            "Unused captures suggest incomplete test coverage. "
+                            "(Ignore for function parameters, block arguments, or other documentation captures.)"
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+
+class FileCheckDirectiveValidator(LintChecker):
+    """Detects typos and malformed FileCheck directives in CHECK lines.
+
+    FileCheck directives must be correctly spelled and include colons. Common
+    typos like CHECK-DAD (should be CHECK-DAG) or CHECK-SMAE (should be
+    CHECK-SAME) cause tests to silently fail - FileCheck ignores malformed
+    directives, so the test passes without actually checking anything.
+
+    Valid directives:
+    - CHECK, CHECK-LABEL, CHECK-SAME, CHECK-DAG, CHECK-NOT, CHECK-NEXT,
+      CHECK-COUNT, CHECK-EMPTY
+
+    Common errors:
+    - Typos: CHECK-DAD, CHECK-SMAE, CHECK-LABLE, CHECK-NEX
+    - Missing colon: CHECK func.func (should be CHECK: func.func)
+    - Malformed: CHEK, CHECKK, CHECk
+
+    Examples:
+      BAD:  // CHECK-DAD: %[[FOO]]    (typo, should be CHECK-DAG)
+      BAD:  // CHECK-SMAE: foo(       (typo, should be CHECK-SAME)
+      BAD:  // CHECK func.func         (missing colon)
+      GOOD: // CHECK-DAG: %[[FOO]]
+      GOOD: // CHECK: func.func
+    """
+
+    # Valid FileCheck directive suffixes (after CHECK-).
+    VALID_DIRECTIVES = {
+        "CHECK",
+        "CHECK-LABEL",
+        "CHECK-SAME",
+        "CHECK-DAG",
+        "CHECK-NOT",
+        "CHECK-NEXT",
+        "CHECK-COUNT",
+        "CHECK-EMPTY",
+    }
+
+    # Pattern to extract CHECK directive from line.
+    # Matches: // CHECK, // CHECK-LABEL:, //CHECK-DAG, etc.
+    # Captures the directive part (CHECK-LABEL) and whether colon is present.
+    DIRECTIVE_PATTERN = re.compile(r"//\s*(CHECK(?:-[A-Z]+)?)\s*(:?)", re.IGNORECASE)
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for malformed FileCheck directives.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only check lines that look like CHECK directives.
+            if "//" not in line or "CHECK" not in line.upper():
+                continue
+
+            # Extract directive using pattern.
+            match = self.DIRECTIVE_PATTERN.search(line)
+            if not match:
+                continue
+
+            directive = match.group(1).upper()
+            has_colon = match.group(2) == ":"
+
+            # Check if directive is valid.
+            if directive not in self.VALID_DIRECTIVES:
+                # Find closest valid directive for suggestion.
+                suggestion = self._find_closest_directive(directive)
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="invalid_filecheck_directive",
+                        message=f"invalid FileCheck directive '{match.group(1)}'",
+                        line=case.start_line + i,
+                        column=match.start(1),
+                        snippet=line.strip(),
+                        help=(
+                            f"Use '{suggestion}' instead of '{match.group(1)}'. "
+                            "Invalid directives are silently ignored by FileCheck, "
+                            "causing tests to pass without actually verifying anything. "
+                            f"Valid directives: {', '.join(sorted(self.VALID_DIRECTIVES))}. "
+                            "(Ignore if this is a custom FileCheck prefix defined in lit.cfg.py - "
+                            "rare in IREE codebase.)"
+                        ),
+                        suggestions=[suggestion],
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+                continue
+
+            # Check for missing colon after directive.
+            # Colon is required unless:
+            # 1. Line ends immediately (standalone CHECK-NOT for example)
+            # 2. Next character is whitespace then end of line
+            remaining = line[match.end() :].lstrip()
+            if not has_colon and remaining and not remaining.startswith("{{"):
+                # There's content after directive but no colon.
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="missing_colon_in_directive",
+                        message=f"FileCheck directive '{directive}' missing colon",
+                        line=case.start_line + i,
+                        column=match.end(1),
+                        snippet=line.strip(),
+                        help=(
+                            f"Add colon after '{directive}': should be '{directive}: {remaining[:20]}...'. "
+                            "FileCheck requires a colon to separate the directive from the pattern. "
+                            "Without it, FileCheck may misinterpret the pattern or ignore the check entirely. "
+                            "(Ignore if directive is intentionally standalone - e.g., CHECK-NOT at end of region.)"
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+    def _find_closest_directive(self, invalid_directive: str) -> str:
+        """Find the closest valid directive using Levenshtein distance.
+
+        Args:
+            invalid_directive: The malformed directive (e.g., "CHECK-DAD")
+
+        Returns:
+            Closest valid directive (e.g., "CHECK-DAG")
+        """
+
+        def levenshtein_distance(s1: str, s2: str) -> int:
+            """Calculate Levenshtein edit distance between two strings."""
+            if len(s1) < len(s2):
+                return levenshtein_distance(s2, s1)
+            if len(s2) == 0:
+                return len(s1)
+
+            prev_row = list(range(len(s2) + 1))
+            for i, c1 in enumerate(s1):
+                curr_row = [i + 1]
+                for j, c2 in enumerate(s2):
+                    insertions = prev_row[j + 1] + 1
+                    deletions = curr_row[j] + 1
+                    substitutions = prev_row[j] + (c1 != c2)
+                    curr_row.append(min(insertions, deletions, substitutions))
+                prev_row = curr_row
+            return prev_row[-1]
+
+        # Find directive with minimum edit distance.
+        min_distance = float("inf")
+        closest = "CHECK"
+
+        for valid in self.VALID_DIRECTIVES:
+            distance = levenshtein_distance(invalid_directive, valid)
+            if distance < min_distance:
+                min_distance = distance
+                closest = valid
+
+        return closest
+
+
+def _get_ir_lines(case: TestCase) -> list[str]:
+    """Extract IR lines from test case (non-comments, non-CHECK).
+
+    Args:
+        case: TestCase to extract from
+
+    Returns:
+        List of IR line strings
+    """
+    lines = case.content.splitlines()
+    ir_lines = []
+    for line in lines:
+        stripped = line.strip()
+        # Skip comment lines and empty lines.
+        if not stripped or stripped.startswith("//"):
+            continue
+        ir_lines.append(line)
+    return ir_lines
+
+
+def _extract_label_text(pattern: str, function_ops: list[str]) -> str | None:
+    """Extract the bare label from CHECK-LABEL pattern.
+
+    Examples:
+        "@function_name" -> "@function_name"
+        "@test(" -> "@test"
+        "func.func @test" -> None (has prefix, skip)
+
+    Args:
+        pattern: The CHECK-LABEL pattern text
+        function_ops: List of known function operation prefixes
+
+    Returns:
+        Bare label text if pattern is bare, None if has prefix
+    """
+    pattern = pattern.strip()
+
+    # Check if pattern has operation prefix.
+    if any(pattern.startswith(op) for op in function_ops):
+        return None  # Has operation prefix, skip check.
+
+    # Extract bare label starting with @.
+    if pattern.startswith("@"):
+        # Extract just the symbol name (up to whitespace, paren, or end).
+        match = re.match(r"(@[a-zA-Z0-9_.$-]+)", pattern)
+        return match.group(1) if match else None
+
+    return None
+
+
+def _find_label_matches(ir_lines: list[str], label: str) -> list[tuple[int, str]]:
+    """Find all IR lines containing the label text.
+
+    Args:
+        ir_lines: List of IR lines (non-comment, non-CHECK)
+        label: Label text to search for (e.g., "@my_function")
+
+    Returns:
+        List of (line_index, full_line_text) for each match
+    """
+    # Escape special regex chars in label.
+    escaped = re.escape(label)
+    # Match label as separate token:
+    # - Not preceded by alphanumeric/underscore (to avoid matching @test in @test_helper)
+    # - Not followed by alphanumeric/underscore (to avoid matching @test in @test_2)
+    # Use lookahead/lookbehind to avoid consuming characters.
+    pattern = re.compile(r"(?<![a-zA-Z0-9_$.-])" + escaped + r"(?![a-zA-Z0-9_$.-])")
+
+    matches = []
+    for i, line in enumerate(ir_lines):
+        if pattern.search(line):
+            matches.append((i, line))
+    return matches
+
+
+def _extract_operation_prefix(ir_line: str, label: str) -> str | None:
+    """Extract the operation prefix before the label in an IR line.
+
+    Examples:
+        "util.func @test(...)" with label "@test" -> "util.func @test"
+        "  func.func private @foo" with label "@foo" -> "func.func private @foo"
+        "%x = some.op @label" with label "@label" -> None (not a declaration)
+        "util.global private @name" with label "@name" -> "util.global private @name"
+
+    Args:
+        ir_line: IR line containing the label
+        label: Label text to find
+
+    Returns:
+        Operation prefix string, or None if not a declaration
+    """
+    # Find position of label in line.
+    label_pos = ir_line.find(label)
+    if label_pos == -1:
+        return None
+
+    # Extract everything before and including the label, up to ( or {.
+    prefix_end = label_pos + len(label)
+    remaining = ir_line[prefix_end:]
+
+    # Extend to include trailing characters until ( or {.
+    for char in remaining:
+        if char in "({":
+            break
+        prefix_end += 1
+
+    full_prefix = ir_line[:prefix_end].strip()
+
+    # Check if this looks like a declaration (starts with operation name or attribute).
+    # Skip if it's an SSA assignment (has = before the operation).
+    if "=" in full_prefix:
+        # Check if the = is before the label (SSA assignment) or after (not a declaration).
+        eq_pos = full_prefix.find("=")
+        if eq_pos < full_prefix.find(label):
+            return None  # SSA assignment, not declaration.
+
+    return full_prefix
+
+
+class CheckLabelFormatChecker(LintChecker):
+    """Ensures CHECK-LABEL uses proper function anchoring format.
+
+    CHECK-LABEL should anchor to the full function operation, not just the
+    function name, when there is ambiguity (multiple occurrences of the label)
+    or when the label doesn't exist in the IR.
+
+    Only warns when:
+    - Label appears multiple times in IR (ambiguous)
+    - Label doesn't appear in IR (likely typo)
+
+    Does NOT warn when:
+    - Label appears exactly once (unambiguous)
+    - Label already has operation prefix (func.func, util.func, etc.)
+
+    Valid patterns:
+    - // CHECK-LABEL: func.func @function_name
+    - // CHECK-LABEL: util.func @function_name
+    - // CHECK-LABEL: util.func private @function_name
+    - // CHECK-LABEL: @unique_name  (OK if appears only once)
+
+    Examples of warnings:
+      AMBIGUOUS: // CHECK-LABEL: @dispatch  (appears in multiple places)
+      NOT FOUND: // CHECK-LABEL: @typo_name (doesn't exist in IR)
+      GOOD:      // CHECK-LABEL: @unique_func (appears exactly once)
+      GOOD:      // CHECK-LABEL: func.func @test (has operation prefix)
+    """
+
+    # Pattern to match CHECK-LABEL lines.
+    CHECK_LABEL_PATTERN = re.compile(r"//\s*CHECK-LABEL:\s*(.+)$")
+
+    # Common function operation prefixes in IREE.
+    FUNCTION_OPS = [
+        "func.func",
+        "util.func",
+        "builtin.func",
+        "llvm.func",
+        "spirv.func",
+    ]
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for CHECK-LABEL format issues.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        # Extract IR lines once for all checks.
+        ir_lines = _get_ir_lines(case)
+
+        for i, line in enumerate(lines):
+            # Only check CHECK-LABEL lines.
+            if "CHECK-LABEL" not in line:
+                continue
+
+            match = self.CHECK_LABEL_PATTERN.search(line)
+            if not match:
+                continue
+
+            pattern = match.group(1).strip()
+
+            # Check if pattern is bare label (no operation prefix).
+            label = _extract_label_text(pattern, self.FUNCTION_OPS)
+            if label is None:
+                continue  # Has operation prefix or not a bare @label, OK.
+
+            # Find all occurrences in IR.
+            matches = _find_label_matches(ir_lines, label)
+
+            if len(matches) == 0:
+                # No matches - likely typo or wrong label.
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="label_not_found_in_ir",
+                        message=f"CHECK-LABEL '{label}' not found in IR",
+                        line=case.start_line + i,
+                        column=match.start(1),
+                        snippet=line.strip(),
+                        help=(
+                            f"Label '{label}' does not appear in the IR. "
+                            "This may indicate a typo or that the test is checking "
+                            "the wrong function name. Verify the label matches an "
+                            "actual symbol in the IR."
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+            elif len(matches) > 1:
+                # Multiple matches - ambiguous!
+                # Format match list (limit to first 5).
+                match_lines_display = []
+                for match_idx, (_line_idx, match_line) in enumerate(matches):
+                    if match_idx >= 5:  # Limit display.
+                        break
+                    # Line number in original file (not in ir_lines).
+                    # We need to find the actual line number in the case.
+                    # Since ir_lines doesn't preserve line numbers, we'll just show the content.
+                    match_lines_display.append(f"  {match_line.strip()}")
+
+                if len(matches) > 5:
+                    match_lines_display.append("  (and more...)")
+
+                match_summary = "\n".join(match_lines_display)
+
+                # Extract suggested prefix from first match.
+                suggested_prefix = _extract_operation_prefix(matches[0][1], label)
+                suggestions = []
+                if suggested_prefix:
+                    suggestions.append(suggested_prefix)
+
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="ambiguous_label",
+                        message=f"CHECK-LABEL uses ambiguous bare label '{label}'",
+                        line=case.start_line + i,
+                        column=match.start(1),
+                        snippet=line.strip(),
+                        help=(
+                            f"Label '{label}' appears {len(matches)} times in the IR:\n"
+                            f"{match_summary}\n\n"
+                            "FileCheck may anchor to the wrong occurrence. "
+                            "Include the operation prefix to make the anchor unambiguous."
+                        ),
+                        suggestions=suggestions,
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+            # elif len(matches) == 1: skip - unambiguous, no warning needed.
+
+            # Check if pattern looks like a bare identifier (no @ prefix).
+            # Pattern doesn't start with known function op or @.
+            # Could be a bare identifier or intentionally checking something else.
+            # Only warn if it looks like a function name (alphanumeric/underscore).
+            if (
+                not pattern.startswith("@")
+                and not any(pattern.startswith(op) for op in self.FUNCTION_OPS)
+                and re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", pattern)
+            ):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="missing_at_prefix_in_label",
+                        message="CHECK-LABEL may be missing @ prefix",
+                        line=case.start_line + i,
+                        column=match.start(1),
+                        snippet=line.strip(),
+                        help=(
+                            f"Use 'func.func @{pattern}' or 'util.func @{pattern}' instead. "
+                            "Function names in MLIR use @ prefix. Without it, FileCheck "
+                            "won't find the function declaration, causing the test to fail "
+                            "or match unintended text. Include both the operation and @ prefix "
+                            "for robust anchoring. "
+                            "(Ignore if intentionally checking non-function constructs.)"
+                        ),
+                        suggestions=[
+                            f"func.func @{pattern}",
+                            f"util.func @{pattern}",
+                        ],
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+
+class BracketBalanceChecker(LintChecker):
+    """Validates balanced brackets in CHECK patterns.
+
+    FileCheck patterns use brackets for captures and regex matching. Unbalanced
+    brackets cause silent failures or unpredictable matching behavior. This
+    checker validates:
+    - Capture brackets: %[[NAME]] must have balanced [[ and ]]
+    - Regex brackets: {{pattern}} must have balanced {{ and }}
+    - Parentheses: (operands) must be balanced
+
+    Common errors:
+    - Missing closing bracket: %[[FOO    (should be %[[FOO]])
+    - Missing opening bracket: FOO]]     (should be %[[FOO]])
+    - Mismatched braces: {{pattern}      (should be {{pattern}})
+    - Unbalanced parens: func.func(%arg0 (missing closing paren)
+
+    Examples:
+      BAD:  // CHECK: %[[FOO:.+] = op      (unbalanced capture)
+      BAD:  // CHECK: {{.+} = op           (unbalanced regex)
+      BAD:  // CHECK: func.func(%arg0      (unbalanced paren)
+      GOOD: // CHECK: %[[FOO:.+]] = op
+      GOOD: // CHECK: {{.+}} = op
+      GOOD: // CHECK: func.func(%arg0)
+    """
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for unbalanced brackets in CHECK patterns.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of issues found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only check CHECK lines.
+            if "//" not in line or "CHECK" not in line:
+                continue
+
+            # Extract the pattern part after the CHECK directive.
+            check_match = re.search(r"//\s*CHECK[^:]*:\s*(.*)$", line)
+            if not check_match:
+                continue
+
+            pattern = check_match.group(1)
+            pattern_start = check_match.start(1)
+
+            # Check different bracket types.
+            bracket_issues = []
+
+            # Check capture brackets [[ ]].
+            capture_balance = self._check_bracket_balance(
+                pattern, "[[", "]]", "capture bracket"
+            )
+            if capture_balance:
+                bracket_issues.append(capture_balance)
+
+            # Check regex braces {{ }}.
+            regex_balance = self._check_bracket_balance(
+                pattern, "{{", "}}", "regex brace"
+            )
+            if regex_balance:
+                bracket_issues.append(regex_balance)
+
+            # Check parentheses ( ).
+            paren_balance = self._check_bracket_balance(
+                pattern, "(", ")", "parenthesis"
+            )
+            if paren_balance:
+                bracket_issues.append(paren_balance)
+
+            # Check square brackets [ ] (used in types, attributes).
+            square_balance = self._check_bracket_balance(
+                pattern, "[", "]", "square bracket"
+            )
+            if square_balance:
+                bracket_issues.append(square_balance)
+
+            # Report all bracket issues for this line.
+            for bracket_type, imbalance_msg in bracket_issues:
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="unbalanced_brackets",
+                        message=f"unbalanced {bracket_type} in CHECK pattern",
+                        line=case.start_line + i,
+                        column=pattern_start,
+                        snippet=line.strip(),
+                        help=(
+                            f"{imbalance_msg}. "
+                            f"Unbalanced {bracket_type}s cause FileCheck to fail or produce "
+                            "unpredictable matches. Check that every opening bracket has a "
+                            "corresponding closing bracket. Common issues: "
+                            "typos (%[[FOO] instead of %[[FOO]]), "
+                            "copy-paste errors (missing closing brackets), "
+                            "or regex escaping issues. "
+                            "(Ignore if pattern intentionally matches literal brackets - "
+                            "use escaping like \\[ \\] for literal brackets.)"
+                        ),
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+        return issues
+
+    def _check_bracket_balance(
+        self, pattern: str, open_bracket: str, close_bracket: str, bracket_name: str
+    ) -> tuple[str, str] | None:
+        """Check if brackets are balanced in a pattern.
+
+        Args:
+            pattern: The CHECK pattern to analyze
+            open_bracket: Opening bracket string (e.g., "[[")
+            close_bracket: Closing bracket string (e.g., "]]")
+            bracket_name: Human-readable name for error messages
+
+        Returns:
+            Tuple of (bracket_name, imbalance_message) if unbalanced, None if balanced
+        """
+        # Count occurrences of opening and closing brackets.
+        open_count = pattern.count(open_bracket)
+        close_count = pattern.count(close_bracket)
+
+        if open_count != close_count:
+            if open_count > close_count:
+                missing = open_count - close_count
+                plural = "s" if missing > 1 else ""
+                return (
+                    bracket_name,
+                    f"Missing {missing} closing {close_bracket}{plural}",
+                )
+            extra = close_count - open_count
+            plural = "s" if extra > 1 else ""
+            return (
+                bracket_name,
+                f"Extra {extra} closing {close_bracket}{plural} without matching opening",
+            )
+
+        return None
+
+
+class WildcardPatternNormalizer(LintChecker):
+    """Suggests simplifications for overly complex wildcard patterns.
+
+    FileCheck supports powerful regex patterns, but overly complex patterns
+    reduce test readability without adding value. This checker suggests
+    simpler alternatives when possible.
+
+    Common simplifications:
+    - {{[a-zA-Z0-9_]+}} → {{.+}}  (match identifier)
+    - {{[0-9]+}} → {{[0-9]+}}     (keep - specific enough)
+    - {{.*}} → {{.+}}             (prefer .+ over .* for non-empty match)
+    - {{.+?}} → {{.+}}            (non-greedy rarely needed in tests)
+
+    The goal is not to catch errors, but to improve test readability by
+    preferring simple patterns when they work equally well.
+
+    Examples:
+      COMPLEX: // CHECK: %[[VAL:.+]] = constant {{[a-zA-Z0-9_]+}}
+      SIMPLE:  // CHECK: %[[VAL:.+]] = constant {{.+}}
+
+      COMPLEX: // CHECK: types = {{.*}}
+      SIMPLE:  // CHECK: types = {{.+}}
+    """
+
+    # Pattern to find {{...}} regex wildcards.
+    WILDCARD_PATTERN = re.compile(r"\{\{(.+?)\}\}")
+
+    # Patterns that can be simplified.
+    SIMPLIFIABLE_PATTERNS = {
+        # Identifier patterns (alphanumeric + underscore).
+        r"[a-zA-Z0-9_]+": "{{.+}}",
+        r"[A-Za-z0-9_]+": "{{.+}}",
+        r"[a-z0-9_]+": "{{.+}}",
+        r"[A-Z0-9_]+": "{{.+}}",
+        r"[a-zA-Z_][a-zA-Z0-9_]*": "{{.+}}",
+        # Word patterns.
+        r"\w+": "{{.+}}",
+        # Any character patterns (prefer non-empty).
+        r".*": "{{.+}}",
+        # Non-greedy patterns (rarely needed in tests).
+        r".+?": "{{.+}}",
+        r".*?": "{{.+}}",
+    }
+
+    def check(self, case: TestCase) -> list[LintIssue]:
+        """Check for overly complex wildcard patterns.
+
+        Args:
+            case: TestCase to examine
+
+        Returns:
+            List of suggestions found
+        """
+        issues = []
+        lines = case.content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Only check CHECK lines.
+            if "//" not in line or "CHECK" not in line:
+                continue
+
+            # Check for invalid zero-or-more patterns on SSA values and symbols.
+            # %{{.*}} and @{{.*}} can match zero-length names which are never valid.
+            if re.search(r"%\{\{\.\*\}\}", line):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="invalid_ssa_zero_or_more",
+                        message="SSA value uses {{.*}} which allows empty names",
+                        line=case.start_line + i,
+                        column=line.find("%{{.*}}"),
+                        snippet=line.strip(),
+                        help=(
+                            "Use %{{.+}} instead of %{{.*}}. SSA values in MLIR must have "
+                            "non-empty names like %0, %value, etc. The pattern {{.*}} matches "
+                            "zero or more characters, allowing invalid matches like bare %. "
+                            "Use {{.+}} (one or more) to ensure the name is non-empty. "
+                            "(Applies to wildcards like %{{.*}}, not captures like %[[NAME:.+]])"
+                        ),
+                        suggestions=["%{{.+}}"],
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+            if re.search(r"@\{\{\.\*\}\}", line):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="invalid_symbol_zero_or_more",
+                        message="symbol uses {{.*}} which allows empty names",
+                        line=case.start_line + i,
+                        column=line.find("@{{.*}}"),
+                        snippet=line.strip(),
+                        help=(
+                            "Use @{{.+}} instead of @{{.*}}. Symbols in MLIR must have "
+                            "non-empty names like @func, @global, etc. The pattern {{.*}} "
+                            "matches zero or more characters, allowing invalid matches like "
+                            "bare @. Use {{.+}} (one or more) to ensure the name is non-empty."
+                        ),
+                        suggestions=["@{{.+}}"],
+                        context_lines=get_context_lines(case, i, self.context_lines),
+                    )
+                )
+
+            # Find all wildcard patterns in line.
+            for match in self.WILDCARD_PATTERN.finditer(line):
+                pattern = match.group(1)
+
+                # Check if pattern can be simplified.
+                suggestion = self.SIMPLIFIABLE_PATTERNS.get(pattern)
+                if suggestion:
+                    issues.append(
+                        LintIssue(
+                            severity="info",
+                            code="complex_wildcard_pattern",
+                            message=f"wildcard pattern {{{{{pattern}}}}} can be simplified",
+                            line=case.start_line + i,
+                            column=match.start(),
+                            snippet=line.strip(),
+                            help=(
+                                f"Use {suggestion} instead of {{{{{pattern}}}}}. "
+                                f"Pattern {{{{{pattern}}}}} works but is unnecessarily complex "
+                                "for typical test matching. The simpler {{.+}} pattern matches "
+                                "the same content while improving readability. Reserve complex "
+                                "regex patterns for cases where you need specific validation "
+                                "(e.g., {{[0-9]+}} to ensure numeric values). "
+                                "(Ignore if complex pattern is intentional - e.g., to document "
+                                "expected format or catch specific patterns.)"
+                            ),
+                            suggestions=[suggestion],
+                            context_lines=get_context_lines(
+                                case, i, self.context_lines
+                            ),
+                        )
+                    )
+
+                # Additional check: suggest {{.+}} over {{.*}} for readability.
+                elif pattern == ".*" and suggestion is None:
+                    # Already handled above, but double-check.
+                    pass
+
+        return issues
+
+
+# Registry of all available checkers.
+# Tier 1: Errors (blocking) - CRITICAL requirements.
+TIER_1_CHECKERS = [
+    RawSSAIdentifierChecker(),  # CRITICAL: No raw %0, %c123 on LHS
+    ZeroCheckLinesChecker(),  # CRITICAL: IR must have CHECKs
+    TodoWithoutExplanationChecker(),  # ERROR: TODOs must explain
+    CHECKNOTWithoutAnchorChecker(),  # ERROR: CHECK-NOT needs anchors
+    FileCheckDirectiveValidator(),  # ERROR: Catch CHECK-DAD, CHECK-SMAE typos
+    BracketBalanceChecker(),  # ERROR: Validate balanced brackets
+    # Note: Separator checking done at file level (check_file_level_issues)
+]
+
+# Tier 2: Warnings (informational) - Best practices.
+TIER_2_CHECKERS = [
+    ExcessiveWildcardChecker(),  # WARN: Too many {{.+}}
+    NonSemanticCaptureChecker(),  # WARN: %[[C0]], %[[ARG0]] anti-patterns
+    MatchedCaptureNameChecker(),  # WARN: CHECK names should match IR
+    WildcardInTerminatorChecker(),  # WARN: Verify terminator operands
+    CHECKWithoutLabelContextChecker(),  # WARN: CHECKs should follow LABEL
+    UnusedCaptureChecker(),  # WARN: Captures should be used
+    NonInterleavedChecksChecker(),  # WARN: Interleave CHECKs with IR
+    CheckLabelFormatChecker(),  # WARN: Ensure CHECK-LABEL: func.func @name
+    WildcardPatternNormalizer(),  # INFO: Suggest {{.+}} simplifications
+]
+
+# All checkers enabled by default.
+DEFAULT_CHECKERS = TIER_1_CHECKERS + TIER_2_CHECKERS
+
+
+def run_all_checkers(
+    case: TestCase,
+    checkers: list[LintChecker] | None = None,
+    context_lines: int = 5,
+) -> list[LintIssue]:
+    """Run all checkers on a test case.
+
+    Args:
+        case: TestCase to lint
+        checkers: List of checkers to run (defaults to DEFAULT_CHECKERS)
+        context_lines: Number of lines before/after for context (default: 5)
+
+    Returns:
+        Combined list of all issues found, sorted by line number
+    """
+    if checkers is None:
+        checkers = DEFAULT_CHECKERS
+
+    all_issues = []
+    for checker in checkers:
+        # Inject context_lines configuration before running checker.
+        checker.context_lines = context_lines
+        issues = checker.check(case)
+        all_issues.extend(issues)
+
+    # Sort by line number for consistent output.
+    all_issues.sort(key=lambda issue: issue.line)
+    return all_issues
+
+
+def _check_separator_extra_text(
+    line: str, line_num: int, extra_text: str
+) -> LintIssue | None:
+    """Check if separator has extra text after dashes.
+
+    Args:
+        line: The separator line
+        line_num: 1-indexed line number
+        extra_text: Text found after the dashes
+
+    Returns:
+        LintIssue if extra text present, None otherwise
+    """
+    if not extra_text:
+        return None
+
+    return LintIssue(
+        severity="error",
+        code="separator_with_extra_text",
+        message="separator line contains extra text",
+        line=line_num,
+        column=None,
+        snippet=line.strip(),
+        help=(
+            f'Separator should be "// -----" only, not "// ----- {extra_text}". '
+            "Test cases are identified by CHECK-LABEL (@function_name) or "
+            'ordinals from --list (e.g., "case 3"), never by text on the '
+            "separator line. Remove extra text to avoid confusion with test "
+            "case identification."
+        ),
+    )
+
+
+def _check_separator_blank_before(
+    lines: list[str], separator_index: int, separator_line: str
+) -> LintIssue | None:
+    """Check if separator has blank line before it.
+
+    Args:
+        lines: All lines in the file
+        separator_index: 0-indexed position of separator
+        separator_line: The separator line content
+
+    Returns:
+        LintIssue if blank line missing, None otherwise
+    """
+    if separator_index == 0:
+        return None
+
+    prev_line = lines[separator_index - 1].strip()
+    if not prev_line:
+        return None
+
+    return LintIssue(
+        severity="error",
+        code="missing_blank_before_separator",
+        message="separator line missing blank line before it",
+        line=separator_index + 1,
+        column=None,
+        snippet=separator_line.strip(),
+        help=(
+            'Add blank line before "// -----" separator. '
+            "Separators delimit test cases and should be visually distinct. "
+            "A blank line before the separator improves readability and makes "
+            "test case boundaries obvious. This is a consistent formatting "
+            "convention across IREE lit tests."
+        ),
+    )
+
+
+def _check_separator_blank_after(
+    lines: list[str], separator_index: int, separator_line: str
+) -> LintIssue | None:
+    """Check if separator has blank line after it.
+
+    Args:
+        lines: All lines in the file
+        separator_index: 0-indexed position of separator
+        separator_line: The separator line content
+
+    Returns:
+        LintIssue if blank line missing, None otherwise
+    """
+    if separator_index >= len(lines) - 1:
+        return None
+
+    next_line = lines[separator_index + 1].strip()
+    if not next_line:
+        return None
+
+    return LintIssue(
+        severity="error",
+        code="missing_blank_after_separator",
+        message="separator line missing blank line after it",
+        line=separator_index + 1,
+        column=None,
+        snippet=separator_line.strip(),
+        help=(
+            'Add blank line after "// -----" separator. '
+            "Separators delimit test cases and should be visually distinct. "
+            "A blank line after the separator improves readability and makes "
+            "test case boundaries obvious. This is a consistent formatting "
+            "convention across IREE lit tests."
+        ),
+    )
+
+
+# Pattern to extract CHECK directive type from a line.
+CHECK_DIRECTIVE_PATTERN = re.compile(
+    r"//\s*(CHECK(?:-(?:LABEL|SAME|DAG|NOT|NEXT|COUNT(?:-\d+)?|EMPTY))?)\s*:",
+    re.IGNORECASE,
+)
+
+
+def _extract_check_directive_type(line: str) -> str | None:
+    """Extract the CHECK directive type from a line.
+
+    Args:
+        line: Source line to examine
+
+    Returns:
+        Directive type (e.g., "CHECK-LABEL", "CHECK-DAG") or None if not a CHECK
+    """
+    match = CHECK_DIRECTIVE_PATTERN.search(line)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def _check_missing_split_input_file(
+    delimiter_lines: tuple[int, ...],
+    lines: list[str],
+) -> LintIssue | None:
+    """Check for // ----- delimiters without --split-input-file flag.
+
+    Args:
+        delimiter_lines: Indices of delimiter lines
+        lines: All lines in the file
+
+    Returns:
+        LintIssue if delimiters present but --split-input-file missing
+    """
+    if not delimiter_lines:
+        return None
+
+    # Report on the first delimiter line.
+    first_delim_idx = delimiter_lines[0]
+    return LintIssue(
+        severity="warning",
+        code="missing_split_input_file",
+        message="file has // ----- delimiters but no --split-input-file",
+        line=first_delim_idx + 1,
+        column=None,
+        snippet=lines[first_delim_idx].strip() if first_delim_idx < len(lines) else "",
+        help=(
+            "Without --split-input-file, delimiters are cosmetic and tests run as "
+            "a single module. Add --split-input-file to iree-opt/iree-compile command "
+            "if tests should be isolated. Otherwise, remove the // ----- separators."
+        ),
+    )
+
+
+def _check_first_check_not_label(
+    line_idx: int,
+    directive_type: str,
+    line: str,
+    delim_line_num: int,
+) -> LintIssue:
+    """Create issue for first CHECK after split not being CHECK-LABEL.
+
+    Args:
+        line_idx: 0-based line index of the CHECK directive
+        directive_type: The type of CHECK directive found
+        line: The source line
+        delim_line_num: 1-based line number of the preceding delimiter
+
+    Returns:
+        LintIssue for the unanchored CHECK
+    """
+    return LintIssue(
+        severity="warning",
+        code="first_check_not_label_after_split",
+        message=f"first CHECK after split (line {delim_line_num}) should be CHECK-LABEL",
+        line=line_idx + 1,
+        column=None,
+        snippet=line.strip(),
+        help=(
+            "Without CHECK-LABEL, patterns may match output from previous test "
+            "modules in --split-input-file mode. Add CHECK-LABEL: @functionName "
+            "or CHECK-LABEL: module to anchor the match scope before other CHECKs."
+        ),
+    )
+
+
+def _check_unanchored_check_dag(
+    line_idx: int,
+    directive_type: str,
+    line: str,
+    delim_line_num: int,
+) -> LintIssue:
+    """Create issue for CHECK-DAG/CHECK-COUNT before CHECK-LABEL after split.
+
+    Args:
+        line_idx: 0-based line index of the CHECK directive
+        directive_type: The type of CHECK directive (CHECK-DAG or CHECK-COUNT-N)
+        line: The source line
+        delim_line_num: 1-based line number of the preceding delimiter
+
+    Returns:
+        LintIssue for the unanchored CHECK-DAG/CHECK-COUNT
+    """
+    return LintIssue(
+        severity="warning",
+        code="unanchored_check_dag_after_split",
+        message=f"{directive_type} without CHECK-LABEL anchor after split (line {delim_line_num})",
+        line=line_idx + 1,
+        column=None,
+        snippet=line.strip(),
+        help=(
+            f"{directive_type} can match across '// -----' boundaries in "
+            "--split-input-file mode. Add CHECK-LABEL before this directive to "
+            "anchor the match scope. Consider whether CHECK-DAG is necessary here - "
+            "use CHECK if order is deterministic after the pass."
+        ),
+    )
+
+
+def _check_split_boundary_issues(
+    lines: list[str],
+    delimiter_lines: tuple[int, ...],
+    uses_split_input: bool,
+) -> list[LintIssue]:
+    """Check for issues related to split boundaries.
+
+    Returns issues for:
+    - Missing --split-input-file when delimiters present
+    - CHECK-DAG/CHECK-COUNT before CHECK-LABEL after split
+    - First CHECK not being CHECK-LABEL after split
+
+    Args:
+        lines: All lines in the file
+        delimiter_lines: Indices of // ----- delimiter lines
+        uses_split_input: Whether --split-input-file is in RUN lines
+
+    Returns:
+        List of issues found
+    """
+    issues = []
+
+    # Check for missing --split-input-file if delimiters present.
+    if delimiter_lines and not uses_split_input:
+        issue = _check_missing_split_input_file(delimiter_lines, lines)
+        if issue:
+            issues.append(issue)
+        return issues
+
+    # Only run further checks if split-input-file is used.
+    if not uses_split_input:
+        return issues
+
+    # For each delimiter, check the region after it.
+    for delim_pos, delim_idx in enumerate(delimiter_lines):
+        # Determine end of this region (next delimiter or EOF).
+        if delim_pos + 1 < len(delimiter_lines):
+            end_idx = delimiter_lines[delim_pos + 1]
+        else:
+            end_idx = len(lines)
+
+        seen_check_label = False
+        first_check_line_idx: int | None = None
+        first_check_type: str | None = None
+
+        # Scan lines after this delimiter.
+        for i in range(delim_idx + 1, end_idx):
+            line = lines[i]
+            directive_type = _extract_check_directive_type(line)
+
+            if directive_type is None:
+                continue
+
+            # Track first CHECK directive.
+            if first_check_line_idx is None:
+                first_check_line_idx = i
+                first_check_type = directive_type
+
+            # Check for CHECK-LABEL.
+            if directive_type == "CHECK-LABEL":
+                seen_check_label = True
+            elif not seen_check_label and (
+                directive_type == "CHECK-DAG"
+                or directive_type.startswith("CHECK-COUNT")
+            ):
+                # CHECK-DAG or CHECK-COUNT-N before CHECK-LABEL.
+                issues.append(
+                    _check_unanchored_check_dag(i, directive_type, line, delim_idx + 1)
+                )
+
+        # After scanning, check if first directive was not CHECK-LABEL.
+        if first_check_line_idx is not None and first_check_type != "CHECK-LABEL":
+            issues.append(
+                _check_first_check_not_label(
+                    first_check_line_idx,
+                    first_check_type,
+                    lines[first_check_line_idx],
+                    delim_idx + 1,
+                )
+            )
+
+    return issues
+
+
+def check_file_level_issues(test_file: TestFile) -> list[LintIssue]:
+    """Check file-level issues that aren't tied to specific test cases.
+
+    This includes checking separator lines, split boundary CHECK anchoring,
+    and formatting issues.
+
+    Args:
+        test_file: Parsed test file
+
+    Returns:
+        List of file-level issues found
+    """
+    issues = []
+    separator_pattern = re.compile(r"^//\s*(-{5,})\s*(.*)$")
+
+    # Get raw lines from the document.
+    lines = [line.get_full_line() for line in test_file.doc.lines]
+
+    # Check split boundary issues (missing --split-input-file, unanchored CHECKs).
+    split_issues = _check_split_boundary_issues(
+        lines,
+        test_file.delimiter_lines,
+        test_file.uses_split_input_file,
+    )
+    issues.extend(split_issues)
+
+    # Check separator formatting.
+    for i, line in enumerate(lines):
+        match = separator_pattern.match(line.strip())
+        if not match:
+            continue
+
+        extra_text = match.group(2)
+
+        # Check for extra text after dashes.
+        issue = _check_separator_extra_text(line, i + 1, extra_text)
+        if issue:
+            issues.append(issue)
+
+        # Check for blank line before separator.
+        issue = _check_separator_blank_before(lines, i, line)
+        if issue:
+            issues.append(issue)
+
+        # Check for blank line after separator.
+        issue = _check_separator_blank_after(lines, i, line)
+        if issue:
+            issues.append(issue)
+
+    # Check for excessive consecutive newlines (max 2 allowed).
+    consecutive_blanks = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            consecutive_blanks += 1
+            # Only report once when we first exceed 2 blank lines.
+            if consecutive_blanks == 3:
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        code="excessive_blank_lines",
+                        message="excessive blank lines (more than 2 consecutive)",
+                        line=i + 1,
+                        column=None,
+                        snippet="(blank line)",
+                        help=(
+                            "Limit consecutive blank lines to 2 maximum. "
+                            "Excessive blank lines reduce code density without improving "
+                            "readability. Use 1 blank line for logical grouping within test "
+                            "cases, 2 blank lines around separators. More than 2 is excessive."
+                        ),
+                    )
+                )
+        else:
+            consecutive_blanks = 0
+
+    return issues

--- a/tools/utils/lit_tools/core/listing.py
+++ b/tools/utils/lit_tools/core/listing.py
@@ -1,0 +1,129 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared listing helpers for lit tools.
+
+Provides common JSON payload construction and text formatting so tools like
+`iree-lit-list` and `iree-lit-extract --list` emit identical output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TCH003
+
+from common import formatting
+
+from lit_tools.core.parser import TestCase, parse_test_file
+
+
+def get_cases(file_path: Path) -> list[TestCase]:
+    """Parse test file and return test cases.
+
+    Args:
+        file_path: Path to test file
+
+    Returns:
+        List of parsed test cases
+    """
+    return list(parse_test_file(file_path).cases)
+
+
+def build_json_payload(file_path: Path, cases: list[TestCase]) -> dict:
+    """Build JSON payload for test case listing.
+
+    Args:
+        file_path: Path to test file
+        cases: List of test cases
+
+    Returns:
+        Dictionary suitable for JSON serialization
+    """
+    return {
+        "file": str(file_path),
+        "count": len(cases),
+        "cases": [
+            {
+                "number": c.number,
+                "name": c.name,
+                "start_line": c.start_line,
+                "end_line": c.end_line,
+                "line_count": c.line_count,
+                "check_count": c.check_count,
+            }
+            for c in cases
+        ],
+    }
+
+
+def format_text_listing(
+    file_path: Path,
+    cases: list[TestCase],
+    *,
+    pretty: bool = False,
+    header: bool = True,
+) -> str:
+    """Format test cases as human-readable text listing.
+
+    Args:
+        file_path: Path to test file
+        cases: List of test cases
+        pretty: Enable colorized output
+        header: Include header line with file name and count
+
+    Returns:
+        Formatted text listing
+    """
+    header_line = (
+        f"{file_path.name}: {len(cases)} test case{'s' if len(cases) != 1 else ''}"
+    )
+    if pretty:
+        header_line = formatting.color("1;33", header_line, True)  # bold yellow
+    lines = [header_line] if header else []
+    for case in cases:
+        name = f"@{case.name}" if case.name else "(unnamed)"
+        line_range = f"lines {case.start_line}-{case.end_line}"
+        line_count_str = f"{case.line_count} line{'s' if case.line_count != 1 else ''}"
+        check_count_str = (
+            f"{case.check_count} CHECK line{'s' if case.check_count != 1 else ''}"
+        )
+        number = f"{case.number:>2}"
+        if pretty:
+            number = formatting.color("1;36", number, True)
+            name_fmt = formatting.color("1", f"{name:30s}", True)
+            meta = formatting.color(
+                "2;37", f"({line_range}, {line_count_str:4s}, {check_count_str})", True
+            )
+            lines.append(f"  {number}: {name_fmt} {meta}")
+        else:
+            lines.append(
+                f"  {case.number}: {name:30s} ({line_range}, {line_count_str:4s}, {check_count_str})"
+            )
+    return "\n".join(lines)
+
+
+def format_names(cases: list[TestCase]) -> str:
+    """Format test case names as space-separated string.
+
+    Args:
+        cases: List of test cases
+
+    Returns:
+        Space-separated names (e.g., "@foo @bar case3")
+    """
+    names = [f"@{c.name}" if c.name else f"case{c.number}" for c in cases]
+    return " ".join(names)
+
+
+def count_cases(cases: list[TestCase]) -> int:
+    """Count test cases.
+
+    Args:
+        cases: List of test cases
+
+    Returns:
+        Number of cases
+    """
+    return len(cases)

--- a/tools/utils/lit_tools/core/lit_wrapper.py
+++ b/tools/utils/lit_tools/core/lit_wrapper.py
@@ -1,0 +1,610 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Wrapper for running LLVM LIT on extracted test cases.
+
+This module integrates with lit programmatically. It avoids writing into the
+source tree by creating a temporary test directory and mapping its lit.cfg.py
+to the real suite configuration discovered from the original test directory.
+"""
+
+import contextlib
+import os
+import re
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from common import build_detection
+
+from lit_tools.core import rendering  # For inject_run_lines_with_case
+from lit_tools.core.parser import TestCase, TestFile
+
+# Error message length limits for readability in diagnostic output.
+MAX_ERROR_LINES_FILECHECK = 10  # FileCheck error preview lines.
+MAX_ERROR_LINES_IR_VALIDATION = 15  # IR verification error lines.
+MAX_ERROR_LINES_IR_OPERATION = 10  # IR operation error context lines.
+ASSERTION_CONTEXT_LINES = 3  # Lines of context around C assertions.
+CHECK_FAILURE_CONTEXT_LINES = 5  # Lines of context around CHECK failures.
+
+
+@dataclass
+class LitResult:
+    """Result from running lit on a test case."""
+
+    passed: bool
+    case_number: int
+    case_name: str | None
+    duration: float  # Execution time in seconds.
+    stdout: str  # Full lit output.
+    stderr: str  # Lit stderr.
+    failure_summary: str | None  # Parsed failure details.
+    run_commands: list[str]  # Executed RUN commands.
+
+
+def inject_extra_flags(content: str, extra_flags: str) -> str:
+    """Inject extra flags into first iree-* tool in each RUN line.
+
+    Only modifies RUN lines that contain iree-* tools.
+    Flags are inserted immediately after the tool name.
+
+    Example:
+        Input:
+            // RUN: iree-opt --split-input-file %s | FileCheck %s
+
+        With extra_flags="--debug --mlir-print-ir-after-all":
+
+        Output:
+            // RUN: iree-opt --debug --mlir-print-ir-after-all --split-input-file %s | FileCheck %s
+
+    Args:
+        content: Test file content (including RUN lines)
+        extra_flags: Space-separated flags to inject
+
+    Returns:
+        Modified content with flags injected into RUN lines
+    """
+    if not extra_flags:
+        return content
+
+    lines = content.splitlines()
+    modified_lines = []
+
+    for line in lines:
+        # Check if this is a RUN line.
+        if re.match(r"^\s*//\s*RUN:", line):
+            # Find first iree-* tool in this line.
+            # Pattern: iree-{letters-digits-and-hyphens}
+            # Matches: iree-opt, iree-compile, iree-run-module, iree-opt-19, etc.
+            match = re.search(r"\b(iree-[a-z0-9-]+)\b", line, re.IGNORECASE)
+
+            if match:
+                tool_end = match.end(1)
+
+                # Insert flags right after tool name.
+                modified_line = line[:tool_end] + " " + extra_flags + line[tool_end:]
+                modified_lines.append(modified_line)
+            else:
+                # No iree-* tool found, keep line unchanged.
+                modified_lines.append(line)
+        else:
+            # Not a RUN line, keep unchanged.
+            modified_lines.append(line)
+
+    return "\n".join(modified_lines)
+
+
+def _ensure_lit_importable() -> None:
+    """Ensures `import lit` works either from third_party or site packages."""
+    try:
+        import lit  # noqa: PLC0415
+
+        return
+    except ImportError:
+        pass
+
+    # Use build_detection to find repo root, then locate lit in third_party.
+    repo_root = build_detection.find_repo_root()
+    if repo_root:
+        lit_path = repo_root / "third_party/llvm-project/llvm/utils/lit"
+        if lit_path.exists():
+            sys.path.insert(0, str(lit_path))
+
+    # Try import again (let ImportError propagate if it still fails).
+    import lit  # noqa: F401, PLC0415
+
+
+def extract_timeout_error(failure_text: str) -> str | None:
+    """Extract timeout error from lit failure output.
+
+    Detects when a test exceeds its time limit.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        Timeout error message, or None if no timeout detected
+    """
+    # Look for timeout indicators from lit.
+    if re.search(r"(TIMEOUT|Timeout|Reached timeout)", failure_text, re.IGNORECASE):
+        return "Test exceeded timeout limit"
+    return None
+
+
+def extract_crash_error(failure_text: str) -> str | None:
+    """Extract crash/segfault error from lit failure output.
+
+    Detects crashes, segmentation faults, and abnormal terminations.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        Crash error message, or None if no crash detected
+    """
+    # Check for signal termination.
+    signal_match = re.search(
+        r"(Command terminated with signal|Exited with signal|killed by signal)\s+(\d+)",
+        failure_text,
+    )
+    if signal_match:
+        signal_num = int(signal_match.group(2))
+        signal_names = {
+            6: "SIGABRT (abort)",
+            11: "SIGSEGV (segmentation fault)",
+            4: "SIGILL (illegal instruction)",
+            8: "SIGFPE (floating point exception)",
+            9: "SIGKILL (killed)",
+        }
+        signal_name = signal_names.get(signal_num, f"signal {signal_num}")
+        return f"Process crashed with {signal_name}"
+
+    # Check for exit codes that indicate crashes (128 + signal).
+    exit_code_match = re.search(r"Command returned exit code (\d+)", failure_text)
+    if exit_code_match:
+        exit_code = int(exit_code_match.group(1))
+        if 128 < exit_code < 160:  # Signal exits are 128 + signal_number.
+            signal_num = exit_code - 128
+            signal_names = {
+                6: "SIGABRT (abort)",
+                11: "SIGSEGV (segmentation fault)",
+                4: "SIGILL (illegal instruction)",
+                8: "SIGFPE (floating point exception)",
+            }
+            signal_name = signal_names.get(signal_num, f"signal {signal_num}")
+            return f"Process crashed with {signal_name} (exit code {exit_code})"
+
+    # Check for segfault text.
+    if re.search(r"Segmentation fault", failure_text, re.IGNORECASE):
+        return "Process crashed with segmentation fault"
+
+    return None
+
+
+def extract_assertion_error(failure_text: str) -> str | None:
+    """Extract assertion failure from lit failure output.
+
+    Detects both C assert() and C++ CHECK/DCHECK failures.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        Assertion error with context, or None if no assertion found
+    """
+    # Look for C assertion failures.
+    assert_match = re.search(
+        r"(Assertion `.*?' failed|assert.*failed)", failure_text, re.MULTILINE
+    )
+    if assert_match:
+        # Extract context lines around assertion.
+        lines = failure_text.splitlines()
+        for i, line in enumerate(lines):
+            if assert_match.group(0) in line:
+                start = max(0, i - 1)
+                end = min(len(lines), i + ASSERTION_CONTEXT_LINES)
+                context = "\n".join(lines[start:end])
+                return f"Assertion failure:\n{context}"
+
+    # Look for CHECK failures (glog style).
+    check_match = re.search(r"Check failed:.*", failure_text, re.MULTILINE)
+    if check_match:
+        # Extract context around CHECK failure.
+        lines = failure_text.splitlines()
+        for i, line in enumerate(lines):
+            if "Check failed:" in line:
+                start = max(0, i)
+                end = min(len(lines), i + CHECK_FAILURE_CONTEXT_LINES)
+                context = "\n".join(lines[start:end])
+                return f"CHECK failure:\n{context}"
+
+    return None
+
+
+def extract_invalid_ir_error(failure_text: str) -> str | None:
+    """Extract MLIR IR verification error from lit failure output.
+
+    Detects when MLIR verification fails due to invalid IR.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        IR verification error, or None if no verification error found
+    """
+    # Look for MLIR verification failures.
+    if re.search(r"error:.*verification failed", failure_text, re.IGNORECASE):
+        # Extract the verification error details.
+        error_match = re.search(
+            r"(error:.*verification failed.*?)(?=\n\n|\nInput file:|\n--|\Z)",
+            failure_text,
+            re.DOTALL | re.IGNORECASE,
+        )
+        if error_match:
+            error = error_match.group(1).strip()
+            error_lines = error.splitlines()
+            if len(error_lines) > MAX_ERROR_LINES_IR_VALIDATION:
+                error_lines = error_lines[:MAX_ERROR_LINES_IR_VALIDATION] + [
+                    "  ... (use -v for full output)"
+                ]
+            return "IR verification failed:\n" + "\n".join(error_lines)
+
+    # Look for operation verification errors (e.g., "'func.func' op ...").
+    op_error_match = re.search(r"error:.*'[\w.]+' op .*", failure_text, re.MULTILINE)
+    if op_error_match:
+        # Extract context around the error.
+        lines = failure_text.splitlines()
+        error_context = []
+        found_error = False
+        for line in lines:
+            if op_error_match.group(0) in line:
+                found_error = True
+            if found_error:
+                error_context.append(line)
+                if len(error_context) >= MAX_ERROR_LINES_IR_OPERATION:
+                    break
+        if error_context:
+            if len(error_context) > MAX_ERROR_LINES_IR_OPERATION:
+                error_context = error_context[:MAX_ERROR_LINES_IR_OPERATION] + [
+                    "  ... (use -v for full output)"
+                ]
+            return "IR validation error:\n" + "\n".join(error_context)
+
+    return None
+
+
+def extract_missing_file_error(failure_text: str) -> str | None:
+    """Extract missing file error from lit failure output.
+
+    Detects when a required file is not found.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        Missing file error, or None if no file error found
+    """
+    # Look for "No such file or directory" errors.
+    file_error_match = re.search(
+        r"(.*?):.*[Nn]o such file or directory", failure_text, re.MULTILINE
+    )
+    if file_error_match:
+        return f"File not found: {file_error_match.group(0)}"
+
+    # Look for "unable to open file" errors.
+    open_error_match = re.search(
+        r"[Uu]nable to open file[: ]+['\"](.*?)['\"]", failure_text, re.MULTILINE
+    )
+    if open_error_match:
+        return f"Unable to open file: {open_error_match.group(1)}"
+
+    # Look for "Could not open" errors.
+    could_not_open_match = re.search(
+        r"[Cc]ould not open[: ]+['\"](.*?)['\"]", failure_text, re.MULTILINE
+    )
+    if could_not_open_match:
+        return f"Could not open file: {could_not_open_match.group(1)}"
+
+    return None
+
+
+def parse_lit_failure(stdout: str, stderr: str) -> tuple[str | None, list[str]]:
+    """Parse lit output to extract failure details.
+
+    Extracts:
+    - Commands that were executed (RUN lines)
+    - FileCheck error messages
+    - Crash/segfault information
+    - Timeout information
+    - Invalid IR errors
+    - Missing file errors
+    - Assertion failures
+
+    Args:
+        stdout: Lit's stdout
+        stderr: Lit's stderr
+
+    Returns:
+        (failure_summary, run_commands)
+        failure_summary: Concise error message, or None if no failure
+        run_commands: List of executed commands
+    """
+    # Extract section between "**********" markers.
+    failure_match = re.search(r"\*+ TEST .* FAILED \*+\n(.*?)\n\*+", stdout, re.DOTALL)
+
+    if not failure_match:
+        return None, []
+
+    failure_text = failure_match.group(1)
+
+    # Extract RUN commands (lines starting with "+").
+    run_commands = [
+        line.strip("+ ") for line in failure_text.splitlines() if line.startswith("+ ")
+    ]
+
+    # Try different error extractors in priority order.
+    error = (
+        extract_timeout_error(failure_text)
+        or extract_crash_error(failure_text)
+        or extract_assertion_error(failure_text)
+        or extract_invalid_ir_error(failure_text)
+        or extract_missing_file_error(failure_text)
+        or extract_filecheck_error(failure_text)
+    )
+
+    # Build concise summary.
+    summary_parts = []
+
+    if run_commands:
+        summary_parts.append(f"Failed command:\n  {run_commands[-1]}")
+
+    if error:
+        summary_parts.append(f"\n{error}")
+
+    return "\n".join(summary_parts) if summary_parts else None, run_commands
+
+
+def extract_filecheck_error(failure_text: str) -> str | None:
+    """Extract the key FileCheck error message from lit failure output.
+
+    Args:
+        failure_text: Text between failure markers
+
+    Returns:
+        Concise FileCheck error, or None if no FileCheck error found
+    """
+    # Look for FileCheck error pattern:
+    # test.mlir:42:11: error: CHECK: expected string not found
+    error_match = re.search(
+        r"([\w/.-]+\.mlir:\d+:\d+: error:.*?)(?=\n\n|\n<stdin>|\nInput file:|\n--)",
+        failure_text,
+        re.DOTALL,
+    )
+
+    if error_match:
+        error = error_match.group(1).strip()
+        # Limit to first few lines for conciseness.
+        error_lines = error.splitlines()
+        if len(error_lines) > MAX_ERROR_LINES_FILECHECK:
+            error_lines = error_lines[:MAX_ERROR_LINES_FILECHECK] + [
+                "  ... (use -v for full output)"
+            ]
+        return "\n".join(error_lines)
+
+    return None
+
+
+def run_lit_on_case(
+    case: TestCase,
+    test_file_obj: "TestFile",
+    build_dir: Path,
+    timeout: int = 60,
+    extra_flags: str | None = None,
+    verbose: bool = False,
+    keep_temps: bool = False,
+) -> LitResult:
+    """Run lit on extracted test case.
+
+    Args:
+        case: Test case to run
+        test_file_obj: Parsed test file object (contains path and cached run lines)
+        build_dir: IREE build directory
+        timeout: Test timeout in seconds (0 = no timeout)
+        extra_flags: Extra flags to inject into iree-* tools
+        verbose: Pass -a to lit (show all output)
+        keep_temps: Don't delete temp file after test
+
+    Returns:
+        LitResult with test outcome and parsed details
+    """
+    # Extract file path from test_file_obj
+    test_file_path = test_file_obj.doc.path
+    # 1. Prepare test content with line preservation.
+    # Use render_for_testing() which preserves exact line count (blanks RUN lines).
+    # Prepend blank lines so line numbers match original file.
+    blank_lines = "\n" * (case.start_line - 1)
+    test_content = blank_lines + case.render_for_testing()
+
+    # 2. Extract and inject RUN lines from cached test file object.
+    header_runs = test_file_obj.extract_run_lines()
+    case_runs_with_indices = case.extract_local_run_lines()
+    case_runs = [(idx, cmd) for idx, cmd in case_runs_with_indices]
+    test_content = rendering.inject_run_lines_with_case(
+        test_content, header_runs, case_runs
+    )
+
+    # 3. Inject extra flags if provided.
+    if extra_flags:
+        test_content = inject_extra_flags(test_content, extra_flags)
+
+    # 3. Prepare a temp directory outside the source tree.
+    temp_root = Path(os.environ.get("TMPDIR", "/tmp")) / f"iree_lit_test_{os.getpid()}"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    # Include thread ID to prevent collisions when running in parallel with --workers.
+    temp_file = temp_root / f"case{case.number}_t{threading.get_ident()}.mlir"
+    temp_file.write_text(test_content)
+
+    try:
+        # 4. Programmatic lit run with config mapping to the real suite config.
+        # Initialize env_backup early so finally block always has it defined.
+        env_backup: dict[str, str | None] = {}
+
+        _ensure_lit_importable()
+        from lit import LitConfig  # noqa: PLC0415
+        from lit import discovery as lit_discovery  # noqa: PLC0415
+        from lit import run as lit_run  # noqa: PLC0415
+
+        # Try to find lit.cfg.py by walking up from test file location.
+        # Use lit's discovery to check the directory first.
+        real_cfg_path = lit_discovery.dirContainsTestSuite(
+            str(test_file_path.parent),
+            LitConfig.LitConfig(
+                progname="iree-lit-test",
+                path=[],
+                diagnostic_level="error",
+                useValgrind=False,
+                valgrindLeakCheck=False,
+                valgrindArgs=[],
+                noExecute=False,
+                debug=False,
+                isWindows=(os.name == "nt"),
+                order=None,
+                params={},
+                config_prefix=None,
+            ),
+        )
+        if not real_cfg_path:
+            # Fall back to walking upwards for lit.cfg.py.
+            for parent in [test_file_path.parent] + list(test_file_path.parent.parents):
+                probe = parent / "lit.cfg.py"
+                if probe.exists():
+                    real_cfg_path = str(probe)
+                    break
+
+        lit_cfg = temp_root / "lit.cfg.py"
+        config_map = {}
+
+        if real_cfg_path:
+            # Found lit.cfg.py - create stub and map to real config.
+            # lit will load real_cfg_path instead of the stub via config_map.
+            lit_cfg.write_text("# stub config mapped via config_map\n")
+            config_map = {os.path.normcase(str(lit_cfg)): str(real_cfg_path)}
+        else:
+            # No lit.cfg.py found - generate complete config in temp_root.
+            # This handles stdin mode, test files in arbitrary locations, etc.
+            # No temp path checking needed - works anywhere!
+            lit_cfg.write_text(
+                f"""# Generated lit configuration (no lit.cfg.py found in directory tree).
+import os
+import lit.formats
+
+config.name = "iree-lit-test"
+config.test_format = lit.formats.ShTest(execute_external=True)
+config.suffixes = [".mlir"]
+config.test_exec_root = r"{temp_root}"
+config.environment = os.environ.copy()
+"""
+            )
+
+        # Compose PATH for tools (like CTest does) and apply to process env so
+        # suite configs that copy os.environ see it.
+        build_bin_paths = [
+            str(build_dir / "llvm-project" / "bin"),
+            str(build_dir / "tools"),
+        ]
+
+        # Save environment for restoration in finally block.
+        env_backup = {
+            "PATH": os.environ.get("PATH"),
+            "FILECHECK_OPTS": os.environ.get("FILECHECK_OPTS"),
+            "TEST_TMPDIR": os.environ.get("TEST_TMPDIR"),
+        }
+
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = os.pathsep.join(build_bin_paths + [old_path])
+        os.environ.setdefault("FILECHECK_OPTS", "--enable-var-scope")
+        os.environ.setdefault("TEST_TMPDIR", str(temp_root))
+
+        # Lit configuration; use our per-test timeout as maxIndividualTestTime.
+        lit_config = LitConfig.LitConfig(
+            progname="iree-lit-test",
+            path=build_bin_paths,
+            diagnostic_level="note" if verbose else "error",
+            useValgrind=False,
+            valgrindLeakCheck=False,
+            valgrindArgs=[],
+            noExecute=False,
+            debug=verbose,
+            isWindows=(os.name == "nt"),
+            order=None,
+            params={
+                # Map stub config to real config (if needed for source tree tests).
+                "config_map": config_map
+            },
+            config_prefix=None,
+            maxIndividualTestTime=timeout if timeout > 0 else 0,
+        )
+
+        # Discover tests for our temp file.
+        tests = lit_discovery.find_tests_for_inputs(lit_config, [str(temp_file)])
+        # Execute with 1 worker; use a reasonable overall run deadline if desired.
+        start_time = time.time()
+
+        runner = lit_run.Run(
+            tests=tests,
+            lit_config=lit_config,
+            workers=1,
+            progress_callback=lambda _: None,
+            max_failures=1,
+            timeout=None,
+        )
+        # Expected when test fails and max_failures=1; results still populated.
+        with contextlib.suppress(lit_run.MaxFailuresError):
+            runner.execute()
+        duration = time.time() - start_time
+
+        # Collect results (single test).
+        test = tests[0] if tests else None
+        passed = bool(test and test.result and not test.result.code.isFailure)
+        stdout = test.result.output if test and test.result else ""
+        stderr = ""  # lit mixes streams in result.output for ShTest
+        failure_summary = None
+        run_commands: list[str] = []
+        if not passed or verbose:
+            failure_summary, run_commands = parse_lit_failure(stdout, stderr)
+
+        return LitResult(
+            passed=passed,
+            case_number=case.number,
+            case_name=case.name,
+            duration=duration,
+            stdout=stdout,
+            stderr=stderr,
+            failure_summary=failure_summary,
+            run_commands=run_commands,
+        )
+
+    finally:
+        # Restore environment to prevent pollution across test runs.
+        for key, value in env_backup.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+        # 8. Clean up temp file.
+        if not keep_temps and temp_file.exists():
+            with contextlib.suppress(Exception):
+                temp_file.unlink()
+        elif keep_temps and temp_file.exists() and verbose:
+            # Note: Only printed if verbose, otherwise clutters output.
+            from common import (  # noqa: PLC0415
+                console as _console,
+            )  # local import to avoid cycles
+
+            _console.note(f"Temp file kept: {temp_file}")

--- a/tools/utils/lit_tools/core/parser.py
+++ b/tools/utils/lit_tools/core/parser.py
@@ -1,0 +1,603 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Parser for LLVM lit test files with line-oriented structure.
+
+This module implements parsing of lit test files into the span-based document model.
+The parser identifies test case boundaries (delimiters), classifies lines by type
+(RUN, CHECK, DELIMITER, BODY), and extracts metadata for each case.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .document import CheckLabelExtractor, FileDoc, Line, Span
+
+# Tag constants for line classification
+TAG_RUN_HEADER = "RUN_HEADER"  # File-level RUN line
+TAG_RUN_CASE = "RUN_CASE"  # Case-local RUN line
+TAG_DELIMITER = "DELIMITER"  # // ----- separator
+TAG_CHECK = "CHECK"  # CHECK directive
+TAG_BODY = "BODY"  # Everything else
+
+# Pattern for identifying RUN lines
+RUN_LINE_PATTERN = re.compile(r"^\s*//\s*RUN:\s*(.*)$")
+
+# Pattern for identifying delimiters (exact match required)
+DELIMITER_PATTERN = re.compile(r"^\s*//\s*-----\s*$")
+
+# Pattern for identifying CHECK directives (CHECK, CHECK-LABEL, FOO-CHECK, etc.)
+CHECK_PATTERN = re.compile(r"^\s*//\s*[\w-]*CHECK")
+
+
+@dataclass(frozen=True)
+class TestCase:
+    """Represents a single test case with metadata.
+
+    A test case is a span of lines in the document, typically separated
+    by // ----- delimiters. Cases may have header RUN lines (file-level)
+    and case-local RUN lines (within the case body).
+    """
+
+    doc: FileDoc  # Document containing this case
+    number: int  # 1-based case number
+    name: str | None  # From CHECK-LABEL or None
+    all_names: tuple[str, ...]  # All CHECK-LABEL names in case
+    span: Span  # Lines belonging to this case
+    header_run_lines: frozenset[int]  # File-level RUN lines
+    local_run_lines: frozenset[int]  # Case-local RUN lines
+    check_count: int  # Number of CHECK directives
+
+    @property
+    def run_lines(self) -> frozenset[int]:
+        """All RUN line indices (header + local)."""
+        return self.header_run_lines | self.local_run_lines
+
+    @property
+    def start_line(self) -> int:
+        """1-based start line number (for backward compatibility)."""
+        return self.span.start + 1
+
+    @property
+    def end_line(self) -> int:
+        """1-based end line number, inclusive (for backward compatibility)."""
+        # Span uses exclusive end, but old API used inclusive
+        return self.span.end
+
+    @property
+    def line_count(self) -> int:
+        """Total number of lines in case."""
+        return self.span.length
+
+    def render_for_testing(self) -> str:
+        """Render case for lit execution with line number preservation.
+
+        This mode is used when extracting a case for testing with lit/FileCheck.
+        RUN lines are replaced with blank lines to preserve line numbers for
+        FileCheck diagnostics, ensuring CHECK directives reference the correct
+        source locations.
+
+        Returns:
+            String with RUN lines blanked, preserving total line count
+
+        Example:
+            Input case (lines 5-8):
+                // RUN: iree-opt %s
+                // CHECK: foo
+                func @test() { }
+                (blank line)
+
+            Output:
+                (blank line)
+                // CHECK: foo
+                func @test() { }
+                (blank line)
+        """
+        case_lines = self.doc.slice(self.span)
+        result_lines = []
+
+        for line in case_lines:
+            if TAG_RUN_HEADER in line.tags or TAG_RUN_CASE in line.tags:
+                # Replace RUN line content with blank, keep newline.
+                result_lines.append(line.newline)
+            else:
+                # Keep all other lines as-is.
+                result_lines.append(line.get_full_line())
+
+        return "".join(result_lines)
+
+    def render_normalized(self) -> str:
+        """Render case body for normalized output.
+
+        This mode is used when rebuilding test files with clean formatting.
+        RUN lines are dropped entirely, leading/trailing newlines are removed,
+        and internal consecutive blank lines are normalized to exactly one.
+
+        Note: This function removes ALL trailing newlines. The caller
+        (typically build_file_content) is responsible for adding a final
+        newline if needed for the file format.
+
+        Returns:
+            String with RUN lines dropped, blanks trimmed, and internal
+            blank lines normalized (sequences of 2+ newlines → 2 newlines)
+
+        Example:
+            Input case (lines 5-8):
+                // RUN: iree-opt %s
+                (blank line)
+                // CHECK: foo
+
+
+                func @test() { }
+
+
+            Output (no trailing newline):
+                // CHECK: foo
+
+                func @test() { }
+        """
+        case_lines = self.doc.slice(self.span)
+        result_lines = []
+
+        for line in case_lines:
+            # Skip RUN lines entirely in normalized mode.
+            if TAG_RUN_HEADER in line.tags or TAG_RUN_CASE in line.tags:
+                continue
+            result_lines.append(line.get_full_line())
+
+        # Join and trim leading/trailing blank lines.
+        content = "".join(result_lines)
+
+        # Strip leading blank lines.
+        while content.startswith("\n") or content.startswith("\r\n"):
+            content = content[2:] if content.startswith("\r\n") else content[1:]
+
+        # Strip ALL trailing newlines (build_file_content will add exactly one).
+        while content.endswith("\n") or content.endswith("\r\n"):
+            content = content[:-2] if content.endswith("\r\n") else content[:-1]
+
+        # Normalize internal consecutive blank lines (max 1 consecutive).
+        # Replace runs of 2+ consecutive newlines with exactly 2 newlines.
+        return re.sub(r"\n\n+", "\n\n", content)
+
+    @property
+    def content(self) -> str:
+        """Get case content (normalized, without RUN lines).
+
+        Returns:
+            Case body with RUN lines removed and formatting normalized
+        """
+        return self.render_normalized()
+
+    def extract_local_run_lines(self) -> list[tuple[int, str]]:
+        """Extract case-local RUN commands with absolute line positions.
+
+        Returns RUN commands that appear within this test case body,
+        along with their absolute line indices for injection purposes.
+
+        Returns:
+            List of (absolute_line_index, command) tuples where absolute_line_index
+            is the 0-based index in synthesized content (with blank line padding)
+
+        Example:
+            >>> case.extract_local_run_lines()
+            [(15, 'iree-opt --pass-pipeline=... %s')]
+        """
+        local_indices = sorted(self.local_run_lines)
+        result = []
+
+        for idx in local_indices:
+            line = self.doc.lines[idx]
+            match = RUN_LINE_PATTERN.match(line.text)
+            if not match:
+                continue
+
+            content = match.group(1).strip()
+
+            # Handle continuation lines
+            current_idx = idx
+            cmd = content
+            while current_idx < self.span.end - 1:
+                current_line = self.doc.lines[current_idx]
+                if not current_line.text.rstrip().endswith("\\"):
+                    break
+
+                current_idx += 1
+                next_line = self.doc.lines[current_idx]
+                next_match = RUN_LINE_PATTERN.match(next_line.text)
+                if next_match:
+                    cmd = (
+                        cmd.rstrip("\\").strip()
+                        + " "
+                        + next_match.group(1).lstrip("\\").strip()
+                    )
+
+            # Calculate absolute index in synthesized content
+            # Synthesized content has (case.start_line - 1) blank lines at top
+            relative_idx = idx - self.span.start
+            absolute_idx = (self.start_line - 1) + relative_idx
+
+            result.append((absolute_idx, cmd.rstrip("\\").strip()))
+
+        return result
+
+
+@dataclass(frozen=True)
+class TestFile:
+    """Parsed lit test file with structure."""
+
+    doc: FileDoc  # The document
+    cases: tuple[TestCase, ...]  # All test cases
+    header_span: Span | None  # Lines before first delimiter
+    delimiter_lines: tuple[int, ...]  # Indices of // ----- lines
+
+    def extract_run_lines(self, raw: bool = False) -> list[str]:
+        """Extract header RUN commands from test file.
+
+        Args:
+            raw: If True, return each RUN line separately (for line preservation).
+                If False, join continuation lines into complete commands.
+
+        Returns:
+            List of RUN command strings
+
+        Example:
+            >>> test_file.extract_run_lines()
+            ['iree-opt --split-input-file %s | FileCheck %s']
+        """
+        if not self.cases:
+            return []
+
+        # Get header RUN line indices from first case
+        header_indices = sorted(self.cases[0].header_run_lines)
+
+        if raw:
+            # Raw mode: return each RUN line separately
+            commands = []
+            for idx in header_indices:
+                line = self.doc.lines[idx]
+                match = RUN_LINE_PATTERN.match(line.text)
+                if match:
+                    commands.append(match.group(1).strip())
+            return commands
+
+        # Normal mode: join continuation lines
+        commands = []
+        current_cmd = None
+        continuing = False
+
+        for idx in header_indices:
+            line = self.doc.lines[idx]
+            match = RUN_LINE_PATTERN.match(line.text)
+            if not match:
+                continue
+
+            content = match.group(1).strip()
+
+            if continuing and current_cmd is not None:
+                current_cmd = (
+                    current_cmd.rstrip("\\").strip()
+                    + " "
+                    + content.lstrip("\\").strip()
+                )
+            else:
+                current_cmd = content
+
+            continuing = content.endswith("\\")
+
+            if not continuing:
+                commands.append(current_cmd.rstrip("\\").strip())
+                current_cmd = None
+
+        if current_cmd is not None:
+            commands.append(current_cmd.rstrip("\\").strip())
+
+        return commands
+
+    def find_case_by_number(self, case_number: int) -> TestCase:
+        """Find test case by number.
+
+        Args:
+            case_number: 1-based case number
+
+        Returns:
+            TestCase object
+
+        Raises:
+            ValueError: If case_number is out of range
+
+        Example:
+            >>> case = test_file.find_case_by_number(2)
+            >>> case.name
+            'second_function'
+        """
+        if case_number < 1 or case_number > len(self.cases):
+            raise ValueError(
+                f"Case number {case_number} out of range (1-{len(self.cases)})"
+            )
+        return self.cases[case_number - 1]
+
+    def find_case_by_name(self, name: str) -> TestCase:
+        """Find test case by CHECK-LABEL name.
+
+        Args:
+            name: Function name (with or without @ prefix)
+
+        Returns:
+            TestCase object
+
+        Raises:
+            ValueError: If no case with given name found
+
+        Example:
+            >>> case = test_file.find_case_by_name("my_function")
+            >>> case.number
+            2
+        """
+        search_name = name.lstrip("@")
+        for case in self.cases:
+            if case.name == search_name:
+                return case
+        raise ValueError(f"No test case found with name '{name}'")
+
+    def find_case_by_line(self, line_number: int) -> TestCase:
+        """Find test case containing a specific line number.
+
+        Useful for locating the test case from error messages that reference
+        line numbers.
+
+        Args:
+            line_number: 1-based line number
+
+        Returns:
+            TestCase containing the specified line
+
+        Raises:
+            ValueError: If line_number is out of range
+
+        Example:
+            >>> # Error at line 142 - which case is that?
+            >>> case = test_file.find_case_by_line(142)
+            >>> case.name
+            'third_function'
+        """
+        if line_number < 1:
+            raise ValueError(f"Line number must be >= 1, got {line_number}")
+
+        for case in self.cases:
+            if case.start_line <= line_number <= case.end_line:
+                return case
+
+        if self.cases:
+            last_line = self.cases[-1].end_line
+            raise ValueError(
+                f"Line number {line_number} out of range (file has {last_line} lines)"
+            )
+        raise ValueError(f"Line number {line_number} out of range (empty file)")
+
+    @property
+    def uses_split_input_file(self) -> bool:
+        """Check if file uses --split-input-file mode.
+
+        Examines RUN lines to determine if --split-input-file flag is present.
+        This affects how FileCheck interprets test boundaries.
+
+        Returns:
+            True if any RUN line contains --split-input-file
+
+        Example:
+            >>> if test_file.uses_split_input_file:
+            ...     # CHECK-DAG can match across // ----- boundaries
+            ...     validate_check_label_anchoring()
+        """
+        run_lines = self.extract_run_lines()
+        return any("--split-input-file" in cmd for cmd in run_lines)
+
+
+def _tag_lines(doc: FileDoc) -> FileDoc:
+    """Classify lines by structural type.
+
+    Tags lines as RUN_HEADER, RUN_CASE, DELIMITER, CHECK, or BODY.
+    RUN lines before first delimiter are header RUNs.
+    RUN lines after delimiter are case-local RUNs.
+
+    Args:
+        doc: Document to tag
+
+    Returns:
+        New FileDoc with lines tagged
+    """
+    delimiter_indices = _find_delimiter_indices(doc)
+    first_delimiter_idx = delimiter_indices[0] if delimiter_indices else len(doc.lines)
+
+    # Build new lines in single O(N) pass to avoid O(N²) behavior
+    updated_lines = []
+    for idx, line in enumerate(doc.lines):
+        tags = set()
+
+        # Check for delimiter
+        if DELIMITER_PATTERN.match(line.text):
+            tags.add(TAG_DELIMITER)
+
+        # Check for RUN line
+        elif RUN_LINE_PATTERN.match(line.text):
+            if idx < first_delimiter_idx:
+                tags.add(TAG_RUN_HEADER)
+            else:
+                tags.add(TAG_RUN_CASE)
+
+        # Check for CHECK directive
+        elif CHECK_PATTERN.match(line.text):
+            tags.add(TAG_CHECK)
+
+        # Everything else is body
+        else:
+            tags.add(TAG_BODY)
+
+        # Create new Line with tags
+        updated_lines.append(
+            Line(
+                text=line.text,
+                newline=line.newline,
+                index=line.index,
+                source_line=line.source_line,
+                tags=frozenset(tags),
+            )
+        )
+
+    return FileDoc(lines=tuple(updated_lines), path=doc.path)
+
+
+def _find_delimiter_indices(doc: FileDoc) -> list[int]:
+    """Find all // ----- delimiter line indices.
+
+    Args:
+        doc: Document to search
+
+    Returns:
+        List of 0-based indices where delimiters appear
+    """
+    indices = []
+    for idx, line in enumerate(doc.lines):
+        if DELIMITER_PATTERN.match(line.text):
+            indices.append(idx)
+    return indices
+
+
+def _build_case_spans(doc: FileDoc, delimiter_indices: list[int]) -> list[Span]:
+    """Build span for each test case based on delimiter positions.
+
+    Cases are regions between delimiters. If no delimiters, entire file
+    is one case. Empty cases (consecutive delimiters) get zero-length spans.
+
+    Args:
+        doc: Document being parsed
+        delimiter_indices: List of delimiter line indices
+
+    Returns:
+        List of Span objects, one per case
+    """
+    if not delimiter_indices:
+        # No delimiters: entire file is one case
+        return [Span(start=0, end=len(doc.lines))]
+
+    spans = []
+
+    # First case: start of file to first delimiter
+    spans.append(Span(start=0, end=delimiter_indices[0]))
+
+    # Middle cases: between consecutive delimiters
+    for i in range(len(delimiter_indices) - 1):
+        start = delimiter_indices[i] + 1
+        end = delimiter_indices[i + 1]
+        spans.append(Span(start=start, end=end))
+
+    # Last case: after last delimiter to EOF
+    last_start = delimiter_indices[-1] + 1
+    if last_start < len(doc.lines):
+        spans.append(Span(start=last_start, end=len(doc.lines)))
+
+    return spans
+
+
+def _extract_case_metadata(
+    doc: FileDoc, span: Span, case_number: int, header_run_indices: frozenset[int]
+) -> TestCase:
+    """Extract metadata for a single test case.
+
+    Extracts:
+    - CHECK-LABEL names
+    - Local RUN line indices
+    - CHECK directive count
+
+    Args:
+        doc: Document containing the case
+        span: Span defining case boundaries
+        case_number: 1-based case number
+        header_run_indices: File-level RUN line indices
+
+    Returns:
+        TestCase with extracted metadata
+    """
+    case_lines = doc.slice(span)
+
+    # Extract CHECK-LABEL names
+    primary_name, all_names = CheckLabelExtractor.extract_primary_name(case_lines)
+
+    # Find local RUN lines within this case
+    local_run_indices = set()
+    for idx in range(span.start, span.end):
+        if TAG_RUN_CASE in doc.lines[idx].tags:
+            local_run_indices.add(idx)
+
+    # Count CHECK directives
+    check_count = sum(1 for line in case_lines if TAG_CHECK in line.tags)
+
+    return TestCase(
+        doc=doc,
+        number=case_number,
+        name=primary_name,
+        all_names=all_names,
+        span=span,
+        header_run_lines=header_run_indices,
+        local_run_lines=frozenset(local_run_indices),
+        check_count=check_count,
+    )
+
+
+def parse_test_file(path: Path) -> TestFile:
+    """Parse a lit test file into structured representation.
+
+    This is the main entry point for parsing. It:
+    1. Reads file into FileDoc
+    2. Tags lines by type
+    3. Finds delimiters
+    4. Builds case spans
+    5. Extracts metadata for each case
+
+    Args:
+        path: Path to lit test file
+
+    Returns:
+        TestFile with all structure and metadata
+
+    Example:
+        >>> test_file = parse_test_file(Path("test.mlir"))
+        >>> for case in test_file.cases:
+        ...     print(f"Case {case.number}: {case.name}")
+    """
+    # Read and parse file
+    text = path.read_text(encoding="utf-8")
+    doc = FileDoc.from_text(text, path=path)
+
+    # Tag lines by type
+    doc = _tag_lines(doc)
+
+    # Find structure
+    delimiter_indices = _find_delimiter_indices(doc)
+    case_spans = _build_case_spans(doc, delimiter_indices)
+
+    # Determine header span (lines before first delimiter)
+    header_span = Span(start=0, end=delimiter_indices[0]) if delimiter_indices else None
+
+    # Find header RUN lines
+    header_run_indices = frozenset(
+        idx for idx in range(len(doc.lines)) if TAG_RUN_HEADER in doc.lines[idx].tags
+    )
+
+    # Extract metadata for each case
+    cases = []
+    for case_num, span in enumerate(case_spans, start=1):
+        case = _extract_case_metadata(doc, span, case_num, header_run_indices)
+        cases.append(case)
+
+    return TestFile(
+        doc=doc,
+        cases=tuple(cases),
+        header_span=header_span,
+        delimiter_lines=tuple(delimiter_indices),
+    )

--- a/tools/utils/lit_tools/core/rendering.py
+++ b/tools/utils/lit_tools/core/rendering.py
@@ -1,0 +1,149 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Rendering utilities for lit test files.
+
+This module provides functions for rebuilding complete test files
+from parsed TestFile objects, with support for both line-preserving
+and normalized output modes.
+"""
+
+from .parser import TAG_RUN_HEADER, TestFile
+
+
+def build_file_content(test_file: TestFile, normalize: bool = False) -> str:
+    """Build complete file content from parsed TestFile.
+
+    This is the main function for rebuilding lit test files after
+    transformations. It handles:
+    - Header RUN lines (always preserved at top)
+    - Case separation with // ----- delimiters
+    - Case rendering (line-preserving or normalized)
+
+    Args:
+        test_file: Parsed test file with structure
+        normalize: If True, use normalized rendering (drop RUNs, trim blanks)
+                   If False, preserve original structure
+
+    Returns:
+        Complete file content as string
+
+    Example (normalize=False):
+        // RUN: iree-opt %s | FileCheck %s
+        // CHECK-LABEL: @foo
+        func @foo() { }
+
+        // -----
+
+        // CHECK-LABEL: @bar
+        func @bar() { }
+
+    Example (normalize=True):
+        // RUN: iree-opt %s | FileCheck %s
+        // CHECK-LABEL: @foo
+        func @foo() { }
+
+        // -----
+
+        // CHECK-LABEL: @bar
+        func @bar() { }
+    """
+    result_parts = []
+
+    # Render header RUN lines first (always at top of file).
+    # For multi-case files, extract from header_span.
+    # For single-case files, scan entire doc for RUN_HEADER tags.
+    header_run_lines = []
+    if test_file.header_span:
+        header_lines = test_file.doc.slice(test_file.header_span)
+        for line in header_lines:
+            if TAG_RUN_HEADER in line.tags:
+                header_run_lines.append(line.get_full_line())
+    else:
+        # Single-case file: scan all lines for RUN_HEADER.
+        for line in test_file.doc.lines:
+            if TAG_RUN_HEADER in line.tags:
+                header_run_lines.append(line.get_full_line())
+
+    if header_run_lines:
+        result_parts.append("".join(header_run_lines))
+
+    # Render each case.
+    for idx, case in enumerate(test_file.cases):
+        # Add delimiter before each case (except first).
+        if idx > 0:
+            if normalize:
+                # Normalized mode: consistent spacing (2 newlines before/after).
+                result_parts.append("\n\n// -----\n\n")
+            else:
+                # Preserving mode: just the delimiter, no added spacing.
+                # Original spacing is preserved in case content (leading/trailing lines).
+                result_parts.append("// -----\n")
+
+        # Render case content.
+        content = case.render_normalized() if normalize else case.render_for_testing()
+
+        if content:  # Skip empty cases.
+            result_parts.append(content)
+
+    # Join all parts.
+    full_content = "".join(result_parts)
+
+    # Ensure file ends with newline.
+    if not full_content.endswith("\n"):
+        full_content += "\n"
+
+    return full_content
+
+
+def inject_run_lines_with_case(
+    content: str, header_runs: list[str], case_runs: list[tuple[int, str]]
+) -> str:
+    """Injects RUN lines for both header and in-body case RUN commands.
+
+    - Replaces the first N lines with header RUN commands.
+    - Replaces specific relative lines (within the case body) with RUN commands.
+
+    Args:
+        content: Test case content (typically with blank lines where RUNs should go)
+        header_runs: List of header RUN command strings (without // RUN: prefix)
+        case_runs: List of (absolute_line_index, command) tuples for case-local RUNs
+
+    Returns:
+        Content with RUN lines injected
+
+    Raises:
+        ValueError: If case_runs indices are out of range for the content.
+                    This can happen if replacement content has different structure
+                    than the original (different number of lines or blank padding).
+
+    Note:
+        iree-lit-replace uses top-injection for case-local RUNs (not this function),
+        so this error primarily affects iree-lit-test's lit_wrapper.
+    """
+    lines = content.splitlines()
+    # Header runs at the very top.
+    for i, cmd in enumerate(header_runs):
+        if i < len(lines):
+            lines[i] = f"// RUN: {cmd}"
+        else:
+            lines.append(f"// RUN: {cmd}")
+
+    # Case-local runs within the case region: absolute positions in synthesized content.
+    # Strict mode: error if indices go out of range due to content structure changes.
+    for abs_index, cmd in case_runs:
+        idx = abs_index
+        if not (0 <= idx < len(lines)):
+            raise ValueError(
+                f"Cannot inject RUN line at index {idx}: content only has {len(lines)} lines.\n"
+                f"This typically happens when replacement content has different structure than original.\n"
+                f"Solutions:\n"
+                f"  1. Use --replace-run-lines to replace RUN lines explicitly\n"
+                f"  2. Adjust replacement content to match original line structure\n"
+                f"  3. Remove RUN lines from replacement (they'll be re-added from original)"
+            )
+        lines[idx] = f"// RUN: {cmd}"
+    return "\n".join(lines)

--- a/tools/utils/lit_tools/core/suggestions.py
+++ b/tools/utils/lit_tools/core/suggestions.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Fuzzy matching utilities for user-friendly error messages.
+
+This module provides utilities for suggesting similar names when a user-provided
+identifier (like a test case name) cannot be found. Uses Python's difflib for
+fuzzy string matching with configurable similarity thresholds.
+"""
+
+import difflib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lit_tools.core.parser import TestCase
+
+
+def find_similar_case_names(
+    target_name: str,
+    all_cases: list["TestCase"],
+    max_suggestions: int = 3,
+    cutoff: float = 0.6,
+) -> list[str]:
+    """Find case names similar to target using fuzzy matching.
+
+    Uses difflib.get_close_matches() to find case names that are similar to
+    the target name. The similarity is based on the SequenceMatcher algorithm
+    which compares sequences of characters.
+
+    Args:
+        target_name: The name that was not found.
+        all_cases: List of all test cases to search.
+        max_suggestions: Maximum number of suggestions to return (default: 3).
+        cutoff: Minimum similarity ratio (0.0-1.0) to consider a match.
+            Default 0.6 means 60% similarity. Lower values are more permissive.
+
+    Returns:
+        List of similar case names, sorted by similarity (most similar first).
+        Empty list if no similar names found or if all_cases has no names.
+
+    Example:
+        >>> cases = [
+        ...     TestCase(name="emplaceDispatch", ...),
+        ...     TestCase(name="dontEmplaceTiedDispatch", ...),
+        ...     TestCase(name="emplaceDispatchSequence", ...),
+        ... ]
+        >>> find_similar_case_names("emplceDispatch", cases)
+        ['emplaceDispatch', 'emplaceDispatchSequence']
+    """
+    # Extract non-empty names from test cases.
+    available_names = [c.name for c in all_cases if c.name]
+    if not available_names:
+        return []
+
+    # difflib.get_close_matches uses SequenceMatcher with configurable cutoff.
+    # It returns matches sorted by similarity (highest first).
+    return difflib.get_close_matches(
+        target_name, available_names, n=max_suggestions, cutoff=cutoff
+    )
+
+
+def format_case_name_error(
+    target_name: str, all_cases: list["TestCase"], file_path: str | None = None
+) -> str:
+    """Format error message with suggestions for case name not found.
+
+    Generates a user-friendly error message that includes suggestions for
+    similar case names if any are found. The format adapts based on the
+    number of suggestions found.
+
+    Args:
+        target_name: The name that was not found.
+        all_cases: List of all test cases.
+        file_path: Optional path to include in message.
+
+    Returns:
+        Formatted error message with suggestions.
+
+    Examples:
+        No suggestions:
+            "Case with name 'xyz' not found"
+
+        Single suggestion:
+            "Case with name 'emplceDispatch' not found. Did you mean 'emplaceDispatch'?"
+
+        Multiple suggestions:
+            "Case with name 'emplace' not found. Did you mean one of: 'emplaceDispatch', 'emplaceDispatchSequence'?"
+
+        With file path:
+            "Case with name 'xyz' not found in test.mlir"
+    """
+    # Build base error message.
+    base_msg = f"Case with name '{target_name}' not found"
+    if file_path:
+        base_msg += f" in {file_path}"
+
+    # Try to find similar names.
+    suggestions = find_similar_case_names(target_name, all_cases)
+    if not suggestions:
+        return base_msg
+
+    # Format suggestions based on count.
+    if len(suggestions) == 1:
+        return f"{base_msg}. Did you mean '{suggestions[0]}'?"
+
+    # Multiple suggestions - format as comma-separated list.
+    suggestion_list = "', '".join(suggestions)
+    return f"{base_msg}. Did you mean one of: '{suggestion_list}'?"
+
+
+def format_case_number_error(
+    requested_number: int, total_cases: int, file_path: str | None = None
+) -> str:
+    """Format error message for invalid case number.
+
+    Generates a user-friendly error message when a case number is out of range,
+    providing context about the valid range.
+
+    Args:
+        requested_number: The case number that was requested.
+        total_cases: Total number of cases in the file.
+        file_path: Optional path to include in message.
+
+    Returns:
+        Formatted error message with range information.
+
+    Examples:
+        "Case 999 not found (file has 10 cases)"
+        "Case 0 not found in test.mlir (file has 5 cases)"
+    """
+    base_msg = f"Case {requested_number} not found"
+    if file_path:
+        base_msg += f" in {file_path}"
+    base_msg += f" (file has {total_cases} case{'s' if total_cases != 1 else ''})"
+    return base_msg

--- a/tools/utils/lit_tools/core/text_utils.py
+++ b/tools/utils/lit_tools/core/text_utils.py
@@ -1,0 +1,209 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Cross-platform text normalization and comparison utilities for lit tools."""
+
+import os
+import re
+
+
+def normalize_line_endings(text: str) -> str:
+    r"""Normalize line endings to platform-specific format.
+
+    Args:
+        text: Text with any line ending style (\n, \r\n, \r)
+
+    Returns:
+        Text with platform-specific line endings (os.linesep)
+    """
+    # Normalize to \n first, then convert to platform line ending.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    if os.linesep != "\n":
+        text = text.replace("\n", os.linesep)
+    return text
+
+
+def split_lines(text: str) -> list[str]:
+    r"""Split text into lines in a cross-platform way.
+
+    Handles \n, \r\n, and \r line endings.
+
+    Args:
+        text: Text to split
+
+    Returns:
+        List of lines (without line ending characters)
+    """
+    return text.splitlines()
+
+
+def join_lines(lines: list[str]) -> str:
+    """Join lines using platform-specific line separator.
+
+    Args:
+        lines: List of lines to join
+
+    Returns:
+        Text with platform-specific line endings
+    """
+    return os.linesep.join(lines)
+
+
+def strip_run_lines(content: str) -> str:
+    """Strip RUN lines from lit test content.
+
+    Removes all lines starting with '// RUN:' (with optional leading whitespace).
+
+    Args:
+        content: Lit test content
+
+    Returns:
+        Content with RUN lines removed
+    """
+    lines = split_lines(content)
+    non_run_lines = [line for line in lines if not line.strip().startswith("// RUN:")]
+    return join_lines(non_run_lines)
+
+
+def normalize_whitespace_for_comparison(content: str) -> str:
+    r"""Normalize whitespace for content comparison.
+
+    - Strips leading/trailing whitespace from each line
+    - Removes empty lines from start and end
+    - Normalizes line endings to \n
+    - Preserves internal blank lines and indentation structure
+
+    Args:
+        content: Text content to normalize
+
+    Returns:
+        Normalized content for comparison
+    """
+    lines = split_lines(content)
+
+    # Strip leading empty lines.
+    while lines and not lines[0].strip():
+        lines.pop(0)
+
+    # Strip trailing empty lines.
+    while lines and not lines[-1].strip():
+        lines.pop()
+
+    # Use \n for comparison (platform-independent).
+    return "\n".join(lines)
+
+
+def compare_ir_content(
+    content1: str, content2: str, ignore_run_lines: bool = True
+) -> bool:
+    """Compare two IR content strings for semantic equality.
+
+    Comparison is done after:
+    - Optionally stripping RUN lines
+    - Normalizing whitespace
+    - Normalizing line endings
+
+    Args:
+        content1: First content to compare
+        content2: Second content to compare
+        ignore_run_lines: If True, strip RUN lines before comparing
+
+    Returns:
+        True if contents are semantically equal
+    """
+    # Strip RUN lines if requested.
+    if ignore_run_lines:
+        content1 = strip_run_lines(content1)
+        content2 = strip_run_lines(content2)
+
+    # Normalize whitespace for comparison.
+    norm1 = normalize_whitespace_for_comparison(content1)
+    norm2 = normalize_whitespace_for_comparison(content2)
+
+    return norm1 == norm2
+
+
+def extract_run_lines_from_content(content: str) -> list[str]:
+    """Extract RUN lines from content.
+
+    Args:
+        content: Content containing RUN lines
+
+    Returns:
+        List of RUN line text (without '// RUN:' prefix)
+    """
+    lines = split_lines(content)
+    run_lines = []
+
+    for line in lines:
+        match = re.match(r"^\s*//\s*RUN:\s?(.*)$", line)
+        if match:
+            run_lines.append(match.group(1))
+
+    return run_lines
+
+
+def _strip_run_lines_preserve_line_numbers(content: str) -> str:
+    """Replace RUN lines with blank lines to preserve line numbers.
+
+    Handles multi-line RUN commands with backslash continuation.
+    RUN lines can appear anywhere in content, not just at the top.
+
+    Args:
+        content: Test case content potentially containing RUN lines
+
+    Returns:
+        Content with RUN lines replaced by blank lines
+    """
+    lines = content.splitlines()
+    result = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        # Check if this is a RUN line.
+        if re.match(r"^\s*//\s*RUN:", line):
+            # Replace RUN line with blank line.
+            result.append("")
+
+            # Handle continuation lines (backslash at end).
+            while i < len(lines) - 1 and lines[i].rstrip().endswith("\\"):
+                i += 1
+                result.append("")  # Replace continuation with blank.
+        else:
+            result.append(line)
+
+        i += 1
+
+    return "\n".join(result)
+
+
+def inject_run_lines(content: str, run_lines: list[str]) -> str:
+    """Inject RUN lines by replacing leading blank lines.
+
+    The content from parse_test_file() has blank lines where RUN lines were
+    stripped. When lit_wrapper prepends more blanks for line preservation,
+    we have a pile of blanks at the top. Just fill the first N of them with
+    RUN lines.
+
+    Args:
+        content: Test case content with leading blanks (from line preservation)
+        run_lines: List of RUN commands (from extract_run_lines)
+
+    Returns:
+        Content with RUN lines injected at top
+    """
+    if not run_lines:
+        return content
+
+    lines = content.splitlines()
+
+    # Replace first N lines with RUN lines.
+    for i, cmd in enumerate(run_lines):
+        if i < len(lines):
+            lines[i] = f"// RUN: {cmd}"
+
+    return "\n".join(lines)

--- a/tools/utils/lit_tools/core/verification.py
+++ b/tools/utils/lit_tools/core/verification.py
@@ -1,0 +1,241 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared IR verification utilities for iree-lit-* tools.
+
+This module provides functions for verifying MLIR IR using iree-opt and
+detecting when IR is intentionally invalid (contains expected-error directives).
+"""
+
+import argparse
+import subprocess
+from typing import TYPE_CHECKING
+
+from common import build_detection
+
+if TYPE_CHECKING:
+    from lit_tools.core.parser import TestCase
+
+
+def verify_ir(
+    content: str,
+    case_info: str = "",
+    args: argparse.Namespace | None = None,
+    timeout: int = 5,
+) -> tuple[bool, str]:
+    """Verifies IR content using iree-opt (MLIR verifier).
+
+    Runs iree-opt with no flags, which invokes the MLIR verifier to check
+    structural validity of the IR.
+
+    Args:
+        content: MLIR IR content to verify
+        case_info: Description of case being verified (for error messages)
+        args: Parsed arguments (for console output control)
+        timeout: Verification timeout in seconds
+
+    Returns:
+        Tuple of (success: bool, error_message: str)
+        - If success=True, error_message is empty
+        - If success=False, error_message contains verification failure details
+    """
+    try:
+        # Find iree-opt
+        iree_opt = build_detection.find_tool("iree-opt")
+    except FileNotFoundError as e:
+        return (False, str(e))
+
+    try:
+        # Run iree-opt on stdin (no flags = just verify IR structure)
+        result = subprocess.run(
+            [str(iree_opt), "-"],
+            input=content,
+            capture_output=True,
+            timeout=timeout,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            # Truncate stderr for human output, keep full for JSON.
+            stderr = result.stderr
+            if args and not args.json and len(stderr) > 1000:
+                stderr = (
+                    stderr[:1000]
+                    + "\n... (output truncated, use --json for full diagnostics)"
+                )
+
+            error_msg = "Verification failed"
+            if case_info:
+                error_msg += f" for {case_info}"
+            error_msg += f":\n{stderr}\nTip: Run iree-opt on extracted case to debug"
+            return (False, error_msg)
+
+        return (True, "")
+
+    except subprocess.TimeoutExpired:
+        error_msg = f"Verification timeout ({timeout}s)"
+        if case_info:
+            error_msg += f" for {case_info}"
+        error_msg += ".\nCheck for infinite loops or increase timeout with --verify-timeout SECONDS"
+        return (False, error_msg)
+
+
+def verify_ir_file(
+    file_path: str, case_info: str, args: argparse.Namespace, timeout: int = 5
+) -> tuple[bool, str]:
+    """Verifies IR from a file using iree-opt (MLIR verifier).
+
+    Args:
+        file_path: Path to MLIR file to verify
+        case_info: Description of case being verified (for error messages)
+        args: Parsed arguments
+        timeout: Verification timeout in seconds
+
+    Returns:
+        Tuple of (success: bool, error_message: str)
+        - If success=True, error_message is empty
+        - If success=False, error_message contains verification failure details
+    """
+    try:
+        # Find iree-opt
+        iree_opt = build_detection.find_tool("iree-opt")
+    except FileNotFoundError as e:
+        return (False, str(e))
+
+    try:
+        # Run iree-opt on file (no flags = just verify IR structure)
+        result = subprocess.run(
+            [str(iree_opt), file_path],
+            capture_output=True,
+            timeout=timeout,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            # Truncate stderr for human output, keep full for JSON
+            stderr = result.stderr
+            if not args.json and len(stderr) > 1000:
+                stderr = (
+                    stderr[:1000]
+                    + "\n... (output truncated, use --json for full diagnostics)"
+                )
+
+            error_msg = (
+                f"Verification failed for {case_info}:\n"
+                f"{stderr}\n"
+                f"Tip: Run iree-opt on extracted case to debug"
+            )
+            return (False, error_msg)
+
+        return (True, "")
+
+    except subprocess.TimeoutExpired:
+        error_msg = (
+            f"Verification timeout ({timeout}s) for {case_info}.\n"
+            f"Check for infinite loops or increase timeout with --verify-timeout SECONDS"
+        )
+        return (False, error_msg)
+
+
+def should_skip_verification_for_case(case: "TestCase") -> bool:
+    """Check if test case expects diagnostic errors and should skip verification.
+
+    Args:
+        case: Test case to check
+
+    Returns:
+        True if case contains expected-error directives, False otherwise
+    """
+    # MLIR diagnostic directives indicate IR is intentionally invalid.
+    diagnostic_patterns = [
+        "// expected-error",
+        "// expected-warning",
+        "// expected-note",
+    ]
+    return any(pattern in case.content for pattern in diagnostic_patterns)
+
+
+def should_skip_verification_for_content(content: str) -> bool:
+    """Check if IR content expects diagnostic errors and should skip verification.
+
+    Args:
+        content: IR content to check
+
+    Returns:
+        True if content contains expected-error directives, False otherwise
+    """
+    # MLIR diagnostic directives indicate IR is intentionally invalid.
+    diagnostic_patterns = [
+        "// expected-error",
+        "// expected-warning",
+        "// expected-note",
+    ]
+    return any(pattern in content for pattern in diagnostic_patterns)
+
+
+def verify_content_with_skip_check(
+    content: str,
+    case_number: int,
+    case_name: str | None,
+    args: argparse.Namespace,
+    timeout: int | None = None,
+) -> tuple[bool, bool, str]:
+    """Verify IR content with automatic skip check for expected-error directives.
+
+    This helper consolidates the common pattern of:
+    1. Check if content should skip verification (has expected-error)
+    2. Print skip note if not quiet
+    3. Run verification if not skipped
+    4. Return structured result
+
+    Args:
+        content: IR content to verify
+        case_number: Case number for error messages
+        case_name: Case name (from CHECK-LABEL) or None
+        args: Parsed arguments (for --quiet, --json, --verify flags)
+        timeout: Optional verification timeout override
+
+    Returns:
+        Tuple of (was_skipped, is_valid, error_message)
+        - was_skipped: True if verification was skipped due to expected-error
+        - is_valid: True if verification passed (always True if skipped)
+        - error_message: Error details if verification failed, empty otherwise
+
+    Example:
+        >>> skipped, valid, error = verify_content_with_skip_check(
+        ...     content, case.number, case.name, args
+        ... )
+        >>> if not skipped and not valid:
+        ...     console.error(error, args=args)
+        ...     return exit_codes.ERROR
+    """
+    from common import console  # noqa: PLC0415
+
+    # Check if verification is disabled globally.
+    if not args.verify:
+        return (False, True, "")
+
+    # Check if content has expected-error directives (skip verification).
+    if should_skip_verification_for_content(content):
+        if not args.quiet:
+            console.note(
+                f"Skipping verification for case {case_number}: "
+                "contains expected-error directives",
+                args=args,
+            )
+        return (True, True, "")
+
+    # Build case info string for error messages.
+    case_info = f"Case {case_number}"
+    if case_name:
+        case_info += f" (@{case_name})"
+
+    # Run verification.
+    if timeout is None:
+        timeout = getattr(args, "verify_timeout", 5)
+
+    valid, error_msg = verify_ir(content, case_info, args, timeout=timeout)
+    return (False, valid, error_msg)

--- a/tools/utils/lit_tools/iree_lit_extract.py
+++ b/tools/utils/lit_tools/iree_lit_extract.py
@@ -1,0 +1,570 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Extract individual test cases from MLIR lit test files.
+
+Lit test files often contain multiple test cases separated by `// -----` delimiters.
+This tool extracts individual test cases for isolated testing and debugging.
+
+Usage:
+  # Extract by case number
+  iree-lit-extract test.mlir --case 2
+
+  # Extract multiple cases (separated by // -----)
+  iree-lit-extract test.mlir --case 1,3,5
+  iree-lit-extract test.mlir --case 1-3
+  iree-lit-extract test.mlir --case 1 --case 3 --case 5
+
+  # Extract by function name
+  iree-lit-extract test.mlir --name function_name
+
+  # Extract test containing a specific line (useful from error messages)
+  iree-lit-extract test.mlir --containing 142
+
+  # Filter by name pattern (extract all cases with "fold" in name)
+  iree-lit-extract test.mlir --filter "fold"
+
+  # Exclude by name pattern (extract all except GPU cases)
+  iree-lit-extract test.mlir --filter-out "gpu"
+
+  # List available test cases first
+  iree-lit-extract test.mlir --list
+
+  # JSON listing (scripting)
+  iree-lit-extract test.mlir --list --json > cases.json
+
+  # Save to file instead of stdout
+  iree-lit-extract test.mlir --case 2 -o /tmp/case2.mlir
+
+  # Extract without RUN lines (just IR)
+  iree-lit-extract test.mlir --case 2 --exclude-run-lines > /tmp/case2.mlir
+
+  # Verify extracted IR is structurally valid
+  iree-lit-extract test.mlir --case 2 --verify
+
+  # Extract with JSON output (array of case objects)
+  iree-lit-extract test.mlir --case 2 --json > cases.json
+
+Examples:
+  # Extract second test case to stdout
+  $ iree-lit-extract test.mlir --case 2
+  // CHECK-LABEL: @second_case
+  util.func @second_case(%arg0: tensor<8xf32>) -> tensor<8xf32> {
+    ...
+  }
+
+  # Extract test case by name
+  $ iree-lit-extract test.mlir --name multiple_transients
+  // CHECK-LABEL: @multiple_transients
+  util.func @multiple_transients() {
+    ...
+  }
+
+  # Find which test contains error at line 142
+  $ iree-lit-extract test.mlir --containing 142
+  // Test case 3: @nested_execute (lines 91-142)
+  // CHECK-LABEL: @nested_execute
+  util.func @nested_execute() {
+    ...  // <- line 142 is here
+  }
+
+  # Extract to stdout for standalone execution (RUN lines included by default)
+  $ iree-lit-extract test.mlir --case 2 > /tmp/case2.mlir
+  $ iree-opt /tmp/case2.mlir  # Can run directly
+
+  # Verify extraction
+  $ iree-lit-extract test.mlir --case 2 --verify
+  Test case 2: @second_case (lines 14-24) extracted successfully
+  Verification: IR is structurally valid
+
+  # Extract all cases with "fold" in name (produces split-input file)
+  $ iree-lit-extract test.mlir --filter "fold" -o /tmp/fold_cases.mlir
+  # Creates file with multiple cases separated by // -----
+
+  # Extract all cases except GPU-related ones
+
+  # Write JSON array to a file
+  $ iree-lit-extract test.mlir --case 2 --json -o /tmp/case2.json
+  $ iree-lit-extract test.mlir --filter-out "gpu" -o /tmp/no_gpu.mlir
+
+Exit codes:
+  0 - Success
+  1 - Error (parse failure, verification failure)
+  2 - Not found (file doesn't exist, case not found, invalid case number)
+
+See Also:
+  iree-lit-list - List all test cases in a file
+  iree-lit-test - Run test cases in isolation
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lit_tools.core.parser import TestCase, TestFile
+
+# Import from other categories (added to sys.path as top-level packages)
+from common import console, exit_codes, formatting, fs
+
+# Import from own category (as absolute path within sys.path)
+from lit_tools.core import (
+    cli,
+    listing,
+    verification,
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Extract individual test cases from MLIR lit test files",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("file", help="Path to lit test file")
+
+    # Selection options (shared with iree-lit-test and iree-lit-lint).
+    cli.add_selection_arguments(parser)
+
+    # Output options
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="FILE",
+        help="Output file (default: stdout)",
+    )
+    parser.add_argument(
+        "--exclude-run-lines",
+        action="store_true",
+        help="Exclude RUN lines from output (default: include for complete, runnable tests)",
+    )
+
+    # Verification options
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify IR is structurally valid with iree-opt (recommended after rebuilding tools)",
+    )
+
+    # Filtering options (consistent with iree-lit-test).
+    cli.add_filter_arguments(parser)
+
+    # Common output flags (--json/--pretty/--quiet)
+    cli.add_common_output_flags(parser)
+
+    return parser.parse_args()
+
+
+def format_case_info(case: TestCase) -> str:
+    """Formats test case information for comment header.
+
+    Args:
+        case: TestCase object
+
+    Returns:
+        Formatted comment string
+    """
+    return formatting.case_banner(case, pretty=False)
+
+
+def list_cases(file_path: Path, *, pretty: bool = False, quiet: bool = False) -> int:
+    """Lists all test cases (delegated to iree-lit-list behavior).
+
+    Args:
+        file_path: Path to lit test file
+        pretty: Enable colorized output
+        quiet: Suppress header
+
+    Returns:
+        Exit code
+    """
+    try:
+        cases = listing.get_cases(file_path)
+        console.out(
+            listing.format_text_listing(
+                file_path, cases, pretty=pretty, header=not quiet
+            )
+        )
+        return exit_codes.SUCCESS
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Listing failed: {e}", args=None)
+        return exit_codes.ERROR
+
+
+def _validate_selection_args(args: argparse.Namespace) -> int:
+    """Validates that exactly one selection method is specified.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS if valid, exit_codes.NOT_FOUND if invalid
+    """
+    has_case = bool(args.case)
+    has_name = bool(args.name)
+    selection_count = (
+        int(has_case)
+        + int(has_name)
+        + int(args.containing is not None)
+        + int(args.list)
+    )
+    using_filters = args.filter or args.filter_out
+    if selection_count != 1 and not (selection_count == 0 and using_filters):
+        console.error(
+            "specify exactly one of: --case, --name, --containing, --list, or --filter",
+            args=args,
+        )
+        return exit_codes.NOT_FOUND
+    return exit_codes.SUCCESS
+
+
+def _handle_list_mode(file_path: Path, args: argparse.Namespace) -> int:
+    """Handles --list mode for displaying available test cases.
+
+    Args:
+        file_path: Path to test file
+        args: Parsed command-line arguments
+
+    Returns:
+        exit code (SUCCESS or ERROR)
+    """
+    if args.json:
+        try:
+            cases = listing.get_cases(file_path)
+            payload = listing.build_json_payload(file_path, cases)
+            console.print_json(payload, args=args)
+            return exit_codes.SUCCESS
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            console.error(f"Listing failed: {e}", args=args)
+            return exit_codes.ERROR
+    return list_cases(file_path, pretty=args.pretty, quiet=args.quiet)
+
+
+def _build_text_output(
+    selected_cases: list[TestCase], test_file: TestFile, args: argparse.Namespace
+) -> str:
+    """Builds text output content from selected cases.
+
+    Args:
+        selected_cases: List of TestCase objects to output
+        test_file: Parsed test file object
+        args: Parsed command-line arguments
+
+    Returns:
+        String containing formatted output content
+    """
+    output_parts = []
+
+    # Include RUN lines by default for complete, runnable test cases.
+    # - Default: include RUN lines (makes extract | test pipeline work naturally)
+    # - --exclude-run-lines: opt-out for workflows that need clean IR
+    # - JSON: never include RUN lines (metadata separate from content)
+    include_runs = not args.exclude_run_lines and not args.json
+    num_header_run_lines = 0
+    if include_runs:
+        run_lines_section = _extract_run_lines_section(test_file, selected_cases, args)
+        if run_lines_section:
+            output_parts.append(run_lines_section)
+            # Count number of header RUN lines (raw format, to get physical line count).
+            num_header_run_lines = len(test_file.extract_run_lines(raw=True))
+
+    # Add case content.
+    # If we included RUN lines, strip corresponding leading newlines from first case
+    # (case.content has leading newlines for each header RUN line that was stripped).
+    case_outputs = []
+    for i, case in enumerate(selected_cases):
+        content = case.content
+        # Strip leading newlines from first case when RUN lines are included.
+        if i == 0 and include_runs:
+            # Strip newlines for header RUN lines.
+            for _ in range(num_header_run_lines):
+                if content.startswith("\n"):
+                    content = content[1:]
+            # Also strip newlines for case-local RUN lines (they were also stripped from content).
+            case_runs = case.extract_local_run_lines()
+            for _ in range(len(case_runs)):
+                if content.startswith("\n"):
+                    content = content[1:]
+        case_outputs.append(content)
+
+    if len(case_outputs) > 1:
+        output_parts.append("\n\n// -----\n\n".join(case_outputs))
+    else:
+        output_parts.append(case_outputs[0])
+
+    return "\n".join(output_parts)
+
+
+def _extract_run_lines_section(
+    test_file: TestFile, selected_cases: list[TestCase], args: argparse.Namespace
+) -> str | None:
+    """Extracts and formats RUN lines section including header and case-local RUN lines.
+
+    Args:
+        test_file: Parsed test file object
+        selected_cases: List of selected test cases
+        args: Parsed command-line arguments
+
+    Returns:
+        Formatted RUN lines string or None if extraction failed
+    """
+    try:
+        # Get header RUN lines.
+        header_runs = test_file.extract_run_lines()
+        run_lines = list(header_runs)  # Copy to avoid modifying original.
+
+        # If extracting specific cases, also include case-local RUN lines.
+        # Combine all case-local RUN lines from selected cases.
+        # Note: We preserve case-local RUNs even if they duplicate header RUNs,
+        # as they may be intentionally specified for that case.
+        for case in selected_cases:
+            case_runs = case.extract_local_run_lines()
+            for _, cmd in case_runs:
+                # Always include case-local RUNs (even if they duplicate header).
+                run_lines.append(cmd)
+
+        if not run_lines:
+            return None
+
+        run_lines_section = []
+        for run_line in run_lines:
+            line = f"// RUN: {run_line}"
+            if args.pretty and not args.output:
+                line = console.maybe_highlight_run(line, args=args)
+            run_lines_section.append(line)
+        # Note: Don't add blank line here - case content preserves the original
+        # blank line after stripping leading newlines for header RUN lines.
+        return "\n".join(run_lines_section)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.warn(f"Could not extract RUN lines: {e}", args=args)
+        return None
+
+
+def _verify_selected_cases(
+    selected_cases: list[TestCase], args: argparse.Namespace
+) -> int:
+    """Verifies IR for all selected cases if requested.
+
+    Args:
+        selected_cases: List of test cases to verify
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS if all valid, exit_codes.ERROR if any invalid
+    """
+    if not args.verify:
+        return exit_codes.SUCCESS
+
+    all_valid = True
+    for case in selected_cases:
+        _, valid, error_msg = verification.verify_content_with_skip_check(
+            case.content, case.number, case.name, args
+        )
+        if not valid:
+            console.error(error_msg, args=args)
+            all_valid = False
+    return exit_codes.SUCCESS if all_valid else exit_codes.ERROR
+
+
+def _build_json_payload(selected_cases: list[TestCase]) -> list[dict]:
+    """Builds JSON payload from selected cases.
+
+    Args:
+        selected_cases: List of test cases to include in payload
+
+    Returns:
+        List of case dictionaries
+    """
+    return [
+        {
+            "number": c.number,
+            "name": c.name,
+            "start_line": c.start_line,
+            "end_line": c.end_line,
+            "line_count": c.line_count,
+            "check_count": c.check_count,
+            "content": c.content,
+        }
+        for c in selected_cases
+    ]
+
+
+def _write_output_file(
+    selected_cases: list[TestCase],
+    output_content: str,
+    output_path: Path,
+    args: argparse.Namespace,
+) -> int:
+    """Writes output to file in JSON or text mode.
+
+    Args:
+        selected_cases: List of test cases to write
+        output_content: Text content to write (if not JSON mode)
+        output_path: Path to output file
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS if write succeeded, exit_codes.ERROR if failed
+    """
+    try:
+        if args.json:
+            payload = _build_json_payload(selected_cases)
+            text = (
+                json.dumps(payload, separators=(",", ":"), sort_keys=True)
+                if args.quiet
+                else json.dumps(payload, indent=2, sort_keys=True)
+            )
+            fs.safe_write_text(output_path, text)
+
+            if not args.quiet:
+                console.note(
+                    f"Wrote JSON for {len(selected_cases)} case(s) to {output_path}",
+                    args=args,
+                )
+        else:
+            fs.safe_write_text(output_path, output_content)
+            if not args.quiet:
+                _print_file_write_summary(selected_cases, output_path, args)
+        return exit_codes.SUCCESS
+    except OSError as e:
+        console.error(f"Write failed: {e}", args=args)
+        return exit_codes.ERROR
+
+
+def _print_file_write_summary(
+    selected_cases: list[TestCase], output_path: Path, args: argparse.Namespace
+) -> None:
+    """Prints summary message after writing cases to file.
+
+    Args:
+        selected_cases: List of test cases written
+        output_path: Path where cases were written
+        args: Parsed command-line arguments
+    """
+    if len(selected_cases) == 1:
+        case = selected_cases[0]
+        name = f"@{case.name}" if case.name else "(unnamed)"
+        banner = (
+            f"Test case {case.number}: {name} (lines {case.start_line}-{case.end_line})"
+        )
+        console.note(f"{banner} extracted to {output_path}", args=args)
+    else:
+        case_nums = ", ".join(str(c.number) for c in selected_cases)
+        console.note(
+            f"{len(selected_cases)} test cases ({case_nums}) extracted to {output_path}",
+            args=args,
+        )
+    if args.verify:
+        console.success("All IR parses correctly", args=args)
+
+
+def _output_to_stdout(
+    selected_cases: list[TestCase], output_content: str, args: argparse.Namespace
+) -> None:
+    """Outputs selected cases to stdout in JSON or text mode.
+
+    Args:
+        selected_cases: List of test cases to output
+        output_content: Text content to output (if not JSON mode)
+        args: Parsed command-line arguments
+    """
+    if args.json:
+        payload = _build_json_payload(selected_cases)
+        console.print_json(payload, args=args)
+    else:
+        console.write(output_content)
+
+
+def _apply_filters_if_needed(
+    all_cases: list[TestCase],
+    selected_cases: list[TestCase],
+    args: argparse.Namespace,
+) -> tuple[list[TestCase] | None, int]:
+    """Applies regex filters if specified and not using explicit selectors.
+
+    Args:
+        all_cases: List of all parsed test cases
+        selected_cases: Currently selected test cases
+        args: Parsed command-line arguments
+
+    Returns:
+        Tuple of (filtered_cases, exit_code). Exit code is NOT_FOUND on filter error.
+    """
+    if (
+        (args.filter or args.filter_out)
+        and not args.case
+        and not args.name
+        and args.containing is None
+    ):
+        filtered = cli.apply_filters(all_cases, args.filter, args.filter_out, args=args)
+        if filtered is None:
+            return None, exit_codes.NOT_FOUND
+        return filtered, exit_codes.SUCCESS
+    return selected_cases, exit_codes.SUCCESS
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS, ERROR, or NOT_FOUND)
+    """
+    file_path = Path(args.file)
+
+    # Enforce selection exclusivity.
+    result = _validate_selection_args(args)
+    if result != exit_codes.SUCCESS:
+        return result
+
+    # Handle --list mode.
+    if args.list:
+        return _handle_list_mode(file_path, args)
+
+    # Parse test file to get all cases.
+    test_file, all_cases, exit_code = cli.load_and_parse_test_file(file_path, args)
+    if exit_code != exit_codes.SUCCESS:
+        return exit_code
+
+    # Select cases based on criteria.
+    selected_cases = cli.select_cases(all_cases, args)
+    if selected_cases is None:
+        return exit_codes.NOT_FOUND
+
+    # Apply regex filters if specified.
+    selected_cases, result = _apply_filters_if_needed(all_cases, selected_cases, args)
+    if result != exit_codes.SUCCESS:
+        return result
+
+    # Build text output.
+    output_content = _build_text_output(selected_cases, test_file, args)
+
+    # Verify if requested.
+    result = _verify_selected_cases(selected_cases, args)
+    if result != exit_codes.SUCCESS:
+        return result
+
+    # Output results.
+    if args.output:
+        output_path = Path(args.output)
+        return _write_output_file(selected_cases, output_content, output_path, args)
+    _output_to_stdout(selected_cases, output_content, args)
+    return exit_codes.SUCCESS
+
+
+if __name__ == "__main__":
+    sys.exit(
+        cli.run_with_argparse_suggestions(
+            parse_arguments, main, cli.suggest_common_mistakes
+        )
+    )

--- a/tools/utils/lit_tools/iree_lit_lint.py
+++ b/tools/utils/lit_tools/iree_lit_lint.py
@@ -1,0 +1,596 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Lint MLIR lit test files for common authoring mistakes.
+
+Catches test authoring errors before running the compiler, provides actionable
+warnings for test smells, and generates training data for fine-tuning models.
+
+Quick Start:
+  # Lint entire file
+  iree-lit-lint test.mlir
+
+  # Lint specific cases
+  iree-lit-lint test.mlir --case 2
+  iree-lit-lint test.mlir --name fold_constants
+
+  # Show only errors
+  iree-lit-lint test.mlir --errors-only
+
+  # JSON output
+  iree-lit-lint test.mlir --json
+
+Key Features:
+
+  Selection:
+    Same selection flags as iree-lit-test and iree-lit-extract:
+    --case, --name, --containing, --filter, --filter-out
+
+  Severity Levels:
+    ERROR: Must fix (raw SSA, zero CHECKs, etc.)
+    WARNING: Should review (wildcards, non-semantic names, etc.)
+    INFO: Suggestions (consider CHECK-NEXT, semantic naming, etc.)
+
+  Filtering:
+    --errors-only: Show only errors (exit code 1 if errors found)
+    --min-severity=warning: Show warnings and errors only
+
+  Output Modes:
+    Grouped (default): Group errors by type, show help once per error
+    Individual (--individual-errors): Show each occurrence separately
+    JSON (--json): Machine-readable for tooling integration
+    Quiet (--quiet): Suppress non-essential output
+
+  Grouped Output Format (default):
+    [ERROR] error_code (N occurrences)
+    Full help text explaining the issue and how to fix it
+
+    file.mlir:45:12: error: error_code: short description
+    file.mlir:67:8: error: error_code: short description
+
+    Each line maintains IDE-parseable format for jump-to-location while
+    deduplicating verbose help text
+
+Common Workflows:
+
+  Check entire file:
+    $ iree-lit-lint test.mlir
+
+  CI integration (block on errors):
+    $ iree-lit-lint test.mlir --errors-only --quiet
+    $ echo $?  # 1 if errors found, 0 otherwise
+
+  Generate training data:
+    $ iree-lit-lint test.mlir --json > training.json
+
+  Lint specific test case:
+    $ iree-lit-lint test.mlir --case 5
+
+Exit Codes:
+  0 - No errors found (warnings/info may exist)
+  1 - One or more errors found
+  2 - File not found or parse error
+
+See Also:
+  iree-lit-test - Run individual test cases
+  iree-lit-extract - Extract test cases to separate files
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lit_tools.core.lint import LintIssue
+    from lit_tools.core.parser import TestCase, TestFile
+
+from common import console, exit_codes, fs
+
+from lit_tools.core import cli, lint, listing
+from lit_tools.core.parser import parse_test_file
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build argument parser.
+
+    Args:
+        argv: Optional argument list (for testing). If None, uses sys.argv.
+    """
+    parser = argparse.ArgumentParser(
+        description="Lint MLIR lit test files for common authoring mistakes",
+        epilog=(
+            __doc__ + "\n\n"
+            "For detailed style guidelines and rationale, see:\n"
+            "  iree-lit-lint --help-style-guide\n"
+            "  tools/utils/lit_tools/STYLE_GUIDE.md"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "test_file",
+        type=Path,
+        nargs="?",  # Make optional for --help-style-guide.
+        help="Test file to lint (.mlir)",
+    )
+
+    # Style guide help.
+    parser.add_argument(
+        "--help-style-guide",
+        action="store_true",
+        help="Print detailed style guide and exit",
+    )
+
+    # Test case selection (shared with iree-lit-test and iree-lit-extract).
+    cli.add_selection_arguments(parser)
+
+    # Filtering options.
+    cli.add_filter_arguments(parser)
+
+    # Lint-specific options.
+    lint_opts = parser.add_argument_group("Linting options")
+    lint_opts.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="Show only errors (exit 1 if any errors found)",
+    )
+    lint_opts.add_argument(
+        "--min-severity",
+        choices=["error", "warning", "info"],
+        default="info",
+        help="Minimum severity level to show (default: info shows all)",
+    )
+    lint_opts.add_argument(
+        "--individual-errors",
+        action="store_true",
+        help="Show individual error occurrences (ungrouped) instead of grouped by error type",
+    )
+
+    # Common output flags.
+    cli.add_common_output_flags(parser)
+
+    # JSON output file.
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Write JSON output to file instead of stdout",
+    )
+    parser.add_argument(
+        "--full-json",
+        action="store_true",
+        help="Include full IR context around each issue in JSON output",
+    )
+    parser.add_argument(
+        "--context-lines",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Number of lines before/after to include in context (default: 5, used with --full-json)",
+    )
+
+    return parser.parse_args(argv)
+
+
+def _filter_issues_by_severity(
+    issues: list[LintIssue], min_severity: str, errors_only: bool
+) -> list[LintIssue]:
+    """Filter issues based on severity settings.
+
+    Args:
+        issues: All issues found
+        min_severity: Minimum severity to include ("error", "warning", "info")
+        errors_only: If True, show only errors
+
+    Returns:
+        Filtered list of issues
+    """
+    if errors_only:
+        return [i for i in issues if i.severity == "error"]
+
+    # Severity hierarchy: error > warning > info (lower numbers = more severe)
+    severity_levels = {"error": 0, "warning": 1, "info": 2}
+    min_level = severity_levels[min_severity]
+
+    return [i for i in issues if severity_levels.get(i.severity, 999) <= min_level]
+
+
+def _format_text_output(
+    issues: list[LintIssue], test_file: Path, args: argparse.Namespace
+) -> str:
+    """Format issues as text output.
+
+    Args:
+        issues: List of lint issues
+        test_file: Path to test file
+        args: Parsed arguments
+
+    Returns:
+        Formatted text string
+    """
+    if not issues:
+        return ""
+
+    lines = []
+    for issue in issues:
+        # Format: file:line:col: severity: message
+        location = f"{test_file}:{issue.line}"
+        if issue.column is not None:
+            location += f":{issue.column}"
+
+        lines.append(f"{location}: {issue.severity}: {issue.message}")
+        lines.append(f"  {issue.snippet}")
+        lines.append(f"  help: {issue.help}")
+        lines.append("")  # Blank line between issues
+
+    # Summary line.
+    error_count = sum(1 for i in issues if i.severity == "error")
+    warning_count = sum(1 for i in issues if i.severity == "warning")
+    info_count = sum(1 for i in issues if i.severity == "info")
+
+    summary_parts = []
+    if error_count:
+        summary_parts.append(f"{error_count} error(s)")
+    if warning_count:
+        summary_parts.append(f"{warning_count} warning(s)")
+    if info_count:
+        summary_parts.append(f"{info_count} info message(s)")
+
+    lines.append(", ".join(summary_parts))
+
+    return "\n".join(lines)
+
+
+def _format_grouped_output(
+    issues: list[LintIssue], test_file: Path, args: argparse.Namespace
+) -> str:
+    """Format issues grouped by error code.
+
+    Groups issues by code to reduce duplicate help text. Each occurrence
+    maintains IDE-parseable file:line:severity format while showing the
+    full help text only once per error type.
+
+    Output format:
+        [SEVERITY] code (N occurrences)
+        Full help text here
+
+        file:line:col: severity: code: message
+        file:line:col: severity: code: message
+
+        [SEVERITY] next_code (M occurrences)
+        ...
+
+    Args:
+        issues: List of lint issues
+        test_file: Path to test file
+        args: Parsed arguments
+
+    Returns:
+        Formatted text string
+    """
+    if not issues:
+        return ""
+
+    # Group issues by code.
+    grouped: dict[str, list[LintIssue]] = {}
+    for issue in issues:
+        if issue.code not in grouped:
+            grouped[issue.code] = []
+        grouped[issue.code].append(issue)
+
+    # Severity hierarchy for sorting: error (0) > warning (1) > info (2)
+    severity_order = {"error": 0, "warning": 1, "info": 2}
+
+    # Sort groups by severity (most severe first) then alphabetically by code.
+    def group_sort_key(item: tuple[str, list[LintIssue]]) -> tuple[int, str]:
+        code, group_issues = item
+        # Use the most severe issue in the group for sorting.
+        min_severity = min(
+            severity_order.get(issue.severity, 999) for issue in group_issues
+        )
+        return (min_severity, code)
+
+    sorted_groups = sorted(grouped.items(), key=group_sort_key)
+
+    lines = []
+    for code, group_issues in sorted_groups:
+        # Determine group severity (use most severe issue).
+        group_severity = min(
+            group_issues, key=lambda i: severity_order.get(i.severity, 999)
+        ).severity
+
+        # Header: [SEVERITY] code (N occurrences)
+        count = len(group_issues)
+        occurrence_text = "occurrence" if count == 1 else "occurrences"
+        lines.append(f"[{group_severity.upper()}] {code} ({count} {occurrence_text})")
+
+        # Full help text (from first issue, should be same for all).
+        lines.append(group_issues[0].help)
+        lines.append("")  # Blank line after help text
+
+        # Individual occurrences in IDE-parseable format.
+        for issue in group_issues:
+            location = f"{test_file}:{issue.line}"
+            if issue.column is not None:
+                location += f":{issue.column}"
+
+            lines.append(f"{location}: {issue.severity}: {issue.code}: {issue.message}")
+
+        lines.append("")  # Blank line between groups
+
+    # Summary line.
+    error_count = sum(1 for i in issues if i.severity == "error")
+    warning_count = sum(1 for i in issues if i.severity == "warning")
+    info_count = sum(1 for i in issues if i.severity == "info")
+
+    summary_parts = []
+    if error_count:
+        summary_parts.append(f"{error_count} error(s)")
+    if warning_count:
+        summary_parts.append(f"{warning_count} warning(s)")
+    if info_count:
+        summary_parts.append(f"{info_count} info message(s)")
+
+    if summary_parts:
+        lines.append(", ".join(summary_parts))
+
+    return "\n".join(lines)
+
+
+def _build_json_output(
+    issues: list[LintIssue],
+    test_file: Path,
+    total_cases: int,
+    linted_cases: int,
+    full_json: bool = False,
+) -> dict:
+    """Build JSON output structure.
+
+    Args:
+        issues: All lint issues found
+        test_file: Path to test file
+        total_cases: Total number of test cases in file
+        linted_cases: Number of cases that were linted
+        full_json: Include full IR context around each issue
+
+    Returns:
+        Dictionary for JSON serialization
+    """
+    error_count = sum(1 for i in issues if i.severity == "error")
+    warning_count = sum(1 for i in issues if i.severity == "warning")
+    info_count = sum(1 for i in issues if i.severity == "info")
+
+    return {
+        "file": str(test_file),
+        "total_cases": total_cases,
+        "cases_linted": linted_cases,
+        "total_issues": len(issues),
+        "errors": error_count,
+        "warnings": warning_count,
+        "info": info_count,
+        "issues": [
+            {
+                "severity": issue.severity,
+                "code": issue.code,
+                "message": issue.message,
+                "line": issue.line,
+                "column": issue.column,
+                "snippet": issue.snippet,
+                "help": issue.help,
+                **({"suggestions": issue.suggestions} if issue.suggestions else {}),
+                **(
+                    {"context_lines": issue.context_lines}
+                    if full_json and issue.context_lines
+                    else {}
+                ),
+            }
+            for issue in issues
+        ],
+    }
+
+
+def _handle_list_mode(
+    test_file: Path, cases: list[TestCase], args: argparse.Namespace
+) -> int:
+    """Handles --list mode to display test cases.
+
+    Args:
+        test_file: Path to test file
+        cases: List of parsed test cases
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS
+    """
+    if args.json:
+        payload = listing.build_json_payload(test_file, cases)
+        console.print_json(payload, args=args)
+    else:
+        console.out(
+            listing.format_text_listing(
+                test_file,
+                cases,
+                pretty=args.pretty,
+                header=not args.quiet,
+            )
+        )
+    return exit_codes.SUCCESS
+
+
+def _handle_style_guide_help() -> int:
+    """Print style guide and exit.
+
+    Returns:
+        exit_codes.SUCCESS
+    """
+    style_guide_path = Path(__file__).parent / "STYLE_GUIDE.md"
+    if style_guide_path.exists():
+        console.out(style_guide_path.read_text())
+    else:
+        console.error(f"Style guide not found at: {style_guide_path}")
+        console.error("Expected location: tools/utils/lit_tools/STYLE_GUIDE.md")
+    return exit_codes.SUCCESS
+
+
+def _load_and_select_cases(
+    test_file: Path, args: argparse.Namespace
+) -> tuple[TestFile | None, list[TestCase] | None, list[TestCase] | None]:
+    """Load test file and select cases to lint.
+
+    Args:
+        test_file: Path to test file
+        args: Parsed command-line arguments
+
+    Returns:
+        Tuple of (test_file_obj, all_cases, selected_cases) or (None, None, None) on error
+    """
+    if not test_file.exists():
+        console.error(f"Test file not found: {test_file}", args=args)
+        return (None, None, None)
+
+    try:
+        test_file_obj = parse_test_file(test_file)
+        all_cases = list(test_file_obj.cases)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Failed to parse test file: {e}", args=args)
+        return (None, None, None)
+
+    if not all_cases:
+        console.error(f"No test cases found in {test_file}", args=args)
+        return (None, None, None)
+
+    # Handle --list mode.
+    if args.list:
+        _handle_list_mode(test_file, all_cases, args)
+        return (test_file_obj, all_cases, None)
+
+    # Select cases to lint.
+    selected_cases = cli.select_cases(all_cases, args)
+    if selected_cases is None:
+        return (test_file_obj, all_cases, None)
+
+    # Apply regex filters if specified.
+    if (args.filter or args.filter_out) and not (
+        args.case or args.name or args.containing
+    ):
+        selected_cases = cli.apply_filters(
+            selected_cases, args.filter, args.filter_out, args=args
+        )
+
+    return (test_file_obj, all_cases, selected_cases)
+
+
+def _run_linting_and_output(
+    test_file_obj: TestFile,
+    all_cases: list[TestCase],
+    selected_cases: list[TestCase],
+    test_file_path: Path,
+    args: argparse.Namespace,
+) -> int:
+    """Run linters and output results.
+
+    Args:
+        test_file_obj: Parsed test file object
+        all_cases: All test cases in file
+        selected_cases: Cases to lint
+        test_file_path: Path to test file
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code
+    """
+    if not args.quiet and not args.json:
+        console.note(f"Linting {len(selected_cases)} test case(s)", args=args)
+
+    all_issues = []
+
+    # Check file-level issues (separators, split boundary checks, etc.).
+    file_level_issues = lint.check_file_level_issues(test_file_obj)
+    all_issues.extend(file_level_issues)
+
+    for case in selected_cases:
+        issues = lint.run_all_checkers(case, context_lines=args.context_lines)
+        all_issues.extend(issues)
+
+    # Filter by severity.
+    filtered_issues = _filter_issues_by_severity(
+        all_issues, args.min_severity, args.errors_only
+    )
+
+    # Output results.
+    if args.json:
+        json_output = _build_json_output(
+            filtered_issues,
+            test_file_path,
+            len(all_cases),
+            len(selected_cases),
+            args.full_json,
+        )
+        if args.json_output:
+            fs.safe_write_text(
+                args.json_output, json.dumps(json_output, indent=2, sort_keys=True)
+            )
+            if not args.quiet:
+                console.note(f"Wrote JSON to {args.json_output}", args=args)
+        else:
+            console.print_json(json_output, args=args)
+    else:
+        # Use grouped output by default, individual output with --individual-errors.
+        if args.individual_errors:
+            text_output = _format_text_output(filtered_issues, test_file_path, args)
+        else:
+            text_output = _format_grouped_output(filtered_issues, test_file_path, args)
+
+        if text_output:
+            console.out(text_output)
+        elif not args.quiet:
+            console.success("No issues found", args=args)
+
+    # Exit code: ERROR if any errors found, SUCCESS otherwise.
+    has_errors = any(i.severity == "error" for i in filtered_issues)
+    return exit_codes.ERROR if has_errors else exit_codes.SUCCESS
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS if no errors, ERROR if errors found, NOT_FOUND on failure)
+    """
+    # Handle --help-style-guide early exit.
+    if args.help_style_guide:
+        return _handle_style_guide_help()
+
+    # Validate test_file is provided.
+    if not args.test_file:
+        console.error("test_file is required (unless using --help-style-guide)")
+        return exit_codes.ERROR
+
+    # Load and select test cases.
+    test_file_obj, all_cases, selected_cases = _load_and_select_cases(
+        args.test_file, args
+    )
+    if test_file_obj is None or all_cases is None:
+        return exit_codes.NOT_FOUND
+
+    # --list mode already handled in _load_and_select_cases.
+    if selected_cases is None:
+        return exit_codes.SUCCESS if args.list else exit_codes.NOT_FOUND
+
+    # Run linting and output results.
+    return _run_linting_and_output(
+        test_file_obj, all_cases, selected_cases, args.test_file, args
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main(parse_arguments()))

--- a/tools/utils/lit_tools/iree_lit_list.py
+++ b/tools/utils/lit_tools/iree_lit_list.py
@@ -1,0 +1,146 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""List test cases in MLIR lit test files.
+
+Parses lit test files and displays metadata about test cases: case number,
+function name (from CHECK-LABEL), line count, and CHECK pattern count.
+
+Lit test files use `// -----` delimiters to separate test cases. This tool
+identifies these boundaries and extracts metadata for each case.
+
+Usage:
+  # List all test cases with metadata
+  iree-lit-list test.mlir
+
+  # Just count test cases
+  iree-lit-list test.mlir --count
+
+  # Just list test case names
+  iree-lit-list test.mlir --names
+
+  # JSON for scripting
+  iree-lit-list test.mlir --json > cases.json
+
+Examples:
+  $ iree-lit-list compiler/.../test/emplace_transients.mlir
+  emplace_transients.mlir: 5 test cases
+    1: @single_transient       (lines 10-45,  36 lines, 2 CHECK lines)
+    2: @multiple_transients    (lines 47-89,  43 lines, 8 CHECK lines)
+    3: @nested_execute         (lines 91-142, 52 lines, 12 CHECK lines)
+    4: @external_transient     (lines 144-178, 35 lines, 4 CHECK lines)
+    5: @scf_for                (lines 180-225, 46 lines, 10 CHECK lines)
+
+  $ iree-lit-list test.mlir --count
+  5
+
+  $ iree-lit-list test.mlir --names
+  @single_transient @multiple_transients @nested_execute @external_transient @scf_for
+
+Exit codes:
+  0 - Success
+  1 - Error (file read failure, parse error)
+  2 - File not found
+
+See Also:
+  iree-lit-extract - Extract individual test cases
+  iree-lit-test - Run test cases in isolation
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Import from own category (as absolute path within sys.path)
+from common import console, exit_codes
+
+from lit_tools.core import cli, listing
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="List test cases in MLIR lit test files",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("file", help="Path to lit test file")
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help="Just print count of test cases",
+    )
+    parser.add_argument(
+        "--names",
+        action="store_true",
+        help="Just print test case names (space-separated)",
+    )
+    # Common output flags (json/pretty/quiet)
+    cli.add_common_output_flags(parser)
+    # Note: --quiet on this tool suppresses the header line in text output.
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS, ERROR, or NOT_FOUND)
+    """
+    file_path = Path(args.file)
+
+    # Validate input
+    if not file_path.exists():
+        console.error(f"File not found: {file_path}", args=args)
+        return exit_codes.NOT_FOUND
+
+    # Parse test file
+    try:
+        cases = listing.get_cases(file_path)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Parsing failed: {e}", args=args)
+        return exit_codes.ERROR
+
+    # Enforce exclusivity uniformly via cli helpers
+    if not cli.require_at_most_one(
+        args,
+        ["count", "names", "json"],
+        "--json cannot be combined with --count or --names",
+    ):
+        return exit_codes.NOT_FOUND
+
+    # Output based on mode
+    if args.json:
+        payload = listing.build_json_payload(file_path, cases)
+        console.print_json(payload, args=args)
+    elif args.count:
+        # Just print count
+        console.out(str(listing.count_cases(cases)))
+
+    elif args.names:
+        # Just print names
+        console.out(listing.format_names(cases))
+
+    else:
+        # Full listing with metadata
+        console.out(
+            listing.format_text_listing(
+                file_path,
+                cases,
+                pretty=getattr(args, "pretty", False),
+                header=not getattr(args, "quiet", False),
+            )
+        )
+    return exit_codes.SUCCESS
+
+
+if __name__ == "__main__":
+    sys.exit(main(parse_arguments()))

--- a/tools/utils/lit_tools/iree_lit_replace.py
+++ b/tools/utils/lit_tools/iree_lit_replace.py
@@ -1,0 +1,2313 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+r"""Replace test cases in MLIR lit test files.
+
+Designed for extract → edit → replace workflows, particularly with LLMs.
+Supports single-case text replacement and batch JSON operations.
+
+Usage:
+  # Text mode (replace single case)
+  iree-lit-replace test.mlir --case 2 < new_content.mlir
+  echo "new content" | iree-lit-replace test.mlir --case 2
+  iree-lit-replace test.mlir --name function_name -i replacement.mlir
+
+  # JSON mode (batch replacements)
+  iree-lit-replace < replacements.json
+  cat edits.json | iree-lit-replace
+  cat edits.json | iree-lit-replace target.mlir  # Override file field
+
+  # Preview changes
+  iree-lit-replace test.mlir --case 2 --dry-run < new_content.mlir
+
+  # Verify IR before replacing
+  iree-lit-replace test.mlir --case 2 --verify < new_content.mlir
+
+Examples:
+  # Simple text replacement
+  $ cat new_case.mlir | iree-lit-replace test.mlir --case 2
+  note: Case 2 replaced successfully (1 file modified)
+
+  # Batch JSON replacement
+  $ iree-lit-extract test.mlir --case 1,3,5 --json > cases.json
+  # Edit cases.json...
+  $ iree-lit-replace < cases.json
+  note: Replaced 3 cases in test.mlir
+
+  # Cross-file move
+  $ iree-lit-extract old.mlir --case 5 --json | \\
+      jq '.[0].file = "new.mlir"' | \\
+      iree-lit-replace
+
+  # Dry-run to preview changes
+  $ cat edited.mlir | iree-lit-replace test.mlir --case 2 --dry-run
+  --- test.mlir (original)
+  +++ test.mlir (modified)
+  @@ -14,3 +14,2 @@
+  -old content
+  +new content
+
+Exit codes:
+  0 - Success (including no-op replacements)
+  1 - Error (verification failure, invalid JSON, etc.)
+  2 - Not found (file doesn't exist, case not found)
+
+Validation:
+  The tool performs strict validation to prevent errors:
+
+  - Name/number consistency: When JSON includes both 'name' and 'number', they
+    must point to the same test case. This catches copy-paste errors and
+    ensures correct case targeting.
+
+  - Duplicate case names: If multiple cases share the same CHECK-LABEL name,
+    you must use --case NUMBER (text mode) or "number" field (JSON mode) to
+    disambiguate.
+
+  - Duplicate replacement entries: JSON mode rejects multiple replacement
+    entries targeting the same case (by number or name) to prevent
+    unintentional overwrites.
+
+  - CLI override warnings: When --test-file is used with JSON mode, warns if
+    JSON entries have different "file" values being overridden.
+
+  All validation errors include actionable "Fix:" suggestions for resolution.
+
+RUN Line Handling:
+  The tool distinguishes between header RUN lines (at file top) and case-local
+  RUN lines (inside individual test cases):
+
+  - Header RUN lines: Preserved automatically. Appear at top of file, apply to
+    all test cases. Example: "// RUN: iree-opt --split-input-file %s"
+
+  - Case-local RUN lines: Validated against original. By default, replacement
+    content must match either header RUN lines OR the original case's RUN lines.
+    Use --replace-run-lines to allow changing them.
+
+  - Replacement content RUN lines: Stripped from replacement by default and
+    re-injected from original. This prevents accidental RUN line changes.
+
+  Validation rules:
+  1. If replacement contains RUN lines, they must match either:
+     - Header RUN lines from file top, OR
+     - Case-local RUN lines from original case
+  2. Use --replace-run-lines to bypass this check (allows RUN changes)
+  3. In JSON mode, per-case "replace_run_lines": true overrides global flag
+
+  This prevents accidentally changing test semantics while allowing intentional
+  RUN line updates when needed.
+
+JSON Schema:
+  The tool uses a unified JSON schema for all modes (text --json, JSON batch):
+
+  Input Format (JSON mode):
+    [
+      {
+        "file": "test.mlir",      // optional if --test-file provided
+        "number": 2,              // XOR with name
+        "name": "func_name",      // XOR with number
+        "content": "...",         // replacement content
+
+        // Optional per-case flags (override global flags):
+        "replace_run_lines": true,  // allow changing RUN lines
+        "allow_empty": true,        // allow empty content
+        "require_label": false      // require CHECK-LABEL
+      }
+    ]
+
+  Output Format (all modes with --json):
+    {
+      "modified_files": 1,
+      "modified_cases": 2,
+      "unchanged_cases": 0,
+      "dry_run": false,           // true for --dry-run mode
+      "file_results": [
+        {
+          "file": "test.mlir",
+          "total_cases": 3,       // total cases replaced in this file
+          "modified": 2,          // how many were actually changed
+          "unchanged": 1,         // how many were skipped (identical)
+          "dry_run": false,
+          "cases": [
+            {
+              "number": 1,
+              "name": "function_name",
+              "changed": true,
+              "reason": "content differs"  // optional explanation
+            }
+          ],
+          "diff": "..."           // unified diff (empty if no changes)
+        }
+      ],
+      "errors": [
+        {
+          "file": "test.mlir",
+          "replacement": 1,       // optional: which replacement entry
+          "error": "..."          // error message
+        }
+      ],
+      "warnings": [
+        {
+          "file": "test.mlir",
+          "warning": "..."        // warning message
+        }
+      ]
+    }
+
+  The schema is consistent across text mode (with --json) and JSON batch mode,
+  both for dry-run and commit operations.
+
+See Also:
+  iree-lit-extract - Extract test cases to JSON or text
+  iree-lit-list - List available test cases
+  iree-lit-test - Run test cases in isolation
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import os
+
+    from lit_tools.core.parser import TestCase, TestFile
+
+# Import from other categories (added to sys.path as top-level packages)
+from common import console, exit_codes, formatting, fs
+
+# Import from own category (as absolute path within sys.path)
+from lit_tools.core import (
+    cli,
+    suggestions,
+    verification,
+)
+from lit_tools.core.parser import parse_test_file
+
+
+class _TemporaryArgsOverride:
+    """Context manager for temporarily overriding argparse.Namespace attributes.
+
+    Usage:
+        with _TemporaryArgsOverride(args, replace_run_lines=True, allow_empty=True):
+            # args.replace_run_lines and args.allow_empty are temporarily set
+            do_something(args)
+        # Original values restored automatically
+
+    This replaces the manual save/restore pattern used in validation code.
+    """
+
+    def __init__(self, args: argparse.Namespace, **overrides: object) -> None:
+        """Initialize with args object and attribute overrides.
+
+        Args:
+            args: argparse.Namespace object to modify
+            **overrides: Keyword arguments specifying attribute overrides
+        """
+        self.args = args
+        self.overrides = overrides
+        self.originals = {}
+
+    def __enter__(self) -> _TemporaryArgsOverride:
+        """Save original values and apply overrides."""
+        for key, value in self.overrides.items():
+            # Save original value (use getattr to handle missing attributes).
+            self.originals[key] = getattr(self.args, key, None)
+            # Apply override.
+            setattr(self.args, key, value)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool:
+        """Restore original values."""
+        for key, original_value in self.originals.items():
+            setattr(self.args, key, original_value)
+        # Return False to propagate exceptions.
+        return False
+
+
+def _suggest_common_mistakes(argv: list[str]) -> str | None:
+    """Check for common CLI mistakes and suggest corrections.
+
+    Args:
+        argv: Command line arguments (sys.argv)
+
+    Returns:
+        Suggestion string if a common mistake is detected, None otherwise
+    """
+    if len(argv) < 2:
+        return None
+
+    # Check if last argument looks like a case number without --case flag.
+    last_arg = argv[-1]
+    if last_arg.isdigit():
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --case {last_arg}"
+
+    # Check if there's an unquoted string that looks like a name without --name flag.
+    if (
+        len(argv) >= 3
+        and not argv[-1].startswith("-")
+        and not Path(argv[-1]).exists()
+        and not argv[-1].endswith(".mlir")
+    ):
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --name {last_arg}"
+
+    return None
+
+
+def check_concurrent_modification(
+    file_path: Path,
+    original_stat: os.stat_result,
+    original_hash: str,
+    args: argparse.Namespace,
+) -> None:
+    """Check if file was modified after parsing (concurrency protection).
+
+    Args:
+        file_path: Path to file being checked
+        original_stat: os.stat_result from when file was parsed
+        original_hash: SHA256 hash of file content when parsed
+        args: Parsed arguments (for fail_if_changed flag)
+
+    Raises:
+        RuntimeError: If file was modified and --fail-if-changed is set
+    """
+    if not args.fail_if_changed:
+        return  # Skip check if flag not set
+
+    # Fast check: compare mtime (modification time)
+    current_stat = file_path.stat()
+    if current_stat.st_mtime == original_stat.st_mtime:
+        return  # File hasn't been modified (mtime unchanged)
+
+    # Slow check: mtime changed, but verify with content hash
+    # (mtime can change due to touch, metadata changes, etc.)
+    current_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    if current_hash == original_hash:
+        return  # False alarm: mtime changed but content identical
+
+    # Content actually changed - abort to prevent data loss
+    raise RuntimeError(
+        f"Concurrent modification detected: {file_path} was modified after parsing.\n"
+        f"Aborting to prevent data loss.\n"
+        f"Tip: Re-run without --fail-if-changed to force replacement, "
+        f"or ensure no other processes are modifying the file."
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Replace test cases in MLIR lit test files",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Positional argument (optional in JSON mode)
+    parser.add_argument(
+        "test_file",
+        nargs="?",
+        help="Target test file (optional in JSON mode if file field present)",
+    )
+
+    # Selection options (text mode only - mutually exclusive)
+    selection = parser.add_argument_group("test case selection (text mode)")
+    selection.add_argument(
+        "--case",
+        "-c",
+        type=int,
+        metavar="N",
+        help="Replace case by number",
+    )
+    selection.add_argument(
+        "--name",
+        "-n",
+        metavar="NAME",
+        help="Replace case by name (from CHECK-LABEL)",
+    )
+    selection.add_argument(
+        "--append",
+        action="store_true",
+        help="Append as new case at end of file",
+    )
+    selection.add_argument(
+        "--insert-after",
+        type=int,
+        metavar="N",
+        help="Insert as new case after case N",
+    )
+    selection.add_argument(
+        "--insert-before",
+        type=int,
+        metavar="N",
+        help="Insert as new case before case N",
+    )
+
+    # Input options
+    input_group = parser.add_argument_group("input")
+    input_group.add_argument(
+        "-i",
+        "--input",
+        metavar="FILE",
+        help="Read replacement from file (default: stdin)",
+    )
+    input_group.add_argument(
+        "--mode",
+        choices=["json", "text"],
+        help="Explicit input mode (default: auto-detect from content)",
+    )
+
+    # RUN line handling
+    run_group = parser.add_argument_group("RUN line handling")
+    run_group.add_argument(
+        "--replace-run-lines",
+        action="store_true",
+        help="Use replacement's RUN lines instead of original (default: strip and preserve original)",
+    )
+
+    # Validation options
+    validation_group = parser.add_argument_group("validation")
+    validation_group.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify IR structural validity with iree-opt (recommended after rebuilding tools)",
+    )
+    validation_group.add_argument(
+        "--require-label",
+        action="store_true",
+        help="Error if replacement lacks CHECK-LABEL",
+    )
+    validation_group.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Allow empty replacement content (default: error)",
+    )
+    validation_group.add_argument(
+        "--verify-timeout",
+        type=int,
+        default=10,
+        metavar="SECONDS",
+        help="Timeout for iree-opt verification (default: 10 seconds)",
+    )
+
+    # Preview/Safety options
+    safety_group = parser.add_argument_group("preview and safety")
+    safety_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show changes without writing file (outputs diff)",
+    )
+    safety_group.add_argument(
+        "--diff-context",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Number of context lines in unified diff (default: 3)",
+    )
+    safety_group.add_argument(
+        "--backup",
+        metavar="SUFFIX",
+        default=".bak",
+        help="Backup file suffix (default: .bak)",
+    )
+    safety_group.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup creation (not recommended)",
+    )
+    safety_group.add_argument(
+        "--fail-if-changed",
+        action="store_true",
+        help="Abort if target file was modified after parsing (concurrency protection)",
+    )
+
+    # Common output flags (--json/--pretty/--quiet)
+    cli.add_common_output_flags(parser)
+
+    # JSON output file
+    parser.add_argument(
+        "--json-output",
+        metavar="FILE",
+        help="Write JSON output to file (implies --json)",
+    )
+
+    args = parser.parse_args()
+
+    # --json-output implies --json
+    if args.json_output:
+        args.json = True
+
+    return args
+
+
+def write_json_output(payload: dict, args: argparse.Namespace) -> None:
+    """Write JSON output to file or stdout.
+
+    Args:
+        payload: JSON payload to write
+        args: Parsed arguments (for json_output flag)
+    """
+    if args.json_output:
+        # Write to file
+        try:
+            with open(args.json_output, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2 if args.pretty else None)
+                f.write("\n")  # Trailing newline
+        except OSError as e:
+            # Fallback to stderr if file write fails
+            console.error(
+                f"Failed to write JSON output to {args.json_output}: {e}", args=args
+            )
+            # Still output to stdout as fallback
+            console.print_json(payload, args=args)
+    else:
+        # Write to stdout (normal behavior)
+        console.print_json(payload, args=args)
+
+
+def detect_input_mode(raw_input: bytes, args: argparse.Namespace) -> str:
+    """Auto-detect JSON vs text mode from input content.
+
+    Args:
+        raw_input: Raw bytes from stdin or file
+        args: Parsed arguments
+
+    Returns:
+        "json" or "text"
+    """
+    if args.mode:
+        return args.mode  # Explicit override
+
+    # Strip UTF-8 BOM if present
+    if raw_input.startswith(b"\xEF\xBB\xBF"):
+        raw_input = raw_input[3:]
+
+    # Find first non-whitespace character
+    content = raw_input.lstrip()
+    if not content:
+        return "text"  # Empty input defaults to text
+
+    first_char = chr(content[0])
+    return "json" if first_char in "{[" else "text"
+
+
+def extract_run_lines_from_string(content: str) -> tuple[list[str], str]:
+    """Extract RUN lines from replacement content string.
+
+    Args:
+        content: Replacement content that may contain RUN lines
+
+    Returns:
+        Tuple of (run_commands, content_without_runs)
+        - run_commands: List of normalized RUN commands (continuations joined)
+        - content_without_runs: Content with RUN lines stripped
+    """
+    lines = content.splitlines()
+    run_commands = []
+    current_run = None
+    continuing = False
+    run_line_indices = set()
+
+    for i, line in enumerate(lines):
+        line_stripped = line.rstrip()
+
+        # Check if this is a RUN line
+        m = re.match(r"^\s*//\s*RUN:\s?(.*)$", line_stripped)
+        if m:
+            run_line_indices.add(i)
+            cmd = m.group(1).strip()
+
+            if continuing and current_run is not None:
+                # Continuation of previous RUN line
+                current_run = current_run.rstrip("\\").strip()
+                current_run += " " + cmd.lstrip("\\").strip()
+            else:
+                # Start new RUN command
+                current_run = cmd
+
+            # Check if this line continues
+            continuing = cmd.endswith("\\")
+
+            if not continuing:
+                # Command is complete, save it
+                run_commands.append(current_run.rstrip("\\").strip())
+                current_run = None
+
+    # Save any pending multi-line command
+    if current_run is not None:
+        run_commands.append(current_run.rstrip("\\").strip())
+
+    # Remove RUN lines from content
+    content_lines = [line for i, line in enumerate(lines) if i not in run_line_indices]
+    content_without_runs = "\n".join(content_lines)
+
+    return run_commands, content_without_runs
+
+
+def _normalize_run_cmd(cmd: str) -> str:
+    """Normalize a RUN command string for comparison (collapse whitespace)."""
+    return " ".join(cmd.split()).strip()
+
+
+def _filter_header_runs_from_case_runs(
+    case_runs_absolute: list[tuple[int, str]],
+    case_content: str,
+) -> list[tuple[int, str]]:
+    """Filter out header RUN lines from case-local RUN lines.
+
+    Header RUN lines appear before actual case content starts. We find the first
+    non-blank line in the case content - RUN lines before that are headers.
+
+    Args:
+        case_runs_absolute: List of (absolute_index, command) from extract_case_run_lines().
+        case_content: The case content string from TestCase.content.
+
+    Returns:
+        Filtered list containing only case-local RUN lines (not header RUN lines).
+    """
+    # Find first non-blank line in case content
+    lines = case_content.split("\n")
+    first_content_idx = 0
+    for i, line in enumerate(lines):
+        if line.strip():
+            first_content_idx = i
+            break
+
+    # Keep only RUN lines at or after the first actual content
+    return [(idx, cmd) for (idx, cmd) in case_runs_absolute if idx >= first_content_idx]
+
+
+def build_file_content(
+    header_runs: list[str],
+    cases: list[TestCase],
+    content_overrides: dict[int, str] | None = None,
+) -> str:
+    """Rebuild complete test file from header RUNs and case objects.
+
+    Args:
+        header_runs: List of header RUN lines. Can be either:
+            - Raw format: Lines with "// RUN:" prefix (from extract_run_lines(raw=True))
+            - Joined format: Commands without prefix (from extract_run_lines(raw=False))
+        cases: List of TestCase objects in original order
+        content_overrides: Optional dict mapping case numbers to replacement content
+
+    Returns:
+        Complete file content as string
+    """
+    result = ""
+
+    # 1. Header RUN lines (if present)
+    if header_runs:
+        # Detect format: raw lines start with "// RUN:", joined lines don't
+        is_raw = header_runs and header_runs[0].lstrip().startswith("//")
+
+        for run_line in header_runs:
+            if is_raw:
+                # Raw format: already has "// RUN:" prefix
+                result += f"{run_line}\n"
+            else:
+                # Joined format: add "// RUN:" prefix
+                result += f"// RUN: {run_line}\n"
+
+    # 2. Cases with separators
+    for i, case in enumerate(cases):
+        # Use override content if provided, otherwise use case.content
+        if content_overrides and case.number in content_overrides:
+            content = content_overrides[case.number]
+        else:
+            content = case.content
+
+        # First case: strip newlines that correspond to stripped RUN lines
+        if i == 0 and header_runs:
+            # Case content has len(header_runs) leading newlines from RUN stripping
+            # Strip them since we've already added the actual RUN lines
+            for _ in range(len(header_runs)):
+                if content.startswith("\n"):
+                    content = content[1:]
+
+        # Normalize trailing blank lines: strip all trailing newlines, then add exactly one.
+        # This ensures consistent formatting and idempotency.
+        content = content.rstrip("\n")
+        if content:  # Only add newline if content is not empty
+            content += "\n"
+
+        # Add separator before subsequent cases
+        if i > 0:
+            result += "\n// -----\n"
+
+        # Add case content
+        result += content
+
+    # 3. Ensure final newline
+    if not result.endswith("\n"):
+        result += "\n"
+
+    return result
+
+
+def generate_unified_diff(
+    original: str, modified: str, file_path: str, args: argparse.Namespace
+) -> str:
+    """Generate unified diff between original and modified content.
+
+    Args:
+        original: Original file content
+        modified: Modified file content after replacement
+        file_path: Path for file labels in diff
+        args: Parsed arguments (for diff_context)
+
+    Returns:
+        Unified diff as string
+    """
+    # splitlines(keepends=True) preserves line endings for difflib
+    original_lines = original.splitlines(keepends=True)
+    modified_lines = modified.splitlines(keepends=True)
+
+    # Get context lines (default 3, matches standard diff)
+    context = args.diff_context
+
+    diff_lines = difflib.unified_diff(
+        original_lines,
+        modified_lines,
+        fromfile=f"{file_path} (original)",
+        tofile=f"{file_path} (modified)",
+        n=context,
+        lineterm="",  # Don't add extra newlines, we'll handle it
+    )
+
+    return "\n".join(diff_lines)
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point."""
+    # Read input (stdin or -i FILE)
+    try:
+        if args.input:
+            with open(args.input, "rb") as f:
+                raw_input = f.read()
+        else:
+            raw_input = sys.stdin.buffer.read()
+    except OSError as e:
+        console.error(f"Failed to read input: {e}", args=args)
+        return exit_codes.ERROR
+
+    # Strip UTF-8 BOM if present.
+    if raw_input.startswith(b"\xEF\xBB\xBF"):
+        raw_input = raw_input[3:]
+
+    # Detect input mode
+    input_mode = detect_input_mode(raw_input, args)
+
+    # Decode input
+    try:
+        input_text = raw_input.decode("utf-8")
+    except UnicodeDecodeError as e:
+        console.error(
+            f"Input contains invalid UTF-8 encoding at byte offset {e.start}.\n"
+            f"Ensure replacement content uses UTF-8 encoding.",
+            args=args,
+        )
+        return exit_codes.ERROR
+
+    # Text mode vs JSON mode
+    if input_mode == "text":
+        return handle_text_mode(input_text, args)
+    return handle_json_mode(input_text, args)
+
+
+def _validate_text_mode_args(args: argparse.Namespace) -> int | None:
+    """Validate text mode arguments.
+
+    Returns:
+        Exit code if validation fails, None if successful.
+    """
+    if not args.test_file:
+        console.error(
+            "Text mode requires test file argument.\n"
+            "Usage: iree-lit-replace <file> --case N < replacement.mlir",
+            args=args,
+        )
+        return exit_codes.ERROR
+
+    if not args.case and not args.name:
+        console.error(
+            "Text mode requires --case N or --name NAME selector.\n"
+            "Use JSON mode for batch operations.",
+            args=args,
+        )
+        return exit_codes.ERROR
+
+    if args.case and args.name:
+        console.error("specify either --case or --name, not both", args=args)
+        return exit_codes.ERROR
+
+    return None
+
+
+def _load_and_parse_test_file(
+    args: argparse.Namespace,
+) -> tuple[
+    Path | None,
+    TestFile | None,
+    list | None,
+    os.stat_result | None,
+    str | None,
+    int | None,
+]:
+    """Load and parse test file, recording state for concurrency detection.
+
+    Returns:
+        Tuple of (file_path, test_file_obj, all_cases, original_stat, original_hash, error_code).
+        If error_code is not None, an error occurred and other values should be ignored.
+    """
+    file_path = Path(args.test_file)
+    if not file_path.exists():
+        console.error(f"File not found: {file_path}", args=args)
+        return None, None, None, None, None, exit_codes.NOT_FOUND
+
+    try:
+        test_file_obj = parse_test_file(file_path)
+        all_cases = list(test_file_obj.cases)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Failed to parse test file: {e}", args=args)
+        return None, None, None, None, None, exit_codes.ERROR
+
+    original_stat = file_path.stat()
+    original_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+    return file_path, test_file_obj, all_cases, original_stat, original_hash, None
+
+
+def _find_target_case_by_number(
+    all_cases: list, file_path: Path, case_number: int, args: argparse.Namespace
+) -> tuple[TestCase | None, int | None]:
+    """Find target case by number.
+
+    Returns:
+        Tuple of (target_case, error_code).
+    """
+    for case in all_cases:
+        if case.number == case_number:
+            return case, None
+
+    available = ", ".join(str(c.number) for c in all_cases[:10])
+    if len(all_cases) > 10:
+        available += f", ... and {len(all_cases) - 10} more"
+    console.error(
+        f"Case {case_number} not found in {file_path}\n"
+        f"Available cases: {available}",
+        args=args,
+    )
+    return None, exit_codes.NOT_FOUND
+
+
+def _find_target_case_by_name(
+    all_cases: list, file_path: Path, case_name: str, args: argparse.Namespace
+) -> tuple[TestCase | None, int | None]:
+    """Find target case by name.
+
+    Returns:
+        Tuple of (target_case, error_code).
+    """
+    name_matches = [c for c in all_cases if c.name == case_name]
+
+    if len(name_matches) > 1:
+        case_numbers = [c.number for c in name_matches]
+        console.error(
+            f"Multiple cases named '{case_name}' found at numbers {case_numbers}.\n"
+            f"Use --case NUMBER to specify which one.",
+            args=args,
+        )
+        return None, exit_codes.ERROR
+
+    if not name_matches:
+        error_msg = suggestions.format_case_name_error(
+            case_name, all_cases, file_path=str(file_path)
+        )
+        console.error(error_msg, args=args)
+        return None, exit_codes.NOT_FOUND
+
+    return name_matches[0], None
+
+
+def _validate_case_run_lines(
+    replacement_runs: list[str],
+    original_case_runs_cmds: list[str],
+    header_runs: list[str],
+    args: argparse.Namespace,
+) -> int | None:
+    """Validate replacement RUN lines against header and case-local RUN lines.
+
+    Replacement RUN lines are allowed if they match either:
+    - Header RUN lines (will be stripped, header takes precedence)
+    - Case-local RUN lines (will be validated for consistency)
+
+    Returns:
+        Exit code if validation fails, None if successful.
+    """
+    if not replacement_runs or args.replace_run_lines:
+        return None
+
+    norm_orig = [_normalize_run_cmd(c) for c in original_case_runs_cmds]
+    norm_repl = [_normalize_run_cmd(c) for c in replacement_runs]
+    norm_header = [_normalize_run_cmd(c) for c in header_runs]
+
+    # Allow if replacement RUNs match header RUNs (user included header in replacement).
+    if norm_repl == norm_header:
+        return None
+
+    # Allow if replacement RUNs match case-local RUNs.
+    if norm_repl == norm_orig:
+        return None
+
+    # Allow if replacement RUNs match header + case-local RUNs.
+    # This happens when extract includes both header and case-local RUN lines
+    # (e.g., with_case_runs.mlir has both).
+    norm_header_plus_case = norm_header + norm_orig
+    if norm_repl == norm_header_plus_case:
+        return None
+
+    # Otherwise, error.
+    console.error(
+        "Replacement contains RUN lines that differ from both header and case-local RUN lines.\n"
+        "Remove RUN lines from replacement or use --replace-run-lines to accept them.",
+        args=args,
+    )
+    return exit_codes.ERROR
+
+
+def _validate_replacement_content_checks(
+    replacement_content_clean: str,
+    target_case: TestCase,
+    args: argparse.Namespace,
+) -> int | None:
+    """Validate replacement content (empty check, CHECK-LABEL, iree-opt).
+
+    Returns:
+        Exit code if validation fails, None if successful.
+    """
+    # Empty content check.
+    if not replacement_content_clean.strip():
+        if not args.allow_empty:
+            console.error(
+                f"Replacement content is empty.\n"
+                f"This would delete case {target_case.number} content (delimiters remain).\n"
+                f"Use --allow-empty to confirm this is intentional.",
+                args=args,
+            )
+            return exit_codes.ERROR
+
+        if not args.quiet:
+            console.warn(
+                f"Replacing case {target_case.number} with empty content (--allow-empty specified)",
+                args=args,
+            )
+
+    # CHECK-LABEL validation.
+    if args.require_label and not re.search(
+        r"//\s*CHECK-LABEL:\s*@\S+", replacement_content_clean
+    ):
+        console.error(
+            f"Replacement content for case {target_case.number} lacks CHECK-LABEL.\n"
+            f"Use --require-label only when replacement should contain a CHECK-LABEL.\n"
+            f"Expected pattern: // CHECK-LABEL: @function_name",
+            args=args,
+        )
+        return exit_codes.ERROR
+
+    # iree-opt verification.
+    _, valid, error_msg = verification.verify_content_with_skip_check(
+        replacement_content_clean,
+        target_case.number,
+        target_case.name,
+        args,
+        timeout=args.verify_timeout,
+    )
+    if not valid:
+        console.error(error_msg, args=args)
+        return exit_codes.ERROR
+
+    return None
+
+
+def _build_final_case_content(
+    replacement_content: str,
+    replacement_content_clean: str,
+    replacement_runs: list[str],
+    case_runs_absolute: list[tuple[int, str]],
+    args: argparse.Namespace,
+) -> tuple[str | None, int | None]:
+    """Build final case content by injecting or replacing RUN lines.
+
+    Args:
+        replacement_content: Original replacement content with RUN lines.
+        replacement_content_clean: Replacement content with RUN lines stripped.
+        replacement_runs: RUN lines extracted from replacement content.
+        case_runs_absolute: Case-local RUN lines with absolute indices.
+        args: Parsed arguments.
+
+    Returns:
+        Tuple of (final_content, error_code).
+    """
+    # When --replace-run-lines is used, replacement RUNs become header RUNs
+    # (handled by caller), so return clean content without RUN lines
+    if args.replace_run_lines and replacement_runs:
+        return replacement_content_clean, None
+
+    # Inject case-local RUN lines into replacement content.
+    # SAFE APPROACH: Since replacement content structure may differ from original
+    # (different line counts, blank padding), we use top-injection instead of
+    # position-based injection. This avoids fragile index-based reinjection errors.
+    # Case-local RUN lines appear at top of case (after header RUNs in final file).
+    if case_runs_absolute:
+        run_lines = [f"// RUN: {cmd}\n" for (_, cmd) in case_runs_absolute]
+        final_content = "".join(run_lines) + replacement_content_clean
+    else:
+        final_content = replacement_content_clean
+
+    return final_content, None
+
+
+def _handle_unchanged_case(
+    target_case: TestCase, file_path: Path, args: argparse.Namespace
+) -> int:
+    """Handle case where content is unchanged.
+
+    Returns:
+        Exit code (always SUCCESS).
+    """
+    if not args.quiet:
+        console.note(
+            f"Case {target_case.number} unchanged (content identical)", args=args
+        )
+
+    if args.json:
+        payload = {
+            "modified_files": 0,
+            "modified_cases": 0,
+            "unchanged_cases": 1,
+            "dry_run": args.dry_run,
+            "file_results": [
+                {
+                    "file": str(file_path),
+                    "total_cases": 1,
+                    "modified": 0,
+                    "unchanged": 1,
+                    "dry_run": args.dry_run,
+                    "cases": [
+                        {
+                            "number": target_case.number,
+                            "name": target_case.name,
+                            "changed": False,
+                            "reason": "content identical",
+                        }
+                    ],
+                    "diff": "",
+                }
+            ],
+            "errors": [],
+            "warnings": [],
+        }
+        write_json_output(payload, args)
+
+    return exit_codes.SUCCESS
+
+
+def _handle_dry_run_output(
+    original_content: str,
+    new_content: str,
+    file_path: Path,
+    target_case: TestCase,
+    args: argparse.Namespace,
+) -> int:
+    """Handle dry-run mode output (diff or JSON).
+
+    Returns:
+        Exit code (always SUCCESS).
+    """
+    diff_text = generate_unified_diff(
+        original_content, new_content, str(file_path), args
+    )
+
+    if args.json:
+        payload = {
+            "modified_files": 0 if not diff_text else 1,
+            "modified_cases": 0 if not diff_text else 1,
+            "unchanged_cases": 1 if not diff_text else 0,
+            "dry_run": True,
+            "file_results": [
+                {
+                    "file": str(file_path),
+                    "total_cases": 1,
+                    "modified": 1 if diff_text else 0,
+                    "unchanged": 0 if diff_text else 1,
+                    "dry_run": True,
+                    "cases": [
+                        {
+                            "number": target_case.number,
+                            "name": target_case.name,
+                            "changed": bool(diff_text),
+                            "reason": "would modify" if diff_text else "no changes",
+                        }
+                    ],
+                    "diff": diff_text if diff_text else "",
+                }
+            ],
+            "errors": [],
+            "warnings": [],
+        }
+        write_json_output(payload, args)
+    else:
+        if not diff_text:
+            console.note(
+                f"Case {target_case.number} unchanged (no differences)", args=args
+            )
+        else:
+            if args.pretty:
+                diff_text = formatting.colorize_diff(diff_text, pretty=True)
+            console.out(diff_text)
+            if not args.quiet:
+                console.note(
+                    f"Dry-run: would modify {file_path} (case {target_case.number})",
+                    args=args,
+                )
+
+    return exit_codes.SUCCESS
+
+
+def _write_modified_file(
+    file_path: Path,
+    new_content: str,
+    original_stat: os.stat_result,
+    original_hash: str,
+    target_case: TestCase,
+    args: argparse.Namespace,
+) -> int:
+    """Write modified file content after concurrency check.
+
+    Returns:
+        Exit code (SUCCESS or ERROR).
+    """
+    try:
+        check_concurrent_modification(file_path, original_stat, original_hash, args)
+    except RuntimeError as e:
+        console.error(str(e), args=args)
+        return exit_codes.ERROR
+
+    try:
+        fs.safe_write_text(
+            file_path, new_content, atomic=True, backup=not args.no_backup
+        )
+
+        if not args.quiet:
+            console.success(
+                f"Case {target_case.number} replaced successfully in {file_path}",
+                args=args,
+            )
+
+        if args.json:
+            payload = {
+                "modified_files": 1,
+                "modified_cases": 1,
+                "unchanged_cases": 0,
+                "dry_run": False,
+                "file_results": [
+                    {
+                        "file": str(file_path),
+                        "total_cases": 1,
+                        "modified": 1,
+                        "unchanged": 0,
+                        "dry_run": False,
+                        "cases": [
+                            {
+                                "number": target_case.number,
+                                "name": target_case.name,
+                                "changed": True,
+                                "reason": "content differs",
+                            }
+                        ],
+                        "diff": "",
+                    }
+                ],
+                "errors": [],
+                "warnings": [],
+            }
+            write_json_output(payload, args)
+
+        return exit_codes.SUCCESS
+    except OSError as e:
+        console.error(f"Failed to write file: {e}", args=args)
+        return exit_codes.ERROR
+
+
+def _extract_and_filter_run_lines(
+    target_case: TestCase,
+    file_path: Path,
+    header_runs_raw: list[str],
+    header_runs_normalized: list[str],
+) -> tuple[list[str], list[str], list[str], list[tuple[int, str]]]:
+    """Extract and filter RUN lines, separating header and case-local RUNs.
+
+    Args:
+        target_case: Target case being modified (contains cached run lines)
+        file_path: Path to the test file (needed for re-reading when filtering)
+        header_runs_raw: Raw header RUN lines
+        header_runs_normalized: Normalized header RUN commands
+
+    Returns:
+        Tuple of (filtered_header_runs_raw, filtered_header_runs_normalized, case_run_cmds, case_runs_filtered)
+    """
+    # Extract case-local RUN lines and filter out header RUN lines.
+    # (Header RUN lines are handled separately by build_file_content)
+    original_case_runs_absolute = target_case.extract_local_run_lines()
+    case_runs_filtered = _filter_header_runs_from_case_runs(
+        original_case_runs_absolute, target_case.content
+    )
+    original_case_runs_cmds = [cmd for (_, cmd) in case_runs_filtered]
+
+    # Also filter header RUN lines to exclude case-local RUN lines
+    # (extract_run_lines includes ALL RUN lines before first non-comment line)
+    #
+    # Use normalized equality for filtering instead of substring matching to avoid
+    # false positives (e.g., "iree-opt" substring matching in "// RUN: iree-opt ...").
+    case_run_cmds_set = set(original_case_runs_cmds)
+
+    # Filter normalized header runs (used for validation).
+    # Note: header_runs_raw and header_runs_normalized have different lengths
+    # when multi-line RUN commands are used (raw has one entry per physical line,
+    # normalized has one entry per logical command), so we can't zip them together.
+    filtered_normalized = [
+        cmd for cmd in header_runs_normalized if cmd not in case_run_cmds_set
+    ]
+
+    # If we filtered out any commands, we need to re-extract the raw lines.
+    # Otherwise, keep the original raw lines (preserves multi-line formatting).
+    if len(filtered_normalized) != len(header_runs_normalized):
+        # Re-extract raw lines, but only for the filtered normalized commands.
+        # Build a set of normalized commands to keep for fast lookup.
+        keep_cmds = set(filtered_normalized)
+
+        # Re-read the file and extract only the raw lines for commands we're keeping.
+        with open(file_path, encoding="utf-8") as f:
+            file_lines = f.readlines()
+
+        filtered_raw = []
+        current_raw_lines = []
+        current_normalized = None
+        continuing = False
+
+        for line in file_lines:
+            line_stripped = line.rstrip()
+            m = re.match(r"^\s*//\s*RUN:\s?(.*)$", line_stripped)
+
+            if m:
+                cmd = m.group(1).strip()
+
+                if continuing and current_normalized is not None:
+                    # Continuation of multi-line RUN command.
+                    current_raw_lines.append(line_stripped)
+                    current_normalized = current_normalized.rstrip("\\").strip()
+                    current_normalized += " " + cmd.lstrip("\\").strip()
+                else:
+                    # Start of new RUN command.
+                    current_raw_lines = [line_stripped]
+                    current_normalized = cmd
+
+                continuing = cmd.endswith("\\")
+
+                if not continuing:
+                    # Command is complete - check if we should keep it.
+                    final_cmd = current_normalized.rstrip("\\").strip()
+                    if final_cmd in keep_cmds:
+                        filtered_raw.extend(current_raw_lines)
+                    current_raw_lines = []
+                    current_normalized = None
+            elif line_stripped and not re.match(r"^\s*//", line_stripped):
+                # Stop at first non-comment, non-empty line.
+                break
+
+        header_runs_raw = filtered_raw
+    # else: No filtering needed, keep original raw lines
+
+    return (
+        header_runs_raw,
+        filtered_normalized,
+        original_case_runs_cmds,
+        case_runs_filtered,
+    )
+
+
+def handle_text_mode(replacement_content: str, args: argparse.Namespace) -> int:
+    """Handle text mode replacement.
+
+    Args:
+        replacement_content: Replacement text for single case
+        args: Parsed arguments
+
+    Returns:
+        Exit code
+    """
+    # 1. Validate arguments.
+    error_code = _validate_text_mode_args(args)
+    if error_code is not None:
+        return error_code
+
+    # 2. Load and parse test file.
+    (
+        file_path,
+        test_file_obj,
+        all_cases,
+        original_stat,
+        original_hash,
+        error_code,
+    ) = _load_and_parse_test_file(args)
+    if error_code is not None:
+        return error_code
+
+    # 3. Find target case.
+    if args.case:
+        target_case, error_code = _find_target_case_by_number(
+            all_cases, file_path, args.case, args
+        )
+    else:
+        target_case, error_code = _find_target_case_by_name(
+            all_cases, file_path, args.name, args
+        )
+
+    if error_code is not None:
+        return error_code
+
+    # 4. Extract and validate RUN lines.
+    replacement_runs, replacement_content_clean = extract_run_lines_from_string(
+        replacement_content
+    )
+
+    try:
+        header_runs_raw = test_file_obj.extract_run_lines(raw=True)
+        header_runs_normalized = test_file_obj.extract_run_lines(raw=False)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Failed to extract header RUN lines: {e}", args=args)
+        return exit_codes.ERROR
+
+    # Extract and filter RUN lines, separating header and case-local RUNs.
+    (
+        header_runs_raw,
+        header_runs_normalized,
+        original_case_runs_cmds,
+        case_runs_filtered,
+    ) = _extract_and_filter_run_lines(
+        target_case, file_path, header_runs_raw, header_runs_normalized
+    )
+
+    error_code = _validate_case_run_lines(
+        replacement_runs, original_case_runs_cmds, header_runs_normalized, args
+    )
+    if error_code is not None:
+        return error_code
+
+    # 5. Validate replacement content.
+    error_code = _validate_replacement_content_checks(
+        replacement_content_clean, target_case, args
+    )
+    if error_code is not None:
+        return error_code
+
+    # 6. Build final content.
+    final_content, error_code = _build_final_case_content(
+        replacement_content,
+        replacement_content_clean,
+        replacement_runs,
+        case_runs_filtered,
+        args,
+    )
+    if error_code is not None:
+        return error_code
+
+    # 7. Replace case content and rebuild file.
+    # If this is the first case and there are header RUN lines, we need to add back
+    # the leading newlines that extract stripped (extract strips len(header_runs_raw)
+    # newlines when including RUN lines in output, but build_file_content expects
+    # the original format and will strip them again).
+    if target_case.number == 1 and header_runs_raw:
+        # Add back the newlines that were stripped by extract.
+        final_content = ("\n" * len(header_runs_raw)) + final_content
+
+    # Create content overrides dict for build_file_content.
+    content_overrides = {target_case.number: final_content}
+
+    # If --replace-run-lines was used, replacement RUNs become new header RUNs
+    if args.replace_run_lines and replacement_runs:
+        # Format as raw RUN lines (with "// RUN:" prefix)
+        new_header_runs_raw = [f"// RUN: {cmd}" for cmd in replacement_runs]
+        new_content = build_file_content(
+            new_header_runs_raw, all_cases, content_overrides
+        )
+    else:
+        new_content = build_file_content(header_runs_raw, all_cases, content_overrides)
+
+    # 8. Handle unchanged, dry-run, or write cases.
+    original_content = file_path.read_text(encoding="utf-8")
+    if new_content == original_content:
+        return _handle_unchanged_case(target_case, file_path, args)
+
+    if args.dry_run:
+        return _handle_dry_run_output(
+            original_content, new_content, file_path, target_case, args
+        )
+
+    return _write_modified_file(
+        file_path, new_content, original_stat, original_hash, target_case, args
+    )
+
+
+# Constants for JSON mode.
+MAX_OVERRIDE_CASES_SHOWN = 5
+
+
+# ==============================================================================
+# Case-finding helper functions
+# ==============================================================================
+
+
+def _find_case_by_number(all_cases: list, case_num: int) -> TestCase | None:
+    """Find case by number.
+
+    Args:
+        all_cases: List of TestCase objects from test_file.parse_test_file().
+        case_num: Case number to find.
+
+    Returns:
+        TestCase object if found, None otherwise.
+    """
+    for case in all_cases:
+        if case.number == case_num:
+            return case
+    return None
+
+
+def _find_cases_by_name(all_cases: list, case_name: str) -> list[TestCase]:
+    """Find all cases matching the given name.
+
+    Args:
+        all_cases: List of TestCase objects from test_file.parse_test_file().
+        case_name: Case name to find (CHECK-LABEL value).
+
+    Returns:
+        List of matching TestCase objects (may be empty or contain multiple entries).
+    """
+    return [c for c in all_cases if c.name == case_name]
+
+
+# ==============================================================================
+# JSON mode helper functions (refactored from handle_json_mode)
+# ==============================================================================
+
+
+def _parse_and_validate_json_schema(
+    json_input: str, args: argparse.Namespace
+) -> list | None:
+    """Parse JSON input and validate schema.
+
+    Args:
+        json_input: JSON input string.
+        args: Parsed arguments.
+
+    Returns:
+        List of replacement objects if valid, None on error.
+        Errors are reported via console.error().
+    """
+    # 1. Parse JSON.
+    try:
+        replacements = json.loads(json_input)
+    except json.JSONDecodeError as e:
+        console.error(
+            f"Invalid JSON input at line {e.lineno}, column {e.colno}:\n{e.msg}",
+            args=args,
+        )
+        return None
+
+    # 2. Validate schema.
+    validation_errors = []
+
+    if not isinstance(replacements, list):
+        console.error(
+            "JSON input must be an array of replacement objects.\n"
+            'Expected: [{"file": "test.mlir", "number": 2, "content": "..."}]',
+            args=args,
+        )
+        return None
+
+    if not replacements:
+        console.error("JSON input is empty (no replacements specified)", args=args)
+        return None
+
+    # Validate each replacement object.
+    for i, repl in enumerate(replacements):
+        if not isinstance(repl, dict):
+            validation_errors.append(
+                f"Replacement {i + 1}: must be an object, got {type(repl).__name__}"
+            )
+            continue
+
+        # Required: content field.
+        if "content" not in repl:
+            validation_errors.append(
+                f"Replacement {i + 1}: missing required 'content' field"
+            )
+            continue
+
+        # Required: either number or name.
+        # Note: iree-lit-extract includes both, so we allow both (prefer number).
+        has_number = "number" in repl
+        has_name = "name" in repl
+        if not has_number and not has_name:
+            validation_errors.append(
+                f"Replacement {i + 1}: must specify either 'number' or 'name' field"
+            )
+
+        # Required (unless CLI override): file field.
+        if not args.test_file and "file" not in repl:
+            validation_errors.append(
+                f"Replacement {i + 1}: missing 'file' field (required when target file not specified via CLI)"
+            )
+
+    if validation_errors:
+        console.error(
+            "JSON schema validation failed:\n"
+            + "\n".join(f"  - {e}" for e in validation_errors),
+            args=args,
+        )
+        return None
+
+    return replacements
+
+
+def _group_by_file_and_check_overrides(
+    replacements: list, args: argparse.Namespace
+) -> dict:
+    """Group replacements by file and check for CLI file overrides.
+
+    Args:
+        replacements: List of replacement dictionaries from JSON.
+        args: Parsed arguments.
+
+    Returns:
+        Dictionary mapping Path -> list of (repl_idx, repl) tuples.
+        Warns via console.warn() if CLI overrides JSON file fields.
+    """
+    file_groups = {}  # file_path -> list of (repl_idx, repl)
+
+    for i, repl in enumerate(replacements):
+        # CLI arg overrides JSON file field.
+        target_file = args.test_file if args.test_file else repl.get("file")
+        file_path = Path(target_file)
+
+        if file_path not in file_groups:
+            file_groups[file_path] = []
+        file_groups[file_path].append((i, repl))
+
+    # Check for CLI file overrides and warn.
+    if args.test_file:
+        overridden_count = 0
+        overridden_cases = []
+        for _file_path, replacements_for_file in file_groups.items():
+            for _repl_idx, repl in replacements_for_file:
+                if "file" in repl and repl["file"] != args.test_file:
+                    overridden_count += 1
+                    case_id = repl.get("number") or repl.get("name")
+                    overridden_cases.append(str(case_id))
+
+        if overridden_count > 0 and not args.quiet:
+            case_list = ", ".join(overridden_cases[:MAX_OVERRIDE_CASES_SHOWN])
+            if len(overridden_cases) > MAX_OVERRIDE_CASES_SHOWN:
+                case_list += (
+                    f", ... ({len(overridden_cases) - MAX_OVERRIDE_CASES_SHOWN} more)"
+                )
+            console.warn(
+                f"CLI argument '{args.test_file}' overriding JSON 'file' field for "
+                f"{overridden_count} replacement(s): cases {case_list}",
+                args=args,
+            )
+
+    return file_groups
+
+
+def _resolve_and_check_duplicates(
+    file_groups: dict, args: argparse.Namespace
+) -> dict | None:
+    """Resolve selectors to canonical form and check for duplicate replacements.
+
+    This implements two-pass duplicate detection:
+    - Pass 1: Resolve all selectors (name/number) to canonical (file, case_number)
+    - Pass 2: Check for duplicates using canonical identifiers
+
+    This fixes the bug where {"number": 2} and {"name": "second_case"} were
+    treated as different selectors even when targeting the same case.
+
+    Args:
+        file_groups: Dictionary from _group_by_file_and_check_overrides().
+        args: Parsed arguments.
+
+    Returns:
+        Dictionary mapping (file_path, case_number) -> (repl_idx, repl, all_cases).
+        Returns None on error (errors reported via console.error()).
+    """
+    all_errors = []
+    resolved_replacements = (
+        {}
+    )  # (file_path, case_num) -> (repl_idx, repl, test_file_obj, all_cases)
+
+    # PASS 1: Resolve all selectors to canonical (file, case_number) form.
+    for file_path, replacements_for_file in file_groups.items():
+        # Check file exists.
+        if not file_path.exists():
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "error": f"File not found: {file_path}",
+                    "replacements": [i + 1 for i, _ in replacements_for_file],
+                }
+            )
+            continue
+
+        # Parse test file.
+        try:
+            test_file_obj = parse_test_file(file_path)
+            all_cases = list(test_file_obj.cases)
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "error": f"Failed to parse test file: {e}",
+                    "replacements": [i + 1 for i, _ in replacements_for_file],
+                }
+            )
+            continue
+
+        # Resolve each replacement to canonical case number.
+        for repl_idx, repl in replacements_for_file:
+            case_num = None
+
+            # Determine case number from selector.
+            if "number" in repl:
+                case_num = repl["number"]
+                # Verify case exists.
+                case = _find_case_by_number(all_cases, case_num)
+                if not case:
+                    all_errors.append(
+                        {
+                            "file": str(file_path),
+                            "replacement": repl_idx + 1,
+                            "error": f"Case {case_num} not found (file has {len(all_cases)} cases)",
+                        }
+                    )
+                    continue
+            elif "name" in repl:
+                case_name = repl["name"]
+                # Find by name - check for duplicates FIRST (fixes P1 issue #4).
+                name_matches = _find_cases_by_name(all_cases, case_name)
+                if len(name_matches) > 1:
+                    case_numbers = [c.number for c in name_matches]
+                    all_errors.append(
+                        {
+                            "file": str(file_path),
+                            "replacement": repl_idx + 1,
+                            "error": (
+                                f"Multiple cases named '{case_name}' found at numbers {case_numbers}. "
+                                f"Fix: Use 'number' field instead of 'name' to disambiguate."
+                            ),
+                        }
+                    )
+                    continue
+                if not name_matches:
+                    error_msg = suggestions.format_case_name_error(
+                        case_name, all_cases, file_path=str(file_path)
+                    )
+                    all_errors.append(
+                        {
+                            "file": str(file_path),
+                            "replacement": repl_idx + 1,
+                            "error": error_msg,
+                        }
+                    )
+                    continue
+                case_num = name_matches[0].number
+            else:
+                # Should be caught by schema validation, but be defensive.
+                all_errors.append(
+                    {
+                        "file": str(file_path),
+                        "replacement": repl_idx + 1,
+                        "error": "Must specify either 'number' or 'name' field",
+                    }
+                )
+                continue
+
+            # Store resolved replacement with canonical key.
+            canonical_key = (file_path, case_num)
+            if canonical_key in resolved_replacements:
+                # PASS 2: Duplicate detected!
+                prev_idx = resolved_replacements[canonical_key][0]
+                all_errors.append(
+                    {
+                        "file": str(file_path),
+                        "error": (
+                            f"Duplicate replacement for case {case_num}: "
+                            f"entries {prev_idx + 1} and {repl_idx + 1}. "
+                            f"Fix: Remove duplicate entries, keep only one."
+                        ),
+                    }
+                )
+            else:
+                resolved_replacements[canonical_key] = (
+                    repl_idx,
+                    repl,
+                    test_file_obj,
+                    all_cases,
+                )
+
+    # Report errors if any.
+    if all_errors:
+        console.error(
+            "Duplicate replacement entries detected:\n"
+            + "\n".join(f"  - {e['error']}" for e in all_errors),
+            args=args,
+        )
+        return None
+
+    return resolved_replacements
+
+
+def _build_final_json_content(
+    use_replacement_runs: bool,
+    original_case_runs_cmds: list[str],
+    replacement_content_clean: str,
+) -> str:
+    """Build final content by prepending case-local RUN lines if needed.
+
+    Args:
+        use_replacement_runs: Whether replacement content uses new RUN lines.
+        original_case_runs_cmds: Original case-local RUN commands.
+        replacement_content_clean: Replacement content with RUN lines stripped.
+
+    Returns:
+        Final content with case-local RUN lines prepended if appropriate.
+    """
+    # When --replace-run-lines is used, replacement RUNs become new header RUNs
+    # (handled by caller), so don't prepend case-local RUNs.
+    if use_replacement_runs:
+        return replacement_content_clean
+
+    # Prepend case-local RUN lines to replacement content.
+    # This mirrors text mode logic in _build_final_case_content().
+    if original_case_runs_cmds:
+        run_lines = [f"// RUN: {cmd}\n" for cmd in original_case_runs_cmds]
+        return "".join(run_lines) + replacement_content_clean
+
+    return replacement_content_clean
+
+
+def _validate_single_replacement_content(
+    file_path: Path,
+    repl_idx: int,
+    repl: dict,
+    target_case: TestCase,
+    header_runs_normalized: list[str],
+    args: argparse.Namespace,
+    all_errors: list,
+    all_warnings: list,
+) -> tuple[bool, dict] | None:
+    """Validate a single replacement's content.
+
+    Returns:
+        Tuple of (use_replacement_runs, replacement_data) if valid, None if error.
+    """
+    # Check for name/number mismatch if both present.
+    if "number" in repl and "name" in repl:
+        case_name = repl["name"]
+        if target_case.name != case_name:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "error": (
+                        f"Name/number mismatch: 'number' {repl['number']} has name '{target_case.name}', "
+                        f"but 'name' field specifies '{case_name}'. "
+                        f"Fix: Remove one field or ensure they match."
+                    ),
+                }
+            )
+            return None
+
+    # Extract and validate RUN lines.
+    replacement_content = repl["content"]
+    replacement_runs, replacement_content_clean = extract_run_lines_from_string(
+        replacement_content
+    )
+
+    # Extract case-local RUN lines from the original case and filter out header RUNs.
+    # This mirrors the text mode logic for consistent validation.
+    original_case_runs_absolute = target_case.extract_local_run_lines()
+    case_runs_filtered = _filter_header_runs_from_case_runs(
+        original_case_runs_absolute, target_case.content
+    )
+    original_case_runs_cmds = [cmd for (_, cmd) in case_runs_filtered]
+
+    # Temporarily override args with per-case values if present.
+    # Use context manager to ensure automatic restoration.
+    with _TemporaryArgsOverride(
+        args,
+        replace_run_lines=repl.get("replace_run_lines", args.replace_run_lines),
+        allow_empty=repl.get("allow_empty", args.allow_empty),
+        require_label=repl.get("require_label", args.require_label),
+    ):
+        # Validate replacement RUN lines against both header and case-local RUNs.
+        # This validates: replacement runs must match either header or case-local,
+        # unless --replace-run-lines is set.
+        validation_error = _validate_case_run_lines(
+            replacement_runs, original_case_runs_cmds, header_runs_normalized, args
+        )
+
+        if validation_error is not None:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "case": target_case.number,
+                    "name": target_case.name,
+                    "error": "RUN line validation failed (see stderr for details)",
+                }
+            )
+            return None
+
+        # Determine if we're using replacement RUNs.
+        use_replacement_runs = False
+        if replacement_runs and args.replace_run_lines:
+            use_replacement_runs = True
+            # Only warn if replacement RUNs differ from both header and case-local.
+            norm_repl = [_normalize_run_cmd(c) for c in replacement_runs]
+            norm_header = [_normalize_run_cmd(c) for c in header_runs_normalized]
+            norm_case = [_normalize_run_cmd(c) for c in original_case_runs_cmds]
+            if norm_repl != norm_header and norm_repl != norm_case:
+                all_warnings.append(
+                    {
+                        "file": str(file_path),
+                        "replacement": repl_idx + 1,
+                        "case": target_case.number,
+                        "warning": f"Replacing RUN lines with {len(replacement_runs)} new RUN line(s)",
+                    }
+                )
+
+        # Validate empty content.
+        if not replacement_content_clean.strip():
+            if not args.allow_empty:
+                all_errors.append(
+                    {
+                        "file": str(file_path),
+                        "replacement": repl_idx + 1,
+                        "case": target_case.number,
+                        "name": target_case.name,
+                        "error": (
+                            "Replacement content is empty. "
+                            "This would delete case content (delimiters remain). "
+                            "Fix: Use --allow-empty to confirm this is intentional."
+                        ),
+                    }
+                )
+                return None
+
+            all_warnings.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "case": target_case.number,
+                    "warning": f"Replacing case {target_case.number} with empty content (--allow-empty specified)",
+                }
+            )
+
+        # Validate CHECK-LABEL requirement.
+        if args.require_label and not re.search(
+            r"//\s*CHECK-LABEL:\s*@\S+", replacement_content_clean
+        ):
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "case": target_case.number,
+                    "name": target_case.name,
+                    "error": (
+                        f"Replacement content for case {target_case.number} lacks CHECK-LABEL. "
+                        "Expected pattern: // CHECK-LABEL: @function_name"
+                    ),
+                }
+            )
+            return None
+
+        # Verify with iree-opt.
+        _, valid, error_msg = verification.verify_content_with_skip_check(
+            replacement_content_clean,
+            target_case.number,
+            target_case.name,
+            args,
+            timeout=args.verify_timeout,
+        )
+        if not valid:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "case": target_case.number,
+                    "name": target_case.name,
+                    "error": error_msg,
+                }
+            )
+            return None
+
+        # Build final content by prepending case-local RUN lines if needed.
+        final_content = _build_final_json_content(
+            use_replacement_runs, original_case_runs_cmds, replacement_content_clean
+        )
+
+    # Return validated replacement data.
+    replacement_data = {
+        "case": target_case,
+        "content": final_content,
+        "use_replacement_runs": use_replacement_runs,
+        "replacement_runs": replacement_runs if use_replacement_runs else None,
+        "repl_idx": repl_idx,
+    }
+    return use_replacement_runs, replacement_data
+
+
+def _check_batch_run_line_consistency(
+    file_path: Path,
+    run_line_replacements: list[tuple[int, list[str]]],
+    all_errors: list,
+) -> None:
+    """Check that all RUN line replacements for a file agree (P0 issue #3)."""
+    if len(run_line_replacements) <= 1:
+        return
+
+    unique_run_lines = set(tuple(runs) for _, runs in run_line_replacements)
+    if len(unique_run_lines) > 1:
+        indices = [idx + 1 for idx, _ in run_line_replacements]
+        all_errors.append(
+            {
+                "file": str(file_path),
+                "error": (
+                    f"Batch mode conflict: Multiple replacements for {file_path} "
+                    f"specify different RUN lines (entries {indices}). "
+                    f"Fix: Ensure all replacements agree on header RUN lines, or use text mode."
+                ),
+            }
+        )
+
+
+def _validate_file_group_replacements(
+    file_path: Path,
+    test_file_obj: TestFile,
+    replacements_list: list[tuple[int, int, dict]],
+    all_cases: list,
+    args: argparse.Namespace,
+    all_errors: list,
+    all_warnings: list,
+) -> dict | None:
+    """Validate all replacements for a single file.
+
+    Returns:
+        Validation results dict for this file, or None if errors occurred.
+    """
+    # Record file state for concurrency detection.
+    original_stat = file_path.stat()
+    original_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+    # Get header RUN lines.
+    try:
+        header_runs_normalized = test_file_obj.extract_run_lines(raw=False)
+        header_runs_raw = test_file_obj.extract_run_lines(raw=True)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        all_errors.append(
+            {
+                "file": str(file_path),
+                "error": f"Failed to extract header RUN lines: {e}",
+            }
+        )
+        return None
+
+    # Validate each replacement.
+    run_line_replacements = []
+    replacements_data = []
+
+    for case_num, repl_idx, repl in replacements_list:
+        # Find target case.
+        target_case = _find_case_by_number(all_cases, case_num)
+        if not target_case:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "replacement": repl_idx + 1,
+                    "error": f"Case {case_num} not found (internal error)",
+                }
+            )
+            continue
+
+        # Validate replacement content.
+        result = _validate_single_replacement_content(
+            file_path,
+            repl_idx,
+            repl,
+            target_case,
+            header_runs_normalized,
+            args,
+            all_errors,
+            all_warnings,
+        )
+        if result is None:
+            continue
+
+        use_replacement_runs, replacement_data = result
+        replacements_data.append(replacement_data)
+
+        if use_replacement_runs:
+            run_line_replacements.append(
+                (repl_idx, replacement_data["replacement_runs"])
+            )
+
+    # Check RUN line batch consistency (P0 issue #3).
+    _check_batch_run_line_consistency(file_path, run_line_replacements, all_errors)
+
+    # Return validation results for this file.
+    if not replacements_data:
+        return None
+
+    return {
+        "all_cases": all_cases,
+        "header_runs_raw": header_runs_raw,
+        "replacements_data": replacements_data,
+        "original_stat": original_stat,
+        "original_hash": original_hash,
+    }
+
+
+def _validate_all_file_replacements(
+    resolved_replacements: dict, args: argparse.Namespace
+) -> tuple[dict, list] | None:
+    """Validate all resolved replacements.
+
+    Performs content validation for each replacement including:
+    - Name/number consistency checking (when both provided)
+    - RUN line extraction and comparison
+    - Empty content checks
+    - CHECK-LABEL requirements
+    - iree-opt validation
+
+    Args:
+        resolved_replacements: Dictionary from _resolve_and_check_duplicates().
+        args: Parsed arguments.
+
+    Returns:
+        Dictionary mapping file_path -> validation results dict.
+        Returns None on error (errors reported via console.error()).
+    """
+    all_errors = []
+    all_warnings = []
+    validation_results = {}
+
+    # Group by file for efficiency.
+    file_to_replacements = {}
+    for (file_path, case_num), (
+        repl_idx,
+        repl,
+        test_file_obj,
+        all_cases,
+    ) in resolved_replacements.items():
+        if file_path not in file_to_replacements:
+            file_to_replacements[file_path] = {
+                "test_file_obj": test_file_obj,
+                "all_cases": all_cases,
+                "replacements": [],
+            }
+        file_to_replacements[file_path]["replacements"].append(
+            (case_num, repl_idx, repl)
+        )
+
+    # Validate each file's replacements.
+    for file_path, file_data in file_to_replacements.items():
+        file_results = _validate_file_group_replacements(
+            file_path,
+            file_data["test_file_obj"],
+            file_data["replacements"],
+            file_data["all_cases"],
+            args,
+            all_errors,
+            all_warnings,
+        )
+        if file_results:
+            validation_results[file_path] = file_results
+
+    # Check if any errors occurred.
+    if all_errors:
+        console.error(
+            f"Validation failed with {len(all_errors)} error(s):\n"
+            + "\n".join(
+                f"  - File {e.get('file', 'unknown')}, replacement {e.get('replacement', '?')}: {e['error']}"
+                for e in all_errors
+            )
+            + "\nFix: Review individual error messages above for specific solutions.",
+            args=args,
+        )
+        return None
+
+    return validation_results, all_warnings
+
+
+def _execute_batch_file_writes(
+    validation_results: dict, all_warnings: list, args: argparse.Namespace
+) -> tuple[int, int, int, list, list]:
+    """Execute batch file writes after all validation passed.
+
+    Args:
+        validation_results: Dictionary from _validate_all_file_replacements().
+        all_warnings: List of warning dicts from validation phase.
+        args: Parsed arguments.
+
+    Returns:
+        Tuple of (exit_code, modified_files, modified_cases, file_results, all_errors).
+    """
+    modified_files = 0
+    modified_cases = 0
+    file_results = []
+    all_errors = []
+
+    for file_path, results in validation_results.items():
+        all_cases = results["all_cases"]
+        header_runs = results["header_runs_raw"]
+        replacements_data = results["replacements_data"]
+
+        # Build content overrides dict for all replacements.
+        content_overrides = {}
+        for repl_data in replacements_data:
+            target_case = repl_data["case"]
+            content_overrides[target_case.number] = repl_data["content"]
+
+            # If this replacement uses different RUN lines, update header.
+            # Note: At this point, batch mode RUN line conflicts have been detected.
+            if repl_data["use_replacement_runs"]:
+                # Convert normalized RUN lines to raw format (with // RUN: prefix).
+                # This fixes P1 issue #5.
+                header_runs = [
+                    f"// RUN: {cmd}" for cmd in repl_data["replacement_runs"]
+                ]
+
+        # Rebuild file content.
+        new_content = build_file_content(header_runs, all_cases, content_overrides)
+
+        # Check if content actually changed.
+        original_content = file_path.read_text(encoding="utf-8")
+        if new_content == original_content:
+            # No changes needed for this file.
+            file_results.append(
+                {
+                    "file": str(file_path),
+                    "modified": False,
+                    "case_count": len(replacements_data),
+                }
+            )
+            continue
+
+        # Dry-run mode: don't write, but compute diffs.
+        if args.dry_run:
+            # Generate diff for this file.
+            diff_text = generate_unified_diff(
+                original_content, new_content, str(file_path), args
+            )
+
+            file_results.append(
+                {
+                    "file": str(file_path),
+                    "total_cases": len(replacements_data),
+                    "modified": len(replacements_data),
+                    "unchanged": 0,
+                    "dry_run": True,
+                    "cases": [
+                        {
+                            "number": r["case"].number,
+                            "name": r["case"].name,
+                            "changed": True,
+                        }
+                        for r in replacements_data
+                    ],
+                    "diff": diff_text,  # Unified diff as string
+                }
+            )
+            modified_files += 1
+            modified_cases += len(replacements_data)
+            continue
+
+        # Check for concurrent modification before writing.
+        try:
+            check_concurrent_modification(
+                file_path,
+                results["original_stat"],
+                results["original_hash"],
+                args,
+            )
+        except RuntimeError as e:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "error": str(e),
+                }
+            )
+            continue
+
+        # Write file atomically with backup.
+        try:
+            fs.safe_write_text(
+                file_path, new_content, atomic=True, backup=not args.no_backup
+            )
+            modified_files += 1
+            modified_cases += len(replacements_data)
+
+            file_results.append(
+                {
+                    "file": str(file_path),
+                    "total_cases": len(replacements_data),
+                    "modified": len(replacements_data),
+                    "unchanged": 0,
+                    "dry_run": False,
+                    "cases": [
+                        {
+                            "number": r["case"].number,
+                            "name": r["case"].name,
+                            "changed": True,
+                        }
+                        for r in replacements_data
+                    ],
+                    "diff": "",
+                }
+            )
+        except OSError as e:
+            all_errors.append(
+                {
+                    "file": str(file_path),
+                    "error": f"Failed to write file: {e}",
+                }
+            )
+
+    # Determine exit code.
+    exit_code = exit_codes.ERROR if all_errors else exit_codes.SUCCESS
+
+    return exit_code, modified_files, modified_cases, file_results, all_errors
+
+
+def handle_json_mode(json_input: str, args: argparse.Namespace) -> int:
+    """Handle JSON mode replacement (batch operations).
+
+    Refactored to use focused helper functions for maintainability.
+    Implements two-pass duplicate detection to fix selector resolution bug.
+
+    Accepts JSON array matching iree-lit-extract output format:
+    [
+      {
+        "file": "test.mlir",      // optional if CLI arg provided
+        "number": 2,              // XOR with name
+        "name": "func_name",      // XOR with number
+        "content": "...",         // replacement content
+        // Optional fields from extract (ignored):
+        "start_line": 10, "end_line": 20, "line_count": 11, "check_count": 3
+      }
+    ]
+
+    Args:
+        json_input: JSON input string.
+        args: Parsed arguments.
+
+    Returns:
+        Exit code.
+    """
+    # 1. Parse and validate JSON schema (~50 lines extracted).
+    replacements = _parse_and_validate_json_schema(json_input, args)
+    if replacements is None:
+        return exit_codes.ERROR
+
+    # 2. Group by file and check CLI overrides (~40 lines extracted).
+    file_groups = _group_by_file_and_check_overrides(replacements, args)
+
+    # 3. Resolve selectors to canonical form and check duplicates (~130 lines extracted).
+    # This fixes the duplicate detection bug (P0 issue #2).
+    resolved_replacements = _resolve_and_check_duplicates(file_groups, args)
+    if resolved_replacements is None:
+        return exit_codes.ERROR
+
+    # 4. Validate all replacements (~250 lines extracted).
+    # This includes P0 issue #3 fix (RUN line consistency in batch mode).
+    validation_result = _validate_all_file_replacements(resolved_replacements, args)
+    if validation_result is None:
+        return exit_codes.ERROR
+    validation_results, all_warnings = validation_result
+
+    # 5. Execute batch writes (~100 lines extracted).
+    # Returns exit_code based on whether errors occurred.
+    (
+        result_exit_code,
+        modified_files,
+        modified_cases,
+        file_results,
+        all_errors,
+    ) = _execute_batch_file_writes(validation_results, all_warnings, args)
+
+    # 6. Report final results and handle JSON output.
+    # Only output messages if there were errors OR if not quiet mode.
+    if all_errors:
+        console.error(
+            f"Write phase failed with {len(all_errors)} error(s)",
+            args=args,
+        )
+    elif not args.quiet:
+        if modified_files == 0:
+            console.note("No files modified (all content identical)", args=args)
+        else:
+            console.success(
+                f"Replaced {modified_cases} case(s) in {modified_files} file(s)",
+                args=args,
+            )
+
+    # JSON output for both success and error cases.
+    if args.json:
+        payload = {
+            "modified_files": modified_files,
+            "modified_cases": modified_cases,
+            "unchanged_cases": 0,  # JSON batch mode doesn't track unchanged cases currently
+            "dry_run": args.dry_run,
+            "file_results": file_results,
+            "errors": all_errors,
+            "warnings": all_warnings,
+        }
+        write_json_output(payload, args)
+
+    return result_exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(
+        cli.run_with_argparse_suggestions(
+            parse_arguments, main, _suggest_common_mistakes
+        )
+    )

--- a/tools/utils/lit_tools/iree_lit_test.py
+++ b/tools/utils/lit_tools/iree_lit_test.py
@@ -1,0 +1,826 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Run individual test cases from MLIR lit test files.
+
+Lit test files use // ----- to separate multiple test cases. This tool runs
+individual cases in isolation using LLVM lit, making debugging and iteration
+much faster than running entire files.
+
+Quick Start:
+  # Run all test cases
+  iree-lit-test test.mlir
+
+  # Run specific case by number
+  iree-lit-test test.mlir --case 2
+
+  # Run specific case by name
+  iree-lit-test test.mlir --name function_name
+
+  # List available cases
+  iree-lit-test test.mlir --list
+
+  # Debug with extra flags
+  iree-lit-test test.mlir --case 3 --extra-flags="--mlir-print-ir-after-all"
+
+  # Stdin mode - test IR without creating files
+  echo "func.func @test() { return }" | iree-lit-test
+  cat snippet.mlir | iree-lit-test --run "iree-opt --canonicalize"
+  iree-lit-extract test.mlir --case 2 | iree-lit-test
+
+Stdin Mode (No File Input):
+  When no test file is provided, iree-lit-test reads IR from stdin.
+  RUN lines are extracted from input, or use --run to override.
+  If no RUN lines found, defaults to verification (iree-opt %s).
+
+  Usage patterns:
+    # Quick IR verification
+    echo "func.func @test() { return }" | iree-lit-test
+
+    # Test IR with specific pass
+    cat snippet.mlir | iree-lit-test --run "iree-opt --canonicalize"
+
+    # Extract and test in one pipeline
+    iree-lit-extract test.mlir --case 2 | iree-lit-test
+
+    # Heredoc input (may prompt once for approval)
+    iree-lit-test << 'EOF'
+    // RUN: iree-opt %s | FileCheck %s
+    // CHECK-LABEL: @test
+    func.func @test() { return }
+    EOF
+
+  Line numbers in errors match original input (RUN lines don't shift numbering).
+
+Key Features:
+
+  Case Selection:
+    Select by number (--case 1,3,5), range (--case 1-3), or name (--name foo).
+    Use --containing LINE to select case containing a specific line number.
+    Combine multiple --case flags: --case 1 --case 3 --case 5
+
+  Filtering:
+    --filter REGEX: Include only cases matching pattern (e.g., --filter "fold")
+    --filter-out REGEX: Exclude cases matching pattern
+    Combine both to narrow down: --filter "op" --filter-out "gpu"
+
+  Timeout Protection:
+    Tests timeout after 60s by default to catch infinite loops.
+    Configure with --timeout SECONDS or disable with --timeout 0.
+
+  Debug Flag Injection:
+    Add flags to iree-opt/iree-compile without editing test files.
+    Example: --extra-flags="--mlir-print-ir-after-all --debug"
+    Flags are inserted after tool name in RUN: lines.
+
+  Parallel Execution:
+    Run multiple cases concurrently with --workers N.
+    Use --keep-going to continue after failures.
+
+  JSON Output:
+    Machine-readable results with --json.
+    Write to file: --json-output FILE
+    Include full output: --full-json
+    Suppress human-readable output: --quiet
+
+Common Workflows:
+
+  Debug single failing case:
+    $ iree-lit-test test.mlir --case 5 --verbose
+
+  Run subset by name pattern:
+    $ iree-lit-test test.mlir --filter "fold" --keep-going
+
+  Parallel execution for large files:
+    $ iree-lit-test test.mlir --workers 4 --keep-going
+
+  JSON output for automation:
+    $ iree-lit-test test.mlir --json --quiet > results.json
+
+  Preview what would run:
+    $ iree-lit-test test.mlir --filter "fold" --dry-run
+
+  Inject debug flags:
+    $ iree-lit-test test.mlir --case 3 --extra-flags="--debug" --verbose
+
+Exit Codes:
+  0 - All selected test cases passed
+  1 - One or more test cases failed or execution error
+  2 - Not found (file doesn't exist, no cases match selection)
+
+Environment Variables:
+  IREE_BUILD_DIR: Override build directory auto-detection
+
+Build Detection:
+  Automatically finds IREE build directory in this order:
+  1. IREE_BUILD_DIR environment variable
+  2. ./build/ (in-tree build)
+  3. ../<worktree>-build/ (for git worktree pattern)
+  4. ../iree-build/ (main repo build)
+
+For comprehensive troubleshooting guide and advanced usage, see:
+  tools/utils/lit_tools/README.md
+
+See Also:
+  iree-lit-list - List test cases in a file
+  iree-lit-extract - Extract test case to separate file
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lit_tools.core.listing import TestCase
+    from lit_tools.core.lit_wrapper import LitResult
+
+from common import build_detection, console, exit_codes, fs
+
+from lit_tools.core import cli, listing, lit_wrapper
+from lit_tools.core.parser import TestCase, TestFile, parse_test_file
+
+
+def _suggest_common_mistakes(argv: list[str]) -> str | None:
+    """Check for common CLI mistakes and suggest corrections.
+
+    Args:
+        argv: Command line arguments (sys.argv)
+
+    Returns:
+        Suggestion string if a common mistake is detected, None otherwise
+    """
+    if len(argv) < 2:
+        return None
+
+    # Check if last argument looks like a case number without --case flag.
+    last_arg = argv[-1]
+    if last_arg.isdigit():
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --case {last_arg}"
+
+    # Check if there's an unquoted string that looks like a name without --name flag.
+    if (
+        len(argv) >= 3
+        and not argv[-1].startswith("-")
+        and not Path(argv[-1]).exists()
+        and not argv[-1].endswith(".mlir")
+    ):
+        tool_name = Path(argv[0]).name
+        file_arg = argv[-2] if len(argv) >= 3 else "FILE"
+        return f"Did you mean: {tool_name} {file_arg} --name {last_arg}"
+
+    return None
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Build argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Run individual test cases from MLIR lit test files",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "test_file",
+        nargs="?",
+        type=Path,
+        help="Test file to run (.mlir, or omit for stdin)",
+    )
+
+    # Test case selection (shared with iree-lit-extract and iree-lit-lint).
+    cli.add_selection_arguments(parser)
+    # Note: If none provided, run ALL cases.
+
+    # Execution options.
+    exec_group = parser.add_argument_group("Execution options")
+    exec_group.add_argument(
+        "--run",
+        action="append",
+        metavar="CMD",
+        help="RUN command for stdin mode (replaces RUN lines in input, can be repeated)",
+    )
+    exec_group.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        metavar="SEC",
+        help="Test timeout in seconds (default: 60, 0=disable)",
+    )
+    exec_group.add_argument(
+        "--extra-flags",
+        type=str,
+        metavar="FLAGS",
+        help="Inject flags into iree-* tools (e.g., '--debug')",
+    )
+    exec_group.add_argument(
+        "--keep-going", "-k", action="store_true", help="Continue after first failure"
+    )
+    exec_group.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show full lit output (including passing tests)",
+    )
+    exec_group.add_argument(
+        "--keep-temps", action="store_true", help="Don't delete temporary test files"
+    )
+    exec_group.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Number of cases to run in parallel (default: 1)",
+    )
+    # Standardized filters (shared across tools)
+    cli.add_filter_arguments(parser)
+    exec_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be run without executing tests",
+    )
+
+    # Build detection.
+    parser.add_argument(
+        "--build-dir", type=Path, help="IREE build directory (auto-detected if omitted)"
+    )
+
+    # Common output flags.
+    cli.add_common_output_flags(parser)
+
+    # JSON controls
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Write JSON output to this file (instead of stdout)",
+    )
+    parser.add_argument(
+        "--full-json",
+        action="store_true",
+        help="Include full per-case output in JSON (may be large)",
+    )
+
+    return parser.parse_args()
+
+
+def _print_result(result: LitResult, args: argparse.Namespace) -> None:
+    """Print test result with appropriate detail level.
+
+    Args:
+        result: LitResult from running a test case
+        args: Parsed command-line arguments
+    """
+    if result.passed:
+        if not args.quiet:
+            console.note(f"  ✓ PASS ({result.duration:.2f}s)", args=args)
+            if args.verbose and result.stdout and not args.json:
+                console.out("")
+                console.out("Full lit output:")
+                console.out(result.stdout)
+    else:
+        console.error(f"  ✗ FAIL ({result.duration:.2f}s)", args=args)
+        if not args.json:
+            if result.failure_summary:
+                console.note(result.failure_summary, args=args)
+            if args.verbose and result.stdout:
+                console.out("")
+                console.out("Full lit output:")
+                console.out(result.stdout)
+
+
+def _handle_result(
+    result: LitResult, results: list[LitResult], args: argparse.Namespace
+) -> bool:
+    """Process test result and determine if execution should continue.
+
+    Args:
+        result: LitResult from test execution
+        results: List to append result to
+        args: Parsed arguments
+
+    Returns:
+        True if should continue execution, False if should stop early
+    """
+    results.append(result)
+    _print_result(result, args)
+    # Continue if test passed OR if --keep-going is enabled.
+    return result.passed or args.keep_going
+
+
+def _handle_list_mode(
+    test_file: Path, cases: list[TestCase], args: argparse.Namespace
+) -> int:
+    """Handles --list mode to display test cases.
+
+    Args:
+        test_file: Path to test file
+        cases: List of parsed test cases
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS
+    """
+    if args.json:
+        payload = listing.build_json_payload(test_file, cases)
+        console.print_json(payload, args=args)
+    else:
+        console.out(
+            listing.format_text_listing(
+                test_file,
+                cases,
+                pretty=args.pretty,
+                header=not args.quiet,
+            )
+        )
+    return exit_codes.SUCCESS
+
+
+def _handle_dry_run_mode(
+    test_file: Path, selected_cases: list[TestCase], args: argparse.Namespace
+) -> int:
+    """Handles --dry-run mode to show what would be executed.
+
+    Args:
+        test_file: Path to test file
+        selected_cases: List of cases that would be run
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS
+    """
+    if args.json:
+        payload = {
+            "file": str(test_file),
+            "total_cases": len(selected_cases),
+            "selected_cases": [
+                {
+                    "number": c.number,
+                    "name": c.name,
+                    "start_line": c.start_line,
+                    "end_line": c.end_line,
+                }
+                for c in selected_cases
+            ],
+        }
+        console.print_json(payload, args=args)
+    else:
+        if not args.quiet:
+            console.note(
+                f"Dry-run: would execute {len(selected_cases)} case(s)", args=args
+            )
+        for i, case in enumerate(selected_cases):
+            case_label = f"  [{i + 1}] Case {case.number}"
+            if case.name:
+                case_label += f": @{case.name}"
+            case_label += f" (lines {case.start_line}-{case.end_line})"
+            console.note(case_label, args=args)
+    return exit_codes.SUCCESS
+
+
+def _run_cases_parallel(
+    selected_cases: list[TestCase],
+    test_file_obj: TestFile,
+    build_dir: Path,
+    args: argparse.Namespace,
+) -> list[LitResult]:
+    """Runs test cases in parallel using ThreadPoolExecutor.
+
+    Args:
+        selected_cases: List of test cases to run
+        test_file_obj: Parsed test file object
+        build_dir: Build directory path
+        args: Parsed command-line arguments
+
+    Returns:
+        List of LitResult objects
+    """
+    results = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        fut_to_case = {
+            ex.submit(
+                lit_wrapper.run_lit_on_case,
+                case,
+                test_file_obj,
+                build_dir,
+                args.timeout,
+                args.extra_flags,
+                args.verbose,
+                args.keep_temps,
+            ): case
+            for case in selected_cases
+        }
+        for i, fut in enumerate(as_completed(fut_to_case), start=1):
+            case = fut_to_case[fut]
+            if not args.quiet and len(selected_cases) > 1:
+                label = (
+                    f"case {case.number}{' (' + case.name + ')' if case.name else ''}"
+                )
+                console.note(
+                    f"[{i}/{len(selected_cases)}] Running {label}...", args=args
+                )
+            result = fut.result()
+            if not _handle_result(result, results, args):
+                break
+    return results
+
+
+def _run_cases_sequential(
+    selected_cases: list[TestCase],
+    test_file_obj: TestFile,
+    build_dir: Path,
+    args: argparse.Namespace,
+) -> list[LitResult]:
+    """Runs test cases sequentially.
+
+    Args:
+        selected_cases: List of test cases to run
+        test_file_obj: Parsed test file object
+        build_dir: Build directory path
+        args: Parsed command-line arguments
+
+    Returns:
+        List of LitResult objects
+    """
+    results = []
+    for i, case in enumerate(selected_cases):
+        if not args.quiet and len(selected_cases) > 1:
+            case_label = f"case {case.number}"
+            if case.name:
+                case_label += f" ({case.name})"
+            console.note(
+                f"[{i + 1}/{len(selected_cases)}] Running {case_label}...", args=args
+            )
+
+        result = lit_wrapper.run_lit_on_case(
+            case=case,
+            test_file_obj=test_file_obj,
+            build_dir=build_dir,
+            timeout=args.timeout,
+            extra_flags=args.extra_flags,
+            verbose=args.verbose,
+            keep_temps=args.keep_temps,
+        )
+
+        if not _handle_result(result, results, args):
+            break
+    return results
+
+
+def _build_json_output(
+    test_file: Path, results: list[LitResult], args: argparse.Namespace
+) -> dict:
+    """Builds JSON output from test results.
+
+    Args:
+        test_file: Path to test file
+        results: List of LitResult objects
+        args: Parsed command-line arguments
+
+    Returns:
+        Dictionary containing JSON output structure
+    """
+    passed = sum(r.passed for r in results)
+    total = len(results)
+    total_time = sum(r.duration for r in results)
+
+    return {
+        "file": str(test_file),
+        "total_cases": total,
+        "passed": passed,
+        "failed": total - passed,
+        "total_time": round(total_time, 2),
+        "results": [
+            {
+                "case_number": r.case_number,
+                "case_name": r.case_name,
+                "passed": r.passed,
+                "duration": round(r.duration, 2),
+                "failure_summary": r.failure_summary if not r.passed else None,
+                **({"run_commands": r.run_commands} if r.run_commands else {}),
+                **({"output": r.stdout} if args.full_json else {}),
+            }
+            for r in results
+        ],
+    }
+
+
+def _output_json_results(json_output: dict, args: argparse.Namespace) -> None:
+    """Outputs JSON results to file or stdout.
+
+    Args:
+        json_output: JSON output dictionary
+        args: Parsed command-line arguments
+    """
+    if args.json_output:
+        fs.safe_write_text(args.json_output, json.dumps(json_output, indent=2))
+        if not args.quiet:
+            console.note(f"Wrote JSON to {args.json_output}", args=args)
+    else:
+        console.print_json(json_output, args=args)
+
+
+def _compute_final_exit_code(results: list[LitResult], args: argparse.Namespace) -> int:
+    """Computes final exit code based on test results.
+
+    Args:
+        results: List of LitResult objects
+        args: Parsed command-line arguments
+
+    Returns:
+        exit_codes.SUCCESS if all passed, exit_codes.ERROR otherwise
+    """
+    passed = sum(r.passed for r in results)
+    total = len(results)
+    total_time = sum(r.duration for r in results)
+
+    if args.json:
+        return exit_codes.SUCCESS if passed == total else exit_codes.ERROR
+
+    # Human-readable output.
+    if passed == total:
+        if not args.quiet:
+            console.success(
+                f"All {total} test case(s) passed ({total_time:.2f}s total)",
+                args=args,
+            )
+        return exit_codes.SUCCESS
+    console.error(f"{total - passed}/{total} test case(s) failed", args=args)
+    return exit_codes.ERROR
+
+
+def _parse_and_validate_test_file(
+    test_file: Path, args: argparse.Namespace
+) -> tuple[TestFile | None, list[TestCase] | None, int]:
+    """Parses test file and validates it contains test cases.
+
+    Args:
+        test_file: Path to test file
+        args: Parsed command-line arguments
+
+    Returns:
+        Tuple of (test_file_obj, cases, exit_code). Exit code is ERROR/NOT_FOUND on failure.
+    """
+    if not test_file.exists():
+        console.error(f"Test file not found: {test_file}", args=args)
+        return None, None, exit_codes.NOT_FOUND
+
+    try:
+        test_file_obj = parse_test_file(test_file)
+        cases = list(test_file_obj.cases)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        console.error(f"Failed to parse test file: {e}", args=args)
+        return None, None, exit_codes.ERROR
+
+    if not cases:
+        console.error(f"No test cases found in {test_file}", args=args)
+        return None, None, exit_codes.ERROR
+
+    return test_file_obj, cases, exit_codes.SUCCESS
+
+
+def _select_and_filter_cases(
+    cases: list[TestCase], args: argparse.Namespace
+) -> tuple[list[TestCase] | None, int]:
+    """Selects and filters test cases based on arguments.
+
+    Args:
+        cases: List of test cases to filter
+        args: Parsed command-line arguments
+
+    Returns:
+        Tuple of (selected_cases, exit_code). Exit code is NOT_FOUND on failure.
+    """
+    selected_cases = cli.select_cases(cases, args)
+    if selected_cases is None:
+        return None, exit_codes.NOT_FOUND
+
+    # Apply regex filters (only when not using explicit selectors).
+    if (args.filter or args.filter_out) and not (
+        args.case or args.name or args.containing
+    ):
+        selected_cases = cli.apply_filters(
+            selected_cases, args.filter, args.filter_out, args=args
+        )
+        if selected_cases is None:
+            return None, exit_codes.NOT_FOUND
+
+    return selected_cases, exit_codes.SUCCESS
+
+
+def _run_tests_and_output_results(
+    selected_cases: list[TestCase],
+    test_file_obj: TestFile,
+    test_file_path: Path,
+    build_dir: Path,
+    args: argparse.Namespace,
+) -> int:
+    """Runs test cases and outputs results.
+
+    Args:
+        selected_cases: List of test cases to run
+        test_file_obj: Parsed test file object
+        test_file_path: Path to test file (for lit.cfg.py lookup)
+        build_dir: Build directory path
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS or ERROR)
+    """
+    if not args.quiet:
+        case_desc = f"{len(selected_cases)} case(s)"
+        if args.extra_flags:
+            case_desc += f" with extra flags: {args.extra_flags}"
+        console.note(f"Running {case_desc}", args=args)
+
+    # Run test cases (parallel or sequential).
+    if args.workers > 1 and len(selected_cases) > 1:
+        results = _run_cases_parallel(selected_cases, test_file_obj, build_dir, args)
+    else:
+        results = _run_cases_sequential(selected_cases, test_file_obj, build_dir, args)
+
+    # Output JSON results if requested.
+    if args.json:
+        json_output = _build_json_output(test_file_path, results, args)
+        _output_json_results(json_output, args)
+
+    # Compute and return final exit code.
+    return _compute_final_exit_code(results, args)
+
+
+def _extract_run_lines(content: str) -> list[str]:
+    """Extract // RUN: lines from lit test content.
+
+    Args:
+        content: Test file content
+
+    Returns:
+        List of RUN lines (e.g., ["// RUN: iree-opt %s", ...])
+    """
+    lines = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("// RUN:"):
+            lines.append(line.rstrip())  # Preserve indentation, strip trailing.
+    return lines
+
+
+def _strip_lit_directives(content: str) -> str:
+    """Remove // RUN: and // CHECK* lines, keep only IR.
+
+    Args:
+        content: Test file content with lit directives
+
+    Returns:
+        Content with only IR (CHECK/RUN lines removed)
+    """
+    lines = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        # Skip RUN and CHECK lines.
+        if stripped.startswith("// RUN:") or stripped.startswith("// CHECK"):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _handle_stdin_mode(args: argparse.Namespace) -> int:
+    """Handle stdin-based IR testing.
+
+    Reads IR from stdin, extracts or generates RUN lines, creates synthetic
+    test case, and runs it using existing test infrastructure.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS, ERROR, or NOT_FOUND)
+    """
+    # Show TTY prompt if interactive and not quiet.
+    if sys.stdin.isatty() and not args.quiet:
+        console.note(
+            "Reading test input from stdin (Ctrl-D to finish, Ctrl-C to cancel)",
+            args=args,
+        )
+
+    # Read all stdin content.
+    stdin_content = sys.stdin.read()
+
+    if not stdin_content.strip():
+        console.error("No input provided on stdin", args=args)
+        return exit_codes.ERROR
+
+    # Build test content based on --run flag and existing RUN lines.
+    if args.run:
+        # --run override: strip all directives and use provided RUN commands.
+        ir_content = _strip_lit_directives(stdin_content)
+        run_lines = [f"// RUN: {cmd}" for cmd in args.run]
+        # Put RUN at top (standard lit format, even though it shifts line numbers).
+        test_content = "\n".join(run_lines) + "\n\n" + ir_content
+    else:
+        # Check if input already has RUN lines.
+        existing_runs = _extract_run_lines(stdin_content)
+        if existing_runs:
+            # Already has RUN lines, use stdin content as-is.
+            test_content = stdin_content
+        else:
+            # No RUN lines found, add default at top.
+            if not args.quiet:
+                console.note(
+                    "No RUN lines found, defaulting to: iree-opt %s", args=args
+                )
+            test_content = "// RUN: iree-opt %s\n\n" + stdin_content
+
+    # Create synthetic test file in temp directory.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".mlir", delete=False, prefix="stdin_test_"
+    ) as f:
+        f.write(test_content)
+        temp_test_file = Path(f.name)
+
+    try:
+        # Parse the synthetic test file.
+        test_file_obj, cases, result = _parse_and_validate_test_file(
+            temp_test_file, args
+        )
+        if result != exit_codes.SUCCESS:
+            return result
+
+        # In stdin mode, always run all cases (there should only be one).
+        selected_cases = cases
+
+        # Detect build directory.
+        try:
+            build_dir = args.build_dir or build_detection.detect_build_dir()
+        except FileNotFoundError as e:
+            console.error(str(e), args=args)
+            return exit_codes.NOT_FOUND
+
+        # Run test (lit.cfg.py lookup will fall back to cwd if needed).
+        return _run_tests_and_output_results(
+            selected_cases, test_file_obj, temp_test_file, build_dir, args
+        )
+    finally:
+        # Clean up temp file unless --keep-temps.
+        if not args.keep_temps:
+            temp_test_file.unlink(missing_ok=True)
+
+
+def main(args: argparse.Namespace) -> int:
+    """Main entry point.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (SUCCESS, ERROR, or NOT_FOUND)
+    """
+    # Handle stdin mode if no file provided.
+    if args.test_file is None:
+        return _handle_stdin_mode(args)
+
+    # Parse and validate test file.
+    test_file_obj, cases, result = _parse_and_validate_test_file(args.test_file, args)
+    if result != exit_codes.SUCCESS:
+        return result
+
+    # Handle --list mode early exit.
+    if args.list:
+        return _handle_list_mode(args.test_file, cases, args)
+
+    # Select and filter cases to run.
+    selected_cases, result = _select_and_filter_cases(cases, args)
+    if result != exit_codes.SUCCESS:
+        return result
+
+    # Handle --dry-run mode early exit.
+    if args.dry_run:
+        return _handle_dry_run_mode(args.test_file, selected_cases, args)
+
+    # Detect build directory (only needed when running tests).
+    try:
+        build_dir = args.build_dir or build_detection.detect_build_dir()
+    except FileNotFoundError as e:
+        console.error(str(e), args=args)
+        return exit_codes.NOT_FOUND
+
+    # Run tests and output results.
+    return _run_tests_and_output_results(
+        selected_cases, test_file_obj, args.test_file, build_dir, args
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(
+        cli.run_with_argparse_suggestions(
+            parse_arguments, main, _suggest_common_mistakes
+        )
+    )

--- a/tools/utils/lit_tools/tests/test_suggestions.py
+++ b/tools/utils/lit_tools/tests/test_suggestions.py
@@ -1,0 +1,213 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for fuzzy matching suggestion utilities."""
+
+import unittest
+from dataclasses import dataclass
+
+from lit_tools.core import suggestions
+
+
+# Mock TestCase for testing (mimics the real TestCase structure).
+@dataclass
+class MockTestCase:
+    """Mock test case for testing suggestions."""
+
+    name: str | None
+    number: int
+
+
+class TestFindSimilarCaseNames(unittest.TestCase):
+    """Tests for find_similar_case_names()."""
+
+    def setUp(self):
+        """Create test cases for use in tests."""
+        self.test_cases = [
+            MockTestCase(name="emplaceDispatch", number=1),
+            MockTestCase(name="dontEmplaceTiedDispatch", number=2),
+            MockTestCase(name="emplaceDispatchSequence", number=3),
+            MockTestCase(name="foldConstants", number=4),
+            MockTestCase(name="optimizeLoops", number=5),
+            MockTestCase(name=None, number=6),  # Case without name.
+        ]
+
+    def test_exact_typo_single_character(self):
+        """Test single-character typo finds correct suggestion."""
+        suggestions_list = suggestions.find_similar_case_names(
+            "emplceDispatch",  # Missing 'a'.
+            self.test_cases,
+        )
+        # Should find emplaceDispatch as first (best) match.
+        self.assertGreater(len(suggestions_list), 0)
+        self.assertEqual("emplaceDispatch", suggestions_list[0])
+
+    def test_similar_prefix_multiple_matches(self):
+        """Test partial match returns multiple similar names."""
+        suggestions_list = suggestions.find_similar_case_names(
+            "emplaceDisp",  # Prefix of multiple names.
+            self.test_cases,
+        )
+        # Should find emplaceDispatch and emplaceDispatchSequence.
+        self.assertIn("emplaceDispatch", suggestions_list)
+        self.assertIn("emplaceDispatchSequence", suggestions_list)
+        self.assertLessEqual(len(suggestions_list), 3)  # Max 3 suggestions.
+
+    def test_no_similar_names(self):
+        """Test completely different name returns empty list."""
+        suggestions_list = suggestions.find_similar_case_names(
+            "completelyDifferentName", self.test_cases
+        )
+        self.assertEqual([], suggestions_list)
+
+    def test_empty_case_list(self):
+        """Test empty case list returns empty suggestions."""
+        suggestions_list = suggestions.find_similar_case_names("anything", [])
+        self.assertEqual([], suggestions_list)
+
+    def test_all_cases_without_names(self):
+        """Test cases with no names returns empty suggestions."""
+        nameless_cases = [
+            MockTestCase(name=None, number=1),
+            MockTestCase(name=None, number=2),
+        ]
+        suggestions_list = suggestions.find_similar_case_names(
+            "anything", nameless_cases
+        )
+        self.assertEqual([], suggestions_list)
+
+    def test_max_suggestions_limit(self):
+        """Test max_suggestions parameter limits results."""
+        # Create many similar names.
+        many_cases = [MockTestCase(name=f"test{i}", number=i) for i in range(10)]
+        suggestions_list = suggestions.find_similar_case_names(
+            "test", many_cases, max_suggestions=2
+        )
+        self.assertLessEqual(len(suggestions_list), 2)
+
+    def test_cutoff_parameter(self):
+        """Test cutoff parameter filters low-similarity matches."""
+        # With high cutoff, only very similar matches returned.
+        suggestions_list = suggestions.find_similar_case_names(
+            "fold", self.test_cases, cutoff=0.9  # 90% similarity.
+        )
+        # "fold" is not very similar to "foldConstants" (only 44% match).
+        # Should return empty with high cutoff.
+        self.assertEqual([], suggestions_list)
+
+        # With low cutoff, more permissive matching.
+        suggestions_list = suggestions.find_similar_case_names(
+            "fold", self.test_cases, cutoff=0.3  # 30% similarity.
+        )
+        # Now "foldConstants" should match.
+        self.assertIn("foldConstants", suggestions_list)
+
+    def test_case_sensitive_matching(self):
+        """Test that matching is case-sensitive."""
+        cases_with_mixed_case = [
+            MockTestCase(name="TestCase", number=1),
+            MockTestCase(name="testCase", number=2),
+        ]
+        # Exact case match should be prioritized.
+        suggestions_list = suggestions.find_similar_case_names(
+            "testcase", cases_with_mixed_case
+        )
+        # Both are similar, but lowercase is closer match.
+        self.assertIn("testCase", suggestions_list)
+
+
+class TestFormatCaseNameError(unittest.TestCase):
+    """Tests for format_case_name_error()."""
+
+    def setUp(self):
+        """Create test cases for use in tests."""
+        self.test_cases = [
+            MockTestCase(name="emplaceDispatch", number=1),
+            MockTestCase(name="dontEmplaceTiedDispatch", number=2),
+            MockTestCase(name="emplaceDispatchSequence", number=3),
+        ]
+
+    def test_no_suggestions_no_file_path(self):
+        """Test error with no suggestions and no file path."""
+        error_msg = suggestions.format_case_name_error(
+            "completelyWrong", self.test_cases
+        )
+        self.assertEqual("Case with name 'completelyWrong' not found", error_msg)
+
+    def test_no_suggestions_with_file_path(self):
+        """Test error with no suggestions but with file path."""
+        error_msg = suggestions.format_case_name_error(
+            "completelyWrong", self.test_cases, file_path="test.mlir"
+        )
+        self.assertEqual(
+            "Case with name 'completelyWrong' not found in test.mlir", error_msg
+        )
+
+    def test_single_suggestion(self):
+        """Test error message with suggestions."""
+        error_msg = suggestions.format_case_name_error(
+            "emplceDispatch",  # Typo: missing 'a'.
+            self.test_cases,
+        )
+        # Should find emplaceDispatch as a suggestion.
+        self.assertIn("emplaceDispatch", error_msg)
+        self.assertIn("Case with name 'emplceDispatch' not found", error_msg)
+        # Check for suggestion format (either single or multiple).
+        self.assertTrue("Did you mean" in error_msg, "Should include 'Did you mean'")
+
+    def test_multiple_suggestions(self):
+        """Test error message with multiple suggestions."""
+        error_msg = suggestions.format_case_name_error(
+            "emplaceDisp",  # Partial match.
+            self.test_cases,
+        )
+        self.assertIn("Did you mean one of:", error_msg)
+        self.assertIn("emplaceDispatch", error_msg)
+        self.assertIn("emplaceDispatchSequence", error_msg)
+
+    def test_suggestion_with_file_path(self):
+        """Test error with suggestion and file path."""
+        error_msg = suggestions.format_case_name_error(
+            "emplceDispatch",
+            self.test_cases,
+            file_path="emplace_allocations.mlir",
+        )
+        self.assertIn("emplace_allocations.mlir", error_msg)
+        self.assertIn("emplaceDispatch", error_msg)
+        self.assertIn("Did you mean", error_msg)
+
+    def test_empty_case_list(self):
+        """Test error with empty case list."""
+        error_msg = suggestions.format_case_name_error("anything", [])
+        self.assertEqual("Case with name 'anything' not found", error_msg)
+
+
+class TestFormatCaseNumberError(unittest.TestCase):
+    """Tests for format_case_number_error()."""
+
+    def test_basic_error_no_file_path(self):
+        """Test basic case number error without file path."""
+        error_msg = suggestions.format_case_number_error(999, 10)
+        self.assertEqual("Case 999 not found (file has 10 cases)", error_msg)
+
+    def test_error_with_file_path(self):
+        """Test case number error with file path."""
+        error_msg = suggestions.format_case_number_error(0, 5, file_path="test.mlir")
+        self.assertEqual("Case 0 not found in test.mlir (file has 5 cases)", error_msg)
+
+    def test_singular_case(self):
+        """Test message with single case (singular 'case' not 'cases')."""
+        error_msg = suggestions.format_case_number_error(2, 1)
+        self.assertEqual("Case 2 not found (file has 1 case)", error_msg)
+
+    def test_plural_cases(self):
+        """Test message with multiple cases (plural 'cases')."""
+        error_msg = suggestions.format_case_number_error(100, 50)
+        self.assertEqual("Case 100 not found (file has 50 cases)", error_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/lit_tools/tests/test_suggestions_integration.py
+++ b/tools/utils/lit_tools/tests/test_suggestions_integration.py
@@ -1,0 +1,158 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Integration tests for fuzzy matching suggestions in iree-lit-* tools.
+
+These tests verify that the suggestions module integrates correctly with
+the actual tools (iree-lit-extract, iree-lit-test, iree-lit-replace) and
+produces helpful error messages with suggestions when case names are not found.
+"""
+
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from common import exit_codes
+from lit_tools import iree_lit_extract, iree_lit_replace, iree_lit_test
+from lit_tools.core.parser import parse_test_file
+from lit_tools.iree_lit_replace import _find_target_case_by_name
+
+TEST_CONTENT = """// RUN: iree-opt %s | FileCheck %s
+
+// -----
+// CHECK-LABEL: @emplaceDispatch
+util.func @emplaceDispatch() {
+  util.return
+}
+
+// -----
+// CHECK-LABEL: @dontEmplaceTiedDispatch
+util.func @dontEmplaceTiedDispatch() {
+  util.return
+}
+
+// -----
+// CHECK-LABEL: @emplaceDispatchSequence
+util.func @emplaceDispatchSequence() {
+  util.return
+}
+"""
+
+
+@contextmanager
+def temp_test_file(content: str, suffix: str = ".mlir"):
+    """Create a temporary test file with automatic cleanup."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        yield tmp_path
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+class TestSuggestionsIntegration(unittest.TestCase):
+    """Integration tests for fuzzy matching across all tools."""
+
+    def test_extract_with_typo_shows_suggestions(self):
+        """Test iree-lit-extract shows suggestions for typo in name."""
+        with temp_test_file(TEST_CONTENT) as tmp_path:
+            # Create args with typo: "emplceDispatch" (missing 'a').
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(tmp_path),
+                    "--name",
+                    "emplceDispatch",
+                    "--quiet",
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+
+            # Run extraction (should fail with suggestions).
+            exit_code = iree_lit_extract.main(args)
+
+            # Should return NOT_FOUND error.
+            self.assertEqual(exit_codes.NOT_FOUND, exit_code)
+
+            # Error message tested manually - suggestions should appear in stderr.
+            # This test verifies the integration works (exit code correct).
+
+    def test_extract_with_no_match_shows_no_suggestions(self):
+        """Test iree-lit-extract shows no suggestions for completely wrong name."""
+        with temp_test_file(TEST_CONTENT) as tmp_path:
+            # Create args with completely wrong name.
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(tmp_path),
+                    "--name",
+                    "completelyWrongName",
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+
+            # Run extraction (should fail without suggestions).
+            exit_code = iree_lit_extract.main(args)
+
+            # Should return NOT_FOUND error.
+            self.assertEqual(exit_codes.NOT_FOUND, exit_code)
+
+    def test_test_with_typo_shows_suggestions(self):
+        """Test iree-lit-test shows suggestions for typo in name."""
+        with temp_test_file(TEST_CONTENT) as tmp_path:
+            # Create args with typo.
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-test",
+                    str(tmp_path),
+                    "--name",
+                    "emplaceDisptch",
+                    "--quiet",
+                ],
+            ):
+                args = iree_lit_test.parse_arguments()
+
+            # Run test (should fail with suggestions).
+            exit_code = iree_lit_test.main(args)
+
+            # Should return error (no cases found).
+            self.assertNotEqual(exit_codes.SUCCESS, exit_code)
+
+    def test_replace_with_invalid_name_shows_suggestions(self):
+        """Test iree-lit-replace shows suggestions for invalid name in text mode."""
+        with temp_test_file(TEST_CONTENT) as tmp_path:
+            # This test is more complex as it requires stdin input.
+            # We test the core function _find_target_case_by_name instead.
+
+            # Parse test cases.
+            test_file_obj = parse_test_file(tmp_path)
+            all_cases = list(test_file_obj.cases)
+
+            # Create minimal args.
+            with patch("sys.argv", ["iree-lit-replace", "--quiet"]):
+                args = iree_lit_replace.parse_arguments()
+
+            # Try to find case with typo.
+            case, error_code = _find_target_case_by_name(
+                all_cases, tmp_path, "emplaceDisptch", args
+            )
+
+            # Should return None and NOT_FOUND error.
+            self.assertIsNone(case)
+            self.assertEqual(exit_codes.NOT_FOUND, error_code)
+
+            # Suggestions tested manually - error message should contain suggestions.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/lit_tools/tests/test_verification.py
+++ b/tools/utils/lit_tools/tests/test_verification.py
@@ -1,0 +1,270 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for verification helper functions and auto-detection logic."""
+
+import unittest
+from dataclasses import dataclass
+
+from lit_tools.core import verification
+
+
+# Mock TestCase for testing verification helpers.
+@dataclass
+class MockTestCase:
+    """Mock test case for testing verification logic."""
+
+    number: int
+    name: str | None
+    content: str
+
+
+class TestShouldSkipVerificationForCase(unittest.TestCase):
+    """Tests for should_skip_verification_for_case() in verification module."""
+
+    def test_detects_expected_error(self):
+        """Test detection of expected-error directive."""
+        case = MockTestCase(
+            number=1,
+            name="test_invalid",
+            content="""
+func.func @test_invalid() {
+  %c0 = arith.constant 0.0 : f32
+  // expected-error @+1 {{invalid operand type}}
+  %bad = arith.addi %c0, %c0 : f32
+  return
+}
+""",
+        )
+        self.assertTrue(verification.should_skip_verification_for_case(case))
+
+    def test_detects_expected_warning(self):
+        """Test detection of expected-warning directive."""
+        case = MockTestCase(
+            number=1,
+            name="test_warning",
+            content="""
+func.func @test_warning() {
+  // expected-warning @+1 {{deprecated API}}
+  %result = some.deprecated.op : i32
+  return
+}
+""",
+        )
+        self.assertTrue(verification.should_skip_verification_for_case(case))
+
+    def test_detects_expected_note(self):
+        """Test detection of expected-note directive."""
+        case = MockTestCase(
+            number=1,
+            name="test_note",
+            content="""
+func.func @test_note() {
+  // expected-note @+1 {{see related diagnostic}}
+  %x = some.op : i32
+  return
+}
+""",
+        )
+        self.assertTrue(verification.should_skip_verification_for_case(case))
+
+    def test_valid_ir_no_skip(self):
+        """Test that valid IR without expected-error is not skipped."""
+        case = MockTestCase(
+            number=1,
+            name="test_valid",
+            content="""
+func.func @test_valid() {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %sum = arith.addi %c0, %c1 : i32
+  return
+}
+""",
+        )
+        self.assertFalse(verification.should_skip_verification_for_case(case))
+
+    def test_empty_content_no_skip(self):
+        """Test that empty content is not skipped."""
+        case = MockTestCase(number=1, name="test_empty", content="")
+        self.assertFalse(verification.should_skip_verification_for_case(case))
+
+    def test_comment_with_expected_word_no_skip(self):
+        """Test that comments mentioning 'expected-error' in prose are not detected."""
+        case = MockTestCase(
+            number=1,
+            name="test_misleading",
+            content="""
+func.func @test_misleading() {
+  // This function tests behavior when we have an expected-error in documentation
+  %x = arith.constant 0 : i32
+  return
+}
+""",
+        )
+        # The pattern "// expected-error" doesn't match "an expected-error" in prose.
+        # This is good - we want to detect directives, not mentions in comments.
+        self.assertFalse(verification.should_skip_verification_for_case(case))
+
+    def test_multiple_directives(self):
+        """Test detection when multiple diagnostic directives present."""
+        case = MockTestCase(
+            number=1,
+            name="test_multiple",
+            content="""
+func.func @test_multiple() {
+  // expected-warning @+1 {{first issue}}
+  %x = some.op : i32
+  // expected-error @+1 {{second issue}}
+  %y = some.bad.op : f32
+  return
+}
+""",
+        )
+        self.assertTrue(verification.should_skip_verification_for_case(case))
+
+
+class TestShouldSkipVerificationForContent(unittest.TestCase):
+    """Tests for should_skip_verification_for_content() in verification module."""
+
+    def test_detects_expected_error(self):
+        """Test detection of expected-error directive in replacement content."""
+        content = """
+func.func @test_invalid() {
+  %c0 = arith.constant 0.0 : f32
+  // expected-error @+1 {{invalid operand type}}
+  %bad = arith.addi %c0, %c0 : f32
+  return
+}
+"""
+        self.assertTrue(verification.should_skip_verification_for_content(content))
+
+    def test_detects_expected_warning(self):
+        """Test detection of expected-warning directive."""
+        content = """
+func.func @test_warning() {
+  // expected-warning @+1 {{deprecated}}
+  %x = deprecated.op : i32
+  return
+}
+"""
+        self.assertTrue(verification.should_skip_verification_for_content(content))
+
+    def test_detects_expected_note(self):
+        """Test detection of expected-note directive."""
+        content = """
+func.func @test_note() {
+  // expected-note @+1 {{see diagnostic}}
+  %x = some.op : i32
+  return
+}
+"""
+        self.assertTrue(verification.should_skip_verification_for_content(content))
+
+    def test_valid_ir_no_skip(self):
+        """Test that valid IR without expected-error is not skipped."""
+        content = """
+func.func @test_valid() {
+  %c0 = arith.constant 0 : i32
+  return
+}
+"""
+        self.assertFalse(verification.should_skip_verification_for_content(content))
+
+    def test_empty_content_no_skip(self):
+        """Test that empty content is not skipped."""
+        self.assertFalse(verification.should_skip_verification_for_content(""))
+
+    def test_whitespace_only_no_skip(self):
+        """Test that whitespace-only content is not skipped."""
+        self.assertFalse(
+            verification.should_skip_verification_for_content("   \n  \n  ")
+        )
+
+
+class TestInvalidIRDetection(unittest.TestCase):
+    """Tests that actually invalid IR is detected by verification."""
+
+    def test_type_mismatch_fails_verification(self):
+        """Test that type mismatch (float value with int type) fails verification."""
+        content = """
+func.func @test_invalid() {
+  %c0 = arith.constant 0.0 : i32
+  return
+}
+"""
+        # This should fail verification (can't use float 0.0 with i32 type).
+        valid, error_msg = verification.verify_ir(content)
+        self.assertFalse(valid)
+        self.assertIn("Verification failed", error_msg)
+
+    def test_undefined_ssa_value_fails_verification(self):
+        """Test that undefined SSA value reference fails verification."""
+        content = """
+func.func @test_undefined() {
+  %result = arith.addi %undefined, %undefined : i32
+  return
+}
+"""
+        # This should fail verification (undefined SSA values).
+        valid, error_msg = verification.verify_ir(content)
+        self.assertFalse(valid)
+        self.assertIn("Verification failed", error_msg)
+
+    def test_invalid_operation_fails_verification(self):
+        """Test that invalid operation structure fails verification."""
+        content = """
+func.func @test_invalid_op() {
+  %c0 = arith.constant 1 : i32
+  %c1 = arith.constant 2 : i32
+  %bad = arith.addi %c0, %c1 : f32
+  return
+}
+"""
+        # This should fail verification (adding i32 values but declaring result as f32).
+        valid, error_msg = verification.verify_ir(content)
+        self.assertFalse(valid)
+        self.assertIn("Verification failed", error_msg)
+
+
+class TestVerificationHelperConsistency(unittest.TestCase):
+    """Test that both helpers behave consistently."""
+
+    def test_same_content_same_result(self):
+        """Test that both helpers give same result for same content."""
+        content = """
+func.func @test() {
+  // expected-error @+1 {{error}}
+  %x = bad.op : i32
+  return
+}
+"""
+        case = MockTestCase(number=1, name="test", content=content)
+
+        extract_result = verification.should_skip_verification_for_case(case)
+        replace_result = verification.should_skip_verification_for_content(content)
+
+        self.assertEqual(extract_result, replace_result)
+
+    def test_valid_content_consistency(self):
+        """Test both helpers agree on valid content."""
+        content = """
+func.func @valid() {
+  %c0 = arith.constant 0 : i32
+  return
+}
+"""
+        case = MockTestCase(number=1, name="valid", content=content)
+
+        extract_result = verification.should_skip_verification_for_case(case)
+        replace_result = verification.should_skip_verification_for_content(content)
+
+        self.assertEqual(extract_result, replace_result)
+        self.assertFalse(extract_result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/pyproject.toml
+++ b/tools/utils/pyproject.toml
@@ -1,0 +1,78 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iree-utils"
+version = "0.1.0"
+description = "IREE developer utilities for lit testing and CI triage"
+requires-python = ">=3.10"
+dependencies = [
+    # Required by LLVM's lit test framework (third_party/llvm-project/llvm/utils/lit/):
+    # - psutil: Used by lit.util.killProcessAndChildren() to terminate timed-out
+    #   tests and their child processes. Only needed when maxIndividualTestTime > 0
+    #   (iree-lit-test uses --timeout 60 by default). Without psutil, lit will error
+    #   if a timeout is set. See lit/LitConfig.py:maxIndividualTestTimeIsSupported.
+    "psutil",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "black",
+]
+
+[tool.setuptools.packages.find]
+include = ["common*", "lit_tools*", "ci*", "triage_common*", "scripts*"]
+
+# Enable preview mode for latest Ruff rules
+[tool.ruff]
+preview = true
+
+[tool.ruff.lint]
+# Enable specific rule sets for code quality
+# Base rules from pre-commit (E=pycodestyle errors, F=pyflakes, I=isort, B=flake8-bugbear, UP=pyupgrade)
+# Additional quality rules for maintainability
+select = [
+    "E",     # pycodestyle errors
+    "F",     # pyflakes (undefined names, unused imports, etc.)
+    "I",     # isort (import sorting)
+    "B",     # flake8-bugbear (common bugs and design problems)
+    "BLE",   # flake8-blind-except (no bare except Exception)
+    "UP",    # pyupgrade (modern Python idioms)
+    "C90",   # mccabe complexity - catches overly complex functions
+    "ANN",   # flake8-annotations - enforces type hints
+    "D",     # pydocstyle - docstring conventions
+    "TCH",   # flake8-type-checking - optimize type checking imports
+    "RET",   # flake8-return - simplify return statements
+    "SIM",   # flake8-simplify - suggest code simplifications
+    "PLC0415",  # import-outside-toplevel (no inline imports in impl/scripts)
+    "RUF100",   # unused-noqa (clean up unused noqa comments)
+    "TID252",   # relative-imports (enforce absolute imports)
+    "T201",     # print found (use logging instead)
+]
+
+ignore = [
+    "E501",  # line-too-long (black handles this)
+    "ANN101",  # missing-type-self (self type is always obvious)
+    "ANN102",  # missing-type-cls (cls type is always obvious)
+    "ANN202",  # missing-return-type-private-function (private functions don't need public API docs)
+    "ANN401",  # any-type (sometimes Any is the right choice)
+]
+
+# Complexity threshold - functions exceeding this trigger C901
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+# Docstring style configuration
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+# Per-file rule exceptions
+[tool.ruff.lint.per-file-ignores]
+"test_*.py" = ["ANN", "D", "BLE001"]  # Relax type hints and docstrings for tests, but enforce import placement
+"**/test/**/*.py" = ["ANN", "D", "BLE001"]  # Relax for test directory files, but enforce import placement
+"scripts/*.py" = ["T201"]  # Allow print in CLI scripts
+"lit_tools/core/lit_wrapper.py" = ["PLC0415"]  # Allow inline imports (from pre-commit config)
+"lit.cfg.py" = ["E", "F", "I", "B", "UP"]  # Exclude lit config files (from pre-commit)
+# No exceptions for complexity - if it's complex, refactor it!

--- a/tools/utils/scripts/lint_hooks.py
+++ b/tools/utils/scripts/lint_hooks.py
@@ -1,0 +1,237 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Custom lint hooks for pre-commit (scoped to tools/utils/*).
+
+Usage (pre-commit local hook): pass staged file paths as arguments. Exits non-zero
+if any violations are found and prints a short diagnostic per violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+LICENSE_LINE = "Licensed under the Apache License v2.0 with LLVM Exceptions."
+SEE_LINE = "See https://llvm.org/LICENSE.txt for license information."
+SPDX_LINE = "SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception"
+
+
+def _read_text(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return p.read_text(errors="ignore")
+
+
+def check_license_header(p: Path, text: str, problems: list[str]) -> None:
+    """Check that file has standard IREE license header.
+
+    Args:
+        p: Path to file being checked
+        text: File contents
+        problems: List to append error messages to
+    """
+    if p.name == "__init__.py":
+        return
+    # Shebang is optional; required only for top-level entrypoints. We don't enforce it here.
+    head = text.splitlines()[:8]
+    if not (
+        any(LICENSE_LINE in line for line in head)
+        and any(SEE_LINE in line for line in head)
+        and any(SPDX_LINE in line for line in head)
+    ):
+        problems.append(f"{p}: missing standard IREE license header")
+
+
+def check_shebang_policy(p: Path, text: str, problems: list[str]) -> None:
+    """Check that shebangs only appear in bin/ entrypoints.
+
+    Args:
+        p: Path to file being checked
+        text: File contents
+        problems: List to append error messages to
+    """
+    # Only allow shebangs in true CLI entry points under tools/utils/bin/
+    if text.startswith("#!/") and not p.as_posix().startswith("tools/utils/bin/"):
+        problems.append(f"{p}: shebang found in non-entrypoint module; remove it")
+
+
+def check_first_line_is_copyright(p: Path, text: str, problems: list[str]) -> None:
+    """Check that copyright header is on first line (or immediately after shebang).
+
+    Args:
+        p: Path to file being checked
+        text: File contents
+        problems: List to append error messages to
+    """
+    # Ensure there is no leading blank line before the copyright header
+    if p.name == "__init__.py":
+        return
+    if text.startswith("#!/"):
+        # Shebang allowed only in bin/, but even there we want copyright next
+        # line without extra blank lines.
+        lines = text.splitlines()
+        if len(lines) >= 2 and not lines[1].startswith("# Copyright "):
+            problems.append(
+                f"{p}: copyright header must immediately follow shebang or be first line"
+            )
+        return
+    if not text.startswith("# Copyright "):
+        problems.append(f"{p}: file must start with the standard IREE copyright header")
+
+
+def check_no_stderr_print(p: Path, tree: ast.AST, problems: list[str]) -> None:
+    """Check that code uses console helpers instead of print(..., file=sys.stderr).
+
+    Args:
+        p: Path to file being checked
+        tree: AST of file
+        problems: List to append error messages to
+    """
+    if p.as_posix().endswith("tools/utils/lit_tools/core/console.py"):
+        return
+
+    class V(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "print":
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "file"
+                        and isinstance(kw.value, ast.Attribute)
+                        and isinstance(kw.value.value, ast.Name)
+                        and kw.value.value.id == "sys"
+                        and kw.value.attr == "stderr"
+                    ):
+                        problems.append(
+                            f"{p}:{node.lineno}:{node.col_offset}: use console.error/warn/note instead of print(..., file=sys.stderr)"
+                        )
+            self.generic_visit(node)
+
+    V().visit(tree)
+
+
+def check_no_numeric_sys_exit(p: Path, tree: ast.AST, problems: list[str]) -> None:
+    """Check that code uses exit_codes constants instead of numeric sys.exit.
+
+    Args:
+        p: Path to file being checked
+        tree: AST of file
+        problems: List to append error messages to
+    """
+
+    class V(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call):
+            is_sys_exit = False
+            if isinstance(node.func, ast.Attribute) and isinstance(
+                node.func.value, ast.Name
+            ):
+                is_sys_exit = node.func.value.id == "sys" and node.func.attr == "exit"
+            if (
+                is_sys_exit
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, int)
+            ):
+                problems.append(
+                    f"{p}:{node.lineno}:{node.col_offset}: use exit_codes.SUCCESS/ERROR/NOT_FOUND instead of numeric sys.exit"
+                )
+            self.generic_visit(node)
+
+    V().visit(tree)
+
+
+def check_open_without_encoding(p: Path, tree: ast.AST, problems: list[str]) -> None:
+    """Check that open() calls for writing include encoding parameter.
+
+    Args:
+        p: Path to file being checked
+        tree: AST of file
+        problems: List to append error messages to
+    """
+
+    class V(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "open":
+                mode = None
+                if (
+                    len(node.args) >= 2
+                    and isinstance(node.args[1], ast.Constant)
+                    and isinstance(node.args[1].value, str)
+                ):
+                    mode = node.args[1].value
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "mode"
+                        and isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)
+                    ):
+                        mode = kw.value.value
+                has_encoding = any(kw.arg == "encoding" for kw in node.keywords)
+                if mode and any(ch in mode for ch in ("w", "a")) and not has_encoding:
+                    problems.append(
+                        f"{p}:{node.lineno}:{node.col_offset}: open(..., '{mode}') without encoding= — use fs.safe_write_text or add encoding='utf-8'"
+                    )
+            self.generic_visit(node)
+
+    V().visit(tree)
+
+
+def check_cli_common_flags(p: Path, text: str, problems: list[str]) -> None:
+    """Check that CLI tools use cli.add_common_output_flags.
+
+    Args:
+        p: Path to file being checked
+        text: File contents
+        problems: List to append error messages to
+    """
+    # Heuristic: if ArgumentParser appears and cli.add_common_output_flags does not, warn.
+    if "# lint: disable=cli-flags" in text:
+        return
+    if "ArgumentParser(" in text and "cli.add_common_output_flags(" not in text:
+        problems.append(
+            f"{p}: add common flags with cli.add_common_output_flags(parser)"
+        )
+
+
+def main(argv: list[str]) -> int:
+    """Main entry point for lint hooks.
+
+    Args:
+        argv: Command line arguments (file paths to check)
+
+    Returns:
+        0 if no problems found, 1 otherwise
+    """
+    problems: list[str] = []
+    for arg in argv[1:]:
+        p = Path(arg)
+        if p.suffix != ".py" or not p.exists():
+            continue
+        text = _read_text(p)
+        try:
+            tree = ast.parse(text, filename=str(p))
+        except SyntaxError as e:
+            problems.append(f"{p}:{e.lineno}:{e.offset}: syntax error: {e.msg}")
+            continue
+        # Checks
+        check_license_header(p, text, problems)
+        check_no_stderr_print(p, tree, problems)
+        check_no_numeric_sys_exit(p, tree, problems)
+        check_open_without_encoding(p, tree, problems)
+        check_cli_common_flags(p, text, problems)
+        check_shebang_policy(p, text, problems)
+        check_first_line_is_copyright(p, text, problems)
+
+    if problems:
+        print("\n".join(problems))  # noqa: T201
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/utils/scripts/precommit_utils.py
+++ b/tools/utils/scripts/precommit_utils.py
@@ -1,0 +1,227 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Pre-commit validations for tools/utils/ (cross-platform, no bash).
+
+Checks:
+  1) Permissions: only bin/* is executable (POSIX); bin/* must have python3 shebang
+  2) Forbidden imports: no "from lit ..." in utils (use lit_tools);
+     allow in lit_tools/core/lit_wrapper.py and integration tests
+  3) JSON purity: no print() immediately after an "if args.json" branch in lit_tools
+
+Outputs short diagnostics and exits non-zero on failure.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    """Find repository root by searching for .git or WORKSPACE file.
+
+    Returns:
+        Path to repository root
+    """
+    p = Path(__file__).resolve()
+    for q in [p.parents[3], p.parents[2], p.parents[1], p.parents[0]]:
+        if (q / ".git").exists() or (q / "WORKSPACE").exists():
+            return q
+    return p.parents[3]
+
+
+# Ensure utils modules are importable at module import time (no inline imports).
+ROOT = repo_root()
+UTILS_DIR = ROOT / "tools" / "utils"
+sys.path.insert(0, str(UTILS_DIR.resolve()))
+from common import console  # type: ignore  # noqa: E402
+
+
+def is_executable(path: Path) -> bool:
+    """Check if file has executable permission (POSIX only).
+
+    Args:
+        path: Path to file to check
+
+    Returns:
+        True if file is executable, False otherwise (including on Windows)
+    """
+    if os.name == "nt":
+        return False
+    try:
+        return bool(path.stat().st_mode & 0o111)
+    except OSError:
+        return False
+
+
+def check_permissions(root: Path) -> list[str]:
+    """Check that only bin/ files are executable and have python3 shebang.
+
+    Args:
+        root: Repository root path
+
+    Returns:
+        List of error messages
+    """
+    errors: list[str] = []
+    utils = root / "tools" / "utils"
+    # 1) Non-bin Python files must not be executable (POSIX only)
+    for py in utils.rglob("*.py"):
+        rel = py.relative_to(root)
+        if "tools/utils/bin/" in str(rel).replace("\\", "/"):
+            continue
+        if is_executable(py):
+            errors.append(f"Non-bin Python file is executable: {rel}")
+
+    # 2) Bin wrappers must be executable (POSIX) and have python3 shebang
+    bin_dir = utils / "bin"
+    if bin_dir.exists():
+        for f in bin_dir.iterdir():
+            if f.is_file():
+                if os.name != "nt" and not is_executable(f):
+                    errors.append(f"Bin wrapper not executable: {f.relative_to(root)}")
+                try:
+                    first = f.read_text(encoding="utf-8", errors="ignore").splitlines()[
+                        :1
+                    ]
+                except OSError:
+                    first = []
+                if not (first and first[0].strip() == "#!/usr/bin/env python3"):
+                    errors.append(
+                        f"Bin wrapper missing python3 shebang: {f.relative_to(root)}"
+                    )
+    return errors
+
+
+def check_forbidden_imports(root: Path) -> list[str]:
+    """Check that code uses lit_tools instead of direct lit imports.
+
+    Args:
+        root: Repository root path
+
+    Returns:
+        List of error messages
+    """
+    errors: list[str] = []
+    utils = root / "tools" / "utils"
+    allowlist = {
+        str((utils / "lit_tools" / "core" / "lit_wrapper.py").resolve()),
+    }
+
+    # Integration tests may import lit directly; allow those
+    def allowed(path: Path) -> bool:
+        p = str(path.resolve())
+        if p in allowlist:
+            return True
+        norm = p.replace("\\", "/")
+        # Allow integration tests (test_*_integration.py pattern)
+        return norm.endswith("_integration.py")
+
+    pattern = re.compile(r"^\s*from\s+lit(\.|\s)", re.MULTILINE)
+    for py in utils.rglob("*.py"):
+        if allowed(py):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if pattern.search(text):
+            errors.append(
+                f"Forbidden import 'from lit ...' in {py.relative_to(root)}; use 'from lit_tools'"
+            )
+    return errors
+
+
+def check_json_purity(root: Path) -> list[str]:
+    """Check that print() is never called inside JSON output branches.
+
+    Args:
+        root: Repository root path
+
+    Returns:
+        List of error messages
+    """
+    errors: list[str] = []
+    lt = root / "tools" / "utils" / "lit_tools"
+    # Heuristic: look for 'if args.json' followed by a 'print(' within next 1 line
+    json_guard = re.compile(r"if\s+args\.json[^\n]*\n\s*print\(", re.MULTILINE)
+    for py in lt.rglob("*.py"):
+        try:
+            text = py.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if json_guard.search(text):
+            errors.append(
+                f"print() inside JSON branch in {py.relative_to(root)}; never print to stdout when --json is set"
+            )
+    return errors
+
+
+def check_forbidden_sys_stream_writes(root: Path) -> list[str]:
+    """Disallow direct sys.stdout/sys.stderr writes in implementation.
+
+    Primary output must go through lit_tools.core.console helpers to ensure
+    consistent behavior and easy policy changes. Allow writes only in the
+    console module itself.
+
+    Args:
+        root: Repository root path
+
+    Returns:
+        List of error messages
+    """
+    errors: list[str] = []
+    lt = root / "tools" / "utils" / "lit_tools"
+    for py in lt.rglob("*.py"):
+        # Allow in core/console.py (the only place where touching sys.* is OK).
+        norm = str(py.resolve()).replace("\\", "/")
+        if norm.endswith("/lit_tools/core/console.py"):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if re.search(r"\bsys\.(stdout|stderr)\.", text):
+            rel = py.relative_to(root)
+            errors.append(
+                f"Forbidden sys.(stdout|stderr) usage in {rel}; use console.out/console.write or console.error/warn/note/success"
+            )
+        if re.search(
+            r"^\s*from\s+sys\s+import\s+(stdout|stderr)\b", text, re.MULTILINE
+        ):
+            rel = py.relative_to(root)
+            errors.append(
+                f"Forbidden 'from sys import stdout/stderr' in {rel}; use console helpers"
+            )
+    return errors
+
+
+def main() -> int:
+    """Main entry point for pre-commit validation checks.
+
+    Returns:
+        0 if all checks pass, 1 if any violations found
+    """
+    root = ROOT
+
+    problems: list[str] = []
+    problems += check_permissions(root)
+    problems += check_forbidden_imports(root)
+    problems += check_json_purity(root)
+    problems += check_forbidden_sys_stream_writes(root)
+    if problems:
+        for p in problems:
+            console.error(str(p))
+        return 1
+    # Be silent on success to avoid noisy pre-commit output.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/utils/test/README.md
+++ b/tools/utils/test/README.md
@@ -1,0 +1,213 @@
+# IREE Lit Tools Test Suite
+
+This directory contains comprehensive tests for the iree-lit-* utilities (iree-lit-test, iree-lit-extract, iree-lit-replace, iree-lit-list).
+
+## Running Tests
+
+Tests work from any location using unittest discovery:
+
+```bash
+# From IREE repo root (primary workflow - works everywhere):
+python -m unittest discover -s tools/utils -p "test_*.py" -v
+
+# From tools/utils directory (local development):
+cd tools/utils
+python -m unittest discover -s . -p "test_*.py" -v
+
+# From any location (absolute path):
+python -m unittest discover -s /absolute/path/to/iree/tools/utils -p "test_*.py" -v
+```
+
+This discovers and runs:
+- Unit tests in `lit_tools/tests/` (40 tests)
+- Integration tests in `test/lit_tests/` (316 tests)
+- **Total: 356 tests**
+
+### Common Issues
+
+**Build detection failures:** Some tests require `iree-opt` and other tools. Set `IREE_BUILD_DIR` or ensure tools are in PATH.
+
+## Test Organization
+
+### `lit_tools/tests/` - Unit Tests
+- `test_suggestions.py` - Fuzzy matching for case names
+- `test_verification.py` - IR verification with iree-opt (18 tests)
+- `test_suggestions_integration.py` - Integration tests for suggestions
+
+### `test/lit_tests/` - Integration Tests
+- `test_core_cli.py` - CLI argument parsing, case selection, filtering
+- `test_extract.py` - iree-lit-extract functionality
+- `test_replace.py` - iree-lit-replace functionality
+- `test_replace_integration.py` - End-to-end workflows
+- `test_list.py` - iree-lit-list functionality
+- `test_lit_test_cli.py` - iree-lit-test CLI integration
+- `test_integration_iree_lit_test.py` - Full tool integration
+- `test_workflows.py` - Multi-tool workflows
+- Additional specialized test files
+
+## Test Coverage
+
+The Python test suite provides comprehensive coverage:
+
+### ✅ Basic Functionality
+- Timeout protection
+- Extra flags injection
+- Verbose/quiet modes
+- Multiple output formats (text, JSON)
+
+### ✅ Case Selection
+- Single case by number/name
+- Comma-separated lists (`--case 1,3,5`)
+- Range syntax (`--case 1-3`, `--case 5-10`)
+- Mixed syntax (`--case 1,3-5,7`)
+- Multiple --case flags
+- Line number selection (`--containing`)
+
+### ✅ Filtering
+- Regex include (`--filter`)
+- Regex exclude (`--filter-out`)
+- Combined filtering
+
+### ✅ Modes
+- List mode (`--list`)
+- Dry-run mode (`--dry-run`)
+- Extraction modes (stdout, file output, JSON)
+
+### ✅ Error Handling
+- File not found
+- Invalid case numbers/names
+- Invalid ranges
+- Filter no matches
+- Missing required tools
+
+### ✅ Edge Cases
+- Whitespace in arguments
+- Empty arguments
+- Zero and negative case numbers
+- Duplicate case numbers (auto-deduplicated)
+- Very large case ranges
+
+### ✅ Tool Integration
+- Extract → edit → replace workflows
+- JSON mode for automation
+- Multi-file operations
+
+## For LLMs and Automation
+
+**Single source of truth for testing:**
+
+```bash
+# From IREE repo root (works everywhere):
+python -m unittest discover -s tools/utils -p "test_*.py" -v
+```
+
+Expected output on success:
+```
+Ran 356 tests in X.XXXs
+
+OK
+```
+
+**Never declare tests passing without running the full suite (356 tests).**
+
+## Adding New Tests
+
+1. **Unit tests** for core modules → `lit_tools/tests/test_*.py`
+2. **Integration tests** for CLI tools → `test/lit_tests/test_*.py`
+3. Use fixtures from `test/lit_tests/fixtures/`
+4. Follow existing patterns (context managers, mocking with `patch()`)
+
+## Subprocess Best Practices
+
+### CRITICAL: Use `run_python_module()` for All Python Module Invocations
+
+**When writing integration tests**, always use the `run_python_module()` helper from `test.test_helpers`:
+
+```python
+from test.test_helpers import run_python_module
+
+# ✅ CORRECT: Use run_python_module for tools/utils modules
+result = run_python_module(
+    "lit_tools.iree_lit_extract",
+    [str(test_file), "--case", "2"],
+    capture_output=True,
+    text=True,
+)
+
+# ✅ CORRECT: External binaries use subprocess.run directly
+result = subprocess.run(
+    ["gh", "pr", "view", "12345"],
+    capture_output=True,
+)
+
+# ❌ WRONG: Hardcoded python3 - breaks in venv, pyenv, etc.
+result = subprocess.run(
+    ["python3", "-m", "lit_tools.iree_lit_extract", ...],
+    ...
+)
+```
+
+### Why run_python_module()?
+
+The helper ensures tests work correctly in ALL environments:
+
+1. **Uses current Python interpreter** (`sys.executable`) instead of hardcoded `"python3"`
+   - Works with pyenv, venv, virtualenv, different Python versions
+2. **Sets up PYTHONPATH** automatically for tools/utils imports
+   - Tests work from repo root AND from tools/utils directory
+3. **Preserves environment** - existing PYTHONPATH, env vars are maintained
+4. **Future-proof** - new tests automatically use correct patterns
+
+### When to Use What
+
+```python
+# Python modules in tools/utils (lit_tools, ci, common):
+from test.test_helpers import run_python_module
+result = run_python_module("lit_tools.iree_lit_list", [str(file)])
+
+# External binaries (gh, git, iree-opt, iree-compile):
+import subprocess
+result = subprocess.run(["gh", "pr", "list"], capture_output=True)
+```
+
+### Examples
+
+```python
+# Extract a test case to JSON
+result = run_python_module(
+    "lit_tools.iree_lit_extract",
+    [str(test_file), "--case", "2", "--json"],
+    capture_output=True,
+    text=True,
+)
+extracted = json.loads(result.stdout)
+
+# Replace with stdin input
+result = run_python_module(
+    "lit_tools.iree_lit_replace",
+    [str(test_file), "--case", "1"],
+    input=new_content,
+    capture_output=True,
+    text=True,
+)
+
+# Run CI triage tool
+result = run_python_module(
+    "ci.iree_ci_triage",
+    ["--pr", "12345", "--verbose"],
+    capture_output=True,
+    text=True,
+)
+```
+
+All `subprocess.run()` kwargs work: `capture_output`, `text`, `input`, `timeout`, `check`, etc.
+
+## Test Fixtures
+
+Located in `test/lit_tests/fixtures/`:
+- `simple_test.mlir` - Single test case
+- `split_test.mlir` - Three test cases with `// -----` separators
+- `ten_cases_test.mlir` - Ten test cases for multi-case selection testing
+- Additional specialized fixtures
+
+All fixtures use valid MLIR syntax and can be processed by iree-opt.

--- a/tools/utils/test/__init__.py
+++ b/tools/utils/test/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for tools/utils/test

--- a/tools/utils/test/ci_tests/__init__.py
+++ b/tools/utils/test/ci_tests/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for CI failure triage tools."""

--- a/tools/utils/test/ci_tests/fixtures/test_cooccurrence_rules.yaml
+++ b/tools/utils/test/ci_tests/fixtures/test_cooccurrence_rules.yaml
@@ -1,0 +1,37 @@
+# Test co-occurrence rules for CI triage tool unit tests.
+# Minimal subset to test root cause grouping logic.
+
+root_cause_rules:
+  - name: "rocm_cleanup_crash"
+    primary_pattern: "rocclr_memobj"
+    secondary_patterns:
+      - "aborted"
+    description: "ROCm memory object cleanup crash during teardown - false CI failure"
+    priority: 100
+    actionable: false
+    category: "infrastructure"
+
+  - name: "compilation_failure"
+    primary_pattern: "compile_error"
+    secondary_patterns: []
+    description: "C++ compilation error - code bug"
+    priority: 80
+    actionable: true
+    category: "code"
+
+  - name: "test_timeout"
+    primary_pattern: "timeout"
+    secondary_patterns:
+      - "lit_test_failed"
+    description: "Test exceeded time limit"
+    priority: 70
+    actionable: true
+    category: "test_failure"
+
+pattern_priorities:
+  filecheck_failed: 80
+  rocclr_memobj: 100
+  aborted: 50
+  compile_error: 80
+  timeout: 70
+  lit_test_failed: 75

--- a/tools/utils/test/ci_tests/fixtures/test_patterns.yaml
+++ b/tools/utils/test/ci_tests/fixtures/test_patterns.yaml
@@ -1,0 +1,58 @@
+# Test error patterns for CI triage tool unit tests.
+# Minimal subset to test pattern matching logic.
+
+patterns:
+  filecheck_failed:
+    pattern: 'CHECK.*expected string not found'
+    severity: high
+    actionable: true
+    context_lines: 2
+    description: "FileCheck test failure - expected pattern not found in output"
+    extract:
+      - name: file_path
+        regex: '(\S+\.mlir):(\d+):'
+      - name: error_message
+        regex: 'error: (.+)'
+
+  rocclr_memobj:
+    pattern: 'rocclr/device/(device|memory)\.cpp'
+    severity: critical
+    actionable: false
+    context_lines: 3
+    description: "ROCm memory object cleanup crash"
+
+  aborted:
+    pattern: 'Aborted \(core dumped\)|signal SIGABRT'
+    severity: critical
+    actionable: false
+    context_lines: 1
+    description: "Process aborted with SIGABRT"
+
+  compile_error:
+    pattern: 'error:.*|fatal error:.*|compilation terminated'
+    severity: critical
+    actionable: true
+    context_lines: 3
+    description: "C++ compilation error"
+    extract:
+      - name: file_path
+        regex: '(\S+\.\w+):(\d+):(\d+):'
+      - name: error_message
+        regex: '(?:fatal )?error: (.+)'
+
+  timeout:
+    pattern: 'TIMEOUT:|exceeded maximum time limit|Killing process group'
+    severity: high
+    actionable: true
+    context_lines: 2
+    description: "Test timeout"
+
+  lit_test_failed:
+    pattern: '\*+ TEST .* FAILED \*+'
+    severity: high
+    actionable: true
+    context_lines: 5
+    description: "LIT test framework failure"
+    extract:
+      - name: test_name
+        regex: "TEST '([^']+)' FAILED"

--- a/tools/utils/test/ci_tests/test_extractors.py
+++ b/tools/utils/test/ci_tests/test_extractors.py
@@ -1,0 +1,468 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for CI triage output formatters."""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core import extractors, patterns
+
+
+class TestMarkdownFormatter(unittest.TestCase):
+    """Tests for markdown output formatting."""
+
+    def test_format_single_actionable_issue(self):
+        """Test markdown output for single actionable root cause."""
+        # Create synthetic triage result.
+        rule = patterns.RootCauseRule(
+            name="filecheck_failure",
+            primary_pattern="filecheck_failed",
+            secondary_patterns=[],
+            description="FileCheck pattern not found",
+            priority=80,
+            actionable=True,
+            category="test_failure",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="filecheck_failed",
+            match_text="CHECK: expected string not found",
+            line_number=42,
+            context_before=["func.func @test() {"],
+            context_after=["  return"],
+            extracted_fields={"file_path": ["test.mlir:42:11"]},
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="12345",
+            job_id="67890",
+            job_name="linux_x64_test",
+            root_causes=[root_cause],
+        )
+
+        formatter = extractors.MarkdownFormatter()
+        output = formatter.format(result)
+
+        # Verify key sections present.
+        self.assertIn("# CI Failure Triage Report", output)
+        self.assertIn("filecheck_failure", output)
+        self.assertIn("Line 42", output)
+        self.assertIn("test.mlir:42:11", output)
+        self.assertIn("1 actionable", output)
+
+    def test_format_infrastructure_issue(self):
+        """Test markdown output for non-actionable infrastructure issue."""
+        rule = patterns.RootCauseRule(
+            name="rocm_cleanup_crash",
+            primary_pattern="rocclr_memobj",
+            secondary_patterns=["aborted"],
+            description="ROCm cleanup crash",
+            priority=100,
+            actionable=False,
+            category="infrastructure",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="rocclr_memobj",
+            match_text="rocclr/device/device.cpp:2891",
+            line_number=15,
+            context_before=[],
+            context_after=[],
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="12345",
+            job_id="67890",
+            job_name="amd_hip_test",
+            root_causes=[root_cause],
+        )
+
+        formatter = extractors.MarkdownFormatter()
+        output = formatter.format(result)
+
+        self.assertIn("Infrastructure Issues (Non-Actionable)", output)
+        self.assertIn("rocm_cleanup_crash", output)
+        self.assertIn("infrastructure", output)
+
+    def test_format_no_context_mode(self):
+        """Test markdown output with context disabled."""
+        rule = patterns.RootCauseRule(
+            name="test_failure",
+            primary_pattern="lit_test_failed",
+            secondary_patterns=[],
+            description="Test failed",
+            priority=75,
+            actionable=True,
+            category="test",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="lit_test_failed",
+            match_text="TEST 'test.mlir' FAILED",
+            line_number=10,
+            context_before=["line before"],
+            context_after=["line after"],
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="12345",
+            job_id="67890",
+            job_name="test_job",
+            root_causes=[root_cause],
+        )
+
+        formatter = extractors.MarkdownFormatter()
+        output_with_context = formatter.format(result, include_context=True)
+        output_no_context = formatter.format(result, include_context=False)
+
+        # With context should include error context section.
+        self.assertIn("Error Context", output_with_context)
+        self.assertIn("line before", output_with_context)
+        self.assertIn("line after", output_with_context)
+
+        # Without context should not.
+        self.assertNotIn("Error Context", output_no_context)
+        self.assertNotIn("line before", output_no_context)
+
+
+class TestJSONFormatter(unittest.TestCase):
+    """Tests for JSON output formatting and LLM usability."""
+
+    def test_json_structure_valid(self):
+        """Test that JSON output is valid and parseable."""
+        rule = patterns.RootCauseRule(
+            name="compile_error",
+            primary_pattern="compile_error",
+            secondary_patterns=[],
+            description="Compilation failed",
+            priority=80,
+            actionable=True,
+            category="code",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="compile_error",
+            match_text="error: use of undeclared identifier 'foo'",
+            line_number=42,
+            context_before=["int main() {"],
+            context_after=["  return 0;"],
+            extracted_fields={
+                "file_path": ["test.c:42:10"],
+                "error_message": ["use of undeclared identifier 'foo'"],
+            },
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="12345",
+            job_id="67890",
+            job_name="build_test",
+            root_causes=[root_cause],
+        )
+
+        # Convert to JSON.
+        json_output = result.to_dict()
+
+        # Verify it's valid JSON by serializing and parsing.
+        json_str = json.dumps(json_output)
+        parsed = json.loads(json_str)
+
+        self.assertIsInstance(parsed, dict)
+        self.assertIn("run_id", parsed)
+        self.assertIn("job_id", parsed)
+        self.assertIn("root_causes", parsed)
+
+    def test_json_required_fields(self):
+        """Test that all required fields are present for LLM consumption."""
+        rule = patterns.RootCauseRule(
+            name="test_error",
+            primary_pattern="test_pattern",
+            secondary_patterns=[],
+            description="Test description",
+            priority=50,
+            actionable=True,
+            category="test",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="test_pattern",
+            match_text="test match",
+            line_number=1,
+            context_before=[],
+            context_after=[],
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="111",
+            job_id="222",
+            job_name="test_job",
+            root_causes=[root_cause],
+        )
+
+        json_output = result.to_dict()
+
+        # Verify top-level fields.
+        self.assertEqual(json_output["run_id"], "111")
+        self.assertEqual(json_output["job_id"], "222")
+        self.assertEqual(json_output["job_name"], "test_job")
+        self.assertIsInstance(json_output["root_causes"], list)
+        self.assertEqual(len(json_output["root_causes"]), 1)
+
+        # Verify root cause fields.
+        rc = json_output["root_causes"][0]
+        self.assertEqual(rc["name"], "test_error")
+        self.assertEqual(rc["category"], "test")
+        self.assertEqual(rc["priority"], 50)
+        self.assertTrue(rc["actionable"])
+        self.assertEqual(rc["description"], "Test description")
+        self.assertEqual(rc["primary_pattern"], "test_pattern")
+        self.assertIsInstance(rc["secondary_patterns"], list)
+
+        # Verify match fields.
+        self.assertIsInstance(rc["matches"], list)
+        self.assertEqual(len(rc["matches"]), 1)
+        m = rc["matches"][0]
+        self.assertEqual(m["pattern_name"], "test_pattern")
+        self.assertEqual(m["match_text"], "test match")
+        self.assertEqual(m["line_number"], 1)
+        self.assertIsInstance(m["context_before"], list)
+        self.assertIsInstance(m["context_after"], list)
+        self.assertIsInstance(m["extracted_fields"], dict)
+
+    def test_json_extracted_fields_format(self):
+        """Test that extracted fields are in LLM-friendly format."""
+        rule = patterns.RootCauseRule(
+            name="error_with_fields",
+            primary_pattern="error_pattern",
+            secondary_patterns=[],
+            description="Error with extracted fields",
+            priority=75,
+            actionable=True,
+            category="test",
+        )
+        match = patterns.PatternMatch(
+            pattern_name="error_pattern",
+            match_text="error at line 42",
+            line_number=10,
+            context_before=[],
+            context_after=[],
+            extracted_fields={
+                "file_path": ["src/test.cpp:42:5"],
+                "error_message": ["undefined reference to 'foo'"],
+                "symbol": ["foo"],
+            },
+        )
+        root_cause = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+        result = extractors.TriageResult(
+            run_id="123",
+            job_id="456",
+            job_name="test",
+            root_causes=[root_cause],
+        )
+
+        json_output = result.to_dict()
+        fields = json_output["root_causes"][0]["matches"][0]["extracted_fields"]
+
+        # Verify extracted fields are accessible.
+        self.assertIn("file_path", fields)
+        self.assertIn("error_message", fields)
+        self.assertIn("symbol", fields)
+
+        # Verify they're lists (for multiple captures).
+        self.assertIsInstance(fields["file_path"], list)
+        self.assertEqual(fields["file_path"][0], "src/test.cpp:42:5")
+
+    def test_json_serialization_complete(self):
+        """Test full JSON serialization with multiple root causes."""
+        # Create two root causes.
+        rule1 = patterns.RootCauseRule(
+            name="error1",
+            primary_pattern="p1",
+            secondary_patterns=[],
+            description="First error",
+            priority=80,
+            actionable=True,
+            category="code",
+        )
+        rule2 = patterns.RootCauseRule(
+            name="error2",
+            primary_pattern="p2",
+            secondary_patterns=["p3"],
+            description="Second error",
+            priority=70,
+            actionable=False,
+            category="infra",
+        )
+
+        match1 = patterns.PatternMatch(
+            pattern_name="p1",
+            match_text="match1",
+            line_number=1,
+            context_before=[],
+            context_after=[],
+        )
+        match2 = patterns.PatternMatch(
+            pattern_name="p2",
+            match_text="match2",
+            line_number=2,
+            context_before=[],
+            context_after=[],
+        )
+        match3 = patterns.PatternMatch(
+            pattern_name="p3",
+            match_text="match3",
+            line_number=3,
+            context_before=[],
+            context_after=[],
+        )
+
+        rc1 = patterns.RootCause(
+            rule=rule1, primary_matches=[match1], secondary_matches=[]
+        )
+        rc2 = patterns.RootCause(
+            rule=rule2, primary_matches=[match2], secondary_matches=[match3]
+        )
+
+        result = extractors.TriageResult(
+            run_id="999",
+            job_id="888",
+            job_name="multi_error_job",
+            root_causes=[rc1, rc2],
+        )
+
+        # Serialize to JSON string.
+        json_str = json.dumps(result.to_dict(), indent=2)
+
+        # Verify it parses back.
+        parsed = json.loads(json_str)
+
+        self.assertEqual(len(parsed["root_causes"]), 2)
+        self.assertEqual(parsed["root_causes"][0]["name"], "error1")
+        self.assertEqual(parsed["root_causes"][1]["name"], "error2")
+
+        # Verify secondary matches included.
+        self.assertEqual(len(parsed["root_causes"][1]["matches"]), 2)
+
+
+class TestChecklistFormatter(unittest.TestCase):
+    """Tests for checklist output formatting."""
+
+    def test_checklist_format_actionable_only(self):
+        """Test checklist only includes actionable items."""
+        # Create one actionable and one non-actionable.
+        actionable_rule = patterns.RootCauseRule(
+            name="fix_this",
+            primary_pattern="error",
+            secondary_patterns=[],
+            description="Needs fixing",
+            priority=80,
+            actionable=True,
+            category="code",
+        )
+        infrastructure_rule = patterns.RootCauseRule(
+            name="infra_issue",
+            primary_pattern="flake",
+            secondary_patterns=[],
+            description="Infrastructure flake",
+            priority=50,
+            actionable=False,
+            category="infrastructure",
+        )
+
+        match1 = patterns.PatternMatch(
+            pattern_name="error",
+            match_text="error: bad code",
+            line_number=10,
+            context_before=[],
+            context_after=[],
+            extracted_fields={"file_path": ["test.c:10:5"]},
+        )
+        match2 = patterns.PatternMatch(
+            pattern_name="flake",
+            match_text="random failure",
+            line_number=20,
+            context_before=[],
+            context_after=[],
+        )
+
+        rc1 = patterns.RootCause(
+            rule=actionable_rule, primary_matches=[match1], secondary_matches=[]
+        )
+        rc2 = patterns.RootCause(
+            rule=infrastructure_rule, primary_matches=[match2], secondary_matches=[]
+        )
+
+        result = extractors.TriageResult(
+            run_id="123",
+            job_id="456",
+            job_name="test",
+            root_causes=[rc1, rc2],
+        )
+
+        formatter = extractors.ChecklistFormatter()
+        output = formatter.format(result)
+
+        # Should only include actionable item.
+        self.assertIn("RC-1: fix_this", output)
+        self.assertNotIn("infra_issue", output)
+
+    def test_checklist_format_with_extracted_fields(self):
+        """Test checklist includes fix hints from extracted fields."""
+        rule = patterns.RootCauseRule(
+            name="compile_failure",
+            primary_pattern="compile_error",
+            secondary_patterns=[],
+            description="Compilation failed",
+            priority=80,
+            actionable=True,
+            category="code",
+        )
+
+        match = patterns.PatternMatch(
+            pattern_name="compile_error",
+            match_text="error: undefined reference",
+            line_number=42,
+            context_before=[],
+            context_after=[],
+            extracted_fields={
+                "file_path": ["build.c:42:10"],
+                "error_message": ["undefined reference to 'foo'"],
+            },
+        )
+
+        rc = patterns.RootCause(
+            rule=rule, primary_matches=[match], secondary_matches=[]
+        )
+
+        result = extractors.TriageResult(
+            run_id="123",
+            job_id="456",
+            job_name="build",
+            root_causes=[rc],
+        )
+
+        formatter = extractors.ChecklistFormatter()
+        output = formatter.format(result)
+
+        # Should include file and error in fix hint.
+        self.assertIn("File: build.c:42:10", output)
+        self.assertIn("Error: undefined reference to 'foo'", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/ci_tests/test_github_client.py
+++ b/tools/utils/test/ci_tests/test_github_client.py
@@ -1,0 +1,216 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for GitHub CLI wrapper."""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core import github_client
+
+
+class TestGitHubClientSetup(unittest.TestCase):
+    """Tests for GitHub CLI availability and authentication."""
+
+    @patch("subprocess.run")
+    def test_check_cli_available(self, mock_run):
+        """Test gh CLI availability check."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        client = github_client.GitHubClient()
+        self.assertTrue(client.check_cli_available())
+
+        # Verify command was correct.
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "--version"])
+
+    @patch("subprocess.run")
+    def test_check_cli_not_available(self, mock_run):
+        """Test gh CLI not available."""
+        mock_run.side_effect = FileNotFoundError()
+
+        client = github_client.GitHubClient()
+        self.assertFalse(client.check_cli_available())
+
+    @patch("subprocess.run")
+    def test_check_authenticated(self, mock_run):
+        """Test gh CLI authentication check."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        client = github_client.GitHubClient()
+        self.assertTrue(client.check_authenticated())
+
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "auth", "status"])
+
+    @patch("subprocess.run")
+    def test_check_not_authenticated(self, mock_run):
+        """Test gh CLI not authenticated."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "gh")
+
+        client = github_client.GitHubClient()
+        self.assertFalse(client.check_authenticated())
+
+
+class TestWorkflowRunQueries(unittest.TestCase):
+    """Tests for fetching workflow runs."""
+
+    @patch("subprocess.run")
+    def test_get_runs_for_pr(self, mock_run):
+        """Test fetching runs for a PR."""
+        # Mock gh pr view response.
+        pr_response = '{"headRefOid": "abc123", "headRefName": "main"}'
+        runs_response = '[{"databaseId": 12345, "workflowName": "CI", "conclusion": "failure", "createdAt": "2025-01-01", "headBranch": "main", "displayTitle": "Test"}]'
+
+        mock_run.side_effect = [
+            MagicMock(stdout=pr_response, returncode=0),
+            MagicMock(stdout=runs_response, returncode=0),
+        ]
+
+        client = github_client.GitHubClient()
+        runs = client.get_runs_for_pr(12345)
+
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0].run_id, "12345")
+        self.assertEqual(runs[0].workflow_name, "CI")
+
+        # Verify two subprocess calls (pr view, then run list).
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("subprocess.run")
+    def test_get_runs_for_commit(self, mock_run):
+        """Test fetching runs for a commit."""
+        runs_response = '[{"databaseId": 67890, "workflowName": "PkgCI", "conclusion": "failure", "createdAt": "2025-01-01", "headBranch": "main", "displayTitle": "Test"}]'
+
+        mock_run.return_value = MagicMock(stdout=runs_response, returncode=0)
+
+        client = github_client.GitHubClient()
+        runs = client.get_runs_for_commit("abc123def")
+
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0].run_id, "67890")
+
+        # Verify command args.
+        args = mock_run.call_args[0][0]
+        self.assertIn("--commit", args)
+        self.assertIn("abc123def", args)
+
+    @patch("subprocess.run")
+    def test_get_runs_for_commit_with_status(self, mock_run):
+        """Test fetching runs with status filter."""
+        runs_response = "[]"
+
+        mock_run.return_value = MagicMock(stdout=runs_response, returncode=0)
+
+        client = github_client.GitHubClient()
+        client.get_runs_for_commit("abc123", status="success")
+
+        # Verify status flag included.
+        args = mock_run.call_args[0][0]
+        self.assertIn("--status", args)
+        self.assertIn("success", args)
+
+    @patch("subprocess.run")
+    def test_get_runs_for_branch(self, mock_run):
+        """Test fetching runs for a branch."""
+        runs_response = '[{"databaseId": 11111, "workflowName": "Test", "conclusion": "failure", "createdAt": "2025-01-01", "headBranch": "main", "displayTitle": "Test"}]'
+
+        mock_run.return_value = MagicMock(stdout=runs_response, returncode=0)
+
+        client = github_client.GitHubClient()
+        runs = client.get_runs_for_branch("main")
+
+        self.assertEqual(len(runs), 1)
+
+        # Verify command args.
+        args = mock_run.call_args[0][0]
+        self.assertIn("--branch", args)
+        self.assertIn("main", args)
+
+
+class TestJobQueries(unittest.TestCase):
+    """Tests for fetching job details."""
+
+    @patch("subprocess.run")
+    def test_get_jobs(self, mock_run):
+        """Test fetching jobs for a run."""
+        run_response = '{"jobs": [{"databaseId": 111, "name": "test_job", "conclusion": "failure", "startedAt": "2025-01-01", "completedAt": "2025-01-01"}]}'
+
+        mock_run.return_value = MagicMock(stdout=run_response, returncode=0)
+
+        client = github_client.GitHubClient()
+        jobs = client.get_jobs("12345")
+
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].job_id, "111")
+        self.assertEqual(jobs[0].name, "test_job")
+
+    @patch("subprocess.run")
+    def test_get_failed_jobs(self, mock_run):
+        """Test fetching only failed jobs."""
+        run_response = '{"jobs": [{"databaseId": 111, "name": "failed", "conclusion": "failure", "startedAt": "2025-01-01", "completedAt": "2025-01-01"}, {"databaseId": 222, "name": "passed", "conclusion": "success", "startedAt": "2025-01-01", "completedAt": "2025-01-01"}]}'
+
+        mock_run.return_value = MagicMock(stdout=run_response, returncode=0)
+
+        client = github_client.GitHubClient()
+        failed = client.get_failed_jobs("12345")
+
+        # Should only return failed job.
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].name, "failed")
+
+    @patch("subprocess.run")
+    def test_get_job_log(self, mock_run):
+        """Test fetching job log."""
+        log_content = "This is a test log\nWith multiple lines\n"
+
+        mock_run.return_value = MagicMock(stdout=log_content, returncode=0)
+
+        client = github_client.GitHubClient()
+        log = client.get_job_log("12345", "67890")
+
+        self.assertEqual(log, log_content)
+
+        # Verify command args.
+        args = mock_run.call_args[0][0]
+        self.assertIn("--log", args)
+        self.assertIn("--job", args)
+        self.assertIn("67890", args)
+
+
+class TestErrorHandling(unittest.TestCase):
+    """Tests for error handling."""
+
+    @patch("subprocess.run")
+    def test_timeout_error(self, mock_run):
+        """Test handling subprocess timeout."""
+        mock_run.side_effect = subprocess.TimeoutExpired("gh", 30)
+
+        client = github_client.GitHubClient()
+
+        with self.assertRaises(github_client.GitHubClientError):
+            client.get_runs_for_commit("abc123")
+
+    @patch("subprocess.run")
+    def test_json_parse_error(self, mock_run):
+        """Test handling invalid JSON response."""
+        mock_run.return_value = MagicMock(stdout="invalid json", returncode=0)
+
+        client = github_client.GitHubClient()
+
+        with self.assertRaises(github_client.GitHubClientError):
+            client.get_runs_for_commit("abc123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/ci_tests/test_iree_ci_garden.py
+++ b/tools/utils/test/ci_tests/test_iree_ci_garden.py
@@ -1,0 +1,429 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree-ci-garden corpus management tool."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core.classifier import Classifier
+from ci.core.corpus import Corpus
+from ci.core.fetcher import GitHubFetcher
+from ci.core.github_client import GitHubClient, GitHubClientError
+
+from test.test_helpers import run_python_module
+
+
+class TestCLIIntegration(unittest.TestCase):
+    """Tests for CLI integration and help output."""
+
+    def test_tool_launches(self):
+        """Test that iree-ci-garden launches and shows help."""
+        result = run_python_module(
+            "ci.iree_ci_garden", ["--help"], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("fetch", result.stdout)
+        self.assertIn("classify", result.stdout)
+        self.assertIn("status", result.stdout)
+        self.assertIn("search", result.stdout)
+
+    def test_fetch_help(self):
+        """Test fetch subcommand help."""
+        result = run_python_module(
+            "ci.iree_ci_garden", ["fetch", "--help"], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--since", result.stdout)
+        self.assertIn("--pr", result.stdout)
+        self.assertIn("--run", result.stdout)
+
+    def test_classify_help(self):
+        """Test classify subcommand help."""
+        result = run_python_module(
+            "ci.iree_ci_garden",
+            ["classify", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--run", result.stdout)
+
+    def test_status_help(self):
+        """Test status subcommand help."""
+        result = run_python_module(
+            "ci.iree_ci_garden", ["status", "--help"], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--json", result.stdout)
+
+    def test_missing_command_error(self):
+        """Test error when no command specified."""
+        result = run_python_module(
+            "ci.iree_ci_garden", [], capture_output=True, text=True
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("No command specified", result.stderr)
+
+
+class TestCorpusManagement(unittest.TestCase):
+    """Tests for corpus directory management and metadata."""
+
+    def setUp(self):
+        """Create temporary corpus directory."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.corpus = Corpus(Path(self.temp_dir.name))
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_corpus_initialization(self):
+        """Test corpus directory structure creation."""
+        self.assertTrue(self.corpus.corpus_dir.exists())
+        self.assertTrue(self.corpus.logs_dir.exists())
+        self.assertTrue(self.corpus.runs_dir.exists())
+        self.assertTrue(self.corpus.classification_dir.exists())
+        self.assertTrue(self.corpus.unrecognized_dir.exists())
+        self.assertTrue(self.corpus.config_path.exists())
+
+    def test_config_version(self):
+        """Test that config has correct version."""
+        config = json.loads(self.corpus.config_path.read_text())
+        self.assertEqual(config["corpus_version"], "2.0")
+
+    def test_add_run_success(self):
+        """Test adding run metadata."""
+        run_data = {
+            "run_id": "12345",
+            "head_sha": "abc123def456",
+            "branch": "main",
+            "workflow": "CI",
+            "event": "push",
+            "pr_number": None,
+            "conclusion": "failure",
+            "attempt": 1,
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        result = self.corpus.add_run(run_data)
+        self.assertTrue(result)
+        self.assertTrue(self.corpus.has_run("12345"))
+
+    def test_duplicate_run_rejected(self):
+        """Test that duplicate runs are rejected."""
+        run_data = {
+            "run_id": "12345",
+            "head_sha": "abc123",
+            "branch": "main",
+            "workflow": "CI",
+            "conclusion": "failure",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        self.corpus.add_run(run_data)
+        result = self.corpus.add_run(run_data)
+        self.assertFalse(result)
+
+    def test_save_and_get_log(self):
+        """Test saving and retrieving log content."""
+        log_content = "ERROR: test failure\nStack trace...\n"
+        self.corpus.save_log("12345", "job_111", log_content)
+
+        log_path = self.corpus.get_log_path("12345", "job_111")
+        self.assertIsNotNone(log_path)
+        self.assertTrue(log_path.exists())
+        self.assertEqual(log_path.read_text(), log_content)
+
+    def test_get_stats(self):
+        """Test corpus statistics."""
+        # Empty corpus.
+        stats = self.corpus.get_stats()
+        self.assertEqual(stats["total_runs"], 0)
+        self.assertEqual(stats["total_logs"], 0)
+
+        # Add run and log.
+        self.corpus.add_run(
+            {"run_id": "12345", "created_at": "2025-01-01", "branch": "main"}
+        )
+        self.corpus.save_log("12345", "111", "log content")
+
+        stats = self.corpus.get_stats()
+        self.assertEqual(stats["total_runs"], 1)
+        self.assertEqual(stats["total_logs"], 1)
+
+
+class TestFetcherWithMocks(unittest.TestCase):
+    """Tests for fetcher with mocked GitHub API."""
+
+    def setUp(self):
+        """Create temporary corpus and mocked client."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.corpus = Corpus(Path(self.temp_dir.name))
+        self.client = GitHubClient()
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    @patch("ci.core.github_client.subprocess.run")
+    def test_fetch_single_run(self, mock_run):
+        """Test fetching single run with mocked GitHub."""
+        # Mock gh run view response (v2.0 schema).
+        run_response = json.dumps(
+            {
+                "workflowName": "CI",
+                "workflowDatabaseId": 67146182,
+                "name": "CI",
+                "headSha": "abc123def456",
+                "headBranch": "main",
+                "event": "push",
+                "number": 12345,
+                "status": "completed",
+                "conclusion": "failure",
+                "attempt": 1,
+                "createdAt": "2025-01-01T00:00:00Z",
+                "startedAt": "2025-01-01T00:00:00Z",
+                "updatedAt": "2025-01-01T01:00:00Z",
+                "displayTitle": "Test commit",
+                "url": "https://github.com/test/repo/actions/runs/12345",
+                "jobs": [
+                    {
+                        "databaseId": 111,
+                        "name": "test_job",
+                        "conclusion": "failure",
+                        "startedAt": "2025-01-01",
+                        "completedAt": "2025-01-01",
+                    }
+                ],
+            }
+        )
+
+        # Mock responses for full fetch flow:
+        # 1. get_run (direct call)
+        # 2. get_run (from get_failed_jobs)
+        # 3. get_job_annotations (returns empty list)
+        # 4. get_job_log (returns log content)
+        log_response = "Sample log content\nERROR: test failure\n"
+
+        mock_run.side_effect = [
+            MagicMock(stdout=run_response, returncode=0),  # get_run (direct)
+            MagicMock(stdout=run_response, returncode=0),  # get_run (from get_jobs)
+            MagicMock(stdout="[]", returncode=0),  # get_job_annotations
+            MagicMock(stdout=log_response, returncode=0),  # get_job_log
+        ]
+
+        fetcher = GitHubFetcher(self.client, self.corpus)
+        result = fetcher.fetch_run("12345")
+
+        self.assertEqual(result.runs_new, 1)
+        self.assertEqual(result.logs_fetched, 1)
+        self.assertTrue(self.corpus.has_run("12345"))
+
+
+class TestTimeChunking(unittest.TestCase):
+    """Tests for time-based chunking logic."""
+
+    def setUp(self):
+        """Create temporary corpus and fetcher."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.corpus = Corpus(Path(self.temp_dir.name))
+        self.client = GitHubClient()
+        self.fetcher = GitHubFetcher(self.client, self.corpus)
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_chunk_time_range_single_month(self):
+        """Test chunking a single month."""
+        since = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        until = datetime(2025, 1, 31, tzinfo=timezone.utc)
+
+        chunks = self.fetcher._chunk_time_range(since, until, chunk_days=30)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0][0], since)
+        self.assertEqual(chunks[0][1], until)
+
+    def test_chunk_time_range_multiple_months(self):
+        """Test chunking multiple months."""
+        since = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        until = datetime(2025, 11, 18, tzinfo=timezone.utc)
+
+        chunks = self.fetcher._chunk_time_range(since, until, chunk_days=30)
+
+        # Should create ~10-11 chunks (320+ days / 30 = ~10-11 chunks).
+        self.assertGreater(len(chunks), 9)
+        self.assertLess(len(chunks), 12)
+
+        # First chunk should start at since.
+        self.assertEqual(chunks[0][0], since)
+
+        # Last chunk should end at until.
+        self.assertEqual(chunks[-1][1], until)
+
+        # Chunks should be contiguous.
+        for i in range(len(chunks) - 1):
+            self.assertEqual(chunks[i][1], chunks[i + 1][0])
+
+
+class TestRetryLogic(unittest.TestCase):
+    """Tests for retry logic with timeout."""
+
+    def setUp(self):
+        """Create GitHub client."""
+        self.client = GitHubClient()
+
+    @patch("subprocess.run")
+    @patch("time.sleep")  # Mock sleep to speed up tests.
+    def test_retry_on_timeout(self, mock_sleep, mock_run):
+        """Test that retry happens on timeout."""
+        # First two attempts timeout, third succeeds.
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired(["gh", "run", "list"], 120),
+            subprocess.TimeoutExpired(["gh", "run", "list"], 120),
+            MagicMock(stdout="[]", returncode=0),
+        ]
+
+        # Should succeed on third attempt.
+        result = self.client._run_gh_command_with_retry(
+            ["gh", "run", "list"], timeout=120
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(mock_run.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)  # Sleep between retries.
+
+    @patch("subprocess.run")
+    @patch("time.sleep")
+    def test_retry_exhausted(self, mock_sleep, mock_run):
+        """Test that error is raised after all retries exhausted."""
+        # All attempts timeout.
+        mock_run.side_effect = subprocess.TimeoutExpired(["gh", "run", "list"], 120)
+
+        # Should raise error after 3 attempts.
+        with self.assertRaises(GitHubClientError) as context:
+            self.client._run_gh_command_with_retry(
+                ["gh", "run", "list"], timeout=120, max_retries=3
+            )
+
+        self.assertIn("timed out after 3 retries", str(context.exception))
+        self.assertEqual(mock_run.call_count, 3)
+
+    @patch("subprocess.run")
+    def test_no_retry_on_non_timeout_error(self, mock_run):
+        """Test that non-timeout errors are not retried."""
+        # Simulate CalledProcessError (non-timeout).
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["gh", "run", "list"], stderr="API error"
+        )
+
+        # Should raise immediately without retry.
+        with self.assertRaises(GitHubClientError) as context:
+            self.client._run_gh_command_with_retry(["gh", "run", "list"], timeout=120)
+
+        self.assertIn("gh CLI command failed", str(context.exception))
+        self.assertEqual(mock_run.call_count, 1)  # Only one attempt.
+
+
+class TestClassifierWithMocks(unittest.TestCase):
+    """Tests for classifier with mocked iree-ci-triage."""
+
+    def setUp(self):
+        """Create temporary corpus."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.corpus = Corpus(Path(self.temp_dir.name))
+
+        # Add sample run and log.
+        self.corpus.add_run(
+            {
+                "run_id": "12345",
+                "head_sha": "abc123",
+                "branch": "main",
+                "workflow": "CI",
+                "conclusion": "failure",
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        )
+        # Include "FAILED:" marker to activate BuildErrorExtractor.
+        self.corpus.save_log(
+            "12345",
+            "111",
+            "FAILED: compiler/CMakeFiles/test.o\n"
+            "undefined reference to `missing_symbol'\n",
+        )
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_classify_recognized_failure(self):
+        """Test classification with recognized pattern."""
+        # The log already contains "undefined reference" pattern which
+        # BuildErrorExtractor recognizes as a linker error.
+        classifier = Classifier(self.corpus)
+        result = classifier.classify_log("12345", "111")
+
+        self.assertIsNotNone(result)
+        self.assertTrue(result.recognized)
+        # Build errors are recognized.
+        self.assertTrue(len(result.categories) > 0)
+
+    def test_classify_unrecognized_failure(self):
+        """Test classification with unrecognized pattern."""
+        # Save a log with no recognizable pattern.
+        self.corpus.save_log("12345", "999", "Random gibberish that matches nothing\n")
+
+        classifier = Classifier(self.corpus)
+        result = classifier.classify_log("12345", "999")
+
+        self.assertIsNotNone(result)
+        self.assertFalse(result.recognized)
+
+
+class TestStatusCommand(unittest.TestCase):
+    """Tests for status command integration."""
+
+    def test_status_with_empty_corpus(self):
+        """Test status on empty corpus."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # --corpus-dir must come before subcommand.
+            result = run_python_module(
+                "ci.iree_ci_garden",
+                ["--corpus-dir", temp_dir, "status"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Total runs: 0", result.stdout)
+            self.assertIn("Total logs: 0", result.stdout)
+
+    def test_status_json_output(self):
+        """Test JSON output format."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # --corpus-dir must come before subcommand.
+            result = run_python_module(
+                "ci.iree_ci_garden",
+                ["--corpus-dir", temp_dir, "status", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            data = json.loads(result.stdout)
+            self.assertIn("statistics", data)
+            self.assertIn("recognition", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/ci_tests/test_iree_ci_triage.py
+++ b/tools/utils/test/ci_tests/test_iree_ci_triage.py
@@ -1,0 +1,187 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree-ci-triage tool."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core.github_client import GitHubClient
+
+from test.test_helpers import run_python_module
+
+
+class TestTriageCLI(unittest.TestCase):
+    """Tests for CLI integration and help output."""
+
+    def test_tool_launches(self):
+        """Test that iree-ci-triage launches and shows help."""
+        result = run_python_module(
+            "ci.iree_ci_triage", ["--help"], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--pr", result.stdout)
+        self.assertIn("--run", result.stdout)
+        self.assertIn("--log-file", result.stdout)
+
+    def test_missing_args_error(self):
+        """Test error when no source specified."""
+        result = run_python_module(
+            "ci.iree_ci_triage", [], capture_output=True, text=True
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_json_flag(self):
+        """Test --json flag in help."""
+        result = run_python_module(
+            "ci.iree_ci_triage", ["--help"], capture_output=True, text=True
+        )
+        self.assertIn("--json", result.stdout)
+
+    def test_checklist_flag(self):
+        """Test --checklist flag in help."""
+        result = run_python_module(
+            "ci.iree_ci_triage", ["--help"], capture_output=True, text=True
+        )
+        self.assertIn("--checklist", result.stdout)
+
+
+class TestTriageWithMockedGitHub(unittest.TestCase):
+    """Tests for triage with mocked GitHub API."""
+
+    @patch("subprocess.run")
+    def test_triage_pr_success(self, mock_run):
+        """Test triaging PR with mocked GitHub."""
+        # Mock gh pr view response.
+        pr_response = json.dumps(
+            {"headRefOid": "abc123def", "headRefName": "feature-branch"}
+        )
+
+        # Mock gh run list response.
+        runs_response = json.dumps(
+            [
+                {
+                    "databaseId": 12345,
+                    "workflowName": "CI",
+                    "conclusion": "failure",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                    "headBranch": "feature-branch",
+                    "displayTitle": "Test commit",
+                }
+            ]
+        )
+
+        # Mock gh run view (for jobs).
+        run_view_response = json.dumps(
+            {
+                "jobs": [
+                    {
+                        "databaseId": 111,
+                        "name": "test_job",
+                        "conclusion": "failure",
+                        "startedAt": "2025-01-01",
+                        "completedAt": "2025-01-01",
+                    }
+                ],
+                "conclusion": "failure",
+                "createdAt": "2025-01-01",
+                "displayTitle": "Test",
+                "headBranch": "main",
+                "workflowName": "CI",
+            }
+        )
+
+        # Mock job log.
+        log_response = "ERROR: test failure\n"
+
+        # Mock gh auth status (for setup check).
+        auth_response = "Logged in to github.com\n"
+
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),  # gh --version
+            MagicMock(stdout=auth_response, returncode=0),  # gh auth status
+            MagicMock(stdout=pr_response, returncode=0),  # gh pr view
+            MagicMock(stdout=runs_response, returncode=0),  # gh run list
+            MagicMock(stdout=run_view_response, returncode=0),  # gh run view
+            MagicMock(stdout=log_response, returncode=0),  # gh run view --log
+        ]
+
+        result = run_python_module(
+            "ci.iree_ci_triage",
+            ["--pr", "12345", "--json"],
+            capture_output=True,
+            text=True,
+        )
+
+        # Should succeed (exit code 0 if patterns match, or specific code if not).
+        # We're mainly testing it doesn't crash.
+        self.assertIn(result.returncode, [0, 1, 2])  # Various valid exit codes.
+
+    @patch("subprocess.run")
+    def test_triage_run_with_log_file(self, mock_run):
+        """Test triaging with log file (no GitHub needed)."""
+        # Mock gh --version and auth status.
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),  # gh --version
+            MagicMock(stdout="Logged in\n", returncode=0),  # gh auth status
+        ]
+
+        # Create temporary log file with sample content.
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log") as tmp:
+            tmp.write("ERROR: compilation failed\n")
+            tmp.write("undefined reference to `symbol`\n")
+            tmp_path = tmp.name
+
+        try:
+            result = run_python_module(
+                "ci.iree_ci_triage",
+                ["--log-file", tmp_path, "--json"],
+                capture_output=True,
+                text=True,
+            )
+
+            # Should complete without crashing.
+            self.assertIsNotNone(result.stdout)
+
+        finally:
+            Path(tmp_path).unlink()
+
+
+class TestTriageAuthentication(unittest.TestCase):
+    """Tests for GitHub authentication checks."""
+
+    @patch("ci.core.github_client.subprocess.run")
+    def test_gh_not_installed(self, mock_run):
+        """Test error when gh CLI not installed."""
+        mock_run.side_effect = FileNotFoundError()
+
+        # Test the client directly (can't mock across process boundaries).
+        client = GitHubClient()
+        self.assertFalse(client.check_cli_available())
+
+    @patch("ci.core.github_client.subprocess.run")
+    def test_gh_not_authenticated(self, mock_run):
+        """Test error when gh CLI not authenticated."""
+        # Mock gh auth status failure.
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["gh", "auth", "status"]
+        )
+
+        # Test the client directly (can't mock across process boundaries).
+        client = GitHubClient()
+        self.assertFalse(client.check_authenticated())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/ci_tests/test_patterns.py
+++ b/tools/utils/test/ci_tests/test_patterns.py
@@ -1,0 +1,189 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for CI pattern matching."""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core import patterns
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+# Synthetic log snippets for testing (small, inline).
+FILECHECK_FAILURE_LOG = """
+test.mlir:15:11: error: CHECK: expected string not found in input
+// CHECK: %[[VAL:.+]] = arith.constant
+          ^
+<stdin>:10:1: note: scanning from here
+func.func @test() {
+^
+"""
+
+ROCM_CLEANUP_CRASH_LOG = """
+==12345== ERROR: AddressSanitizer: heap-use-after-free
+    #0 0x7f9876543210 in rocclr/device/device.cpp:2891
+    #1 0x7f9876543211 in ~Memory() rocclr/device/memory.cpp:456
+    #2 0x7f9876543212 in release() rocclr/platform/object.hpp:123
+
+Aborted (core dumped)
+"""
+
+COMPILE_ERROR_LOG = """
+/usr/bin/c++ -o runtime/src/iree/hal/buffer.o -c runtime/src/iree/hal/buffer.c
+runtime/src/iree/hal/buffer.c:42:10: fatal error: 'iree/base/api.h' file not found
+#include "iree/base/api.h"
+         ^~~~~~~~~~~~~~~~~
+1 error generated.
+"""
+
+TIMEOUT_LOG = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-compile test.mlir --iree-hal-target-backends=vulkan-spirv
+TIMEOUT: test exceeded maximum time limit of 60 seconds
+Killing process group
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+
+
+class TestPatternLoading(unittest.TestCase):
+    """Tests for loading patterns from YAML."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.patterns_file = _FIXTURES_DIR / "test_patterns.yaml"
+        self.rules_file = _FIXTURES_DIR / "test_cooccurrence_rules.yaml"
+
+    def test_load_patterns_from_yaml(self):
+        """Test loading pattern definitions."""
+        loader = patterns.PatternLoader(self.patterns_file, self.rules_file)
+        loader.load()
+
+        self.assertIn("filecheck_failed", loader.patterns)
+        self.assertEqual(loader.patterns["filecheck_failed"].severity, "high")
+        self.assertTrue(loader.patterns["filecheck_failed"].actionable)
+
+    def test_load_rules_from_yaml(self):
+        """Test loading co-occurrence rules."""
+        loader = patterns.PatternLoader(self.patterns_file, self.rules_file)
+        loader.load()
+
+        self.assertGreater(len(loader.rules), 0)
+
+        # Find rocm_cleanup_crash rule.
+        rocm_rule = next(
+            (r for r in loader.rules if r.name == "rocm_cleanup_crash"), None
+        )
+        self.assertIsNotNone(rocm_rule)
+        self.assertEqual(rocm_rule.primary_pattern, "rocclr_memobj")
+        self.assertIn("aborted", rocm_rule.secondary_patterns)
+        self.assertFalse(rocm_rule.actionable)
+
+
+class TestPatternMatching(unittest.TestCase):
+    """Tests for pattern matching logic."""
+
+    def setUp(self):
+        """Load test patterns."""
+        self.patterns_file = _FIXTURES_DIR / "test_patterns.yaml"
+        self.rules_file = _FIXTURES_DIR / "test_cooccurrence_rules.yaml"
+        self.loader = patterns.PatternLoader(self.patterns_file, self.rules_file)
+        self.loader.load()
+        self.matcher = patterns.PatternMatcher(self.loader)
+
+    def test_filecheck_pattern_match(self):
+        """Test FileCheck failure pattern detection."""
+        matches = self.matcher.analyze_log(FILECHECK_FAILURE_LOG)
+
+        self.assertIn("filecheck_failed", matches)
+        self.assertEqual(len(matches["filecheck_failed"]), 1)
+
+        match = matches["filecheck_failed"][0]
+        self.assertIn("CHECK", match.match_text)
+        self.assertEqual(match.line_number, 2)
+
+    def test_filecheck_field_extraction(self):
+        """Test extracting fields from FileCheck failure."""
+        matches = self.matcher.analyze_log(FILECHECK_FAILURE_LOG)
+
+        match = matches["filecheck_failed"][0]
+        self.assertIn("file_path", match.extracted_fields)
+
+        # Should extract test.mlir:15.
+        file_paths = match.extracted_fields["file_path"]
+        self.assertTrue(any("test.mlir" in fp for fp in file_paths))
+
+    def test_rocm_crash_pattern_match(self):
+        """Test ROCm cleanup crash pattern detection."""
+        matches = self.matcher.analyze_log(ROCM_CLEANUP_CRASH_LOG)
+
+        # Should match both rocclr_memobj and aborted.
+        self.assertIn("rocclr_memobj", matches)
+        self.assertIn("aborted", matches)
+
+        rocm_match = matches["rocclr_memobj"][0]
+        self.assertIn("rocclr/device/device.cpp", rocm_match.match_text)
+
+    def test_compile_error_pattern_match(self):
+        """Test compilation error pattern detection."""
+        matches = self.matcher.analyze_log(COMPILE_ERROR_LOG)
+
+        self.assertIn("compile_error", matches)
+
+        match = matches["compile_error"][0]
+        self.assertIn("fatal error", match.match_text)
+
+    def test_compile_error_field_extraction(self):
+        """Test extracting file path and error message from compile error."""
+        matches = self.matcher.analyze_log(COMPILE_ERROR_LOG)
+
+        match = matches["compile_error"][0]
+
+        # Should extract file path.
+        self.assertIn("file_path", match.extracted_fields)
+        file_paths = match.extracted_fields["file_path"]
+        self.assertTrue(any("buffer.c" in fp for fp in file_paths))
+
+        # Should extract error message.
+        self.assertIn("error_message", match.extracted_fields)
+        errors = match.extracted_fields["error_message"]
+        self.assertTrue(any("file not found" in e for e in errors))
+
+    def test_timeout_pattern_match(self):
+        """Test timeout pattern detection."""
+        matches = self.matcher.analyze_log(TIMEOUT_LOG)
+
+        self.assertIn("timeout", matches)
+
+        match = matches["timeout"][0]
+        self.assertIn("TIMEOUT", match.match_text)
+
+    def test_context_lines_extraction(self):
+        """Test context line extraction."""
+        matches = self.matcher.analyze_log(FILECHECK_FAILURE_LOG)
+
+        match = matches["filecheck_failed"][0]
+
+        # Should have context before and after.
+        self.assertGreater(len(match.context_before), 0)
+        self.assertGreater(len(match.context_after), 0)
+
+    def test_no_match_returns_empty(self):
+        """Test that non-matching logs return empty results."""
+        log = "This log has no error patterns"
+
+        matches = self.matcher.analyze_log(log)
+
+        self.assertEqual(len(matches), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/ci_tests/test_root_cause.py
+++ b/tools/utils/test/ci_tests/test_root_cause.py
@@ -1,0 +1,219 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for root cause analysis."""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add project tools/utils to path for imports.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from ci.core import patterns
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestRootCauseAnalyzer(unittest.TestCase):
+    """Tests for root cause identification and grouping."""
+
+    def setUp(self):
+        """Load test patterns and rules."""
+        self.patterns_file = _FIXTURES_DIR / "test_patterns.yaml"
+        self.rules_file = _FIXTURES_DIR / "test_cooccurrence_rules.yaml"
+        self.loader = patterns.PatternLoader(self.patterns_file, self.rules_file)
+        self.loader.load()
+        self.analyzer = patterns.RootCauseAnalyzer(self.loader)
+
+    def test_group_cooccurring_patterns(self):
+        """Test grouping ROCm cleanup crash with abort."""
+        # Create pattern matches for rocclr_memobj and aborted.
+        pattern_matches = {
+            "rocclr_memobj": [
+                patterns.PatternMatch(
+                    pattern_name="rocclr_memobj",
+                    match_text="rocclr/device/device.cpp:2891",
+                    line_number=10,
+                    context_before=[],
+                    context_after=[],
+                )
+            ],
+            "aborted": [
+                patterns.PatternMatch(
+                    pattern_name="aborted",
+                    match_text="Aborted (core dumped)",
+                    line_number=15,
+                    context_before=[],
+                    context_after=[],
+                )
+            ],
+        }
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        # Should group into single "rocm_cleanup_crash" root cause.
+        self.assertEqual(len(root_causes), 1)
+        self.assertEqual(root_causes[0].rule.name, "rocm_cleanup_crash")
+        self.assertFalse(root_causes[0].rule.actionable)
+
+        # Should include both matches.
+        self.assertEqual(len(root_causes[0].primary_matches), 1)
+        self.assertEqual(len(root_causes[0].secondary_matches), 1)
+
+    def test_single_pattern_not_grouped(self):
+        """Test single pattern creates individual root cause."""
+        pattern_matches = {
+            "compile_error": [
+                patterns.PatternMatch(
+                    pattern_name="compile_error",
+                    match_text="fatal error: file not found",
+                    line_number=42,
+                    context_before=[],
+                    context_after=[],
+                )
+            ]
+        }
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        # Should create one root cause for compile error.
+        self.assertEqual(len(root_causes), 1)
+        self.assertEqual(root_causes[0].rule.name, "compilation_failure")
+        self.assertTrue(root_causes[0].rule.actionable)
+
+    def test_priority_based_rule_selection(self):
+        """Test higher priority rules are selected first."""
+        # Create matches for timeout and lit_test_failed.
+        pattern_matches = {
+            "timeout": [
+                patterns.PatternMatch(
+                    pattern_name="timeout",
+                    match_text="TIMEOUT: exceeded limit",
+                    line_number=5,
+                    context_before=[],
+                    context_after=[],
+                )
+            ],
+            "lit_test_failed": [
+                patterns.PatternMatch(
+                    pattern_name="lit_test_failed",
+                    match_text="TEST 'test.mlir' FAILED",
+                    line_number=10,
+                    context_before=[],
+                    context_after=[],
+                )
+            ],
+        }
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        # Should group into test_timeout rule (has both as patterns).
+        self.assertEqual(len(root_causes), 1)
+        self.assertEqual(root_causes[0].rule.name, "test_timeout")
+
+    def test_multiple_matches_same_pattern(self):
+        """Test multiple matches of same pattern."""
+        pattern_matches = {
+            "compile_error": [
+                patterns.PatternMatch(
+                    pattern_name="compile_error",
+                    match_text="error: undefined reference to 'foo'",
+                    line_number=10,
+                    context_before=[],
+                    context_after=[],
+                ),
+                patterns.PatternMatch(
+                    pattern_name="compile_error",
+                    match_text="error: undefined reference to 'bar'",
+                    line_number=20,
+                    context_before=[],
+                    context_after=[],
+                ),
+            ]
+        }
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        # Should create one root cause with multiple matches.
+        self.assertEqual(len(root_causes), 1)
+        self.assertEqual(len(root_causes[0].primary_matches), 2)
+
+    def test_no_matches_returns_empty(self):
+        """Test empty pattern matches returns empty root causes."""
+        pattern_matches = {}
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        self.assertEqual(len(root_causes), 0)
+
+    def test_unassigned_patterns_create_individual_causes(self):
+        """Test patterns not in rules create individual root causes."""
+        # Use filecheck_failed which is not in our test rules.
+        pattern_matches = {
+            "filecheck_failed": [
+                patterns.PatternMatch(
+                    pattern_name="filecheck_failed",
+                    match_text="CHECK: expected string not found",
+                    line_number=5,
+                    context_before=[],
+                    context_after=[],
+                )
+            ]
+        }
+
+        root_causes = self.analyzer.identify_root_causes(pattern_matches)
+
+        # Should create a synthetic root cause for unassigned pattern.
+        self.assertEqual(len(root_causes), 1)
+
+        # Root cause should use pattern as name.
+        self.assertEqual(root_causes[0].rule.primary_pattern, "filecheck_failed")
+
+
+class TestRootCauseDataStructure(unittest.TestCase):
+    """Tests for RootCause data structure."""
+
+    def test_all_matches_property(self):
+        """Test all_matches combines primary and secondary."""
+        rule = patterns.RootCauseRule(
+            name="test_rule",
+            primary_pattern="p1",
+            secondary_patterns=["p2"],
+            description="Test",
+            priority=50,
+            actionable=True,
+            category="test",
+        )
+
+        primary = patterns.PatternMatch(
+            pattern_name="p1",
+            match_text="primary",
+            line_number=1,
+            context_before=[],
+            context_after=[],
+        )
+        secondary = patterns.PatternMatch(
+            pattern_name="p2",
+            match_text="secondary",
+            line_number=2,
+            context_before=[],
+            context_after=[],
+        )
+
+        rc = patterns.RootCause(
+            rule=rule, primary_matches=[primary], secondary_matches=[secondary]
+        )
+
+        # all_matches should combine both.
+        self.assertEqual(len(rc.all_matches), 2)
+        self.assertIn(primary, rc.all_matches)
+        self.assertIn(secondary, rc.all_matches)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/__init__.py
+++ b/tools/utils/test/common_tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for common tests

--- a/tools/utils/test/common_tests/extractor_tests/__init__.py
+++ b/tools/utils/test/common_tests/extractor_tests/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for log extractors."""

--- a/tools/utils/test/common_tests/extractor_tests/test_base.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_base.py
@@ -1,0 +1,105 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for Extractor base class.
+
+Tests cover:
+- ABC enforcement (can't instantiate without implementing methods)
+- extract() contract
+- Basic mock extractor implementation
+"""
+
+import unittest
+
+from common.extractors.base import Extractor
+from common.issues import Issue, Severity
+from common.log_buffer import LogBuffer
+
+
+class MockExtractor(Extractor):
+    """Mock extractor for testing."""
+
+    name = "mock"
+
+    def __init__(self) -> None:
+        """Initialize mock extractor."""
+        self.extract_called = False
+
+    def extract(self, log_buffer: LogBuffer) -> list[Issue]:
+        """Mock extract implementation."""
+        self.extract_called = True
+
+        if "ERROR" in log_buffer.content:
+            return [
+                Issue(
+                    severity=Severity.HIGH,
+                    actionable=True,
+                    message="Mock error found",
+                    source_extractor=self.name,
+                )
+            ]
+        return []
+
+
+class TestExtractorABC(unittest.TestCase):
+    """Test Extractor ABC enforcement."""
+
+    def test_cannot_instantiate_abstract_class(self):
+        """Test that Extractor cannot be instantiated directly."""
+        with self.assertRaises(TypeError) as context:
+            Extractor()
+
+        self.assertIn("abstract", str(context.exception).lower())
+
+    def test_must_implement_extract(self):
+        """Test that subclasses must implement extract()."""
+
+        class IncompleteExtractor(Extractor):
+            name = "incomplete"
+
+        with self.assertRaises(TypeError) as context:
+            IncompleteExtractor()
+
+        self.assertIn("abstract", str(context.exception).lower())
+
+
+class TestMockExtractor(unittest.TestCase):
+    """Test MockExtractor implementation."""
+
+    def test_name_attribute(self):
+        """Test extractor has name attribute."""
+        extractor = MockExtractor()
+        self.assertEqual(extractor.name, "mock")
+
+    def test_extract_with_error(self):
+        """Test extract finds issues when log contains ERROR."""
+        extractor = MockExtractor()
+        log_buffer = LogBuffer(
+            "Some log content\nERROR: Something failed\nMore content"
+        )
+
+        issues = extractor.extract(log_buffer)
+
+        self.assertTrue(extractor.extract_called)
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].message, "Mock error found")
+        self.assertEqual(issues[0].severity, Severity.HIGH)
+        self.assertTrue(issues[0].actionable)
+        self.assertEqual(issues[0].source_extractor, "mock")
+
+    def test_extract_without_error(self):
+        """Test extract returns empty list when no issues found."""
+        extractor = MockExtractor()
+        log_buffer = LogBuffer("Clean log with no errors")
+
+        issues = extractor.extract(log_buffer)
+
+        self.assertTrue(extractor.extract_called)
+        self.assertEqual(len(issues), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_bazel_error.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_bazel_error.py
@@ -1,0 +1,204 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for BazelErrorExtractor."""
+
+import unittest
+
+from common.extractors.bazel_error import BazelErrorExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestBazelErrorExtractor(unittest.TestCase):
+    """Test BazelErrorExtractor for Bazel build failures."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = BazelErrorExtractor()
+
+    def test_missing_target_error(self):
+        """Test Bazel missing target error extraction."""
+        log = """
+INFO: Analyzed target //compiler/bindings/c:loader_test (0 packages loaded, 0 targets configured).
+INFO: Found 1 target...
+ERROR: /github/home/.cache/bazel/_bazel_runner/install/d5f43c91aa9bf04c810a8cdf7/external/llvm-project/mlir/BUILD.bazel:1234:56: no such target '@@llvm-project//mlir:OpAsmInterfaceTdFiles': target 'OpAsmInterfaceTdFiles' not declared in package 'mlir'; did you mean 'OpBaseTdFiles'?
+ERROR: /home/runner/work/iree/iree/compiler/bindings/c/BUILD.bazel:123:45 declared in package 'compiler/bindings/c'
+Target //compiler/bindings/c:loader_test failed to build
+Use --verbose_failures to see the command lines of failed build steps.
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.error_type, "missing_target")
+        self.assertIn("OpAsmInterfaceTdFiles", issue.message)
+        self.assertEqual(issue.workspace, "llvm-project")
+        self.assertEqual(issue.package, "mlir")
+        self.assertEqual(issue.target, "OpAsmInterfaceTdFiles")
+        self.assertIn("BUILD.bazel", issue.bazel_file)
+        self.assertEqual(issue.bazel_line, 1234)
+
+    def test_missing_target_without_line_number(self):
+        """Test missing target error without line/column numbers."""
+        log = """
+Loading: 0 packages loaded
+ERROR: /external/llvm-project/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel: no such target '@@llvm-project//mlir:IR': target 'IR' not declared in package 'mlir'
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertEqual(issue.error_type, "missing_target")
+        self.assertEqual(issue.workspace, "llvm-project")
+        self.assertEqual(issue.target, "IR")
+        self.assertEqual(issue.bazel_line, 0)  # No line number in error.
+
+    def test_build_failed_with_summary(self):
+        """Test Bazel build failure with failed target summary."""
+        log = """
+INFO: Elapsed time: 1234.567s, Critical Path: 567.89s
+INFO: 12345 processes: 10000 internal, 2345 linux-sandbox.
+ERROR: Build did NOT complete successfully
+
+//compiler/bindings/c:loader_test                               FAILED TO BUILD
+//compiler/plugins/input/StableHLO/Conversion/Preprocessing/test:canonicalization.mlir.test FAILED TO BUILD
+
+INFO: Build completed, 2 total actions
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.error_type, "build_failed")
+        self.assertEqual(len(issue.failed_targets), 2)
+        self.assertIn("//compiler/bindings/c:loader_test", issue.failed_targets)
+        self.assertIn(
+            "//compiler/plugins/input/StableHLO/Conversion/Preprocessing/test:canonicalization.mlir.test",
+            issue.failed_targets,
+        )
+        self.assertIn("2 target(s)", issue.message)
+
+    def test_multiple_missing_targets(self):
+        """Test multiple missing target errors in one log."""
+        log = """
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@@workspace1//pkg1:target1': target 'target1' not declared in package 'pkg1'
+ERROR: /path/to/BUILD.bazel:30:40: no such target '@@workspace2//pkg2:target2': target 'target2' not declared in package 'pkg2'
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0].error_type, "missing_target")
+        self.assertEqual(issues[1].error_type, "missing_target")
+        self.assertEqual(issues[0].target, "target1")
+        self.assertEqual(issues[1].target, "target2")
+
+    def test_no_errors_on_success(self):
+        """Test that no errors are extracted on successful build."""
+        log = """
+INFO: Analyzed 1234 targets (0 packages loaded, 0 targets configured).
+INFO: Found 1234 targets...
+INFO: Elapsed time: 123.456s, Critical Path: 45.67s
+INFO: 10000 processes: 9000 internal, 1000 linux-sandbox.
+INFO: Build completed successfully, 10000 total actions
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_deduplication_by_target(self):
+        """Test that duplicate missing target errors are deduplicated."""
+        log = """
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@@workspace//pkg:target': target 'target' not declared
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@@workspace//pkg:target': target 'target' not declared
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should only report once.
+        self.assertEqual(len(issues), 1)
+
+    def test_compiler_errors_not_extracted(self):
+        """Test that compiler errors are not extracted by BazelErrorExtractor."""
+        log = """
+compiler/src/iree/compiler/API/test.cpp:123:45: error: use of undeclared identifier 'foo'
+  foo();
+  ^
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should not extract compiler error - that's BuildErrorExtractor's job.
+        # Only build summary.
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0].error_type, "build_failed")
+
+    def test_single_at_workspace_reference(self):
+        """Test missing target with single @ workspace reference (legacy format)."""
+        log = """
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@llvm-project//mlir:IR': target 'IR' not declared in package 'mlir'
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.workspace, "llvm-project")
+        self.assertEqual(issue.package, "mlir")
+        self.assertEqual(issue.target, "IR")
+
+    def test_error_context_extraction(self):
+        """Test that error context is extracted from following lines."""
+        log = """
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@@workspace//pkg:target':
+target 'TargetName' not declared in package 'pkg'
+and referenced by '//other/package:other_target'
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertIn("target 'TargetName' not declared", issue.message)
+        self.assertIn("and referenced by", issue.message)
+
+    def test_chronological_ordering(self):
+        """Test that issues are returned in chronological order."""
+        log = """
+ERROR: /path/to/BUILD.bazel:10:20: no such target '@@ws1//pkg1:t1': target 't1' not declared
+ERROR: /path/to/BUILD.bazel:30:40: no such target '@@ws2//pkg2:t2': target 't2' not declared
+ERROR: /path/to/BUILD.bazel:50:60: no such target '@@ws3//pkg3:t3': target 't3' not declared
+ERROR: Build did NOT complete successfully
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 3)
+        # Should be in order of appearance (not reversed).
+        self.assertEqual(issues[0].target, "t1")
+        self.assertEqual(issues[1].target, "t2")
+        self.assertEqual(issues[2].target, "t3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_build_error.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_build_error.py
@@ -1,0 +1,108 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for BuildErrorExtractor."""
+
+import unittest
+
+from common.extractors.build_error import BuildErrorExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestBuildErrorExtractor(unittest.TestCase):
+    """Test BuildErrorExtractor for C/C++ compilation errors."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = BuildErrorExtractor()
+
+    def test_simple_compile_error(self):
+        """Test basic C++ compilation error."""
+        log = """
+[ 45%] Building CXX object runtime/src/iree/hal/CMakeFiles/iree_hal.dir/device.c.o
+/home/user/iree/runtime/src/iree/hal/device.c:123:5: error: use of undeclared identifier 'foo'
+  foo();
+  ^
+1 error generated.
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertTrue(issue.actionable)
+        self.assertIn("undeclared identifier", issue.message)
+        self.assertIn("device.c", issue.file_path or "")
+
+    def test_multiple_errors_same_file(self):
+        """Test multiple errors from same file."""
+        log = """
+/home/user/iree/compiler/src/test.cpp:10:3: error: expected ';' after expression
+  x = 5
+  ^
+/home/user/iree/compiler/src/test.cpp:15:10: error: no matching function for call to 'bar'
+  return bar();
+         ^~~
+2 errors generated.
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0].severity, Severity.CRITICAL)
+        self.assertEqual(issues[1].severity, Severity.CRITICAL)
+        self.assertIn("expected ';'", issues[0].message)
+        self.assertIn("no matching function", issues[1].message)
+
+    def test_linker_error(self):
+        """Test linker undefined reference error."""
+        log = """
+[100%] Linking CXX executable iree-run-module
+/usr/bin/ld: CMakeFiles/iree_run_module.dir/main.o: undefined reference to `iree_hal_device_create'
+collect2: error: ld returned 1 exit status
+ninja: build stopped: subcommand failed.
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertTrue(issue.actionable)
+        self.assertIn(
+            "Undefined reference", issue.message
+        )  # Capital U to match actual output.
+
+    def test_warning_not_extracted(self):
+        """Test that warnings are not extracted (unless treated as errors)."""
+        log = """
+/home/user/iree/runtime/src/test.c:50:10: warning: unused variable 'x' [-Wunused-variable]
+  int x = 5;
+      ^
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # BuildErrorExtractor only extracts errors, not warnings.
+        self.assertEqual(len(issues), 0)
+
+    def test_no_errors(self):
+        """Test log with no build errors."""
+        log = """
+[ 45%] Building CXX object runtime/src/iree/hal/CMakeFiles/iree_hal.dir/device.c.o
+[ 46%] Building CXX object runtime/src/iree/hal/CMakeFiles/iree_hal.dir/buffer.c.o
+[100%] Built target iree_hal
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_infrastructure_flake.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_infrastructure_flake.py
@@ -1,0 +1,465 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for InfrastructureFlakeExtractor."""
+
+import unittest
+
+from common.extractors.infrastructure_flake import InfrastructureFlakeExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestInfrastructureFlakeExtractor(unittest.TestCase):
+    """Test InfrastructureFlakeExtractor for all infrastructure flakes."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = InfrastructureFlakeExtractor()
+
+    def test_rocm_cleanup_crash_with_passed_test(self):
+        """Test ROCm cleanup crash detection after passing test."""
+        log = """
+[       OK ] TestSuite.TestCase (15 ms)
+[  PASSED  ] 10 tests.
+/opt/rocm/rocclr/device/rocm/rocmemory.cpp:2345: int rocmemobj::mapMemory()
+Assertion 'Memobj map does not have ptr' failed
+Aborted (core dumped)
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "rocclr_memobj")
+        self.assertEqual(issue.error_type, "cleanup_crash")
+        self.assertFalse(issue.actionable)  # Infrastructure bug!
+        self.assertEqual(
+            issue.severity, Severity.HIGH
+        )  # Passed test = HIGH not CRITICAL.
+        self.assertTrue(issue.test_passed_before_crash)
+
+    def test_rocm_cleanup_crash_with_failed_test(self):
+        """Test ROCm cleanup crash detection after failed test."""
+        log = """
+[  FAILED  ] TestSuite.TestCase (timeout)
+:0:/long_pathname/src/external/clr/rocclr/device/device.cpp:321 : 12074 us: [pid:123] Memobj map does not have ptr: 0x0
+Aborted (core dumped)
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertFalse(issue.actionable)  # Still infrastructure!
+        self.assertEqual(issue.severity, Severity.CRITICAL)  # Failed test = CRITICAL.
+        self.assertFalse(issue.test_passed_before_crash)
+
+    def test_hip_file_not_found(self):
+        """Test hipErrorFileNotFound detection (missing device libraries)."""
+        log = """
+[IREE-PJRT] HIP error: hipErrorFileNotFound
+Failed to find device kernel library at /opt/rocm/lib/bitcode
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "hipErrorFileNotFound")
+        self.assertEqual(issue.error_type, "missing_library")
+        self.assertTrue(issue.actionable)  # Missing libraries - should fix!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_hip_device_lost(self):
+        """Test HIP device lost detection (driver crash)."""
+        log = """
+iree-run-module: HIP device lost during execution
+Error: device communication failed
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "HIP_DEVICE_LOST")
+        self.assertEqual(issue.error_type, "device_lost")
+        self.assertFalse(issue.actionable)  # Driver crash - infrastructure!
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+
+    def test_hip_error_generic(self):
+        """Test generic HIP error detection."""
+        log = """
+Runtime error: hipErrorInvalidValue at line 123
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "hipErrorInvalidValue")
+        self.assertTrue(issue.actionable)  # Code bug.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_hip_device_lost_alternate_pattern(self):
+        """Test HIP device lost with alternate wording."""
+        log = """
+Error: device lost in HIP runtime
+Device reset required
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.error_type, "device_lost")
+        self.assertFalse(issue.actionable)
+
+    def test_rocm_hsa_error(self):
+        """Test ROCm HSA error detection."""
+        log = """
+HSA_STATUS_ERROR_INVALID_QUEUE at line 456
+ROCm runtime initialization failed
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "ROCM_ERROR")
+        self.assertTrue(issue.actionable)  # Could be code or config.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_rocclr_internal_error(self):
+        """Test ROCm CLR internal error detection."""
+        log = """
+rocclr/device/gpu/gpudevice.cpp:789: error: internal assertion failed
+Device initialization error
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "ROCCLR_ERROR")
+        self.assertEqual(issue.error_type, "internal_error")
+        self.assertFalse(issue.actionable)  # Internal ROCm error.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_hsa_queue_destroy_error(self):
+        """Test HSA queue destroy error detection (ROCm runtime teardown)."""
+        log = """
+error in hsa_queue_destroy: Invalid PCI BUS ID
+terminate called after throwing an instance of 'std::runtime_error'
+  what():  Invalid PCI BUS ID
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hip")
+        self.assertEqual(issue.error_code, "HSA_QUEUE_DESTROY_ERROR")
+        self.assertEqual(issue.error_type, "queue_teardown")
+        self.assertFalse(issue.actionable)  # ROCm runtime error.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_hsa_queue_destroy_exception(self):
+        """Test HSA queue destroy exception variant (ERROR: threw an exception)."""
+        log = """
+ERROR: hsa_queue_destroy threw an exception: Invalid PCI BUS ID
+ERROR: hsa_queue_destroy threw an exception: Invalid PCI BUS ID
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should extract both occurrences.
+        self.assertEqual(len(issues), 2)
+        for issue in issues:
+            self.assertEqual(issue.gpu_type, "hip")
+            self.assertEqual(issue.error_code, "HSA_QUEUE_DESTROY_ERROR")
+            self.assertEqual(issue.error_type, "queue_teardown")
+            self.assertFalse(issue.actionable)
+            self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_cuda_out_of_memory(self):
+        """Test CUDA OOM detection."""
+        log = """
+RuntimeError: CUDA out of memory. Tried to allocate 2.00 GiB
+cudaMalloc failed: out of memory
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "cuda")
+        self.assertEqual(issue.error_code, "CUDA_OOM")
+        self.assertEqual(issue.error_type, "oom")
+        self.assertFalse(issue.actionable)  # Infrastructure - not enough memory.
+        self.assertEqual(issue.severity, Severity.MEDIUM)
+
+    def test_cuda_device_lost(self):
+        """Test CUDA device lost detection."""
+        log = """
+CUDA error: device lost during kernel execution
+cudaDeviceSynchronize returned cudaErrorDeviceLost
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "cuda")
+        self.assertIn("lost", issue.error_code.lower())
+        self.assertEqual(issue.error_type, "device_lost")
+        self.assertFalse(issue.actionable)  # Driver issue!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_cuda_error_generic(self):
+        """Test generic CUDA error (actionable)."""
+        log = """
+CUDA error: cudaErrorInvalidConfiguration at line 234
+Invalid block/grid dimensions
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "cuda")
+        self.assertTrue(issue.actionable)  # Code bug.
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+
+    def test_vulkan_device_lost(self):
+        """Test Vulkan device lost (infrastructure flake)."""
+        log = """
+vkQueueSubmit failed with VK_ERROR_DEVICE_LOST
+Device reset detected by driver
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "vulkan")
+        self.assertEqual(issue.error_code, "VK_ERROR_DEVICE_LOST")
+        self.assertEqual(issue.error_type, "device_lost")
+        self.assertFalse(issue.actionable)  # Driver crash - infrastructure!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_vulkan_out_of_memory(self):
+        """Test Vulkan OOM (infrastructure flake)."""
+        log = """
+vkAllocateMemory failed: VK_ERROR_OUT_OF_DEVICE_MEMORY
+Failed to allocate 512MB device memory
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "vulkan")
+        self.assertEqual(issue.error_code, "VK_ERROR_OUT_OF_DEVICE_MEMORY")
+        self.assertEqual(issue.error_type, "oom")
+        self.assertFalse(issue.actionable)  # Infrastructure - not enough memory.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_vulkan_initialization_failed(self):
+        """Test Vulkan initialization failure (could be code or infrastructure)."""
+        log = """
+vkCreateInstance failed: VK_ERROR_INITIALIZATION_FAILED
+Failed to initialize Vulkan runtime
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "vulkan")
+        self.assertEqual(issue.error_code, "VK_ERROR_INITIALIZATION_FAILED")
+        self.assertEqual(issue.error_type, "initialization")
+        self.assertTrue(issue.actionable)  # Could be config issue - investigate!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_vulkan_error_actionable(self):
+        """Test Vulkan error that is actionable (code bug)."""
+        log = """
+vkCreateGraphicsPipeline failed: VK_ERROR_INVALID_SHADER
+Shader compilation failed
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "vulkan")
+        self.assertEqual(issue.error_code, "VK_ERROR_INVALID_SHADER")
+        self.assertTrue(issue.actionable)  # Code bug!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_vulkan_generic_error(self):
+        """Test generic Vulkan error from vkCreate failure."""
+        log = """
+vulkan runtime error: vkCreateCommandPool failed
+Command pool creation error
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "vulkan")
+        self.assertEqual(issue.error_code, "VULKAN_ERROR")
+        self.assertTrue(issue.actionable)  # Generic API error - investigate.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_metal_error(self):
+        """Test Metal API error detection."""
+        log = """
+MTLCreateSystemDefaultDevice failed
+Metal initialization error: device not available
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "metal")
+        self.assertEqual(issue.error_code, "METAL_ERROR")
+        self.assertTrue(issue.actionable)  # Metal API error.
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_multiple_gpu_errors_in_log(self):
+        """Test detection of multiple different GPU errors in one log."""
+        log = """
+Test starting...
+hipErrorFileNotFound: missing device library
+Test continues...
+VK_ERROR_DEVICE_LOST: vulkan device reset
+Test ending...
+CUDA error: cudaErrorInvalidValue
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find all 3 errors.
+        self.assertEqual(len(issues), 3)
+
+        # Verify each type was detected.
+        error_codes = {issue.error_code for issue in issues}
+        self.assertIn("hipErrorFileNotFound", error_codes)
+        self.assertIn("VK_ERROR_DEVICE_LOST", error_codes)
+        self.assertIn("cudaErrorInvalidValue", error_codes)
+
+    def test_no_gpu_errors(self):
+        """Test log with no GPU errors."""
+        log = """
+Running tests...
+All tests passed successfully
+No GPU errors detected
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_permission_denied_shark_cache(self):
+        """Test permission denied on /shark-cache/data (infrastructure flake)."""
+        log = """
+Test Torch / torch_models tests :: amdgpu_mi325_gfx942    UNKNOWN STEP    2025-10-14T15:34:17.3331033Z INTERNALERROR> PermissionError: [Errno 13] Permission denied: '/shark-cache/data'
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "filesystem")
+        self.assertEqual(issue.error_code, "SHARK_CACHE_PERMISSION")
+        self.assertEqual(issue.error_type, "infrastructure")
+        self.assertFalse(issue.actionable)  # Infrastructure flake!
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_git_fetch_error(self):
+        """Test Git fetch failure (network infrastructure flake)."""
+        log = """
+setup / setup    UNKNOWN STEP    2025-11-18T20:58:35.5778693Z ##[group]Fetching the repository
+setup / setup    UNKNOWN STEP    2025-11-18T21:00:30.5839972Z ##[error]fatal: unable to access 'https://github.com/iree-org/iree/': The requested URL returned error: 502
+setup / setup    UNKNOWN STEP    2025-11-18T21:00:30.5847541Z The process '/usr/bin/git' failed with exit code 128
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "network")
+        self.assertEqual(issue.error_code, "GIT_FETCH_ERROR")
+        self.assertEqual(issue.error_type, "infrastructure")
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_rate_limit_exceeded(self):
+        """Test API rate limit exceeded (infrastructure flake)."""
+        log = """
+publish_website    UNKNOWN STEP    2025-10-30T15:58:19.8199355Z Traceback (most recent call last):
+publish_website    UNKNOWN STEP    2025-10-30T15:58:19.8222430Z RuntimeError: Request was not successful, reason: rate limit exceeded
+publish_website    UNKNOWN STEP    2025-10-30T15:58:19.8239891Z Error: Process completed with exit code 1.
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "network")
+        self.assertEqual(issue.error_code, "RATE_LIMIT_EXCEEDED")
+        self.assertEqual(issue.error_type, "infrastructure")
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_artifact_download_failed(self):
+        """Test GitHub artifact download failure (infrastructure flake)."""
+        log = """
+Test Sharktank / sharktank_tests :: amdgpu_rocm_mi250_gfx90a    UNKNOWN STEP    2025-11-03T23:51:23.0495851Z ##[error]Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries.
+Test Sharktank / sharktank_tests :: amdgpu_rocm_mi250_gfx90a    UNKNOWN STEP    2025-11-03T23:54:18.2244146Z Post job cleanup.
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "network")
+        self.assertEqual(issue.error_code, "ARTIFACT_DOWNLOAD_FAILED")
+        self.assertEqual(issue.error_type, "infrastructure")
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_compiler_bus_error(self):
+        """Test compiler crash with bus error (hardware issue on CI runner)."""
+        log = """
+Test AMD W7900 / test_w7900    UNKNOWN STEP    2025-10-13T23:24:54.1865087Z /usr/bin/cc -DCPUINFO_LOG_LEVEL=2 -o third_party/cpuinfo/CMakeFiles/cpuinfo.dir/src/init.c.o -c /home/svcnod/actions-runner-2/_work/iree/iree/third_party/cpuinfo/src/init.c
+Test AMD W7900 / test_w7900    UNKNOWN STEP    2025-10-13T23:24:54.1867472Z /home/svcnod/actions-runner-2/_work/iree/iree/third_party/cpuinfo/src/init.c:65:1: internal compiler error: Bus error
+Test AMD W7900 / test_w7900    UNKNOWN STEP    2025-10-13T23:24:54.1868111Z    65 | void CPUINFO_ABI cpuinfo_deinitialize(void) {}
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.gpu_type, "hardware")
+        self.assertEqual(issue.error_code, "COMPILER_BUS_ERROR")
+        self.assertEqual(issue.error_type, "infrastructure")
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_mlir_compiler.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_mlir_compiler.py
@@ -1,0 +1,670 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for MLIRCompilerExtractor.
+
+Tests cover:
+- Simple errors with source context
+- Multi-line errors with operation dumps
+- Operation name extraction (from message and source)
+- Note collection (see current operation, called from)
+- FileCheck error exclusion
+- Error type inference
+- Test target inference
+"""
+
+import unittest
+
+from common.extractors.mlir_compiler import MLIRCompilerExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestMLIRCompilerExtraction(unittest.TestCase):
+    """Test MLIR compiler error extraction."""
+
+    def setUp(self):
+        self.extractor = MLIRCompilerExtractor()
+
+    def test_simple_error_with_source_context(self):
+        """Test simple MLIR error with source snippet and caret."""
+        log_content = """
+artifacts/model_zoo/validated/vision/classification/vgg19-7.mlir:80:11: error: slice along dimension 3 runs out-of-bounds: 255 >= 16
+    %76 = torch.operator "onnx.Gemm"(%75, %32, %33) {...}
+          ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(
+            issue.file_path,
+            "artifacts/model_zoo/validated/vision/classification/vgg19-7.mlir",
+        )
+        self.assertEqual(issue.error_line, 80)
+        self.assertEqual(issue.error_column, 11)
+        self.assertEqual(
+            issue.error_message, "slice along dimension 3 runs out-of-bounds: 255 >= 16"
+        )
+        self.assertEqual(issue.error_type, "out-of-bounds")
+        self.assertEqual(issue.severity, Severity.HIGH)
+        self.assertTrue(issue.actionable)
+
+        # Check source snippet and caret.
+        self.assertIn('torch.operator "onnx.Gemm"', issue.source_snippet)
+        self.assertIn("^", issue.caret_line)
+
+        # Check full diagnostic.
+        self.assertIn("error: slice along dimension", issue.full_diagnostic)
+
+    def test_error_with_operation_dump_note(self):
+        """Test error with 'note: see current operation:' and multi-line dump."""
+        log_content = """
+model.mlir:4:10: error: operand #0 does not dominate this use
+    %0 = torch.operator "onnx.TfIdfVectorizer"(%arg0) {...}
+         ^
+model.mlir:4:10: note: see current operation:
+%38:3 = "stream.async.execute"(%23#0, %6, %5, %5, %23#2) <{affinity = #hal.device.affinity<@dev>}> ({
+^bb0(%arg7: !stream.resource<external>):
+  %50 = "stream.async.slice"(%arg7, %6, %33, %34, %5) : (...)
+  %51 = "stream.async.dispatch"(...) : (...) -> !stream.resource<external>
+  stream.yield %50, %51 : !stream.resource<external>
+}) : (...) -> (!stream.timepoint, !stream.resource<external>, !stream.resource<external>)
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.file_path, "model.mlir")
+        self.assertEqual(issue.error_line, 4)
+        self.assertEqual(issue.error_column, 10)
+        self.assertEqual(issue.error_message, "operand #0 does not dominate this use")
+        self.assertEqual(issue.error_type, "operand-does-not-dominate")
+
+        # Check notes.
+        self.assertEqual(len(issue.notes), 1)
+        note = issue.notes[0]
+        self.assertEqual(note["file"], "model.mlir")
+        self.assertEqual(note["line"], 4)
+        self.assertEqual(note["column"], 10)
+        self.assertEqual(note["type"], "see current operation:")
+
+        # Check operation dump in note body.
+        self.assertIn("stream.async.execute", note["body"])
+        self.assertIn("stream.async.slice", note["body"])
+        self.assertIn("stream.yield", note["body"])
+
+    def test_multiple_notes_chain(self):
+        """Test error with multiple notes (called from chain)."""
+        log_content = """
+/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir:17:15: error: 'linalg.generic' op Failed to analyze the reduction operation.
+  %result:2 = linalg.generic {
+              ^
+/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir:17:15: note: called from
+  %result:2 = linalg.generic {
+              ^
+/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir:17:15: note: failed to tile operation
+  %result:2 = linalg.generic {
+              ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(
+            issue.file_path, "/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir"
+        )
+        self.assertEqual(issue.error_line, 17)
+        self.assertEqual(issue.error_column, 15)
+        self.assertEqual(issue.operation, "linalg.generic")
+        self.assertEqual(issue.error_type, "failed-to-analyze")
+
+        # Check multiple notes.
+        self.assertEqual(len(issue.notes), 2)
+        self.assertEqual(issue.notes[0]["type"], "called from")
+        self.assertEqual(issue.notes[1]["type"], "failed to tile operation")
+
+        # Check test target inference.
+        self.assertEqual(issue.test_target, "tests/e2e/linalg/argmax.mlir")
+
+    def test_operation_name_extraction_from_message(self):
+        """Test operation name extracted from error message: 'op_name' op."""
+        log_content = """
+/compiler/test/fold_unit_dims.mlir:175:8: error: 'iree_linalg_ext.map_scatter' op expected input type to have non-zero rank
+  %0 = iree_linalg_ext.map_scatter %input into %empty {
+       ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.operation, "iree_linalg_ext.map_scatter")
+        self.assertIn("iree_linalg_ext.map_scatter", issue.error_message)
+
+    def test_operation_name_extraction_from_source(self):
+        """Test operation name extracted from source when not in message."""
+        log_content = """
+test.mlir:10:5: error: failed to materialize conversion
+    %1 = tensor.extract_slice %0[0, 0] [16, 32] [1, 1] : tensor<16x32xf32>
+    ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        # Operation name extracted from source: %1 = tensor.extract_slice ...
+        self.assertEqual(issue.operation, "tensor.extract_slice")
+
+    def test_exclude_filecheck_errors(self):
+        """Test that FileCheck errors are excluded (test infrastructure, not compiler)."""
+        log_content = """
+test.mlir:307:12: error: CHECK: expected string not found in input
+ // CHECK: %[[IF_RESULT:.+]] = scf.if
+           ^
+<stdin>:248:56: note: scanning from here
+  %25 = scf.if %24 -> (i32) {
+                                                       ^
+test.mlir:307:12: note: possible intended match here
+ // CHECK: %[[IF_RESULT:.+]] = scf.if
+           ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should be zero issues (FileCheck errors excluded).
+        self.assertEqual(len(issues), 0)
+
+    def test_error_type_inference(self):
+        """Test error type categorization from message."""
+        test_cases = [
+            ("slice runs out-of-bounds", "out-of-bounds"),
+            ("does not dominate this use", "does-not-dominate"),
+            ("Failed to tile operation", "failed-to-tile"),
+            ("Failed to analyze the reduction", "failed-to-analyze"),
+            ("type mismatch in operation", "type-mismatch"),
+            ("invalid operation detected", "invalid-operation"),
+            ("expected input type to have", "expectation-failed"),
+        ]
+
+        for error_msg, expected_type in test_cases:
+            inferred = self.extractor._infer_error_type(error_msg)
+            self.assertEqual(
+                inferred,
+                expected_type,
+                f"Error message '{error_msg}' should infer type '{expected_type}', got '{inferred}'",
+            )
+
+    def test_test_target_inference(self):
+        """Test inference of test target from file paths."""
+        test_cases = [
+            (
+                "/home/runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir",
+                "tests/e2e/linalg/argmax.mlir",
+            ),
+            (
+                "/path/to/iree/compiler/src/iree/compiler/Dialect/test/foo.mlir",
+                "compiler/src/iree/compiler/Dialect/test/foo.mlir",
+            ),
+            (
+                "artifacts/model_zoo/validated/vision/vgg19.mlir",
+                "artifacts/model_zoo/validated/vision/vgg19.mlir",
+            ),
+            ("model.mlir", None),  # No test context - can't infer
+        ]
+
+        for file_path, expected_target in test_cases:
+            inferred = self.extractor._infer_test_target(file_path)
+            self.assertEqual(
+                inferred,
+                expected_target,
+                f"File path '{file_path}' should infer target '{expected_target}', got '{inferred}'",
+            )
+
+    def test_multiple_errors_in_log(self):
+        """Test extraction of multiple separate errors from same log."""
+        log_content = """
+test1.mlir:10:5: error: type mismatch
+    %1 = test.op %0 : i32
+    ^
+
+test2.mlir:20:10: error: invalid operation
+    %2 = invalid.op %1
+         ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+
+        # First error.
+        self.assertEqual(issues[0].file_path, "test1.mlir")
+        self.assertEqual(issues[0].error_line, 10)
+        self.assertEqual(issues[0].error_message, "type mismatch")
+
+        # Second error.
+        self.assertEqual(issues[1].file_path, "test2.mlir")
+        self.assertEqual(issues[1].error_line, 20)
+        self.assertEqual(issues[1].error_message, "invalid operation")
+
+    def test_graceful_degradation_missing_source(self):
+        """Test extraction works even without source snippet."""
+        log_content = """
+test.mlir:10:5: error: compilation failed
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should still extract the error, just without source snippet.
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.file_path, "test.mlir")
+        self.assertEqual(issue.error_line, 10)
+        self.assertEqual(issue.error_message, "compilation failed")
+        self.assertEqual(issue.source_snippet, "")  # No source available
+        self.assertEqual(issue.caret_line, "")  # No caret available
+
+    def test_full_diagnostic_completeness(self):
+        """Test that full_diagnostic captures complete error text."""
+        log_content = """
+test.mlir:10:5: error: failed to compile
+    %1 = test.op %0
+    ^
+test.mlir:10:5: note: see operation dump
+  %1 = "test.op"(%0) : (i32) -> i32
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        # Full diagnostic should include error + source + note.
+        self.assertIn("error: failed to compile", issue.full_diagnostic)
+        self.assertIn("%1 = test.op %0", issue.full_diagnostic)
+        self.assertIn("note: see operation dump", issue.full_diagnostic)
+        self.assertIn('"test.op"', issue.full_diagnostic)
+
+    def test_error_type_operand_dominate_specific(self):
+        """Test operand-does-not-dominate is distinct from does-not-dominate."""
+        # Specific operand error should get specific type.
+        operand_msg = "operand #0 does not dominate this use"
+        self.assertEqual(
+            self.extractor._infer_error_type(operand_msg),
+            "operand-does-not-dominate",
+        )
+
+        # General dominate error should get general type.
+        general_msg = "value does not dominate this use"
+        self.assertEqual(
+            self.extractor._infer_error_type(general_msg),
+            "does-not-dominate",
+        )
+
+    def test_compile_command_compiled_with(self):
+        """Test extraction of compile command with 'Compiled with:' marker (Pattern 1)."""
+        log_content = """
+model.mlir:4:10: error: 'linalg.generic' op Failed to analyze the reduction operation.
+    %0 = torch.operator "onnx.ArgMax"(%arg0) {...}
+         ^
+model.mlir:4:10: note: see current operation:
+%7:2 = "linalg.generic"(...) : (...) -> (tensor<2xf32>, tensor<2xi64>)
+
+Compiled with:
+  cd /home/nod/actions-runner/_work/iree/iree/iree-test-suites/onnx_ops && iree-compile model.mlir --iree-hal-target-device=vulkan --iree-input-demote-f64-to-f32 --iree-opt-level=O0 -o model_gpu_vulkan.vmfb
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        self.assertIn("iree-compile model.mlir", issues[0].compile_command)
+        self.assertIn("--iree-hal-target-device=vulkan", issues[0].compile_command)
+        self.assertIn("cd /home/nod/actions-runner", issues[0].compile_command)
+
+    def test_compile_command_cmake_cd(self):
+        """Test extraction of compile command from CMake 'cd ... &&' pattern (Pattern 2)."""
+        log_content = """
+cd /groups/aig_sharks/actions-runner/_work/iree/iree/build-tests/tests/e2e/linalg && /groups/aig_sharks/actions-runner/_work/iree/iree/.venv/bin/iree-compile --output-format=vm-bytecode --iree-hal-target-backends=rocm --iree-hip-target=gfx90a /groups/aig_sharks/actions-runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir -o check_rocm_hip_argmax.mlir_module.vmfb --iree-hal-executable-object-search-path=\\"/groups/aig_sharks/actions-runner/_work/iree/iree/build-tests\\"
+/groups/aig_sharks/actions-runner/_work/iree/iree/tests/e2e/linalg/argmax.mlir:17:15: error: 'linalg.generic' op Failed to analyze the reduction operation.
+  %result:2 = linalg.generic {
+              ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        self.assertIn(
+            "iree-compile --output-format=vm-bytecode", issues[0].compile_command
+        )
+        self.assertIn("--iree-hal-target-backends=rocm", issues[0].compile_command)
+        # Verify quote unescaping worked.
+        self.assertIn(
+            '--iree-hal-executable-object-search-path="/groups',
+            issues[0].compile_command,
+        )
+        self.assertNotIn('\\"', issues[0].compile_command)
+
+    def test_compile_command_lit_xtrace(self):
+        """Test extraction of compile command from lit shell xtrace (Pattern 3)."""
+        log_content = """
++ iree-opt '--pass-pipeline=builtin.module(func.func(iree-codegen-gpu-convert-to-coalesced-dma,canonicalize))' /__w/iree/iree/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir --split-input-file
+/__w/iree/iree/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir:10:5: error: failed to materialize conversion
+    %1 = tensor.extract_slice %0[0, 0] [16, 32] [1, 1] : tensor<16x32xf32>
+    ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        self.assertIn("iree-opt", issues[0].compile_command)
+        self.assertIn("--pass-pipeline=", issues[0].compile_command)
+        # Verify shell xtrace prefix was stripped.
+        self.assertFalse(issues[0].compile_command.startswith("+ "))
+
+    def test_compile_command_not_found(self):
+        """Test graceful handling when no compile command found."""
+        log_content = """
+model.mlir:10:5: error: compilation failed
+    %1 = test.op %0
+    ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNone(issues[0].compile_command)
+
+    def test_compile_command_ci_prefix_stripped(self):
+        """Test that CI log prefixes are properly stripped from commands."""
+        log_content = """
+Test ONNX / test_onnx_ops :: amdgpu_vulkan_O0\tUNKNOWN STEP\t2025-11-12T03:13:55.5396889Z model.mlir:4:10: error: 'linalg.generic' op Failed to analyze
+Test ONNX / test_onnx_ops :: amdgpu_vulkan_O0\tUNKNOWN STEP\t2025-11-12T03:13:55.5410291Z Compiled with:
+Test ONNX / test_onnx_ops :: amdgpu_vulkan_O0\tUNKNOWN STEP\t2025-11-12T03:13:55.5410687Z   cd /home/nod/iree-test-suites && iree-compile model.mlir -o output.vmfb
+"""
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        # Verify CI prefix was stripped.
+        self.assertNotIn("Test ONNX", issues[0].compile_command)
+        self.assertNotIn("UNKNOWN STEP", issues[0].compile_command)
+        self.assertIn("cd /home/nod/iree-test-suites", issues[0].compile_command)
+
+    def test_source_snippet_stops_at_diagnostic(self):
+        """Test source snippet collection stops at next error/warning."""
+        log_content = """
+test.mlir:10:5: error: first error
+    %1 = test.op %0
+test.mlir:11:5: error: second error immediately after
+    %2 = another.op %1
+    ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+        self.assertIn("%1 = test.op %0", issues[0].source_snippet)
+        self.assertNotIn("second error", issues[0].source_snippet)
+        self.assertNotIn("%2", issues[0].source_snippet)
+
+    def test_compile_command_onnx_compiled_with_large_ir(self):
+        """Test ONNX 'Compiled with:' extraction with large IR dump (Pattern 1 + adaptive boundary)."""
+        log_content = """
+Error invoking iree-compile
+Error code: 1
+Stderr diagnostics:
+model.mlir:4:10: error: 'linalg.generic' op Failed to anaysis the reduction operation.
+    %0 = torch.operator "onnx.ArgMax"(%arg0) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[2,2],f32>) -> !torch.vtensor<[1,2],si64>
+         ^
+model.mlir:4:10: note: see current operation:
+%7:2 = "linalg.generic"(%2, %6, %4) <{indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<reduction>]}> ({
+^bb0(%arg3: f32, %arg4: f32, %arg5: i64):
+  %11 = "linalg.index"() <{dim = 0 : i64}> : () -> index
+  "linalg.yield"(%13, %15) : (f32, i64) -> ()
+}) : (tensor<2x2xf32>, tensor<2xf32>, tensor<2xi64>) -> (tensor<2xf32>, tensor<2xi64>)
+model.mlir:4:10: error: 'linalg.generic' op failed to tile using scf.forall
+    %0 = torch.operator "onnx.ArgMax"(%arg0) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[2,2],f32>) -> !torch.vtensor<[1,2],si64>
+         ^
+model.mlir:4:10: note: see current operation:
+%7:2 = "linalg.generic"(%2, %6, %4) <{indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>]}> ({
+^bb0(%arg3: f32, %arg4: f32, %arg5: i64):
+  "linalg.yield"(%13, %15) : (f32, i64) -> ()
+}) : (tensor<2x2xf32>, tensor<2xf32>, tensor<2xi64>) -> (tensor<2xf32>, tensor<2xi64>)
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_argmax_default_axis_example
+
+Input program:
+```
+module {
+  func.func @test_argmax_default_axis_example(%arg0: !torch.vtensor<[2,2],f32>) -> !torch.vtensor<[1,2],si64> {
+    %0 = torch.operator "onnx.ArgMax"(%arg0) {torch.onnx.keepdims = 1 : si64}
+    return %0 : !torch.vtensor<[1,2],si64>
+  }
+}
+```
+
+Compiled with:
+  cd /home/runner/work/iree/iree/iree-test-suites/onnx_ops/onnx/node/generated/test_argmax_default_axis_example && iree-compile model.mlir --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu --iree-input-demote-f64-to-f32=false --iree-opt-level=O0 -o model_cpu_llvm_sync.vmfb
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)  # Two errors extracted.
+        # Both errors should have same compile command.
+        for issue in issues:
+            self.assertIsNotNone(issue.compile_command)
+            self.assertIn(
+                "cd /home/runner/work/iree/iree/iree-test-suites", issue.compile_command
+            )
+            self.assertIn("iree-compile model.mlir", issue.compile_command)
+            self.assertIn("--iree-hal-target-device=local", issue.compile_command)
+        # Verify adaptive boundary detection worked (marker is ~35 lines after first error).
+
+    def test_compile_command_python_api_invoked_with(self):
+        """Test Python API 'Invoked with:' extraction (Pattern 2)."""
+        log_content = """
+Traceback (most recent call last):
+  File "/__w/iree/iree/samples/sink_callback/sink_callback_log.py", line 97, in <module>
+    main()
+  File "/__w/iree/iree/samples/sink_callback/sink_callback_log.py", line 19, in main
+    vmfb_contents = compiler.compile_file(
+  File "/__w/iree/iree/build-byo-llvm/iree/compiler/bindings/python/iree/compiler/tools/binaries.py", line 201, in invoke_immediate
+    raise CompilerToolError(process)
+iree.compiler.tools.binaries.CompilerToolError: Error invoking IREE compiler tool iree-compile
+Error code: 1
+Diagnostics:
+IREE was not built with support for LLD
+Linking failed; escaped command line returned exit code 256:
+
+/__w/iree/iree/samples/sink_callback/model.mlir:0:0: error: failed to link executable and generate target dylib (check above for more specific error messages)
+/__w/iree/iree/samples/sink_callback/model.mlir:0:0: error: failed to serialize executable for target backend llvm-cpu
+/__w/iree/iree/samples/sink_callback/model.mlir:0:0: error: failed to serialize executables
+
+
+Invoked with:
+ iree-compile /__w/iree/iree/build-byo-llvm/iree/compiler/bindings/python/iree/compiler/tools/../_mlir_libs/iree-compile /__w/iree/iree/samples/sink_callback/model.mlir --iree-input-type=auto --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=llvm-cpu --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false --iree-llvmcpu-target-cpu=host
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 3)  # Three errors extracted.
+        # All should have same compile command.
+        for issue in issues:
+            self.assertIsNotNone(issue.compile_command)
+            self.assertIn("iree-compile", issue.compile_command)
+            self.assertIn("model.mlir", issue.compile_command)
+            self.assertIn("--iree-input-type=auto", issue.compile_command)
+            # Verify leading space was stripped.
+            self.assertFalse(issue.compile_command.startswith(" "))
+
+    def test_compile_command_cmake_backward_search(self):
+        """Test CMake 'cd &&' backward proximity search (Pattern 3)."""
+        log_content = """
+[8413/8447] Generating simple_mul_module.vmfb from simple_mul.mlir
+FAILED: runtime/src/iree/runtime/demo/simple_mul_module.vmfb
+cd /__w/iree/iree/build-tsan/runtime/src/iree/runtime/demo && /__w/iree/iree/build-tsan/tools/iree-compile --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false --iree-hal-target-device=local --iree-hal-local-target-device-backends=vmvx /__w/iree/iree/runtime/src/iree/runtime/demo/simple_mul.mlir -o simple_mul_module.vmfb --iree-hal-executable-object-search-path=\"/__w/iree/iree/build-tsan\"
+simple_mul.mlir:5:10: error: 'arith.addi' op result type 'i32' does not match operand type 'i64'
+  %result = arith.addi %arg0, %arg1 : i64
+          ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        # Verify command extracted from line BEFORE error (backward search).
+        self.assertIn("cd /__w/iree/iree/build-tsan", issues[0].compile_command)
+        self.assertIn(
+            "iree-compile --output-format=vm-bytecode", issues[0].compile_command
+        )
+        # Verify quote unescaping worked.
+        self.assertIn(
+            '--iree-hal-executable-object-search-path="/__w/iree/iree/build-tsan"',
+            issues[0].compile_command,
+        )
+        self.assertNotIn(r"\"", issues[0].compile_command)
+
+    def test_compile_command_lit_shell_xtrace(self):
+        """Test Lit/Bazel shell xtrace extraction (Pattern 4)."""
+        log_content = """
+FAIL: IREE :: src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir (1 of 1)
+******************** TEST 'IREE :: src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir' FAILED ********************
+Exit Code: 1
+
+Command Output (stderr):
+--
+ERROR: ld.so: object 'libvulkan.so.1' from LD_PRELOAD cannot be preloaded: ignored.
++ iree-opt /dev/shm/bazel-sandbox.77efa1afd21a6a756aca4546a3434b69c714acccffdac2a35c681913d3c6fbf7/processwrapper-sandbox/13947/execroot/_main/bazel-out/k8-opt/bin/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir.test.runfiles/_main/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir --split-input-file --verify-diagnostics
++ FileCheck /dev/shm/bazel-sandbox.77efa1afd21a6a756aca4546a3434b69c714acccffdac2a35c681913d3c6fbf7/processwrapper-sandbox/13947/execroot/_main/bazel-out/k8-opt/bin/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir.test.runfiles/_main/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+ERROR: ld.so: object 'libvulkan.so.1' from LD_PRELOAD cannot be preloaded: ignored.
+/dev/shm/bazel-sandbox.77efa1afd21a6a756aca4546a3434b69c714acccffdac2a35c681913d3c6fbf7/iree_gpu_ops.mlir:104:7: error: unexpected error: 'iree_gpu.coalesced_gather_dma' op operand #1 must be variadic of ranked tensor of 32-bit signless integer values
+      iree_gpu.coalesced_gather_dma %source[%idx0] into %out lane(%lane)
+      ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        # Verify shell xtrace command extracted (backward search).
+        self.assertIn("iree-opt", issues[0].compile_command)
+        self.assertIn("/dev/shm/bazel-sandbox", issues[0].compile_command)
+        self.assertIn(
+            "--split-input-file --verify-diagnostics", issues[0].compile_command
+        )
+        # Verify "+ " prefix was stripped.
+        self.assertFalse(issues[0].compile_command.startswith("+ "))
+
+    def test_compile_command_windows_cmake(self):
+        """Test Windows-style CMake command extraction (Pattern 3 with cmd.exe wrapper)."""
+        log_content = """
+[8413/8447] Generating simple_mul_module.vmfb from simple_mul.mlir
+FAILED: runtime/src/iree/runtime/demo/simple_mul_module.vmfb
+C:\\Windows\\system32\\cmd.exe /C "cd /D B:\\tmpbuild\\runtime\\src\\iree\\runtime\\demo && B:\\tmpbuild\\tools\\iree-compile.exe --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false --iree-hal-target-device=local --iree-hal-local-target-device-backends=vmvx B:\\iree\\runtime\\src\\iree\\runtime\\demo\\simple_mul.mlir -o simple_mul_module.vmfb"
+simple_mul.mlir:5:10: error: 'arith.addi' op result type 'i32' does not match operand type 'i64'
+  %result = arith.addi %arg0, %arg1 : i64
+          ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        # Verify Windows command extracted (cd is NOT at line start due to cmd.exe wrapper).
+        self.assertIn("cd /D B:\\tmpbuild", issues[0].compile_command)
+        self.assertIn("iree-compile.exe", issues[0].compile_command)
+        # Verify this works because we use search() not match().
+        self.assertIn("--output-format=vm-bytecode", issues[0].compile_command)
+
+    def test_compile_command_pattern_priority(self):
+        """Test that marker-based patterns (1,2) take precedence over proximity-based (3,4)."""
+        log_content = """
++ iree-compile /tmp/test.mlir --iree-hal-target-backends=llvm-cpu
+test.mlir:10:5: error: 'linalg.generic' op failed to tile
+    %0 = linalg.generic {
+         ^
+
+[... 40 lines of IR dump ...]
+
+Compiled with:
+  cd /home/user/iree && iree-compile /tmp/test.mlir --iree-hal-target-backends=vulkan --iree-vulkan-target-triple=valhall-unknown-android31
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        self.assertIsNotNone(issues[0].compile_command)
+        # Should extract marker-based command (Pattern 1), NOT proximity-based (Pattern 4).
+        self.assertIn("--iree-hal-target-backends=vulkan", issues[0].compile_command)
+        self.assertIn("--iree-vulkan-target-triple=valhall", issues[0].compile_command)
+        self.assertNotIn("llvm-cpu", issues[0].compile_command)
+
+
+class TestFalsePositivePrevention(unittest.TestCase):
+    """Test that extractor doesn't produce false positives."""
+
+    def setUp(self):
+        self.extractor = MLIRCompilerExtractor()
+
+    def test_no_match_non_mlir_file(self):
+        """Test C++ compiler errors don't match."""
+        log_content = """
+test.cpp:10:5: error: expected ';' at end of declaration
+    int x = 42
+    ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find nothing (not .mlir file).
+        self.assertEqual(len(issues), 0)
+
+    def test_no_match_normal_log(self):
+        """Test normal build log produces no issues."""
+        log_content = """
+[ 25%] Building MLIR test.mlir
+[ 50%] Compiling model.mlir
+[100%] Built target iree-compile
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find nothing.
+        self.assertEqual(len(issues), 0)
+
+    def test_no_match_filecheck_only(self):
+        """Test log with only FileCheck errors produces no issues."""
+        log_content = """
+test.mlir:10:12: error: CHECK: expected string not found
+ // CHECK: scf.if
+           ^
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find nothing (FileCheck excluded).
+        self.assertEqual(len(issues), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_onnx_test.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_onnx_test.py
@@ -1,0 +1,292 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for ONNXTestExtractor."""
+
+import unittest
+
+from common.extractors.onnx_test import ONNXTestExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestONNXTestExtractor(unittest.TestCase):
+    """Test ONNXTestExtractor for ONNX test failures."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = ONNXTestExtractor()
+
+    def test_onnx_test_with_full_context(self):
+        """Test ONNX test extraction with complete reproduction context."""
+        log = """
+_ IREE compile and run: test_mean_example::model.mlir::model.mlir::gpu_vulkan __
+[gw2] linux -- Python 3.11.13 /home/svcnod/actions-runner-2/_work/iree/iree/venv/bin/python
+Error invoking iree-run-module
+Error code: 1
+Stderr diagnostics:
+iree/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc:546: NOT_FOUND; physical device 0 invalid; 1 physical devices available; 0 visible; creating device 'vulkan'; resolving dependencies for 'module'; creating VM context; creating run context
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_mean_example
+
+Input program:
+```
+module {
+  func.func @test_mean_example(%arg0: !torch.vtensor<[3],f32>, %arg1: !torch.vtensor<[3],f32>, %arg2: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    %none = torch.constant.none
+    %0 = torch.operator "onnx.Mean"(%arg0, %arg1, %arg2) : (!torch.vtensor<[3],f32>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32>
+    return %0 : !torch.vtensor<[3],f32>
+  }
+}
+```
+
+Compiled with:
+  cd /home/svcnod/actions-runner-2/_work/iree/iree/iree-test-suites/onnx_ops/onnx/node/generated/test_mean_example && iree-compile model.mlir --iree-hal-target-device=vulkan --iree-input-demote-f64-to-f32 --iree-opt-level=O0 -o model_gpu_vulkan.vmfb
+
+Run with:
+  cd /home/svcnod/actions-runner-2/_work/iree/iree/iree-test-suites/onnx_ops/onnx/node/generated/test_mean_example && iree-run-module --module=model_gpu_vulkan.vmfb --device=vulkan --flagfile=run_module_io_flags.txt
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify test name extraction.
+        self.assertEqual(issue.test_name, "test_mean_example")
+
+        # Verify error details.
+        self.assertEqual(issue.error_tool, "iree-run-module")
+        self.assertEqual(issue.error_code, 1)
+        self.assertIn("physical device 0 invalid", issue.error_message)
+
+        # Verify MLIR extraction.
+        self.assertIn("func.func @test_mean_example", issue.input_mlir)
+        self.assertIn("onnx.Mean", issue.input_mlir)
+        self.assertEqual(len(issue.input_mlir.splitlines()), 7)
+
+        # Verify command extraction.
+        self.assertIn("iree-compile model.mlir", issue.compile_command)
+        self.assertIn("--iree-hal-target-device=vulkan", issue.compile_command)
+        self.assertIn("iree-run-module", issue.run_command)
+        self.assertIn("--device=vulkan", issue.run_command)
+
+        # Verify test source URL.
+        self.assertEqual(
+            issue.test_source_url,
+            "https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_mean_example",
+        )
+
+        # Verify severity and actionability (infrastructure error in this case).
+        self.assertEqual(issue.severity, Severity.HIGH)
+        self.assertFalse(issue.actionable)
+
+    def test_onnx_compile_error(self):
+        """Test ONNX test with compilation error (actionable)."""
+        log = """
+______ IREE compile and run: test_conv_example::model.mlir::model.mlir::gpu_vulkan ______
+[gw0] linux -- Python 3.11.13 /home/svcnod/actions-runner-2/_work/iree/iree/venv/bin/python
+Error invoking iree-compile
+Error code: 1
+Stderr diagnostics:
+mlir/lib/IR/Verifier.cpp:123: Verification failed: unexpected operand type
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_conv_example
+
+Input program:
+```
+module {
+  func.func @test_conv_example(%arg0: !torch.vtensor<[1,1,5,5],f32>) -> !torch.vtensor<[1,1,5,5],f32> {
+    return %arg0 : !torch.vtensor<[1,1,5,5],f32>
+  }
+}
+```
+
+Compiled with:
+  cd /home/svcnod/actions-runner-2/_work/iree/iree/iree-test-suites/onnx_ops/onnx/node/generated/test_conv_example && iree-compile model.mlir --iree-hal-target-device=vulkan -o model_gpu_vulkan.vmfb
+
+Run with:
+  cd /home/svcnod/actions-runner-2/_work/iree/iree/iree-test-suites/onnx_ops/onnx/node/generated/test_conv_example && iree-run-module --module=model_gpu_vulkan.vmfb --device=vulkan --flagfile=run_module_io_flags.txt
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify compilation error extraction.
+        self.assertEqual(issue.test_name, "test_conv_example")
+        self.assertEqual(issue.error_tool, "iree-compile")
+        self.assertEqual(issue.error_code, 1)
+        self.assertIn("Verification failed", issue.error_message)
+
+        # Compilation errors are actionable (code bug).
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+
+    def test_onnx_multiple_tests_in_log(self):
+        """Test extraction of multiple ONNX test failures in one log."""
+        log = """
+_ IREE compile and run: test_abs::model.mlir::model.mlir::gpu_vulkan _
+[gw1] linux -- Python 3.11.13 /home/svcnod/actions-runner-2/_work/iree/iree/venv/bin/python
+Error invoking iree-run-module
+Error code: 1
+Stderr diagnostics:
+vulkan_driver.cc:546: NOT_FOUND; physical device 0 invalid
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_abs
+
+Input program:
+```
+module {
+  func.func @test_abs(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> {
+    %0 = torch.operator "onnx.Abs"(%arg0) : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32>
+    return %0 : !torch.vtensor<[3,4,5],f32>
+  }
+}
+```
+
+Compiled with:
+  iree-compile model.mlir -o model.vmfb
+
+Run with:
+  iree-run-module --module=model.vmfb --device=vulkan
+
+
+______ IREE compile and run: test_acos::model.mlir::model.mlir::gpu_vulkan ______
+[gw2] linux -- Python 3.11.13 /home/svcnod/actions-runner-2/_work/iree/iree/venv/bin/python
+Error invoking iree-run-module
+Error code: 1
+Stderr diagnostics:
+vulkan_driver.cc:546: NOT_FOUND; physical device 0 invalid
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/onnx/node/generated/test_acos
+
+Input program:
+```
+module {
+  func.func @test_acos(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> {
+    %0 = torch.operator "onnx.Acos"(%arg0) : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32>
+    return %0 : !torch.vtensor<[3,4,5],f32>
+  }
+}
+```
+
+Compiled with:
+  iree-compile model.mlir -o model.vmfb
+
+Run with:
+  iree-run-module --module=model.vmfb --device=vulkan
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should extract both tests.
+        self.assertEqual(len(issues), 2)
+
+        # Verify test names.
+        test_names = {issue.test_name for issue in issues}
+        self.assertEqual(test_names, {"test_abs", "test_acos"})
+
+        # Both should have same error (infrastructure flake).
+        for issue in issues:
+            self.assertEqual(issue.error_tool, "iree-run-module")
+            self.assertIn("physical device", issue.error_message)
+            self.assertFalse(issue.actionable)
+
+    def test_onnx_test_missing_some_context(self):
+        """Test ONNX test with partial context (missing MLIR or commands)."""
+        log = """
+_ IREE compile and run: test_partial::model.mlir::model.mlir::gpu_vulkan _
+[gw0] linux -- Python 3.11.13 /venv/bin/python
+Error invoking iree-run-module
+Error code: 1
+Stderr diagnostics:
+Some error occurred
+
+Stdout diagnostics:
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should still extract even without full context.
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        self.assertEqual(issue.test_name, "test_partial")
+        self.assertEqual(issue.error_tool, "iree-run-module")
+        self.assertEqual(issue.error_code, 1)
+        self.assertIn("Some error occurred", issue.error_message)
+
+        # Context may be missing.
+        self.assertEqual(issue.input_mlir, "")
+        self.assertEqual(issue.compile_command, "")
+        self.assertEqual(issue.run_command, "")
+
+    def test_no_onnx_tests(self):
+        """Test log with no ONNX test failures."""
+        log = """
+Running some other tests...
+All tests passed successfully
+No ONNX test errors detected
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_vulkan_device_invalid_infrastructure_classification(self):
+        """Test that Vulkan device invalid errors are classified as infrastructure flakes."""
+        log = """
+_ IREE compile and run: test_gpu::model.mlir::model.mlir::gpu_vulkan _
+[gw0] linux -- Python 3.11.13 /venv/bin/python
+Error invoking iree-run-module
+Error code: 1
+Stderr diagnostics:
+vulkan_driver.cc:546: NOT_FOUND; physical device 0 invalid
+
+Stdout diagnostics:
+
+Test case source:
+  https://github.com/iree-org/iree-test-suites/blob/main/onnx_ops/test_gpu
+
+Input program:
+```
+module { }
+```
+
+Compiled with:
+  iree-compile model.mlir -o model.vmfb
+
+Run with:
+  iree-run-module --module=model.vmfb --device=vulkan
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify infrastructure flake classification.
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.severity, Severity.HIGH)
+        self.assertIn("physical device", issue.error_message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_precommit.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_precommit.py
@@ -1,0 +1,155 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for PrecommitErrorExtractor.
+
+All test data is extracted verbatim from actual CI failure logs in the corpus
+at /home/ben/src/iree/.vscode/notes/tools/ci_failure_corpus/logs/.
+"""
+
+import unittest
+
+from common.extractors.precommit import PrecommitErrorExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestPrecommitErrorExtractor(unittest.TestCase):
+    """Test PrecommitErrorExtractor for pre-commit hook failures."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = PrecommitErrorExtractor()
+
+    def test_hook_modified_files(self):
+        """Test pre-commit hook that modified files.
+
+        Real data from: run_19267500160_job_55086837291.log
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-11T13:42:12.4259043Z Run bazel_to_cmake.py on BUILD.bazel files...............................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-11T13:42:12.4260318Z [2m- hook id: bazel_to_cmake_1[m
+pre-commit\tUNKNOWN STEP\t2025-11-11T13:42:12.4263309Z [2m- files were modified by this hook[m
+pre-commit\tUNKNOWN STEP\t2025-11-11T13:42:12.4263924Z
+pre-commit\tUNKNOWN STEP\t2025-11-11T13:42:12.4265196Z Using repo root /home/runner/work/iree/iree
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.LOW)
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.hook_id, "bazel_to_cmake_1")
+        self.assertEqual(
+            issue.hook_description, "Run bazel_to_cmake.py on BUILD.bazel files"
+        )
+        self.assertEqual(issue.error_type, "modified_files")
+        self.assertTrue(issue.files_modified)
+
+    def test_hook_check_failed_no_files_modified(self):
+        """Test pre-commit hook that failed a check without modifying files.
+
+        Real data from: run_19043165665_job_54385002311.log
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:17.4197193Z DO NOT SUBMIT............................................................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:17.4197958Z [2m- hook id: do-not-submit[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:17.4198374Z [2m- exit code: 1[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:17.4198575Z
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:17.4198804Z Error: The string "DO NOT SUBMIT" was found!
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.MEDIUM)
+        self.assertEqual(issue.hook_id, "do-not-submit")
+        self.assertEqual(issue.error_type, "check_failed")
+        self.assertFalse(issue.files_modified)
+
+    def test_multiple_hooks_failed(self):
+        """Test multiple pre-commit hooks failing.
+
+        Real data from: run_19043165665_job_54385002311.log
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5509294Z Fix End of Files.........................................................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5510914Z [2m- hook id: end-of-file-fixer[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5511804Z [2m- exit code: 1[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5512735Z [2m- files were modified by this hook[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5513327Z
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5514300Z Fixing compiler/src/iree/compiler/Codegen/Common/test/convert_workgroup_forall_to_pcf.mlir
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.5515592Z
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833012Z Trim Trailing Whitespace.................................................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833593Z [2m- hook id: trailing-whitespace[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833935Z [2m- exit code: 1[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9834225Z [2m- files were modified by this hook[m
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0].hook_id, "end-of-file-fixer")
+        self.assertEqual(issues[1].hook_id, "trailing-whitespace")
+        self.assertTrue(all(i.files_modified for i in issues))
+        self.assertTrue(all(i.severity == Severity.LOW for i in issues))
+
+    def test_clang_format_with_ansi_codes(self):
+        """Test pre-commit hook failure with ANSI color codes.
+
+        Real data from: run_19011226316_job_54292428222.log
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:26.3289419Z Run clang-format on C/C++/etc. files.....................................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:26.3289932Z [2m- hook id: clang-format[m
+pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:26.3290217Z [2m- files were modified by this hook[m
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.hook_id, "clang-format")
+        self.assertTrue(issue.files_modified)
+        self.assertEqual(issue.severity, Severity.LOW)
+
+    def test_no_failures(self):
+        """Test log with no pre-commit failures.
+
+        Real data from: run_19011226316_job_54292428222.log
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:17.1074234Z Check Yaml...............................................................[42mPassed[m
+pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:17.3922618Z Fix End of Files.........................................................[42mPassed[m
+pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:17.8250992Z Trim Trailing Whitespace.................................................[42mPassed[m
+pre-commit\tUNKNOWN STEP\t2025-11-02T10:54:20.9548651Z Run Black to format Python files.........................................[42mPassed[m
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_hook_with_exit_code_and_files_modified(self):
+        """Test pre-commit hook with both exit code and files modified.
+
+        Real data from: run_19043165665_job_54385002311.log
+        Even with exit code, files_modified takes precedence for severity.
+        """
+        log = """pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833012Z Trim Trailing Whitespace.................................................[41mFailed[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833593Z [2m- hook id: trailing-whitespace[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9833935Z [2m- exit code: 1[m
+pre-commit\tUNKNOWN STEP\t2025-11-03T17:17:06.9834225Z [2m- files were modified by this hook[m
+"""
+        log_buffer = LogBuffer(log, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.hook_id, "trailing-whitespace")
+        # Even with exit code, files_modified takes precedence for severity.
+        self.assertEqual(issue.severity, Severity.LOW)
+        self.assertTrue(issue.files_modified)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_pytest_error.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_pytest_error.py
@@ -1,0 +1,62 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for PytestErrorExtractor."""
+
+import unittest
+
+from common.extractors.pytest_error import PytestErrorExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestPytestErrorExtractor(unittest.TestCase):
+    """Test PytestErrorExtractor for Python test failures."""
+
+    def setUp(self):
+        """Set up extractor for tests."""
+        self.extractor = PytestErrorExtractor()
+
+    def test_qualified_exception_name(self):
+        """Test pytest FAILED with qualified exception name (e.g., onnx_models.utils.IreeRunException)."""
+        log = """
+pytest session starts
+FAILED iree-test-suites/onnx_models/tests/test.py::test_models[alexnet.onnx] - onnx_models.utils.IreeRunException: 'alexnet.vmfb' run failed
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.severity, Severity.HIGH)
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.test_name, "test_models[alexnet.onnx]")
+        self.assertEqual(issue.exception_type, "onnx_models.utils.IreeRunException")
+        self.assertIn("alexnet.vmfb", issue.exception_message)
+
+    def test_any_exception_type(self):
+        """Test that we catch ANY exception type, not just standard Error/Exception suffixes."""
+        log = """
+pytest session starts
+FAILED tests/test_custom.py::test_foo - CustomTestFailure: something went wrong
+FAILED tests/test_timeout.py::test_bar - TestTimeout: test took too long
+"""
+        log_buffer = LogBuffer(log)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 2)
+
+        # Verify we caught CustomTestFailure (doesn't end in Error or Exception).
+        self.assertEqual(issues[0].exception_type, "CustomTestFailure")
+        self.assertIn("something went wrong", issues[0].exception_message)
+
+        # Verify we caught TestTimeout (doesn't end in Error or Exception).
+        self.assertEqual(issues[1].exception_type, "TestTimeout")
+        self.assertIn("test took too long", issues[1].exception_message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/extractor_tests/test_sanitizer.py
+++ b/tools/utils/test/common_tests/extractor_tests/test_sanitizer.py
@@ -1,0 +1,741 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for SanitizerExtractor.
+
+Tests cover:
+- ASAN: heap-buffer-overflow with deep stacks (41+ frames)
+- LSAN: single leak, multiple leaks under one ERROR section
+- TSAN: data races with dual stack traces
+- MSAN: uninitialized value usage
+- UBSAN: inline format undefined behavior
+- Edge cases: symbol lookup errors, missing SUMMARY, truncated reports
+- False positive prevention: build logs, gdb traces, timeout packages
+- Corpus validation: All 18 CI logs
+"""
+
+import os
+import unittest
+
+from common.extractors.sanitizer import SanitizerExtractor
+from common.issues import Severity
+from common.log_buffer import LogBuffer
+
+
+class TestASANExtraction(unittest.TestCase):
+    """Test AddressSanitizer extraction."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_asan_heap_overflow_ctest_format(self):
+        """Test ASAN heap-buffer-overflow with ctest prefix."""
+        # Load real log from /home/ben/src/iree/asan_runtime.txt
+        log_path = "/home/ben/src/iree/asan_runtime.txt"
+        if not os.path.exists(log_path):
+            self.skipTest(f"Log file not found: {log_path}")
+
+        with open(log_path, encoding="utf-8") as f:
+            log_content = f.read()
+
+        # Create LogBuffer with auto-detection (strips [ctest] prefix).
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Extract issues.
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find exactly 1 ASAN heap-buffer-overflow.
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "asan")
+        self.assertEqual(issue.error_type, "heap-buffer-overflow")
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertTrue(issue.actionable)
+
+        # Check PID extracted.
+        self.assertGreater(issue.pid, 0)
+
+        # Check stacks extracted.
+        self.assertGreater(len(issue.primary_stack), 0)
+        # ASAN should have allocation stack.
+        self.assertGreater(len(issue.allocation_stack), 0)
+
+        # Check memory info.
+        self.assertIn(issue.access_type, ["READ", "WRITE"])
+        self.assertGreater(issue.access_size, 0)
+        self.assertTrue(issue.address.startswith("0x"))
+
+        # Check full report captured.
+        self.assertIn("AddressSanitizer", issue.full_report)
+        self.assertIn("SUMMARY", issue.summary_line)
+
+        # Check line number is reasonable (original content line number).
+        self.assertGreater(issue.line_number, 0)
+
+    def test_asan_heap_overflow_lit_format_deep_stack(self):
+        """Test ASAN with LIT format and very deep stack (41+ frames)."""
+        log_path = "/home/ben/src/iree/asan_comiler.txt"
+        if not os.path.exists(log_path):
+            self.skipTest(f"Log file not found: {log_path}")
+
+        with open(log_path, encoding="utf-8") as f:
+            log_content = f.read()
+
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find exactly 1 ASAN error.
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "asan")
+        self.assertEqual(issue.error_type, "heap-buffer-overflow")
+
+        # Check deep stack trace (MLIR compiler has 40+ frames).
+        self.assertGreater(
+            len(issue.primary_stack), 30, "Expected deep stack trace (30+ frames)"
+        )
+
+        # Check allocation stack also present.
+        self.assertGreater(len(issue.allocation_stack), 0)
+
+        # Verify frames are properly formatted.
+        for frame in issue.primary_stack[:5]:  # Check first 5 frames.
+            self.assertRegex(frame, r"#\d+", "Frame should start with #NUM")
+
+    def test_asan_memory_info_extraction(self):
+        """Test detailed memory info extraction (offset, region size)."""
+        log_content = """
+==12345==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000001234 at pc 0x000000400abc
+WRITE of size 4 at 0x602000001234 thread T0
+    #0 0x400abb in main test.c:10:5
+    #1 0x7f1234567890 in __libc_start_main
+0x602000001234 is located 4 bytes after 100-byte region [0x602000001190,0x6020000011f4)
+allocated by thread T0 here:
+    #0 0x400def in malloc
+SUMMARY: AddressSanitizer: heap-buffer-overflow test.c:10:5 in main
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify memory info fields.
+        self.assertEqual(issue.access_type, "WRITE")
+        self.assertEqual(issue.access_size, 4)
+        self.assertEqual(issue.address, "0x602000001234")
+        self.assertEqual(issue.memory_offset, 4)  # 4 bytes after
+        self.assertEqual(issue.memory_region_size, 100)
+        self.assertEqual(issue.memory_region_start, "0x602000001190")
+        self.assertEqual(issue.memory_region_end, "0x6020000011f4")
+
+
+class TestLSANExtraction(unittest.TestCase):
+    """Test LeakSanitizer extraction."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_lsan_direct_leak_simple(self):
+        """Test simple LSAN direct leak."""
+        log_path = "/home/ben/src/iree/lsan_runtime.txt"
+        if not os.path.exists(log_path):
+            self.skipTest(f"Log file not found: {log_path}")
+
+        with open(log_path, encoding="utf-8") as f:
+            log_content = f.read()
+
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find exactly 1 leak.
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "lsan")
+        self.assertEqual(issue.error_type, "memory-leak")
+        self.assertEqual(issue.leak_type, "Direct")
+        self.assertGreater(issue.leaked_bytes, 0)
+        self.assertGreater(issue.leaked_objects, 0)
+
+        # Should have stack trace.
+        self.assertGreater(len(issue.primary_stack), 0)
+
+    def test_lsan_multiple_leaks_one_error_section(self):
+        """Test LSAN with multiple leak blocks under ONE ERROR section.
+
+        This is the critical LSAN edge case: one ==PID==ERROR: LeakSanitizer
+        section can contain 3+ separate "Direct leak of..." blocks.
+        We should return separate SanitizerIssue for each leak block.
+        """
+        log_path = "/home/ben/src/iree/lsan_compiler.txt"
+        if not os.path.exists(log_path):
+            self.skipTest(f"Log file not found: {log_path}")
+
+        with open(log_path, encoding="utf-8") as f:
+            log_content = f.read()
+
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find 6 separate leak issues (3 Direct + 3 Indirect) from the same ERROR section.
+        self.assertGreaterEqual(len(issues), 6, "Expected at least 6 leak blocks")
+
+        # Verify all are LSAN memory leaks with proper types.
+        direct_leaks = [i for i in issues if i.leak_type == "Direct"]
+        indirect_leaks = [i for i in issues if i.leak_type == "Indirect"]
+
+        self.assertGreaterEqual(
+            len(direct_leaks), 3, "Expected at least 3 Direct leaks"
+        )
+        self.assertGreaterEqual(
+            len(indirect_leaks), 3, "Expected at least 3 Indirect leaks"
+        )
+
+        for issue in issues:
+            self.assertEqual(issue.sanitizer_type, "lsan")
+            self.assertEqual(issue.error_type, "memory-leak")
+            self.assertIn(issue.leak_type, ["Direct", "Indirect"])
+            self.assertGreater(issue.leaked_bytes, 0)
+            self.assertGreater(issue.leaked_objects, 0)
+
+        # Verify they have different line numbers (different leak blocks).
+        line_numbers = [issue.line_number for issue in issues]
+        self.assertEqual(
+            len(line_numbers),
+            len(set(line_numbers)),
+            "Each leak should have unique line number",
+        )
+
+    def test_lsan_with_symbol_lookup_error(self):
+        """Test LSAN extraction with interleaved symbol lookup errors."""
+        log_path = "/home/ben/src/iree/lsan_runtime2.txt"
+        if not os.path.exists(log_path):
+            self.skipTest(f"Log file not found: {log_path}")
+
+        with open(log_path, encoding="utf-8") as f:
+            log_content = f.read()
+
+        log_buffer = LogBuffer(log_content, auto_detect_format=True)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should still find leak despite symbol lookup error.
+        self.assertGreaterEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "lsan")
+        self.assertEqual(issue.error_type, "memory-leak")
+
+    def test_lsan_leak_info_parsing(self):
+        """Test parsing of leak size, object count, and type."""
+        log_content = """
+==98765==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 128 byte(s) in 4 object(s) allocated from:
+    #0 0x400abc in malloc
+    #1 0x400def in allocate_memory
+
+Indirect leak of 64 byte(s) in 2 object(s) allocated from:
+    #0 0x400abc in malloc
+    #1 0x401234 in indirect_allocate
+
+SUMMARY: AddressSanitizer: 192 byte(s) leaked in 6 allocation(s).
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find 2 leaks (1 direct + 1 indirect).
+        self.assertEqual(len(issues), 2)
+
+        # First leak: Direct, 128 bytes, 4 objects.
+        direct_leak = issues[0]
+        self.assertEqual(direct_leak.leak_type, "Direct")
+        self.assertEqual(direct_leak.leaked_bytes, 128)
+        self.assertEqual(direct_leak.leaked_objects, 4)
+
+        # Second leak: Indirect, 64 bytes, 2 objects.
+        indirect_leak = issues[1]
+        self.assertEqual(indirect_leak.leak_type, "Indirect")
+        self.assertEqual(indirect_leak.leaked_bytes, 64)
+        self.assertEqual(indirect_leak.leaked_objects, 2)
+
+
+class TestTSANExtraction(unittest.TestCase):
+    """Test ThreadSanitizer extraction."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_tsan_data_race_dual_stacks(self):
+        """Test TSAN data race with dual stack traces (conflicting accesses)."""
+        log_content = """
+==================
+WARNING: ThreadSanitizer: data-race (pid=12345)
+  Write of size 8 at 0x7b0400001234 by thread T1:
+    #0 write_function file.c:100:5
+    #1 thread_worker file.c:200:10
+
+  Previous read of size 8 at 0x7b0400001234 by main thread:
+    #0 read_function file.c:50:10
+    #1 main file.c:300:5
+
+SUMMARY: ThreadSanitizer: data-race file.c:100:5 in write_function
+==================
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "tsan")
+        self.assertEqual(issue.error_type, "data-race")
+        self.assertEqual(issue.pid, 12345)
+
+        # Check access info.
+        self.assertEqual(issue.access_type, "Write")
+        self.assertEqual(issue.access_size, 8)
+        self.assertEqual(issue.address, "0x7b0400001234")
+        self.assertEqual(issue.thread_id, "thread T1")
+
+        # Check both stacks extracted.
+        self.assertGreater(
+            len(issue.primary_stack), 0, "Primary stack (write) should be extracted"
+        )
+        self.assertGreater(
+            len(issue.conflicting_stack),
+            0,
+            "Conflicting stack (previous read) should be extracted",
+        )
+
+        # Verify SUMMARY extracted.
+        self.assertIn("ThreadSanitizer", issue.summary_line)
+
+
+class TestMSANExtraction(unittest.TestCase):
+    """Test MemorySanitizer extraction."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_msan_uninitialized_value(self):
+        """Test MSAN use-of-uninitialized-value."""
+        log_content = """
+==54321== WARNING: MemorySanitizer: use-of-uninitialized-value
+    #0 use_value file.c:50:10
+    #1 process_data file.c:100:5
+  Uninitialized value was created by an allocation of 'buffer' in the stack frame
+    #0 allocate_buffer file.c:30:3
+SUMMARY: MemorySanitizer: use-of-uninitialized-value file.c:50:10 in use_value
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "msan")
+        self.assertEqual(issue.error_type, "use-of-uninitialized-value")
+        self.assertEqual(issue.pid, 54321)
+
+        # Check stacks.
+        self.assertGreater(len(issue.primary_stack), 0)
+        self.assertGreater(len(issue.allocation_stack), 0)
+
+        # Check origin description.
+        self.assertIn("Uninitialized value was created", issue.origin_description)
+
+
+class TestUBSANExtraction(unittest.TestCase):
+    """Test UndefinedBehaviorSanitizer extraction."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_ubsan_signed_overflow(self):
+        """Test UBSAN signed integer overflow."""
+        log_content = """
+test.c:42:15: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior test.c:42:15 in
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "ubsan")
+        self.assertEqual(issue.error_type, "undefined-behavior")
+
+        # Check file/line/column extracted.
+        self.assertEqual(issue.ubsan_file, "test.c")
+        self.assertEqual(issue.ubsan_line, 42)
+        self.assertEqual(issue.ubsan_column, 15)
+
+        # Check message contains overflow description.
+        self.assertIn("signed integer overflow", issue.message)
+
+    def test_ubsan_shift_exponent(self):
+        """Test UBSAN shift exponent too large."""
+        log_content = """
+shift.cpp:10:20: runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int'
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "ubsan")
+        self.assertEqual(issue.ubsan_file, "shift.cpp")
+        self.assertEqual(issue.ubsan_line, 10)
+        self.assertEqual(issue.ubsan_column, 20)
+        self.assertIn("shift exponent", issue.message)
+
+
+class TestParsingEdgeCases(unittest.TestCase):
+    """Test parsing edge cases found in real CI corpus."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_very_long_stack_frame_line(self):
+        """Test parser handles 900+ character lines without truncation.
+
+        Real pattern: Nested C++ templates like
+        DenseMapBase<SmallDenseMap<pair<AACacheLoc, AACacheLoc>, ...>>
+        can produce 985+ character stack frames.
+        """
+        # Create a realistic 950+ character frame with nested templates.
+        long_frame = (
+            "#3 0x55b311147ebf in llvm::detail::DenseMapPair<std::pair<llvm::AACacheLoc, "
+            "llvm::AACacheLoc>, llvm::AAQueryInfo::CacheEntry>* "
+            "llvm::DenseMapBase<llvm::SmallDenseMap<std::pair<llvm::AACacheLoc, llvm::AACacheLoc>, "
+            "llvm::AAQueryInfo::CacheEntry, 8u, llvm::DenseMapInfo<std::pair<llvm::AACacheLoc, "
+            "llvm::AACacheLoc>, void>, llvm::detail::DenseMapPair<std::pair<llvm::AACacheLoc, "
+            "llvm::AACacheLoc>, llvm::AAQueryInfo::CacheEntry>>, std::pair<llvm::AACacheLoc, "
+            "llvm::AACacheLoc>, llvm::AAQueryInfo::CacheEntry, llvm::DenseMapInfo<std::pair<"
+            "llvm::AACacheLoc, llvm::AACacheLoc>, void>, llvm::detail::DenseMapPair<std::pair<"
+            "llvm::AACacheLoc, llvm::AACacheLoc>, llvm::AAQueryInfo::CacheEntry>>::"
+            "findBucketForInsertion<std::pair<llvm::AACacheLoc, llvm::AACacheLoc>>"
+            "(std::pair<llvm::AACacheLoc, llvm::AACacheLoc> const&, "
+            "llvm::detail::DenseMapPair<std::pair<llvm::AACacheLoc, llvm::AACacheLoc>, "
+            "llvm::AAQueryInfo::CacheEntry>*) /__w/iree/iree/third_party/llvm-project/llvm/include/llvm/ADT/DenseMap.h:553:43"
+        )
+
+        self.assertGreater(len(long_frame), 900, "Test frame should be 900+ chars")
+
+        log_content = f"""
+==12345==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 442880 byte(s) in 17 object(s) allocated from:
+    #0 0x55b30e1f4e02 in operator new(unsigned long) build/bin/clang+0x30bde02
+    #1 0x55b31376d3dc in llvm::allocate_buffer(unsigned long, unsigned long) llvm/lib/Support/MemAlloc.cpp:16:18
+    #2 0x55b311147ebf in llvm::DenseMapBase::grow(unsigned int) llvm/include/llvm/ADT/DenseMap.h:553:43
+    {long_frame}
+
+SUMMARY: AddressSanitizer: 442880 byte(s) leaked in 17 allocation(s).
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify long frame is captured completely.
+        self.assertEqual(len(issue.primary_stack), 4)
+        frame_3 = issue.primary_stack[3]
+
+        # Check it's the long frame and hasn't been truncated.
+        self.assertGreater(len(frame_3), 900, "Long frame should be preserved")
+        self.assertIn("DenseMapBase", frame_3)
+        self.assertIn("SmallDenseMap", frame_3)
+        self.assertIn("findBucketForInsertion", frame_3)
+        self.assertIn("DenseMap.h:553:43", frame_3)
+        self.assertNotIn("...", frame_3, "Should not be truncated")
+
+    def test_large_integer_leak_size(self):
+        """Test parser handles large integers (400KB+) correctly as int.
+
+        Real pattern: LLVM DenseMap growth can leak 442880 bytes (432KB).
+        Must parse as int, not float or overflow.
+        """
+        log_content = """
+==12345==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 442880 byte(s) in 17 object(s) allocated from:
+    #0 0x123456 in operator new(unsigned long) build/bin/clang
+    #1 0x234567 in llvm::allocate_buffer llvm/lib/Support/MemAlloc.cpp:16
+
+SUMMARY: AddressSanitizer: 442880 byte(s) leaked in 17 allocation(s).
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify large leak size parsed correctly.
+        self.assertEqual(issue.leaked_bytes, 442880)
+        self.assertEqual(issue.leaked_objects, 17)
+
+        # Verify types are int, not float.
+        self.assertIsInstance(issue.leaked_bytes, int)
+        self.assertIsInstance(issue.leaked_objects, int)
+
+        # Verify SUMMARY contains same value.
+        self.assertIn("442880 byte(s) leaked in 17 allocation(s)", issue.summary_line)
+
+    def test_binary_only_stack_frames(self):
+        """Test parser handles frames with no source location.
+
+        Real pattern: System library frames like libc.so.6 have no source,
+        only binary path and offset: #78 0xADDR  (/path/to/lib.so+0xOFFSET)
+        """
+        log_content = """
+==12345==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 288 byte(s) in 3 object(s) allocated from:
+    #0 0x56340cc225df in malloc build/tools/iree-opt+0xcb5df
+    #1 0x7f9d6604f79a in mlir::Operation::create mlir/lib/IR/Operation.cpp:114
+    #2 0x7f9d65bceb2b in ireeOptRunMain compiler/API/IREEOptToolEntryPoint.cpp:170
+    #3 0x7f9d60981d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
+
+SUMMARY: AddressSanitizer: 288 byte(s) leaked in 3 allocation(s).
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify all 4 frames captured including binary-only frame.
+        self.assertEqual(len(issue.primary_stack), 4)
+
+        # Verify binary-only frame (no source location).
+        libc_frame = issue.primary_stack[3]
+        self.assertIn("#3", libc_frame)
+        self.assertIn("0x7f9d60981d8f", libc_frame)
+        self.assertIn("/lib/x86_64-linux-gnu/libc.so.6", libc_frame)
+        self.assertIn("+0x29d8f", libc_frame)
+        self.assertIn("BuildId: 490fef8403240c91833978d494d39e537409b92e", libc_frame)
+
+    def test_stack_collection_loop_deep_frames(self):
+        """Test stack collection loop reads until blank line, not arbitrary limit.
+
+        Real pattern: MLIR compiler stacks can reach 79 frames through deep
+        pass pipeline execution. Parser must continue reading frames until
+        it hits blank line or SUMMARY, not stop at arbitrary count.
+        """
+        # Create 45 realistic frames to test the collection loop.
+        frames = []
+        frames.append("#0 0x56340cc225df in malloc build/tools/iree-opt+0xcb5df")
+        frames.append(
+            "#1 0x7f9d6604f79a in mlir::Operation::create mlir/lib/IR/Operation.cpp:114"
+        )
+
+        # Add middle frames (MLIR pass pipeline).
+        for i in range(2, 43):
+            frames.append(
+                f"#{i} 0x7f9d6664e7ca in mlir::detail::OpToOpPassAdaptor::run "
+                f"mlir/lib/Pass/Pass.cpp:603"
+            )
+
+        frames.append(
+            "#43 0x7f9d65bceb2b in ireeOptRunMain compiler/API/IREEOptToolEntryPoint.cpp:170"
+        )
+        frames.append("#44 0x7f9d60981d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)")
+
+        log_content = f"""
+==12345==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 288 byte(s) in 3 object(s) allocated from:
+{chr(10).join('    ' + f for f in frames)}
+
+SUMMARY: AddressSanitizer: 288 byte(s) leaked in 3 allocation(s).
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+
+        # Verify all 45 frames collected.
+        self.assertEqual(len(issue.primary_stack), 45, "Should collect all 45 frames")
+
+        # Verify first and last frames correct.
+        self.assertIn("malloc", issue.primary_stack[0])
+        self.assertIn("libc.so.6", issue.primary_stack[44])
+
+        # Verify middle frames are pass pipeline.
+        self.assertIn("OpToOpPassAdaptor", issue.primary_stack[20])
+        self.assertIn("Pass.cpp", issue.primary_stack[30])
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Test edge cases and partial report handling."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_missing_summary_line(self):
+        """Test ASAN report with missing SUMMARY (truncated log)."""
+        log_content = """
+==99999==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12345678
+WRITE of size 4 at 0x12345678 thread T0
+    #0 0x400abc in main test.c:10:5
+    #1 0x7f1234567890 in __libc_start_main
+"""
+        # No SUMMARY line - simulates truncated log.
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should still extract the error with available data.
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(issue.sanitizer_type, "asan")
+        self.assertEqual(issue.error_type, "heap-buffer-overflow")
+        self.assertEqual(issue.pid, 99999)
+
+        # Stack should be extracted.
+        self.assertGreater(len(issue.primary_stack), 0)
+
+        # SUMMARY may be empty.
+        # Full report should still be captured.
+        self.assertIn("heap-buffer-overflow", issue.full_report)
+
+    def test_stack_trace_with_lambda(self):
+        """Test stack trace parsing with lambda functions."""
+        log_content = """
+==11111==ERROR: AddressSanitizer: heap-use-after-free on address 0xdeadbeef
+READ of size 8 at 0xdeadbeef thread T0
+    #0 0x123456 in std::function<void ()>::operator()() const
+    #1 0x234567 in lambda_caller<lambda()>
+    #2 0x345678 in main test.cpp:42:10
+SUMMARY: AddressSanitizer: heap-use-after-free test.cpp:42:10 in main
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        self.assertEqual(len(issue.primary_stack), 3)
+
+        # Verify lambda frames captured.
+        self.assertIn("operator()", issue.primary_stack[0])
+        self.assertIn("lambda", issue.primary_stack[1])
+
+    def test_line_number_preservation_after_stripping(self):
+        """Test that original line numbers are preserved after prefix stripping."""
+        # Simulate log with ctest prefix (no leading newline).
+        log_content = "[ctest] Running tests...\n[ctest] ==12345==ERROR: AddressSanitizer: heap-buffer-overflow\n[ctest] WRITE of size 4 at 0x12345678\n[ctest]     #0 0x400abc in main test.c:10\n[ctest] SUMMARY: AddressSanitizer: heap-buffer-overflow"
+
+        # Strip ctest prefix.
+        log_buffer = LogBuffer(log_content, strip_formats=["ctest"])
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 1)
+
+        issue = issues[0]
+        # Line number should be 1 (0-indexed: line 0 = "Running tests...", line 1 = ERROR line).
+        # Since prefix stripping doesn't remove lines, just prefixes,
+        # the line numbers should match.
+        self.assertEqual(issue.line_number, 1)
+
+
+class TestFalsePositivePrevention(unittest.TestCase):
+    """Test that extractor doesn't produce false positives."""
+
+    def setUp(self):
+        self.extractor = SanitizerExtractor()
+
+    def test_no_sanitizer_build_log(self):
+        """Test normal build log produces no issues."""
+        log_content = """
+[ 25%] Building CXX object CMakeFiles/test.dir/test.cpp.o
+[ 50%] Linking CXX executable test
+[100%] Built target test
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        # Should find nothing.
+        self.assertEqual(len(issues), 0)
+
+    def test_no_match_timeout_package(self):
+        """Test pip install 'timeout' package doesn't trigger false positive."""
+        log_content = """
+Collecting timeout==1.0.0
+  Downloading timeout-1.0.0-py3-none-any.whl
+Installing collected packages: timeout
+Successfully installed timeout-1.0.0
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_no_match_gdb_backtrace(self):
+        """Test gdb/lldb stack traces don't trigger false positive."""
+        log_content = """
+#0  0x00007ffff7a1234 in malloc () from /lib/x86_64-linux-gnu/libc.so.6
+#1  0x0000000000400abc in main () at test.c:10
+#2  0x00007ffff7a45678 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
+"""
+        # No ==PID== prefix, so not a sanitizer report.
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_no_match_disabled_message(self):
+        """Test 'AddressSanitizer is disabled' message doesn't match."""
+        log_content = """
+Note: AddressSanitizer is disabled for this build.
+Configure with -DCMAKE_BUILD_TYPE=ASan to enable.
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_empty_log(self):
+        """Test empty log produces no issues."""
+        log_buffer = LogBuffer("")
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_partial_separator_only(self):
+        """Test log with just separator lines produces no issues."""
+        log_content = """
+=================================================================
+==================
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+    def test_summary_without_error(self):
+        """Test SUMMARY line without ERROR header doesn't match."""
+        log_content = """
+Build complete.
+SUMMARY: 100% tests passed, 0 tests failed out of 42
+Total time: 5.2 seconds
+"""
+        log_buffer = LogBuffer(log_content)
+        issues = self.extractor.extract(log_buffer)
+
+        self.assertEqual(len(issues), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/test_build_detection.py
+++ b/tools/utils/test/common_tests/test_build_detection.py
@@ -1,0 +1,256 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for common.build_detection module."""
+
+import os
+
+# Add project tools/utils to path for imports
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from common import build_detection
+
+
+class TestDetectBuildDir(unittest.TestCase):
+    """Tests for detect_build_dir function."""
+
+    def setUp(self):
+        """Create temporary directory structure for testing."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+        # Create worktree structure: /tmp/xxx/iree-loom/
+        self.worktree = self.root / "iree-loom"
+        self.worktree.mkdir()
+
+        # Create build directory: /tmp/xxx/iree-loom-build/ with tools/ subdir.
+        self.build_dir = self.root / "iree-loom-build"
+        self.build_dir.mkdir()
+        (self.build_dir / "tools").mkdir()
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+        # Clear environment variable if set
+        if "IREE_BUILD_DIR" in os.environ:
+            del os.environ["IREE_BUILD_DIR"]
+
+    def test_detect_from_worktree(self):
+        """Test detection from worktree directory."""
+        result = build_detection.detect_build_dir(cwd=self.worktree)
+        self.assertEqual(result, self.build_dir)
+
+    def test_environment_variable_override(self):
+        """Test IREE_BUILD_DIR environment variable override."""
+        custom_build = self.root / "custom-build"
+        custom_build.mkdir()
+
+        os.environ["IREE_BUILD_DIR"] = str(custom_build)
+        result = build_detection.detect_build_dir(cwd=self.worktree)
+        self.assertEqual(result, custom_build)
+
+    def test_environment_variable_nonexistent(self):
+        """Test error when IREE_BUILD_DIR points to nonexistent directory."""
+        os.environ["IREE_BUILD_DIR"] = "/nonexistent/path"
+
+        with self.assertRaises(FileNotFoundError) as cm:
+            build_detection.detect_build_dir(cwd=self.worktree)
+
+        self.assertIn("IREE_BUILD_DIR", str(cm.exception))
+        self.assertIn("/nonexistent/path", str(cm.exception))
+
+    def test_fallback_to_build_subdir(self):
+        """Test fallback to ./build directory."""
+        # Remove default build directory (need to remove tools/ first).
+        (self.build_dir / "tools").rmdir()
+        self.build_dir.rmdir()
+
+        # Create ./build subdirectory with CMakeCache to mark it as valid build.
+        build_subdir = self.worktree / "build"
+        build_subdir.mkdir()
+        (build_subdir / "CMakeCache.txt").touch()
+
+        result = build_detection.detect_build_dir(cwd=self.worktree)
+        self.assertEqual(result, build_subdir)
+
+    def test_fallback_to_builds_dir(self):
+        """Test fallback to ../builds/<name>/ directory."""
+        # Remove default build directory (need to remove tools/ first).
+        (self.build_dir / "tools").rmdir()
+        self.build_dir.rmdir()
+
+        # Create ../builds/iree-loom/ with tools/ to mark as valid.
+        builds_dir = self.root / "builds" / "iree-loom"
+        builds_dir.mkdir(parents=True)
+        (builds_dir / "tools").mkdir()
+
+        result = build_detection.detect_build_dir(cwd=self.worktree)
+        self.assertEqual(result, builds_dir)
+
+    def test_no_build_dir_found(self):
+        """Test error when no build directory can be found."""
+        # Remove build directory (need to remove tools/ first).
+        (self.build_dir / "tools").rmdir()
+        self.build_dir.rmdir()
+
+        with self.assertRaises(FileNotFoundError) as cm:
+            build_detection.detect_build_dir(cwd=self.worktree)
+
+        error_msg = str(cm.exception)
+        self.assertIn("Cannot find build directory", error_msg)
+        self.assertIn("iree-loom-build", error_msg)
+        self.assertIn("IREE_BUILD_DIR", error_msg)
+
+
+class TestFindTool(unittest.TestCase):
+    """Tests for find_tool function."""
+
+    def setUp(self):
+        """Create temporary build directory with tool locations."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.build_dir = Path(self.temp_dir.name)
+
+        # Create tool directories
+        self.tools_dir = self.build_dir / "tools"
+        self.tools_dir.mkdir()
+
+        self.llvm_bin = self.build_dir / "llvm-project" / "bin"
+        self.llvm_bin.mkdir(parents=True)
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_find_iree_tool(self):
+        """Test finding IREE tool in tools/ directory."""
+        iree_opt = self.tools_dir / "iree-opt"
+        iree_opt.touch()
+
+        result = build_detection.find_tool("iree-opt", build_dir=self.build_dir)
+        self.assertEqual(result, iree_opt)
+
+    def test_find_llvm_tool(self):
+        """Test finding LLVM tool in llvm-project/bin/ directory."""
+        filecheck = self.llvm_bin / "FileCheck"
+        filecheck.touch()
+
+        result = build_detection.find_tool("FileCheck", build_dir=self.build_dir)
+        self.assertEqual(result, filecheck)
+
+    def test_tool_not_found(self):
+        """Test error when tool cannot be found."""
+        with self.assertRaises(FileNotFoundError) as cm:
+            build_detection.find_tool("nonexistent-tool", build_dir=self.build_dir)
+
+        error_msg = str(cm.exception)
+        self.assertIn("Cannot find tool 'nonexistent-tool'", error_msg)
+        self.assertIn("tools/nonexistent-tool", error_msg)
+
+    def test_auto_detect_build_dir(self):
+        """Test auto-detection of build directory when not provided."""
+        # This would require mocking detect_build_dir, skip for now
+        pass
+
+
+class TestIsDebugBuild(unittest.TestCase):
+    """Tests for is_debug_build function."""
+
+    def setUp(self):
+        """Create temporary build directory."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.build_dir = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_debug_build_assertions_on(self):
+        """Test detection of debug build with assertions ON."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("LLVM_ENABLE_ASSERTIONS:BOOL=ON\n")
+
+        result = build_detection.is_debug_build(build_dir=self.build_dir)
+        self.assertTrue(result)
+
+    def test_release_build_assertions_off(self):
+        """Test detection of release build with assertions OFF."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("LLVM_ENABLE_ASSERTIONS:BOOL=OFF\n")
+
+        result = build_detection.is_debug_build(build_dir=self.build_dir)
+        self.assertFalse(result)
+
+    def test_no_cmake_cache(self):
+        """Test behavior when CMakeCache.txt doesn't exist."""
+        result = build_detection.is_debug_build(build_dir=self.build_dir)
+        self.assertFalse(result)
+
+    def test_assertions_setting_not_found(self):
+        """Test behavior when LLVM_ENABLE_ASSERTIONS not in cache."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("OTHER_SETTING:BOOL=ON\n")
+
+        result = build_detection.is_debug_build(build_dir=self.build_dir)
+        self.assertFalse(result)
+
+
+class TestGetBuildType(unittest.TestCase):
+    """Tests for get_build_type function."""
+
+    def setUp(self):
+        """Create temporary build directory."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.build_dir = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+
+    def test_debug_build_type(self):
+        """Test detection of Debug build type."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("CMAKE_BUILD_TYPE:STRING=Debug\n")
+
+        result = build_detection.get_build_type(build_dir=self.build_dir)
+        self.assertEqual(result, "Debug")
+
+    def test_release_build_type(self):
+        """Test detection of Release build type."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("CMAKE_BUILD_TYPE:STRING=Release\n")
+
+        result = build_detection.get_build_type(build_dir=self.build_dir)
+        self.assertEqual(result, "Release")
+
+    def test_relwithdebinfo_build_type(self):
+        """Test detection of RelWithDebInfo build type."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("CMAKE_BUILD_TYPE:STRING=RelWithDebInfo\n")
+
+        result = build_detection.get_build_type(build_dir=self.build_dir)
+        self.assertEqual(result, "RelWithDebInfo")
+
+    def test_no_cmake_cache(self):
+        """Test behavior when CMakeCache.txt doesn't exist."""
+        result = build_detection.get_build_type(build_dir=self.build_dir)
+        self.assertEqual(result, "Unknown")
+
+    def test_build_type_not_found(self):
+        """Test behavior when CMAKE_BUILD_TYPE not in cache."""
+        cmake_cache = self.build_dir / "CMakeCache.txt"
+        cmake_cache.write_text("OTHER_SETTING:STRING=Value\n")
+
+        result = build_detection.get_build_type(build_dir=self.build_dir)
+        self.assertEqual(result, "Unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/test_issues.py
+++ b/tools/utils/test/common_tests/test_issues.py
@@ -1,0 +1,290 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for Issue type hierarchy.
+
+Tests cover:
+- Base Issue class instantiation
+- All specific Issue subclasses
+- Field validation and defaults
+- Severity enum
+"""
+
+import unittest
+
+from common.issues import (
+    DeprecatedAPIIssue,
+    Issue,
+    LITTestIssue,
+    MissingDependencyIssue,
+    PythonTestIssue,
+    ROCmInfrastructureIssue,
+    SanitizerIssue,
+    Severity,
+)
+
+
+class TestSeverity(unittest.TestCase):
+    """Test Severity enum."""
+
+    def test_severity_values(self):
+        """Test all severity levels exist with correct ordering values."""
+        # Severity uses numeric values for sorting (higher = more severe).
+        self.assertEqual(Severity.CRITICAL.value, 4)
+        self.assertEqual(Severity.HIGH.value, 3)
+        self.assertEqual(Severity.MEDIUM.value, 2)
+        self.assertEqual(Severity.LOW.value, 1)
+
+    def test_severity_ordering(self):
+        """Test severity levels can be sorted by value."""
+        severities = [Severity.LOW, Severity.HIGH, Severity.CRITICAL, Severity.MEDIUM]
+        sorted_severities = sorted(severities, key=lambda s: s.value, reverse=True)
+        expected = [Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW]
+        self.assertEqual(sorted_severities, expected)
+
+
+class TestBaseIssue(unittest.TestCase):
+    """Test base Issue class."""
+
+    def test_minimal_issue(self):
+        """Test Issue with minimal required fields."""
+        issue = Issue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="Test issue",
+        )
+
+        self.assertEqual(issue.severity, Severity.HIGH)
+        self.assertTrue(issue.actionable)
+        self.assertEqual(issue.message, "Test issue")
+        self.assertEqual(issue.context_lines, [])
+        self.assertIsNone(issue.line_number)
+        self.assertEqual(issue.source_extractor, "Unknown")
+
+    def test_issue_with_all_fields(self):
+        """Test Issue with all fields populated."""
+        context = ["line 1", "line 2", ">>> error line", "line 4"]
+        issue = Issue(
+            severity=Severity.CRITICAL,
+            actionable=False,
+            message="Infrastructure flake",
+            context_lines=context,
+            line_number=42,
+            source_extractor="TestExtractor",
+        )
+
+        self.assertEqual(issue.severity, Severity.CRITICAL)
+        self.assertFalse(issue.actionable)
+        self.assertEqual(issue.message, "Infrastructure flake")
+        self.assertEqual(issue.context_lines, context)
+        self.assertEqual(issue.line_number, 42)
+        self.assertEqual(issue.source_extractor, "TestExtractor")
+
+
+class TestSanitizerIssue(unittest.TestCase):
+    """Test SanitizerIssue class."""
+
+    def test_tsan_data_race(self):
+        """Test TSAN data race issue."""
+        issue = SanitizerIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message="Data race in Device::Submit",
+            sanitizer_type="TSAN",
+            error_type="data-race",
+            primary_stack=[
+                "#0 iree::hal::Device::Submit() device.cc:123",
+                "#1 main() main.cc:42",
+            ],
+            thread_id="T1",
+            address="0x7b0400001234",
+        )
+
+        self.assertEqual(issue.sanitizer_type, "TSAN")
+        self.assertEqual(issue.error_type, "data-race")
+        self.assertEqual(len(issue.primary_stack), 2)
+        self.assertEqual(issue.thread_id, "T1")
+        self.assertEqual(issue.address, "0x7b0400001234")
+        self.assertEqual(len(issue.allocation_stack), 0)
+
+    def test_asan_use_after_free(self):
+        """Test ASAN use-after-free issue."""
+        issue = SanitizerIssue(
+            severity=Severity.CRITICAL,
+            actionable=True,
+            message="Heap use after free",
+            sanitizer_type="ASAN",
+            error_type="heap-use-after-free",
+            primary_stack=["#0 iree::hal::Buffer::Map() buffer.cc:456"],
+            allocation_stack=["Allocated at buffer.cc:123"],
+            address="0x12345678",
+        )
+
+        self.assertEqual(issue.sanitizer_type, "ASAN")
+        self.assertEqual(issue.error_type, "heap-use-after-free")
+        self.assertEqual(len(issue.allocation_stack), 1)
+        self.assertEqual(issue.allocation_stack[0], "Allocated at buffer.cc:123")
+
+
+class TestLITTestIssue(unittest.TestCase):
+    """Test LITTestIssue class."""
+
+    def test_filecheck_mismatch(self):
+        """Test FileCheck pattern mismatch."""
+        issue = LITTestIssue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="CHECK-SAME pattern mismatch",
+            test_file="test.mlir",
+            test_line=42,
+            check_type="CHECK-SAME",
+            check_pattern="expected pattern",
+            expected="expected pattern",
+            actual="actual output",
+            run_command="iree-opt --pass-pipeline='...'",
+        )
+
+        self.assertEqual(issue.test_file, "test.mlir")
+        self.assertEqual(issue.test_line, 42)
+        self.assertEqual(issue.check_type, "CHECK-SAME")
+        self.assertIsNotNone(issue.expected)
+        self.assertIsNotNone(issue.actual)
+        self.assertIsNotNone(issue.run_command)
+
+    def test_minimal_lit_issue(self):
+        """Test LIT issue with minimal fields."""
+        issue = LITTestIssue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="Test failed",
+            test_file="test.mlir",
+            test_line=10,
+            check_type="CHECK",
+        )
+
+        self.assertEqual(issue.test_file, "test.mlir")
+        self.assertEqual(issue.test_line, 10)
+        self.assertIsNone(issue.check_pattern)
+        self.assertIsNone(issue.expected)
+
+
+class TestMissingDependencyIssue(unittest.TestCase):
+    """Test MissingDependencyIssue class."""
+
+    def test_bazel_missing_header(self):
+        """Test Bazel missing header dependency."""
+        issue = MissingDependencyIssue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="Missing header mlir/IR/Builders.h",
+            missing_header="mlir/IR/Builders.h",
+            target="//compiler/src/iree:Foo",
+            suggested_dep="MLIRIR",
+            fix_suggestion="Add MLIRIR to BUILD.bazel deps",
+        )
+
+        self.assertEqual(issue.missing_header, "mlir/IR/Builders.h")
+        self.assertEqual(issue.target, "//compiler/src/iree:Foo")
+        self.assertEqual(issue.suggested_dep, "MLIRIR")
+        self.assertIsNotNone(issue.fix_suggestion)
+
+
+class TestDeprecatedAPIIssue(unittest.TestCase):
+    """Test DeprecatedAPIIssue class."""
+
+    def test_deprecated_api_usage(self):
+        """Test deprecated API usage."""
+        issue = DeprecatedAPIIssue(
+            severity=Severity.MEDIUM,
+            actionable=True,
+            message="'oldFunction' is deprecated",
+            deprecated_symbol="oldFunction",
+            replacement="newFunction",
+            file_path="src/foo.cpp",
+            line=123,
+            column=10,
+        )
+
+        self.assertEqual(issue.deprecated_symbol, "oldFunction")
+        self.assertEqual(issue.replacement, "newFunction")
+        self.assertEqual(issue.file_path, "src/foo.cpp")
+        self.assertEqual(issue.line, 123)
+        self.assertEqual(issue.column, 10)
+
+
+class TestPythonTestIssue(unittest.TestCase):
+    """Test PythonTestIssue class."""
+
+    def test_pytest_assertion_error(self):
+        """Test pytest assertion error."""
+        issue = PythonTestIssue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="Assertion failed in test_foo",
+            test_name="test_foo",
+            exception_type="AssertionError",
+            exception_message="assert 1 == 2",
+            stack_trace=[
+                "test_foo.py:42: in test_foo",
+                "    assert 1 == 2",
+            ],
+            assertion_details="Expected 1, got 2",
+        )
+
+        self.assertEqual(issue.test_name, "test_foo")
+        self.assertEqual(issue.exception_type, "AssertionError")
+        self.assertEqual(len(issue.stack_trace), 2)
+        self.assertIsNotNone(issue.assertion_details)
+
+    def test_python_exception(self):
+        """Test general Python exception."""
+        issue = PythonTestIssue(
+            severity=Severity.HIGH,
+            actionable=True,
+            message="ValueError in test_bar",
+            test_name="test_bar",
+            exception_type="ValueError",
+            exception_message="invalid literal for int()",
+            stack_trace=["test_bar.py:10: in test_bar"],
+        )
+
+        self.assertEqual(issue.exception_type, "ValueError")
+        self.assertIsNone(issue.assertion_details)
+
+
+class TestROCmInfrastructureIssue(unittest.TestCase):
+    """Test ROCmInfrastructureIssue class."""
+
+    def test_cleanup_crash(self):
+        """Test ROCm cleanup crash."""
+        issue = ROCmInfrastructureIssue(
+            severity=Severity.MEDIUM,
+            actionable=False,
+            message="ROCm cleanup crash after tests passed",
+            error_pattern="cleanup_crash",
+            test_passed=True,
+        )
+
+        self.assertEqual(issue.error_pattern, "cleanup_crash")
+        self.assertTrue(issue.test_passed)
+        self.assertFalse(issue.actionable)
+
+    def test_device_lost(self):
+        """Test ROCm device lost error."""
+        issue = ROCmInfrastructureIssue(
+            severity=Severity.HIGH,
+            actionable=False,
+            message="GPU device lost during test",
+            error_pattern="device_lost",
+            test_passed=False,
+        )
+
+        self.assertEqual(issue.error_pattern, "device_lost")
+        self.assertFalse(issue.test_passed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/test_log_buffer.py
+++ b/tools/utils/test/common_tests/test_log_buffer.py
@@ -1,0 +1,335 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for LogBuffer class.
+
+Tests cover:
+- Line access (get_line, get_lines_around)
+- Offset to line number conversion
+- Forward and backward pattern searching
+- Edge cases (empty logs, single line, boundary conditions)
+"""
+
+import unittest
+
+from common.log_buffer import LogBuffer
+
+
+class TestLogBuffer(unittest.TestCase):
+    """Test LogBuffer class functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Simple multi-line log.
+        self.simple_log = """Line 0: First line
+Line 1: Second line
+Line 2: Third line
+Line 3: Fourth line
+Line 4: Fifth line"""
+
+        # Empty log.
+        self.empty_log = ""
+
+        # Single line log.
+        self.single_line_log = "Only line"
+
+        # Log with pattern matching test cases.
+        self.pattern_log = """Build started
+ERROR: Compilation failed
+file.cpp:42:10: error: undefined symbol 'foo'
+int x = foo();
+        ^
+ERROR: Build failed
+Tests passed"""
+
+        # Real-world CI log snippet (TSAN style).
+        self.tsan_log = """==================
+WARNING: ThreadSanitizer: data race (pid=12345)
+  Write of size 4 at 0x7b0400001234 by thread T1:
+    #0 iree::hal::Device::Submit() device.cc:123
+    #1 iree::hal::CommandBuffer::End() command_buffer.cc:456
+
+  Previous write of size 4 at 0x7b0400001234 by main thread:
+    #0 iree::hal::Device::Create() device.cc:789
+    #1 main() main.cc:42
+
+SUMMARY: ThreadSanitizer: data race device.cc:123 in iree::hal::Device::Submit()
+=================="""
+
+    def test_get_line_valid(self):
+        """Test get_line with valid line numbers."""
+        buffer = LogBuffer(self.simple_log)
+
+        self.assertEqual(buffer.get_line(0), "Line 0: First line")
+        self.assertEqual(buffer.get_line(2), "Line 2: Third line")
+        self.assertEqual(buffer.get_line(4), "Line 4: Fifth line")
+
+    def test_get_line_invalid(self):
+        """Test get_line with invalid line numbers."""
+        buffer = LogBuffer(self.simple_log)
+
+        self.assertIsNone(buffer.get_line(-1))
+        self.assertIsNone(buffer.get_line(5))
+        self.assertIsNone(buffer.get_line(100))
+
+    def test_get_line_empty_log(self):
+        """Test get_line on empty log."""
+        buffer = LogBuffer(self.empty_log)
+
+        self.assertIsNone(buffer.get_line(0))
+        self.assertIsNone(buffer.get_line(1))
+
+    def test_get_line_single_line(self):
+        """Test get_line on single line log."""
+        buffer = LogBuffer(self.single_line_log)
+
+        self.assertEqual(buffer.get_line(0), "Only line")
+        self.assertIsNone(buffer.get_line(1))
+
+    def test_get_lines_around_center(self):
+        """Test get_lines_around with center context."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Line 2 with context=1.
+        lines = buffer.get_lines_around(2, context=1)
+        self.assertEqual(
+            lines,
+            ["Line 1: Second line", "Line 2: Third line", "Line 3: Fourth line"],
+        )
+
+    def test_get_lines_around_start_boundary(self):
+        """Test get_lines_around at start of log."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Line 0 with context=2 (should not include negative lines).
+        lines = buffer.get_lines_around(0, context=2)
+        self.assertEqual(
+            lines,
+            [
+                "Line 0: First line",
+                "Line 1: Second line",
+                "Line 2: Third line",
+            ],
+        )
+
+    def test_get_lines_around_end_boundary(self):
+        """Test get_lines_around at end of log."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Line 4 with context=2 (should not include lines beyond end).
+        lines = buffer.get_lines_around(4, context=2)
+        self.assertEqual(
+            lines,
+            [
+                "Line 2: Third line",
+                "Line 3: Fourth line",
+                "Line 4: Fifth line",
+            ],
+        )
+
+    def test_get_lines_around_large_context(self):
+        """Test get_lines_around with context larger than log."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Context=100 should return entire log.
+        lines = buffer.get_lines_around(2, context=100)
+        self.assertEqual(len(lines), 5)  # All 5 lines.
+        self.assertEqual(lines[0], "Line 0: First line")
+        self.assertEqual(lines[4], "Line 4: Fifth line")
+
+    def test_line_count(self):
+        """Test line_count property."""
+        self.assertEqual(LogBuffer(self.simple_log).line_count, 5)
+        self.assertEqual(
+            LogBuffer(self.empty_log).line_count, 0
+        )  # Empty string returns no lines.
+        self.assertEqual(LogBuffer(self.single_line_log).line_count, 1)
+        self.assertEqual(LogBuffer(self.tsan_log).line_count, 12)
+
+    def test_get_line_number_from_offset_start(self):
+        """Test offset to line conversion at start."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Offset 0 is start of line 0.
+        self.assertEqual(buffer.get_line_number_from_offset(0), 0)
+
+        # Offset 5 is within line 0.
+        self.assertEqual(buffer.get_line_number_from_offset(5), 0)
+
+    def test_get_line_number_from_offset_middle(self):
+        """Test offset to line conversion in middle."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Calculate offset to line 2.
+        # Line 0: "Line 0: First line\n" = 19 bytes
+        # Line 1: "Line 1: Second line\n" = 20 bytes
+        # Line 2 starts at offset 39.
+        offset_line_2_start = len("Line 0: First line\n") + len("Line 1: Second line\n")
+        self.assertEqual(buffer.get_line_number_from_offset(offset_line_2_start), 2)
+
+        # Middle of line 2.
+        self.assertEqual(buffer.get_line_number_from_offset(offset_line_2_start + 5), 2)
+
+    def test_get_line_number_from_offset_end(self):
+        """Test offset to line conversion at end."""
+        buffer = LogBuffer(self.simple_log)
+
+        # Offset beyond end should return last line.
+        self.assertEqual(buffer.get_line_number_from_offset(1000), 4)
+
+    def test_find_previous_match_found(self):
+        """Test backward search finding a match."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Find line 1 ("ERROR: Compilation failed") when searching from line 4.
+        # Calculate offset for line 4 (middle of log).
+        lines_before = self.pattern_log.split("\n")[:4]
+        offset = sum(len(line) + 1 for line in lines_before)
+
+        match = buffer.find_previous_match(offset, r"ERROR:")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(), "ERROR:")
+
+    def test_find_previous_match_not_found(self):
+        """Test backward search not finding a match."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Search from line 1 for pattern that only exists later.
+        lines_before = self.pattern_log.split("\n")[:1]
+        offset = sum(len(line) + 1 for line in lines_before)
+
+        match = buffer.find_previous_match(offset, r"Tests passed")
+        self.assertIsNone(match)
+
+    def test_find_previous_match_max_lines_limit(self):
+        """Test backward search respects max_lines limit."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Search from last line for first "ERROR:" with max_lines=3.
+        # Pattern log has ERROR on lines 1 and 5.
+        # From line 6, max_lines=3 searches lines 5, 4, 3.
+        # Should find ERROR on line 5, NOT line 1.
+        offset = len(self.pattern_log)
+
+        match = buffer.find_previous_match(offset, r"ERROR:", max_lines=3)
+        self.assertIsNotNone(match)  # Should find line 5.
+        self.assertIn("Build failed", buffer.get_line(5))  # Verify it's line 5 ERROR.
+
+        # Now search with max_lines=1 - should NOT find ERROR.
+        # From line 6, max_lines=1 only searches line 5.
+        # But line 5 has ERROR, so this WILL find it.
+        # Let's search from line 3 with max_lines=1 instead.
+        lines_before = self.pattern_log.split("\n")[:3]
+        offset_line_3 = sum(len(line) + 1 for line in lines_before)
+
+        match = buffer.find_previous_match(offset_line_3, r"ERROR:", max_lines=1)
+        self.assertIsNone(match)  # Should NOT find line 1 (too far).
+
+    def test_find_next_match_found(self):
+        """Test forward search finding a match."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Find "error:" when searching from line 0.
+        match = buffer.find_next_match(0, r"error:")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(), "error:")
+
+    def test_find_next_match_not_found(self):
+        """Test forward search not finding a match."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Search from last line for pattern that doesn't exist.
+        offset = len(self.pattern_log)
+
+        match = buffer.find_next_match(offset, r"NONEXISTENT")
+        self.assertIsNone(match)
+
+    def test_find_next_match_max_lines_limit(self):
+        """Test forward search respects max_lines limit."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Search from line 0 for "Tests passed" with max_lines=2.
+        # Should NOT find it (it's on line 6).
+        match = buffer.find_next_match(0, r"Tests passed", max_lines=2)
+        self.assertIsNone(match)
+
+    def test_find_all_matches(self):
+        """Test finding all matches in log."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Find all "ERROR:" occurrences.
+        matches = buffer.find_all_matches(r"ERROR:")
+        self.assertEqual(len(matches), 2)
+
+        # Verify line numbers.
+        line_nums = [line_num for line_num, _ in matches]
+        self.assertEqual(line_nums, [1, 5])
+
+    def test_find_all_matches_no_matches(self):
+        """Test find_all_matches with no matches."""
+        buffer = LogBuffer(self.simple_log)
+
+        matches = buffer.find_all_matches(r"NONEXISTENT")
+        self.assertEqual(len(matches), 0)
+
+    def test_find_all_matches_with_groups(self):
+        """Test find_all_matches with regex groups."""
+        buffer = LogBuffer(self.pattern_log)
+
+        # Find file:line:col patterns.
+        matches = buffer.find_all_matches(r"(\w+)\.cpp:(\d+):(\d+):")
+        self.assertEqual(len(matches), 1)
+
+        line_num, match = matches[0]
+        self.assertEqual(line_num, 2)
+        self.assertEqual(match.group(1), "file")
+        self.assertEqual(match.group(2), "42")
+        self.assertEqual(match.group(3), "10")
+
+    def test_tsan_log_context_extraction(self):
+        """Test realistic TSAN log context extraction."""
+        buffer = LogBuffer(self.tsan_log)
+
+        # Find "WARNING: ThreadSanitizer" line.
+        matches = buffer.find_all_matches(r"WARNING: ThreadSanitizer")
+        self.assertEqual(len(matches), 1)
+
+        line_num, _ = matches[0]
+        context = buffer.get_lines_around(line_num, context=2)
+
+        # Verify context includes separator and error details.
+        self.assertTrue(any("==================" in line for line in context))
+        self.assertTrue(any("data race" in line for line in context))
+
+    def test_tsan_log_stack_trace_search(self):
+        """Test searching for stack frames in TSAN log."""
+        buffer = LogBuffer(self.tsan_log)
+
+        # Find all stack frames (lines starting with #N).
+        matches = buffer.find_all_matches(r"^\s+#\d+")
+        self.assertEqual(len(matches), 4)  # 2 frames in each stack trace.
+
+        # Verify first frame contains function name.
+        line_num, _ = matches[0]
+        line = buffer.get_line(line_num)
+        self.assertIn("iree::hal::Device::Submit()", line)
+
+    def test_empty_log_operations(self):
+        """Test all operations on empty log."""
+        buffer = LogBuffer(self.empty_log)
+
+        self.assertEqual(buffer.line_count, 0)
+        self.assertIsNone(buffer.get_line(0))  # Empty log has no lines.
+        self.assertEqual(buffer.get_lines_around(0, context=5), [])
+        # Empty log returns -1 for offset conversion (no lines exist).
+        self.assertEqual(buffer.get_line_number_from_offset(0), -1)
+        self.assertIsNone(buffer.find_previous_match(0, r"test"))
+        self.assertIsNone(buffer.find_next_match(0, r"test"))
+        self.assertEqual(len(buffer.find_all_matches(r"test")), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/test_log_buffer_stripping.py
+++ b/tools/utils/test/common_tests/test_log_buffer_stripping.py
@@ -1,0 +1,281 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for LogBuffer prefix stripping functionality.
+
+Tests cover:
+- GitHub Actions timestamp prefix detection and stripping
+- ctest/cmake prefix stripping
+- Auto-format detection
+- Backward compatibility (no stripping by default)
+- Original content preservation
+- Edge cases (BOM, mixed prefixes, empty logs)
+"""
+
+import unittest
+
+from common.log_buffer import LogBuffer
+
+
+class TestGitHubActionsStripping(unittest.TestCase):
+    """Test GitHub Actions log format handling."""
+
+    def test_github_actions_auto_detection(self):
+        """Test auto-detection of GitHub Actions format."""
+        log_content = (
+            "linux_x64_gcc\tUNKNOWN STEP\t2025-09-16T09:23:05.2141216Z Starting build\n"
+            "linux_x64_gcc\tUNKNOWN STEP\t2025-09-16T09:23:06.1234567Z Running tests\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Verify prefix was stripped.
+        self.assertEqual(buffer.get_line(0), "Starting build")
+        self.assertEqual(buffer.get_line(1), "Running tests")
+
+    def test_github_actions_explicit_stripping(self):
+        """Test explicit GitHub Actions format stripping."""
+        log_content = (
+            "Test Job / task\tUNKNOWN STEP\t2025-11-13T16:46:34.2164128Z Content here\n"
+        )
+
+        buffer = LogBuffer(log_content, strip_formats=["github_actions"])
+
+        self.assertEqual(buffer.get_line(0), "Content here")
+
+    def test_github_actions_complex_job_name(self):
+        """Test GitHub Actions with complex job names (slashes, spaces)."""
+        log_content = (
+            "linux_x64_bazel / linux_x64_bazel\tUNKNOWN STEP\t"
+            "2025-11-13T16:46:34.9136874Z Building targets\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        self.assertEqual(buffer.get_line(0), "Building targets")
+
+    def test_github_actions_with_bom(self):
+        """Test GitHub Actions format with BOM character on first line."""
+        # BOM character (\ufeff) can appear before timestamp.
+        log_content = (
+            "job\tstep\t\ufeff2025-09-16T09:23:05.2141216Z First line with BOM\n"
+            "job\tstep\t2025-09-16T09:23:06.0000000Z Second line normal\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Both lines should be stripped (BOM is part of prefix).
+        self.assertEqual(buffer.get_line(0), "First line with BOM")
+        self.assertEqual(buffer.get_line(1), "Second line normal")
+
+    def test_github_actions_bom_on_all_lines(self):
+        """Test BOM character on every line (real corpus pattern).
+
+        Analysis of 18 corpus logs shows BOM appears on EVERY line, not just
+        the first line. This is the actual format from GitHub Actions.
+        """
+        log_content = (
+            "job\tstep\t\ufeff2025-09-16T09:23:05.0000000Z Line 1\n"
+            "job\tstep\t\ufeff2025-09-16T09:23:06.0000000Z Line 2\n"
+            "job\tstep\t\ufeff2025-09-16T09:23:07.0000000Z Line 3\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # All lines should strip BOM correctly.
+        self.assertEqual(buffer.get_line(0), "Line 1")
+        self.assertEqual(buffer.get_line(1), "Line 2")
+        self.assertEqual(buffer.get_line(2), "Line 3")
+
+    def test_github_actions_mixed_lines(self):
+        """Test log with some lines having prefix, some without."""
+        log_content = (
+            "job\tstep\t2025-09-16T09:23:05.0000000Z Prefixed line\n"
+            "Raw line without prefix\n"
+            "job\tstep\t2025-09-16T09:23:07.0000000Z Another prefixed line\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Prefixed lines stripped, unprefixed preserved.
+        self.assertEqual(buffer.get_line(0), "Prefixed line")
+        self.assertEqual(buffer.get_line(1), "Raw line without prefix")
+        self.assertEqual(buffer.get_line(2), "Another prefixed line")
+
+
+class TestCtestCmakeStripping(unittest.TestCase):
+    """Test ctest and cmake prefix handling."""
+
+    def test_ctest_prefix_stripping(self):
+        """Test stripping of [ctest] prefix."""
+        log_content = (
+            "[ctest] Running test suite\n" "[ctest] Test passed\n" "Raw output line\n"
+        )
+
+        buffer = LogBuffer(log_content, strip_formats=["ctest"])
+
+        self.assertEqual(buffer.get_line(0), "Running test suite")
+        self.assertEqual(buffer.get_line(1), "Test passed")
+        self.assertEqual(buffer.get_line(2), "Raw output line")
+
+    def test_cmake_prefix_stripping(self):
+        """Test stripping of [cmake] and [build] prefixes."""
+        log_content = (
+            "[cmake] Configuring project\n"
+            "[build] Building target foo\n"
+            "[cmake] Build complete\n"
+        )
+
+        buffer = LogBuffer(log_content, strip_formats=["cmake"])
+
+        self.assertEqual(buffer.get_line(0), "Configuring project")
+        self.assertEqual(buffer.get_line(1), "Building target foo")
+        self.assertEqual(buffer.get_line(2), "Build complete")
+
+    def test_multiple_format_stripping(self):
+        """Test stripping multiple formats in same log."""
+        log_content = "[ctest] Test output\n" "[cmake] Build message\n" "Raw line\n"
+
+        buffer = LogBuffer(log_content, strip_formats=["ctest", "cmake"])
+
+        self.assertEqual(buffer.get_line(0), "Test output")
+        self.assertEqual(buffer.get_line(1), "Build message")
+        self.assertEqual(buffer.get_line(2), "Raw line")
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """Test that default behavior is unchanged."""
+
+    def test_no_stripping_by_default(self):
+        """Test that logs are not stripped by default."""
+        log_content = (
+            "job\tstep\t2025-09-16T09:23:05.0000000Z Prefixed line\n"
+            "[ctest] Test line\n"
+        )
+
+        # Default: no stripping.
+        buffer = LogBuffer(log_content)
+
+        # Original content preserved.
+        self.assertIn("2025-09-16T09:23:05.0000000Z", buffer.get_line(0))
+        self.assertIn("[ctest]", buffer.get_line(1))
+
+    def test_empty_strip_formats_list(self):
+        """Test that empty strip_formats list does nothing."""
+        log_content = "job\tstep\t2025-09-16T09:23:05.0000000Z Content\n"
+
+        buffer = LogBuffer(log_content, strip_formats=[])
+
+        # No stripping with empty list.
+        self.assertIn("2025-09-16T09:23:05.0000000Z", buffer.get_line(0))
+
+
+class TestOriginalContentPreservation(unittest.TestCase):
+    """Test that original content is preserved."""
+
+    def test_get_original_content(self):
+        """Test accessing original unstripped content."""
+        original = (
+            "job\tstep\t2025-09-16T09:23:05.0000000Z Line 1\n"
+            "job\tstep\t2025-09-16T09:23:06.0000000Z Line 2\n"
+        )
+
+        buffer = LogBuffer(original, auto_detect_format=True)
+
+        # Stripped content different from original.
+        self.assertEqual(buffer.get_line(0), "Line 1")
+        self.assertNotIn("2025-09-16", buffer.content)
+
+        # Original content preserved.
+        self.assertEqual(buffer.get_original_content(), original)
+        self.assertIn("2025-09-16T09:23:05.0000000Z", buffer.get_original_content())
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Test edge cases and error handling."""
+
+    def test_empty_log(self):
+        """Test stripping on empty log."""
+        buffer = LogBuffer("", auto_detect_format=True)
+
+        self.assertEqual(buffer.line_count, 0)
+        self.assertEqual(buffer.content, "")
+        self.assertEqual(buffer.get_original_content(), "")
+
+    def test_log_with_only_newlines(self):
+        """Test log with only newlines."""
+        buffer = LogBuffer("\n\n\n", auto_detect_format=True)
+
+        self.assertEqual(buffer.line_count, 3)
+        self.assertEqual(buffer.get_line(0), "")
+        self.assertEqual(buffer.get_line(1), "")
+
+    def test_no_format_detected(self):
+        """Test log where auto-detection finds no known format."""
+        log_content = "Plain log line 1\nPlain log line 2"
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # No format detected, content unchanged.
+        self.assertEqual(buffer.get_line(0), "Plain log line 1")
+        self.assertEqual(buffer.content, "Plain log line 1\nPlain log line 2")
+
+    def test_line_offsets_after_stripping(self):
+        """Test that line offsets are computed correctly after stripping."""
+        log_content = (
+            "job\tstep\t2025-09-16T09:23:05.0000000Z Line 1\n"
+            "job\tstep\t2025-09-16T09:23:06.0000000Z Line 2\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Line offsets should correspond to stripped content.
+        offset_line_0 = 0
+        offset_line_1 = len("Line 1\n")
+
+        self.assertEqual(buffer.get_line_number_from_offset(offset_line_0), 0)
+        self.assertEqual(buffer.get_line_number_from_offset(offset_line_1), 1)
+
+    def test_pattern_matching_on_stripped_content(self):
+        """Test that pattern matching works on stripped content."""
+        log_content = (
+            "job\tstep\t2025-09-16T09:23:05.0000000Z ERROR: Something failed\n"
+            "job\tstep\t2025-09-16T09:23:06.0000000Z Normal output\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Search for ERROR in stripped content.
+        matches = buffer.find_all_matches(r"^ERROR:")
+
+        self.assertEqual(len(matches), 1)
+        line_num, _ = matches[0]
+        self.assertEqual(line_num, 0)
+        self.assertEqual(buffer.get_line(line_num), "ERROR: Something failed")
+
+    def test_context_extraction_with_stripping(self):
+        """Test get_lines_around works correctly with stripped content."""
+        log_content = (
+            "job\tstep\t2025-09-16T09:23:01.0000000Z Line 0\n"
+            "job\tstep\t2025-09-16T09:23:02.0000000Z Line 1\n"
+            "job\tstep\t2025-09-16T09:23:03.0000000Z ERROR HERE\n"
+            "job\tstep\t2025-09-16T09:23:04.0000000Z Line 3\n"
+            "job\tstep\t2025-09-16T09:23:05.0000000Z Line 4\n"
+        )
+
+        buffer = LogBuffer(log_content, auto_detect_format=True)
+
+        # Get context around error line.
+        context = buffer.get_lines_around(2, context=1)
+
+        self.assertEqual(len(context), 3)
+        self.assertEqual(context[0], "Line 1")
+        self.assertEqual(context[1], "ERROR HERE")
+        self.assertEqual(context[2], "Line 3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/common_tests/test_test_helpers.py
+++ b/tools/utils/test/common_tests/test_test_helpers.py
@@ -1,0 +1,285 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for test.test_helpers module."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add project tools/utils to path for imports
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from test.test_helpers import run_python_module
+
+
+class TestRunPythonModule(unittest.TestCase):
+    """Tests for run_python_module helper function."""
+
+    def test_basic_invocation(self):
+        """Test basic module invocation with arguments."""
+        # Use a simple built-in module that's guaranteed to exist
+        result = run_python_module(
+            "json.tool",
+            ["--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout.lower())
+
+    def test_uses_current_python_executable(self):
+        """Verify run_python_module uses sys.executable, not hardcoded 'python3'."""
+        # Create a simple test module that prints sys.executable
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_dir = Path(tmpdir) / "test_module"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("")
+            (module_dir / "__main__.py").write_text(
+                "import sys\nprint(sys.executable)\n"
+            )
+
+            # Add tmpdir to PYTHONPATH so we can import test_module
+            original_pythonpath = os.environ.get("PYTHONPATH", "")
+            try:
+                os.environ["PYTHONPATH"] = str(tmpdir)
+                result = run_python_module(
+                    "test_module",
+                    [],
+                    capture_output=True,
+                    text=True,
+                )
+                # The subprocess should report the same executable we're using
+                reported_executable = result.stdout.strip()
+                self.assertEqual(reported_executable, sys.executable)
+            finally:
+                if original_pythonpath:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+                elif "PYTHONPATH" in os.environ:
+                    del os.environ["PYTHONPATH"]
+
+    def test_pythonpath_setup(self):
+        """Verify PYTHONPATH is set up correctly for tools/utils imports."""
+        # Test that lit_tools module is importable (uses lit_tools.iree_lit_list)
+        # Create a minimal test file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write("// RUN: test\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            result = run_python_module(
+                "lit_tools.iree_lit_list",
+                [str(tmp_path)],
+                capture_output=True,
+                text=True,
+            )
+            # If PYTHONPATH wasn't set correctly, the import would fail
+            self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        finally:
+            tmp_path.unlink()
+
+    def test_kwargs_passed_through(self):
+        """Verify subprocess kwargs are passed through correctly."""
+        # Test with input parameter using json.tool which reads stdin
+        result = run_python_module(
+            "json.tool",
+            [],
+            input='{"test": "value"}',
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        # json.tool formats the input JSON
+        self.assertIn('"test"', result.stdout)
+        self.assertIn('"value"', result.stdout)
+
+    def test_timeout_parameter(self):
+        """Verify timeout parameter works."""
+        # Create a module that sleeps
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_dir = Path(tmpdir) / "sleep_module"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("")
+            (module_dir / "__main__.py").write_text("import time\ntime.sleep(10)\n")
+
+            # Add tmpdir to PYTHONPATH
+            original_pythonpath = os.environ.get("PYTHONPATH", "")
+            try:
+                os.environ["PYTHONPATH"] = str(tmpdir)
+                # Test that timeout is respected
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    run_python_module(
+                        "sleep_module",
+                        [],
+                        timeout=0.1,
+                    )
+            finally:
+                if original_pythonpath:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+                elif "PYTHONPATH" in os.environ:
+                    del os.environ["PYTHONPATH"]
+
+    def test_environment_preservation(self):
+        """Verify existing environment variables are preserved."""
+        # Create a module that prints an environment variable
+        test_var = "TEST_RUN_PYTHON_MODULE_VAR"
+        test_value = "test_value_12345"
+        os.environ[test_var] = test_value
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                module_dir = Path(tmpdir) / "env_module"
+                module_dir.mkdir()
+                (module_dir / "__init__.py").write_text("")
+                (module_dir / "__main__.py").write_text(
+                    f"import os\nprint(os.environ.get('{test_var}', 'NOT_FOUND'))\n"
+                )
+
+                # Add tmpdir to PYTHONPATH
+                original_pythonpath = os.environ.get("PYTHONPATH", "")
+                try:
+                    os.environ["PYTHONPATH"] = str(tmpdir)
+                    result = run_python_module(
+                        "env_module",
+                        [],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, 0)
+                    self.assertIn(test_value, result.stdout)
+                finally:
+                    if original_pythonpath:
+                        os.environ["PYTHONPATH"] = original_pythonpath
+                    elif "PYTHONPATH" in os.environ:
+                        del os.environ["PYTHONPATH"]
+        finally:
+            # Clean up
+            del os.environ[test_var]
+
+    def test_pythonpath_preservation(self):
+        """Verify existing PYTHONPATH is preserved and extended."""
+        # Create a module that prints PYTHONPATH
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_dir = Path(tmpdir) / "path_module"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("")
+            (module_dir / "__main__.py").write_text(
+                "import os\nprint(os.environ['PYTHONPATH'])\n"
+            )
+
+            # Set a custom PYTHONPATH
+            original_pythonpath = os.environ.get("PYTHONPATH", "")
+            custom_path = "/custom/test/path"
+            os.environ["PYTHONPATH"] = f"{str(tmpdir)}{os.pathsep}{custom_path}"
+
+            try:
+                result = run_python_module(
+                    "path_module",
+                    [],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0)
+                # Both custom path and tools/utils should be in PYTHONPATH
+                self.assertIn(custom_path, result.stdout)
+                self.assertIn("tools/utils", result.stdout)
+            finally:
+                # Restore original
+                if original_pythonpath:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+                elif "PYTHONPATH" in os.environ:
+                    del os.environ["PYTHONPATH"]
+
+    def test_error_propagation(self):
+        """Verify errors from subprocess are properly propagated."""
+        # Create a module that exits with error code 42
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_dir = Path(tmpdir) / "error_module"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("")
+            (module_dir / "__main__.py").write_text("import sys\nsys.exit(42)\n")
+
+            # Add tmpdir to PYTHONPATH
+            original_pythonpath = os.environ.get("PYTHONPATH", "")
+            try:
+                os.environ["PYTHONPATH"] = str(tmpdir)
+                result = run_python_module(
+                    "error_module",
+                    [],
+                    capture_output=True,
+                )
+                self.assertEqual(result.returncode, 42)
+            finally:
+                if original_pythonpath:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+                elif "PYTHONPATH" in os.environ:
+                    del os.environ["PYTHONPATH"]
+
+    def test_stderr_capture(self):
+        """Verify stderr is captured when requested."""
+        # Create a module that writes to stderr
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_dir = Path(tmpdir) / "stderr_module"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("")
+            (module_dir / "__main__.py").write_text(
+                "import sys\nsys.stderr.write('ERROR MESSAGE\\n')\n"
+            )
+
+            # Add tmpdir to PYTHONPATH
+            original_pythonpath = os.environ.get("PYTHONPATH", "")
+            try:
+                os.environ["PYTHONPATH"] = str(tmpdir)
+                result = run_python_module(
+                    "stderr_module",
+                    [],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertIn("ERROR MESSAGE", result.stderr)
+            finally:
+                if original_pythonpath:
+                    os.environ["PYTHONPATH"] = original_pythonpath
+                elif "PYTHONPATH" in os.environ:
+                    del os.environ["PYTHONPATH"]
+
+    def test_lit_tools_module_invocation(self):
+        """Test invoking a real lit_tools module (integration test)."""
+        # Create a minimal test file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(
+                """// RUN: some-command
+// CHECK: test
+func.func @test() {
+  return
+}
+"""
+            )
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Use iree-lit-list which should work on any valid test file
+            result = run_python_module(
+                "lit_tools.iree_lit_list",
+                [str(tmp_path)],
+                capture_output=True,
+                text=True,
+            )
+            # Should succeed and list the test
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"stdout: {result.stdout}\nstderr: {result.stderr}",
+            )
+        finally:
+            tmp_path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/__init__.py
+++ b/tools/utils/test/lit_tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for lit tests

--- a/tools/utils/test/lit_tests/fixtures/README.md
+++ b/tools/utils/test/lit_tests/fixtures/README.md
@@ -1,0 +1,213 @@
+# Lit Test Fixtures
+
+Test fixtures for validating lit tool functionality. Each fixture tests specific edge cases and scenarios.
+
+## Fixture Catalog
+
+### `simple_test.mlir`
+**Purpose**: Single test case without delimiters
+
+**Characteristics**:
+- No `// -----` delimiter (single test case file)
+- Has `CHECK-LABEL` for named case extraction
+- Contains RUN line at beginning
+- 1 test case named `@simple_function`
+
+**Used to test**:
+- Parsing files with single test case
+- Extracting test case by name
+- Extracting RUN lines from file header
+- Basic CHECK pattern counting
+
+**Structure**:
+```
+Lines 1-2:  RUN directive
+Lines 3-9:  Single test case with CHECK patterns
+```
+
+---
+
+### `split_test.mlir`
+**Purpose**: Multiple test cases separated by `// -----` delimiters
+
+**Characteristics**:
+- Uses `// -----` delimiters to separate cases
+- Has multi-line RUN directive at beginning
+- 3 test cases, all named with `CHECK-LABEL`
+- Each case has different complexity (varying CHECK patterns)
+
+**Test cases**:
+1. `@first_case` (lines 5-11) - 2 CHECK patterns
+2. `@second_case` (lines 15-23) - 3 CHECK patterns
+3. `@third_case` (lines 27-33) - 2 CHECK patterns
+
+**Used to test**:
+- Parsing files with multiple test cases
+- Splitting on `// -----` delimiter
+- Extracting individual test cases by number
+- Extracting test cases by name
+- Boundary detection (start/end lines)
+- Multi-line RUN directive handling
+
+**Structure**:
+```
+Lines 1-3:   Multi-line RUN directive (with continuations)
+Lines 5-11:  Test case 1: @first_case
+Line 13:     Delimiter: // -----
+Lines 15-23: Test case 2: @second_case
+Line 25:     Delimiter: // -----
+Lines 27-33: Test case 3: @third_case
+```
+
+---
+
+### `names_test.mlir`
+**Purpose**: Function names with special characters
+
+**Characteristics**:
+- Single test case (no delimiters)
+- Function name contains punctuation: `@foo.bar$baz-1`
+- Tests CHECK-LABEL extraction with special characters
+
+**Used to test**:
+- Parsing function names with dots (`.`)
+- Parsing function names with dollar signs (`$`)
+- Parsing function names with hyphens (`-`)
+- Parsing function names with numbers
+- CHECK-LABEL regex robustness
+
+**Structure**:
+```
+Lines 1-2: RUN directive
+Lines 3-7: Single test case with punctuated name
+```
+
+---
+
+### `run_variants.mlir`
+**Purpose**: RUN line format variations
+
+**Characteristics**:
+- Indented comments before RUN lines
+- Mixed RUN line formats: `//RUN:` (no space) and `// RUN:` (with space)
+- Multi-line RUN directive with continuations
+- Tests RUN line extraction with various whitespace patterns
+
+**Used to test**:
+- Extracting RUN lines with no space after `//`
+- Extracting RUN lines with space after `//`
+- Handling indented comments before RUN lines
+- Multi-line RUN directive extraction
+- RUN line normalization
+
+**Structure**:
+```
+Lines 1-2: Indented comments (NOT RUN lines)
+Lines 3-5: Multi-line RUN directive with mixed formatting
+Lines 7-11: Single test case
+```
+
+---
+
+### `invalid_ir.mlir`
+**Purpose**: Test invalid MLIR that fails verification
+
+**Characteristics**:
+- Contains intentionally invalid IR (arith.addi with float operands)
+- Uses `--verify-diagnostics` flag
+- Demonstrates IR verification error detection
+- Uses `expected-error` directive to mark expected failures
+
+**Used to test**:
+- Invalid IR error detection in lit_wrapper
+- Error message extraction from verification failures
+- Diagnostic handling with `--verify-diagnostics`
+- Error classification (IR validation vs other errors)
+
+**Structure**:
+```
+Lines 1:     RUN directive with --verify-diagnostics
+Lines 3-6:   Comment explaining the invalid IR
+Lines 8-13:  Function with intentionally invalid arith.addi operation
+```
+
+**Expected behavior**:
+- Test will FAIL with IR verification error when run without `--verify-diagnostics`
+- Test will PASS when run with `--verify-diagnostics` (diagnostics are expected)
+- Error extractor should detect and classify as "IR verification failed"
+
+---
+
+### `failing_scattered_run_lines.mlir`
+**Purpose**: Test cases with RUN lines scattered throughout (edge case)
+
+**Characteristics**:
+- Has RUN lines interspersed within test cases (non-standard)
+- Multiple delimited test cases
+- Each case has its own RUN line (not in file header)
+- Tests handling of non-standard RUN line placement
+
+**Used to test**:
+- RUN line extraction from within test cases
+- Proper association of RUN lines with specific cases
+- Handling edge cases in RUN line placement
+- Validation of scattered vs header RUN line patterns
+
+**Structure**:
+```
+Lines vary: RUN lines scattered throughout cases
+Multiple test cases with // ----- delimiters
+Non-standard but valid lit test format
+```
+
+**Expected behavior**:
+- Tool should extract case-specific RUN lines correctly
+- May require special handling vs standard header RUN lines
+- Used to verify robustness of RUN line extraction logic
+
+---
+
+## Fixture Naming Convention
+
+Fixtures follow the pattern: `<scenario>_test.mlir`
+
+**Examples**:
+- `simple_test.mlir` - Simple/basic scenario
+- `split_test.mlir` - Split file scenario
+- `names_test.mlir` - Special names scenario
+- `run_variants.mlir` - RUN line variants
+
+## Adding New Fixtures
+
+When adding a new fixture:
+
+1. **Name it descriptively**: `<what_it_tests>_test.mlir`
+2. **Document it in this README**: Add a new section explaining:
+   - Purpose (one-line summary)
+   - Characteristics (what makes it special)
+   - Used to test (what scenarios it covers)
+   - Structure (line-by-line breakdown)
+3. **Keep it minimal**: Only include what's needed to test the scenario
+4. **Use real MLIR syntax**: Fixtures should be valid MLIR (even if simplified)
+
+## Test Coverage Matrix
+
+| Scenario | Fixture | Test Cases | Notes |
+|----------|---------|-----------|-------|
+| Single case file | `simple_test.mlir` | 1 | No delimiters |
+| Multiple cases | `split_test.mlir` | 3 | With `// -----` |
+| Special characters in names | `names_test.mlir` | 1 | Dots, dollars, hyphens |
+| RUN line variations | `run_variants.mlir` | 1 | Mixed formatting |
+| Invalid IR | `invalid_ir.mlir` | 1 | Verification failure |
+| Scattered RUN lines | `failing_scattered_run_lines.mlir` | Multiple | RUN lines within cases |
+
+## Missing Coverage (Potential Future Fixtures)
+
+**Suggested additions**:
+- `unnamed_cases_test.mlir` - Test cases without CHECK-LABEL (unnamed)
+- `large_file_test.mlir` - File with 10+ test cases (stress test)
+- `empty_case_test.mlir` - Test case with no content between delimiters
+- `nested_labels_test.mlir` - Multiple CHECK-LABELs in one case
+- `no_checks_test.mlir` - Test case with no CHECK patterns at all
+
+These are not currently needed but could be added if new edge cases are discovered.

--- a/tools/utils/test/lit_tests/fixtures/duplicate_labels.mlir
+++ b/tools/utils/test/lit_tests/fixtures/duplicate_labels.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @foo
+func.func @foo() {
+  return
+}
+
+// -----
+// CHECK-LABEL: @foo
+func.func @foo() {
+  // Second function with same label.
+  return
+}
+
+// -----
+// CHECK-LABEL: @bar
+func.func @bar() {
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/edge_cases_run_lines.mlir
+++ b/tools/utils/test/lit_tests/fixtures/edge_cases_run_lines.mlir
@@ -1,0 +1,61 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @simple_case
+util.func @simple_case() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @with_case_run
+// RUN: iree-opt %s --canonicalize | FileCheck %s --check-prefix=CANON
+util.func @with_case_run() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @long_pipeline
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(cse,canonicalize,symbol-dce))' %s | FileCheck %s
+util.func @long_pipeline() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @verify_diagnostics
+// RUN: iree-opt %s --verify-diagnostics
+util.func @verify_diagnostics() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @multiple_check_prefixes
+// RUN: iree-opt %s | FileCheck %s --check-prefixes=CHECK,EXTRA
+util.func @multiple_check_prefixes() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @with_argument
+util.func @with_argument(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @pipeline_chain
+// RUN: iree-opt %s | iree-opt | FileCheck %s
+util.func @pipeline_chain() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @environment_variable
+// RUN: IREE_TEST_VAR=value iree-opt %s | FileCheck %s
+util.func @environment_variable() {
+  util.return
+}

--- a/tools/utils/test/lit_tests/fixtures/edge_cases_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/edge_cases_test.mlir
@@ -1,0 +1,51 @@
+// RUN: iree-opt %s | FileCheck %s
+
+// Test case 1: Single quotes in comments (common in English text).
+// CHECK-LABEL: @single_quotes_in_comments
+func.func @single_quotes_in_comments() {
+  // This function doesn't use single quotes in attributes.
+  // They're only valid in comments like "can't" or "won't".
+  return
+}
+
+// -----
+
+// Test case 2: Double quotes in string literals.
+// CHECK-LABEL: @double_quotes
+util.global private @str = "string with \"escaped\" quotes" : !util.buffer
+func.func @double_quotes() {
+  return
+}
+
+// -----
+
+// Test case 3: Backticks in comments (common in markdown/code examples).
+// CHECK-LABEL: @backticks_in_comments
+func.func @backticks_in_comments() {
+  // Example code: `some_function(arg1, arg2)`
+  // Template literal: `value is ${expr}`
+  return
+}
+
+// -----
+
+// Test case 4: Dollar signs in comments (common in cost analysis, bash vars).
+// CHECK-LABEL: @dollar_signs
+func.func @dollar_signs() {
+  // Cost analysis: $100 per operation
+  // Environment: $HOME, $PATH
+  // Math: cost = $O(n^2)$
+  return
+}
+
+// -----
+
+// Test case 5: Unicode characters in comments and names.
+// CHECK-LABEL: @unicode_test
+func.func @unicode_test() {
+  // Japanese: 日本語テスト
+  // Chinese: 测试
+  // Emoji: 🔧 🚀
+  // Math: ∑ ∫ ∂
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/failing_scattered_run_lines.mlir
+++ b/tools/utils/test/lit_tests/fixtures/failing_scattered_run_lines.mlir
@@ -1,0 +1,31 @@
+// RUN: echo "ok" | FileCheck %s --check-prefix=HDR
+// RUN: echo "alpha" | FileCheck %s --check-prefix=ALPHA
+
+// HDR: ok
+// ALPHA: alpha
+
+// -----
+
+// CHECK-LABEL: @case1
+// CASE1: hello
+func @case1() {
+}
+
+// -----
+
+// CHECK-LABEL: @case2
+// Some comment
+// CASE2: world
+func @case2() {
+}
+
+// -----
+
+// CHECK-LABEL: @case3
+// CASE3: gamma
+func @case3() {
+}
+
+// Additional scattered RUN lines that should be preserved and not interfere:
+// RUN: echo "world" | FileCheck %s --check-prefix=NOTUSED
+// NOTUSED: something-else-entirely

--- a/tools/utils/test/lit_tests/fixtures/filecheck_error_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/filecheck_error_test.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-opt %s --split-input-file | FileCheck %s
+
+// CHECK-LABEL: @case1
+func.func @case1() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case2
+func.func @case2() {
+  // CHECK: this pattern will not be found
+  %c0 = arith.constant 0 : i32
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case3
+func.func @case3() {
+  // CHECK: return
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/five_cases.mlir
+++ b/tools/utils/test/lit_tests/fixtures/five_cases.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @case_one
+func.func @case_one() {
+  return
+}
+
+// -----
+// CHECK-LABEL: @case_two
+func.func @case_two() {
+  return
+}
+
+// -----
+// CHECK-LABEL: @case_three
+func.func @case_three() {
+  return
+}
+
+// -----
+// CHECK-LABEL: @case_four
+func.func @case_four() {
+  return
+}
+
+// -----
+// CHECK-LABEL: @case_five
+func.func @case_five() {
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/invalid_ir.mlir
+++ b/tools/utils/test/lit_tests/fixtures/invalid_ir.mlir
@@ -1,0 +1,12 @@
+// RUN: iree-opt --verify-diagnostics %s
+
+// This test intentionally contains invalid IR to demonstrate error detection.
+// The arith.addi operation expects integer types but receives tensor<f32>.
+
+func.func @invalid_addi() {
+  %c0 = arith.constant 0.0 : f32
+  %c1 = arith.constant 1.0 : f32
+  // expected-error @+1 {{'arith.addi' op operand #0 must be signless-integer-like}}
+  %sum = arith.addi %c0, %c1 : f32
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/lint_good_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/lint_good_test.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+// Test case following best practices (should have no issues).
+// CHECK-LABEL: util.func @good_example
+util.func @good_example(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[RESULT:.+]] = arith.addf %[[ARG:.+]], %[[ARG]]
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  // CHECK: util.return %[[RESULT]]
+  util.return %0 : tensor<4xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/lint_split_boundary.mlir
+++ b/tools/utils/test/lit_tests/fixtures/lint_split_boundary.mlir
@@ -1,0 +1,78 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+//
+// This file tests split boundary CHECK warnings.
+
+// First case is fine (no split boundary before it).
+// CHECK-LABEL: @test0
+util.func @test0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// BAD: first CHECK after split is not CHECK-LABEL (warning: first_check_not_label_after_split).
+// Also BAD: CHECK-DAG before CHECK-LABEL (warning: unanchored_check_dag_after_split).
+// CHECK-DAG: util.global
+// CHECK-LABEL: @test1
+util.global private @global1 : index
+util.func @test1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// BAD: first CHECK after split is CHECK (not LABEL).
+// CHECK-LABEL: @test2_anchor
+// CHECK: some.op
+// CHECK-LABEL: @test2
+util.func @test2_anchor() {}
+util.func @test2(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  "some.op"() : () -> ()
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// BAD: first CHECK after split is CHECK-SAME (not LABEL).
+// CHECK-SAME: something
+// CHECK-LABEL: @test3
+util.func @test3(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// BAD: first CHECK after split is CHECK-NEXT (not LABEL).
+// CHECK-NEXT: arith.constant
+// CHECK-LABEL: @test4
+util.func @test4(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// GOOD: CHECK-LABEL first, then CHECK-DAG.
+// CHECK-LABEL: @test5
+// CHECK-DAG: util.global
+util.global private @global5 : index
+util.func @test5(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// GOOD: CHECK-LABEL on module is valid anchoring.
+// CHECK-LABEL: module
+module {
+  // CHECK: util.global
+  util.global private @nested_global : index
+}
+
+// -----
+
+// GOOD: CHECK-LABEL first (this case tests that first case with LABEL is fine).
+// CHECK-LABEL: @test_good_label
+util.func @test_good_label(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/lint_split_good.mlir
+++ b/tools/utils/test/lit_tests/fixtures/lint_split_good.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+//
+// This file tests that proper split boundary usage doesn't trigger warnings.
+
+// First case - CHECK-LABEL first (no split boundary before it).
+// CHECK-LABEL: @test0
+util.func @test0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// GOOD: CHECK-LABEL first, then other CHECKs.
+// CHECK-LABEL: @test1
+// CHECK: arith.constant
+util.func @test1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// GOOD: CHECK-LABEL first, then CHECK-DAG.
+// CHECK-LABEL: @test2
+// CHECK-DAG: util.global
+util.global private @global2 : index
+util.func @test2(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// GOOD: CHECK-LABEL on module is valid anchoring.
+// CHECK-LABEL: module
+module {
+  // CHECK: util.global
+  util.global private @nested_global : index
+}

--- a/tools/utils/test/lit_tests/fixtures/lint_split_missing.mlir
+++ b/tools/utils/test/lit_tests/fixtures/lint_split_missing.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt %s | FileCheck %s
+//
+// This file tests the missing_split_input_file warning.
+// It has // ----- delimiters but no --split-input-file flag.
+
+// CHECK-LABEL: @test1
+util.func @test1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test2
+util.func @test2(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/lint_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/lint_test.mlir
@@ -1,0 +1,678 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+// Tests that raw SSA identifiers in CHECK lines trigger errors.
+
+// CHECK-LABEL: @raw_ssa_bad
+util.func @raw_ssa_bad(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %offset = arith.constant 0 : index
+  // CHECK: %0 = arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  // CHECK: %offset = arith.constant
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that IR without CHECK lines triggers error.
+
+util.func @no_checks(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that bare TODO/FIXME/NOTE comments trigger errors.
+
+// CHECK-LABEL: @bare_todo
+util.func @bare_todo(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // TODO
+  %c0 = arith.constant 0 : index
+  // FIXME
+  // NOTE
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that weak TODO explanations (1-3 words) trigger errors.
+
+// CHECK-LABEL: @weak_todo
+util.func @weak_todo(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // TODO: fix this
+  %c0 = arith.constant 0 : index
+  // FIXME: broken
+  // NOTE: important
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that detailed TODO explanations pass.
+
+// CHECK-LABEL: @good_todo
+util.func @good_todo(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // TODO(#1234): Add support for dynamic shapes after upstream MLIR lands the DynamicShapeInterface.
+  %c0 = arith.constant 0 : index
+  // FIXME: The dominance check fails for block arguments in loop headers because SSA def precedes use.
+  // NOTE: This await cannot be eliminated because public functions can't return timepoints per the ABI.
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that CHECK-NOT without any anchors triggers error.
+
+// CHECK-LABEL: @unanchored_check_not
+util.func @unanchored_check_not(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK-NOT: stream.timepoint.await
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that CHECK-NOT without before anchor triggers error.
+
+// CHECK-LABEL: @missing_before_anchor
+util.func @missing_before_anchor(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK-NOT: stream.timepoint.await
+  // CHECK: util.return
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that CHECK-NOT without after anchor triggers error.
+
+// CHECK-LABEL: @missing_after_anchor
+util.func @missing_after_anchor(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant
+  // CHECK-NOT: stream.timepoint.await
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that properly anchored CHECK-NOT passes.
+
+// CHECK-LABEL: @properly_anchored
+util.func @properly_anchored(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant
+  // CHECK-NOT: stream.timepoint.await
+  // CHECK: util.return
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that excessive wildcards (>2) trigger warnings.
+
+// CHECK-LABEL: @excessive_wildcards
+util.func @excessive_wildcards(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex::@dispatch[{{.+}}]({{.+}}, {{.+}}, {{.+}}) : ({{.+}})
+  %0 = stream.async.dispatch @ex::@dispatch[%c0](%arg0, %arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that %[[C0]], %[[ARG0]] style names trigger warnings.
+
+// CHECK-LABEL: @bad_names
+util.func @bad_names(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant 0
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[C123_I32:.+]] = arith.constant 123
+  %c123 = arith.constant 123 : i32
+  // CHECK: %[[RESULT:.+]] = arith.addf %[[ARG0:.+]], %[[ARG1:.+]]
+  %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that IR/CHECK name mismatches trigger warnings.
+
+// CHECK-LABEL: @mismatched_names
+util.func @mismatched_names(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[SIZE:.+]] = arith.constant
+  %transient_size = arith.constant 123 : index
+  // CHECK: %[[READY:.+]] = stream.timepoint.await
+  %slice_ready = stream.timepoint.immediate => !stream.timepoint
+  // CHECK: %[[RESULT:.+]] = arith.addf
+  %double_value = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %double_value : tensor<4xf32>
+}
+
+// -----
+
+// Tests that matched IR/CHECK names don't trigger warnings.
+
+// CHECK-LABEL: @matched_names
+util.func @matched_names(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[TRANSIENT_SIZE:.+]] = arith.constant
+  %transient_size = arith.constant 123 : index
+  // CHECK: %[[SLICE_READY:.+]] = stream.timepoint.await
+  %slice_ready = stream.timepoint.immediate => !stream.timepoint
+  // CHECK: %[[DOUBLE_VALUE:.+]] = arith.addf
+  %double_value = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %double_value : tensor<4xf32>
+}
+
+// -----
+
+// Tests that non-semantic IR names don't trigger mismatch warnings.
+
+// CHECK-LABEL: @no_semantic_names
+util.func @no_semantic_names(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[RESULT:.+]] = arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that wildcards in terminators trigger warnings.
+
+// CHECK-LABEL: @wildcard_terminators
+util.func @wildcard_terminators(%arg0: tensor<4xf32>, %arg1: i1) -> tensor<4xf32> {
+  // CHECK: scf.yield {{.+}}, {{.+}}
+  %result = scf.if %arg1 -> (tensor<4xf32>) {
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    scf.yield %0 : tensor<4xf32>
+  } else {
+    scf.yield %arg0 : tensor<4xf32>
+  }
+  // CHECK: util.return {{.+}}
+  util.return %result : tensor<4xf32>
+}
+
+// -----
+
+// Tests that explicit terminator operands don't trigger warnings.
+
+// CHECK-LABEL: @explicit_terminators
+util.func @explicit_terminators(%arg0: tensor<4xf32>, %arg1: i1) -> tensor<4xf32> {
+  // CHECK: %[[RESULT:.+]] = scf.if
+  %result = scf.if %arg1 -> (tensor<4xf32>) {
+    // CHECK: %[[SUM:.+]] = arith.addf
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    // CHECK: scf.yield %[[SUM]]
+    scf.yield %0 : tensor<4xf32>
+  } else {
+    // CHECK: scf.yield %arg0
+    scf.yield %arg0 : tensor<4xf32>
+  }
+  // CHECK: util.return %[[RESULT]]
+  util.return %result : tensor<4xf32>
+}
+
+// -----
+
+// Tests that func.return and cf.br with wildcards trigger warnings.
+
+// CHECK-LABEL: @other_terminators
+func.func @other_terminators(%arg0: i32, %arg1: i1) -> i32 {
+  // CHECK: cf.cond_br {{.+}}, ^bb1({{.+}} : i32), ^bb2
+  cf.cond_br %arg1, ^bb1(%arg0 : i32), ^bb2
+^bb1(%val: i32):
+  // CHECK: func.return {{.+}}
+  func.return %val : i32
+^bb2:
+  %c0 = arith.constant 0 : i32
+  // CHECK: cf.br ^bb1({{.+}} : i32)
+  cf.br ^bb1(%c0 : i32)
+}
+
+// -----
+
+// Tests that CHECK before LABEL triggers warning.
+
+// CHECK: %[[FOO:.+]] = arith.constant
+// CHECK-LABEL: @check_before_label
+util.func @check_before_label(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that CHECK after LABEL doesn't trigger warning.
+
+// CHECK-LABEL: @proper_label_context
+util.func @proper_label_context(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[RESULT:.+]] = arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  // CHECK: util.return %[[RESULT]]
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that CHECK after first LABEL is ok (multi-function file).
+
+// CHECK-LABEL: @first_function
+util.func @first_function(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// CHECK-LABEL: @second_function
+util.func @second_function(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that unused captures trigger warnings.
+
+// CHECK-LABEL: @unused_captures
+util.func @unused_captures(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[UNUSED:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[ANOTHER_UNUSED:.+]] = arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  // CHECK: util.return
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that used captures don't trigger warnings.
+
+// CHECK-LABEL: @used_captures
+util.func @used_captures(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[RESULT:.+]] = arith.addf
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  // CHECK: some.op %[[C0]]
+  // CHECK: util.return %[[RESULT]]
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that captures used in CHECK-SAME don't trigger warnings.
+
+// CHECK-LABEL: @check_same_usage
+util.func @check_same_usage(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[TP:.+]] = stream.timepoint.immediate
+  %tp = stream.timepoint.immediate => !stream.timepoint
+  // CHECK: stream.async.execute
+  // CHECK-SAME: await(%[[TP]])
+  %result = stream.async.execute await(%tp) => with() {
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    stream.yield %0 : tensor<4xf32>
+  } => !stream.timepoint
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that captures used in same line don't trigger warnings.
+
+// CHECK-LABEL: @inline_usage
+util.func @inline_usage(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: util.return %[[RESULT:.+]]
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that tuple destructuring extracts ALL variable names correctly.
+
+// CHECK-LABEL: @tuple_destructuring
+util.func @tuple_destructuring(%arg0: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  // CHECK: %[[INIT:.+]], %[[INIT_TP:.+]] = stream.test.timeline_op
+  %init, %init_tp = stream.test.timeline_op with(%arg0) : (tensor<4xf32>) -> (tensor<4xf32>, !stream.timepoint)
+  util.return %init, %init : tensor<4xf32>, tensor<4xf32>
+}
+
+// -----
+
+// Tests that FileCheck tuple syntax (:N suffix) is recognized correctly.
+
+// CHECK-LABEL: @filecheck_tuple_syntax
+util.func @filecheck_tuple_syntax(%arg0: tensor<4xf32>, %cond: i1) -> (tensor<4xf32>, !stream.timepoint) {
+  // CHECK: %[[BRANCH:.+]]:2 = scf.if
+  %branch_resource, %branch_tp = scf.if %cond -> (tensor<4xf32>, !stream.timepoint) {
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    %tp = stream.timepoint.immediate => !stream.timepoint
+    scf.yield %0, %tp : tensor<4xf32>, !stream.timepoint
+  } else {
+    %tp = stream.timepoint.immediate => !stream.timepoint
+    scf.yield %arg0, %tp : tensor<4xf32>, !stream.timepoint
+  }
+  util.return %branch_resource, %branch_tp : tensor<4xf32>, !stream.timepoint
+}
+
+// -----
+
+// Tests that intentional naming variance doesn't trigger false positives.
+
+// CHECK-LABEL: @intentional_variance
+util.func @intentional_variance(%arg0: tensor<4xf32>, %cond: i1) -> tensor<4xf32> {
+  // CHECK: %[[TP_IMMEDIATE:.+]] = stream.timepoint.immediate
+  %tp = stream.timepoint.immediate => !stream.timepoint
+  // CHECK: %[[RESULT:.+]] = scf.if
+  %result = scf.if %cond -> (tensor<4xf32>) {
+    // CHECK: %[[TP_THEN:.+]] = stream.timepoint.immediate
+    %tp_then = stream.timepoint.immediate => !stream.timepoint
+    %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+    scf.yield %0 : tensor<4xf32>
+  } else {
+    // CHECK: %[[TP_ELSE:.+]] = stream.timepoint.immediate
+    %tp_else = stream.timepoint.immediate => !stream.timepoint
+    scf.yield %arg0 : tensor<4xf32>
+  }
+  util.return %result : tensor<4xf32>
+}
+
+// -----
+
+// Tests that scope-aware matching prevents false positives from distant variables.
+
+// CHECK-LABEL: @scope_aware_matching
+util.func @scope_aware_matching(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[TP0:.+]] = stream.timepoint.immediate
+  %tp0 = stream.timepoint.immediate => !stream.timepoint
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  // More than 5 lines away from %tp0 - should not trigger false positive.
+  // CHECK: %[[TP1:.+]] = stream.timepoint.immediate
+  %tp1 = stream.timepoint.immediate => !stream.timepoint
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Regression test for Bug #1: Tuple positional pairing.
+// Verifies that CHECK captures are paired positionally with IR variables in tuples.
+// Without positional pairing, R_DEFAULT would incorrectly match against tp_default.
+
+// CHECK-LABEL: @tuple_positional_pairing
+util.func @tuple_positional_pairing(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[R_DEFAULT:.+]], %[[TP_DEFAULT:.+]] = stream.test.timeline_op
+  %r_default, %tp_default = stream.test.timeline_op with() : () -> (!stream.resource<external>, !stream.timepoint)
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Regression test for Bug #2: Target line detection for scope.
+// Verifies that CHECK only compares against the next IR line, not distant variables.
+// Without target line detection, INNER would incorrectly match against %iter from line 8.
+
+// CHECK-LABEL: @target_line_scope
+util.func @target_line_scope(%arg0: tensor<4xf32>, %cond: i1) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %iter = arith.constant 0 : index
+  %result = scf.for %i = %c0 to %c10 step %c1 iter_args(%arg = %arg0) -> (tensor<4xf32>) {
+    // CHECK: %[[INNER:.+]]:2 = scf.if
+    %inner, %inner_tp = scf.if %cond -> (tensor<4xf32>, !stream.timepoint) {
+      %tp = stream.timepoint.immediate => !stream.timepoint
+      scf.yield %arg, %tp : tensor<4xf32>, !stream.timepoint
+    } else {
+      %tp = stream.timepoint.immediate => !stream.timepoint
+      scf.yield %arg, %tp : tensor<4xf32>, !stream.timepoint
+    }
+    scf.yield %inner : tensor<4xf32>
+  }
+  util.return %result : tensor<4xf32>
+}
+
+// -----
+
+// Tests that non-semantic capture warnings only fire on definitions, not usages.
+// Definitions have : pattern like %[[C0:.+]], usages are bare like %[[C0]].
+
+// CHECK-LABEL: @definition_vs_usage
+util.func @definition_vs_usage(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // These definitions should warn (non-semantic names).
+  // CHECK: %[[C0:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[ARG1:.*]] = some.op
+  %value = some.op %arg0 : tensor<4xf32>
+
+  // These usages should NOT warn (no : pattern).
+  // CHECK: scf.yield %[[C0]], %[[ARG1]]
+  // CHECK-SAME: uses(%[[C0]])
+  // CHECK: util.return %[[ARG1]]
+
+  util.return %value : tensor<4xf32>
+}
+
+// -----
+
+// Tests that hardened patterns handle various FileCheck regex syntaxes.
+
+// CHECK-LABEL: @hardened_patterns
+util.func @hardened_patterns(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // Different pattern types - all should warn on definition.
+  // CHECK: %[[C0:.+]] = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[C1:.*]] = arith.constant
+  %c1 = arith.constant 1 : index
+  // CHECK: %[[ARG1:[a-zA-Z0-9]+]] = some.op
+  %value1 = some.op %arg0 : tensor<4xf32>
+  // CHECK: %[[C2_I32:\d+]] = arith.constant
+  %c2 = arith.constant 2 : i32
+
+  // Usages with same patterns should NOT warn.
+  // CHECK: another.op %[[C0]], %[[C1]], %[[ARG1]], %[[C2_I32]]
+
+  util.return %value1 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that unambiguous bare labels don't trigger warnings.
+
+// CHECK-LABEL: @unambiguous_label
+util.func @unambiguous_label(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that ambiguous bare labels trigger warnings with all matches shown.
+
+// CHECK-LABEL: @dispatch
+util.func @dispatch(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // This should warn because @dispatch appears in multiple places.
+  // CHECK: stream.async.dispatch @dispatch
+  %result = stream.async.dispatch @dispatch[%c0](%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  util.return %result : tensor<4xf32>
+}
+
+stream.executable private @dispatch {
+  stream.executable.export public @entry
+  builtin.module {
+    func.func @entry(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+      return %arg0 : tensor<4xf32>
+    }
+  }
+}
+
+// -----
+
+// Tests that labels not found in IR trigger warnings.
+
+// CHECK-LABEL: @typo_in_label
+util.func @typo_in_function_name(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // Label doesn't match actual function name - should warn.
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that labels with operation prefix don't trigger checks.
+
+// CHECK-LABEL: util.func @proper_prefix
+util.func @proper_prefix(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // Has operation prefix, no check needed even if ambiguous.
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that globals with ambiguous names trigger warnings.
+
+// CHECK-LABEL: @common_global
+util.global private @common_global : tensor<4xf32>
+util.global private mutable @common_global_2 : tensor<4xf32>
+
+util.func @use_common_global(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // Reference to @common_global - creates ambiguity.
+  %0 = util.global.load @common_global : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that SSA wildcards using {{.*}} trigger warnings.
+
+// CHECK-LABEL: @invalid_ssa_wildcard
+util.func @invalid_ssa_wildcard(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %{{.*}} = arith.constant
+  %c0 = arith.constant 0 : index
+  // CHECK: %{{.+}} = arith.constant
+  %c1 = arith.constant 1 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that symbol wildcards using {{.*}} trigger warnings.
+
+// CHECK-LABEL: @invalid_symbol_wildcard
+util.func @invalid_symbol_wildcard(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: util.global.load @{{.*}}
+  %0 = util.global.load @some_global : tensor<4xf32>
+  // CHECK: util.global.load @{{.+}}
+  %1 = util.global.load @another_global : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+util.global private @some_global : tensor<4xf32>
+util.global private @another_global : tensor<4xf32>
+
+// -----
+
+// Tests that %arg0 in operands triggers error.
+
+// CHECK-LABEL: @raw_arg_in_operand
+util.func @raw_arg_in_operand(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.addf %arg0, %arg1
+  %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that semantic names like %buffer trigger error.
+
+// CHECK-LABEL: @semantic_names
+util.func @semantic_names(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: stream.async.dispatch @dispatch(%buffer, %offset)
+  "stream.async.dispatch"(%arg0, %arg0) {callee = @dispatch} : (tensor<4xf32>, tensor<4xf32>) -> ()
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that %arg0 in function signatures triggers error.
+
+// CHECK: util.func public @sig_test(%arg0: tensor<4xf32>)
+util.func public @sig_test(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that multiple raw SSA on same line all trigger errors.
+
+// CHECK-LABEL: @multiple_raw_ssa
+util.func @multiple_raw_ssa(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.addf %a, %b, %c, %d
+  %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that NOLINT on preceding line suppresses errors.
+
+// CHECK-LABEL: @nolint_test
+util.func @nolint_test(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // NOLINT: raw_ssa_identifier - crash reproducer test
+  // CHECK: %0 = arith.constant
+  // CHECK: return %0
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that captures are NOT flagged.
+
+// CHECK-LABEL: @captures_ok
+util.func @captures_ok(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.addf %[[A:.+]], %[[B:.+]]
+  %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+  // CHECK: util.return %[[RES:.+]]
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// Tests that MLIR constants (%c0, %c123, %cst) are exempted (anti-pattern but widespread).
+
+// CHECK-LABEL: @constants_exempted
+util.func @constants_exempted(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %c0 = arith.constant 0
+  %c0 = arith.constant 0 : index
+  // CHECK: %c123_i32 = arith.constant 123
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %cst = arith.constant 3.14
+  %cst = arith.constant 3.14 : f32
+  // CHECK: %cst_0 = arith.constant 2.71
+  %cst_0 = arith.constant 2.71 : f32
+  util.return %arg0 : tensor<4xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/lit.cfg.py
+++ b/tools/utils/test/lit_tests/fixtures/lit.cfg.py
@@ -1,0 +1,58 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Lit configuration for test fixtures."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import lit.formats
+
+config.name = "IREE Utils Test Fixtures"
+config.test_format = lit.formats.ShTest(execute_external=True)
+config.suffixes = [".mlir"]
+
+# Route artifacts to temp directory to avoid polluting source tree.
+config.test_exec_root = (
+    os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    or os.environ.get("TEST_TMPDIR")
+    or os.path.join(tempfile.gettempdir(), "lit")
+)
+
+# Pass through environment variables.
+config.environment = os.environ.copy()
+
+# Add build directory tools to PATH for integration tests.
+# Build directory detection: IREE_BUILD_DIR env var, or common locations.
+build_dir = None
+if "IREE_BUILD_DIR" in os.environ:
+    build_dir = Path(os.environ["IREE_BUILD_DIR"])
+else:
+    # Try common locations relative to repo root.
+    repo_root = Path(__file__).resolve().parents[5]
+    parent = repo_root.parent
+    candidates = [
+        repo_root / "build",  # In-tree: repo/build/
+        parent / f"{repo_root.name}-build",  # Sibling: ../main-build/
+        parent / "builds" / repo_root.name,  # Builds dir: ../builds/main/
+    ]
+    for candidate in candidates:
+        if candidate.exists() and (candidate / "tools").is_dir():
+            build_dir = candidate
+            break
+
+if build_dir and build_dir.exists():
+    iree_tools = build_dir / "tools"
+    filecheck_dir = build_dir / "llvm-project" / "bin"
+    if iree_tools.exists() and filecheck_dir.exists():
+        path_additions = f"{iree_tools}:{filecheck_dir}"
+        if "PATH" in config.environment:
+            config.environment[
+                "PATH"
+            ] = f"{path_additions}:{config.environment['PATH']}"
+        else:
+            config.environment["PATH"] = path_additions

--- a/tools/utils/test/lit_tests/fixtures/names_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/names_test.mlir
@@ -1,0 +1,7 @@
+// RUN: iree-opt %s | FileCheck %s
+
+// CHECK-LABEL: @foo.bar$baz-1
+util.func @foo.bar$baz-1() {
+  // CHECK: util.return
+  util.return
+}

--- a/tools/utils/test/lit_tests/fixtures/no_run_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/no_run_test.mlir
@@ -1,0 +1,7 @@
+// This test intentionally has NO RUN lines in header or body.
+// CHECK-LABEL: @no_run
+// CHECK: constant
+func @no_run() {
+  // CHECK: return
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/run_variants.mlir
+++ b/tools/utils/test/lit_tests/fixtures/run_variants.mlir
@@ -1,0 +1,11 @@
+  // Copyright Header: some indented comment line
+  // with multiple lines preceding the RUN directives
+//RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline='builtin.module(util.func(test-pass))' \
+//RUN:   %s | FileCheck %s
+
+// CHECK-LABEL: @run_variants
+util.func @run_variants() {
+  // CHECK: util.return
+  util.return
+}

--- a/tools/utils/test/lit_tests/fixtures/simple_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/simple_test.mlir
@@ -1,0 +1,9 @@
+// RUN: iree-opt %s | FileCheck %s
+
+// CHECK-LABEL: @simple_function
+util.func @simple_function(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant 0
+  %c0 = arith.constant 0 : index
+  // CHECK: util.return %arg0
+  util.return %arg0 : tensor<4xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/split_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/split_test.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt --split-input-file \
+// RUN: --pass-pipeline='builtin.module(symbol-dce)' \
+// RUN: %s | FileCheck %s
+// CHECK-LABEL: @first_case
+util.func @first_case(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C0:.+]] = arith.constant 0
+  %c0 = arith.constant 0 : index
+  // CHECK: util.return %arg0
+  util.return %arg0 : tensor<4xf32>
+}
+
+// -----
+// CHECK-LABEL: @second_case
+util.func @second_case(%arg0: tensor<8xf32>) -> tensor<8xf32> {
+  // CHECK: %[[C1:.+]] = arith.constant 1
+  %c1 = arith.constant 1 : index
+  // CHECK: %[[C2:.+]] = arith.constant 2
+  %c2 = arith.constant 2 : index
+  // CHECK: util.return %arg0
+  util.return %arg0 : tensor<8xf32>
+}
+
+// -----
+// CHECK-LABEL: @third_case
+util.func @third_case(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+  // CHECK: %[[RESULT:.+]] = arith.addf
+  %result = arith.addf %arg0, %arg0 : tensor<16xf32>
+  // CHECK: util.return %[[RESULT]]
+  util.return %result : tensor<16xf32>
+}

--- a/tools/utils/test/lit_tests/fixtures/ten_cases_test.mlir
+++ b/tools/utils/test/lit_tests/fixtures/ten_cases_test.mlir
@@ -1,0 +1,79 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @case_one
+func.func @case_one() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_two
+func.func @case_two() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_three
+func.func @case_three() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_four
+func.func @case_four() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_five
+func.func @case_five() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_six
+func.func @case_six() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_seven
+func.func @case_seven() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_eight
+func.func @case_eight() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_nine
+func.func @case_nine() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_ten
+func.func @case_ten() {
+  // CHECK: return
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/weird_delimiters.mlir
+++ b/tools/utils/test/lit_tests/fixtures/weird_delimiters.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @first
+func.func @first() {
+  return
+}
+
+//-----
+
+// CHECK-LABEL: @second
+func.func @second() {
+  return
+}
+
+//   -----
+
+// CHECK-LABEL: @third
+func.func @third() {
+  return
+}

--- a/tools/utils/test/lit_tests/fixtures/with_case_runs.mlir
+++ b/tools/utils/test/lit_tests/fixtures/with_case_runs.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @case_one
+// This case has an in-body RUN directive used by lit
+// RUN: echo "alpha" | FileCheck %s --check-prefix=ALPHA
+// ALPHA: alpha
+func.func @case_one() {
+  // CHECK: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @case_two
+// Another in-body RUN directive
+// RUN: echo "beta" | FileCheck %s --check-prefix=BETA
+// BETA: beta
+func.func @case_two() {
+  // CHECK: return
+  return
+}

--- a/tools/utils/test/lit_tests/test_check_matcher.py
+++ b/tools/utils/test/lit_tests/test_check_matcher.py
@@ -1,0 +1,337 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for CHECK pattern matching module."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools.core.check_matcher import CheckMatcher
+from lit_tools.core.check_pattern import CheckPattern, CheckPatternParser
+from lit_tools.core.ir_index import IRIndex
+
+
+class TestBasicMatching(unittest.TestCase):
+    """Tests for basic CHECK to IR matching."""
+
+    def test_single_check_single_ir(self):
+        """Test matching single CHECK to single IR line."""
+        # IR starts at line 10.
+        ir_lines = ["%x = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines, start_line=10)
+
+        # CHECK at line 5 (before IR, common pattern).
+        check = CheckPattern(
+            check_type="CHECK",
+            line_num=5,
+            operation="arith.constant",
+            captures=[],
+            raw_pattern="%x = arith.constant 0",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNotNone(matches[0].ir_line)
+        self.assertEqual(matches[0].ir_line.operation, "arith.constant")
+        self.assertEqual(matches[0].ir_line.line_num, 10)
+        self.assertEqual(matches[0].confidence, 1.0)
+
+    def test_no_operation_in_check(self):
+        """Test CHECK without operation returns None match."""
+        ir_lines = ["%x = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines)
+
+        check = CheckPattern(
+            check_type="CHECK",
+            line_num=0,
+            operation=None,  # No operation.
+            captures=[],
+            raw_pattern="%[[A]], %[[B]]",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].ir_line)
+        self.assertEqual(matches[0].confidence, 0.0)
+        self.assertIn("No operation", matches[0].match_reason)
+
+    def test_no_matching_ir(self):
+        """Test CHECK with operation not found in IR."""
+        ir_lines = ["%x = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines)
+
+        check = CheckPattern(
+            check_type="CHECK",
+            line_num=0,
+            operation="scf.for",  # Not in IR.
+            captures=[],
+            raw_pattern="scf.for %i = %c0",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].ir_line)
+        self.assertEqual(matches[0].confidence, 0.0)
+        self.assertIn("No IR line", matches[0].match_reason)
+
+
+class TestProximityMatching(unittest.TestCase):
+    """Tests for proximity-based matching."""
+
+    def test_prefer_closer_match(self):
+        """Test that closer IR line is preferred."""
+        ir_lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "",
+            "",
+            "",
+            "",
+            "%c1 = arith.constant 1 : index",  # line 5
+        ]
+        ir_index = IRIndex(ir_lines)
+
+        # CHECK near line 1 should match line 0 (distance 1).
+        check = CheckPattern(
+            check_type="CHECK",
+            line_num=1,
+            operation="arith.constant",
+            captures=[],
+            raw_pattern="%c0 = arith.constant",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNotNone(matches[0].ir_line)
+        self.assertEqual(matches[0].ir_line.line_num, 0)  # Closest.
+
+    def test_outside_window(self):
+        """Test IR line outside proximity window is not matched."""
+        ir_lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+        ]
+        ir_index = IRIndex(ir_lines)
+
+        # CHECK at line 100, with default window=50, won't find line 0.
+        check = CheckPattern(
+            check_type="CHECK",
+            line_num=100,
+            operation="arith.constant",
+            captures=[],
+            raw_pattern="%c0 = arith.constant",
+        )
+
+        matcher = CheckMatcher(ir_index, [check], proximity_window=50)
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].ir_line)
+
+
+class TestSequentialMatching(unittest.TestCase):
+    """Tests for multiple CHECKs with same operation."""
+
+    def test_multiple_checks_multiple_ir(self):
+        """Test multiple CHECKs match to multiple IR lines sequentially."""
+        ir_lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "%c1 = arith.constant 1 : index",  # line 1
+            "%c2 = arith.constant 2 : index",  # line 2
+        ]
+        ir_index = IRIndex(ir_lines)
+
+        checks = [
+            CheckPattern(
+                check_type="CHECK",
+                line_num=0,
+                operation="arith.constant",
+                captures=[],
+                raw_pattern="%c0",
+            ),
+            CheckPattern(
+                check_type="CHECK",
+                line_num=1,
+                operation="arith.constant",
+                captures=[],
+                raw_pattern="%c1",
+            ),
+        ]
+
+        matcher = CheckMatcher(ir_index, checks)
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 2)
+        # First CHECK should match line 0 (closest).
+        self.assertEqual(matches[0].ir_line.line_num, 0)
+        # Second CHECK should match line 1 (closest to CHECK at line 1).
+        self.assertEqual(matches[1].ir_line.line_num, 1)
+
+
+class TestCheckNextSame(unittest.TestCase):
+    """Tests for CHECK-NEXT and CHECK-SAME semantics."""
+
+    def test_check_next_success(self):
+        """Test CHECK-NEXT matches next IR line."""
+        ir_lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "%c1 = arith.constant 1 : index",  # line 1
+        ]
+        ir_index = IRIndex(ir_lines)
+
+        checks = [
+            CheckPattern(
+                check_type="CHECK",
+                line_num=0,
+                operation="arith.constant",
+                captures=[],
+                raw_pattern="%c0",
+            ),
+            CheckPattern(
+                check_type="CHECK-NEXT",
+                line_num=1,
+                operation="arith.constant",
+                captures=[],
+                raw_pattern="%c1",
+            ),
+        ]
+
+        matcher = CheckMatcher(ir_index, checks)
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 2)
+        # First CHECK matches line 0.
+        self.assertEqual(matches[0].ir_line.line_num, 0)
+        # CHECK-NEXT matches line 1 (next line after previous match).
+        self.assertEqual(matches[1].ir_line.line_num, 1)
+        self.assertEqual(matches[1].confidence, 1.0)
+
+    def test_check_next_no_previous(self):
+        """Test CHECK-NEXT fails without previous match."""
+        ir_lines = ["%c0 = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines)
+
+        check = CheckPattern(
+            check_type="CHECK-NEXT",
+            line_num=0,
+            operation="arith.constant",
+            captures=[],
+            raw_pattern="%c0",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].ir_line)
+        self.assertEqual(matches[0].confidence, 0.0)
+        self.assertIn("requires previous match", matches[0].match_reason)
+
+    def test_check_same_success(self):
+        """Test CHECK-SAME matches same IR line as previous."""
+        ir_lines = ["%c0 = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines)
+
+        checks = [
+            CheckPattern(
+                check_type="CHECK",
+                line_num=0,
+                operation="arith.constant",
+                captures=[],
+                raw_pattern="%c0 = arith.constant 0",
+            ),
+            CheckPattern(
+                check_type="CHECK-SAME",
+                line_num=1,
+                operation=None,  # Doesn't matter for SAME.
+                captures=[],
+                raw_pattern=": index",
+            ),
+        ]
+
+        matcher = CheckMatcher(ir_index, checks)
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 2)
+        # Both should match the same line.
+        self.assertEqual(matches[0].ir_line.line_num, 0)
+        self.assertEqual(matches[1].ir_line.line_num, 0)
+        self.assertEqual(matches[1].confidence, 1.0)
+
+    def test_check_same_no_previous(self):
+        """Test CHECK-SAME fails without previous match."""
+        ir_lines = ["%c0 = arith.constant 0 : index"]
+        ir_index = IRIndex(ir_lines)
+
+        check = CheckPattern(
+            check_type="CHECK-SAME",
+            line_num=0,
+            operation=None,
+            captures=[],
+            raw_pattern=": index",
+        )
+
+        matcher = CheckMatcher(ir_index, [check])
+        matches = matcher.match_all()
+
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].ir_line)
+        self.assertEqual(matches[0].confidence, 0.0)
+
+
+class TestRealWorldScenario(unittest.TestCase):
+    """Test realistic scenario from bug report."""
+
+    def test_bug_report_case(self):
+        """Test the actual bug scenario: CHECK before IR it verifies."""
+        # Simplified version of the bug report scenario.
+        ir_lines = [
+            "func @test() {",
+            "  %awaited = stream.timepoint.await %tp => %clone",  # line 1
+            "  %loop_result = scf.for %i = %c0 to %c10",  # line 2
+            "    iter_args(%iter = %awaited) -> (!stream.resource<external>)",
+            "}",
+        ]
+        ir_index = IRIndex(ir_lines, start_line=0)
+
+        # Parse CHECK patterns (simplified).
+        parser = CheckPatternParser()
+        check_lines = [
+            "// CHECK: %[[AWAITED:.+]] = stream.timepoint.await %[[TP]] => %[[CLONE]]",
+            "// CHECK: %[[LOOP_RESULT:.+]] = scf.for %{{.+}} = %c0 to %c10",
+        ]
+
+        checks = [
+            parser.parse_check_line(line, i) for i, line in enumerate(check_lines)
+        ]
+        checks = [c for c in checks if c is not None]
+
+        matcher = CheckMatcher(ir_index, checks)
+        matches = matcher.match_all()
+
+        # First CHECK should match line 1 (stream.timepoint.await).
+        self.assertEqual(len(matches), 2)
+        self.assertIsNotNone(matches[0].ir_line)
+        self.assertEqual(matches[0].ir_line.operation, "stream.timepoint.await")
+        self.assertEqual(matches[0].ir_line.line_num, 1)
+
+        # Second CHECK should match line 2 (scf.for).
+        self.assertIsNotNone(matches[1].ir_line)
+        self.assertEqual(matches[1].ir_line.operation, "scf.for")
+        self.assertEqual(matches[1].ir_line.line_num, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_check_pattern.py
+++ b/tools/utils/test/lit_tests/test_check_pattern.py
@@ -1,0 +1,348 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for CHECK pattern parsing module."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools.core.check_pattern import CheckPatternParser
+
+
+class TestCheckDirectiveRecognition(unittest.TestCase):
+    """Tests for recognizing different CHECK directive types."""
+
+    def setUp(self):
+        self.parser = CheckPatternParser()
+
+    def test_basic_check(self):
+        """Test parsing basic CHECK directive."""
+        line = "// CHECK: %x = arith.constant 0"
+        pattern = self.parser.parse_check_line(line, 42)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK")
+        self.assertEqual(pattern.line_num, 42)
+        self.assertEqual(pattern.raw_pattern, "%x = arith.constant 0")
+
+    def test_check_next(self):
+        """Test parsing CHECK-NEXT directive."""
+        line = "// CHECK-NEXT: scf.yield %x"
+        pattern = self.parser.parse_check_line(line, 10)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK-NEXT")
+
+    def test_check_same(self):
+        """Test parsing CHECK-SAME directive."""
+        line = "// CHECK-SAME: iter_args(%y)"
+        pattern = self.parser.parse_check_line(line, 10)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK-SAME")
+
+    def test_check_label(self):
+        """Test parsing CHECK-LABEL directive."""
+        line = "// CHECK-LABEL: func @test"
+        pattern = self.parser.parse_check_line(line, 10)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK-LABEL")
+
+    def test_check_not(self):
+        """Test parsing CHECK-NOT directive."""
+        line = "// CHECK-NOT: stream.timepoint.await"
+        pattern = self.parser.parse_check_line(line, 10)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK-NOT")
+
+    def test_non_check_line(self):
+        """Test that non-CHECK lines return None."""
+        test_cases = [
+            "// This is a comment",
+            "%x = arith.constant 0",
+            "  // CHECK without colon",
+            "",
+        ]
+
+        for line in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertIsNone(pattern)
+
+    def test_check_with_whitespace(self):
+        """Test CHECK with various whitespace."""
+        test_cases = [
+            "//CHECK: %x = arith.constant",
+            "  // CHECK: %x = arith.constant",
+            "//  CHECK  :  %x = arith.constant",
+        ]
+
+        for line in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertIsNotNone(pattern)
+                self.assertEqual(pattern.check_type, "CHECK")
+
+    def test_custom_check_prefixes(self):
+        """Test custom check prefixes via --check-prefix."""
+        test_cases = [
+            ("// AMDGPU: %x = arith.constant", "AMDGPU"),
+            ("// VULKAN-NEXT: scf.yield", "VULKAN-NEXT"),
+            ("// DEBUG-SAME: iter_args", "DEBUG-SAME"),
+            ("// SPIRV-LABEL: func @test", "SPIRV-LABEL"),
+            ("// CPU-NOT: stream.timepoint", "CPU-NOT"),
+        ]
+
+        for line, expected_type in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertIsNotNone(pattern)
+                self.assertEqual(pattern.check_type, expected_type)
+
+
+class TestCaptureExtraction(unittest.TestCase):
+    """Tests for extracting FileCheck captures."""
+
+    def setUp(self):
+        self.parser = CheckPatternParser()
+
+    def test_single_capture_definition(self):
+        """Test extracting a single capture definition."""
+        line = "// CHECK: %[[X:.+]] = arith.constant"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(len(pattern.captures), 1)
+        cap = pattern.captures[0]
+        self.assertEqual(cap.name, "X")
+        self.assertEqual(cap.pattern, ".+")
+        self.assertTrue(cap.is_definition)
+
+    def test_single_capture_reference(self):
+        """Test extracting a single capture reference."""
+        line = "// CHECK: scf.yield %[[X]]"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(len(pattern.captures), 1)
+        cap = pattern.captures[0]
+        self.assertEqual(cap.name, "X")
+        self.assertIsNone(cap.pattern)
+        self.assertFalse(cap.is_definition)
+
+    def test_multiple_captures(self):
+        """Test extracting multiple captures."""
+        line = "// CHECK: %[[A:.+]], %[[B:.+]] = some.op(%[[C]])"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(len(pattern.captures), 3)
+
+        # First two are definitions.
+        self.assertEqual(pattern.captures[0].name, "A")
+        self.assertTrue(pattern.captures[0].is_definition)
+
+        self.assertEqual(pattern.captures[1].name, "B")
+        self.assertTrue(pattern.captures[1].is_definition)
+
+        # Third is a reference.
+        self.assertEqual(pattern.captures[2].name, "C")
+        self.assertFalse(pattern.captures[2].is_definition)
+
+    def test_capture_with_complex_pattern(self):
+        """Test capture with complex regex pattern."""
+        line = "// CHECK: %[[RESULT:[a-z0-9_]+]] = arith.constant"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(len(pattern.captures), 1)
+        self.assertEqual(pattern.captures[0].pattern, "[a-z0-9_]+")
+
+    def test_no_captures(self):
+        """Test line with no captures."""
+        line = "// CHECK: scf.yield"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(len(pattern.captures), 0)
+
+    def test_upper_snake_case_enforcement(self):
+        """Test that capture names must be UPPER_SNAKE_CASE."""
+        # Valid names.
+        valid_lines = [
+            "// CHECK: %[[X]]",
+            "// CHECK: %[[AWAITED]]",
+            "// CHECK: %[[LOOP_RESULT]]",
+            "// CHECK: %[[_PRIVATE]]",
+            "// CHECK: %[[VALUE123]]",
+        ]
+
+        for line in valid_lines:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertGreaterEqual(len(pattern.captures), 1)
+
+        # Invalid names (should not be recognized as captures).
+        invalid_lines = [
+            "// CHECK: %[[x]]",  # Lowercase.
+            "// CHECK: %[[awaited]]",  # Lowercase.
+            "// CHECK: %[[123]]",  # Starts with digit.
+        ]
+
+        for line in invalid_lines:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                # These won't be recognized as captures.
+                self.assertEqual(len(pattern.captures), 0)
+
+
+class TestOperationExtraction(unittest.TestCase):
+    """Tests for extracting operation names from CHECK patterns."""
+
+    def setUp(self):
+        self.parser = CheckPatternParser()
+
+    def test_operation_with_capture(self):
+        """Test extracting operation when capture is present."""
+        line = "// CHECK: %[[X:.+]] = arith.constant 0"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(pattern.operation, "arith.constant")
+
+    def test_operation_without_capture(self):
+        """Test extracting operation without captures."""
+        line = "// CHECK: scf.yield %x"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertEqual(pattern.operation, "scf.yield")
+
+    def test_namespaced_operations(self):
+        """Test extracting various namespaced operations."""
+        test_cases = [
+            ("// CHECK: stream.timepoint.await %tp", "stream.timepoint.await"),
+            ("// CHECK: scf.for %i = %c0 to %c10", "scf.for"),
+            ("// CHECK: util.func @test", "util.func"),
+            ("// CHECK: stream.async.execute with()", "stream.async.execute"),
+        ]
+
+        for line, expected_op in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertEqual(pattern.operation, expected_op)
+
+    def test_single_word_operations(self):
+        """Test extracting single-word operations."""
+        test_cases = [
+            ("// CHECK: call @function()", "call"),
+            ("// CHECK: return %x", "return"),
+            ("// CHECK: yield %value", "yield"),
+        ]
+
+        for line, expected_op in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertEqual(pattern.operation, expected_op)
+
+    def test_no_operation(self):
+        """Test line with no operation."""
+        test_cases = [
+            "// CHECK: %[[A]], %[[B]]",  # Just captures.
+            "// CHECK: iter_args(%[[X]])",  # Structural syntax.
+        ]
+
+        for line in test_cases:
+            with self.subTest(line=line):
+                pattern = self.parser.parse_check_line(line, 0)
+                self.assertIsNone(pattern.operation)
+
+    def test_capture_sanitization(self):
+        """Test that captures are properly sanitized before operation extraction."""
+        # The capture %[[AWAITED:.+]] should not confuse operation extraction.
+        line = "// CHECK: %[[AWAITED:.+]] = stream.timepoint.await %[[TP]]"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        # Should extract "stream.timepoint.await", not be confused by ".+" in capture.
+        self.assertEqual(pattern.operation, "stream.timepoint.await")
+
+    def test_filecheck_regex_ignored(self):
+        """Test that FileCheck regex syntax {{...}} is ignored."""
+        line = "// CHECK: %[[X:.+]] = arith.constant {{.+}} : index"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        # Should extract "arith.constant", not be confused by {{.+}}.
+        self.assertEqual(pattern.operation, "arith.constant")
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Tests for edge cases and corner scenarios."""
+
+    def setUp(self):
+        self.parser = CheckPatternParser()
+
+    def test_check_same_without_operation(self):
+        """Test CHECK-SAME with no operation (continues previous line)."""
+        line = "// CHECK-SAME: iter_args(%{{.+}} = %[[AWAITED]])"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.check_type, "CHECK-SAME")
+        self.assertIsNone(pattern.operation)
+        self.assertEqual(len(pattern.captures), 1)
+        self.assertEqual(pattern.captures[0].name, "AWAITED")
+
+    def test_multiple_operations_in_check(self):
+        """Test CHECK with multiple operations (extracts first)."""
+        # This is a rare case but can occur.
+        line = "// CHECK: %[[X:.+]] = scf.for %{{.+}} = %c0"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        # Should extract first operation found.
+        self.assertEqual(pattern.operation, "scf.for")
+
+    def test_empty_pattern(self):
+        """Test CHECK with empty pattern."""
+        line = "// CHECK:"
+        pattern = self.parser.parse_check_line(line, 0)
+
+        self.assertIsNotNone(pattern)
+        self.assertEqual(pattern.raw_pattern, "")
+        self.assertIsNone(pattern.operation)
+        self.assertEqual(len(pattern.captures), 0)
+
+    def test_parse_file(self):
+        """Test parsing multiple CHECK directives from file."""
+        lines = [
+            "func @test() {",
+            "  // CHECK-LABEL: func @test",
+            "  %c0 = arith.constant 0 : index",
+            "  // CHECK: %[[C0:.+]] = arith.constant 0",
+            "  %c1 = arith.constant 1 : index",
+            "  // CHECK: %[[C1:.+]] = arith.constant 1",
+            "  scf.yield %c0",
+            "  // CHECK: scf.yield %[[C0]]",
+            "}",
+        ]
+
+        patterns = self.parser.parse_file(lines)
+
+        # Should find 4 CHECK directives.
+        self.assertEqual(len(patterns), 4)
+
+        # Verify line numbers are correct.
+        self.assertEqual(patterns[0].line_num, 1)  # CHECK-LABEL on line 1.
+        self.assertEqual(patterns[1].line_num, 3)  # First CHECK on line 3.
+        self.assertEqual(patterns[2].line_num, 5)  # Second CHECK on line 5.
+        self.assertEqual(patterns[3].line_num, 7)  # Third CHECK on line 7.
+
+        # Verify check types.
+        self.assertEqual(patterns[0].check_type, "CHECK-LABEL")
+        self.assertEqual(patterns[1].check_type, "CHECK")
+        self.assertEqual(patterns[2].check_type, "CHECK")
+        self.assertEqual(patterns[3].check_type, "CHECK")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_cli_helpers.py
+++ b/tools/utils/test/lit_tests/test_cli_helpers.py
@@ -1,0 +1,156 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for lit_tools.core.cli helper functions."""
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from common import exit_codes
+from lit_tools.core import cli
+
+
+class TestLoadAndParseTestFile(unittest.TestCase):
+    """Tests for load_and_parse_test_file helper function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.args = argparse.Namespace(quiet=False, json=False)
+
+    def test_successful_parse(self):
+        """Test successful parsing of a valid test file."""
+        # Create temporary test file.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(
+                """// RUN: iree-opt %s
+// CHECK-LABEL: @test_func
+func.func @test_func() {
+  return
+}
+"""
+            )
+            test_file_path = Path(f.name)
+
+        try:
+            test_file, cases, exit_code = cli.load_and_parse_test_file(
+                test_file_path, self.args
+            )
+
+            self.assertEqual(exit_code, exit_codes.SUCCESS)
+            self.assertIsNotNone(test_file)
+            self.assertEqual(len(cases), 1)
+            self.assertEqual(cases[0].name, "test_func")
+        finally:
+            test_file_path.unlink()
+
+    def test_file_not_found(self):
+        """Test handling of non-existent file."""
+        test_file_path = Path("/nonexistent/file.mlir")
+
+        with patch("lit_tools.core.cli.console") as mock_console:
+            test_file, cases, exit_code = cli.load_and_parse_test_file(
+                test_file_path, self.args
+            )
+
+        self.assertEqual(exit_code, exit_codes.NOT_FOUND)
+        self.assertIsNone(test_file)
+        self.assertEqual(cases, [])
+        # Should have printed error
+        mock_console.error.assert_called_once()
+        call_args = mock_console.error.call_args[0]
+        self.assertIn("File not found", call_args[0])
+
+    def test_unicode_decode_error(self):
+        """Test handling of files with invalid encoding."""
+        # Create file with invalid UTF-8
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".mlir", delete=False) as f:
+            f.write(b"\xff\xfe Invalid UTF-8")
+            test_file_path = Path(f.name)
+
+        try:
+            with patch("lit_tools.core.cli.console") as mock_console:
+                test_file, cases, exit_code = cli.load_and_parse_test_file(
+                    test_file_path, self.args
+                )
+
+            self.assertEqual(exit_code, exit_codes.ERROR)
+            self.assertIsNone(test_file)
+            self.assertEqual(cases, [])
+            mock_console.error.assert_called_once()
+        finally:
+            test_file_path.unlink()
+
+    def test_parse_error_invalid_syntax(self):
+        """Test handling of files with invalid lit syntax."""
+        # Create file with content that causes ValueError
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            # Write content that might trigger parser errors
+            f.write("// CHECK-LABEL without separator")
+            test_file_path = Path(f.name)
+
+        try:
+            # The parser might raise ValueError for certain malformed content
+            # This test verifies the error handling path works
+            _, _, exit_code = cli.load_and_parse_test_file(test_file_path, self.args)
+
+            # Parser should succeed for this simple case (or fail gracefully)
+            # This mainly tests that exception handling is in place
+            self.assertIn(exit_code, [exit_codes.SUCCESS, exit_codes.ERROR])
+        finally:
+            test_file_path.unlink()
+
+    def test_multiple_cases(self):
+        """Test parsing file with multiple test cases."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(
+                """// RUN: iree-opt %s
+// CHECK-LABEL: @case1
+func.func @case1() { return }
+
+// -----
+// CHECK-LABEL: @case2
+func.func @case2() { return }
+
+// -----
+// CHECK-LABEL: @case3
+func.func @case3() { return }
+"""
+            )
+            test_file_path = Path(f.name)
+
+        try:
+            test_file, cases, exit_code = cli.load_and_parse_test_file(
+                test_file_path, self.args
+            )
+
+            self.assertEqual(exit_code, exit_codes.SUCCESS)
+            self.assertIsNotNone(test_file)
+            self.assertEqual(len(cases), 3)
+            self.assertEqual([c.name for c in cases], ["case1", "case2", "case3"])
+        finally:
+            test_file_path.unlink()
+
+    def test_error_message_includes_exception_details(self):
+        """Test that error messages include exception details."""
+        test_file_path = Path("/nonexistent/specific_file.mlir")
+
+        with patch("lit_tools.core.cli.console") as mock_console:
+            cli.load_and_parse_test_file(test_file_path, self.args)
+
+        # Verify error message format
+        mock_console.error.assert_called_once()
+        error_msg = mock_console.error.call_args[0][0]
+        # Should mention file not found
+        self.assertTrue("File not found" in error_msg or "Failed to parse" in error_msg)
+        # Should include file name
+        self.assertIn("specific_file.mlir", error_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_core_cli.py
+++ b/tools/utils/test/lit_tests/test_core_cli.py
@@ -1,0 +1,327 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for lit_tools/core/cli.py."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lit_tools.core import cli
+
+
+def _make_mock_case(number, name=None, check_count=0):
+    """Create a mock TestCase for testing filters."""
+    case = Mock()
+    case.number = number
+    case.name = name
+    case.check_count = check_count
+    return case
+
+
+class TestParseCaseNumbers(unittest.TestCase):
+    """Tests for parse_case_numbers() function."""
+
+    def test_parse_single(self):
+        """Test parsing single case number."""
+        self.assertEqual(cli.parse_case_numbers("1"), [1])
+        self.assertEqual(cli.parse_case_numbers("5"), [5])
+        self.assertEqual(cli.parse_case_numbers("100"), [100])
+
+    def test_parse_comma_separated(self):
+        """Test parsing comma-separated case numbers."""
+        self.assertEqual(cli.parse_case_numbers("1,3,5"), [1, 3, 5])
+        self.assertEqual(cli.parse_case_numbers("10,20,30"), [10, 20, 30])
+        self.assertEqual(cli.parse_case_numbers("1,2,3,4,5"), [1, 2, 3, 4, 5])
+
+    def test_parse_range(self):
+        """Test parsing range syntax."""
+        self.assertEqual(cli.parse_case_numbers("1-3"), [1, 2, 3])
+        self.assertEqual(cli.parse_case_numbers("5-8"), [5, 6, 7, 8])
+        self.assertEqual(cli.parse_case_numbers("1-1"), [1])
+
+    def test_parse_mixed_comma_and_range(self):
+        """Test parsing mixed comma-separated and ranges."""
+        self.assertEqual(cli.parse_case_numbers("1,3-5,7"), [1, 3, 4, 5, 7])
+        self.assertEqual(cli.parse_case_numbers("1-3,5,7-9"), [1, 2, 3, 5, 7, 8, 9])
+        self.assertEqual(cli.parse_case_numbers("10,1-3,20"), [1, 2, 3, 10, 20])
+
+    def test_parse_list_input(self):
+        """Test parsing list of strings (multiple --case flags)."""
+        self.assertEqual(cli.parse_case_numbers(["1", "3", "5"]), [1, 3, 5])
+        self.assertEqual(cli.parse_case_numbers(["1", "2", "3"]), [1, 2, 3])
+
+    def test_parse_list_with_comma(self):
+        """Test parsing list containing comma-separated values."""
+        self.assertEqual(cli.parse_case_numbers(["1,2", "3", "5"]), [1, 2, 3, 5])
+        self.assertEqual(cli.parse_case_numbers(["1-3", "5"]), [1, 2, 3, 5])
+
+    def test_parse_whitespace_handling(self):
+        """Test that whitespace is handled correctly."""
+        self.assertEqual(cli.parse_case_numbers(" 1 "), [1])
+        self.assertEqual(cli.parse_case_numbers("1, 3, 5"), [1, 3, 5])
+        self.assertEqual(cli.parse_case_numbers(" 1 - 3 "), [1, 2, 3])
+        self.assertEqual(cli.parse_case_numbers("1 , 3 - 5 , 7"), [1, 3, 4, 5, 7])
+
+    def test_parse_deduplication(self):
+        """Test that duplicate numbers are removed."""
+        self.assertEqual(cli.parse_case_numbers("1,1,3"), [1, 3])
+        self.assertEqual(cli.parse_case_numbers("1-3,2-4"), [1, 2, 3, 4])
+        self.assertEqual(cli.parse_case_numbers(["1", "1", "3"]), [1, 3])
+
+    def test_parse_sorted_output(self):
+        """Test that output is always sorted."""
+        self.assertEqual(cli.parse_case_numbers("5,1,3"), [1, 3, 5])
+        self.assertEqual(cli.parse_case_numbers("10,5,1"), [1, 5, 10])
+        self.assertEqual(cli.parse_case_numbers("3,1-2"), [1, 2, 3])
+
+    def test_parse_empty_string_error(self):
+        """Test that empty string raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("")
+        self.assertIn("No case numbers specified", str(cm.exception))
+
+    def test_parse_whitespace_only_error(self):
+        """Test that whitespace-only string raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("   ")
+        self.assertIn("No case numbers specified", str(cm.exception))
+
+    def test_parse_empty_list_error(self):
+        """Test that empty list raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers([])
+        self.assertIn("No case numbers specified", str(cm.exception))
+
+    def test_parse_invalid_number_error(self):
+        """Test that non-numeric input raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("abc")
+        self.assertIn("Invalid case number: 'abc'", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1,x,3")
+        self.assertIn("Invalid case number: 'x'", str(cm.exception))
+
+    def test_parse_zero_error(self):
+        """Test that zero raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("0")
+        self.assertIn("Case numbers must be positive, got 0", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1,0,3")
+        self.assertIn("Case numbers must be positive, got 0", str(cm.exception))
+
+    def test_parse_negative_error(self):
+        """Test that negative numbers raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("-1")
+        self.assertIn("Case numbers must be positive, got -1", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1,-3,5")
+        self.assertIn("Case numbers must be positive, got -3", str(cm.exception))
+
+    def test_parse_invalid_range_format_error(self):
+        """Test that invalid range format raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1-")
+        self.assertIn("Invalid case number: '1-'", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("-3")
+        # This is parsed as a negative number, not a range.
+        self.assertIn("Case numbers must be positive, got -3", str(cm.exception))
+
+    def test_parse_invalid_range_order_error(self):
+        """Test that backward ranges raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("5-1")
+        self.assertIn("start must be <= end", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("10-5")
+        self.assertIn("start must be <= end", str(cm.exception))
+
+    def test_parse_range_with_zero_error(self):
+        """Test that ranges with zero raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("0-3")
+        self.assertIn("Case numbers must be positive", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1-0")
+        self.assertIn("Case numbers must be positive", str(cm.exception))
+
+    def test_parse_range_with_negative_error(self):
+        """Test that ranges with negative numbers raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("-1-3")
+        self.assertIn("Invalid case number: '-1-3'", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1--3")
+        # This is parsed as range 1 to -3, which fails validation.
+        self.assertIn("Case numbers must be positive", str(cm.exception))
+
+    def test_parse_non_integer_in_range_error(self):
+        """Test that non-integer range bounds raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("a-3")
+        self.assertIn("both start and end must be integers", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            cli.parse_case_numbers("1-b")
+        self.assertIn("both start and end must be integers", str(cm.exception))
+
+
+class TestApplyFilters(unittest.TestCase):
+    """Tests for apply_filters() function."""
+
+    def setUp(self):
+        """Create test cases for filtering."""
+        self.cases = [
+            _make_mock_case(1, "fold_constant", 2),
+            _make_mock_case(2, "fold_operation", 3),
+            _make_mock_case(3, "gpu_kernel", 1),
+            _make_mock_case(4, "cpu_optimization", 4),
+            _make_mock_case(5, None, 0),  # Unnamed case.
+        ]
+
+    def test_no_filters_returns_all_cases(self):
+        """Test that no filters returns original list."""
+        result = cli.apply_filters(self.cases, None, None)
+        self.assertEqual(result, self.cases)
+
+    def test_filter_include_single_match(self):
+        """Test positive filter with single match."""
+        result = cli.apply_filters(self.cases, "gpu", None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "gpu_kernel")
+
+    def test_filter_include_multiple_matches(self):
+        """Test positive filter with multiple matches."""
+        result = cli.apply_filters(self.cases, "fold", None)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "fold_constant")
+        self.assertEqual(result[1].name, "fold_operation")
+
+    def test_filter_include_regex_pattern(self):
+        """Test positive filter with regex pattern."""
+        result = cli.apply_filters(self.cases, "fold.*ion", None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "fold_operation")
+
+    def test_filter_include_or_pattern(self):
+        """Test positive filter with OR pattern."""
+        result = cli.apply_filters(self.cases, "gpu|cpu", None)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "gpu_kernel")
+        self.assertEqual(result[1].name, "cpu_optimization")
+
+    def test_filter_exclude_single_match(self):
+        """Test negative filter excluding single case."""
+        result = cli.apply_filters(self.cases, None, "gpu")
+        self.assertEqual(len(result), 4)  # Excludes gpu_kernel, keeps unnamed.
+        self.assertNotIn("gpu_kernel", [c.name for c in result])
+
+    def test_filter_exclude_multiple_matches(self):
+        """Test negative filter excluding multiple cases."""
+        result = cli.apply_filters(self.cases, None, "fold")
+        self.assertEqual(len(result), 3)  # Excludes 2 fold cases, keeps unnamed.
+        self.assertEqual(result[0].name, "gpu_kernel")
+        self.assertEqual(result[1].name, "cpu_optimization")
+        self.assertIsNone(result[2].name)  # Unnamed case kept.
+
+    def test_filter_exclude_or_pattern(self):
+        """Test negative filter with OR pattern."""
+        result = cli.apply_filters(self.cases, None, "gpu|cpu")
+        self.assertEqual(len(result), 3)  # Keeps fold cases and unnamed.
+        self.assertEqual(result[0].name, "fold_constant")
+        self.assertEqual(result[1].name, "fold_operation")
+        self.assertIsNone(result[2].name)  # Unnamed case kept.
+
+    def test_combined_filters(self):
+        """Test combining positive and negative filters."""
+        # Include anything with 'fold' or 'cpu', exclude 'constant'.
+        result = cli.apply_filters(self.cases, "fold|cpu", "constant")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "fold_operation")
+        self.assertEqual(result[1].name, "cpu_optimization")
+
+    def test_combined_filters_narrow_down(self):
+        """Test using both filters to narrow down results."""
+        # Include anything with 'o', exclude 'gpu'.
+        result = cli.apply_filters(self.cases, "o", "gpu")
+        self.assertEqual(len(result), 3)
+        names = [c.name for c in result]
+        self.assertIn("fold_constant", names)
+        self.assertIn("fold_operation", names)
+        self.assertIn("cpu_optimization", names)
+
+    def test_filter_excludes_unnamed_cases(self):
+        """Test that unnamed cases are excluded when filters are active."""
+        # Apply filter that would match everything (if cases had names).
+        result = cli.apply_filters(self.cases, ".*", None)
+        self.assertEqual(len(result), 4)
+        self.assertNotIn(None, [c.name for c in result])
+
+    def test_filter_include_no_match_returns_none(self):
+        """Test that no matches for positive filter returns None."""
+        result = cli.apply_filters(self.cases, "nonexistent", None)
+        self.assertIsNone(result)
+
+    def test_filter_exclude_all_named_keeps_unnamed(self):
+        """Test that excluding all named cases keeps unnamed cases."""
+        result = cli.apply_filters(self.cases, None, ".*")
+        self.assertEqual(len(result), 1)  # Only unnamed case remains.
+        self.assertIsNone(result[0].name)
+
+    def test_combined_filter_no_match_returns_none(self):
+        """Test that combined filters with no results returns None."""
+        # Include 'fold', exclude 'fold' -> no results.
+        result = cli.apply_filters(self.cases, "fold", "fold")
+        self.assertIsNone(result)
+
+    def test_filter_case_sensitive(self):
+        """Test that filtering is case-sensitive by default."""
+        result = cli.apply_filters(self.cases, "GPU", None)
+        self.assertIsNone(result)  # No match (gpu vs GPU).
+
+    def test_filter_case_insensitive_pattern(self):
+        """Test case-insensitive filtering with regex flag."""
+        result = cli.apply_filters(self.cases, "(?i)GPU", None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "gpu_kernel")
+
+    def test_filter_preserves_order(self):
+        """Test that filtering preserves original case order."""
+        result = cli.apply_filters(self.cases, "fold|gpu", None)
+        self.assertEqual(result[0].number, 1)
+        self.assertEqual(result[1].number, 2)
+        self.assertEqual(result[2].number, 3)
+
+    def test_empty_case_list_returns_empty(self):
+        """Test that filtering empty list returns empty list."""
+        result = cli.apply_filters([], "fold", None)
+        self.assertIsNone(result)  # No matches in empty list.
+
+    def test_all_unnamed_cases_with_filter(self):
+        """Test filtering list with all unnamed cases."""
+        unnamed = [
+            _make_mock_case(1, None, 0),
+            _make_mock_case(2, None, 0),
+        ]
+        result = cli.apply_filters(unnamed, ".*", None)
+        self.assertIsNone(result)  # All cases excluded (no names).
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_core_test_file.py
+++ b/tools/utils/test/lit_tests/test_core_test_file.py
@@ -1,0 +1,309 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for lit.core.test_file module."""
+
+# Add project tools/utils to path for imports
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools.core.parser import parse_test_file
+from lit_tools.core.rendering import inject_run_lines_with_case
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestParseTestFile(unittest.TestCase):
+    """Tests for parse_test_file function."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.simple_test = _FIXTURES_DIR / "simple_test.mlir"
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.names_test = _FIXTURES_DIR / "names_test.mlir"
+
+    def test_parse_simple_file(self):
+        """Test parsing file with single test case (no delimiters)."""
+        test_file_obj = parse_test_file(self.simple_test)
+        cases = list(test_file_obj.cases)
+
+        self.assertEqual(len(cases), 1)
+
+        case = cases[0]
+        self.assertEqual(case.number, 1)
+        self.assertEqual(case.name, "simple_function")
+        self.assertEqual(case.start_line, 1)
+        self.assertGreater(case.line_count, 0)
+        self.assertEqual(case.check_count, 3)  # CHECK-LABEL + 2 CHECK lines
+
+    def test_parse_split_file(self):
+        """Test parsing file with multiple test cases separated by delimiters."""
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+
+        self.assertEqual(len(cases), 3)
+
+        # First case
+        self.assertEqual(cases[0].number, 1)
+        self.assertEqual(cases[0].name, "first_case")
+        self.assertEqual(cases[0].check_count, 3)
+
+        # Second case
+        self.assertEqual(cases[1].number, 2)
+        self.assertEqual(cases[1].name, "second_case")
+        self.assertEqual(cases[1].check_count, 4)  # CHECK-LABEL + 3 CHECKs
+
+        # Third case
+        self.assertEqual(cases[2].number, 3)
+        self.assertEqual(cases[2].name, "third_case")
+        self.assertEqual(cases[2].check_count, 3)
+
+    def test_parse_names_with_punctuation(self):
+        """Test CHECK-LABEL name extraction with punctuation characters."""
+        test_file_obj = parse_test_file(self.names_test)
+        cases = list(test_file_obj.cases)
+        self.assertEqual(len(cases), 1)
+        self.assertEqual(cases[0].name, "foo.bar$baz-1")
+
+    def test_line_ranges(self):
+        """Test that line ranges are correctly calculated."""
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+
+        # First case starts at line 1
+        self.assertEqual(cases[0].start_line, 1)
+
+        # Subsequent cases start after delimiters
+        self.assertGreater(cases[1].start_line, cases[0].end_line)
+        self.assertGreater(cases[2].start_line, cases[1].end_line)
+
+        # Line counts reflect original file structure (may include trailing blank lines).
+        # Content is normalized (trailing blank lines stripped).
+        for case in cases:
+            lines_in_content = case.content.count("\n") + 1
+            # line_count >= lines in content (trailing blank lines may be stripped from content)
+            self.assertGreaterEqual(case.line_count, lines_in_content)
+
+    def test_content_extraction(self):
+        """Test that full content is extracted for each case."""
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+
+        # Each case should contain its function
+        self.assertIn("@first_case", cases[0].content)
+        self.assertIn("@second_case", cases[1].content)
+        self.assertIn("@third_case", cases[2].content)
+
+        # Cases should not contain delimiter lines
+        for case in cases:
+            self.assertNotIn("// -----", case.content)
+
+
+class TestExtractCaseByNumber(unittest.TestCase):
+    """Tests for extract_case_by_number function."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_first_case(self):
+        """Test extracting first test case."""
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_number(1)
+        self.assertEqual(case.number, 1)
+        self.assertEqual(case.name, "first_case")
+
+    def test_extract_middle_case(self):
+        """Test extracting middle test case."""
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_number(2)
+        self.assertEqual(case.number, 2)
+        self.assertEqual(case.name, "second_case")
+
+    def test_extract_last_case(self):
+        """Test extracting last test case."""
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_number(3)
+        self.assertEqual(case.number, 3)
+        self.assertEqual(case.name, "third_case")
+
+    def test_invalid_case_number_too_low(self):
+        """Test error when case number is too low."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_number(0)
+        self.assertIn("out of range", str(cm.exception))
+
+    def test_invalid_case_number_too_high(self):
+        """Test error when case number is too high."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_number(10)
+        self.assertIn("out of range", str(cm.exception))
+
+
+class TestExtractCaseByName(unittest.TestCase):
+    """Tests for extract_case_by_name function."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_by_name(self):
+        """Test extracting test case by function name."""
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_name("second_case")
+        self.assertEqual(case.number, 2)
+        self.assertEqual(case.name, "second_case")
+
+    def test_extract_by_name_with_at_prefix(self):
+        """Test extracting with @ prefix in name."""
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_name("@second_case")
+        self.assertEqual(case.number, 2)
+        self.assertEqual(case.name, "second_case")
+
+    def test_invalid_name(self):
+        """Test error when name doesn't exist."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_name("nonexistent")
+        self.assertIn("No test case found", str(cm.exception))
+
+
+class TestExtractCaseByLineNumber(unittest.TestCase):
+    """Tests for extract_case_by_line_number function."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_first_case_by_line(self):
+        """Test extracting first case by line number."""
+        # Line 5 is in first case
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_line(5)
+        self.assertEqual(case.number, 1)
+        self.assertEqual(case.name, "first_case")
+
+    def test_extract_second_case_by_line(self):
+        """Test extracting second case by line number."""
+        # Line 18 is in second case
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_line(18)
+        self.assertEqual(case.number, 2)
+        self.assertEqual(case.name, "second_case")
+
+    def test_extract_third_case_by_line(self):
+        """Test extracting third case by line number."""
+        # Line 30 is in third case
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_line(30)
+        self.assertEqual(case.number, 3)
+        self.assertEqual(case.name, "third_case")
+
+    def test_line_at_case_boundary_start(self):
+        """Test line number at start of case."""
+        # First line of second case
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_line(14)
+        self.assertEqual(case.number, 2)
+
+    def test_line_at_case_boundary_end(self):
+        """Test line number at end of case."""
+        # Last line of first case
+        test_file_obj = parse_test_file(self.split_test)
+        case = test_file_obj.find_case_by_line(11)
+        self.assertEqual(case.number, 1)
+
+    def test_invalid_line_number_zero(self):
+        """Test error when line number is zero."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_line(0)
+        self.assertIn("must be >= 1", str(cm.exception))
+
+    def test_invalid_line_number_negative(self):
+        """Test error when line number is negative."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_line(-5)
+        self.assertIn("must be >= 1", str(cm.exception))
+
+    def test_invalid_line_number_too_high(self):
+        """Test error when line number exceeds file length."""
+        with self.assertRaises(ValueError) as cm:
+            test_file_obj = parse_test_file(self.split_test)
+            test_file_obj.find_case_by_line(1000)
+        self.assertIn("out of range", str(cm.exception))
+
+
+class TestExtractRunLines(unittest.TestCase):
+    """Tests for extract_run_lines function."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.simple_test = _FIXTURES_DIR / "simple_test.mlir"
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.run_variants = _FIXTURES_DIR / "run_variants.mlir"
+
+    def test_extract_single_run_line(self):
+        """Test extracting single RUN line."""
+        test_file_obj = parse_test_file(self.simple_test)
+        run_lines = test_file_obj.extract_run_lines()
+        self.assertEqual(len(run_lines), 1)
+        self.assertIn("iree-opt", run_lines[0])
+        self.assertIn("FileCheck", run_lines[0])
+
+    def test_extract_multiline_run(self):
+        """Test extracting multi-line RUN command with continuations."""
+        test_file_obj = parse_test_file(self.split_test)
+        run_lines = test_file_obj.extract_run_lines()
+        self.assertEqual(len(run_lines), 1)
+
+        # Should be joined into single line
+        run_line = run_lines[0]
+        self.assertIn("--split-input-file", run_line)
+        self.assertIn("--pass-pipeline", run_line)
+        self.assertIn("FileCheck", run_line)
+
+        # Should not contain backslashes (continuations removed)
+        self.assertNotIn("\\", run_line)
+
+    def test_extract_run_without_space_after_slashes(self):
+        """Test extracting RUN lines with //RUN: (no space) and indented comments."""
+        test_file_obj = parse_test_file(self.run_variants)
+        run_lines = test_file_obj.extract_run_lines()
+        # Should still parse into a single combined command
+        self.assertEqual(len(run_lines), 1)
+        self.assertIn("--pass-pipeline", run_lines[0])
+        self.assertNotIn("\\", run_lines[0])
+
+    def test_inject_run_lines_with_case_out_of_range_error(self):
+        """Test that inject_run_lines_with_case errors with clear message when indices go out of range."""
+        # Content with only 3 lines
+        content = "line1\nline2\nline3"
+        header_runs = []
+        # Try to inject at index 5 (out of range)
+        case_runs = [(5, "echo test")]
+
+        with self.assertRaises(ValueError) as ctx:
+            inject_run_lines_with_case(content, header_runs, case_runs)
+
+        error_msg = str(ctx.exception)
+        # Verify error message contains actionable guidance
+        self.assertIn("Cannot inject RUN line at index 5", error_msg)
+        self.assertIn("content only has 3 lines", error_msg)
+        self.assertIn("--replace-run-lines", error_msg)
+        self.assertIn("Solutions:", error_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_document_model.py
+++ b/tools/utils/test/lit_tests/test_document_model.py
@@ -1,0 +1,373 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tests for the core document model (Line, Span, FileDoc, CheckLabelExtractor).
+
+These tests verify the foundational data structures for line-oriented
+lit test file parsing.
+"""
+
+import unittest
+from pathlib import Path
+
+from lit_tools.core.document import (
+    CheckLabelExtractor,
+    FileDoc,
+    Line,
+    Span,
+)
+
+
+class TestLine(unittest.TestCase):
+    """Tests for Line dataclass."""
+
+    def test_line_creation_with_lf(self):
+        """Test Line creation with LF newline."""
+        line = Line(text="hello world", newline="\n", index=0, source_line=1)
+        self.assertEqual(line.text, "hello world")
+        self.assertEqual(line.newline, "\n")
+        self.assertEqual(line.index, 0)
+        self.assertEqual(line.source_line, 1)
+        self.assertEqual(line.tags, frozenset())
+
+    def test_line_creation_with_crlf(self):
+        """Test Line creation with CRLF newline."""
+        line = Line(text="test", newline="\r\n", index=5, source_line=6)
+        self.assertEqual(line.newline, "\r\n")
+        self.assertEqual(line.get_full_line(), "test\r\n")
+
+    def test_line_creation_without_newline(self):
+        """Test Line creation for EOF without trailing newline."""
+        line = Line(text="last line", newline="", index=10, source_line=11)
+        self.assertEqual(line.newline, "")
+        self.assertEqual(line.get_full_line(), "last line")
+
+    def test_line_with_tags(self):
+        """Test Line creation with tags."""
+        line = Line(
+            text="// RUN: test",
+            newline="\n",
+            index=0,
+            source_line=1,
+            tags=frozenset(["RUN_HEADER"]),
+        )
+        self.assertIn("RUN_HEADER", line.tags)
+
+    def test_line_with_tags_immutable_update(self):
+        """Test immutable tag update via with_tags()."""
+        line1 = Line(text="test", newline="\n", index=0, source_line=1)
+        line2 = line1.with_tags(frozenset(["CHECK"]))
+
+        self.assertEqual(line1.tags, frozenset())
+        self.assertEqual(line2.tags, frozenset(["CHECK"]))
+        self.assertEqual(line1.text, line2.text)  # Other fields unchanged
+
+    def test_line_get_full_line(self):
+        """Test get_full_line() returns text + newline."""
+        line1 = Line(text="hello", newline="\n", index=0, source_line=1)
+        self.assertEqual(line1.get_full_line(), "hello\n")
+
+        line2 = Line(text="world", newline="", index=1, source_line=2)
+        self.assertEqual(line2.get_full_line(), "world")
+
+    def test_line_invalid_newline_raises(self):
+        """Test that invalid newline character raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Line(text="test", newline="\r", index=0, source_line=1)
+        self.assertIn("Invalid newline character", str(cm.exception))
+
+    def test_line_negative_index_raises(self):
+        """Test that negative index raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Line(text="test", newline="\n", index=-1, source_line=1)
+        self.assertIn("index must be non-negative", str(cm.exception))
+
+    def test_line_invalid_source_line_raises(self):
+        """Test that source_line < 1 raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Line(text="test", newline="\n", index=0, source_line=0)
+        self.assertIn("Source line must be >= 1", str(cm.exception))
+
+
+class TestSpan(unittest.TestCase):
+    """Tests for Span dataclass."""
+
+    def test_span_creation_valid(self):
+        """Test valid Span creation."""
+        span = Span(start=5, end=10)
+        self.assertEqual(span.start, 5)
+        self.assertEqual(span.end, 10)
+
+    def test_span_length(self):
+        """Test Span.length property."""
+        span = Span(start=5, end=10)
+        self.assertEqual(span.length, 5)
+
+    def test_span_zero_length(self):
+        """Test zero-length Span (empty case)."""
+        span = Span(start=5, end=5)
+        self.assertEqual(span.length, 0)
+        self.assertTrue(span.is_empty)
+
+    def test_span_is_empty(self):
+        """Test Span.is_empty property."""
+        self.assertTrue(Span(start=0, end=0).is_empty)
+        self.assertFalse(Span(start=0, end=1).is_empty)
+
+    def test_span_contains(self):
+        """Test Span.contains() method."""
+        span = Span(start=5, end=10)
+        self.assertTrue(span.contains(5))
+        self.assertTrue(span.contains(7))
+        self.assertTrue(span.contains(9))
+        self.assertFalse(span.contains(4))
+        self.assertFalse(span.contains(10))  # Exclusive end
+
+    def test_span_invalid_negative_start(self):
+        """Test that negative start raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Span(start=-1, end=5)
+        self.assertIn("start must be non-negative", str(cm.exception))
+
+    def test_span_invalid_end_before_start(self):
+        """Test that end < start raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Span(start=10, end=5)
+        self.assertIn("end must be >= start", str(cm.exception))
+
+
+class TestFileDoc(unittest.TestCase):
+    """Tests for FileDoc class."""
+
+    def test_from_text_simple_lf(self):
+        """Test parsing simple text with LF newlines."""
+        text = "line1\nline2\nline3\n"
+        doc = FileDoc.from_text(text)
+
+        self.assertEqual(len(doc.lines), 3)
+        self.assertEqual(doc.lines[0].text, "line1")
+        self.assertEqual(doc.lines[0].newline, "\n")
+        self.assertEqual(doc.lines[0].index, 0)
+        self.assertEqual(doc.lines[0].source_line, 1)
+
+        self.assertEqual(doc.lines[2].text, "line3")
+        self.assertEqual(doc.lines[2].source_line, 3)
+
+    def test_from_text_no_trailing_newline(self):
+        """Test parsing file without trailing newline."""
+        text = "line1\nline2"
+        doc = FileDoc.from_text(text)
+
+        self.assertEqual(len(doc.lines), 2)
+        self.assertEqual(doc.lines[1].text, "line2")
+        self.assertEqual(doc.lines[1].newline, "")
+
+    def test_from_text_crlf_newlines(self):
+        """Test parsing file with CRLF newlines."""
+        text = "line1\r\nline2\r\n"
+        doc = FileDoc.from_text(text)
+
+        self.assertEqual(len(doc.lines), 2)
+        self.assertEqual(doc.lines[0].newline, "\r\n")
+        self.assertEqual(doc.lines[1].newline, "\r\n")
+
+    def test_from_text_mixed_newlines(self):
+        """Test parsing file with mixed LF and CRLF."""
+        text = "line1\nline2\r\nline3\n"
+        doc = FileDoc.from_text(text)
+
+        self.assertEqual(len(doc.lines), 3)
+        self.assertEqual(doc.lines[0].newline, "\n")
+        self.assertEqual(doc.lines[1].newline, "\r\n")
+        self.assertEqual(doc.lines[2].newline, "\n")
+
+    def test_from_text_empty_string(self):
+        """Test parsing empty string."""
+        doc = FileDoc.from_text("")
+        self.assertEqual(len(doc.lines), 0)
+
+    def test_from_text_single_line_no_newline(self):
+        """Test parsing single line without newline."""
+        doc = FileDoc.from_text("single line")
+        self.assertEqual(len(doc.lines), 1)
+        self.assertEqual(doc.lines[0].text, "single line")
+        self.assertEqual(doc.lines[0].newline, "")
+
+    def test_from_text_with_path(self):
+        """Test that path is stored in FileDoc."""
+        doc = FileDoc.from_text("test", path=Path("/tmp/test.mlir"))
+        self.assertEqual(doc.path, Path("/tmp/test.mlir"))
+
+    def test_to_text_preserves_content(self):
+        """Test that to_text() preserves exact content."""
+        original = "line1\nline2\r\nline3"
+        doc = FileDoc.from_text(original)
+        reconstructed = doc.to_text()
+        self.assertEqual(original, reconstructed)
+
+    def test_to_text_roundtrip_with_trailing_newline(self):
+        """Test roundtrip with trailing newline."""
+        original = "// RUN: test\n// CHECK: foo\nfunc @test() { }\n"
+        doc = FileDoc.from_text(original)
+        self.assertEqual(doc.to_text(), original)
+
+    def test_to_text_roundtrip_without_trailing_newline(self):
+        """Test roundtrip without trailing newline."""
+        original = "// RUN: test\n// CHECK: foo\nfunc @test() { }"
+        doc = FileDoc.from_text(original)
+        self.assertEqual(doc.to_text(), original)
+
+    def test_slice_valid_range(self):
+        """Test slicing valid range."""
+        doc = FileDoc.from_text("line1\nline2\nline3\nline4\n")
+        span = Span(start=1, end=3)
+        sliced = doc.slice(span)
+
+        self.assertEqual(len(sliced), 2)
+        self.assertEqual(sliced[0].text, "line2")
+        self.assertEqual(sliced[1].text, "line3")
+
+    def test_slice_entire_document(self):
+        """Test slicing entire document."""
+        doc = FileDoc.from_text("line1\nline2\n")
+        span = Span(start=0, end=2)
+        sliced = doc.slice(span)
+
+        self.assertEqual(len(sliced), 2)
+        self.assertEqual(sliced[0].text, "line1")
+        self.assertEqual(sliced[1].text, "line2")
+
+    def test_slice_empty_span(self):
+        """Test slicing with empty span."""
+        doc = FileDoc.from_text("line1\nline2\n")
+        span = Span(start=1, end=1)
+        sliced = doc.slice(span)
+
+        self.assertEqual(len(sliced), 0)
+
+    def test_slice_out_of_bounds_raises(self):
+        """Test that slicing beyond document raises IndexError."""
+        doc = FileDoc.from_text("line1\nline2\n")
+        span = Span(start=0, end=10)
+
+        with self.assertRaises(IndexError) as cm:
+            doc.slice(span)
+        self.assertIn("extends beyond document", str(cm.exception))
+
+    def test_with_line_tags_updates_single_line(self):
+        """Test updating tags for a single line."""
+        doc = FileDoc.from_text("line1\nline2\n")
+        new_doc = doc.with_line_tags(0, frozenset(["RUN_HEADER"]))
+
+        # Original unchanged
+        self.assertEqual(doc.lines[0].tags, frozenset())
+
+        # New doc has updated tags
+        self.assertIn("RUN_HEADER", new_doc.lines[0].tags)
+        self.assertEqual(new_doc.lines[1].tags, frozenset())
+
+    def test_with_line_tags_invalid_index_raises(self):
+        """Test that invalid line index raises IndexError."""
+        doc = FileDoc.from_text("line1\n")
+        with self.assertRaises(IndexError):
+            doc.with_line_tags(10, frozenset(["TEST"]))
+
+
+class TestCheckLabelExtractor(unittest.TestCase):
+    """Tests for CheckLabelExtractor utility."""
+
+    def test_extract_simple_check_label(self):
+        """Test extracting simple CHECK-LABEL."""
+        lines = [
+            Line("// CHECK-LABEL: @foo", "\n", 0, 1),
+            Line("func @foo() { }", "\n", 1, 2),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["foo"])
+
+    def test_extract_check_label_with_prefix(self):
+        """Test extracting CHECK-LABEL with operation prefix."""
+        lines = [
+            Line("// CHECK-LABEL: util.func @bar", "\n", 0, 1),
+            Line("util.func @bar() { }", "\n", 1, 2),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["bar"])
+
+    def test_extract_multiple_check_labels(self):
+        """Test extracting multiple CHECK-LABELs in one case."""
+        lines = [
+            Line("// CHECK-LABEL: @first", "\n", 0, 1),
+            Line("// FOO-LABEL: @first", "\n", 1, 2),
+            Line("// BAR-LABEL: @second", "\n", 2, 3),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["first", "second"])
+
+    def test_extract_no_labels(self):
+        """Test extraction when no CHECK-LABELs present."""
+        lines = [
+            Line("// CHECK: constant", "\n", 0, 1),
+            Line("func @test() { }", "\n", 1, 2),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, [])
+
+    def test_extract_special_characters_in_name(self):
+        """Test extracting names with dots, $, hyphens."""
+        lines = [
+            Line("// CHECK-LABEL: @foo.bar$baz-test_1", "\n", 0, 1),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["foo.bar$baz-test_1"])
+
+    def test_extract_with_signature(self):
+        """Test extracting name when followed by function signature."""
+        lines = [
+            Line("// CHECK-LABEL: @test(%arg0: i32)", "\n", 0, 1),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["test"])
+
+    def test_extract_stream_executable(self):
+        """Test extracting from stream.executable pattern."""
+        lines = [
+            Line("// CHECK-LABEL: stream.executable @my_dispatch", "\n", 0, 1),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["my_dispatch"])
+
+    def test_extract_primary_name_returns_first(self):
+        """Test that extract_primary_name returns first name found."""
+        lines = [
+            Line("// CHECK-LABEL: @first", "\n", 0, 1),
+            Line("// FOO-LABEL: @second", "\n", 1, 2),
+        ]
+        primary, all_names = CheckLabelExtractor.extract_primary_name(lines)
+        self.assertEqual(primary, "first")
+        self.assertEqual(all_names, ("first", "second"))
+
+    def test_extract_primary_name_no_labels(self):
+        """Test extract_primary_name when no labels present."""
+        lines = [
+            Line("func @test() { }", "\n", 0, 1),
+        ]
+        primary, all_names = CheckLabelExtractor.extract_primary_name(lines)
+        self.assertIsNone(primary)
+        self.assertEqual(all_names, ())
+
+    def test_extract_custom_prefix_label(self):
+        """Test extracting with custom prefix (e.g., ORDINAL-LABEL)."""
+        lines = [
+            Line("// ORDINAL-LABEL: @custom", "\n", 0, 1),
+        ]
+        names = CheckLabelExtractor.extract_all_names(lines)
+        self.assertEqual(names, ["custom"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_error_extraction.py
+++ b/tools/utils/test/lit_tests/test_error_extraction.py
@@ -1,0 +1,324 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for error extraction functions in lit_wrapper module."""
+
+# Add project tools/utils to path for imports
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools.core import lit_wrapper
+
+
+class TestExtractTimeoutError(unittest.TestCase):
+    """Tests for extract_timeout_error function."""
+
+    def test_timeout_uppercase(self):
+        """Test detecting TIMEOUT."""
+        failure_text = "Command execution TIMEOUT after 60 seconds"
+        error = lit_wrapper.extract_timeout_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertEqual(error, "Test exceeded timeout limit")
+
+    def test_timeout_mixed_case(self):
+        """Test detecting Timeout."""
+        failure_text = "Test failed: Timeout reached"
+        error = lit_wrapper.extract_timeout_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertEqual(error, "Test exceeded timeout limit")
+
+    def test_reached_timeout(self):
+        """Test detecting 'Reached timeout'."""
+        failure_text = "Reached timeout of 120 seconds"
+        error = lit_wrapper.extract_timeout_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertEqual(error, "Test exceeded timeout limit")
+
+    def test_no_timeout(self):
+        """Test no timeout in normal failure."""
+        failure_text = "FileCheck error: expected string not found"
+        error = lit_wrapper.extract_timeout_error(failure_text)
+        self.assertIsNone(error)
+
+
+class TestExtractCrashError(unittest.TestCase):
+    """Tests for extract_crash_error function."""
+
+    def test_segfault_signal_11(self):
+        """Test detecting SIGSEGV (signal 11)."""
+        failure_text = "Command terminated with signal 11"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("SIGSEGV", error)
+        self.assertIn("segmentation fault", error)
+
+    def test_abort_signal_6(self):
+        """Test detecting SIGABRT (signal 6)."""
+        failure_text = "Process killed by signal 6"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("SIGABRT", error)
+        self.assertIn("abort", error)
+
+    def test_illegal_instruction_signal_4(self):
+        """Test detecting SIGILL (signal 4)."""
+        failure_text = "Exited with signal 4"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("SIGILL", error)
+        self.assertIn("illegal instruction", error)
+
+    def test_exit_code_139(self):
+        """Test detecting segfault from exit code 139 (128 + 11)."""
+        failure_text = "Command returned exit code 139"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("SIGSEGV", error)
+        self.assertIn("exit code 139", error)
+
+    def test_exit_code_134(self):
+        """Test detecting abort from exit code 134 (128 + 6)."""
+        failure_text = "Command returned exit code 134"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("SIGABRT", error)
+        self.assertIn("exit code 134", error)
+
+    def test_segfault_text(self):
+        """Test detecting 'Segmentation fault' text."""
+        failure_text = "Process terminated with: Segmentation fault (core dumped)"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("segmentation fault", error.lower())
+
+    def test_no_crash(self):
+        """Test no crash in normal failure."""
+        failure_text = "FileCheck error: expected string not found"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNone(error)
+
+    def test_normal_exit_code(self):
+        """Test normal exit code is not detected as crash."""
+        failure_text = "Command returned exit code 1"
+        error = lit_wrapper.extract_crash_error(failure_text)
+        self.assertIsNone(error)
+
+
+class TestExtractAssertionError(unittest.TestCase):
+    """Tests for extract_assertion_error function."""
+
+    def test_c_assertion_failure(self):
+        """Test detecting C assertion failure."""
+        failure_text = """
+test.cpp:42: main: Assertion `x > 0' failed.
+Aborted (core dumped)
+"""
+        error = lit_wrapper.extract_assertion_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("Assertion failure", error)
+        self.assertIn("Assertion `x > 0' failed", error)
+
+    def test_check_failure(self):
+        """Test detecting CHECK failure (glog style)."""
+        failure_text = """
+F0115 12:34:56.789012 12345 test.cc:42] Check failed: x > 0 (0 vs. 0)
+Value was: 0
+Expected: > 0
+"""
+        error = lit_wrapper.extract_assertion_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("CHECK failure", error)
+        self.assertIn("Check failed:", error)
+
+    def test_no_assertion(self):
+        """Test no assertion in normal failure."""
+        failure_text = "FileCheck error: expected string not found"
+        error = lit_wrapper.extract_assertion_error(failure_text)
+        self.assertIsNone(error)
+
+
+class TestExtractInvalidIRError(unittest.TestCase):
+    """Tests for extract_invalid_ir_error function."""
+
+    def test_verification_failed(self):
+        """Test detecting MLIR verification failure."""
+        failure_text = """
+test.mlir:15:5: error: 'func.func' op verification failed
+  %0 = arith.addi %arg0, %arg1 : tensor<10xf32>
+       ^ note: expected integer type
+"""
+        error = lit_wrapper.extract_invalid_ir_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("IR verification failed", error)
+        self.assertIn("verification failed", error)
+
+    def test_operation_error(self):
+        """Test detecting operation validation error."""
+        failure_text = """
+test.mlir:20:10: error: 'tensor.empty' op result #0 must be shaped of any type values
+  %1 = tensor.empty() : tensor<*xf32>
+       ^
+"""
+        error = lit_wrapper.extract_invalid_ir_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("IR validation error", error)
+        self.assertIn("'tensor.empty' op", error)
+
+    def test_no_ir_error(self):
+        """Test no IR error in normal failure."""
+        failure_text = "FileCheck error: expected string not found"
+        error = lit_wrapper.extract_invalid_ir_error(failure_text)
+        self.assertIsNone(error)
+
+    def test_truncation_for_long_error(self):
+        """Test that very long IR errors are truncated."""
+        # Create a verification error with many lines.
+        failure_text = "error: verification failed\n" + "\n".join(
+            [f"Line {i} of error details" for i in range(20)]
+        )
+        error = lit_wrapper.extract_invalid_ir_error(failure_text)
+        self.assertIsNotNone(error)
+        # Should be truncated to 15 lines + ellipsis message.
+        lines = error.splitlines()
+        self.assertLessEqual(
+            len(lines), 17
+        )  # "IR verification failed:" + 15 + ellipsis
+        self.assertIn("use -v for full output", error)
+
+
+class TestExtractMissingFileError(unittest.TestCase):
+    """Tests for extract_missing_file_error function."""
+
+    def test_no_such_file_or_directory(self):
+        """Test detecting 'No such file or directory'."""
+        failure_text = "/usr/bin/iree-opt: error: input.mlir: No such file or directory"
+        error = lit_wrapper.extract_missing_file_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("File not found", error)
+        self.assertIn("No such file or directory", error)
+
+    def test_unable_to_open_file(self):
+        """Test detecting 'unable to open file'."""
+        failure_text = "Unable to open file: 'test_data.bin'"
+        error = lit_wrapper.extract_missing_file_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("Unable to open file", error)
+        self.assertIn("test_data.bin", error)
+
+    def test_could_not_open_file(self):
+        """Test detecting 'Could not open file'."""
+        failure_text = 'Error: Could not open: "/path/to/missing.mlir"'
+        error = lit_wrapper.extract_missing_file_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("Could not open file", error)
+        self.assertIn("/path/to/missing.mlir", error)
+
+    def test_no_file_error(self):
+        """Test no file error in normal failure."""
+        failure_text = "FileCheck error: expected string not found"
+        error = lit_wrapper.extract_missing_file_error(failure_text)
+        self.assertIsNone(error)
+
+
+class TestParseRealLitOutput(unittest.TestCase):
+    """Tests for parse_lit_failure with realistic lit output."""
+
+    def test_filecheck_failure(self):
+        """Test parsing FileCheck failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-opt --split-input-file test.mlir | FileCheck test.mlir
+test.mlir:15:11: error: CHECK: expected string not found in input
+// CHECK: %[[VAL:.+]] = arith.constant
+          ^
+<stdin>:10:1: note: scanning from here
+func.func @test() {
+^
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, commands = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("Failed command:", summary)
+        self.assertIn("iree-opt", summary)
+        self.assertIn("CHECK: expected string not found", summary)
+        self.assertEqual(len(commands), 1)
+        self.assertIn("iree-opt", commands[0])
+
+    def test_crash_failure(self):
+        """Test parsing crash failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-opt --some-pass test.mlir
+Command terminated with signal 11
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("Failed command:", summary)
+        self.assertIn("SIGSEGV", summary)
+        self.assertIn("segmentation fault", summary)
+
+    def test_timeout_failure(self):
+        """Test parsing timeout failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-compile test.mlir --iree-hal-target-backends=vulkan-spirv
+TIMEOUT: test exceeded maximum time limit of 60 seconds
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("timeout limit", summary.lower())
+
+    def test_assertion_failure(self):
+        """Test parsing assertion failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-opt --some-pass test.mlir
+iree-opt: SomePass.cpp:123: void runPass(): Assertion `result != nullptr' failed.
+Aborted (core dumped)
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("Assertion", summary)
+        self.assertIn("result != nullptr", summary)
+
+    def test_ir_verification_failure(self):
+        """Test parsing IR verification failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-opt --verify-each test.mlir
+test.mlir:10:5: error: 'func.func' op verification failed
+  func.func @test(%arg0: tensor<10xf32>) {
+  ^
+test.mlir:11:10: note: see current operation: "func.return"() : () -> ()
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("IR verification failed", summary)
+        self.assertIn("verification failed", summary)
+
+    def test_missing_file_failure(self):
+        """Test parsing missing file failure."""
+        stdout = """
+*********************** TEST 'test.mlir' FAILED ***********************
++ iree-opt nonexistent.mlir
+error: nonexistent.mlir: No such file or directory
+*********************** TEST 'test.mlir' FAILED ***********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("File not found", summary)
+        self.assertIn("No such file or directory", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_ir_index.py
+++ b/tools/utils/test/lit_tests/test_ir_index.py
@@ -1,0 +1,304 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for IR indexing module."""
+
+import unittest
+
+from lit_tools.core.ir_index import IRIndex
+
+
+class TestIRLineParsing(unittest.TestCase):
+    """Tests for parsing individual IR lines into IRLine objects."""
+
+    def test_single_assignment(self):
+        """Test parsing single SSA value assignment."""
+        lines = ["%x = arith.constant 0 : index"]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+        ir = index.ir_lines[0]
+        self.assertEqual(ir.operation, "arith.constant")
+        self.assertEqual(ir.ssa_results, ["x"])
+        self.assertTrue(ir.is_assignment)
+
+    def test_tuple_assignment(self):
+        """Test parsing tuple assignment with multiple SSA results."""
+        lines = ["%a, %b = some.op : () -> (i32, i32)"]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+        ir = index.ir_lines[0]
+        self.assertEqual(ir.ssa_results, ["a", "b"])
+        self.assertTrue(ir.is_assignment)
+
+    def test_no_assignment(self):
+        """Test parsing operation without assignment (e.g., scf.yield)."""
+        lines = ["scf.yield %x : i32"]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+        ir = index.ir_lines[0]
+        self.assertEqual(ir.operation, "scf.yield")
+        self.assertEqual(ir.ssa_results, [])
+        self.assertFalse(ir.is_assignment)
+
+    def test_semantic_ssa_names_not_filtered(self):
+        """Test that ALL SSA names are kept, including %0, %c0, %arg0."""
+        lines = [
+            "%0 = arith.constant 0 : index",
+            "%c0 = arith.constant 0 : index",
+            "%arg0 = some.op : () -> i32",
+        ]
+        index = IRIndex(lines)
+
+        # All three lines should be indexed.
+        self.assertEqual(len(index.ir_lines), 3)
+
+        # Check each SSA name is preserved.
+        self.assertEqual(index.ir_lines[0].ssa_results, ["0"])
+        self.assertEqual(index.ir_lines[1].ssa_results, ["c0"])
+        self.assertEqual(index.ir_lines[2].ssa_results, ["arg0"])
+
+    def test_empty_lines_skipped(self):
+        """Test that empty lines are skipped."""
+        lines = ["", "  ", "%x = arith.constant 0"]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+
+    def test_comment_lines_skipped(self):
+        """Test that comment lines are skipped."""
+        lines = [
+            "// This is a comment",
+            "  // Another comment",
+            "%x = arith.constant 0",
+        ]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+
+
+class TestOperationExtraction(unittest.TestCase):
+    """Tests for extracting operation names from IR lines."""
+
+    def test_standard_operations(self):
+        """Test extracting standard namespaced operations."""
+        test_cases = [
+            ("stream.timepoint.await %tp => %x", "stream.timepoint.await"),
+            ("scf.for %i = %c0 to %c10", "scf.for"),
+            ("util.func @test() {", "util.func"),
+            ("arith.addf %x, %y : f32", "arith.addf"),
+        ]
+
+        for line, expected_op in test_cases:
+            with self.subTest(line=line):
+                index = IRIndex([line])
+                if index.ir_lines:
+                    self.assertEqual(index.ir_lines[0].operation, expected_op)
+
+    def test_nested_namespaces(self):
+        """Test operations with deeply nested namespaces."""
+        lines = ["%x = stream.async.execute with() {"]
+        index = IRIndex(lines)
+
+        self.assertEqual(len(index.ir_lines), 1)
+        self.assertEqual(index.ir_lines[0].operation, "stream.async.execute")
+
+    def test_operation_without_assignment(self):
+        """Test extracting operations from non-assignment lines."""
+        test_cases = [
+            "scf.yield %x : i32",
+            "func.return %result : tensor<4xf32>",
+            "cf.br ^bb1(%x : i32)",
+        ]
+
+        for line in test_cases:
+            with self.subTest(line=line):
+                index = IRIndex([line])
+                self.assertEqual(len(index.ir_lines), 1)
+                self.assertIsNotNone(index.ir_lines[0].operation)
+
+    def test_single_word_operations(self):
+        """Test extracting single-word operations (call, return, etc.)."""
+        test_cases = [
+            ("call @function(%x) : (i32) -> i32", "call"),
+            ("return %result : tensor<4xf32>", "return"),
+            ("yield %value : i32", "yield"),
+        ]
+
+        for line, expected_op in test_cases:
+            with self.subTest(line=line):
+                index = IRIndex([line])
+                self.assertEqual(len(index.ir_lines), 1)
+                self.assertEqual(index.ir_lines[0].operation, expected_op)
+
+
+class TestIndexing(unittest.TestCase):
+    """Tests for index building and lookup."""
+
+    def test_by_operation_single(self):
+        """Test looking up single operation type."""
+        lines = [
+            "%x = arith.constant 0 : index",
+            "%y = arith.addf %x, %x : f32",
+        ]
+        index = IRIndex(lines)
+
+        constants = index.find_by_operation("arith.constant")
+        self.assertEqual(len(constants), 1)
+        self.assertEqual(constants[0].ssa_results, ["x"])
+
+    def test_by_operation_multiple(self):
+        """Test looking up multiple instances of same operation."""
+        lines = [
+            "%c0 = arith.constant 0 : index",
+            "%c1 = arith.constant 1 : index",
+            "%c2 = arith.constant 2 : index",
+        ]
+        index = IRIndex(lines)
+
+        constants = index.find_by_operation("arith.constant")
+        self.assertEqual(len(constants), 3)
+
+    def test_by_operation_not_found(self):
+        """Test looking up operation that doesn't exist."""
+        lines = ["%x = arith.constant 0 : index"]
+        index = IRIndex(lines)
+
+        result = index.find_by_operation("scf.for")
+        self.assertEqual(result, [])
+
+    def test_by_line_num(self):
+        """Test looking up IR line by line number."""
+        lines = ["%x = arith.constant 0 : index"]
+        index = IRIndex(lines, start_line=100)
+
+        ir_line = index.get_line(100)
+        self.assertIsNotNone(ir_line)
+        self.assertEqual(ir_line.ssa_results, ["x"])
+
+        # Line that doesn't exist.
+        self.assertIsNone(index.get_line(999))
+
+
+class TestProximitySearch(unittest.TestCase):
+    """Tests for proximity-based operation search."""
+
+    def test_proximity_filter_basic(self):
+        """Test filtering by proximity window."""
+        lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "%c1 = arith.constant 1 : index",  # line 1
+            "",
+            "",
+            "",
+            "%c2 = arith.constant 2 : index",  # line 5
+        ]
+        index = IRIndex(lines)
+
+        # Search near line 0 with window=2.
+        result = index.find_by_operation("arith.constant", near_line=0, window=2)
+        # Should find lines 0, 1 (within 2 lines of line 0).
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].line_num, 0)  # Closest
+        self.assertEqual(result[1].line_num, 1)
+
+    def test_proximity_prefer_closer(self):
+        """Test that closer matches are returned first."""
+        lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "",
+            "%c1 = arith.constant 1 : index",  # line 2
+            "",
+            "",
+            "%c2 = arith.constant 2 : index",  # line 5
+        ]
+        index = IRIndex(lines)
+
+        # Search near line 3.
+        result = index.find_by_operation("arith.constant", near_line=3, window=10)
+
+        # All three should be found, sorted by distance from line 3.
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0].line_num, 2)  # Distance 1
+        self.assertEqual(result[1].line_num, 5)  # Distance 2
+        self.assertEqual(result[2].line_num, 0)  # Distance 3
+
+    def test_proximity_return_all_ties(self):
+        """Test that when multiple lines are equidistant, all are returned."""
+        lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "",
+            "%c1 = arith.constant 1 : index",  # line 2
+        ]
+        index = IRIndex(lines)
+
+        # Search near line 1 - both line 0 and line 2 are distance 1.
+        result = index.find_by_operation("arith.constant", near_line=1, window=10)
+
+        # Both should be returned.
+        self.assertEqual(len(result), 2)
+        # When tied, preserve original line order.
+        self.assertEqual(result[0].line_num, 0)
+        self.assertEqual(result[1].line_num, 2)
+
+    def test_proximity_window_boundary(self):
+        """Test behavior at exact window boundary."""
+        lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "",
+            "",
+            "",
+            "",
+            "%c1 = arith.constant 1 : index",  # line 5 (exactly 5 away from line 0)
+        ]
+        index = IRIndex(lines)
+
+        # Search near line 0 with window=5.
+        result = index.find_by_operation("arith.constant", near_line=0, window=5)
+
+        # Line 5 is exactly at the boundary (5 lines away), should be included.
+        self.assertEqual(len(result), 2)
+
+    def test_proximity_beyond_window(self):
+        """Test that lines beyond window are excluded."""
+        lines = [
+            "%c0 = arith.constant 0 : index",  # line 0
+            "",
+            "",
+            "",
+            "",
+            "",
+            "%c1 = arith.constant 1 : index",  # line 6 (beyond window of 5)
+        ]
+        index = IRIndex(lines)
+
+        # Search near line 0 with window=5.
+        result = index.find_by_operation("arith.constant", near_line=0, window=5)
+
+        # Only line 0 should be found.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].line_num, 0)
+
+    def test_proximity_no_near_line(self):
+        """Test that omitting near_line returns all candidates."""
+        lines = [
+            "%c0 = arith.constant 0 : index",
+            "%c1 = arith.constant 1 : index",
+            "%c2 = arith.constant 2 : index",
+        ]
+        index = IRIndex(lines)
+
+        # No proximity filter.
+        result = index.find_by_operation("arith.constant")
+
+        # All three should be returned.
+        self.assertEqual(len(result), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_extract.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_extract.py
@@ -1,0 +1,680 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree_lit_extract tool."""
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add project tools/utils to path for imports
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_extract
+from lit_tools.core.parser import parse_test_file
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestExtractByNumber(unittest.TestCase):
+    """Tests for extracting test cases by number."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.argv", ["iree-lit-extract", "dummy.mlir", "--case", "2"])
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_second_case_to_stdout(self, mock_stdout):
+        """Test extracting second case to stdout."""
+        args = iree_lit_extract.parse_arguments()
+        args.file = str(self.split_test)
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 0)
+        output = mock_stdout.getvalue()
+
+        # Should contain the actual function
+        self.assertIn("util.func @second_case", output)
+
+    def test_extract_to_file(self):
+        """Test extracting test case to file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.split_test),
+                    "--case",
+                    "2",
+                    "-o",
+                    str(tmp_path),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+
+            result = iree_lit_extract.main(args)
+
+            self.assertEqual(result, 0)
+            self.assertTrue(tmp_path.exists())
+
+            # Verify content
+            content = tmp_path.read_text()
+            self.assertIn("@second_case", content)
+            self.assertIn("util.func @second_case", content)
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestExtractByName(unittest.TestCase):
+    """Tests for extracting test cases by name."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_by_name(self, mock_stdout):
+        """Test extracting by function name."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split_test), "--name", "third_case"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 0)
+        output = mock_stdout.getvalue()
+
+        self.assertIn("util.func @third_case", output)
+
+
+class TestExtractByLineNumber(unittest.TestCase):
+    """Tests for extracting test cases by line number."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_by_containing_line(self, mock_stdout):
+        """Test extracting test case containing specific line."""
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.split_test), "--containing", "18"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 0)
+        output = mock_stdout.getvalue()
+
+        # Should extract second case body
+        self.assertIn("util.func @second_case", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_containing_on_delimiter_line(self, mock_stdout):
+        """Test --containing with line number exactly on delimiter."""
+        # split_test.mlir has delimiters around line 10 and 18.
+        # Line 10 is the first delimiter (between cases 1 and 2).
+        # This tests boundary condition: which case does the delimiter belong to?
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.split_test), "--containing", "10"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 0)
+        output = mock_stdout.getvalue()
+
+        # Delimiter line should belong to previous case or next case (implementation defined).
+        # Verify we get exactly one case, not an error.
+        # Current implementation: delimiter belongs to the case it ends.
+        self.assertTrue(
+            "util.func @first_case" in output or "util.func @second_case" in output,
+            "Should extract a case when line number is on delimiter",
+        )
+
+
+class TestListMode(unittest.TestCase):
+    """Tests for --list mode."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_mode(self, mock_stdout):
+        """Test listing test cases."""
+        with patch("sys.argv", ["iree-lit-extract", str(self.split_test), "--list"]):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 0)
+        output = mock_stdout.getvalue()
+
+        # Should list all cases
+        self.assertIn("3 test cases", output)
+        self.assertIn("@first_case", output)
+        self.assertIn("@second_case", output)
+        self.assertIn("@third_case", output)
+
+
+class TestErrorCases(unittest.TestCase):
+    """Tests for error handling."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_file_not_found(self, mock_stderr):
+        """Test error when file doesn't exist."""
+        with patch(
+            "sys.argv", ["iree-lit-extract", "/nonexistent/file.mlir", "--case", "1"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 2)
+        error = mock_stderr.getvalue()
+        self.assertIn("File not found", error)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_invalid_case_number(self, mock_stderr):
+        """Test error when case number is out of range."""
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.split_test), "--case", "99"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 2)
+        error = mock_stderr.getvalue()
+        self.assertIn("not found", error)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_invalid_name(self, mock_stderr):
+        """Test error when function name doesn't exist."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(self.split_test),
+                "--name",
+                "nonexistent_function",
+            ],
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 2)
+        error = mock_stderr.getvalue()
+        self.assertIn("Case with name", error)
+        self.assertIn("not found", error)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_invalid_line_number(self, mock_stderr):
+        """Test error when line number is out of range."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split_test), "--containing", "9999"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+
+        self.assertEqual(result, 2)
+        error = mock_stderr.getvalue()
+        self.assertIn("No case contains line", error)
+
+
+class TestArgumentExclusivity(unittest.TestCase):
+    """Tests for mutually exclusive argument handling."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_selector_and_list_conflict(self, mock_stderr):
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split_test), "--case", "1", "--list"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+        self.assertEqual(result, 2)
+        self.assertIn("specify exactly one", mock_stderr.getvalue())
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_missing_all_selection(self, mock_stderr):
+        with patch("sys.argv", ["iree-lit-extract", str(self.split_test)]):
+            args = iree_lit_extract.parse_arguments()
+
+        result = iree_lit_extract.main(args)
+        self.assertEqual(result, 2)
+        self.assertIn("specify exactly one", mock_stderr.getvalue())
+
+
+class TestValidationStrict(unittest.TestCase):
+    """Tests for strict validation when iree-opt is unavailable."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_error_on_missing_iree_opt(self, mock_stdout, mock_stderr):
+        # Mock build_detection.find_tool to raise FileNotFoundError
+        with patch(
+            "lit_tools.core.verification.build_detection.find_tool",
+            side_effect=FileNotFoundError("iree-opt not found"),
+        ):
+            with patch(
+                "sys.argv",
+                ["iree-lit-extract", str(self.split_test), "--case", "1", "--verify"],
+            ):
+                args = iree_lit_extract.parse_arguments()
+
+            result = iree_lit_extract.main(args)
+            self.assertEqual(result, 1)
+            err = mock_stderr.getvalue()
+            self.assertIn("iree-opt", err)
+            self.assertIn("not found", err)
+
+
+class TestJSON(unittest.TestCase):
+    """Tests for JSON output from iree-lit-extract."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_json(self, mock_stdout):
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.split_test), "--list", "--json"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        rc = iree_lit_extract.main(args)
+        self.assertEqual(rc, 0)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertEqual(payload["count"], 3)
+        self.assertEqual(len(payload["cases"]), 3)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_json_to_stdout_array(self, mock_stdout):
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split_test), "--case", "2", "--json"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+
+        rc = iree_lit_extract.main(args)
+        self.assertEqual(rc, 0)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertIsInstance(payload, list)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["number"], 2)
+        # Content included
+        self.assertIn("util.func @second_case", payload[0]["content"])
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_multiple_json_array(self, mock_stdout):
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(self.split_test),
+                "--case",
+                "1,3",
+                "--json",
+            ],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        rc = iree_lit_extract.main(args)
+        self.assertEqual(rc, 0)
+        arr = json.loads(mock_stdout.getvalue())
+        self.assertIsInstance(arr, list)
+        self.assertEqual(len(arr), 2)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_extract_json_success(self, mock_stdout):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            out = Path(tmp.name)
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.split_test),
+                    "--case",
+                    "2",
+                    "-o",
+                    str(out),
+                    "--json",
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            # With -o and --json, JSON should be written to the file, not stdout.
+            self.assertEqual(mock_stdout.getvalue(), "")
+            self.assertTrue(out.exists())
+            data = json.loads(out.read_text())
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["number"], 2)
+            self.assertIn("util.func @second_case", data[0]["content"])
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_filter_extraction(self):
+        ten_cases = Path(_FIXTURES_DIR / "ten_cases_test.mlir")
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(ten_cases),
+                "--filter",
+                "five",
+            ],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            out = mock_stdout.getvalue()
+            self.assertIn("@case_five", out)
+        # no temp files to clean up in this test
+
+
+class TestFormatCaseInfo(unittest.TestCase):
+    """Tests for format_case_info helper."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_format_named_case(self):
+        """Test formatting named test case."""
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+        # Use second case which has name "second_case"
+        case = cases[1]
+
+        result = iree_lit_extract.format_case_info(case)
+
+        self.assertIn("Test case 2", result)
+        self.assertIn("@second_case", result)
+        self.assertIn("lines", result)
+
+    def test_format_unnamed_case(self):
+        """Test formatting unnamed test case with real parsed fixture."""
+        # Use a simple test that has a name, verify format includes it
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+        # Third case also has a name
+        case = cases[2]
+
+        result = iree_lit_extract.format_case_info(case)
+
+        self.assertIn("Test case 3", result)
+        self.assertIn("@third_case", result)
+        self.assertIn("lines", result)
+
+
+class TestRunLineInclusion(unittest.TestCase):
+    """Tests for RUN line inclusion (default) and exclusion (--exclude-run-lines)."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.with_case_runs = _FIXTURES_DIR / "with_case_runs.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch(
+        "sys.argv",
+        ["iree-lit-extract", str(_FIXTURES_DIR / "split_test.mlir"), "--case", "1"],
+    )
+    def test_stdout_includes_run_by_default(self, mock_stdout):
+        """Test that stdout mode includes RUN lines by default."""
+        args = iree_lit_extract.parse_arguments()
+        rc = iree_lit_extract.main(args)
+
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        # RUN lines should be in stdout output by default.
+        self.assertIn("// RUN:", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch(
+        "sys.argv",
+        [
+            "iree-lit-extract",
+            str(_FIXTURES_DIR / "split_test.mlir"),
+            "--case",
+            "1",
+            "--exclude-run-lines",
+        ],
+    )
+    def test_exclude_run_lines_flag(self, mock_stdout):
+        """Test --exclude-run-lines flag excludes RUN lines from stdout."""
+        args = iree_lit_extract.parse_arguments()
+        rc = iree_lit_extract.main(args)
+
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        # RUN lines should NOT be included with --exclude-run-lines flag.
+        self.assertNotIn("// RUN:", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch(
+        "sys.argv",
+        [
+            "iree-lit-extract",
+            str(_FIXTURES_DIR / "split_test.mlir"),
+            "--case",
+            "1",
+            "--json",
+        ],
+    )
+    def test_json_excludes_run(self, mock_stdout):
+        """Test JSON mode excludes RUN lines."""
+        args = iree_lit_extract.parse_arguments()
+        rc = iree_lit_extract.main(args)
+
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        payload = json.loads(output)
+        # JSON payload should not contain RUN lines in content.
+        # JSON mode returns an array of cases.
+        self.assertEqual(len(payload), 1)
+        case_content = payload[0]["content"]
+        self.assertNotIn("// RUN:", case_content)
+
+
+class TestEdgeCaseRunLines(unittest.TestCase):
+    """Tests for RUN line edge cases and case-local RUN line extraction."""
+
+    def setUp(self):
+        self.fixture = _FIXTURES_DIR / "edge_cases_run_lines.mlir"
+
+    def test_case_with_case_local_run(self):
+        """Test extracting case with case-local RUN line."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.fixture), "--name", "with_case_run"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            output = mock_stdout.getvalue()
+            # Should have header + case-local RUN lines.
+            self.assertIn("iree-opt --split-input-file", output)
+            self.assertIn("--canonicalize", output)
+            self.assertIn("--check-prefix=CANON", output)
+
+    def test_long_pipeline_extraction(self):
+        """Test extracting case with long pipeline command."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.fixture), "--name", "long_pipeline"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            output = mock_stdout.getvalue()
+            self.assertIn("cse,canonicalize,symbol-dce", output)
+
+    def test_special_flags_extraction(self):
+        """Test extracting cases with special flags."""
+        test_cases = [
+            ("verify_diagnostics", "--verify-diagnostics"),
+            ("multiple_check_prefixes", "--check-prefixes=CHECK,EXTRA"),
+        ]
+        for case_name, expected_flag in test_cases:
+            with self.subTest(case=case_name):
+                with patch(
+                    "sys.argv",
+                    ["iree-lit-extract", str(self.fixture), "--name", case_name],
+                ):
+                    args = iree_lit_extract.parse_arguments()
+                with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                    self.assertEqual(iree_lit_extract.main(args), 0)
+                    output = mock_stdout.getvalue()
+                    self.assertIn(expected_flag, output)
+
+    def test_pipeline_chain_extraction(self):
+        """Test extracting case with piped commands."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.fixture), "--name", "pipeline_chain"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            output = mock_stdout.getvalue()
+            # Should have header + case-local with pipe.
+            self.assertEqual(output.count("iree-opt"), 3)  # Header + two in pipeline
+
+    def test_environment_variable_extraction(self):
+        """Test extracting case with environment variable."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.fixture), "--name", "environment_variable"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            output = mock_stdout.getvalue()
+            self.assertIn("IREE_TEST_VAR=value", output)
+
+    def test_all_cases_have_labels(self):
+        """Verify all cases in edge_cases_run_lines.mlir have labels."""
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.fixture), "--list", "--json"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            payload = json.loads(mock_stdout.getvalue())
+            self.assertEqual(payload["count"], 8)
+            # All cases should have names (labels).
+            for case in payload["cases"]:
+                self.assertIsNotNone(
+                    case["name"], f"Case {case['number']} missing label"
+                )
+
+    def test_ghost_case_trailing_delimiter(self):
+        """Test that file ending with delimiter doesn't create empty ghost case."""
+        # Create a fixture with trailing delimiter.
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @first
+func @first() { return }
+
+// -----
+
+// CHECK-LABEL: @second
+func @second() { return }
+
+// -----
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            # List all cases to check count.
+            with patch("sys.argv", ["iree-lit-extract", str(path), "--list", "--json"]):
+                args = iree_lit_extract.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                self.assertEqual(iree_lit_extract.main(args), 0)
+                payload = json.loads(mock_stdout.getvalue())
+                # Should have exactly 2 cases, not 3 (no empty ghost case).
+                self.assertEqual(payload["count"], 2)
+                self.assertEqual(len(payload["cases"]), 2)
+        finally:
+            path.unlink()
+
+    def test_case_local_run_identical_to_header(self):
+        """Test that case-local RUN identical to header is preserved."""
+        # Scenario: Case has a local RUN line that duplicates a header RUN.
+        # This should NOT be stripped just because it's a duplicate.
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @first
+func @first() { return }
+
+// -----
+
+// CHECK-LABEL: @second
+// RUN: iree-opt %s | FileCheck %s
+func @second() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            # Extract case 2 which has the duplicate RUN line.
+            with patch("sys.argv", ["iree-lit-extract", str(path), "--case", "2"]):
+                args = iree_lit_extract.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                self.assertEqual(iree_lit_extract.main(args), 0)
+                output = mock_stdout.getvalue()
+                # Should have 2 RUN lines in output (header + case-local duplicate).
+                run_count = output.count("// RUN:")
+                self.assertEqual(
+                    run_count,
+                    2,
+                    f"Expected 2 RUN lines (header + case-local), got {run_count}",
+                )
+        finally:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_list.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_list.py
@@ -1,0 +1,61 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree_lit_list tool."""
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_list
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestJSONOutput(unittest.TestCase):
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_json_full_metadata(self, mock_stdout):
+        with patch("sys.argv", ["iree-lit-list", str(self.split_test), "--json"]):
+            args = iree_lit_list.parse_arguments()
+
+        rc = iree_lit_list.main(args)
+        self.assertEqual(rc, 0)
+        data = json.loads(mock_stdout.getvalue())
+        self.assertEqual(data["file"], str(self.split_test))
+        self.assertEqual(data["count"], 3)
+        self.assertEqual(len(data["cases"]), 3)
+        self.assertEqual(data["cases"][0]["number"], 1)
+        self.assertIn("start_line", data["cases"][0])
+        self.assertIn("end_line", data["cases"][0])
+
+
+class TestJSONExclusivity(unittest.TestCase):
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_json_with_count_rejected(self, mock_stderr):
+        with patch(
+            "sys.argv", ["iree-lit-list", str(self.split_test), "--count", "--json"]
+        ):
+            args = iree_lit_list.parse_arguments()
+
+        rc = iree_lit_list.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("--json cannot be combined", mock_stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_replace.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_replace.py
@@ -1,0 +1,3123 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree_lit_replace tool."""
+
+import inspect
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add project tools/utils to path for imports
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_extract, iree_lit_replace
+from lit_tools.core import verification
+from lit_tools.core.parser import parse_test_file
+
+from test.test_helpers import run_python_module
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class MockStdin:
+    """Mock stdin object with buffer attribute for testing."""
+
+    def __init__(self, content: bytes):
+        """Initialize with binary content."""
+        self.buffer = io.BytesIO(content)
+
+
+class TestBasicReplacement(unittest.TestCase):
+    """Tests for basic text mode replacement."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_replace_by_number(self):
+        """Test replacing a case by number."""
+        # Create a temp copy of the test file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # New content for replacement
+            new_content = """// CHECK-LABEL: @replaced_case
+util.func @replaced_case() {
+  return
+}
+"""
+
+            # Replace case 2
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(new_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement
+            content = tmp_path.read_text()
+            self.assertIn("@replaced_case", content)
+            self.assertIn("// -----", content)  # Delimiters preserved
+
+            # Verify we can still parse it
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(len(cases), 3)  # Still 3 cases
+            self.assertEqual(cases[1].name, "replaced_case")  # Case 2 (index 1)
+
+        finally:
+            tmp_path.unlink()
+
+    def test_replace_by_name(self):
+        """Test replacing a case by name."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_content = """// CHECK-LABEL: @third_case
+util.func @third_case(%arg0: tensor<4xf32>) {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--name", "third_case"]
+            ), patch("sys.stdin", MockStdin(new_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[2].name, "third_case")
+            self.assertIn("tensor<4xf32>", cases[2].content)
+
+        finally:
+            tmp_path.unlink()
+
+    def test_round_trip_extract_replace(self):
+        """Test extract → replace → extract produces same result."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Extract case 2
+            original_cases = list(parse_test_file(tmp_path).cases)
+            original_case_2 = original_cases[1]
+
+            # Replace with same content
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(original_case_2.content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Extract again
+            new_cases = list(parse_test_file(tmp_path).cases)
+            new_case_2 = new_cases[1]
+
+            # Should be identical
+            self.assertEqual(original_case_2.content, new_case_2.content)
+            self.assertEqual(original_case_2.name, new_case_2.name)
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestErrorHandling(unittest.TestCase):
+    """Tests for error conditions."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_case_not_found(self):
+        """Test error when case number doesn't exist."""
+        with patch(
+            "sys.argv", ["iree-lit-replace", str(self.split_test), "--case", "99"]
+        ), patch("sys.stdin", MockStdin(b"replacement")):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 2)  # NOT_FOUND
+
+    def test_name_not_found(self):
+        """Test error when case name doesn't exist."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-replace", str(self.split_test), "--name", "nonexistent"],
+        ), patch("sys.stdin", MockStdin(b"replacement")):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 2)  # NOT_FOUND
+
+    def test_file_not_found(self):
+        """Test error when file doesn't exist."""
+        with patch(
+            "sys.argv", ["iree-lit-replace", "/nonexistent/file.mlir", "--case", "1"]
+        ), patch("sys.stdin", MockStdin(b"replacement")):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 2)  # NOT_FOUND
+
+    def test_missing_selector_in_text_mode(self):
+        """Test error when no case selector provided in text mode."""
+        with patch("sys.argv", ["iree-lit-replace", str(self.split_test)]), patch(
+            "sys.stdin", MockStdin(b"replacement")
+        ):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+    def test_both_case_and_name(self):
+        """Test error when both --case and --name provided."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-replace",
+                str(self.split_test),
+                "--case",
+                "1",
+                "--name",
+                "first",
+            ],
+        ), patch("sys.stdin", MockStdin(b"replacement")):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+    def test_duplicate_check_label_names(self):
+        """Test error when using --name with ambiguous duplicate labels."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        duplicate_labels = fixtures_dir / "duplicate_labels.mlir"
+
+        with patch(
+            "sys.argv", ["iree-lit-replace", str(duplicate_labels), "--name", "foo"]
+        ), patch("sys.stdin", MockStdin(b"replacement")):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        # Should fail with ambiguous name error.
+        self.assertNotEqual(result, 0, "Should error when name is ambiguous")
+
+
+class TestIdempotency(unittest.TestCase):
+    """Tests for idempotent behavior (no-op replacements)."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_no_op_replacement(self):
+        """Test that replacing with identical content is a no-op."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Extract original case 2 content
+            cases = list(parse_test_file(tmp_path).cases)
+            original_content = cases[1].content
+
+            # Replace with identical content
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(original_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify case content is preserved
+            new_cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(original_content, new_cases[1].content)
+
+        finally:
+            tmp_path.unlink()
+            # Clean up backup if created
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_byte_for_byte_idempotency(self):
+        """Test that parse → rebuild produces byte-for-byte identical output."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Get original file content
+            original_file_content = tmp_path.read_text()
+
+            # Parse and rebuild without any changes
+            test_file_obj = parse_test_file(tmp_path)
+            cases = list(test_file_obj.cases)
+            header_runs = test_file_obj.extract_run_lines(raw=True)
+            rebuilt_content = iree_lit_replace.build_file_content(header_runs, cases)
+
+            # Should be byte-for-byte identical
+            self.assertEqual(
+                original_file_content,
+                rebuilt_content,
+                "Parse and rebuild should be byte-for-byte identical",
+            )
+
+            # Verify rebuilt content ends with newline (pre-commit requirement)
+            self.assertTrue(
+                rebuilt_content.endswith("\n"),
+                "Rebuilt file must end with newline",
+            )
+
+        finally:
+            tmp_path.unlink()
+            # Clean up backup if created
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestRunLineHandling(unittest.TestCase):
+    """Tests for RUN line validation and replacement."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.with_case_runs = _FIXTURES_DIR / "with_case_runs.mlir"
+
+    def test_replacement_with_matching_run_lines(self):
+        """Test that replacement with matching RUN lines succeeds."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Create replacement content with matching RUN lines
+            replacement = """// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(symbol-dce)' %s | FileCheck %s
+
+// CHECK-LABEL: @new_case
+util.func @new_case() {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify case was replaced and RUN lines were stripped
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "new_case")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replacement_with_different_run_lines_errors(self):
+        """Test that replacement with different RUN lines errors by default."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Create replacement content with DIFFERENT RUN lines
+            replacement = """// RUN: iree-opt --different-flag %s
+
+// CHECK-LABEL: @new_case
+util.func @new_case() {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail with ERROR
+            self.assertEqual(result, 1)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_text_mode_injects_case_local_runs(self):
+        """Text mode: omit RUNs in replacement; original case-local RUNs are reinjected."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+        try:
+            replacement = """// CHECK-LABEL: @case_one
+func.func @case_one() {
+  // CHECK: return
+  return
+}
+"""
+            # Replace case 1 with content without RUN lines
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 0)
+
+            # After replacement, file should include the case-local RUN line again
+            # (Check raw file, not parsed content, since parse_test_file strips RUN lines)
+            file_content = tmp_path.read_text()
+            self.assertIn('// RUN: echo "alpha"', file_content)
+            # Verify the replacement content was applied
+            self.assertIn("@case_one", file_content)
+            self.assertIn("// CHECK: return", file_content)
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_text_mode_case_local_run_mismatch_errors(self):
+        """Text mode: different case-local RUNs should error without --replace-run-lines."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+        try:
+            replacement = """// RUN: echo \"DIFF\" | FileCheck %s --check-prefix=ALPHA
+// CHECK-LABEL: @case_one
+func.func @case_one() { return }
+"""
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 1)
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_duplicate_replacements_error(self):
+        """JSON mode: duplicate entries for the same case should error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+        try:
+            dup_json = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @a\nfunc.func @a() { return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @b\nfunc.func @b() { return }\n",
+                    },
+                ]
+            )
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(dup_json.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 1)
+        finally:
+            tmp_path.unlink()
+
+    def test_json_name_number_mismatch_error(self):
+        """JSON mode: when both name and number are present but mismatch, error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+        try:
+            # number points to 2, but name points to first_case
+            bad = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "name": "first_case",
+                        "content": "// CHECK-LABEL: @x\nfunc.func @x() { return }\n",
+                    }
+                ]
+            )
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(bad.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 1)
+        finally:
+            tmp_path.unlink()
+
+    def test_text_mode_duplicate_name_error(self):
+        """Text mode: replacing by --name with duplicates should error."""
+        # Build a small file with duplicate names
+        dup = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @dup
+func.func @dup() { return }
+
+// -----
+
+// CHECK-LABEL: @dup
+func.func @dup_v2() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(dup)
+            tmp_path = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--name", "dup"]
+            ), patch(
+                "sys.stdin",
+                MockStdin(b"// CHECK-LABEL: @dup\nfunc.func @dup() { return }\n"),
+            ):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 1)
+        finally:
+            tmp_path.unlink()
+
+    def test_replacement_with_different_run_lines_and_flag(self):
+        """Test that --replace-run-lines allows replacing RUN lines."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Create replacement content with DIFFERENT RUN lines
+            replacement = """// RUN: iree-opt --different-flag %s
+
+// CHECK-LABEL: @new_case
+util.func @new_case() {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--replace-run-lines",
+                ],
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should succeed
+            self.assertEqual(result, 0)
+
+            # Verify RUN lines were replaced
+            new_runs = parse_test_file(tmp_path).extract_run_lines(raw=False)
+            self.assertEqual(len(new_runs), 1)
+            self.assertIn("--different-flag", new_runs[0])
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_case_local_run_drift_error(self):
+        """Test that changing case-local RUN line without --replace-run-lines errors."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Case 2 has case-local RUN at line 16: echo "beta" | FileCheck %s --check-prefix=BETA
+            # Replace with DIFFERENT case-local RUN (should error without --replace-run-lines).
+            replacement = """// RUN: echo "modified" | FileCheck %s --check-prefix=MODIFIED
+// CHECK-LABEL: @case_two
+func.func @case_two() {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail (RUN line drift without --replace-run-lines).
+            self.assertNotEqual(result, 0, "Should error when case-local RUN changes")
+
+            # Original file should be unchanged.
+            file_content = tmp_path.read_text()
+            self.assertIn("@case_two", file_content)
+            self.assertNotIn("MODIFIED", file_content)
+        finally:
+            tmp_path.unlink()
+
+
+class TestJSONMode(unittest.TestCase):
+    """Tests for JSON mode batch replacements."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_json_single_replacement(self):
+        """Test JSON mode with single replacement."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # JSON input for single replacement
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @replaced\nutil.func @replaced() {\n  return\n}\n",
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "replaced")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_batch_replacement(self):
+        """Test JSON mode with multiple replacements in same file."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # JSON input for batch replacement (cases 1 and 3)
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": "// CHECK-LABEL: @batch_1\nutil.func @batch_1() {\n  return\n}\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 3,
+                        "content": "// CHECK-LABEL: @batch_3\nutil.func @batch_3() {\n  return\n}\n",
+                    },
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify both replacements
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[0].name, "batch_1")
+            self.assertEqual(cases[2].name, "batch_3")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_file_override(self):
+        """Test CLI file argument overrides JSON file field."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # JSON has different file, but CLI overrides
+            json_input = json.dumps(
+                [
+                    {
+                        "file": "ignored.mlir",  # This should be ignored
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @overridden\nutil.func @overridden() {\n  return\n}\n",
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace", str(tmp_path)]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement went to tmp_path, not "ignored.mlir"
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "overridden")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_schema_validation_errors(self):
+        """Test JSON schema validation catches errors."""
+
+        # Test: missing content field
+        json_input = json.dumps([{"file": "test.mlir", "number": 2}])
+
+        with patch("sys.argv", ["iree-lit-replace"]), patch(
+            "sys.stdin", MockStdin(json_input.encode("utf-8"))
+        ):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+        # Test: neither number nor name specified
+        json_input = json.dumps([{"file": "test.mlir", "content": "test"}])
+
+        with patch("sys.argv", ["iree-lit-replace"]), patch(
+            "sys.stdin", MockStdin(json_input.encode("utf-8"))
+        ):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+        # Test: missing file field when no CLI arg
+        json_input = json.dumps([{"number": 2, "content": "test"}])
+
+        with patch("sys.argv", ["iree-lit-replace"]), patch(
+            "sys.stdin", MockStdin(json_input.encode("utf-8"))
+        ):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+    def test_json_case_not_found(self):
+        """Test JSON mode error when case not found."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Request non-existent case
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 99,
+                        "content": "replacement",
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail during validation
+            self.assertEqual(result, 1)
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_round_trip_with_extract(self):
+        """Test round-trip: extract → edit → replace."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Simulate iree-lit-extract output
+            cases = list(parse_test_file(tmp_path).cases)
+            extract_output = [
+                {
+                    "number": cases[1].number,
+                    "name": cases[1].name,
+                    "start_line": cases[1].start_line,
+                    "end_line": cases[1].end_line,
+                    "line_count": cases[1].line_count,
+                    "check_count": cases[1].check_count,
+                    "content": "// CHECK-LABEL: @edited\nutil.func @edited() {\n  return\n}\n",
+                    "file": str(tmp_path),  # Add file field
+                }
+            ]
+
+            json_input = json.dumps(extract_output)
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement
+            new_cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(new_cases[1].name, "edited")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_run_line_validation(self):
+        """Test RUN line validation in JSON mode."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Content with different RUN lines (should error)
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// RUN: iree-opt --different-flag %s\n\n// CHECK-LABEL: @test\nutil.func @test() {\n  return\n}\n",
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail due to RUN line mismatch
+            self.assertEqual(result, 1)
+
+            # Now with --replace-run-lines flag (should succeed)
+            with patch("sys.argv", ["iree-lit-replace", "--replace-run-lines"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_case_local_runs_match_original(self):
+        """JSON mode: replacement with matching case-local RUNs succeeds."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        with_case_runs = fixtures_dir / "with_case_runs.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replacement for case 2 includes the original case-local RUN line (should succeed)
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": (
+                            '// RUN: echo "beta" | FileCheck %s --check-prefix=BETA\n'
+                            "// CHECK-LABEL: @case_two\n"
+                            "func.func @case_two() {\n"
+                            "  // CHECK: return\n"
+                            "  return\n"
+                            "}\n"
+                        ),
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0, "Should succeed when case-local RUNs match")
+
+            # Verify the case-local RUN is still present
+            file_content = tmp_path.read_text()
+            self.assertIn('// RUN: echo "beta"', file_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_case_local_runs_mismatch(self):
+        """JSON mode: replacement with different case-local RUNs errors without replace_run_lines."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        with_case_runs = fixtures_dir / "with_case_runs.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replacement with DIFFERENT case-local RUN line (should error)
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": (
+                            '// RUN: echo "DIFFERENT" | FileCheck %s --check-prefix=ALPHA\n'
+                            "// CHECK-LABEL: @case_one\n"
+                            "func.func @case_one() { return }\n"
+                        ),
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 1, "Should error when case-local RUNs don't match")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_replace_run_lines_with_case_local(self):
+        """JSON mode: replace_run_lines allows changing case-local RUNs."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        with_case_runs = fixtures_dir / "with_case_runs.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(with_case_runs.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replacement with different case-local RUN, but replace_run_lines=true
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "replace_run_lines": True,
+                        "content": (
+                            '// RUN: echo "gamma" | FileCheck %s --check-prefix=GAMMA\n'
+                            "// CHECK-LABEL: @case_one\n"
+                            "func.func @case_one() { return }\n"
+                        ),
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(
+                result,
+                0,
+                "Should succeed with replace_run_lines even when RUNs differ",
+            )
+
+            # Verify the NEW case-local RUN is present
+            file_content = tmp_path.read_text()
+            self.assertIn('// RUN: echo "gamma"', file_content)
+            self.assertNotIn('// RUN: echo "alpha"', file_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestValidation(unittest.TestCase):
+    """Tests for --verify flag (IR validation with iree-opt)."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_validate_valid_ir(self):
+        """Test that valid MLIR passes validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Valid replacement content
+            valid_content = """// CHECK-LABEL: @valid_case
+util.func @valid_case(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  util.return %arg0 : tensor<4xf32>
+}
+"""
+
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--verify"],
+            ), patch("sys.stdin", MockStdin(valid_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should succeed
+            self.assertEqual(result, 0)
+
+            # Verify replacement happened
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "valid_case")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_validate_invalid_ir(self):
+        """Test that invalid MLIR fails validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Invalid replacement content (bad syntax)
+            invalid_content = """// CHECK-LABEL: @invalid_case
+util.func @invalid_case(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %bad = arith.addf %arg0 : tensor<4xf32>
+  util.return %bad : tensor<4xf32>
+}
+"""
+
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--verify"],
+            ), patch("sys.stdin", MockStdin(invalid_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail validation
+            self.assertEqual(result, 1)
+
+            # Verify file was NOT modified
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "second_case")  # Original name
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestDryRun(unittest.TestCase):
+    """Tests for --dry-run flag (preview changes without writing)."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_dry_run_shows_diff(self):
+        """Test that dry-run outputs unified diff."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_content = """// CHECK-LABEL: @modified_case
+util.func @modified_case() {
+  return
+}
+"""
+
+            # Capture stdout to check diff output
+            captured_output = io.StringIO()
+
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--dry-run"],
+            ), patch("sys.stdin", MockStdin(new_content.encode("utf-8"))), patch(
+                "sys.stdout", captured_output
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Check diff output
+            diff_output = captured_output.getvalue()
+            self.assertIn("---", diff_output)  # Diff header
+            self.assertIn("+++", diff_output)  # Diff header
+            self.assertIn("@@", diff_output)  # Hunk marker
+
+            # Verify file was NOT modified
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "second_case")  # Original unchanged
+
+        finally:
+            tmp_path.unlink()
+
+    def test_dry_run_no_changes(self):
+        """Test dry-run with no changes shows appropriate message."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Extract original case 2 content
+            cases = list(parse_test_file(tmp_path).cases)
+            original_content = cases[1].content
+
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--dry-run"],
+            ), patch("sys.stdin", MockStdin(original_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+        finally:
+            tmp_path.unlink()
+
+    def test_dry_run_json_mode(self):
+        """Test dry-run in JSON mode includes diff in output."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @dry_run_test\nutil.func @dry_run_test() {\n  return\n}\n",
+                    }
+                ]
+            )
+
+            # Capture stdout for JSON output
+            captured_output = io.StringIO()
+
+            with patch("sys.argv", ["iree-lit-replace", "--dry-run", "--json"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ), patch("sys.stdout", captured_output):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Parse JSON output
+            output = json.loads(captured_output.getvalue())
+
+            # Check structure
+            self.assertIn("file_results", output)
+            self.assertEqual(len(output["file_results"]), 1)
+
+            file_result = output["file_results"][0]
+            self.assertTrue(file_result["dry_run"])
+            self.assertIn("diff", file_result)
+            self.assertIn("---", file_result["diff"])  # Diff present
+
+            # Verify file NOT modified
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "second_case")
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestContentValidation(unittest.TestCase):
+    """Tests for --require-label and --allow-empty flags."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_require_label_present(self):
+        """Test --require-label passes when CHECK-LABEL present."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content_with_label = """// CHECK-LABEL: @has_label
+util.func @has_label() {
+  return
+}
+"""
+
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--require-label",
+                ],
+            ), patch("sys.stdin", MockStdin(content_with_label.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_require_label_missing(self):
+        """Test --require-label fails when CHECK-LABEL missing."""
+        content_without_label = """util.func @no_label() {
+  return
+}
+"""
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-replace",
+                str(self.split_test),
+                "--case",
+                "2",
+                "--require-label",
+            ],
+        ), patch("sys.stdin", MockStdin(content_without_label.encode("utf-8"))):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+    def test_allow_empty_with_flag(self):
+        """Test --allow-empty allows empty content."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            empty_content = ""
+
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--allow-empty"],
+            ), patch("sys.stdin", MockStdin(empty_content.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify case content is empty
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].content.strip(), "")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_empty_without_flag(self):
+        """Test empty content errors without --allow-empty."""
+        empty_content = ""
+
+        with patch(
+            "sys.argv", ["iree-lit-replace", str(self.split_test), "--case", "2"]
+        ), patch("sys.stdin", MockStdin(empty_content.encode("utf-8"))):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertEqual(result, 1)  # ERROR
+
+
+class TestMultiFileReplacements(unittest.TestCase):
+    """Stress tests for multi-file JSON replacements."""
+
+    def setUp(self):
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    def _make_temp_file(self, src: Path) -> Path:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(src.read_text())
+            return Path(tmp.name)
+
+    def test_json_multi_file_dry_run_summary(self):
+        """Dry-run JSON over multiple files shows per-file diffs and counts."""
+        a = self._make_temp_file(self.ten_cases)
+        b = self._make_temp_file(self.ten_cases)
+        c = self._make_temp_file(self.ten_cases)
+        try:
+            payload = [
+                {
+                    "file": str(a),
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @aa\nfunc.func @aa() { return }\n",
+                },
+                {
+                    "file": str(a),
+                    "number": 3,
+                    "content": "// CHECK-LABEL: @ac\nfunc.func @ac() { return }\n",
+                },
+                {
+                    "file": str(b),
+                    "number": 2,
+                    "content": "// CHECK-LABEL: @bb\nfunc.func @bb() { return }\n",
+                },
+                {
+                    "file": str(b),
+                    "number": 4,
+                    "content": "// CHECK-LABEL: @bd\nfunc.func @bd() { return }\n",
+                },
+                {
+                    "file": str(c),
+                    "number": 5,
+                    "content": "// CHECK-LABEL: @ce\nfunc.func @ce() { return }\n",
+                },
+            ]
+            data = json.dumps(payload)
+            with patch("sys.argv", ["iree-lit-replace", "--dry-run", "--json"]):
+                out = io.StringIO()
+                with patch("sys.stdin", MockStdin(data.encode("utf-8"))), patch(
+                    "sys.stdout", out
+                ):
+                    args = iree_lit_replace.parse_arguments()
+                    rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 0)
+            report = json.loads(out.getvalue())
+            self.assertIn("file_results", report)
+            self.assertEqual(len(report["file_results"]), 3)
+            # Each file result should include a diff and correct total_cases
+            file_map = {fr["file"]: fr for fr in report["file_results"]}
+            self.assertEqual(file_map[str(a)]["total_cases"], 2)
+            self.assertIn("diff", file_map[str(a)])
+            self.assertEqual(file_map[str(b)]["total_cases"], 2)
+            self.assertEqual(file_map[str(c)]["total_cases"], 1)
+        finally:
+            for p in [a, b, c]:
+                if p.exists():
+                    p.unlink()
+
+    def test_json_multi_file_commit_and_verify(self):
+        """Replacing across multiple files writes expected changes."""
+        a = self._make_temp_file(self.ten_cases)
+        b = self._make_temp_file(self.ten_cases)
+        try:
+            payload = [
+                {
+                    "file": str(a),
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @aa\nfunc.func @aa() { return }\n",
+                },
+                {
+                    "file": str(b),
+                    "number": 10,
+                    "content": "// CHECK-LABEL: @bz\nfunc.func @bz() { return }\n",
+                },
+            ]
+            data = json.dumps(payload)
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(data.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 0)
+
+            # Verify replacements
+            ca = list(parse_test_file(a).cases)
+            cb = list(parse_test_file(b).cases)
+            self.assertEqual(ca[0].name, "aa")
+            self.assertEqual(cb[9].name, "bz")
+        finally:
+            for p in [a, b]:
+                if p.exists():
+                    p.unlink()
+
+    def test_json_multi_file_with_error_aborts_without_modifying(self):
+        """If any file errors, no writes occur for others in the batch."""
+        a = self._make_temp_file(self.ten_cases)
+        b = self._make_temp_file(self.ten_cases)
+        nonexist = str(Path(a.parent) / "does_not_exist.mlir")
+        try:
+            original_a = a.read_text()
+            original_b = b.read_text()
+            payload = [
+                {
+                    "file": str(a),
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @aa\nfunc.func @aa() { return }\n",
+                },
+                {
+                    "file": nonexist,
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @x\nfunc.func @x() { return }\n",
+                },
+                {
+                    "file": str(b),
+                    "number": 2,
+                    "content": "// CHECK-LABEL: @bb\nfunc.func @bb() { return }\n",
+                },
+            ]
+            data = json.dumps(payload)
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(data.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 1)
+            # Files should be unmodified
+            self.assertEqual(a.read_text(), original_a)
+            self.assertEqual(b.read_text(), original_b)
+        finally:
+            for p in [a, b]:
+                if p.exists():
+                    p.unlink()
+
+    def test_json_cli_override_warns(self):
+        """CLI test_file overrides JSON file fields and warns."""
+        a = self._make_temp_file(self.ten_cases)
+        try:
+            payload = [
+                {
+                    "file": str(a),
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @aa\nfunc.func @aa() { return }\n",
+                },
+                {
+                    "file": str(a) + ".other",
+                    "number": 3,
+                    "content": "// CHECK-LABEL: @ac\nfunc.func @ac() { return }\n",
+                },
+            ]
+            data = json.dumps(payload)
+            err = io.StringIO()
+            with patch("sys.argv", ["iree-lit-replace", str(a)]), patch(
+                "sys.stderr", err
+            ), patch("sys.stdin", MockStdin(data.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                rc = iree_lit_replace.main(args)
+            self.assertEqual(rc, 0)
+            self.assertIn("overriding JSON 'file' field", err.getvalue())
+        finally:
+            if a.exists():
+                a.unlink()
+
+
+class TestRoundtrip(unittest.TestCase):
+    """Tests for roundtrip workflows between tools."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_dry_run_replace(self):
+        """Test extract → dry-run → replace workflow."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Step 1: Extract case 2 with JSON
+            with patch(
+                "sys.argv", ["iree-lit-extract", str(tmp_path), "--case", "2", "--json"]
+            ):
+                extract_args = iree_lit_extract.parse_arguments()
+
+                # Capture extract output
+                captured = io.StringIO()
+                with patch("sys.stdout", captured):
+                    iree_lit_extract.main(extract_args)
+
+                extracted = json.loads(captured.getvalue())
+
+            # Step 2: Modify content
+            extracted[0][
+                "content"
+            ] = "// CHECK-LABEL: @roundtrip\nutil.func @roundtrip() {\n  return\n}\n"
+            extracted[0]["file"] = str(tmp_path)
+
+            # Step 3: Dry-run to preview
+            json_input = json.dumps(extracted)
+
+            with patch("sys.argv", ["iree-lit-replace", "--dry-run", "--json"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                dry_run_output = io.StringIO()
+                with patch("sys.stdout", dry_run_output):
+                    args = iree_lit_replace.parse_arguments()
+                    result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            dry_result = json.loads(dry_run_output.getvalue())
+            self.assertTrue(dry_result["file_results"][0]["dry_run"])
+
+            # Step 4: Actually replace
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify final state
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(cases[1].name, "roundtrip")
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestOutputFormats(unittest.TestCase):
+    """Tests for output format consistency and combinations."""
+
+    def setUp(self):
+        """Set up fixture paths."""
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_text_mode_with_json_output(self):
+        """Test text mode with --json flag produces valid JSON."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_content = """// CHECK-LABEL: @json_output
+util.func @json_output() {
+  return
+}
+"""
+
+            # Capture JSON output
+            captured = io.StringIO()
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2", "--json"]
+            ), patch("sys.stdin", MockStdin(new_content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Validate JSON structure
+            output = json.loads(captured.getvalue())
+            self.assertIn("modified_files", output)
+            self.assertIn("modified_cases", output)
+            self.assertIn("file_results", output)
+            self.assertIn("dry_run", output)
+            self.assertEqual(output["modified_files"], 1)
+            self.assertEqual(output["modified_cases"], 1)
+            self.assertEqual(output["dry_run"], False)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_mode_with_json_output(self):
+        """Test JSON mode with --json flag (double JSON)."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @double_json\nutil.func @double_json() {\n  return\n}\n",
+                    }
+                ]
+            )
+
+            captured = io.StringIO()
+
+            with patch("sys.argv", ["iree-lit-replace", "--json"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ), patch("sys.stdout", captured):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Validate JSON output
+            output = json.loads(captured.getvalue())
+            self.assertIn("file_results", output)
+            self.assertEqual(output["modified_files"], 1)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_validate_dry_run_json_consistency(self):
+        """Test --verify and --dry-run with --json produce consistent schema."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            valid_content = """// CHECK-LABEL: @consistency_test
+util.func @consistency_test() {
+  util.return
+}
+"""
+
+            # Test 1: --verify with --json
+            captured1 = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--verify",
+                    "--json",
+                ],
+            ), patch("sys.stdin", MockStdin(valid_content.encode("utf-8"))), patch(
+                "sys.stdout", captured1
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result1 = iree_lit_replace.main(args)
+
+            self.assertEqual(result1, 0)
+            output1 = json.loads(captured1.getvalue())
+
+            # Test 2: --dry-run with --json (reset file first)
+            tmp_path.write_text(self.split_test.read_text())
+
+            captured2 = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--dry-run",
+                    "--json",
+                ],
+            ), patch("sys.stdin", MockStdin(valid_content.encode("utf-8"))), patch(
+                "sys.stdout", captured2
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result2 = iree_lit_replace.main(args)
+
+            self.assertEqual(result2, 0)
+            output2 = json.loads(captured2.getvalue())
+
+            # Both should have same top-level keys
+            self.assertEqual(set(output1.keys()), set(output2.keys()))
+            self.assertIn("modified_files", output1)
+            self.assertIn("errors", output1)
+            self.assertIn("warnings", output1)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestBatchMode(unittest.TestCase):
+    """Tests for batch mode operations with multiple files and cases."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_batch_validation_all_valid(self):
+        """Test batch validation with all valid replacements."""
+
+        # Create two temp files
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp1:
+            tmp1.write(self.split_test.read_text())
+            tmp1_path = Path(tmp1.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp2:
+            tmp2.write(self.split_test.read_text())
+            tmp2_path = Path(tmp2.name)
+
+        try:
+            valid_content = """// CHECK-LABEL: @batch_test
+util.func @batch_test() {
+  util.return
+}
+"""
+
+            # Batch JSON with two files, two cases each
+            batch_json = json.dumps(
+                [
+                    {"file": str(tmp1_path), "number": 1, "content": valid_content},
+                    {"file": str(tmp1_path), "number": 2, "content": valid_content},
+                    {"file": str(tmp2_path), "number": 1, "content": valid_content},
+                    {"file": str(tmp2_path), "number": 2, "content": valid_content},
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", "--mode", "json", "--verify"]
+            ), patch("sys.stdin", MockStdin(batch_json.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify both files were modified
+            self.assertNotEqual(tmp1_path.read_text(), self.split_test.read_text())
+            self.assertNotEqual(tmp2_path.read_text(), self.split_test.read_text())
+
+        finally:
+            tmp1_path.unlink()
+            tmp2_path.unlink()
+            for path in [tmp1_path, tmp2_path]:
+                backup = path.with_suffix(".mlir.bak")
+                if backup.exists():
+                    backup.unlink()
+
+    def test_batch_validation_one_invalid(self):
+        """Test batch validation fails atomically when one replacement is invalid."""
+
+        # Create two temp files
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp1:
+            tmp1.write(self.split_test.read_text())
+            tmp1_path = Path(tmp1.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp2:
+            tmp2.write(self.split_test.read_text())
+            tmp2_path = Path(tmp2.name)
+
+        try:
+            valid_content = """// CHECK-LABEL: @valid_test
+util.func @valid_test() {
+  util.return
+}
+"""
+            invalid_content = """// Invalid MLIR - missing comma
+util.func @invalid_test(%arg0: tensor<4xf32>) {
+  %bad = arith.addf %arg0 : tensor<4xf32>
+  util.return
+}
+"""
+
+            # Store original content
+            orig1 = tmp1_path.read_text()
+            orig2 = tmp2_path.read_text()
+
+            # Batch JSON with one invalid replacement
+            batch_json = json.dumps(
+                [
+                    {"file": str(tmp1_path), "number": 1, "content": valid_content},
+                    {"file": str(tmp2_path), "number": 1, "content": invalid_content},
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", "--mode", "json", "--verify"]
+            ), patch("sys.stdin", MockStdin(batch_json.encode("utf-8"))), patch(
+                "sys.stderr", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail
+            self.assertNotEqual(result, 0)
+
+            # Files should be unchanged (atomic batch)
+            self.assertEqual(tmp1_path.read_text(), orig1)
+            self.assertEqual(tmp2_path.read_text(), orig2)
+
+        finally:
+            tmp1_path.unlink()
+            tmp2_path.unlink()
+
+    def test_batch_dry_run_multiple_files(self):
+        """Test batch dry-run shows diffs for multiple files."""
+
+        # Create two temp files
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp1:
+            tmp1.write(self.split_test.read_text())
+            tmp1_path = Path(tmp1.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp2:
+            tmp2.write(self.split_test.read_text())
+            tmp2_path = Path(tmp2.name)
+
+        try:
+            new_content = """// CHECK-LABEL: @modified_function
+util.func @modified_function() {
+  util.return
+}
+"""
+
+            # Store original content
+            orig1 = tmp1_path.read_text()
+            orig2 = tmp2_path.read_text()
+
+            # Batch JSON
+            batch_json = json.dumps(
+                [
+                    {"file": str(tmp1_path), "number": 2, "content": new_content},
+                    {"file": str(tmp2_path), "number": 2, "content": new_content},
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", "--mode", "json", "--dry-run", "--json"],
+            ), patch("sys.stdin", MockStdin(batch_json.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Parse JSON output
+            output = json.loads(captured.getvalue())
+
+            # Should have 2 files in output
+            self.assertEqual(len(output["file_results"]), 2)
+
+            # Both should have dry_run=True and diffs
+            for file_result in output["file_results"]:
+                self.assertTrue(file_result["dry_run"])
+                self.assertTrue(file_result["diff"])  # Should have diff text
+
+            # Files should be unchanged
+            self.assertEqual(tmp1_path.read_text(), orig1)
+            self.assertEqual(tmp2_path.read_text(), orig2)
+
+        finally:
+            tmp1_path.unlink()
+            tmp2_path.unlink()
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Tests for edge cases and error conditions."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_single_case_file(self):
+        """Test replacement in file with only one case (no delimiters)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            # Create a single-case file (no delimiters)
+            single_case = """// RUN: iree-opt %s
+// CHECK-LABEL: @single_case
+util.func @single_case() {
+  util.return
+}
+"""
+            tmp.write(single_case)
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_content = """// CHECK-LABEL: @replaced_single
+util.func @replaced_single() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(new_content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify replacement
+            final = tmp_path.read_text()
+            self.assertIn("@replaced_single", final)
+            self.assertIn("// RUN: iree-opt %s", final)  # RUN line preserved
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replace_first_case(self):
+        """Test replacing the first case in a multi-case file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_first = """// CHECK-LABEL: @new_first_case
+util.func @new_first_case() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(new_first.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify first case replaced, others unchanged
+            final = tmp_path.read_text()
+            self.assertIn("@new_first_case", final)
+            self.assertIn("@second_case", final)  # Second case unchanged
+            self.assertIn("@third_case", final)  # Third case unchanged
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replace_last_case(self):
+        """Test replacing the last case in a multi-case file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            new_last = """// CHECK-LABEL: @new_last_case
+util.func @new_last_case() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "3"]
+            ), patch("sys.stdin", MockStdin(new_last.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify last case replaced, others unchanged
+            final = tmp_path.read_text()
+            self.assertIn("@new_last_case", final)
+            self.assertIn("@first_case", final)  # First case unchanged
+            self.assertIn("@second_case", final)  # Second case unchanged
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replace_with_very_long_content(self):
+        """Test replacement with very long content (stress test)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Generate large content (1000 lines)
+            large_content = "// CHECK-LABEL: @large_test\n"
+            large_content += "util.func @large_test() {\n"
+            for i in range(1000):
+                large_content += f"  // Line {i}\n"
+            large_content += "  util.return\n"
+            large_content += "}\n"
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(large_content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify content was replaced
+            new_content = tmp_path.read_text()
+            self.assertIn("Line 999", new_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replace_with_unicode_content(self):
+        """Test replacement with Unicode characters."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            unicode_content = """// CHECK-LABEL: @unicode_test
+// Test with Unicode: 你好 世界 🚀
+util.func @unicode_test() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(unicode_content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify Unicode content was preserved
+            new_content = tmp_path.read_text()
+            self.assertIn("你好", new_content)
+            self.assertIn("🚀", new_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_validate_timeout_behavior(self):
+        """Test that verification timeout is configurable."""
+        # Note: This is a structural test - we verify the timeout parameter exists
+        # Actual timeout testing would require malicious/hanging IR
+        # Verify timeout parameter is respected in verify_ir
+        # (This is a code structure test, not a runtime test)
+
+        sig = inspect.signature(verification.verify_ir)
+        # Function should accept content, case_info, args, and timeout
+        self.assertEqual(len(sig.parameters), 4)
+
+    def test_malformed_json_input(self):
+        """Test error handling for malformed JSON."""
+        captured = io.StringIO()
+        with patch("sys.argv", ["iree-lit-replace", "--mode", "json"]), patch(
+            "sys.stdin", MockStdin(b"not valid json {")
+        ), patch("sys.stderr", captured):
+            args = iree_lit_replace.parse_arguments()
+            result = iree_lit_replace.main(args)
+
+        self.assertNotEqual(result, 0)
+        error_output = captured.getvalue()
+        self.assertIn("error", error_output.lower())
+
+
+class TestAdvancedWorkflows(unittest.TestCase):
+    """Tests for complex multi-step workflows and tool integration."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_validate_dry_run_replace_pipeline(self):
+        """Test complete pipeline: extract → validate → dry-run → replace."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Step 1: Extract case 2 with iree-lit-extract --json
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            extracted = json.loads(extract_result.stdout)
+
+            # Step 2: Modify content and ensure file field is present
+            modified_content = """// CHECK-LABEL: @pipeline_test
+util.func @pipeline_test() {
+  util.return
+}
+"""
+            extracted[0]["content"] = modified_content
+            extracted[0]["file"] = str(tmp_path)  # Ensure file field is present
+
+            # Step 3: Validate with --verify --dry-run --json
+            validate_input = json.dumps(extracted)
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    "--mode",
+                    "json",
+                    "--verify",
+                    "--dry-run",
+                    "--json",
+                ],
+            ), patch("sys.stdin", MockStdin(validate_input.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            validate_output = json.loads(captured.getvalue())
+
+            # Verify dry-run flag and diff present
+            self.assertTrue(validate_output["file_results"][0]["dry_run"])
+            self.assertTrue(validate_output["file_results"][0]["diff"])
+
+            # Step 4: Actually replace (without dry-run)
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", "--mode", "json", "--verify"]
+            ), patch("sys.stdin", MockStdin(validate_input.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Step 5: Verify final content
+            final_content = tmp_path.read_text()
+            self.assertIn("@pipeline_test", final_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_batch_mixed_operations(self):
+        """Test batch with some cases valid, some identical, some changed."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Read original case 2 content
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            original_case2 = extract_result.stdout
+
+            new_content = """// CHECK-LABEL: @new_test
+util.func @new_test() {
+  util.return
+}
+"""
+
+            # Batch: case 1 changed, case 2 identical, case 3 changed
+            batch_json = json.dumps(
+                [
+                    {"file": str(tmp_path), "number": 1, "content": new_content},
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": original_case2,
+                    },  # Identical
+                    {"file": str(tmp_path), "number": 3, "content": new_content},
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", "--mode", "json", "--json"]
+            ), patch("sys.stdin", MockStdin(batch_json.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            output = json.loads(captured.getvalue())
+
+            # All 3 cases processed, but case 2 content is identical
+            # The tool reports all cases in batch as processed
+            self.assertEqual(output["modified_files"], 1)
+            # Note: modified_cases may be 2 or 3 depending on idempotency detection
+            # in batch mode - as long as file was updated, test passes
+            self.assertGreaterEqual(output["modified_cases"], 2)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_iterative_refinement_workflow(self):
+        """Test workflow: extract → edit → dry-run → edit again → replace."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Iteration 1: First attempt
+            attempt1 = """// CHECK-LABEL: @attempt1
+util.func @attempt1() {
+  util.return
+}
+"""
+
+            # Dry-run to see diff
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--dry-run"],
+            ), patch("sys.stdin", MockStdin(attempt1.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            diff1 = captured.getvalue()
+            self.assertIn("@attempt1", diff1)
+
+            # Iteration 2: Refined attempt
+            attempt2 = """// CHECK-LABEL: @refined_version
+util.func @refined_version() {
+  util.return
+}
+"""
+
+            # Dry-run again to see new diff
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--dry-run"],
+            ), patch("sys.stdin", MockStdin(attempt2.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            diff2 = captured.getvalue()
+            self.assertIn("@refined_version", diff2)
+
+            # Final: Replace with refined version
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "2"]
+            ), patch("sys.stdin", MockStdin(attempt2.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify final state
+            final = tmp_path.read_text()
+            self.assertIn("@refined_version", final)
+            self.assertNotIn("@attempt1", final)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestFlagCombinations(unittest.TestCase):
+    """Tests for various CLI flag combinations."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_validate_require_label_combination(self):
+        """Test --verify and --require-label together."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            valid_with_label = """// CHECK-LABEL: @labeled_function
+util.func @labeled_function() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--verify",
+                    "--require-label",
+                ],
+            ), patch("sys.stdin", MockStdin(valid_with_label.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_dry_run_with_all_validation_flags(self):
+        """Test --dry-run with --verify, --require-label, and --json."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = """// CHECK-LABEL: @all_flags_test
+util.func @all_flags_test() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--dry-run",
+                    "--verify",
+                    "--require-label",
+                    "--json",
+                ],
+            ), patch("sys.stdin", MockStdin(content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Parse JSON output
+            output = json.loads(captured.getvalue())
+
+            # Should have dry_run flag and diff
+            self.assertTrue(output["file_results"][0]["dry_run"])
+            self.assertTrue(output["file_results"][0]["diff"])
+            self.assertTrue(output["dry_run"])
+
+            # File should be unchanged (dry-run)
+            self.assertEqual(tmp_path.read_text(), self.split_test.read_text())
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_mode_with_pretty_flag(self):
+        """Test --mode json with --pretty flag."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = """// CHECK-LABEL: @pretty_test
+util.func @pretty_test() {
+  util.return
+}
+"""
+
+            batch_json = json.dumps(
+                [{"file": str(tmp_path), "number": 2, "content": content}]
+            )
+
+            # Note: --pretty affects console output, not JSON structure
+            # This test verifies it doesn't break JSON mode
+            captured = io.StringIO()
+            with patch(
+                "sys.argv", ["iree-lit-replace", "--mode", "json", "--pretty"]
+            ), patch("sys.stdin", MockStdin(batch_json.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_quiet_with_json_output(self):
+        """Test --quiet with --json (JSON output should still appear)."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = """// CHECK-LABEL: @quiet_test
+util.func @quiet_test() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--quiet", "--json"],
+            ), patch("sys.stdin", MockStdin(content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Should have JSON output despite --quiet
+            output = json.loads(captured.getvalue())
+            self.assertEqual(output["modified_files"], 1)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_no_backup_flag(self):
+        """Test --no-backup flag prevents backup file creation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = """// CHECK-LABEL: @no_backup_test
+util.func @no_backup_test() {
+  util.return
+}
+"""
+
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--no-backup"],
+            ), patch("sys.stdin", MockStdin(content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify no backup file created
+            backup = tmp_path.with_suffix(".mlir.bak")
+            self.assertFalse(backup.exists())
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestUnifiedJSONSchema(unittest.TestCase):
+    """Tests for unified JSON schema across all modes."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def _validate_schema_structure(self, output: dict, dry_run: bool):
+        """Validate the unified JSON output schema structure."""
+        # Top-level required fields
+        self.assertIn("modified_files", output)
+        self.assertIn("modified_cases", output)
+        self.assertIn("unchanged_cases", output)
+        self.assertIn("dry_run", output)
+        self.assertIn("file_results", output)
+        self.assertIn("errors", output)
+        self.assertIn("warnings", output)
+
+        # Verify types
+        self.assertIsInstance(output["modified_files"], int)
+        self.assertIsInstance(output["modified_cases"], int)
+        self.assertIsInstance(output["unchanged_cases"], int)
+        self.assertIsInstance(output["dry_run"], bool)
+        self.assertIsInstance(output["file_results"], list)
+        self.assertIsInstance(output["errors"], list)
+        self.assertIsInstance(output["warnings"], list)
+
+        # Verify dry_run value matches expected
+        self.assertEqual(output["dry_run"], dry_run)
+
+        # Validate file_results structure
+        for file_result in output["file_results"]:
+            self.assertIn("file", file_result)
+            self.assertIn("total_cases", file_result)
+            self.assertIn("modified", file_result)
+            self.assertIn("unchanged", file_result)
+            self.assertIn("dry_run", file_result)
+            self.assertIn("cases", file_result)
+            self.assertIn("diff", file_result)
+
+            # Verify file_result types
+            self.assertIsInstance(file_result["file"], str)
+            self.assertIsInstance(file_result["total_cases"], int)
+            self.assertIsInstance(file_result["modified"], int)
+            self.assertIsInstance(file_result["unchanged"], int)
+            self.assertIsInstance(file_result["dry_run"], bool)
+            self.assertIsInstance(file_result["cases"], list)
+            self.assertIsInstance(file_result["diff"], str)
+
+            # Validate cases array structure (must be objects, not just numbers)
+            for case in file_result["cases"]:
+                self.assertIsInstance(case, dict)
+                self.assertIn("number", case)
+                self.assertIn("name", case)
+                self.assertIn("changed", case)
+                self.assertIsInstance(case["number"], int)
+                self.assertIsInstance(case["changed"], bool)
+                # name can be None for unnamed cases
+                self.assertTrue(case["name"] is None or isinstance(case["name"], str))
+
+    def test_text_mode_json_output_schema(self):
+        """Text mode with --json follows unified schema."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = "// Modified\nutil.func @test() { util.return }\n"
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                ["iree-lit-replace", str(tmp_path), "--case", "2", "--json"],
+            ), patch("sys.stdin", MockStdin(content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            output = json.loads(captured.getvalue())
+            self._validate_schema_structure(output, dry_run=False)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_text_mode_dry_run_json_schema(self):
+        """Text mode --dry-run --json follows unified schema."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            content = "// Modified\nutil.func @test() { util.return }\n"
+            captured = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-replace",
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--dry-run",
+                    "--json",
+                ],
+            ), patch("sys.stdin", MockStdin(content.encode("utf-8"))), patch(
+                "sys.stdout", captured
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            output = json.loads(captured.getvalue())
+            self._validate_schema_structure(output, dry_run=True)
+            # Dry-run should have diff
+            self.assertTrue(len(output["file_results"][0]["diff"]) > 0)
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_batch_mode_schema(self):
+        """JSON batch mode follows unified schema."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": "// Modified 1\nutil.func @test1() { util.return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 3,
+                        "content": "// Modified 3\nutil.func @test3() { util.return }\n",
+                    },
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch("sys.argv", ["iree-lit-replace", "--json"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ), patch("sys.stdout", captured):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            output = json.loads(captured.getvalue())
+            self._validate_schema_structure(output, dry_run=False)
+            # Should have modified 2 cases
+            self.assertEqual(output["modified_cases"], 2)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_batch_dry_run_schema(self):
+        """JSON batch mode --dry-run follows unified schema."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// Modified\nutil.func @test() { util.return }\n",
+                    }
+                ]
+            )
+
+            captured = io.StringIO()
+            with patch("sys.argv", ["iree-lit-replace", "--dry-run", "--json"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ), patch("sys.stdout", captured):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+            output = json.loads(captured.getvalue())
+            self._validate_schema_structure(output, dry_run=True)
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestInputValidation(unittest.TestCase):
+    """Tests for input validation and edge cases."""
+
+    def test_windows_crlf_input_handling(self):
+        """Test that Windows CRLF line endings are handled correctly."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replacement content with Windows CRLF line endings.
+            replacement_with_crlf = (
+                "// CHECK-LABEL: @first_crlf\r\nutil.func @first_crlf() { return }\r\n"
+            )
+
+            with patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(replacement_with_crlf.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            # Verify output uses consistent Unix line endings (LF only).
+            file_content = tmp_path.read_bytes()
+            self.assertNotIn(b"\r\n", file_content, "Should not have CRLF in output")
+            self.assertIn(b"@first_crlf", file_content)
+        finally:
+            tmp_path.unlink()
+
+    def test_empty_replacement_content_with_allow_empty(self):
+        """Test that empty content with --allow-empty wipes case body."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "",
+                        "allow_empty": True,
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            file_content = tmp_path.read_text()
+            # Case 2 should be wiped (empty or minimal content).
+            self.assertNotIn("@second_case", file_content)
+
+            # Delimiters should remain.
+            self.assertGreater(file_content.count("// -----"), 0)
+
+            # Other cases preserved.
+            self.assertIn("@first_case", file_content)
+            self.assertIn("@third_case", file_content)
+        finally:
+            tmp_path.unlink()
+
+    def test_utf8_bom_handling(self):
+        """Test that UTF-8 BOM in input is handled correctly."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # JSON input with UTF-8 BOM prefix.
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": "// CHECK-LABEL: @first_bom\nutil.func @first_bom() { return }\n",
+                    }
+                ]
+            )
+            json_with_bom = b"\xEF\xBB\xBF" + json_input.encode("utf-8")
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_with_bom)
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should succeed (BOM is stripped).
+            self.assertEqual(result, 0)
+
+            file_content = tmp_path.read_text()
+            self.assertIn("@first_bom", file_content)
+        finally:
+            tmp_path.unlink()
+
+    def test_concurrent_modification_detection(self):
+        """Test that concurrent file modification is detected."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            replacement = (
+                "// CHECK-LABEL: @modified\nutil.func @modified() { return }\n"
+            )
+
+            # Mock Path.stat to return different mtime on second call.
+            original_stat = tmp_path.stat
+
+            call_count = [0]
+
+            def mock_stat(self, *, follow_symlinks=True):
+                call_count[0] += 1
+                stat_result = original_stat(follow_symlinks=follow_symlinks)
+                if call_count[0] > 1:
+                    # Simulate file modification by changing mtime.
+                    # Create a new stat_result with modified mtime.
+                    return os.stat_result(
+                        (
+                            stat_result.st_mode,
+                            stat_result.st_ino,
+                            stat_result.st_dev,
+                            stat_result.st_nlink,
+                            stat_result.st_uid,
+                            stat_result.st_gid,
+                            stat_result.st_size,
+                            stat_result.st_atime,
+                            stat_result.st_mtime + 1,  # Modified time.
+                            stat_result.st_ctime,
+                        )
+                    )
+                return stat_result
+
+            with patch.object(Path, "stat", mock_stat), patch(
+                "sys.argv", ["iree-lit-replace", str(tmp_path), "--case", "1"]
+            ), patch("sys.stdin", MockStdin(replacement.encode("utf-8"))):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail with concurrent modification error.
+            self.assertNotEqual(result, 0, "Should detect concurrent modification")
+
+            # Original file should be unchanged.
+            file_content = tmp_path.read_text()
+            self.assertIn("@first_case", file_content)
+            self.assertNotIn("@modified", file_content)
+        finally:
+            tmp_path.unlink()
+
+
+class TestJSONBatchEdgeCases(unittest.TestCase):
+    """Tests for JSON batch mode edge cases and corner conditions."""
+
+    def test_json_batch_reordering_cases(self):
+        """Test that JSON batch mode handles out-of-order case updates."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Update case 3, then case 1 (out of order).
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 3,
+                        "content": "// CHECK-LABEL: @third_updated\nutil.func @third_updated() { return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": "// CHECK-LABEL: @first_updated\nutil.func @first_updated() { return }\n",
+                    },
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0, "Should succeed with out-of-order updates")
+
+            # Verify both cases were updated in correct positions.
+            file_content = tmp_path.read_text()
+            self.assertIn("@first_updated", file_content)
+            self.assertIn("@third_updated", file_content)
+
+            # Verify case 2 is untouched.
+            self.assertIn("@second_case", file_content)
+        finally:
+            tmp_path.unlink()
+
+    def test_json_batch_hole_in_updates(self):
+        """Test updating non-consecutive cases leaves middle cases untouched."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        five_cases = fixtures_dir / "five_cases.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(five_cases.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Update cases 1 and 5, leaving 2, 3, 4 untouched.
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "content": "// CHECK-LABEL: @case_one_modified\nfunc.func @case_one_modified() { return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 5,
+                        "content": "// CHECK-LABEL: @case_five_modified\nfunc.func @case_five_modified() { return }\n",
+                    },
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            file_content = tmp_path.read_text()
+            # Updated cases.
+            self.assertIn("@case_one_modified", file_content)
+            self.assertIn("@case_five_modified", file_content)
+
+            # Untouched cases.
+            self.assertIn("@case_two", file_content)
+            self.assertIn("@case_three", file_content)
+            self.assertIn("@case_four", file_content)
+
+            # Delimiters preserved.
+            self.assertEqual(file_content.count("// -----"), 4)
+        finally:
+            tmp_path.unlink()
+
+    def test_weird_delimiter_spacing_normalization(self):
+        """Test that delimiters with weird spacing are normalized."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        weird_delimiters = fixtures_dir / "weird_delimiters.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(weird_delimiters.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replace case 2 (triggers rebuild).
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @second_modified\nfunc.func @second_modified() { return }\n",
+                    }
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            file_content = tmp_path.read_text()
+            # Delimiters should be normalized to standard "// -----".
+            # Count normalized delimiters.
+            normalized_count = file_content.count("\n// -----\n")
+            self.assertGreater(
+                normalized_count,
+                0,
+                "Should have normalized delimiters with newlines before/after",
+            )
+
+            # Verify no weird spacing remains.
+            self.assertNotIn(
+                "//-----", file_content, "Should not have compact delimiter"
+            )
+            self.assertNotIn(
+                "//   -----", file_content, "Should not have extra-spaced delimiter"
+            )
+        finally:
+            tmp_path.unlink()
+
+    def test_json_per_case_run_line_flags(self):
+        """Test that per-case replace_run_lines flag is isolated."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Entry 1 has replace_run_lines: true, Entry 2 doesn't.
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "replace_run_lines": True,
+                        "content": "// RUN: new-tool %s | FileCheck %s\n// CHECK-LABEL: @first_new\nutil.func @first_new() { return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// CHECK-LABEL: @second_same\nutil.func @second_same() { return }\n",
+                    },
+                ]
+            )
+
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            self.assertEqual(result, 0)
+
+            file_content = tmp_path.read_text()
+            # Header should be replaced with new RUN line.
+            self.assertIn("new-tool", file_content)
+            self.assertNotIn("iree-opt", file_content)
+
+            # Both cases updated.
+            self.assertIn("@first_new", file_content)
+            self.assertIn("@second_same", file_content)
+        finally:
+            tmp_path.unlink()
+
+    def test_json_header_run_line_poisoning(self):
+        """Test that conflicting replace_run_lines values are caught."""
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        split_test = fixtures_dir / "split_test.mlir"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Two entries with different replace_run_lines values (conflict).
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "replace_run_lines": True,
+                        "content": "// RUN: tool-a %s\n// CHECK-LABEL: @first\nutil.func @first() { return }\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "replace_run_lines": True,
+                        "content": "// RUN: tool-b %s\n// CHECK-LABEL: @second\nutil.func @second() { return }\n",
+                    },
+                ]
+            )
+
+            captured_stderr = io.StringIO()
+            with patch("sys.argv", ["iree-lit-replace"]), patch(
+                "sys.stdin", MockStdin(json_input.encode("utf-8"))
+            ), patch("sys.stderr", captured_stderr):
+                args = iree_lit_replace.parse_arguments()
+                result = iree_lit_replace.main(args)
+
+            # Should fail with batch consistency error.
+            self.assertNotEqual(result, 0, "Should fail on conflicting RUN lines")
+
+            # Verify file was not modified.
+            file_content = tmp_path.read_text()
+            self.assertIn(
+                "@first_case", file_content, "Original content should be preserved"
+            )
+        finally:
+            tmp_path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_replace_integration.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_replace_integration.py
@@ -1,0 +1,1114 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Integration tests for iree-lit-replace with other tools.
+
+Tests multi-tool workflows and cross-tool consistency:
+- iree-lit-extract → iree-lit-replace round-trips
+- iree-lit-list → iree-lit-replace consistency
+- Cross-file operations
+- Batch stability
+- Complete workflows (extract → edit → replace → test)
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from test.test_helpers import run_python_module
+
+# Import the tools
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestExtractReplaceRoundTrip(unittest.TestCase):
+    """Tests for extract → replace → extract idempotency."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_round_trip_single_case(self):
+        """Test extract → replace (unchanged) → extract produces identical output."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Step 1: Extract case 2
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            original_content = extract_result.stdout
+
+            # Step 2: Replace with same content
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2"],
+                input=original_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Step 3: Extract again
+            extract2_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract2_result.returncode, 0)
+            final_content = extract2_result.stdout
+
+            # Verify identical
+            self.assertEqual(original_content, final_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_round_trip_multiple_cases_json(self):
+        """Test extract multiple → replace → extract with JSON."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Step 1: Extract cases 1,2,3 as JSON
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "1,2,3", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            original_json = extract_result.stdout
+            original_data = json.loads(original_json)
+
+            # Step 2: Replace all with same content (via JSON)
+            # Need to add file field to each replacement since extract doesn't include it
+            for case in original_data:
+                case["file"] = str(tmp_path)
+            modified_json = json.dumps(original_data)
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=modified_json,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Step 3: Extract again
+            extract2_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "1,2,3", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract2_result.returncode, 0)
+            final_data = json.loads(extract2_result.stdout)
+
+            # Verify content identical for each case
+            for orig, final in zip(original_data, final_data, strict=False):
+                self.assertEqual(orig["content"], final["content"])
+                self.assertEqual(orig["number"], final["number"])
+                self.assertEqual(orig["name"], final["name"])
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestCrossFileOperations(unittest.TestCase):
+    """Tests for cross-file moves and operations."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_from_a_replace_into_b(self):
+        """Test extracting from file A and replacing into file B."""
+        # Create two temp files
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_a:
+            tmp_a.write(self.split_test.read_text())
+            tmp_a_path = Path(tmp_a.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_b:
+            tmp_b.write(self.split_test.read_text())
+            tmp_b_path = Path(tmp_b.name)
+
+        try:
+            # Step 1: Extract case 2 from file A
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_a_path), "--case", "2", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            extracted = json.loads(extract_result.stdout)
+
+            # Step 2: Modify JSON to target file B, case 1
+            extracted[0]["file"] = str(tmp_b_path)
+            extracted[0]["number"] = 1
+            # Remove name to avoid mismatch (cross-file replacement).
+            if "name" in extracted[0]:
+                del extracted[0]["name"]
+            modified_json = json.dumps(extracted)
+
+            # Step 3: Replace into file B
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=modified_json,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Step 4: Verify file B case 1 now has content from file A case 2
+            extract_b_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_b_path), "--case", "1"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_b_result.returncode, 0)
+
+            # Content should match original file A case 2 content
+            self.assertIn("@second_case", extract_b_result.stdout)
+
+        finally:
+            tmp_a_path.unlink()
+            tmp_b_path.unlink()
+            for path in [tmp_a_path, tmp_b_path]:
+                backup = path.with_suffix(".mlir.bak")
+                if backup.exists():
+                    backup.unlink()
+
+    def test_move_multiple_cases_across_files(self):
+        """Test moving multiple cases from one file to another."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_a:
+            tmp_a.write(self.split_test.read_text())
+            tmp_a_path = Path(tmp_a.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_b:
+            tmp_b.write(self.split_test.read_text())
+            tmp_b_path = Path(tmp_b.name)
+
+        try:
+            # Extract cases 1,3 from file A
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_a_path), "--case", "1,3", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            extracted = json.loads(extract_result.stdout)
+
+            # Modify to target file B
+            for entry in extracted:
+                entry["file"] = str(tmp_b_path)
+
+            modified_json = json.dumps(extracted)
+
+            # Replace into file B
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=modified_json,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Verify file B now has the moved content
+            final_content = tmp_b_path.read_text()
+            self.assertIn("@first_case", final_content)
+            self.assertIn("@third_case", final_content)
+
+        finally:
+            tmp_a_path.unlink()
+            tmp_b_path.unlink()
+            for path in [tmp_a_path, tmp_b_path]:
+                backup = path.with_suffix(".mlir.bak")
+                if backup.exists():
+                    backup.unlink()
+
+
+class TestBatchStability(unittest.TestCase):
+    """Tests for batch replacement stability with varying content sizes."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_replace_with_varying_sizes(self):
+        """Test replacing cases with varying content sizes (larger and smaller)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Create replacements with different sizes
+            small = "// CHECK-LABEL: @small\nutil.func @small() { util.return }\n"
+            large = (
+                "// CHECK-LABEL: @large\n"
+                + "\n".join([f"// Line {i}" for i in range(50)])
+                + "\nutil.func @large() { util.return }\n"
+            )
+            medium = (
+                "// CHECK-LABEL: @medium\n"
+                + "\n".join([f"// Line {i}" for i in range(10)])
+                + "\nutil.func @medium() { util.return }\n"
+            )
+
+            # Replace cases 1, 2, 3 with varying sizes
+            batch = [
+                {"file": str(tmp_path), "number": 1, "content": large},  # Expand
+                {"file": str(tmp_path), "number": 2, "content": small},  # Shrink
+                {"file": str(tmp_path), "number": 3, "content": medium},  # Medium
+            ]
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=json.dumps(batch),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Verify all cases were replaced correctly
+            final_content = tmp_path.read_text()
+            self.assertIn("@small", final_content)
+            self.assertIn("@large", final_content)
+            self.assertIn("@medium", final_content)
+            self.assertIn("Line 49", final_content)  # From large replacement
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_replace_non_sequential_cases(self):
+        """Test replacing non-sequential cases (out of order)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replace cases in non-sequential order: 3, 1, 2
+            batch = [
+                {
+                    "file": str(tmp_path),
+                    "number": 3,
+                    "content": "// CHECK-LABEL: @third\nutil.func @third() { util.return }\n",
+                },
+                {
+                    "file": str(tmp_path),
+                    "number": 1,
+                    "content": "// CHECK-LABEL: @first\nutil.func @first() { util.return }\n",
+                },
+                {
+                    "file": str(tmp_path),
+                    "number": 2,
+                    "content": "// CHECK-LABEL: @second\nutil.func @second() { util.return }\n",
+                },
+            ]
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=json.dumps(batch),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Verify all cases replaced
+            final_content = tmp_path.read_text()
+            self.assertIn("@first", final_content)
+            self.assertIn("@second", final_content)
+            self.assertIn("@third", final_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestCompleteWorkflows(unittest.TestCase):
+    """Tests for complete end-to-end workflows."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_edit_validate_replace_workflow(self):
+        """Test complete workflow: extract → edit → validate → replace."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Step 1: Extract
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+
+            # Step 2: Edit content (create valid MLIR)
+            edited_content = """// CHECK-LABEL: @edited_workflow
+util.func @edited_workflow() {
+  util.return
+}
+"""
+
+            # Step 3: Validate with --verify flag
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--verify"],
+                input=edited_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Step 4: Verify replacement
+            final_content = tmp_path.read_text()
+            self.assertIn("@edited_workflow", final_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_extract_dry_run_confirm_replace_workflow(self):
+        """Test workflow: extract → edit → dry-run → confirm → replace."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Extract
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+
+            # Edit
+            edited_content = """// CHECK-LABEL: @dry_run_test
+util.func @dry_run_test() {
+  util.return
+}
+"""
+
+            # Dry-run to preview
+            dry_run_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--dry-run"],
+                input=edited_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(dry_run_result.returncode, 0)
+            self.assertIn("---", dry_run_result.stdout)  # Diff output
+            self.assertIn("@dry_run_test", dry_run_result.stdout)
+
+            # File should be unchanged after dry-run
+            original_content = self.split_test.read_text()
+            current_content = tmp_path.read_text()
+            self.assertEqual(original_content, current_content)
+
+            # Actually replace
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2"],
+                input=edited_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Verify final replacement
+            final_content = tmp_path.read_text()
+            self.assertIn("@dry_run_test", final_content)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestMultiToolConsistency(unittest.TestCase):
+    """Tests for consistency between different tools."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_json_schema_consistency_with_extract(self):
+        """Test that replace accepts exact output from extract."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Extract with --json
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+
+            # Add file field to extracted JSON since extract doesn't include it
+            extracted_data = json.loads(extract_result.stdout)
+            for case in extracted_data:
+                case["file"] = str(tmp_path)
+            modified_json = json.dumps(extracted_data)
+
+            # Replace directly with extract output (no modification)
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=modified_json,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # First replace may normalize whitespace. Extract again and verify
+            # second replace is idempotent.
+            extract_result2 = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2", "--json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result2.returncode, 0)
+
+            extracted_data2 = json.loads(extract_result2.stdout)
+            for case in extracted_data2:
+                case["file"] = str(tmp_path)
+            modified_json2 = json.dumps(extracted_data2)
+
+            replace_result2 = run_python_module(
+                "lit_tools.iree_lit_replace",
+                ["--mode", "json"],
+                input=modified_json2,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result2.returncode, 0)
+
+            # Second replace should be idempotent (no changes).
+            self.assertIn("no files modified", replace_result2.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+
+    def test_list_after_replace_preserves_structure(self):
+        """Test that list output is consistent before and after replace."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # List before
+            list_before = run_python_module(
+                "lit_tools.iree_lit_list",
+                [str(tmp_path)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(list_before.returncode, 0)
+
+            # Replace case 2 (no structural changes)
+            replace_content = """// CHECK-LABEL: @modified
+util.func @modified() {
+  util.return
+}
+"""
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2"],
+                input=replace_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # List after
+            list_after = run_python_module(
+                "lit_tools.iree_lit_list",
+                [str(tmp_path)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(list_after.returncode, 0)
+
+            # Case count should be same
+            before_lines = [
+                line for line in list_before.stdout.splitlines() if "Test case" in line
+            ]
+            after_lines = [
+                line for line in list_after.stdout.splitlines() if "Test case" in line
+            ]
+            self.assertEqual(len(before_lines), len(after_lines))
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestConcurrencyProtection(unittest.TestCase):
+    """Tests for --fail-if-changed concurrency protection."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_fail_if_changed_detects_modification(self):
+        """Test that --fail-if-changed aborts when file is modified during replacement."""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Start replacement with --fail-if-changed
+            # We'll simulate modification by touching the file between parse and write
+            # Since this is an integration test, we test the flag works at all
+            # (unit tests would test the actual modification detection logic)
+
+            # First: successful replacement without modification
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--fail-if-changed"],
+                input="// Modified content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # For actual concurrent modification test, we'd need to modify the file
+            # during replacement, which is hard to do in an integration test.
+            # The unit tests cover the actual detection logic.
+            # Here we just verify the flag is accepted and doesn't break normal operation.
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_fail_if_changed_success_when_unchanged(self):
+        """Test that --fail-if-changed succeeds when file is not modified."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp.write(self.split_test.read_text())
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Replace with --fail-if-changed should succeed normally
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--fail-if-changed"],
+                input="// Modified content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+            self.assertIn("replaced successfully", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+class TestJsonOutput(unittest.TestCase):
+    """Tests for --json-output FILE feature."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_json_output_to_file(self):
+        """Test that --json-output writes JSON to file instead of stdout."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as tmp_json:
+            json_path = Path(tmp_json.name)
+
+        try:
+            # Replace with --json-output
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--json-output", str(json_path)],
+                input="// Modified content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Stdout should be empty (output went to file)
+            self.assertEqual(replace_result.stdout.strip(), "")
+
+            # JSON file should contain valid JSON
+            self.assertTrue(json_path.exists())
+            json_content = json_path.read_text()
+            json_data = json.loads(json_content)
+
+            # Verify JSON structure
+            self.assertIn("modified_files", json_data)
+            self.assertIn("modified_cases", json_data)
+            self.assertEqual(json_data["modified_files"], 1)
+            self.assertEqual(json_data["modified_cases"], 1)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+            if json_path.exists():
+                json_path.unlink()
+
+    def test_json_output_implies_json_mode(self):
+        """Test that --json-output automatically enables --json."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as tmp_json:
+            json_path = Path(tmp_json.name)
+
+        try:
+            # Use --json-output without --json flag
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2", "--json-output", str(json_path)],
+                input="// Modified content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # JSON should still be written to file
+            self.assertTrue(json_path.exists())
+            json_data = json.loads(json_path.read_text())
+            self.assertIn("modified_files", json_data)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+            if json_path.exists():
+                json_path.unlink()
+
+    def test_json_output_with_dry_run(self):
+        """Test that --json-output works with --dry-run."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as tmp_json:
+            json_path = Path(tmp_json.name)
+
+        try:
+            # Dry-run with --json-output
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [
+                    str(tmp_path),
+                    "--case",
+                    "2",
+                    "--dry-run",
+                    "--json-output",
+                    str(json_path),
+                ],
+                input="// Modified content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # JSON output should include dry_run flag and diff
+            json_data = json.loads(json_path.read_text())
+            self.assertIn("file_results", json_data)
+            self.assertTrue(json_data["dry_run"])
+            self.assertTrue(len(json_data["file_results"]) > 0)
+            file_result = json_data["file_results"][0]
+            self.assertTrue(file_result.get("dry_run", False))
+            self.assertIn("diff", file_result)
+
+        finally:
+            tmp_path.unlink()
+            # Dry-run shouldn't create backup
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+            if json_path.exists():
+                json_path.unlink()
+
+
+class TestDuplicateHandling(unittest.TestCase):
+    """Tests for duplicate case name and entry handling (Phase 1 validation)."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_json_name_number_mismatch(self):
+        """Test that JSON with both 'number' and 'name' pointing to different cases errors."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            # Create JSON with mismatched number and name.
+            # split_test.mlir has 3 cases - case 1 and case 2 have different names
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 1,
+                        "name": "second_case",  # This is actually case 2's name
+                        "content": "// Test content\nutil.func @test() { util.return }\n",
+                    }
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [],
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should error
+            self.assertNotEqual(replace_result.returncode, 0)
+            self.assertIn("name/number mismatch", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_json_name_number_match(self):
+        """Test that JSON with both 'number' and 'name' pointing to same case succeeds."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            # Create JSON with matching number and name (case 2 is "second_case")
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "name": "second_case",  # Correct match
+                        "content": "// Test content\nutil.func @test() { util.return }\n",
+                    }
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [],
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should succeed
+            self.assertEqual(replace_result.returncode, 0)
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+    def test_text_duplicate_name_error(self):
+        """Test that text mode with duplicate case names errors with disambiguation."""
+        # Create a file with duplicate case names
+        duplicate_content = """// RUN: iree-opt %s
+
+// CHECK-LABEL: @duplicate
+util.func @duplicate() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @duplicate
+util.func @duplicate() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @unique
+util.func @unique() {
+  util.return
+}
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(duplicate_content)
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--name", "duplicate"],
+                input="// New content\nutil.func @test() { util.return }\n",
+                capture_output=True,
+                text=True,
+            )
+
+            # Should error with case numbers
+            self.assertNotEqual(replace_result.returncode, 0)
+            self.assertIn("multiple cases named", replace_result.stderr.lower())
+            self.assertIn("--case number", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_duplicate_name_error(self):
+        """Test that JSON mode with duplicate case names errors."""
+        # Create a file with duplicate case names
+        duplicate_content = """// RUN: iree-opt %s
+
+// CHECK-LABEL: @duplicate
+util.func @duplicate() {
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @duplicate
+util.func @duplicate() {
+  util.return
+}
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(duplicate_content)
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "name": "duplicate",
+                        "content": "// New content\nutil.func @test() { util.return }\n",
+                    }
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [],
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should error
+            self.assertNotEqual(replace_result.returncode, 0)
+            self.assertIn("multiple cases", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_duplicate_entries_by_number(self):
+        """Test that JSON with duplicate entries for same case number errors."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            # Two entries for case 2
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// First replacement\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "number": 2,
+                        "content": "// Second replacement\n",
+                    },
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [],
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should error
+            self.assertNotEqual(replace_result.returncode, 0)
+            self.assertIn("duplicate replacement", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+
+    def test_json_duplicate_entries_by_name(self):
+        """Test that JSON with duplicate entries for same case name errors."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            # Two entries for "second_case"
+            json_input = json.dumps(
+                [
+                    {
+                        "file": str(tmp_path),
+                        "name": "second_case",
+                        "content": "// First replacement\n",
+                    },
+                    {
+                        "file": str(tmp_path),
+                        "name": "second_case",
+                        "content": "// Second replacement\n",
+                    },
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [],
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should error
+            self.assertNotEqual(replace_result.returncode, 0)
+            self.assertIn("duplicate replacement", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+
+
+class TestCLIOverrideWarning(unittest.TestCase):
+    """Tests for CLI file override warning (Phase 2 UX)."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_cli_file_override_warning(self):
+        """Test that warning appears when CLI file overrides JSON file field."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp_mlir:
+            tmp_mlir.write(self.split_test.read_text())
+            tmp_path = Path(tmp_mlir.name)
+
+        try:
+            # JSON specifies different file, but CLI overrides it
+            json_input = json.dumps(
+                [
+                    {
+                        "file": "original_file.mlir",  # This will be overridden
+                        "number": 2,
+                        "content": "// Test content\nutil.func @test() { util.return }\n",
+                    }
+                ]
+            )
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path)],  # CLI file override
+                input=json_input,
+                capture_output=True,
+                text=True,
+            )
+
+            # Should succeed with warning
+            self.assertEqual(replace_result.returncode, 0)
+            self.assertIn("overriding", replace_result.stderr.lower())
+
+        finally:
+            tmp_path.unlink()
+            backup = tmp_path.with_suffix(".mlir.bak")
+            if backup.exists():
+                backup.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_test_cli.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_test_cli.py
@@ -1,0 +1,805 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""CLI tests for iree_lit_test with mocked execution.
+
+We avoid invoking real tools by stubbing lit_wrapper.run_lit_on_case.
+"""
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lit_tools import iree_lit_test
+from lit_tools.core.lit_wrapper import LitResult
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestCLIJSON(unittest.TestCase):
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_json_shape_minimal(self, mock_stdout, mock_run):
+        # Two cases: 1 pass, 1 fail
+        mock_run.side_effect = [
+            LitResult(True, 1, "first_case", 0.12, "out1", "", None, []),
+            LitResult(False, 2, "second_case", 0.34, "out2", "", "fail", ["cmd"]),
+        ]
+
+        with patch("sys.argv", ["iree-lit-test", str(self.split_test), "--json"]):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 1)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertEqual(payload["total_cases"], 2)
+        self.assertEqual(payload["passed"], 1)
+        self.assertEqual(payload["failed"], 1)
+        self.assertIn("results", payload)
+        self.assertIsNone(payload["results"][0].get("output"))
+        self.assertEqual(payload["results"][1]["run_commands"], ["cmd"])
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_json_full_includes_output(self, mock_stdout, mock_run):
+        mock_run.return_value = LitResult(
+            False, 1, "first_case", 0.12, "out1", "", "fail", []
+        )
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.split_test),
+                "--case",
+                "1",
+                "--json",
+                "--full-json",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 1)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertIn("output", payload["results"][0])
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_json_verbose_purity(self, mock_run):
+        # Even with verbose=True, when --json is set, stdout must be pure JSON.
+        mock_run.return_value = LitResult(
+            True, 1, "first_case", 0.12, "VERBOSE OUT", "", None, []
+        )
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.split_test),
+                "--case",
+                "1",
+                "--verbose",
+                "--json",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            rc = iree_lit_test.main(args)
+        self.assertIn('"results"', out.getvalue())
+        self.assertNotIn("VERBOSE OUT", out.getvalue())
+        self.assertEqual(rc, 0)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_filter_and_workers(self, mock_run):
+        # Three cases, only second matches filter; with workers=2 ensure only one run occurs
+        mock_run.return_value = LitResult(
+            True, 2, "second_case", 0.01, "out", "", None, []
+        )
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.split_test),
+                "--filter",
+                "second",
+                "--workers",
+                "2",
+                "--quiet",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, 1)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_workers_stop_on_first_failure(self, mock_run):
+        # side effects for all 3 cases (even though we break after first failure)
+        mock_run.side_effect = [
+            LitResult(False, 1, "first", 0.01, "out", "", "fail", []),
+            LitResult(True, 2, "second", 0.01, "out", "", None, []),
+            LitResult(True, 3, "third", 0.01, "out", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.split_test), "--workers", "2", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 1)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_json_output_file(self, mock_run):
+        mock_run.return_value = LitResult(
+            True, 1, "first_case", 0.12, "out1", "", None, []
+        )
+
+        with NamedTemporaryFile("r+", suffix=".json", delete=False) as tmp:
+            out = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-test",
+                    str(self.split_test),
+                    "--case",
+                    "1",
+                    "--json",
+                    "--json-output",
+                    str(out),
+                    "--quiet",
+                ],
+            ):
+                args = iree_lit_test.parse_arguments()
+
+            rc = iree_lit_test.main(args)
+            self.assertEqual(rc, 0)
+            data = json.loads(out.read_text())
+            self.assertEqual(data["passed"], 1)
+        finally:
+            out.unlink()
+
+
+class TestMultipleCaseSelection(unittest.TestCase):
+    """Tests for multiple --case selection (comma, ranges, multiple flags)."""
+
+    def setUp(self):
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_multiple_case_comma_separated(self, mock_run):
+        """Test --case with comma-separated values."""
+        mock_run.side_effect = [
+            LitResult(True, 1, "case_one", 0.1, "", "", None, []),
+            LitResult(True, 3, "case_three", 0.1, "", "", None, []),
+            LitResult(True, 5, "case_five", 0.1, "", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--case", "1,3,5", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        # Verify run_lit_on_case was called 3 times.
+        self.assertEqual(mock_run.call_count, 3)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_multiple_case_flags(self, mock_run):
+        """Test multiple --case flags."""
+        mock_run.side_effect = [
+            LitResult(True, 2, "case_two", 0.1, "", "", None, []),
+            LitResult(True, 4, "case_four", 0.1, "", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--case",
+                "2",
+                "--case",
+                "4",
+                "--quiet",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_case_range(self, mock_run):
+        """Test --case with range syntax."""
+        mock_run.side_effect = [
+            LitResult(True, 1, "case_one", 0.1, "", "", None, []),
+            LitResult(True, 2, "case_two", 0.1, "", "", None, []),
+            LitResult(True, 3, "case_three", 0.1, "", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--case", "1-3", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, 3)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_case_mixed_comma_and_range(self, mock_run):
+        """Test --case with mixed comma and range."""
+        mock_run.side_effect = [
+            LitResult(True, 1, "case_one", 0.1, "", "", None, []),
+            LitResult(True, 3, "case_three", 0.1, "", "", None, []),
+            LitResult(True, 4, "case_four", 0.1, "", "", None, []),
+            LitResult(True, 5, "case_five", 0.1, "", "", None, []),
+            LitResult(True, 7, "case_seven", 0.1, "", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--case", "1,3-5,7", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, 5)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_case_not_found_in_multi(self, mock_stderr):
+        """Test that error is reported when one case in multi-case doesn't exist."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--case", "1,99"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)  # NOT_FOUND exit code.
+        self.assertIn("Case 99 not found", mock_stderr.getvalue())
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_case_invalid_format(self, mock_stderr):
+        """Test that error is reported for invalid --case format."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--case", "abc"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)  # NOT_FOUND exit code.
+        self.assertIn("Invalid case number", mock_stderr.getvalue())
+
+
+class TestListMode(unittest.TestCase):
+    """Tests for --list mode."""
+
+    def setUp(self):
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_shows_all_cases(self, mock_stdout):
+        """Test that --list shows all cases."""
+        with patch("sys.argv", ["iree-lit-test", str(self.ten_cases), "--list"]):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        # Verify header and all 10 cases are listed.
+        self.assertIn("ten_cases_test.mlir: 10 test cases", output)
+        for i in range(1, 11):
+            self.assertIn(f"{i}:", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_ignores_case_filter(self, mock_stdout):
+        """Test that --list ignores --case filter and shows all cases."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--case",
+                "1",
+                "--case",
+                "3",
+                "--list",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        # All 10 cases should still be listed.
+        self.assertIn("10 test cases", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_json_output(self, mock_stdout):
+        """Test --list with --json outputs JSON."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--list", "--json"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertEqual(payload["count"], 10)
+        self.assertEqual(len(payload["cases"]), 10)
+        self.assertEqual(payload["cases"][0]["number"], 1)
+        self.assertEqual(payload["cases"][0]["name"], "case_one")
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_list_quiet_suppresses_header(self, mock_stdout):
+        """Test --list with --quiet suppresses header."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--list", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stdout.getvalue()
+        # Header should be suppressed.
+        self.assertNotIn("ten_cases_test.mlir:", output)
+        # But cases should still be listed.
+        self.assertIn("1:", output)
+
+
+class TestDryRunMode(unittest.TestCase):
+    """Tests for --dry-run mode."""
+
+    def setUp(self):
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_dry_run_shows_all_cases(self, mock_stderr):
+        """Test that --dry-run shows all cases without executing."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--dry-run"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        # Verify all 10 cases are listed (note goes to stderr).
+        for i in range(1, 11):
+            self.assertIn(f"Case {i}", output)
+            self.assertIn(f"[{i}]", output)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_dry_run_with_case_filter(self, mock_stderr):
+        """Test --dry-run with --case filter."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--case",
+                "1",
+                "--case",
+                "3",
+                "--case",
+                "5",
+                "--dry-run",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        # Verify selected cases are listed.
+        self.assertIn("Case 1", output)
+        self.assertIn("Case 3", output)
+        self.assertIn("Case 5", output)
+        # Should not include other cases.
+        self.assertNotIn("Case 2", output)
+        self.assertNotIn("Case 4", output)
+        # Verify numbering is correct ([1], [2], [3] not [1], [3], [5]).
+        self.assertIn("[1] Case 1", output)
+        self.assertIn("[2] Case 3", output)
+        self.assertIn("[3] Case 5", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_dry_run_json_output(self, mock_stdout):
+        """Test --dry-run with --json."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--case",
+                "1-3",
+                "--dry-run",
+                "--json",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        payload = json.loads(mock_stdout.getvalue())
+        self.assertEqual(payload["total_cases"], 3)
+        self.assertEqual(len(payload["selected_cases"]), 3)
+        self.assertEqual(payload["selected_cases"][0]["number"], 1)
+        self.assertEqual(payload["selected_cases"][1]["number"], 2)
+        self.assertEqual(payload["selected_cases"][2]["number"], 3)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_dry_run_quiet_suppresses_note(self, mock_stderr):
+        """Test --dry-run with --quiet suppresses note but shows cases."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--case",
+                "1",
+                "--case",
+                "2",
+                "--dry-run",
+                "--quiet",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        # With --quiet, all note() calls are suppressed, so output should be empty.
+        self.assertEqual(output, "")
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_dry_run_with_filter(self, mock_stderr):
+        """Test --dry-run with --filter."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--filter",
+                "five|seven",
+                "--dry-run",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        # Verify filtered cases are listed.
+        self.assertIn("@case_five", output)
+        self.assertIn("@case_seven", output)
+        # Should only have 2 cases (count lines with "[N]" pattern).
+        lines = [line for line in output.split("\n") if "  [" in line and "]" in line]
+        self.assertEqual(len(lines), 2)
+
+
+class TestFilterAndFilterOut(unittest.TestCase):
+    """Tests for --filter and --filter-out regex filtering."""
+
+    def setUp(self):
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_filter_only(self, mock_run):
+        """Test --filter to include only matching cases."""
+        # Mock for cases matching "five|seven".
+        mock_run.side_effect = [
+            LitResult(True, 5, "case_five", 0.1, "", "", None, []),
+            LitResult(True, 7, "case_seven", 0.1, "", "", None, []),
+        ]
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--filter", "five|seven", "--quiet"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_filter_out_only(self, mock_run):
+        """Test --filter-out to exclude matching cases."""
+        # All 10 cases except those with "five|seven" should run (8 cases).
+        mock_run.return_value = LitResult(True, 1, "case_one", 0.1, "", "", None, [])
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--filter-out",
+                "five|seven",
+                "--quiet",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        # Should run 8 cases (10 total - 2 excluded).
+        self.assertEqual(mock_run.call_count, 8)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    def test_filter_and_filter_out_combined(self, mock_run):
+        """Test --filter and --filter-out combined."""
+        # All cases contain "e" in "case_" (10 total), then exclude "five|seven" (2 cases).
+        mock_run.return_value = LitResult(True, 1, "case_one", 0.1, "", "", None, [])
+
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--filter",
+                "e",
+                "--filter-out",
+                "five|seven",
+                "--quiet",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        # Should run: all except five and seven (8 cases).
+        self.assertEqual(mock_run.call_count, 8)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_filter_no_matches(self, mock_stderr):
+        """Test --filter with no matches returns error."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--filter", "nonexistent_pattern"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("No cases matched --filter", mock_stderr.getvalue())
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_filter_out_excludes_all(self, mock_stderr):
+        """Test --filter-out that excludes all cases returns error."""
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten_cases), "--filter-out", "case_"],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("All cases excluded by --filter-out", mock_stderr.getvalue())
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_filter_out_with_dry_run(self, mock_stderr):
+        """Test --filter-out with --dry-run."""
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(self.ten_cases),
+                "--filter-out",
+                "five|seven",
+                "--dry-run",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        # Should list 8 cases (all except five and seven).
+        self.assertNotIn("@case_five", output)
+        self.assertNotIn("@case_seven", output)
+        self.assertIn("@case_one", output)
+        self.assertIn("@case_two", output)
+
+
+class MockStdin:
+    """Mock stdin object with buffer attribute for testing."""
+
+    def __init__(self, content: bytes, is_tty: bool = False):
+        """Initialize with binary content."""
+        self.buffer = io.BytesIO(content)
+        self._is_tty = is_tty
+        self._content = content
+
+    def isatty(self) -> bool:
+        """Return whether this is a TTY (default: False for piped input)."""
+        return self._is_tty
+
+    def read(self) -> str:
+        """Read all content and return as string."""
+        return self._content.decode("utf-8")
+
+
+class TestStdinMode(unittest.TestCase):
+    """Tests for stdin mode with mocked lit execution."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.simple_test = _FIXTURES_DIR / "simple_test.mlir"
+        self.edge_cases = _FIXTURES_DIR / "edge_cases_test.mlir"
+        self.with_case_runs = _FIXTURES_DIR / "with_case_runs.mlir"
+        self.no_run = _FIXTURES_DIR / "no_run_test.mlir"
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stdin", MockStdin(b"func.func @test() { return }"))
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_basic_echo_pipe(self, mock_run):
+        """Test basic stdin input with simple IR."""
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        args = iree_lit_test.parse_arguments()
+        rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(mock_run.called)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_with_existing_run_lines(self, mock_run):
+        """Test stdin with RUN lines already present in input."""
+        ir_with_run = b"// RUN: iree-opt %s\nfunc.func @test() { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_with_run)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stderr", new_callable=io.StringIO)
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_no_run_defaults_to_ireeopt(self, mock_stderr, mock_run):
+        """Test stdin without RUN lines defaults to iree-opt %s."""
+        ir_no_run = b"func.func @test() { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_no_run)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("defaulting to: iree-opt %s", mock_stderr.getvalue())
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.argv", ["iree-lit-test", "--run", "iree-opt --canonicalize %s"])
+    def test_stdin_run_flag_override(self, mock_run):
+        """Test --run flag overrides RUN lines in stdin."""
+        ir_with_run = b"// RUN: iree-opt %s\nfunc.func @test() { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_with_run)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+        # Verify --run was used (RUN override worked).
+        self.assertTrue(mock_run.called)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_empty_input_errors(self, mock_stderr):
+        """Test empty stdin input produces error."""
+        with patch("sys.stdin", MockStdin(b"")):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 1)
+        self.assertIn("No input provided", mock_stderr.getvalue())
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_special_chars_single_quotes(self, mock_run):
+        """Test stdin with single quotes in attributes."""
+        # Case 1 from edge_cases_test.mlir
+        ir_content = b"func.func @test() attributes {foo = 'bar'} { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_content)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_special_chars_double_quotes(self, mock_run):
+        """Test stdin with double quotes in string literals."""
+        ir_content = b'util.global @str = "escaped\\"quote" : !util.buffer'
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_content)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_special_chars_unicode(self, mock_run):
+        """Test stdin with unicode characters."""
+        ir_content = "// 日本語テスト\nfunc.func @test() { return }".encode()
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_content)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stderr", new_callable=io.StringIO)
+    @patch("sys.argv", ["iree-lit-test"])
+    def test_stdin_tty_detection_shows_prompt(self, mock_stderr, mock_run):
+        """Test TTY detection shows prompt message."""
+        ir_content = b"func.func @test() { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_content, is_tty=True)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        self.assertIn("Reading test input from stdin", output)
+        self.assertIn("Ctrl-D to finish", output)
+
+    @patch("lit_tools.iree_lit_test.lit_wrapper.run_lit_on_case")
+    @patch("sys.stderr", new_callable=io.StringIO)
+    @patch("sys.argv", ["iree-lit-test", "--quiet"])
+    def test_stdin_quiet_suppresses_prompt(self, mock_stderr, mock_run):
+        """Test --quiet suppresses TTY prompt."""
+        ir_content = b"func.func @test() { return }"
+        mock_run.return_value = LitResult(True, 1, None, 0.1, "out", "", None, [])
+
+        with patch("sys.stdin", MockStdin(ir_content, is_tty=True)):
+            args = iree_lit_test.parse_arguments()
+            rc = iree_lit_test.main(args)
+
+        self.assertEqual(rc, 0)
+        output = mock_stderr.getvalue()
+        self.assertNotIn("Reading test input from stdin", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_test_integration.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_test_integration.py
@@ -1,0 +1,475 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Integration tests for iree-lit-test that actually run lit (not mocked).
+
+These tests require:
+- LLVM lit to be importable
+- IREE build directory with iree-opt and FileCheck
+
+Tests are automatically skipped if dependencies are unavailable.
+"""
+
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stderr, redirect_stdout, suppress
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from common import build_detection
+from lit_tools import iree_lit_test
+from lit_tools.core import lit_wrapper
+from lit_tools.core.parser import parse_test_file
+
+from test.test_helpers import run_python_module
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestIntegrationBasic(unittest.TestCase):
+    """Basic end-to-end integration tests."""
+
+    def setUp(self):
+        """Set up test fixtures and skip if dependencies unavailable."""
+        # Check if lit is importable.
+        try:
+            lit_wrapper._ensure_lit_importable()
+        except Exception:
+            self.skipTest("lit not importable in this environment")
+
+        # Check if build directory is available.
+        try:
+            self.build_dir = build_detection.detect_build_dir()
+        except FileNotFoundError:
+            self.skipTest("Build directory not available (set IREE_BUILD_DIR)")
+
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_basic_passing_case(self):
+        """Run a simple passing test case end-to-end through lit pipeline."""
+        # Parse test file to get cases.
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+        self.assertGreater(len(cases), 0, "split_test.mlir should have test cases")
+
+        # Run first case (known to pass).
+        result = lit_wrapper.run_lit_on_case(
+            case=cases[0],
+            test_file_obj=test_file_obj,
+            build_dir=self.build_dir,
+            timeout=60,
+            extra_flags=None,
+            verbose=False,
+            keep_temps=False,
+        )
+
+        # Verify results.
+        self.assertTrue(result.passed, f"Test should pass but failed: {result.stderr}")
+        self.assertEqual(result.case_number, 1)
+        self.assertGreater(result.duration, 0, "Duration should be positive")
+        self.assertIsNotNone(result.case_name)
+
+    def test_keep_temps_preserves_file(self):
+        """Verify --keep-temps actually keeps temp files."""
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+
+        # Capture stdout to get "Temp file kept:" message.
+        stdout_capture = io.StringIO()
+
+        with redirect_stdout(stdout_capture):
+            # Run with keep_temps=True and verbose to see temp file message.
+            result = lit_wrapper.run_lit_on_case(
+                case=cases[0],
+                test_file_obj=test_file_obj,
+                build_dir=self.build_dir,
+                timeout=60,
+                extra_flags=None,
+                verbose=True,
+                keep_temps=True,
+            )
+
+        # Verify test passed.
+        self.assertTrue(result.passed, f"Test should pass: {result.stderr}")
+
+        captured_output = stdout_capture.getvalue()
+
+        # Extract temp file path from captured stdout.
+        # Message format: "Temp file kept: <path>"
+        temp_file_match = re.search(r"Temp file kept: (.+\.mlir)", captured_output)
+
+        if not temp_file_match:
+            # Fallback: construct expected temp directory using same logic as lit_wrapper.
+            temp_dir = Path(os.environ.get("TMPDIR", tempfile.gettempdir()))
+            temp_root = temp_dir / f"iree_lit_test_{os.getpid()}"
+
+            # Find .mlir files in temp directory.
+            if temp_root.exists():
+                mlir_files = list(temp_root.glob("case*.mlir"))
+                self.assertGreater(
+                    len(mlir_files),
+                    0,
+                    f"Should find temp file in {temp_root}",
+                )
+                temp_file = mlir_files[0]
+            else:
+                self.fail(
+                    f"Could not find temp file. Captured output:\n{captured_output}\n"
+                    f"Expected temp dir: {temp_root}"
+                )
+        else:
+            temp_file = Path(temp_file_match.group(1))
+
+        self.assertTrue(
+            temp_file.exists(),
+            f"Temp file should exist with keep_temps=True: {temp_file}",
+        )
+
+        # Verify file contains test content.
+        content = temp_file.read_text()
+        self.assertIn("util.func", content, "Temp file should contain test content")
+
+        # Clean up.
+        temp_file.unlink()
+        # Try to clean up parent directory if empty.
+        with suppress(OSError):  # Directory not empty, that's fine.
+            temp_file.parent.rmdir()
+
+    def test_multiline_run_with_extra_flags(self):
+        """Verify --extra-flags works with multi-line RUN directives."""
+        # split_test.mlir has a 3-line RUN directive.
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+
+        # Run with extra flags (use a harmless flag that shouldn't break test).
+        result = lit_wrapper.run_lit_on_case(
+            case=cases[0],
+            test_file_obj=test_file_obj,
+            build_dir=self.build_dir,
+            timeout=60,
+            extra_flags="--mlir-print-debuginfo",
+            verbose=False,
+            keep_temps=False,
+        )
+
+        # Should still pass (flag doesn't break the test).
+        self.assertTrue(
+            result.passed,
+            f"Test should pass with extra flags, but failed: {result.stderr}",
+        )
+
+    def test_filecheck_line_numbers_match_lit(self):
+        """Verify FileCheck error line numbers match between lit and iree-lit-test.
+
+        This tests the core line number preservation feature - errors reported
+        by FileCheck should show the same line numbers whether running via
+        raw lit or iree-lit-test (which extracts cases to temp files with
+        blank line padding).
+        """
+        # Use filecheck_error_test.mlir which is designed to fail.
+        error_test = _FIXTURES_DIR / "filecheck_error_test.mlir"
+
+        # Helper to extract first error line number from output.
+        def first_error_line(text):
+            m = re.search(r"\.mlir:(\d+):\d+:\s+error:", text)
+            return int(m.group(1)) if m else None
+
+        # 1) Run raw LLVM lit on the original file.
+        try:
+            from lit import (  # noqa: PLC0415 (deferred import for availability check)
+                main as lit_main,
+            )
+        except Exception:
+            self.skipTest("lit main not importable")
+
+        saved_argv = sys.argv
+        out_io, err_io = io.StringIO(), io.StringIO()
+        try:
+            sys.argv = ["lit", str(error_test), "-v"]
+            with redirect_stdout(out_io), redirect_stderr(err_io), suppress(SystemExit):
+                lit_main.main({})
+        finally:
+            sys.argv = saved_argv
+
+        lit_output = out_io.getvalue() + "\n" + err_io.getvalue()
+        lit_line = first_error_line(lit_output)
+        self.assertIsNotNone(lit_line, "lit should report an error line number")
+
+        # 2) Run iree-lit-test on case 2 with full JSON output.
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-test",
+                str(error_test),
+                "--case",
+                "2",
+                "--json",
+                "--full-json",
+            ],
+        ):
+            args = iree_lit_test.parse_arguments()
+
+        out_json = io.StringIO()
+        with redirect_stdout(out_json):
+            rc = iree_lit_test.main(args)
+
+        # Test should fail.
+        self.assertNotEqual(rc, 0, "filecheck_error_test.mlir should fail")
+
+        # Parse JSON and extract error line from failing case.
+        payload = json.loads(out_json.getvalue())
+        iree_lit_line = None
+        for r in payload["results"]:
+            if not r["passed"]:
+                iree_lit_line = first_error_line(r.get("output", ""))
+                break
+
+        self.assertIsNotNone(
+            iree_lit_line,
+            "iree-lit-test should report an error line number",
+        )
+
+        # 3) Compare - line numbers should match.
+        self.assertEqual(
+            iree_lit_line,
+            lit_line,
+            f"Line numbers should match between lit ({lit_line}) "
+            f"and iree-lit-test ({iree_lit_line})",
+        )
+
+
+class TestIntegrationParallel(unittest.TestCase):
+    """Parallel execution integration tests."""
+
+    def setUp(self):
+        """Set up test fixtures and skip if dependencies unavailable."""
+        # Check if lit is importable.
+        try:
+            lit_wrapper._ensure_lit_importable()
+        except Exception:
+            self.skipTest("lit not importable in this environment")
+
+        # Check if build directory is available.
+        try:
+            self.build_dir = build_detection.detect_build_dir()
+        except FileNotFoundError:
+            self.skipTest("Build directory not available (set IREE_BUILD_DIR)")
+
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_workers_actually_run_parallel(self):
+        """Verify --workers N runs faster than sequential execution.
+
+        This is a timing-based test with conservative threshold to avoid flakiness.
+        """
+        test_file_obj = parse_test_file(self.split_test)
+        cases = list(test_file_obj.cases)
+        if len(cases) < 3:
+            self.skipTest("Need at least 3 test cases for meaningful parallel test")
+
+        # Run first 3 cases sequentially (workers=1).
+        start_time = time.time()
+        sequential_results = []
+        for case in cases[:3]:
+            result = lit_wrapper.run_lit_on_case(
+                case=case,
+                test_file_obj=test_file_obj,
+                build_dir=self.build_dir,
+                timeout=60,
+                extra_flags=None,
+                verbose=False,
+                keep_temps=False,
+            )
+            sequential_results.append(result)
+        sequential_duration = time.time() - start_time
+
+        # All should pass.
+        for result in sequential_results:
+            self.assertTrue(result.passed, f"Sequential test failed: {result.stderr}")
+
+        # Run same 3 cases in parallel (workers=3).
+        start_time = time.time()
+        parallel_results = []
+
+        def run_case(case):
+            return lit_wrapper.run_lit_on_case(
+                case=case,
+                test_file_obj=test_file_obj,
+                build_dir=self.build_dir,
+                timeout=60,
+                extra_flags=None,
+                verbose=False,
+                keep_temps=False,
+            )
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [executor.submit(run_case, case) for case in cases[:3]]
+            parallel_results = [f.result() for f in futures]
+
+        parallel_duration = time.time() - start_time
+
+        # All should pass.
+        for result in parallel_results:
+            self.assertTrue(result.passed, f"Parallel test failed: {result.stderr}")
+
+        # Verify parallel execution is faster than sequential.
+        # Use conservative threshold (1.5x speedup) to avoid flaky failures.
+        # This accounts for overhead, scheduling variance, and single-core systems.
+        speedup_threshold = 0.67  # Parallel should take <=67% of sequential time.
+
+        # Only assert if both runs took measurable time (>0.1s).
+        if sequential_duration > 0.1 and parallel_duration > 0.1:
+            speedup_ratio = parallel_duration / sequential_duration
+            self.assertLess(
+                speedup_ratio,
+                speedup_threshold,
+                f"Parallel execution should be faster. "
+                f"Sequential: {sequential_duration:.2f}s, "
+                f"Parallel: {parallel_duration:.2f}s, "
+                f"Ratio: {speedup_ratio:.2f} (expected <{speedup_threshold})",
+            )
+        else:
+            # Tests ran too fast to measure speedup reliably.
+            # Just verify parallel execution completed without error.
+            self.assertGreater(
+                len(parallel_results),
+                0,
+                "Parallel execution completed successfully",
+            )
+
+
+class TestStdinIntegration(unittest.TestCase):
+    """Integration tests for stdin mode with real lit execution."""
+
+    def setUp(self):
+        self.edge_cases = _FIXTURES_DIR / "edge_cases_test.mlir"
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    def test_stdin_from_subprocess_echo(self):
+        """Test stdin input from echo via subprocess."""
+        ir_content = "func.func @test() { return }"
+
+        result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("1 test case(s) passed", result.stderr)
+
+    def test_stdin_from_subprocess_cat(self):
+        """Test stdin input from file content via subprocess."""
+        # Read edge case 1 (single quotes).
+        with open(self.edge_cases) as f:
+            lines = f.readlines()
+        # Extract case 1: lines up to first separator.
+        case_1_lines = []
+        for line in lines:
+            if "// -----" in line:
+                break
+            case_1_lines.append(line)
+        ir_content = "".join(case_1_lines)
+
+        result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_stdin_with_run_override(self):
+        """Test stdin with --run flag override."""
+        ir_content = "func.func @test() { return }"
+
+        result = run_python_module(
+            "lit_tools.iree_lit_test",
+            ["--run", "iree-opt --split-input-file %s"],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_stdin_unicode_handling(self):
+        """Test stdin with unicode characters."""
+        ir_content = "// 日本語テスト\nfunc.func @test() { return }"
+
+        result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_stdin_long_input(self):
+        """Test stdin with large multi-case file content."""
+        # Use entire ten_cases_test.mlir as stdin.
+        with open(self.ten_cases) as f:
+            ir_content = f.read()
+
+        result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        # Should process all 10 cases.
+        self.assertIn("10 test case(s) passed", result.stderr)
+
+    def test_stdin_edge_cases_all_special_chars(self):
+        """Test all edge cases from edge_cases_test.mlir via stdin."""
+        for case_num in range(1, 6):
+            with self.subTest(case=case_num):
+                # Extract each case individually.
+                extract_result = run_python_module(
+                    "lit_tools.iree_lit_extract",
+                    [str(self.edge_cases), "--case", str(case_num)],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(extract_result.returncode, 0)
+
+                # Pass extracted case to stdin of iree-lit-test.
+                test_result = run_python_module(
+                    "lit_tools.iree_lit_test",
+                    [],
+                    input=extract_result.stdout,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(
+                    test_result.returncode,
+                    0,
+                    f"Case {case_num} failed: {test_result.stderr}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_iree_lit_workflows.py
+++ b/tools/utils/test/lit_tests/test_iree_lit_workflows.py
@@ -1,0 +1,1254 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""End-to-end workflow tests across lit tools.
+
+Covers combinations of:
+- Text vs JSON
+- stdout vs file (-o)
+- List -> Extract -> List roundtrips
+- Filters and selectors
+- iree-lit-test dry-run integration on extracted files
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_extract, iree_lit_list, iree_lit_test
+from lit_tools.core import text_utils
+from lit_tools.core.parser import parse_test_file
+
+from test.test_helpers import run_python_module
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestWorkflows(unittest.TestCase):
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+
+    # ---------- Roundtrips (text) ----------
+
+    def test_extract_text_file_then_list_json_matches_selection(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            out = Path(tmp.name)
+        try:
+            # Extract cases 1 and 3 to file (text mode includes RUN header; multiple are separated by // -----)
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.split_test),
+                    "--case",
+                    "1,3",
+                    "-o",
+                    str(out),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            text = out.read_text()
+            self.assertIn("// -----", text)
+            # Only one header RUN block should be present
+            self.assertEqual(text.count("// RUN:"), 1)
+
+            # List the extracted file as JSON and verify just 2 cases remain with expected names
+            with patch("sys.argv", ["iree-lit-list", str(out), "--json"]):
+                list_args = iree_lit_list.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as out_json:
+                rc2 = iree_lit_list.main(list_args)
+                self.assertEqual(rc2, 0)
+                payload = json.loads(out_json.getvalue())
+                self.assertEqual(payload["count"], 2)
+                names = [c["name"] for c in payload["cases"]]
+                self.assertEqual(names, ["first_case", "third_case"])
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_extract_text_stdout_then_reparse(self):
+        # Extract case 2 to stdout and reparse by writing to a temporary file
+        with patch(
+            "sys.argv", ["iree-lit-extract", str(self.split_test), "--case", "2"]
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            content = mock_stdout.getvalue()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            tmp_path.write_text(content)
+            cases = list(parse_test_file(tmp_path).cases)
+            self.assertEqual(len(cases), 1)
+            self.assertEqual(cases[0].name, "second_case")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    # ---------- JSON extraction semantics ----------
+
+    def test_extract_json_stdout_array(self):
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.ten_cases), "--case", "1,3,5", "--json"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as out_json:
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            data = json.loads(out_json.getvalue())
+            self.assertEqual(len(data), 3)
+            self.assertEqual([d["number"] for d in data], [1, 3, 5])
+            # Each JSON object must include content
+            for d in data:
+                self.assertIn("content", d)
+
+    def test_extract_json_file_written(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            out = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten_cases),
+                    "--case",
+                    "2-4",
+                    "--json",
+                    "-o",
+                    str(out),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            # Should not print JSON to stdout; writes to file
+            with patch("sys.stdout", new_callable=io.StringIO) as so:
+                rc = iree_lit_extract.main(args)
+                self.assertEqual(rc, 0)
+                self.assertEqual(so.getvalue(), "")
+            data = json.loads(out.read_text())
+            nums = [d["number"] for d in data]
+            self.assertEqual(nums, [2, 3, 4])
+        finally:
+            out.unlink(missing_ok=True)
+
+    # ---------- Filters across tools ----------
+
+    def test_filter_and_list_equivalence(self):
+        # Extract by filter (text stdout), then list that content again via parser
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(self.ten_cases),
+                "--filter",
+                "case_(one|three|five)",
+            ],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so:
+            rc = iree_lit_extract.main(args)
+            self.assertEqual(rc, 0)
+            text = so.getvalue()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            subset = Path(tmp.name)
+        try:
+            subset.write_text(text)
+            cases = list(parse_test_file(subset).cases)
+            self.assertEqual(
+                [c.name for c in cases], ["case_one", "case_three", "case_five"]
+            )
+        finally:
+            subset.unlink(missing_ok=True)
+
+    # ---------- iree-lit-test dry-run integration ----------
+
+    def test_dry_run_on_extracted_file_text(self):
+        # Extract a subset to a file (text), then run iree-lit-test --dry-run on it
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            subset = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten_cases),
+                    "--case",
+                    "1,3,5",
+                    "-o",
+                    str(subset),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            self.assertEqual(iree_lit_extract.main(args), 0)
+
+            # Now dry-run the subset file (should see exactly 3 cases)
+            with patch(
+                "sys.argv", ["iree-lit-test", str(subset), "--dry-run", "--json"]
+            ):
+                targs = iree_lit_test.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as so:
+                rc = iree_lit_test.main(targs)
+                self.assertEqual(rc, 0)
+                payload = json.loads(so.getvalue())
+                self.assertEqual(payload["total_cases"], 3)
+                self.assertEqual(
+                    [c["number"] for c in payload["selected_cases"]], [1, 2, 3]
+                )
+        finally:
+            subset.unlink(missing_ok=True)
+
+    def test_dry_run_on_extracted_json_file(self):
+        # Extract JSON to a file, then ensure that the tool chain still functions
+        # (this checks that JSON write mode does not interfere with text workflows)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            json_out = Path(tmp.name)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False
+        ) as tmp2:
+            text_out = Path(tmp2.name)
+        try:
+            # Write JSON to file for cases 6-7
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten_cases),
+                    "--case",
+                    "6-7",
+                    "--json",
+                    "-o",
+                    str(json_out),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO):
+                self.assertEqual(iree_lit_extract.main(args), 0)
+
+            # Now extract the same selection in text mode to a file and dry-run it
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten_cases),
+                    "--case",
+                    "6-7",
+                    "-o",
+                    str(text_out),
+                ],
+            ):
+                targs = iree_lit_extract.parse_arguments()
+            self.assertEqual(iree_lit_extract.main(targs), 0)
+
+            with patch(
+                "sys.argv", ["iree-lit-test", str(text_out), "--dry-run", "--json"]
+            ):
+                rargs = iree_lit_test.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as so:
+                rc = iree_lit_test.main(rargs)
+                self.assertEqual(rc, 0)
+                payload = json.loads(so.getvalue())
+                self.assertEqual(payload["total_cases"], 2)
+                self.assertEqual(
+                    [c["number"] for c in payload["selected_cases"]], [1, 2]
+                )
+        finally:
+            json_out.unlink(missing_ok=True)
+            text_out.unlink(missing_ok=True)
+
+    # ---------- Additional roundtrips & edge cases ----------
+
+    def test_text_json_equivalence_for_selection(self):
+        # Compare text stdout with JSON-assembled text for the same selection
+        selection = "1-3"
+        # Text stdout (exclude RUN lines for comparison with JSON content)
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(self.split_test),
+                "--case",
+                selection,
+                "--exclude-run-lines",
+            ],
+        ):
+            args_text = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so_text:
+            self.assertEqual(iree_lit_extract.main(args_text), 0)
+            text_out = so_text.getvalue()
+
+        # JSON stdout for same selection
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split_test), "--case", selection, "--json"],
+        ):
+            args_json = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so_json:
+            self.assertEqual(iree_lit_extract.main(args_json), 0)
+            data = json.loads(so_json.getvalue())
+            # Assemble text from JSON content with separators
+            assembled = "\n\n// -----\n\n".join(d["content"].rstrip() for d in data)
+            # Normalize leading blanks and trailing newlines for stable comparison
+            norm_text = text_out.lstrip("\n").rstrip()
+            norm_assembled = assembled.lstrip("\n").rstrip()
+            self.assertEqual(norm_text, norm_assembled)
+
+    def test_no_run_header_behavior(self):
+        # File without RUN header lines should not gain any in -o
+        no_run = _FIXTURES_DIR / "no_run_test.mlir"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            out = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv",
+                ["iree-lit-extract", str(no_run), "--case", "1", "-o", str(out)],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            text = out.read_text()
+            self.assertNotIn("// RUN:", text)
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_run_variants_include_run_lines_stdout(self):
+        # Verify that RUN lines are included by default for variant formatting.
+        run_variants = _FIXTURES_DIR / "run_variants.mlir"
+        with patch(
+            "sys.argv",
+            [
+                "iree-lit-extract",
+                str(run_variants),
+                "--case",
+                "1",
+            ],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            out_text = so.getvalue()
+            # Expect header RUN commands present at top.
+            self.assertIn("// RUN:", out_text)
+            # Only header runs, not duplicated within content.
+            self.assertGreaterEqual(out_text.count("// RUN:"), 1)
+
+    def test_renumber_after_subset_and_reextract(self):
+        # Extract cases 2,4,6 to file; verify renumbering and re-extract by new case number
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            subset = Path(tmp.name)
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten_cases),
+                    "--case",
+                    "2,4,6",
+                    "-o",
+                    str(subset),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            # Re-parse subset: should have 3 cases numbered 1..3 with names preserved
+            cases = list(parse_test_file(subset).cases)
+            self.assertEqual(len(cases), 3)
+            self.assertEqual(
+                [c.name for c in cases], ["case_two", "case_four", "case_six"]
+            )
+            self.assertEqual([c.number for c in cases], [1, 2, 3])
+            # Re-extract case 2 from subset and verify content name
+            with patch("sys.argv", ["iree-lit-extract", str(subset), "--case", "2"]):
+                args2 = iree_lit_extract.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO) as so:
+                self.assertEqual(iree_lit_extract.main(args2), 0)
+                text = so.getvalue()
+                self.assertIn("@case_four", text)
+        finally:
+            subset.unlink(missing_ok=True)
+
+
+# ========================
+# Cross-tool flow tests
+# (migrated from test_integration_flows.py)
+# ========================
+
+
+class TestListExtractFlows(unittest.TestCase):
+    def setUp(self):
+        self.fixtures = Path(__file__).parent / "fixtures"
+        self.split = self.fixtures / "split_test.mlir"
+        self.ten = self.fixtures / "ten_cases_test.mlir"
+
+    def test_list_names_drive_extract_by_name_stdout(self):
+        # Get names from list --names
+        with patch("sys.argv", ["iree-lit-list", str(self.split), "--names"]):
+            args = iree_lit_list.parse_arguments()
+        out_names = io.StringIO()
+        with patch("sys.stdout", out_names):
+            self.assertEqual(iree_lit_list.main(args), 0)
+        names = out_names.getvalue().strip().split()
+        # Extract each by name; verify some content for each
+        for name in names:
+            with patch(
+                "sys.argv",
+                ["iree-lit-extract", str(self.split), "--name", name.lstrip("@")],
+            ):
+                eargs = iree_lit_extract.parse_arguments()
+            out = io.StringIO()
+            with patch("sys.stdout", out):
+                self.assertEqual(iree_lit_extract.main(eargs), 0)
+            text = out.getvalue()
+            self.assertIn(name, text)
+            self.assertIn("util.func", text)
+
+    def test_list_json_drive_extract_json_file(self):
+        # Use list JSON to select first 3 cases by number and write JSON subset to a file
+        with patch("sys.argv", ["iree-lit-list", str(self.ten), "--json"]):
+            args = iree_lit_list.parse_arguments()
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            self.assertEqual(iree_lit_list.main(args), 0)
+        listing = json.loads(out.getvalue())
+        nums = [c["number"] for c in listing["cases"][:3]]
+        # Extract JSON to a file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            dst = Path(tmp.name)
+        try:
+            sel = ",".join(map(str, nums))
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.ten),
+                    "--case",
+                    sel,
+                    "--json",
+                    "-o",
+                    str(dst),
+                ],
+            ):
+                eargs = iree_lit_extract.parse_arguments()
+            with patch("sys.stdout", new_callable=io.StringIO):
+                self.assertEqual(iree_lit_extract.main(eargs), 0)
+            subset = json.loads(dst.read_text())
+            self.assertEqual([d["number"] for d in subset], nums)
+        finally:
+            dst.unlink(missing_ok=True)
+
+
+class TestListTestFlows(unittest.TestCase):
+    def setUp(self):
+        self.fixtures = Path(__file__).parent / "fixtures"
+        self.split = self.fixtures / "split_test.mlir"
+        self.ten = self.fixtures / "ten_cases_test.mlir"
+
+    def test_list_count_matches_test_dry_run_total(self):
+        # list --count
+        with patch("sys.argv", ["iree-lit-list", str(self.ten), "--count"]):
+            largs = iree_lit_list.parse_arguments()
+        count_io = io.StringIO()
+        with patch("sys.stdout", count_io):
+            self.assertEqual(iree_lit_list.main(largs), 0)
+        count = int(count_io.getvalue().strip())
+        # iree-lit-test --dry-run --json
+        with patch("sys.argv", ["iree-lit-test", str(self.ten), "--dry-run", "--json"]):
+            targs = iree_lit_test.parse_arguments()
+        jout = io.StringIO()
+        with patch("sys.stdout", jout):
+            self.assertEqual(iree_lit_test.main(targs), 0)
+        payload = json.loads(jout.getvalue())
+        self.assertEqual(payload["total_cases"], count)
+
+    def test_list_json_drive_test_dry_run_selection(self):
+        # pick even-numbered cases via list JSON
+        with patch("sys.argv", ["iree-lit-list", str(self.ten), "--json"]):
+            largs = iree_lit_list.parse_arguments()
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            self.assertEqual(iree_lit_list.main(largs), 0)
+        listing = json.loads(out.getvalue())
+        even = [c["number"] for c in listing["cases"] if c["number"] % 2 == 0][:4]
+        sel = ",".join(map(str, even))
+        # Drive iree-lit-test --dry-run with those selections
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten), "--case", sel, "--dry-run", "--json"],
+        ):
+            targs = iree_lit_test.parse_arguments()
+        jout = io.StringIO()
+        with patch("sys.stdout", jout):
+            self.assertEqual(iree_lit_test.main(targs), 0)
+        payload = json.loads(jout.getvalue())
+        sel_nums = [c["number"] for c in payload["selected_cases"]]
+        self.assertEqual(sel_nums, even)
+
+
+class TestReplaceFlows(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Skip entire class if iree_lit_replace is not available yet.
+        try:
+            import lit_tools.iree_lit_replace as _unused  # noqa: F401, PLC0415 (deferred import for availability check)
+        except Exception as err:
+            raise unittest.SkipTest(
+                "iree-lit-replace not implemented in this tree"
+            ) from err
+
+    def test_placeholder(self):
+        # This is a placeholder to reserve flow tests once the tool exists.
+        self.assertTrue(True)
+
+
+# ========================
+# Roundtrip robustness
+# ========================
+
+
+class TestRoundtripRobustness(unittest.TestCase):
+    def setUp(self):
+        self.fixtures = Path(__file__).parent / "fixtures"
+        self.names = self.fixtures / "names_test.mlir"
+        self.scattered = self.fixtures / "failing_scattered_run_lines.mlir"
+        self.run_variants = self.fixtures / "run_variants.mlir"
+
+    def test_single_case_with_special_name_roundtrip(self):
+        # Extract text to stdout and reparse, name should be preserved
+        with patch("sys.argv", ["iree-lit-extract", str(self.names), "--case", "1"]):
+            args = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so:
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            text = so.getvalue()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            path = Path(tmp.name)
+        try:
+            path.write_text(text)
+            cases = list(parse_test_file(path).cases)
+            self.assertEqual(len(cases), 1)
+            # Name contains punctuation that must survive parsing
+            self.assertEqual(cases[0].name, "foo.bar$baz-1")
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_scattered_run_lines_header_injection_only(self):
+        # Extract the final case to a file; header + case-local RUN lines should be injected
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            out = Path(tmp.name)
+        try:
+            cases = list(parse_test_file(self.scattered).cases)
+            last_num = cases[-1].number
+            with patch(
+                "sys.argv",
+                [
+                    "iree-lit-extract",
+                    str(self.scattered),
+                    "--case",
+                    str(last_num),
+                    "-o",
+                    str(out),
+                ],
+            ):
+                args = iree_lit_extract.parse_arguments()
+            self.assertEqual(iree_lit_extract.main(args), 0)
+            content = out.read_text()
+            # Header RUN lines (2) + case-local RUN line (1) = 3 total
+            self.assertEqual(content.count("// RUN:"), 3)
+            # Lines referencing NOTUSED are not RUN directives and should remain as comments
+            self.assertIn("NOTUSED:", content)
+        finally:
+            out.unlink(missing_ok=True)
+
+    def test_run_variants_text_json_equivalence(self):
+        # JSON assembled content must match text stdout (normalized, excluding RUN lines).
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.run_variants), "--case", "1"],
+        ):
+            targs = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so_text:
+            self.assertEqual(iree_lit_extract.main(targs), 0)
+            text_out = so_text.getvalue()
+
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.run_variants), "--case", "1", "--json"],
+        ):
+            jargs = iree_lit_extract.parse_arguments()
+        with patch("sys.stdout", new_callable=io.StringIO) as so_json:
+            self.assertEqual(iree_lit_extract.main(jargs), 0)
+            data = json.loads(so_json.getvalue())
+        assembled = "\n\n// -----\n\n".join(d["content"].rstrip() for d in data)
+
+        # Strip RUN lines from text output for comparison with JSON (which never has RUN lines).
+        text_lines = text_out.split("\n")
+        non_run_lines = [
+            line for line in text_lines if not line.strip().startswith("// RUN:")
+        ]
+        text_without_runs = "\n".join(non_run_lines)
+
+        self.assertEqual(
+            text_without_runs.lstrip("\n").rstrip(), assembled.lstrip("\n").rstrip()
+        )
+
+
+# ========================
+# Negative-path handling
+# ========================
+
+
+class TestNegativePaths(unittest.TestCase):
+    def setUp(self):
+        self.fixtures = Path(__file__).parent / "fixtures"
+        self.split = self.fixtures / "split_test.mlir"
+        self.ten = self.fixtures / "ten_cases_test.mlir"
+
+    def test_list_json_cannot_combine_with_count(self):
+        with patch("sys.argv", ["iree-lit-list", str(self.split), "--json", "--count"]):
+            args = iree_lit_list.parse_arguments()
+        err = io.StringIO()
+        with patch("sys.stderr", err):
+            rc = iree_lit_list.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("cannot be combined", err.getvalue())
+
+    def test_extract_invalid_name(self):
+        with patch(
+            "sys.argv",
+            ["iree-lit-extract", str(self.split), "--name", "does_not_exist"],
+        ):
+            args = iree_lit_extract.parse_arguments()
+        err = io.StringIO()
+        with patch("sys.stderr", err):
+            rc = iree_lit_extract.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("Case with name", err.getvalue())
+        self.assertIn("not found", err.getvalue())
+
+    def test_test_invalid_case_number(self):
+        with patch(
+            "sys.argv", ["iree-lit-test", str(self.split), "--case", "999", "--dry-run"]
+        ):
+            args = iree_lit_test.parse_arguments()
+        err = io.StringIO()
+        with patch("sys.stderr", err):
+            rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("Case 999 not found", err.getvalue())
+
+    def test_test_filter_no_matches(self):
+        with patch(
+            "sys.argv",
+            ["iree-lit-test", str(self.ten), "--filter", "nevermatch", "--dry-run"],
+        ):
+            args = iree_lit_test.parse_arguments()
+        err = io.StringIO()
+        with patch("sys.stderr", err):
+            rc = iree_lit_test.main(args)
+        self.assertEqual(rc, 2)
+        self.assertIn("No cases matched --filter", err.getvalue())
+
+
+class TestExtractToStdinPipeline(unittest.TestCase):
+    """End-to-end tests for extract → stdin → test pipeline."""
+
+    def setUp(self):
+        self.split = _FIXTURES_DIR / "split_test.mlir"
+        self.edge_cases = _FIXTURES_DIR / "edge_cases_test.mlir"
+
+    def test_extract_stdout_to_test_stdin(self):
+        """Test extract case → pipe to test stdin workflow."""
+        # Extract second_case.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split), "--name", "second_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Pass extracted output to iree-lit-test via stdin.
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=extract_result.stdout,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(test_result.returncode, 0)
+        self.assertIn("1 test case(s) passed", test_result.stderr)
+
+    def test_extract_with_run_override(self):
+        """Test extract → test with --run override."""
+        # Extract first_case.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split), "--name", "first_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Test with custom RUN command.
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            ["--run", "iree-opt --canonicalize %s"],
+            input=extract_result.stdout,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(test_result.returncode, 0)
+
+    def test_extract_multiple_cases_to_stdin(self):
+        """Test extracting and testing multiple cases sequentially."""
+        for case_name in ["first_case", "second_case", "third_case"]:
+            with self.subTest(case=case_name):
+                extract_result = run_python_module(
+                    "lit_tools.iree_lit_extract",
+                    [str(self.split), "--name", case_name],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(extract_result.returncode, 0)
+
+                test_result = run_python_module(
+                    "lit_tools.iree_lit_test",
+                    [],
+                    input=extract_result.stdout,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(test_result.returncode, 0)
+
+    def test_pipeline_with_edge_cases(self):
+        """Test pipeline with special character edge cases."""
+        # Test all cases from edge_cases_test.mlir.
+        for case_name in [
+            "single_quotes_in_comments",
+            "double_quotes",
+            "backticks_in_comments",
+            "dollar_signs",
+            "unicode_test",
+        ]:
+            with self.subTest(case=case_name):
+                extract_result = run_python_module(
+                    "lit_tools.iree_lit_extract",
+                    [str(self.edge_cases), "--name", case_name],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(extract_result.returncode, 0)
+
+                test_result = run_python_module(
+                    "lit_tools.iree_lit_test",
+                    [],
+                    input=extract_result.stdout,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(
+                    test_result.returncode,
+                    0,
+                    f"Edge case {case_name} failed in pipeline",
+                )
+
+    def test_extract_json_content_to_stdin(self):
+        """Test extract JSON → parse → test stdin workflow."""
+        # Extract second_case as JSON.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split), "--name", "second_case", "--json"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Parse JSON and extract content field.
+        payload = json.loads(extract_result.stdout)
+        # JSON mode returns an array of cases.
+        ir_content = payload[0]["content"]
+
+        # Test the IR content via stdin.
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+        # Note: JSON mode excludes RUN lines, so this will use default.
+        self.assertEqual(test_result.returncode, 0)
+
+
+class TestRoundTripIntegrity(unittest.TestCase):
+    """Tests for round-trip integrity: extract | replace produces identical output."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.with_case_runs = _FIXTURES_DIR / "with_case_runs.mlir"
+        self.ten_cases = _FIXTURES_DIR / "ten_cases_test.mlir"
+        self.edge_cases = _FIXTURES_DIR / "edge_cases_test.mlir"
+
+    def test_split_test_roundtrip_case1(self):
+        """Test extract | replace round-trip on split_test.mlir first_case."""
+        # Extract first_case with RUN lines (default).
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--name", "first_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+        extracted_content = extract_result.stdout
+
+        # Replace first_case with extracted content.
+        replace_result = run_python_module(
+            "lit_tools.iree_lit_replace",
+            [str(self.split_test), "--name", "first_case"],
+            input=extracted_content,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(replace_result.returncode, 0)
+        # Should succeed - content is identical (RUN lines normalized but IR unchanged).
+        self.assertTrue(
+            "unchanged" in replace_result.stderr.lower()
+            or "successfully" in replace_result.stderr.lower()
+        )
+
+    def test_split_test_roundtrip_all_cases(self):
+        """Test extract | replace round-trip for all cases in split_test.mlir."""
+        # Load original file.
+        original_content = self.split_test.read_text()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(original_content)
+
+        try:
+            # Extract each case and replace it.
+            for case_name in ["first_case", "second_case", "third_case"]:
+                extract_result = run_python_module(
+                    "lit_tools.iree_lit_extract",
+                    [str(tmp_path), "--name", case_name],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(extract_result.returncode, 0)
+
+                replace_result = run_python_module(
+                    "lit_tools.iree_lit_replace",
+                    [str(tmp_path), "--name", case_name],
+                    input=extract_result.stdout,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(replace_result.returncode, 0)
+
+            # After all replacements, parse and compare cases.
+            # Strip RUN lines for comparison since replace canonicalizes their position.
+            original_cases = list(parse_test_file(self.split_test).cases)
+            final_cases = list(parse_test_file(tmp_path).cases)
+
+            self.assertEqual(len(original_cases), len(final_cases))
+            for orig, final in zip(original_cases, final_cases, strict=False):
+                # Compare case metadata.
+                self.assertEqual(orig.number, final.number)
+                self.assertEqual(orig.name, final.name)
+                # Compare IR content (ignore RUN line positions and whitespace differences).
+                self.assertTrue(
+                    text_utils.compare_ir_content(orig.content, final.content),
+                    f"Case {orig.number} content differs",
+                )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_with_case_runs_roundtrip(self):
+        """Test round-trip on file with both header and case-local RUN lines."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(self.with_case_runs.read_text())
+
+        try:
+            # Extract and replace case 1 (has case-local RUN line).
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "1"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "1"],
+                input=extract_result.stdout,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Compare cases (strip RUN lines since position may differ).
+            original_cases = list(parse_test_file(self.with_case_runs).cases)
+            final_cases = list(parse_test_file(tmp_path).cases)
+
+            self.assertEqual(len(original_cases), len(final_cases))
+            for orig, final in zip(original_cases, final_cases, strict=False):
+                self.assertEqual(orig.number, final.number)
+                self.assertEqual(orig.name, final.name)
+                self.assertTrue(
+                    text_utils.compare_ir_content(orig.content, final.content),
+                    f"Case {orig.number} content differs",
+                )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_edge_cases_roundtrip(self):
+        """Test round-trip on edge_cases_test.mlir with unicode and special chars."""
+        if not self.edge_cases.exists():
+            self.skipTest("edge_cases_test.mlir not found")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".mlir", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(self.edge_cases.read_text(encoding="utf-8"))
+
+        try:
+            # Get all cases.
+            all_cases = list(parse_test_file(tmp_path).cases)
+
+            # Extract and replace each case.
+            for case in all_cases:
+                extract_result = run_python_module(
+                    "lit_tools.iree_lit_extract",
+                    [str(tmp_path), "--case", str(case.number)],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(extract_result.returncode, 0)
+
+                replace_result = run_python_module(
+                    "lit_tools.iree_lit_replace",
+                    [str(tmp_path), "--case", str(case.number)],
+                    input=extract_result.stdout,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(replace_result.returncode, 0)
+
+            # Compare cases (strip RUN lines since position may differ).
+            original_cases = list(parse_test_file(self.edge_cases).cases)
+            final_cases = list(parse_test_file(tmp_path).cases)
+
+            self.assertEqual(len(original_cases), len(final_cases))
+            for orig, final in zip(original_cases, final_cases, strict=False):
+                self.assertEqual(orig.number, final.number)
+                self.assertEqual(orig.name, final.name)
+                self.assertTrue(
+                    text_utils.compare_ir_content(orig.content, final.content),
+                    f"Case {orig.number} content differs",
+                )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+class TestPipelineChaining(unittest.TestCase):
+    """Tests for piping tools together: extract | test | replace workflows."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+        self.with_case_runs = _FIXTURES_DIR / "with_case_runs.mlir"
+
+    def test_extract_pipe_test(self):
+        """Test extract | test pipeline with stdout/stdin."""
+        # Extract case 2 to stdout (case 1 has intentionally invalid content).
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--name", "second_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Pipe to test via stdin.
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=extract_result.stdout,
+            capture_output=True,
+            text=True,
+        )
+        # Test should pass if tools are available, or gracefully handle missing tools.
+        if test_result.returncode == 0:
+            self.assertIn("PASS", test_result.stderr.upper())
+        else:
+            # Tool not found is acceptable in test environment.
+            self.assertIn("not found", test_result.stderr.lower())
+
+    def test_extract_pipe_replace(self):
+        """Test extract | replace pipeline."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(self.split_test.read_text())
+
+        try:
+            # Extract case 2.
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+
+            # Pipe to replace via stdin.
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2"],
+                input=extract_result.stdout,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Should succeed (may report "replaced successfully" due to whitespace normalization).
+            self.assertIn("case 2", replace_result.stderr.lower())
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_extract_test_replace_full_pipeline(self):
+        """Test full extract | test | replace pipeline."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(self.split_test.read_text())
+
+        try:
+            # Step 1: Extract case 2 (case 1 has intentionally invalid content).
+            extract_result = run_python_module(
+                "lit_tools.iree_lit_extract",
+                [str(tmp_path), "--case", "2"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extract_result.returncode, 0)
+            extracted_content = extract_result.stdout
+
+            # Step 2: Test the extracted content.
+            test_result = run_python_module(
+                "lit_tools.iree_lit_test",
+                [],
+                input=extracted_content,
+                capture_output=True,
+                text=True,
+            )
+            # May fail if iree-opt isn't available.
+            if test_result.returncode == 0:
+                self.assertIn("PASS", test_result.stderr.upper())
+            else:
+                # Skip rest of test if tool not available.
+                if "not found" in test_result.stderr.lower():
+                    self.skipTest("iree-opt not found")
+                # Otherwise test should pass.
+                self.fail(f"Test failed: {test_result.stderr}")
+
+            # Step 3: Replace back into file.
+            replace_result = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "2"],
+                input=extracted_content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace_result.returncode, 0)
+
+            # Verify content is preserved (semantically, ignoring whitespace/RUN positions).
+            original_cases = list(parse_test_file(self.split_test).cases)
+            final_cases = list(parse_test_file(tmp_path).cases)
+            self.assertTrue(
+                text_utils.compare_ir_content(
+                    original_cases[1].content, final_cases[1].content
+                )
+            )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_extract_with_case_runs_pipe_test(self):
+        """Test extract | test with file that has case-local RUN lines."""
+        # Extract case 1 (has case-local RUN line).
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.with_case_runs), "--name", "case_one"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Pipe to test - should handle both header and case-local RUN lines.
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=extract_result.stdout,
+            capture_output=True,
+            text=True,
+        )
+        # Note: This may fail if iree-opt isn't available, but shouldn't crash.
+        self.assertIn(test_result.returncode, [0, 1])  # 0 = pass, 1 = fail/missing tool
+
+    def test_error_propagation_missing_file(self):
+        """Test error handling when file doesn't exist in pipeline."""
+        # Try to extract from non-existent file.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            ["/nonexistent/file.mlir", "--case", "1"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(extract_result.returncode, 0)
+        self.assertIn("not found", extract_result.stderr.lower())
+
+    def test_error_propagation_malformed_stdin(self):
+        """Test replace error handling with malformed JSON stdin."""
+        # Send malformed JSON to replace (incomplete JSON object).
+        replace_result = run_python_module(
+            "lit_tools.iree_lit_replace",
+            [str(self.split_test), "--case", "1", "--mode", "json"],
+            input='{"incomplete": "json"',  # Missing closing brace
+            capture_output=True,
+            text=True,
+        )
+        # Should detect malformed JSON and fail gracefully.
+        self.assertNotEqual(replace_result.returncode, 0)
+
+    def test_json_mode_through_pipeline(self):
+        """Test JSON mode compatibility through pipeline."""
+        # Extract as JSON.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--case", "1", "--json"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+
+        # Parse JSON.
+        payload = json.loads(extract_result.stdout)
+        self.assertEqual(len(payload), 1)
+        ir_content = payload[0]["content"]
+
+        # Test the IR content (JSON mode excludes RUN lines).
+        test_result = run_python_module(
+            "lit_tools.iree_lit_test",
+            [],
+            input=ir_content,
+            capture_output=True,
+            text=True,
+        )
+        # Should work with default RUN line since JSON excludes RUNs.
+        self.assertIn(test_result.returncode, [0, 1])
+
+
+class TestIdempotency(unittest.TestCase):
+    """Tests for idempotency: running tools multiple times produces same output."""
+
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    def test_extract_idempotency(self):
+        """Test that extracting same case multiple times produces identical output."""
+        # Extract case 1 first time.
+        result1 = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--name", "first_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 0)
+
+        # Extract case 1 second time.
+        result2 = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--name", "first_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result2.returncode, 0)
+
+        # Outputs should be byte-for-byte identical.
+        self.assertEqual(result1.stdout, result2.stdout)
+
+    def test_replace_idempotency(self):
+        """Test that replacing same content multiple times produces no changes."""
+        # Extract case 1.
+        extract_result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(self.split_test), "--name", "first_case"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(extract_result.returncode, 0)
+        content = extract_result.stdout
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(self.split_test.read_text())
+
+        try:
+            # First replace.
+            replace1 = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "1"],
+                input=content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace1.returncode, 0)
+            content_after_first = tmp_path.read_text()
+
+            # Second replace with same content.
+            replace2 = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "1"],
+                input=content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace2.returncode, 0)
+            content_after_second = tmp_path.read_text()
+
+            # Third replace with same content.
+            replace3 = run_python_module(
+                "lit_tools.iree_lit_replace",
+                [str(tmp_path), "--case", "1"],
+                input=content,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replace3.returncode, 0)
+            content_after_third = tmp_path.read_text()
+
+            # All should be identical.
+            self.assertEqual(content_after_first, content_after_second)
+            self.assertEqual(content_after_second, content_after_third)
+
+            # All should report unchanged.
+            self.assertIn("unchanged", replace2.stderr.lower())
+            self.assertIn("unchanged", replace3.stderr.lower())
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_lint.py
+++ b/tools/utils/test/lit_tests/test_lint.py
@@ -1,0 +1,1169 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for iree-lit-lint tool."""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+# Add tools/utils to path.
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from common import exit_codes
+from lit_tools import iree_lit_lint
+
+
+class TestRawSSAIdentifierChecker(unittest.TestCase):
+    """Test detection of raw SSA identifiers in CHECK lines."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_raw_ssa_identifiers(self):
+        """Test that raw SSA identifiers are detected as errors."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "1", "--json", "--quiet"]
+        )
+        result = iree_lit_lint.main(args)
+
+        # Should exit with error code since errors were found.
+        self.assertEqual(result, exit_codes.ERROR)
+
+    def test_json_output_structure(self):
+        """Test JSON output contains proper issue structure."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "1", "--json", "--quiet"]
+        )
+
+        # Capture stdout.
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        self.assertIn("issues", output)
+        self.assertGreater(len(output["issues"]), 0)
+
+        # Find raw_ssa_identifier issue (may not be first due to other checks).
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        self.assertGreater(
+            len(raw_ssa_issues), 0, "Should find at least one raw_ssa_identifier issue"
+        )
+
+        issue = raw_ssa_issues[0]
+        self.assertEqual(issue["severity"], "error")
+        self.assertEqual(issue["code"], "raw_ssa_identifier")
+        self.assertIn("message", issue)
+        self.assertIn("line", issue)
+        self.assertIn("help", issue)
+
+    def test_errors_only_flag(self):
+        """Test --errors-only filters to only errors."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "1", "--errors-only", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # All issues should be errors.
+        for issue in output["issues"]:
+            self.assertEqual(issue["severity"], "error")
+
+    def test_detects_arg_in_operands(self):
+        """Test that %arg0 in operands is flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "40", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Should find %arg0 and %arg1.
+        self.assertGreaterEqual(len(raw_ssa_issues), 2)
+        self.assertEqual(result, exit_codes.ERROR)
+
+    def test_detects_semantic_names(self):
+        """Test that %buffer, %offset are flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "41", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Should find %buffer and %offset.
+        self.assertGreaterEqual(len(raw_ssa_issues), 2)
+        self.assertEqual(result, exit_codes.ERROR)
+
+    def test_detects_in_signatures(self):
+        """Test that %arg0 in signatures is flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "42", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Should find %arg0 in signature.
+        self.assertGreaterEqual(len(raw_ssa_issues), 1)
+        self.assertEqual(result, exit_codes.ERROR)
+
+    def test_multiple_raw_ssa_per_line(self):
+        """Test that multiple raw SSA on one line are all flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "43", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Should find %a, %b, %c, %d (4 raw SSA values).
+        self.assertGreaterEqual(len(raw_ssa_issues), 4)
+        self.assertEqual(result, exit_codes.ERROR)
+
+    def test_nolint_suppresses(self):
+        """Test that NOLINT on preceding line suppresses rest of case."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "44", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # NOLINT should suppress all raw_ssa_identifier errors.
+        self.assertEqual(len(raw_ssa_issues), 0)
+
+    def test_captures_not_flagged(self):
+        """Test that %[[NAME]] captures are not flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "45", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Captures should NOT trigger raw_ssa_identifier.
+        self.assertEqual(len(raw_ssa_issues), 0)
+
+    def test_constants_exempted(self):
+        """Test that MLIR constants (%c0, %c123, %cst) are exempted."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "46", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+        raw_ssa_issues = [
+            i for i in output["issues"] if i["code"] == "raw_ssa_identifier"
+        ]
+        # Constants (%c0, %c123_i32, %cst, %cst_0) are exempted.
+        self.assertEqual(len(raw_ssa_issues), 0)
+
+
+class TestExcessiveWildcardChecker(unittest.TestCase):
+    """Test detection of excessive wildcards in CHECK lines."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_excessive_wildcards(self):
+        """Test that excessive wildcards trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "10", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings but not errors.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        self.assertGreater(output["warnings"], 0)
+
+        # Check for wildcard warning.
+        wildcard_issues = [
+            i for i in output["issues"] if i["code"] == "excessive_wildcards"
+        ]
+        self.assertGreater(len(wildcard_issues), 0)
+
+
+class TestNonSemanticCaptureChecker(unittest.TestCase):
+    """Test detection of non-semantic capture names."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_constant_based_names(self):
+        """Test detection of %[[C0]] style names."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "11", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings for non-semantic names.
+        semantic_issues = [
+            i for i in output["issues"] if i["code"] == "non_semantic_capture"
+        ]
+        self.assertGreater(len(semantic_issues), 0)
+
+    def test_provides_suggestions(self):
+        """Test that suggestions are provided for better names."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "11", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Check that some issues have suggestions.
+        issues_with_suggestions = [i for i in output["issues"] if "suggestions" in i]
+        self.assertGreater(len(issues_with_suggestions), 0)
+
+
+class TestZeroCheckLinesChecker(unittest.TestCase):
+    """Test detection of test cases with no CHECK lines."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_zero_checks(self):
+        """Test that cases with no CHECKs are flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "2", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should be an error.
+        self.assertEqual(result, exit_codes.ERROR)
+
+        # Check for zero_check_lines error.
+        zero_check_issues = [
+            i for i in output["issues"] if i["code"] == "zero_check_lines"
+        ]
+        self.assertGreater(len(zero_check_issues), 0)
+
+
+class TestTodoWithoutExplanationChecker(unittest.TestCase):
+    """Test detection of TODO/FIXME without explanation."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_bare_todo(self):
+        """Test that bare TODO comments are flagged as errors."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "3", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have errors for bare TODOs.
+        self.assertEqual(result, exit_codes.ERROR)
+
+        # Check for TODO errors.
+        todo_issues = [
+            i for i in output["issues"] if i["code"] == "todo_without_explanation"
+        ]
+        self.assertGreater(len(todo_issues), 0)
+
+    def test_detects_weak_explanation(self):
+        """Test that weak TODO explanations are flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "4", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have errors for weak TODOs.
+        self.assertEqual(result, exit_codes.ERROR)
+
+        # Check for TODO errors.
+        todo_issues = [
+            i for i in output["issues"] if i["code"] == "todo_without_explanation"
+        ]
+        self.assertGreater(len(todo_issues), 0)
+
+    def test_accepts_good_explanation(self):
+        """Test that detailed TODO explanations pass."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "5", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no TODO errors.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        todo_issues = [
+            i for i in output["issues"] if i["code"] == "todo_without_explanation"
+        ]
+        self.assertEqual(len(todo_issues), 0)
+
+
+class TestCHECKNOTWithoutAnchorChecker(unittest.TestCase):
+    """Test detection of CHECK-NOT without anchors."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_unanchored_check_not(self):
+        """Test that CHECK-NOT without any anchors is flagged."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "6", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have errors.
+        self.assertEqual(result, exit_codes.ERROR)
+
+        # Check for anchor errors.
+        anchor_issues = [
+            i for i in output["issues"] if i["code"] == "check_not_without_anchor"
+        ]
+        self.assertGreater(len(anchor_issues), 0)
+
+    def test_accepts_properly_anchored(self):
+        """Test that CHECK-NOT with both anchors passes."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "9", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no errors.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        anchor_issues = [
+            i for i in output["issues"] if i["code"] == "check_not_without_anchor"
+        ]
+        self.assertEqual(len(anchor_issues), 0)
+
+
+class TestMatchedCaptureNameChecker(unittest.TestCase):
+    """Test detection of mismatched capture names."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_mismatched_names(self):
+        """Test that mismatched IR/CHECK names trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "12", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings (not errors).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for mismatch warnings.
+        mismatch_issues = [
+            i for i in output["issues"] if i["code"] == "mismatched_capture_name"
+        ]
+        self.assertGreater(len(mismatch_issues), 0)
+        self.assertEqual(mismatch_issues[0]["severity"], "warning")
+
+    def test_accepts_matched_names(self):
+        """Test that matched names don't trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "13", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no mismatch warnings.
+        mismatch_issues = [
+            i for i in output["issues"] if i["code"] == "mismatched_capture_name"
+        ]
+        self.assertEqual(len(mismatch_issues), 0)
+
+
+class TestWildcardInTerminatorChecker(unittest.TestCase):
+    """Test detection of wildcards in terminators."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_wildcard_terminators(self):
+        """Test that wildcards in terminators trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "15", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings.
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for wildcard warnings.
+        wildcard_issues = [
+            i for i in output["issues"] if i["code"] == "wildcard_in_terminator"
+        ]
+        self.assertGreater(len(wildcard_issues), 0)
+        self.assertEqual(wildcard_issues[0]["severity"], "warning")
+
+    def test_accepts_explicit_terminators(self):
+        """Test that explicit terminator operands pass."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "16", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no wildcard warnings.
+        wildcard_issues = [
+            i for i in output["issues"] if i["code"] == "wildcard_in_terminator"
+        ]
+        self.assertEqual(len(wildcard_issues), 0)
+
+
+class TestCHECKWithoutLabelContextChecker(unittest.TestCase):
+    """Test detection of CHECK without LABEL context."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_check_before_label(self):
+        """Test that CHECK before LABEL triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "18", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings.
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for label context warnings.
+        label_issues = [
+            i for i in output["issues"] if i["code"] == "check_without_label_context"
+        ]
+        self.assertGreater(len(label_issues), 0)
+        self.assertEqual(label_issues[0]["severity"], "warning")
+
+    def test_accepts_proper_label_context(self):
+        """Test that CHECK after LABEL passes."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "19", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no label context warnings.
+        label_issues = [
+            i for i in output["issues"] if i["code"] == "check_without_label_context"
+        ]
+        self.assertEqual(len(label_issues), 0)
+
+
+class TestUnusedCaptureChecker(unittest.TestCase):
+    """Test detection of unused captures."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_unused_captures(self):
+        """Test that unused captures trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "21", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings.
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for unused capture warnings.
+        unused_issues = [i for i in output["issues"] if i["code"] == "unused_capture"]
+        self.assertGreater(len(unused_issues), 0)
+        self.assertEqual(unused_issues[0]["severity"], "warning")
+
+    def test_accepts_used_captures(self):
+        """Test that used captures don't trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "22", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no unused capture warnings.
+        unused_issues = [i for i in output["issues"] if i["code"] == "unused_capture"]
+        self.assertEqual(len(unused_issues), 0)
+
+    def test_accepts_check_same_usage(self):
+        """Test that captures used in CHECK-SAME pass."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "23", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no unused capture warnings.
+        unused_issues = [i for i in output["issues"] if i["code"] == "unused_capture"]
+        self.assertEqual(len(unused_issues), 0)
+
+
+class TestGoodPractices(unittest.TestCase):
+    """Test that good practices don't trigger false positives."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_good_test.mlir"
+
+    def test_no_issues_for_good_test(self):
+        """Test that well-written tests pass linting."""
+        args = iree_lit_lint.parse_arguments([str(self.fixture), "--json", "--quiet"])
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no errors.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        self.assertEqual(output["errors"], 0)
+        self.assertEqual(len(output["issues"]), 0)
+
+
+class TestCLIIntegration(unittest.TestCase):
+    """Test CLI argument parsing and integration."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_good_test.mlir"
+
+    def test_list_mode(self):
+        """Test --list mode shows test cases."""
+        args = iree_lit_lint.parse_arguments([str(self.fixture), "--list"])
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = f.getvalue()
+
+        self.assertEqual(result, exit_codes.SUCCESS)
+        self.assertIn("good_example", output)
+
+    def test_case_selection(self):
+        """Test --case selection works."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "1", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        self.assertEqual(result, exit_codes.SUCCESS)
+        self.assertEqual(output["cases_linted"], 1)
+
+    def test_min_severity_filtering(self):
+        """Test --min-severity filters correctly."""
+        fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+        # Get all issues.
+        args_all = iree_lit_lint.parse_arguments(
+            [str(fixture), "--case", "10", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args_all)
+
+        output_all = json.loads(f.getvalue())
+        total_issues = len(output_all["issues"])
+
+        # Get only errors.
+        args_errors = iree_lit_lint.parse_arguments(
+            [
+                str(fixture),
+                "--case",
+                "10",
+                "--min-severity",
+                "error",
+                "--json",
+                "--quiet",
+            ]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            iree_lit_lint.main(args_errors)
+
+        output_errors = json.loads(f.getvalue())
+        error_issues = len(output_errors["issues"])
+
+        # Should have fewer issues when filtering to errors only.
+        # (This fixture has warnings, not errors)
+        self.assertLessEqual(error_issues, total_issues)
+
+
+class TestCheckLabelFormatChecker(unittest.TestCase):
+    """Test detection of CHECK-LABEL format issues."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_accepts_unambiguous_bare_label(self):
+        """Test that unambiguous bare labels don't trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "33", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no warnings for unambiguous labels.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        label_issues = [
+            i
+            for i in output["issues"]
+            if i["code"] in ["bare_function_name_in_label", "ambiguous_label"]
+        ]
+        self.assertEqual(len(label_issues), 0)
+
+    def test_detects_ambiguous_label(self):
+        """Test that ambiguous bare labels trigger warnings with matches shown."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "34", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warning for ambiguous label.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        ambiguous_issues = [
+            i for i in output["issues"] if i["code"] == "ambiguous_label"
+        ]
+        self.assertGreater(len(ambiguous_issues), 0)
+
+        # Check that issue shows matches.
+        issue = ambiguous_issues[0]
+        self.assertIn("@dispatch", issue["message"])
+        # Check help text shows the matches
+        self.assertIn("appears", issue["help"])
+        self.assertIn("times", issue["help"])
+
+    def test_detects_label_not_found(self):
+        """Test that labels not in IR trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "35", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warning for label not found.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        not_found_issues = [
+            i for i in output["issues"] if i["code"] == "label_not_found_in_ir"
+        ]
+        self.assertGreater(len(not_found_issues), 0)
+
+        # Check message mentions label not found.
+        issue = not_found_issues[0]
+        self.assertIn("not found", issue["message"])
+
+    def test_accepts_label_with_operation_prefix(self):
+        """Test that labels with operation prefix don't trigger checks."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "36", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no label format warnings.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        label_issues = [
+            i
+            for i in output["issues"]
+            if i["code"]
+            in [
+                "bare_function_name_in_label",
+                "ambiguous_label",
+                "label_not_found_in_ir",
+            ]
+        ]
+        self.assertEqual(len(label_issues), 0)
+
+    def test_detects_ambiguous_global(self):
+        """Test that ambiguous global labels trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "37", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warning for ambiguous global.
+        self.assertEqual(result, exit_codes.SUCCESS)
+        ambiguous_issues = [
+            i for i in output["issues"] if i["code"] == "ambiguous_label"
+        ]
+        self.assertGreater(len(ambiguous_issues), 0)
+
+
+class TestInvalidWildcardPatterns(unittest.TestCase):
+    """Test detection of invalid wildcard patterns in SSA and symbol references."""
+
+    def setUp(self):
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_detects_invalid_ssa_wildcard(self):
+        """Test that %{{.*}} triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "38", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings (not errors).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for invalid SSA zero-or-more pattern warnings.
+        ssa_issues = [
+            i for i in output["issues"] if i["code"] == "invalid_ssa_zero_or_more"
+        ]
+        self.assertGreater(len(ssa_issues), 0)
+        self.assertEqual(ssa_issues[0]["severity"], "warning")
+
+        # Verify suggestion.
+        self.assertIn("suggestions", ssa_issues[0])
+        self.assertIn("%{{.+}}", ssa_issues[0]["suggestions"])
+
+    def test_detects_invalid_symbol_wildcard(self):
+        """Test that @{{.*}} triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--case", "39", "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings (not errors).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for invalid symbol zero-or-more pattern warnings.
+        symbol_issues = [
+            i for i in output["issues"] if i["code"] == "invalid_symbol_zero_or_more"
+        ]
+        self.assertGreater(len(symbol_issues), 0)
+        self.assertEqual(symbol_issues[0]["severity"], "warning")
+
+        # Verify suggestion.
+        self.assertIn("suggestions", symbol_issues[0])
+        self.assertIn("@{{.+}}", symbol_issues[0]["suggestions"])
+
+
+class TestParseArguments(unittest.TestCase):
+    """Test argument parsing."""
+
+    def test_parse_minimal_args(self):
+        """Test parsing minimal required arguments."""
+        args = iree_lit_lint.parse_arguments(["test.mlir"])
+        self.assertEqual(args.test_file, Path("test.mlir"))
+        self.assertFalse(args.json)
+        self.assertFalse(args.errors_only)
+        self.assertEqual(args.min_severity, "info")
+
+    def test_parse_all_options(self):
+        """Test parsing all options."""
+        args = iree_lit_lint.parse_arguments(
+            [
+                "test.mlir",
+                "--case",
+                "1",
+                "--errors-only",
+                "--json",
+                "--quiet",
+            ]
+        )
+        self.assertEqual(args.test_file, Path("test.mlir"))
+        self.assertEqual(args.case, ["1"])
+        self.assertTrue(args.errors_only)
+        self.assertTrue(args.json)
+        self.assertTrue(args.quiet)
+
+
+class TestGroupedOutput(unittest.TestCase):
+    """Test grouped output format."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+        self.good_fixture = Path(__file__).parent / "fixtures" / "lint_good_test.mlir"
+
+    def test_grouped_output_format(self):
+        """Test that default output groups errors by code."""
+        args = iree_lit_lint.parse_arguments([str(self.good_fixture), "--quiet"])
+
+        result = iree_lit_lint.main(args)
+
+        # Should succeed (no errors in good test file).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+    def test_grouped_output_shows_occurrences(self):
+        """Test that grouped output shows occurrence count."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--errors-only", "--case", "1"]
+        )
+
+        # Capture stdout to check format.
+        output = io.StringIO()
+        with redirect_stdout(output):
+            iree_lit_lint.main(args)
+
+        output_text = output.getvalue()
+
+        # Should have [ERROR] headers with occurrence counts.
+        self.assertIn("[ERROR]", output_text)
+        self.assertIn("occurrence", output_text)
+
+        # Should have file:line:severity:code:message format for each occurrence.
+        self.assertRegex(
+            output_text,
+            r"lint_test\.mlir:\d+:?\d*: error: \w+: .+",
+            "Expected IDE-parseable format in output",
+        )
+
+    def test_grouped_output_deduplicates_help(self):
+        """Test that help text appears once per error type."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--errors-only", "--case", "1"]
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            iree_lit_lint.main(args)
+
+        output_text = output.getvalue()
+
+        # raw_ssa_identifier appears twice in case 1 (lines 6 and 8).
+        # Help text should appear once, not twice.
+        help_text = "Use %[[NAME:.+]] instead of %0"
+        occurrences = output_text.count(help_text)
+        self.assertEqual(
+            occurrences,
+            1,
+            f"Expected help text to appear once, found {occurrences} times",
+        )
+
+        # But should have two file:line occurrences for raw_ssa_identifier.
+        raw_ssa_lines = [
+            line
+            for line in output_text.split("\n")
+            if "raw_ssa_identifier" in line and "lint_test.mlir:" in line
+        ]
+        self.assertEqual(len(raw_ssa_lines), 2)
+
+
+class TestIndividualErrorsFlag(unittest.TestCase):
+    """Test --individual-errors flag for ungrouped output."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.fixture = Path(__file__).parent / "fixtures" / "lint_test.mlir"
+
+    def test_individual_errors_flag(self):
+        """Test that --individual-errors shows old format."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--errors-only", "--case", "1", "--individual-errors"]
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            iree_lit_lint.main(args)
+
+        output_text = output.getvalue()
+
+        # Should NOT have grouped format headers.
+        self.assertNotIn("[ERROR]", output_text)
+        self.assertNotIn("occurrences", output_text)
+
+        # Should have snippet lines (old format).
+        self.assertIn("  help:", output_text)
+
+        # Should still have file:line:severity format.
+        self.assertRegex(output_text, r"lint_test\.mlir:\d+:?\d*: error:")
+
+    def test_individual_errors_duplicates_help(self):
+        """Test that --individual-errors shows help for each occurrence."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture), "--errors-only", "--case", "1", "--individual-errors"]
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            iree_lit_lint.main(args)
+
+        output_text = output.getvalue()
+
+        # raw_ssa_identifier appears twice - should have two separate help blocks.
+        # Count occurrences of "  help:" to verify help appears for each error.
+        help_lines = output_text.count("  help:")
+        self.assertEqual(
+            help_lines,
+            2,
+            f"Expected help to appear twice (once per error), found {help_lines}",
+        )
+
+
+class TestSplitBoundaryChecks(unittest.TestCase):
+    """Test detection of split boundary issues."""
+
+    def setUp(self):
+        self.fixture_missing = (
+            Path(__file__).parent / "fixtures" / "lint_split_missing.mlir"
+        )
+        self.fixture_boundary = (
+            Path(__file__).parent / "fixtures" / "lint_split_boundary.mlir"
+        )
+        self.fixture_good = Path(__file__).parent / "fixtures" / "lint_split_good.mlir"
+
+    def test_detects_missing_split_input_file(self):
+        """Test that delimiters without --split-input-file triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture_missing), "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warning (not error).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for missing split input file warning.
+        missing_issues = [
+            i for i in output["issues"] if i["code"] == "missing_split_input_file"
+        ]
+        self.assertGreater(len(missing_issues), 0)
+        self.assertEqual(missing_issues[0]["severity"], "warning")
+        self.assertIn("--split-input-file", missing_issues[0]["help"])
+
+    def test_detects_first_check_not_label(self):
+        """Test that first CHECK after split not being CHECK-LABEL triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture_boundary), "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings (not errors).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for first check not label warnings.
+        not_label_issues = [
+            i
+            for i in output["issues"]
+            if i["code"] == "first_check_not_label_after_split"
+        ]
+        # Should have 3: case 2 (CHECK-DAG), case 4 (CHECK-SAME), case 5 (CHECK-NEXT).
+        self.assertGreaterEqual(len(not_label_issues), 3)
+        self.assertEqual(not_label_issues[0]["severity"], "warning")
+
+    def test_detects_unanchored_check_dag(self):
+        """Test that CHECK-DAG before CHECK-LABEL after split triggers warning."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture_boundary), "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have warnings (not errors).
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+        # Check for unanchored CHECK-DAG warnings.
+        dag_issues = [
+            i
+            for i in output["issues"]
+            if i["code"] == "unanchored_check_dag_after_split"
+        ]
+        # Should have 1: case 2 (CHECK-DAG).
+        self.assertGreaterEqual(len(dag_issues), 1)
+        self.assertEqual(dag_issues[0]["severity"], "warning")
+        self.assertIn("CHECK-LABEL", dag_issues[0]["help"])
+
+    def test_accepts_proper_label_patterns(self):
+        """Test that CHECK-LABEL first after split doesn't trigger warnings."""
+        args = iree_lit_lint.parse_arguments(
+            [str(self.fixture_good), "--json", "--quiet"]
+        )
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = iree_lit_lint.main(args)
+
+        output = json.loads(f.getvalue())
+
+        # Should have no split boundary warnings.
+        split_issues = [
+            i
+            for i in output["issues"]
+            if i["code"]
+            in [
+                "first_check_not_label_after_split",
+                "unanchored_check_dag_after_split",
+                "missing_split_input_file",
+            ]
+        ]
+        self.assertEqual(len(split_issues), 0)
+        self.assertEqual(result, exit_codes.SUCCESS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_list_equivalence.py
+++ b/tools/utils/test/lit_tests/test_list_equivalence.py
@@ -1,0 +1,83 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Equivalence tests for shared listing output.
+
+Ensures that `iree-lit-list` and `iree-lit-extract --list` produce identical
+output for both text and JSON, preventing drift between tools.
+"""
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parents[2]))
+
+from lit_tools import iree_lit_extract, iree_lit_list
+
+# Module-level fixture directory (absolute path for CWD-independence).
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TestEquivalence(unittest.TestCase):
+    def setUp(self):
+        self.split_test = _FIXTURES_DIR / "split_test.mlir"
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_text_equivalence(self, out1):
+        # list tool output
+        with patch("sys.argv", ["iree-lit-list", str(self.split_test)]):
+            args_list = iree_lit_list.parse_arguments()
+
+        rc = iree_lit_list.main(args_list)
+        self.assertEqual(rc, 0)
+        text_list = out1.getvalue()
+
+        # extract --list output
+        out2 = io.StringIO()
+        with patch("sys.stdout", out2):
+            with patch(
+                "sys.argv", ["iree-lit-extract", str(self.split_test), "--list"]
+            ):
+                args_extract = iree_lit_extract.parse_arguments()
+
+            rc2 = iree_lit_extract.main(args_extract)
+            self.assertEqual(rc2, 0)
+        text_extract = out2.getvalue()
+
+        self.assertEqual(text_list.strip(), text_extract.strip())
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_json_equivalence(self, out1):
+        # list tool JSON
+        with patch("sys.argv", ["iree-lit-list", str(self.split_test), "--json"]):
+            args_list = iree_lit_list.parse_arguments()
+
+        rc = iree_lit_list.main(args_list)
+        self.assertEqual(rc, 0)
+        payload_list = json.loads(out1.getvalue())
+
+        # extract --list JSON
+        out2 = io.StringIO()
+        with patch("sys.stdout", out2):
+            with patch(
+                "sys.argv",
+                ["iree-lit-extract", str(self.split_test), "--list", "--json"],
+            ):
+                args_extract = iree_lit_extract.parse_arguments()
+
+            rc2 = iree_lit_extract.main(args_extract)
+            self.assertEqual(rc2, 0)
+        payload_extract = json.loads(out2.getvalue())
+
+        self.assertEqual(payload_list, payload_extract)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_lit_wrapper.py
+++ b/tools/utils/test/lit_tests/test_lit_wrapper.py
@@ -1,0 +1,338 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for lit/core/lit_wrapper.py."""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lit_tools.core import lit_wrapper
+from lit_tools.core.parser import parse_test_file
+from lit_tools.core.rendering import inject_run_lines_with_case
+from lit_tools.core.text_utils import _strip_run_lines_preserve_line_numbers
+
+
+class TestInjectExtraFlags(unittest.TestCase):
+    """Tests for inject_extra_flags() function."""
+
+    def test_inject_simple_flags(self):
+        """Test basic flag injection."""
+        content = "// RUN: iree-opt %s | FileCheck %s"
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        self.assertEqual(result, "// RUN: iree-opt --debug %s | FileCheck %s")
+
+    def test_inject_multiple_flags(self):
+        """Test multiple flags."""
+        content = "// RUN: iree-opt --split-input-file %s"
+        result = lit_wrapper.inject_extra_flags(
+            content, "--debug --mlir-print-ir-after-all"
+        )
+        expected = (
+            "// RUN: iree-opt --debug --mlir-print-ir-after-all --split-input-file %s"
+        )
+        self.assertEqual(result, expected)
+
+    def test_inject_only_first_tool(self):
+        """Test that only first iree-* tool is modified."""
+        content = "// RUN: iree-opt %s | iree-compile - | FileCheck %s"
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        # Only iree-opt gets flags, not iree-compile.
+        expected = "// RUN: iree-opt --debug %s | iree-compile - | FileCheck %s"
+        self.assertEqual(result, expected)
+
+    def test_inject_ignores_non_iree_tools(self):
+        """Test that FileCheck and other tools are not modified."""
+        content = "// RUN: FileCheck %s"
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        self.assertEqual(result, content)  # unchanged
+
+    def test_inject_multiline_run(self):
+        """Test multi-line RUN with backslash continuation."""
+        content = """// RUN: iree-opt \\
+// RUN:   --split-input-file \\
+// RUN:   %s | FileCheck %s"""
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        # Only first line should be modified.
+        expected = """// RUN: iree-opt --debug \\
+// RUN:   --split-input-file \\
+// RUN:   %s | FileCheck %s"""
+        self.assertEqual(result, expected)
+
+    def test_inject_with_iree_compile(self):
+        """Test injection with iree-compile."""
+        content = "// RUN: iree-compile %s"
+        result = lit_wrapper.inject_extra_flags(
+            content, "--iree-hal-target-backends=llvm-cpu"
+        )
+        expected = "// RUN: iree-compile --iree-hal-target-backends=llvm-cpu %s"
+        self.assertEqual(result, expected)
+
+    def test_inject_with_iree_run_module(self):
+        """Test injection with iree-run-module."""
+        content = "// RUN: iree-run-module --module=test.vmfb"
+        result = lit_wrapper.inject_extra_flags(content, "--device=local-task")
+        expected = "// RUN: iree-run-module --device=local-task --module=test.vmfb"
+        self.assertEqual(result, expected)
+
+    def test_inject_empty_flags(self):
+        """Test with empty flags (no-op)."""
+        content = "// RUN: iree-opt %s"
+        result = lit_wrapper.inject_extra_flags(content, "")
+        self.assertEqual(result, content)
+
+    def test_inject_none_flags(self):
+        """Test with None flags (no-op)."""
+        content = "// RUN: iree-opt %s"
+        result = lit_wrapper.inject_extra_flags(content, None)
+        self.assertEqual(result, content)
+
+    def test_inject_preserves_non_run_lines(self):
+        """Test that non-RUN lines are preserved."""
+        content = """// Copyright notice
+// Some comment
+// RUN: iree-opt %s
+func @test() { }"""
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        expected = """// Copyright notice
+// Some comment
+// RUN: iree-opt --debug %s
+func @test() { }"""
+        self.assertEqual(result, expected)
+
+    def test_inject_with_indented_run(self):
+        """Test with indented RUN line."""
+        content = "  // RUN: iree-opt %s"
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        expected = "  // RUN: iree-opt --debug %s"
+        self.assertEqual(result, expected)
+
+    def test_inject_with_no_space_after_comment(self):
+        """Test with no space after //."""
+        content = "//RUN: iree-opt %s"
+        result = lit_wrapper.inject_extra_flags(content, "--debug")
+        expected = "//RUN: iree-opt --debug %s"
+        self.assertEqual(result, expected)
+
+
+class TestParseLitFailure(unittest.TestCase):
+    """Tests for parse_lit_failure() function."""
+
+    def test_parse_success_no_failure(self):
+        """Test parsing successful lit output."""
+        stdout = """-- Testing: 1 tests, 1 workers --
+PASS: IREE :: test.mlir (1 of 1)
+
+Testing Time: 0.18s
+  Passed: 1 (100.00%)
+"""
+        summary, cmds = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNone(summary)
+        self.assertEqual(cmds, [])
+
+    def test_parse_simple_failure(self):
+        """Test parsing simple failure with commands."""
+        stdout = """FAIL: IREE :: test.mlir (1 of 1)
+******************** TEST 'IREE :: test.mlir' FAILED ********************
+Exit Code: 1
+
+Command Output (stderr):
+--
++ iree-opt test.mlir
++ FileCheck test.mlir
+
+********************
+"""
+        summary, cmds = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("Failed command", summary)
+        self.assertEqual(len(cmds), 2)
+        self.assertEqual(cmds[0], "iree-opt test.mlir")
+        self.assertEqual(cmds[1], "FileCheck test.mlir")
+
+    def test_parse_filecheck_error(self):
+        """Test extraction of FileCheck error."""
+        stdout = """FAIL: IREE :: test.mlir (1 of 1)
+******************** TEST 'IREE :: test.mlir' FAILED ********************
+Command Output (stderr):
+--
++ iree-opt --canonicalize test.mlir
++ FileCheck test.mlir
+test.mlir:10:11: error: CHECK: expected string not found in input
+// CHECK: some_pattern
+          ^
+
+Input file: <stdin>
+********************
+"""
+        summary, _ = lit_wrapper.parse_lit_failure(stdout, "")
+        self.assertIsNotNone(summary)
+        self.assertIn("error: CHECK:", summary)
+        self.assertIn("test.mlir:10:11", summary)
+
+
+class TestExtractFileCheckError(unittest.TestCase):
+    """Tests for extract_filecheck_error() function."""
+
+    def test_extract_basic_error(self):
+        """Test extracting basic FileCheck error."""
+        failure_text = """+ FileCheck test.mlir
+test.mlir:10:11: error: CHECK: expected string not found in input
+// CHECK: pattern
+          ^
+
+Input file: <stdin>
+"""
+        error = lit_wrapper.extract_filecheck_error(failure_text)
+        self.assertIsNotNone(error)
+        self.assertIn("test.mlir:10:11", error)
+        self.assertIn("CHECK: expected string not found", error)
+
+    def test_extract_no_error(self):
+        """Test when no FileCheck error present."""
+        failure_text = """+ iree-opt test.mlir
+Some other error message
+"""
+        error = lit_wrapper.extract_filecheck_error(failure_text)
+        self.assertIsNone(error)
+
+    def test_extract_truncates_long_errors(self):
+        """Test that very long errors are truncated."""
+        # Create error with more than 10 lines.
+        error_lines = ["test.mlir:1:1: error: CHECK: failed"] + [
+            f"line {i}" for i in range(15)
+        ]
+        failure_text = "\n".join(error_lines) + "\n\nInput file: test"
+
+        error = lit_wrapper.extract_filecheck_error(failure_text)
+        self.assertIsNotNone(error)
+        result_lines = error.split("\n")
+        # Should be truncated to 11 lines (10 + "... use -v" message).
+        self.assertLessEqual(len(result_lines), 11)
+        self.assertIn("use -v", error)
+
+
+class TestLitImport(unittest.TestCase):
+    """Smoke test to ensure lit is importable from tree or site."""
+
+    def test_import_lit(self):
+        # Call _ensure_lit_importable() which uses build_detection to find lit.
+        try:
+            lit_wrapper._ensure_lit_importable()
+            import lit  # noqa: F401, PLC0415 (deferred import for availability check)
+        except Exception:
+            self.skipTest("lit not importable in this environment")
+
+
+class TestCaseRunLineReinjection(unittest.TestCase):
+    """Ensure case-local RUN lines are re-injected at correct positions."""
+
+    def test_case_local_run_lines_positions(self):
+        # Multi-case file where case 2 has a case-local RUN line.
+        file_text = "\n".join(
+            [
+                "// RUN: iree-opt %s | FileCheck %s",
+                "// CHECK-LABEL: @first",
+                "func @first() {}",
+                "",
+                "// -----",
+                "",
+                "// CHECK-LABEL: @second",
+                "// CHECK: A",
+                "// RUN: iree-opt --canonicalize %s | FileCheck %s",
+                "// CHECK: B",
+                "func @second() {}",
+            ]
+        )
+
+        with NamedTemporaryFile("w", suffix=".mlir", delete=False) as tmp:
+            p = Path(tmp.name)
+            tmp.write(file_text)
+
+        try:
+            # Parse to get second case which has case-local RUN
+            test_file_obj = parse_test_file(p)
+            cases = list(test_file_obj.cases)
+            self.assertEqual(len(cases), 2)
+            case = cases[1]  # Second case has the case-local RUN
+
+            # Extract case-local RUN lines using new API
+            case_runs = case.extract_local_run_lines()
+            self.assertEqual(len(case_runs), 1, "Should have 1 case-local RUN")
+
+            # Strip and re-inject into synthesized content (with blank prefix)
+            stripped = _strip_run_lines_preserve_line_numbers(case.render_for_testing())
+            content = ("\n" * (case.start_line - 1)) + stripped
+            rebuilt = inject_run_lines_with_case(content, [], case_runs)
+            lines = rebuilt.split("\n")
+
+            # Verify the RUN line was injected back at correct position
+            found_run = False
+            for line in lines:
+                if "// RUN:" in line and "--canonicalize" in line:
+                    found_run = True
+                    break
+            self.assertTrue(found_run, "Case-local RUN line should be present")
+        finally:
+            p.unlink()
+
+    def test_case_local_run_lines_continuation(self):
+        # Multi-case file with case-local RUN continuation.
+        file_text = "\n".join(
+            [
+                "// RUN: iree-opt %s | FileCheck %s",
+                "// CHECK-LABEL: @first",
+                "func @first() {}",
+                "",
+                "// -----",
+                "",
+                "// CHECK-LABEL: @second",
+                "// CHECK: A",
+                "// RUN: iree-opt \\",
+                "// RUN:   --canonicalize %s | FileCheck %s",
+                "func @second() {}",
+            ]
+        )
+
+        with NamedTemporaryFile("w", suffix=".mlir", delete=False) as tmp:
+            p = Path(tmp.name)
+            tmp.write(file_text)
+        try:
+            # Parse to get second case with case-local RUN continuation
+            test_file_obj = parse_test_file(p)
+            cases = list(test_file_obj.cases)
+            self.assertEqual(len(cases), 2)
+            case = cases[1]  # Second case has the case-local RUN
+
+            # Extract case-local RUN lines using new API
+            case_runs = case.extract_local_run_lines()
+            # Continuation lines are returned as separate entries
+            self.assertEqual(
+                len(case_runs), 2, "Should have 2 RUN lines (continuation)"
+            )
+
+            stripped = _strip_run_lines_preserve_line_numbers(case.render_for_testing())
+            content = ("\n" * (case.start_line - 1)) + stripped
+            rebuilt = inject_run_lines_with_case(content, [], case_runs)
+
+            # Verify the RUN line was injected and contains the expected flag
+            found_run = False
+            for line in rebuilt.split("\n"):
+                if "// RUN:" in line and "--canonicalize" in line:
+                    found_run = True
+                    break
+            self.assertTrue(
+                found_run, "Case-local RUN with continuation should be present"
+            )
+        finally:
+            p.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_parser.py
+++ b/tools/utils/test/lit_tests/test_parser.py
@@ -1,0 +1,451 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tests for lit test file parser.
+
+These tests verify the parser correctly identifies test case boundaries,
+classifies lines, and extracts metadata.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from lit_tools.core.parser import (
+    TAG_CHECK,
+    TAG_DELIMITER,
+    TAG_RUN_CASE,
+    TAG_RUN_HEADER,
+    parse_test_file,
+)
+
+
+class TestParserBasics(unittest.TestCase):
+    """Basic parser functionality tests."""
+
+    def test_parse_single_case_file(self):
+        """Test parsing file with no delimiters (single case)."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @simple
+func @simple() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            self.assertEqual(len(test_file.cases), 1)
+            self.assertEqual(test_file.cases[0].number, 1)
+            self.assertEqual(test_file.cases[0].name, "simple")
+            self.assertIsNone(test_file.header_span)  # No delimiter, no header
+            self.assertEqual(len(test_file.delimiter_lines), 0)
+        finally:
+            path.unlink()
+
+    def test_parse_multi_case_file(self):
+        """Test parsing file with multiple cases separated by delimiters."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @first
+func @first() { return }
+
+// -----
+
+// CHECK-LABEL: @second
+func @second() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            self.assertEqual(len(test_file.cases), 2)
+            self.assertEqual(test_file.cases[0].name, "first")
+            self.assertEqual(test_file.cases[1].name, "second")
+            self.assertEqual(len(test_file.delimiter_lines), 1)
+        finally:
+            path.unlink()
+
+    def test_parse_empty_case(self):
+        """Test parsing empty case (consecutive delimiters)."""
+        content = """// RUN: test
+// CHECK-LABEL: @first
+func @first() { }
+
+// -----
+
+// -----
+
+// CHECK-LABEL: @third
+func @third() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            # Should have 3 cases: first, middle (blank line), third
+            self.assertEqual(len(test_file.cases), 3)
+            self.assertEqual(test_file.cases[0].name, "first")
+            self.assertIsNone(test_file.cases[1].name)  # Middle case (just blank line)
+            # Middle case has the blank line between delimiters, so length=1
+            self.assertEqual(test_file.cases[1].span.length, 1)
+            self.assertEqual(test_file.cases[2].name, "third")
+        finally:
+            path.unlink()
+
+
+class TestLineTagging(unittest.TestCase):
+    """Tests for line classification/tagging."""
+
+    def test_tag_header_run_lines(self):
+        """Test that RUN lines before delimiter are tagged as header."""
+        content = """// RUN: iree-opt %s
+// RUN:   | FileCheck %s
+// CHECK-LABEL: @test
+func @test() { }
+
+// -----
+
+// CHECK-LABEL: @case2
+func @case2() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            doc = test_file.doc
+
+            # Lines 0-1 should be RUN_HEADER
+            self.assertIn(TAG_RUN_HEADER, doc.lines[0].tags)
+            self.assertIn(TAG_RUN_HEADER, doc.lines[1].tags)
+
+            # Line 5 should be DELIMITER
+            self.assertIn(TAG_DELIMITER, doc.lines[5].tags)
+        finally:
+            path.unlink()
+
+    def test_tag_case_local_run_lines(self):
+        """Test that RUN lines after delimiter are tagged as case-local."""
+        content = """// RUN: header-command
+
+// -----
+
+// RUN: case-local-command
+// CHECK-LABEL: @test
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            doc = test_file.doc
+
+            # Line 0 should be RUN_HEADER
+            self.assertIn(TAG_RUN_HEADER, doc.lines[0].tags)
+
+            # After delimiter, RUN should be RUN_CASE
+            run_case_indices = [
+                i for i, line in enumerate(doc.lines) if TAG_RUN_CASE in line.tags
+            ]
+            self.assertEqual(len(run_case_indices), 1)
+            self.assertIn("case-local", doc.lines[run_case_indices[0]].text)
+        finally:
+            path.unlink()
+
+    def test_tag_check_lines(self):
+        """Test that CHECK directives are tagged."""
+        content = """// RUN: test
+// CHECK-LABEL: @foo
+// CHECK: constant
+// CHECK-NEXT: return
+func @foo() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            doc = test_file.doc
+
+            # Count CHECK-tagged lines
+            check_lines = [line for line in doc.lines if TAG_CHECK in line.tags]
+            self.assertEqual(len(check_lines), 3)  # LABEL, CHECK, CHECK-NEXT
+        finally:
+            path.unlink()
+
+
+class TestCaseMetadata(unittest.TestCase):
+    """Tests for case metadata extraction."""
+
+    def test_extract_single_check_label(self):
+        """Test extracting single CHECK-LABEL name."""
+        content = """// RUN: test
+// CHECK-LABEL: @my_function
+func @my_function() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            self.assertEqual(case.name, "my_function")
+            self.assertEqual(case.all_names, ("my_function",))
+        finally:
+            path.unlink()
+
+    def test_extract_multiple_check_labels(self):
+        """Test extracting multiple CHECK-LABEL names (different prefixes)."""
+        content = """// RUN: test
+// CHECK-LABEL: @foo
+// FOO-LABEL: @foo
+// BAR-LABEL: @bar
+func @foo() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            self.assertEqual(case.name, "foo")  # Primary name
+            self.assertIn("foo", case.all_names)
+            self.assertIn("bar", case.all_names)
+        finally:
+            path.unlink()
+
+    def test_case_without_check_label(self):
+        """Test case without CHECK-LABEL gets None name."""
+        content = """// RUN: test
+// CHECK: constant
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            self.assertIsNone(case.name)
+            self.assertEqual(case.all_names, ())
+        finally:
+            path.unlink()
+
+    def test_check_count(self):
+        """Test that CHECK directive count is correct."""
+        content = """// RUN: test
+// CHECK-LABEL: @foo
+// CHECK: line1
+// CHECK-NEXT: line2
+// CHECK: line3
+func @foo() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            self.assertEqual(case.check_count, 4)  # LABEL + 3 CHECKs
+        finally:
+            path.unlink()
+
+
+class TestRealWorldPatterns(unittest.TestCase):
+    """Tests based on real IREE patterns."""
+
+    def test_stream_dialect_pattern(self):
+        """Test pattern from stream dialect tests."""
+        content = """// RUN: iree-opt --iree-stream-propagate-timepoints %s | FileCheck %s
+
+// Tests that resource global loads work.
+
+// CHECK: util.global private mutable @global
+util.global private mutable @global : !stream.resource<constant>
+
+// CHECK-LABEL: @globalLoad
+util.func private @globalLoad() {
+  %0 = util.global.load @global : !stream.resource<constant>
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @globalStore
+util.func private @globalStore(%arg0: !stream.resource<variable>) {
+  util.global.store %arg0, @global : !stream.resource<variable>
+  util.return
+}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            self.assertEqual(len(test_file.cases), 2)
+            self.assertEqual(test_file.cases[0].name, "globalLoad")
+            self.assertEqual(test_file.cases[1].name, "globalStore")
+
+            # Both cases should have header RUN lines
+            self.assertGreater(len(test_file.cases[0].header_run_lines), 0)
+            self.assertEqual(
+                test_file.cases[0].header_run_lines, test_file.cases[1].header_run_lines
+            )
+        finally:
+            path.unlink()
+
+
+class TestRUNLineEdgeCases(unittest.TestCase):
+    """Tests for RUN line parsing corner cases and edge conditions."""
+
+    def test_code_before_first_delimiter(self):
+        """Test that IR code before first delimiter is handled correctly."""
+        # Scenario: File has actual IR (not just RUN lines) before first delimiter.
+        # Parser should treat this as the first case, not as header content.
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @prelude
+func @prelude() { return }
+
+// -----
+
+// CHECK-LABEL: @second
+func @second() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            # Should have 2 cases
+            self.assertEqual(len(test_file.cases), 2)
+
+            # First case should include the IR code before delimiter
+            self.assertEqual(test_file.cases[0].name, "prelude")
+            self.assertIn("func @prelude", test_file.cases[0].content)
+
+            # Header RUN lines should be properly identified
+            header_runs = test_file.extract_run_lines(raw=False)
+            self.assertEqual(len(header_runs), 1)
+            self.assertIn("iree-opt", header_runs[0])
+        finally:
+            path.unlink()
+
+    def test_backslash_continuation_with_trailing_whitespace(self):
+        """Test that backslash continuation works with trailing whitespace."""
+        # Scenario: RUN line ending in backslash followed by spaces/tabs.
+        # The rstrip() in parser should handle this correctly.
+        content = """// RUN: iree-opt \\
+// RUN:   --pass-pipeline='builtin.module(func.func(cse))' \\
+// RUN:   %s
+// CHECK-LABEL: @test
+func @test() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            # Should have 1 case
+            self.assertEqual(len(test_file.cases), 1)
+
+            # Should extract as a single multi-line RUN command
+            runs = test_file.extract_run_lines(raw=False)
+            self.assertEqual(len(runs), 1)
+            self.assertIn("pass-pipeline", runs[0])
+            self.assertIn("%s", runs[0])
+        finally:
+            path.unlink()
+
+    def test_quoted_backslashes_not_continuation(self):
+        """Test that backslashes inside quotes are not treated as continuation."""
+        # Scenario: RUN line with Windows path or regex containing backslash.
+        # Should NOT treat the quoted backslash as line continuation.
+        content = """// RUN: tool --arg="path\\to\\file"
+// CHECK-LABEL: @test
+func @test() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            # Should have 1 case
+            self.assertEqual(len(test_file.cases), 1)
+
+            # Should be a single RUN line (not continuation)
+            runs = test_file.extract_run_lines(raw=True)
+            self.assertEqual(len(runs), 1)
+            self.assertIn('--arg="path\\to\\file"', runs[0])
+
+            # CHECK-LABEL should be in the case content, not consumed by RUN
+            self.assertIn("CHECK-LABEL", test_file.cases[0].content)
+        finally:
+            path.unlink()
+
+    def test_interleaved_comments_in_multiline_runs(self):
+        """Test that comments between RUN continuation lines are handled."""
+        # Scenario: Multi-line RUN with a comment line in the middle.
+        # Current parser should either break on comment or handle gracefully.
+        content = """// RUN: iree-opt \\
+// NOTE: This is a comment about the pass
+// RUN:   --pass-one %s
+// CHECK-LABEL: @test
+func @test() { return }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            # Should have 1 case
+            self.assertEqual(len(test_file.cases), 1)
+
+            # The comment breaks continuation, so we should have either:
+            # - 1 incomplete RUN (just "iree-opt"), or
+            # - 2 separate RUNs
+            runs = test_file.extract_run_lines(raw=False)
+            # Parser will likely break at the comment, resulting in incomplete command
+            # This test documents current behavior - we're checking it doesn't crash
+            self.assertGreater(len(runs), 0, "Should extract at least one RUN line")
+        finally:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_rendering.py
+++ b/tools/utils/test/lit_tests/test_rendering.py
@@ -1,0 +1,517 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tests for lit test file rendering.
+
+These tests verify that test cases and complete files can be rendered
+correctly in both line-preserving and normalized modes.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from lit_tools.core.parser import parse_test_file
+from lit_tools.core.rendering import build_file_content
+
+
+class TestCaseRenderForTesting(unittest.TestCase):
+    """Tests for TestCase.render_for_testing() method."""
+
+    def test_preserves_line_count(self):
+        """Test that render_for_testing preserves total line count."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @foo
+func @foo() {
+  return
+}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_for_testing()
+
+            # Count lines in original vs rendered.
+            original_lines = content.count("\n")
+            rendered_lines = rendered.count("\n")
+            self.assertEqual(original_lines, rendered_lines)
+        finally:
+            path.unlink()
+
+    def test_blanks_run_lines(self):
+        """Test that RUN lines are replaced with blank lines."""
+        content = """// RUN: iree-opt %s
+// CHECK: constant
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_for_testing()
+
+            # First line should be blank (RUN replaced).
+            lines = rendered.split("\n")
+            self.assertEqual(lines[0], "")
+            # CHECK line should remain.
+            self.assertIn("// CHECK: constant", lines[1])
+        finally:
+            path.unlink()
+
+    def test_preserves_check_positions(self):
+        """Test that CHECK directives stay at original line numbers."""
+        content = """// RUN: test
+// First comment
+// CHECK-LABEL: @foo
+// CHECK: line1
+// CHECK: line2
+func @foo() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_for_testing()
+
+            lines = rendered.split("\n")
+            # Line 0: blank (was RUN).
+            self.assertEqual(lines[0], "")
+            # Line 1: comment.
+            self.assertIn("First comment", lines[1])
+            # Line 2: CHECK-LABEL.
+            self.assertIn("CHECK-LABEL", lines[2])
+            # Line 3: CHECK.
+            self.assertIn("CHECK: line1", lines[3])
+        finally:
+            path.unlink()
+
+    def test_preserves_blank_lines(self):
+        """Test that existing blank lines are preserved."""
+        content = """// RUN: test
+
+// CHECK: foo
+
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_for_testing()
+
+            lines = rendered.split("\n")
+            # Blank line after RUN preserved.
+            self.assertEqual(lines[1], "")
+            # Blank line before func preserved.
+            self.assertEqual(lines[3], "")
+        finally:
+            path.unlink()
+
+
+class TestCaseRenderNormalized(unittest.TestCase):
+    """Tests for TestCase.render_normalized() method."""
+
+    def test_drops_run_lines(self):
+        """Test that RUN lines are dropped entirely."""
+        content = """// RUN: iree-opt %s
+// CHECK: foo
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_normalized()
+
+            # RUN line should not appear.
+            self.assertNotIn("RUN", rendered)
+            # CHECK and body should remain.
+            self.assertIn("// CHECK: foo", rendered)
+            self.assertIn("func @test()", rendered)
+        finally:
+            path.unlink()
+
+    def test_trims_leading_blank_lines(self):
+        """Test that leading blank lines are removed."""
+        content = """// RUN: test
+
+
+// CHECK: foo
+func @test() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_normalized()
+
+            # Should not start with blank lines.
+            self.assertFalse(rendered.startswith("\n"))
+            # Should start with CHECK.
+            self.assertTrue(rendered.startswith("// CHECK:"))
+        finally:
+            path.unlink()
+
+    def test_trims_trailing_blank_lines(self):
+        """Test that trailing blank lines are removed."""
+        content = """// RUN: test
+// CHECK: foo
+func @test() { }
+
+
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_normalized()
+
+            # render_normalized removes ALL trailing newlines.
+            self.assertTrue(rendered.endswith("}"))
+            self.assertFalse(rendered.endswith("\n"))
+        finally:
+            path.unlink()
+
+    def test_preserves_internal_content(self):
+        """Test that internal structure is preserved."""
+        content = """// RUN: test
+// CHECK-LABEL: @foo
+
+util.func @foo(%arg0: i32) {
+  %c = arith.constant 1 : i32
+  util.return
+}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            case = test_file.cases[0]
+            rendered = case.render_normalized()
+
+            # All body content should be present.
+            self.assertIn("CHECK-LABEL", rendered)
+            self.assertIn("util.func @foo", rendered)
+            self.assertIn("arith.constant", rendered)
+            self.assertIn("util.return", rendered)
+        finally:
+            path.unlink()
+
+
+class TestBuildFileContent(unittest.TestCase):
+    """Tests for build_file_content() function."""
+
+    def test_preserving_mode_single_case(self):
+        """Test preserving mode with single case file."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @foo
+func @foo() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            rebuilt = build_file_content(test_file, normalize=False)
+
+            # Should have header RUN.
+            self.assertIn("// RUN:", rebuilt)
+            # Should have CHECK.
+            self.assertIn("CHECK-LABEL", rebuilt)
+            # Should have body.
+            self.assertIn("func @foo", rebuilt)
+        finally:
+            path.unlink()
+
+    def test_preserving_mode_multi_case(self):
+        """Test preserving mode with multiple cases."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @first
+func @first() { }
+
+// -----
+
+// CHECK-LABEL: @second
+func @second() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            rebuilt = build_file_content(test_file, normalize=False)
+
+            # Should have header RUN.
+            lines = rebuilt.split("\n")
+            self.assertIn("RUN", lines[0])
+
+            # Should have delimiter.
+            self.assertIn("// -----", rebuilt)
+
+            # Should have both cases.
+            self.assertIn("@first", rebuilt)
+            self.assertIn("@second", rebuilt)
+        finally:
+            path.unlink()
+
+    def test_normalized_mode_drops_runs(self):
+        """Test that normalized mode drops case-local RUN lines."""
+        content = """// RUN: iree-opt %s | FileCheck %s
+// CHECK-LABEL: @foo
+func @foo() { }
+
+// -----
+
+// RUN: case-local-command
+// CHECK-LABEL: @bar
+func @bar() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            rebuilt = build_file_content(test_file, normalize=True)
+
+            # Should have header RUN.
+            self.assertIn("// RUN: iree-opt", rebuilt)
+
+            # Should NOT have case-local RUN.
+            self.assertNotIn("case-local-command", rebuilt)
+
+            # Should have both cases.
+            self.assertIn("@foo", rebuilt)
+            self.assertIn("@bar", rebuilt)
+        finally:
+            path.unlink()
+
+    def test_normalized_mode_trims_blanks(self):
+        """Test that normalized mode trims excess blank lines."""
+        content = """// RUN: test
+
+// CHECK-LABEL: @foo
+
+
+func @foo() { }
+
+
+// -----
+
+
+// CHECK-LABEL: @bar
+func @bar() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            rebuilt = build_file_content(test_file, normalize=True)
+
+            # Should not have consecutive blank lines within cases.
+            self.assertNotIn("\n\n\n", rebuilt)
+        finally:
+            path.unlink()
+
+    def test_idempotency(self):
+        """Test that normalize(normalize(x)) == normalize(x)."""
+        content = """// RUN: test
+
+
+// CHECK-LABEL: @foo
+
+
+func @foo() { }
+
+
+// -----
+
+
+// CHECK-LABEL: @bar
+
+
+func @bar() { }
+
+
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+
+            # First normalization.
+            normalized1 = build_file_content(test_file, normalize=True)
+
+            # Parse normalized output and normalize again.
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".mlir", delete=False
+            ) as f2:
+                f2.write(normalized1)
+                f2.flush()
+                path2 = Path(f2.name)
+
+            try:
+                test_file2 = parse_test_file(path2)
+                normalized2 = build_file_content(test_file2, normalize=True)
+
+                # Should be identical.
+                self.assertEqual(normalized1, normalized2)
+            finally:
+                path2.unlink()
+        finally:
+            path.unlink()
+
+    def test_handles_empty_cases(self):
+        """Test that empty cases are handled correctly."""
+        content = """// RUN: test
+// CHECK-LABEL: @first
+func @first() { }
+
+// -----
+
+// -----
+
+// CHECK-LABEL: @third
+func @third() { }
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+            rebuilt = build_file_content(test_file, normalize=True)
+
+            # Should have both non-empty cases.
+            self.assertIn("@first", rebuilt)
+            self.assertIn("@third", rebuilt)
+
+            # Should have delimiters.
+            self.assertIn("// -----", rebuilt)
+        finally:
+            path.unlink()
+
+    def test_ends_with_newline(self):
+        """Test that built content always ends with newline."""
+        content = """// RUN: test
+// CHECK: foo
+func @test() { }"""  # No trailing newline.
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+
+            # Both modes should end with newline.
+            preserved = build_file_content(test_file, normalize=False)
+            self.assertTrue(preserved.endswith("\n"))
+
+            normalized = build_file_content(test_file, normalize=True)
+            self.assertTrue(normalized.endswith("\n"))
+        finally:
+            path.unlink()
+
+
+class TestRealWorldPatterns(unittest.TestCase):
+    """Tests with real IREE patterns."""
+
+    def test_stream_dialect_file(self):
+        """Test rendering file with stream dialect patterns."""
+        content = """// RUN: iree-opt --iree-stream-propagate-timepoints %s | FileCheck %s
+
+// Tests that resource global loads work.
+
+// CHECK: util.global private mutable @global
+util.global private mutable @global : !stream.resource<constant>
+
+// CHECK-LABEL: @globalLoad
+util.func private @globalLoad() {
+  %0 = util.global.load @global : !stream.resource<constant>
+  util.return
+}
+
+// -----
+
+// CHECK-LABEL: @globalStore
+util.func private @globalStore(%arg0: !stream.resource<variable>) {
+  util.global.store %arg0, @global : !stream.resource<variable>
+  util.return
+}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            test_file = parse_test_file(path)
+
+            # Test preserving mode.
+            preserved = build_file_content(test_file, normalize=False)
+            self.assertIn("// RUN:", preserved)
+            self.assertIn("globalLoad", preserved)
+            self.assertIn("globalStore", preserved)
+
+            # Test normalized mode.
+            normalized = build_file_content(test_file, normalize=True)
+            self.assertIn("// RUN:", normalized)
+            self.assertIn("globalLoad", normalized)
+            self.assertIn("globalStore", normalized)
+            self.assertIn("// -----", normalized)
+        finally:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_run_line_handling.py
+++ b/tools/utils/test/lit_tests/test_run_line_handling.py
@@ -1,0 +1,238 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Tests for RUN line stripping and injection."""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lit_tools.core.parser import parse_test_file
+from lit_tools.core.rendering import inject_run_lines_with_case
+from lit_tools.core.text_utils import (
+    _strip_run_lines_preserve_line_numbers,
+    inject_run_lines,
+)
+
+
+class TestStripRunLines(unittest.TestCase):
+    """Tests for _strip_run_lines_preserve_line_numbers()."""
+
+    def test_single_run_line(self):
+        """Test stripping single RUN line."""
+        content = "// RUN: iree-opt %s\n// CHECK: foo\nbar"
+        result = _strip_run_lines_preserve_line_numbers(content)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "", "Line 1 should be blank (was RUN)")
+        self.assertEqual(lines[1], "// CHECK: foo", "Line 2 should be preserved")
+        self.assertEqual(lines[2], "bar", "Line 3 should be preserved")
+
+    def test_multiline_run_with_backslash(self):
+        """Test stripping multi-line RUN with backslash continuation."""
+        content = (
+            "// RUN: iree-opt --pass1 \\\n"
+            "// RUN:   --pass2 \\\n"
+            "// RUN:   %s | FileCheck %s\n"
+            "// CHECK: foo"
+        )
+        result = _strip_run_lines_preserve_line_numbers(content)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "", "Line 1 should be blank")
+        self.assertEqual(lines[1], "", "Line 2 should be blank")
+        self.assertEqual(lines[2], "", "Line 3 should be blank")
+        self.assertEqual(lines[3], "// CHECK: foo", "Line 4 should be preserved")
+
+    def test_run_line_in_middle_of_file(self):
+        """Test that RUN lines anywhere in file are stripped."""
+        content = (
+            "// Some comment\n"
+            "// RUN: iree-opt %s\n"
+            "// CHECK: foo\n"
+            "// RUN: another-tool\n"
+            "bar"
+        )
+        result = _strip_run_lines_preserve_line_numbers(content)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "// Some comment", "Line 1 preserved")
+        self.assertEqual(lines[1], "", "Line 2 should be blank (was RUN)")
+        self.assertEqual(lines[2], "// CHECK: foo", "Line 3 preserved")
+        self.assertEqual(lines[3], "", "Line 4 should be blank (was RUN)")
+        self.assertEqual(lines[4], "bar", "Line 5 preserved")
+
+    def test_no_run_lines(self):
+        """Test no-op when no RUN lines present."""
+        content = "// CHECK: foo\nbar\nbaz"
+        result = _strip_run_lines_preserve_line_numbers(content)
+
+        self.assertEqual(result, content, "Content should be unchanged")
+
+    def test_indented_run_line(self):
+        """Test stripping indented RUN line."""
+        content = "  // RUN: iree-opt %s\n// CHECK: foo"
+        result = _strip_run_lines_preserve_line_numbers(content)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "", "Line 1 should be blank")
+        self.assertEqual(lines[1], "// CHECK: foo", "Line 2 preserved")
+
+    def test_preserves_empty_lines(self):
+        """Test that existing blank lines are preserved."""
+        content = "// RUN: tool\n\n// CHECK: foo\n\nbar"
+        result = _strip_run_lines_preserve_line_numbers(content)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "", "Line 1 blank (was RUN)")
+        self.assertEqual(lines[1], "", "Line 2 blank (original)")
+        self.assertEqual(lines[2], "// CHECK: foo", "Line 3 preserved")
+        self.assertEqual(lines[3], "", "Line 4 blank (original)")
+        self.assertEqual(lines[4], "bar", "Line 5 preserved")
+
+
+class TestInjectRunLines(unittest.TestCase):
+    """Tests for inject_run_lines()."""
+
+    def test_case1_scenario(self):
+        """Test case 1: start_line=1, content has blanks from stripped RUNs."""
+        # Simulate case 1: RUN lines were at lines 1-3, now blanks
+        content = "\n\n\n\n// CHECK-LABEL: @first_case\nutil.func..."
+        run_lines = ["iree-opt %s | FileCheck %s"]
+
+        # No blanks prepended (start_line = 1)
+        result = inject_run_lines(content, run_lines)
+        lines = result.split("\n")
+
+        self.assertTrue(lines[0].startswith("// RUN:"), "Line 1 should be RUN")
+        self.assertEqual(lines[1], "", "Line 2 should be blank")
+        self.assertTrue("CHECK-LABEL" in lines[4], "Line 5 should be CHECK-LABEL")
+
+    def test_case2_scenario(self):
+        """Test case 2: start_line=14, prepended blanks + content blank."""
+        # Simulate case 2: 13 prepended blanks + content with leading blank
+        blank_prefix = "\n" * 13
+        content = "\n// CHECK-LABEL: @second_case\nutil.func..."
+        content_with_blanks = blank_prefix + content
+        run_lines = ["iree-opt %s | FileCheck %s"]
+
+        result = inject_run_lines(content_with_blanks, run_lines)
+        lines = result.split("\n")
+
+        self.assertTrue(lines[0].startswith("// RUN:"), "Line 1 should be RUN")
+        self.assertEqual(lines[1], "", "Line 2 should be blank")
+        self.assertTrue("CHECK-LABEL" in lines[14], "Line 15 should be CHECK-LABEL")
+
+    def test_case3_scenario(self):
+        """Test case 3: start_line=26, more prepended blanks."""
+        blank_prefix = "\n" * 25
+        content = "\n// CHECK-LABEL: @third_case\nutil.func..."
+        content_with_blanks = blank_prefix + content
+        run_lines = ["iree-opt %s | FileCheck %s"]
+
+        result = inject_run_lines(content_with_blanks, run_lines)
+        lines = result.split("\n")
+
+        self.assertTrue(lines[0].startswith("// RUN:"), "Line 1 should be RUN")
+        self.assertTrue("CHECK-LABEL" in lines[26], "Line 27 should be CHECK-LABEL")
+
+    def test_multiple_run_lines(self):
+        """Test injecting multiple RUN lines."""
+        content = "\n\n\n\n\n// CHECK: foo"
+        run_lines = ["cmd1", "cmd2", "cmd3"]
+
+        result = inject_run_lines(content, run_lines)
+        lines = result.split("\n")
+
+        self.assertEqual(lines[0], "// RUN: cmd1", "Line 1 should be RUN 1")
+        self.assertEqual(lines[1], "// RUN: cmd2", "Line 2 should be RUN 2")
+        self.assertEqual(lines[2], "// RUN: cmd3", "Line 3 should be RUN 3")
+        self.assertEqual(lines[3], "", "Line 4 should be blank")
+        self.assertTrue("CHECK" in lines[5], "Line 6 should be CHECK")
+
+    def test_no_run_lines(self):
+        """Test no-op when no RUN lines to inject."""
+        content = "\n\n// CHECK: foo"
+        result = inject_run_lines(content, [])
+
+        self.assertEqual(result, content, "Content should be unchanged")
+
+    def test_no_run_fixture_header_and_body(self):
+        """Ensure extract_run_lines returns empty and reinjection keeps content."""
+        fixture = Path(__file__).parent / "fixtures" / "no_run_test.mlir"
+        test_file_obj = parse_test_file(fixture)
+        header_runs = test_file_obj.extract_run_lines(raw=False)
+        self.assertEqual(header_runs, [])
+        cases = list(test_file_obj.cases)
+        self.assertEqual(len(cases), 1)
+        case = cases[0]
+        # Build synthesized content (blank prefix + stripped case)
+        stripped = _strip_run_lines_preserve_line_numbers(case.content)
+        synthesized = ("\n" * (case.start_line - 1)) + stripped
+        rebuilt = inject_run_lines_with_case(
+            synthesized, header_runs, case.extract_local_run_lines()
+        )
+        self.assertEqual(rebuilt, synthesized)
+
+    def test_immediate_ir_no_leading_blanks(self):
+        """Test when content has no leading blanks (shouldn't happen but handle it)."""
+        content = "// CHECK-LABEL: @foo\nutil.func..."
+        run_lines = ["iree-opt %s"]
+
+        result = inject_run_lines(content, run_lines)
+        lines = result.split("\n")
+
+        # RUN line replaces first line (CHECK-LABEL)
+        self.assertTrue(lines[0].startswith("// RUN:"), "Line 1 should be RUN")
+        self.assertTrue("util.func" in lines[1], "Line 2 should be util.func")
+
+
+class TestIntegrationWithParse(unittest.TestCase):
+    """Test integration of strip and inject with parse_test_file()."""
+
+    def setUp(self):
+        """Set up test fixture path."""
+        self.fixture_path = Path(__file__).parent / "fixtures" / "split_test.mlir"
+
+    def test_all_cases_preserve_line_numbers(self):
+        """Test that all 3 cases preserve line numbers through strip/inject cycle."""
+        test_file_obj = parse_test_file(self.fixture_path)
+        cases = list(test_file_obj.cases)
+        run_lines = test_file_obj.extract_run_lines(raw=True)
+
+        # inject_run_lines preserves original line numbers by replacing leading blanks.
+        # The test verifies CHECK-LABELs remain at their original file line numbers.
+        expected_check_lines = {
+            1: 4,  # CHECK-LABEL for first_case at line 4
+            2: 13,  # CHECK-LABEL for second_case at line 13
+            3: 24,  # CHECK-LABEL for third_case at line 24
+        }
+
+        for case in cases:
+            # Simulate lit_wrapper processing
+            blank_prefix = "\n" * (case.start_line - 1)
+            content_with_blanks = blank_prefix + case.render_for_testing()
+            result = inject_run_lines(content_with_blanks, run_lines)
+
+            # Verify CHECK-LABEL is at expected line
+            lines = result.split("\n")
+            expected_line = expected_check_lines[case.number]
+
+            self.assertTrue(
+                len(lines) >= expected_line, f"Case {case.number}: not enough lines"
+            )
+            self.assertTrue(
+                "CHECK-LABEL" in lines[expected_line - 1],
+                f"Case {case.number}: CHECK-LABEL not at line {expected_line}, "
+                f"found: {lines[expected_line - 1][:40]}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/lit_tests/test_verification.py
+++ b/tools/utils/test/lit_tests/test_verification.py
@@ -1,0 +1,187 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for lit_tools.core.verification module."""
+
+import argparse
+import unittest
+from unittest.mock import patch
+
+from lit_tools.core import verification
+
+
+class TestVerifyContentWithSkipCheck(unittest.TestCase):
+    """Tests for verify_content_with_skip_check helper function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.args = argparse.Namespace(
+            verify=True,
+            quiet=False,
+            json=False,
+            verify_timeout=5,
+        )
+
+    def test_verification_disabled_globally(self):
+        """Test that verification is skipped when --verify not set."""
+        self.args.verify = False
+        content = "func.func @test() { return }"
+
+        skipped, valid, error = verification.verify_content_with_skip_check(
+            content, case_number=1, case_name="test", args=self.args
+        )
+
+        self.assertFalse(skipped)  # Not skipped due to expected-error
+        self.assertTrue(valid)  # Considered valid when disabled
+        self.assertEqual(error, "")
+
+    def test_skip_due_to_expected_error(self):
+        """Test that content with expected-error skips verification."""
+        content = """
+        func.func @test() {
+            // expected-error @+1 {{test error}}
+            %bad = arith.invalid
+            return
+        }
+        """
+
+        with patch("common.console") as mock_console:
+            skipped, valid, error = verification.verify_content_with_skip_check(
+                content, case_number=2, case_name="test_func", args=self.args
+            )
+
+        self.assertTrue(skipped)
+        self.assertTrue(valid)
+        self.assertEqual(error, "")
+        # Should have printed skip note
+        mock_console.note.assert_called_once()
+        call_args = mock_console.note.call_args[0]
+        self.assertIn("Skipping verification for case 2", call_args[0])
+        self.assertIn("expected-error", call_args[0])
+
+    def test_skip_quiet_mode(self):
+        """Test that skip note is suppressed in quiet mode."""
+        self.args.quiet = True
+        content = "// expected-error @+1 {{error}}\n%bad = invalid"
+
+        with patch("common.console") as mock_console:
+            skipped, valid, _ = verification.verify_content_with_skip_check(
+                content, case_number=3, case_name=None, args=self.args
+            )
+
+        self.assertTrue(skipped)
+        self.assertTrue(valid)
+        # Should NOT have printed anything in quiet mode
+        mock_console.note.assert_not_called()
+
+    def test_verification_success(self):
+        """Test successful verification of valid IR."""
+        content = "func.func @test() { return }"
+
+        # Mock verify_ir to return success
+        with patch("lit_tools.core.verification.verify_ir") as mock_verify:
+            mock_verify.return_value = (True, "")
+
+            skipped, valid, error = verification.verify_content_with_skip_check(
+                content, case_number=4, case_name="test", args=self.args
+            )
+
+        self.assertFalse(skipped)
+        self.assertTrue(valid)
+        self.assertEqual(error, "")
+
+        # Verify that verify_ir was called with correct case_info
+        mock_verify.assert_called_once()
+        call_args = mock_verify.call_args[0]
+        self.assertEqual(call_args[0], content)
+        self.assertEqual(call_args[1], "Case 4 (@test)")
+
+    def test_verification_failure(self):
+        """Test verification failure with error message."""
+        content = "func.func @test() { %invalid syntax }"
+        error_msg = "Verification failed for Case 5: syntax error"
+
+        # Mock verify_ir to return failure
+        with patch("lit_tools.core.verification.verify_ir") as mock_verify:
+            mock_verify.return_value = (False, error_msg)
+
+            skipped, valid, error = verification.verify_content_with_skip_check(
+                content, case_number=5, case_name=None, args=self.args
+            )
+
+        self.assertFalse(skipped)
+        self.assertFalse(valid)
+        self.assertEqual(error, error_msg)
+
+        # Verify case_info without name
+        call_args = mock_verify.call_args[0]
+        self.assertEqual(call_args[1], "Case 5")
+
+    def test_custom_timeout(self):
+        """Test that custom timeout is passed through."""
+        content = "func.func @test() { return }"
+
+        with patch("lit_tools.core.verification.verify_ir") as mock_verify:
+            mock_verify.return_value = (True, "")
+
+            verification.verify_content_with_skip_check(
+                content,
+                case_number=6,
+                case_name="test",
+                args=self.args,
+                timeout=10,
+            )
+
+        # Verify timeout parameter
+        call_kwargs = mock_verify.call_args[1]
+        self.assertEqual(call_kwargs["timeout"], 10)
+
+    def test_default_timeout_from_args(self):
+        """Test that default timeout comes from args.verify_timeout."""
+        self.args.verify_timeout = 15
+        content = "func.func @test() { return }"
+
+        with patch("lit_tools.core.verification.verify_ir") as mock_verify:
+            mock_verify.return_value = (True, "")
+
+            verification.verify_content_with_skip_check(
+                content,
+                case_number=7,
+                case_name="test",
+                args=self.args,
+            )
+
+        # Verify default timeout from args
+        call_kwargs = mock_verify.call_args[1]
+        self.assertEqual(call_kwargs["timeout"], 15)
+
+    def test_expected_warning_also_skips(self):
+        """Test that expected-warning also triggers skip."""
+        content = "// expected-warning @+1 {{deprecated}}\nfunc.func @old() { return }"
+
+        with patch("common.console"):
+            skipped, valid, _ = verification.verify_content_with_skip_check(
+                content, case_number=8, case_name="old", args=self.args
+            )
+
+        self.assertTrue(skipped)
+        self.assertTrue(valid)
+
+    def test_expected_note_also_skips(self):
+        """Test that expected-note also triggers skip."""
+        content = "// expected-note @+1 {{info}}\nfunc.func @info() { return }"
+
+        with patch("common.console"):
+            skipped, valid, _ = verification.verify_content_with_skip_check(
+                content, case_number=9, case_name="info", args=self.args
+            )
+
+        self.assertTrue(skipped)
+        self.assertTrue(valid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/utils/test/test_helpers.py
+++ b/tools/utils/test/test_helpers.py
@@ -1,0 +1,87 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared test utilities for subprocess execution.
+
+This module provides helpers for running Python modules from tools/utils
+as subprocesses with proper environment setup.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def run_python_module(
+    module_name: str, args: list[str], **subprocess_kwargs: Any
+) -> subprocess.CompletedProcess:
+    """Run a Python module from tools/utils with correct environment setup.
+
+    This helper ensures that:
+    - The current Python interpreter is used (sys.executable), not hardcoded "python3"
+    - PYTHONPATH is set so tools/utils modules are importable
+    - Tests work from any directory (repo root or tools/utils)
+
+    Args:
+        module_name: Module to run (e.g., "lit_tools.iree_lit_extract",
+                     "ci.iree_ci_triage", "common.some_tool")
+        args: Command-line arguments to pass to the module
+        **subprocess_kwargs: Additional arguments for subprocess.run()
+                            (capture_output, text, input, timeout, etc.)
+
+    Returns:
+        CompletedProcess from subprocess.run()
+
+    Examples:
+        # Extract a test case
+        result = run_python_module(
+            "lit_tools.iree_lit_extract",
+            [str(test_file), "--case", "2"],
+            capture_output=True,
+            text=True
+        )
+
+        # Run with stdin input
+        result = run_python_module(
+            "lit_tools.iree_lit_replace",
+            [str(test_file), "--case", "2"],
+            input="new content",
+            capture_output=True,
+            text=True
+        )
+
+        # Run CI triage tool
+        result = run_python_module(
+            "ci.iree_ci_triage",
+            ["--pr", "12345"],
+            capture_output=True
+        )
+
+    Note:
+        This helper is ONLY for Python modules in tools/utils.
+        For external binaries (gh, git, iree-opt), use subprocess.run() directly.
+    """
+    # Calculate tools/utils directory.
+    # test/test_helpers.py is in tools/utils/test/, so parent.parent is tools/utils
+    tools_utils_dir = Path(__file__).resolve().parent.parent
+
+    # Prepare environment with PYTHONPATH for tools/utils directory.
+    # This makes lit_tools, ci, common modules directly importable.
+    env = os.environ.copy()
+    pythonpath = str(tools_utils_dir)
+    if "PYTHONPATH" in env:
+        pythonpath += os.pathsep + env["PYTHONPATH"]
+    env["PYTHONPATH"] = pythonpath
+
+    # Build command with current Python interpreter.
+    cmd = [sys.executable, "-m", module_name] + list(args)
+
+    # Inject environment into subprocess kwargs.
+    subprocess_kwargs["env"] = env
+
+    return subprocess.run(cmd, **subprocess_kwargs)

--- a/tools/utils/triage_common/__init__.py
+++ b/tools/utils/triage_common/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Common utilities for triage tools (formatters, etc.).
+
+This package provides shared functionality used across multiple triage tools,
+including result formatters and common triage logic.
+"""

--- a/tools/utils/triage_common/formatters.py
+++ b/tools/utils/triage_common/formatters.py
@@ -1,0 +1,229 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Formatters for triage results (markdown, JSON, checklist).
+
+This module provides formatters that work with TriageResult containing
+structured Issue objects (replacing the old pattern-based root cause system).
+
+Example usage:
+    from triage_common.formatters import MarkdownFormatter
+
+    formatter = MarkdownFormatter()
+    markdown = formatter.format(result)
+    print(markdown)
+"""
+
+from typing import Any
+
+from common.issues import Issue
+from common.triage_result import TriageResult
+
+
+class MarkdownFormatter:
+    """Formats triage results as human-readable markdown."""
+
+    def format(self, result: TriageResult, include_context: bool = True) -> str:
+        """Generate markdown triage report.
+
+        Args:
+            result: TriageResult to format.
+            include_context: Whether to include error context lines.
+
+        Returns:
+            Formatted markdown string.
+        """
+        lines = []
+
+        # Header with summary.
+        lines.append("# CI Failure Triage Report")
+        lines.append("")
+        lines.append(f"**Total Issues**: {len(result.issues)}")
+        lines.append(f"**Actionable**: {len(result.get_actionable())}")
+        lines.append(f"**Infrastructure**: {len(result.get_infrastructure())}")
+        lines.append("")
+
+        # Show actionable issues first (fix checklist).
+        actionable = result.get_actionable()
+        if actionable:
+            lines.extend(self._format_actionable_section(actionable, include_context))
+            lines.append("")
+
+        # Show infrastructure issues.
+        infrastructure = result.get_infrastructure()
+        if infrastructure:
+            lines.extend(self._format_infrastructure_section(infrastructure))
+            lines.append("")
+
+        # Summary line.
+        lines.extend(self._format_summary(actionable, infrastructure))
+
+        return "\n".join(lines)
+
+    def _format_actionable_section(
+        self, issues: list[Issue], include_context: bool
+    ) -> list[str]:
+        """Format actionable issues as fix checklist."""
+        lines = ["## Fix Checklist", ""]
+
+        for _i, issue in enumerate(issues, 1):
+            lines.extend(self._format_issue_item(issue, include_context))
+            lines.append("")
+
+        return lines
+
+    def _format_issue_item(self, issue: Issue, include_context: bool) -> list[str]:
+        """Format a single issue item."""
+        # Use issue type name as title.
+        issue_type = type(issue).__name__.replace("Issue", "")
+
+        lines = [
+            f"- [ ] **{issue_type}** ({issue.severity.name})",
+            f"  - {issue.message}",
+            f"  - **Source**: {issue.source_extractor}",
+        ]
+
+        if issue.line_number is not None:
+            lines.append(f"  - **Line**: {issue.line_number}")
+
+        # Show type-specific fields (polymorphic).
+        if hasattr(issue, "file_path") and issue.file_path:
+            lines.append(f"  - **File**: {issue.file_path}")
+        if hasattr(issue, "error_line") and issue.error_line:
+            lines.append(
+                f"  - **Location**: {issue.file_path}:{issue.error_line}:{issue.error_column}"
+            )
+        if hasattr(issue, "operation") and issue.operation:
+            lines.append(f"  - **Operation**: {issue.operation}")
+        if hasattr(issue, "test_name") and issue.test_name:
+            lines.append(f"  - **Test**: {issue.test_name}")
+        if hasattr(issue, "cmake_file") and issue.cmake_file:
+            lines.append(f"  - **CMake**: {issue.cmake_file}:{issue.cmake_line}")
+
+        # Show context.
+        if include_context and issue.context_lines:
+            lines.extend(self._format_context(issue.context_lines))
+
+        return lines
+
+    def _format_context(self, context_lines: list[str]) -> list[str]:
+        """Format error context lines."""
+        lines = ["  - **Context**:", "    ```"]
+
+        # Show ALL context lines - no truncation.
+        # The error line must always be included in the output.
+        for ctx_line in context_lines:
+            stripped = ctx_line.strip()
+            if stripped:  # Skip empty lines.
+                lines.append(f"    {stripped}")
+
+        lines.append("    ```")
+        return lines
+
+    def _format_infrastructure_section(self, infrastructure: list[Issue]) -> list[str]:
+        """Format infrastructure issues section."""
+        lines = [
+            "## Infrastructure Issues (Non-Actionable)",
+            "",
+            "These failures are not code bugs:",
+            "- Driver crashes or GPU hangs",
+            "- Network timeouts or download failures",
+            "- Resource exhaustion (OOM, disk full)",
+            "",
+        ]
+
+        for issue in infrastructure:
+            issue_type = type(issue).__name__.replace("Issue", "")
+            lines.extend(
+                [
+                    f"### {issue_type}",
+                    f"- {issue.message}",
+                    f"- **Source**: {issue.source_extractor}",
+                    f"- **Severity**: {issue.severity.name}",
+                    "",
+                ]
+            )
+
+        return lines
+
+    def _format_summary(
+        self, actionable: list[Issue], infrastructure: list[Issue]
+    ) -> list[str]:
+        """Format the TL;DR summary line."""
+        lines = ["---"]
+
+        if not actionable and infrastructure:
+            issue_names = [
+                type(issue).__name__.replace("Issue", "") for issue in infrastructure
+            ]
+            lines.append(
+                f"**TL;DR**: Infrastructure flake ({', '.join(issue_names[:3])}). No code changes needed."
+            )
+        elif actionable and not infrastructure:
+            lines.append(
+                f"**TL;DR**: {len(actionable)} code bug(s) to fix. See checklist above."
+            )
+        elif actionable and infrastructure:
+            lines.append(
+                f"**TL;DR**: {len(actionable)} code bug(s) + {len(infrastructure)} infrastructure issue(s)."
+            )
+        else:
+            lines.append("**TL;DR**: No issues found.")
+
+        return lines
+
+
+class JSONFormatter:
+    """Formats triage results as JSON."""
+
+    def format(self, result: TriageResult) -> dict[str, Any]:
+        """Generate JSON triage report.
+
+        Args:
+            result: TriageResult to format.
+
+        Returns:
+            Dictionary suitable for JSON serialization.
+        """
+        return result.to_dict()
+
+
+class ChecklistFormatter:
+    """Formats triage results as a simple checklist for LLMs."""
+
+    def format(self, result: TriageResult) -> str:
+        """Generate simple checklist for LLM consumption.
+
+        Args:
+            result: TriageResult to format.
+
+        Returns:
+            Formatted checklist string.
+        """
+        lines = []
+        lines.append("# Fix Checklist")
+        lines.append("")
+
+        # Only include actionable items.
+        actionable = result.get_actionable()
+
+        if not actionable:
+            lines.append("No actionable issues found.")
+            return "\n".join(lines)
+
+        for i, issue in enumerate(actionable, 1):
+            # Simplified checkbox item.
+            issue_type = type(issue).__name__.replace("Issue", "")
+            identifier = f"{issue_type}-{i}"
+            lines.append(f"- [ ] {identifier}: {issue.message}")
+
+            # Show location if available.
+            if hasattr(issue, "file_path") and issue.file_path:
+                lines.append(f"     File: {issue.file_path}")
+            if issue.line_number is not None:
+                lines.append(f"     Line: {issue.line_number}")
+
+        return "\n".join(lines)


### PR DESCRIPTION
Developer-facing utilities  for IREE contributors, organized as:

**Lit Test Tools** (`tools/utils/bin/iree-lit-*`):
- `iree-lit-list`: List test cases in files
- `iree-lit-extract`: Extract individual test cases
- `iree-lit-replace`: Replace test case content atomically
- `iree-lit-test`: Run tests in isolation with debug capabilities
- `iree-lit-lint`: Lint tests against STYLE_GUIDE.md

**CI Triage Tools** (`tools/utils/bin/iree-ci-*`):
- `iree-ci-triage`: Analyze CI failures from GitHub Actions
- `iree-ci-garden`: Manage failure corpus for pattern development

Use `--help` on any tool for detailed usage.
See `tools/utils/README.md` for full documentation.

**Setup**:
```bash
pip install -e tools/utils
export PATH="$PATH:$PWD/tools/utils/bin"
# or, if you use direnv:
cp .envrc.example .envrc
direnv allow
```

**Claude Code Integration**:
- Skill: iree-lit-tools for MLIR test authoring guidance
- Commands: /iree-ci-triage, /iree-lit-test, /iree-lit-lint

Skills and commands should be detected automatically.
The `auto-approve-iree-tools.sh` is a useful pre-bash hook that approves all iree-* tools. Somewhat #yolo so it's opt in, but it does allow for much less naggy triage sessions and is required to get smooth heredoc support. `cp .claude/settings.json.template .claude/settings.json` to enable.

## Tool Reference

### iree-lit-list
List test cases in a file.
```bash
iree-lit-list test.mlir              # Show all cases with metadata
iree-lit-list test.mlir --count      # Just the count
iree-lit-list test.mlir --names      # Space-separated names
iree-lit-list test.mlir --json       # Machine-readable
```

### iree-lit-extract
Extract individual test cases.
```bash
iree-lit-extract test.mlir --case 3        # Extract case #3
iree-lit-extract test.mlir --line 123      # Extract case containing line 123
iree-lit-extract test.mlir --name "foo"    # Extract case named "foo"
iree-lit-extract test.mlir -c 1,3,5        # Multiple cases
```

### iree-lit-replace
Replace a test case atomically (reads new content from stdin).
```bash
iree-lit-replace test.mlir --case 3 < fixed_case.mlir

# Heredoc for inline replacement (no temp files needed):
iree-lit-replace test.mlir --case 3 <<'EOF'
// RUN: iree-opt --my-pass %s | FileCheck %s
// CHECK-LABEL: @my_test
func.func @my_test() {
  return
}
EOF
```

### iree-lit-test
Run tests in isolation with debug capabilities.
```bash
iree-lit-test test.mlir                    # Run all cases
iree-lit-test test.mlir --case 2           # Run only case #2
iree-lit-test test.mlir -c 1-3             # Run cases 1, 2, 3
iree-lit-test test.mlir --name "foo"       # Run case named "foo"
iree-lit-test test.mlir --verbose          # Show full output
iree-lit-test test.mlir --extra-flags "--debug"  # Inject flags
iree-lit-test test.mlir --dry-run          # Show commands without running

# Heredoc for rapid testing (no temp files needed):
iree-lit-test --run 'iree-opt --my-pass %s | FileCheck %s' <<'EOF'
// CHECK-LABEL: @test_fusion
// CHECK: my.fused_op
func.func @test_fusion() {
  %0 = my.op1
  %1 = my.op2 %0
  return
}
EOF
```

### iree-lit-lint
Lint tests against the style guide.
```bash
iree-lit-lint test.mlir                    # Lint all cases
iree-lit-lint test.mlir --case 2           # Lint only case #2
iree-lit-lint test.mlir --errors-only      # Only show errors
iree-lit-lint test.mlir --help-style-guide # Show full style guide
```

(most of this was authored with claude and dogfooded on significant test refactoring/authoring, YMMV and it needs refinement but it's already been a massive help)