### PR TITLE
[Runtime][HIP] Correct O(log n) bound search logic and eliminate O(n) loop(#22733)

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/util/tree.c
+++ b/runtime/src/iree/hal/drivers/hip/util/tree.c
@@ -498,44 +498,31 @@ iree_hal_hip_util_tree_node_t* iree_hal_hip_util_tree_get(
 iree_hal_hip_util_tree_node_t* iree_hal_hip_util_tree_lower_bound(
     const iree_hal_hip_util_tree_t* tree, iree_host_size_t key) {
   iree_hal_hip_util_tree_node_t* node = tree->root;
-  iree_hal_hip_util_tree_node_t* last = NULL;
+  iree_hal_hip_util_tree_node_t* result = NULL;
   while (node->is_sentinel == false) {
-    last = node;
-    if (key == node->key) {
-      return node;
-    } else if (key < node->key) {
+    if (key <= node->key) {
+      result = node;
       node = node->left;
     } else {
       node = node->right;
     }
   }
-  if (!last || last->key > key) {
-    return last;
-  }
-  return iree_hal_hip_util_tree_node_next(last);
+  return result;
 }
 
 iree_hal_hip_util_tree_node_t* iree_hal_hip_util_tree_upper_bound(
     const iree_hal_hip_util_tree_t* tree, iree_host_size_t key) {
   iree_hal_hip_util_tree_node_t* node = tree->root;
-  iree_hal_hip_util_tree_node_t* last = NULL;
+  iree_hal_hip_util_tree_node_t* result = NULL;
   while (node->is_sentinel == false) {
-    last = node;
-    if (key == node->key) {
-      return node;
-    } else if (key < node->key) {
+    if (key < node->key) {
+      result = node;
       node = node->left;
     } else {
       node = node->right;
     }
   }
-  if (!last || last->key > key) {
-    return last;
-  }
-  while (last && last->key <= key) {
-    last = iree_hal_hip_util_tree_node_next(last);
-  }
-  return last;
+  return result;
 }
 
 iree_hal_hip_util_tree_node_t* iree_hal_hip_util_tree_first(

--- a/runtime/src/iree/hal/drivers/hip/util/tree_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/util/tree_test.cc
@@ -88,6 +88,12 @@ TEST_F(RedBlackTreeTest, boundary_conditions) {
   EXPECT_EQ(iree_hal_hip_util_tree_node_get_key(
                 iree_hal_hip_util_tree_upper_bound(&tree_, 15)),
             20);
+  EXPECT_EQ(iree_hal_hip_util_tree_node_get_key(
+                iree_hal_hip_util_tree_lower_bound(&tree_, 20)),
+            20);
+  EXPECT_EQ(iree_hal_hip_util_tree_node_get_key(
+                iree_hal_hip_util_tree_upper_bound(&tree_, 20)),
+            30);
 }
 
 TEST_F(RedBlackTreeTest, move_node) {


### PR DESCRIPTION
Refactors `iree_hal_hip_util_tree_lower_bound` and `iree_hal_hip_util_tree_upper_bound` to use the standard O(log n) bound search algorithm.

This resolves two issues:
1. **Misbehavior:** Ensures `upper_bound` adheres to the strict 'greater than' definition.
2. **Performance:** Eliminates the previous O(n) post-traversal loop which relied on repeated, inefficient calls to `iree_hal_hip_util_tree_node_next`.

fixes : #22733