### PR TITLE
Disable conversion of Accumulated GEMM to GEMM pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -667,7 +667,7 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       // TODO(#13888): This(createExpandF16OpToF32Pass()) pass is being added
       // way to late and should insted be be done during lowering to LLVM.
       .addPass(createExpandF16OpToF32Pass)
-      .addPass(createConvertAccGEMMToGEMMPass)
+      // .addPass(createConvertAccGEMMToGEMMPass)  // Commented out for testing
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
       .addPass(createEraseHALDescriptorTypeFromMemRefPass);


### PR DESCRIPTION
The conversion from Accumulated GEMM to a GEMM is a bit of anti-pattern. The accumulated GEMM is a more "native" operation since it is perfectly nested loop nest. That should be something we should be handling better, and not forcing it to go to the non-accumulated version that is breaking the "perfectly-nested"-ness of the computation (not to mention changing computation order).