### PR TITLE
[GPU] Fix alignment check for scaled matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -175,7 +175,7 @@ static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
            << schedule << "\nShrinking schedule...";
 
     auto decrementIfPossible =
-        [](SmallVectorImpl<int64_t> &sizes) -> LogicalResult {
+        [](MutableArrayRef<int64_t> sizes) -> LogicalResult {
       for (int64_t &size : sizes) {
         if (size <= 1)
           continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -98,7 +98,7 @@ static bool isScheduleAligned(const GPUMatmulShapeType &problem,
     // d*y].
     assert(intrinsicSizes.size() <= sizes.size() &&
            "intrinsic sizes should not exceed tile count sizes");
-    for (auto &&[intrinsicSize, size] :
+    for (auto [intrinsicSize, size] :
          llvm::zip(llvm::reverse(intrinsicSizes), llvm::reverse(sizes))) {
       size *= intrinsicSize;
     }
@@ -175,7 +175,7 @@ static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
            << schedule << "\nShrinking schedule...";
 
     auto decrementIfPossible =
-        [](SmallVector<int64_t, 2> &sizes) -> LogicalResult {
+        [](SmallVectorImpl<int64_t> &sizes) -> LogicalResult {
       for (int64_t &size : sizes) {
         if (size <= 1)
           continue;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -68,12 +68,10 @@ struct GPUMMAHeuristicSeeds {
 struct GPUMMASchedule {
   // The MMA intrinsic kind to use for this schedule.
   IREE::Codegen::InnerTileDescAttrInterface mmaKind;
-  // Native MMA intrinsic size along M dimension for a subgroup.
-  int64_t mSize = 0;
-  // Native MMA intrinsic size along N dimension for a subgroup.
-  int64_t nSize = 0;
-  // Native MMA intrinsic size along K dimension for a subgroup.
-  int64_t kSize = 0;
+  // Native MMA intrinsic sizes along M, N and K dimensions for a subgroup.
+  SmallVector<int64_t> mSizes;
+  SmallVector<int64_t> nSizes;
+  SmallVector<int64_t> kSizes;
 
   // Number of subgroups along each M and N dimension.
   SmallVector<int64_t> mSubgroupCounts;
@@ -89,13 +87,15 @@ struct GPUMMASchedule {
 
   // Constructor for multi M, N, K dim schedules.
   GPUMMASchedule(IREE::Codegen::InnerTileDescAttrInterface kind,
-                 int64_t mIntrinsicSize, int64_t nIntrinsicSize,
-                 int64_t kIntrinsicSize, ArrayRef<int64_t> mSubgroupCounts,
+                 ArrayRef<int64_t> mIntrinsicSizes,
+                 ArrayRef<int64_t> nIntrinsicSizes,
+                 ArrayRef<int64_t> kIntrinsicSizes,
+                 ArrayRef<int64_t> mSubgroupCounts,
                  ArrayRef<int64_t> nSubgroupCounts,
                  ArrayRef<int64_t> mTileSizes, ArrayRef<int64_t> nTileSizes,
                  ArrayRef<int64_t> kTileSizes)
-      : mmaKind(kind), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
-        kSize(kIntrinsicSize), mSubgroupCounts(mSubgroupCounts),
+      : mmaKind(kind), mSizes(mIntrinsicSizes), nSizes(nIntrinsicSizes),
+        kSizes(kIntrinsicSizes), mSubgroupCounts(mSubgroupCounts),
         nSubgroupCounts(nSubgroupCounts), mTileSizes(mTileSizes),
         nTileSizes(nTileSizes), kTileSizes(kTileSizes) {}
 
@@ -104,8 +104,8 @@ struct GPUMMASchedule {
                  int64_t mIntrinsicSize, int64_t nIntrinsicSize,
                  int64_t kIntrinsicSize, int64_t mSubgroup, int64_t nSubgroup,
                  int64_t mTileSize, int64_t nTileSize, int64_t kTileSize)
-      : mmaKind(kind), mSize(mIntrinsicSize), nSize(nIntrinsicSize),
-        kSize(kIntrinsicSize), mSubgroupCounts({mSubgroup}),
+      : mmaKind(kind), mSizes({mIntrinsicSize}), nSizes({nIntrinsicSize}),
+        kSizes({kIntrinsicSize}), mSubgroupCounts({mSubgroup}),
         nSubgroupCounts({nSubgroup}), mTileSizes({mTileSize}),
         nTileSizes({nTileSize}), kTileSizes({kTileSize}) {}
 };

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -130,10 +130,10 @@ struct GPUMMASchedule {
 
   // Check if all schedule dimensions are single-element.
   bool hasSingleDimensions() const {
-    return mSubgroupCounts.size() == 1 && nSubgroupCounts.size() == 1 &&
-           mTileSizes.size() == 1 && nTileSizes.size() == 1 &&
-           kTileSizes.size() == 1 && mSizes.size() == 1 && nSizes.size() == 1 &&
-           kSizes.size() == 1;
+    return llvm::all_equal({size_t(1), mSubgroupCounts.size(),
+                            nSubgroupCounts.size(), mTileSizes.size(),
+                            nTileSizes.size(), kTileSizes.size(), mSizes.size(),
+                            nSizes.size(), kSizes.size()});
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -761,7 +761,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // Multiply by the intrinsic shape for the inner most dim as we distribute
     // to workgroups before packing to intrinsic.
     if (i == mDims.size() - 1) {
-      workgroupTileSizes[mDim] *= schedule->mSize;
+      workgroupTileSizes[mDim] *= llvm::product_of(schedule->mSizes);
     }
     subgroupTileSizes[mDim] = schedule->mTileSizes[i];
   }
@@ -771,7 +771,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // Multiply by the intrinsic shape for the inner most dim as we distribute
     // to workgroups before packing to intrinsic.
     if (i == nDims.size() - 1) {
-      workgroupTileSizes[nDim] *= schedule->nSize;
+      workgroupTileSizes[nDim] *= llvm::product_of(schedule->nSizes);
     }
     subgroupTileSizes[nDim] = schedule->nTileSizes[i];
   }
@@ -1737,11 +1737,13 @@ setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
   }
 
   // Compute the M/N dimension tile size by multiply subgroup information.
-  workgroupTileSizes[mDim] =
-      schedule->mSubgroupCounts[0] * schedule->mTileSizes[0] * schedule->mSize;
+  workgroupTileSizes[mDim] = schedule->mSubgroupCounts[0] *
+                             schedule->mTileSizes[0] *
+                             llvm::product_of(schedule->mSizes);
   subgroupTileSizes[mDim] = schedule->mTileSizes[0];
-  workgroupTileSizes[nDim] =
-      schedule->nSubgroupCounts[0] * schedule->nTileSizes[0] * schedule->nSize;
+  workgroupTileSizes[nDim] = schedule->nSubgroupCounts[0] *
+                             schedule->nTileSizes[0] *
+                             llvm::product_of(schedule->nSizes);
   subgroupTileSizes[nDim] = schedule->nTileSizes[0];
 
   // The reduction tile size is just the post-packing tile count.
@@ -1758,7 +1760,8 @@ setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
 
   if (!mustBeAligned) {
     SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
-    paddingTileSizes[kDim] = reductionTileSizes[kDim] * schedule->kSize;
+    paddingTileSizes[kDim] =
+        reductionTileSizes[kDim] * llvm::product_of(schedule->kSizes);
     attrs.emplace_back("padding_conv", b.getI64ArrayAttr(paddingTileSizes));
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -368,12 +368,15 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
     reductionTileSizes[ic] = 1;
   }
   // Compute the M/N dimension tile size by multiply subgroup information.
-  workgroupTileSizes[mDim] =
-      schedule->mSubgroupCounts[0] * schedule->mTileSizes[0] * schedule->mSize;
-  workgroupTileSizes[nDim] =
-      schedule->nSubgroupCounts[0] * schedule->nTileSizes[0] * schedule->nSize;
+  workgroupTileSizes[mDim] = schedule->mSubgroupCounts[0] *
+                             schedule->mTileSizes[0] *
+                             llvm::product_of(schedule->mSizes);
+  workgroupTileSizes[nDim] = schedule->nSubgroupCounts[0] *
+                             schedule->nTileSizes[0] *
+                             llvm::product_of(schedule->nSizes);
 
-  reductionTileSizes[kDim] = schedule->kTileSizes[0] * schedule->kSize;
+  reductionTileSizes[kDim] =
+      schedule->kTileSizes[0] * llvm::product_of(schedule->kSizes);
 
   // Tile all filter loop dimensions to 1.
   for (int64_t filterDim : convolutionDims->filterLoop) {
@@ -623,12 +626,15 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   }
 
   // Compute the M/N dimension tile size by multiply subgroup information.
-  workgroupTileSizes[mDim] =
-      schedule->mSubgroupCounts[0] * schedule->mTileSizes[0] * schedule->mSize;
-  workgroupTileSizes[nDim] =
-      schedule->nSubgroupCounts[0] * schedule->nTileSizes[0] * schedule->nSize;
+  workgroupTileSizes[mDim] = schedule->mSubgroupCounts[0] *
+                             schedule->mTileSizes[0] *
+                             llvm::product_of(schedule->mSizes);
+  workgroupTileSizes[nDim] = schedule->nSubgroupCounts[0] *
+                             schedule->nTileSizes[0] *
+                             llvm::product_of(schedule->nSizes);
 
-  reductionTileSizes[kDim] = schedule->kTileSizes[0] * schedule->kSize;
+  reductionTileSizes[kDim] =
+      schedule->kTileSizes[0] * llvm::product_of(schedule->kSizes);
 
   LLVM_DEBUG(debugPrintContractionInfo("Workgroup tile sizes", op.getNumLoops(),
                                        *contractionDims, workgroupTileSizes));
@@ -893,7 +899,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
         pvSchedule.mSubgroupCounts[i] * pvSchedule.mTileSizes[i];
     // Multiply by the intrinsic shape for the inner most dim.
     if (i == mDims.size() - 1) {
-      workgroupTileSizes[mDim] *= pvSchedule.mSize;
+      workgroupTileSizes[mDim] *= llvm::product_of(pvSchedule.mSizes);
     }
     subgroupBasis.counts[mDim] = pvSchedule.mSubgroupCounts[i];
   }
@@ -902,7 +908,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
         pvSchedule.nSubgroupCounts[i] * pvSchedule.nTileSizes[i];
     // Multiply by the intrinsic shape for the inner most dim.
     if (i == nDims.size() - 1) {
-      workgroupTileSizes[nDim] *= pvSchedule.nSize;
+      workgroupTileSizes[nDim] *= llvm::product_of(pvSchedule.nSizes);
     }
     subgroupBasis.counts[nDim] = pvSchedule.nSubgroupCounts[i];
   }
@@ -910,7 +916,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
     reductionTileSizes[k2Dim] = pvSchedule.kTileSizes[i];
     // Multiply by the intrinsic shape for the inner most dim.
     if (i == k2Dims.size() - 1) {
-      reductionTileSizes[k2Dim] *= pvSchedule.kSize;
+      reductionTileSizes[k2Dim] *= llvm::product_of(pvSchedule.kSizes);
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -100,6 +100,40 @@ func.func @scaled_matmul_with_dynamic_red_dim(
 
 // -----
 
+#lhs_map = affine_map<(b, m, n, ko, kb) -> (b, m, ko, kb)>
+#rhs_map = affine_map<(b, m, n, ko, kb) -> (n, ko, kb)>
+#scale_lhs = affine_map<(b, m, n, ko, kb) -> (b, m, ko)>
+#scale_rhs = affine_map<(b, m, n, ko, kb) -> (n, ko)>
+#out_map = affine_map<(b, m, n, ko, kb) -> (b, m, n)>
+func.func @scaled_matmul_with_dynamic_batch(
+    %A: tensor<?x128x512x32xf4E2M1FN>, %B: tensor<16384x512x32xf4E2M1FN>, %A_scales: tensor<?x128x512xf8E8M0FNU>, %B_scales: tensor<16384x512xf8E8M0FNU>, %C: tensor<?x128x16384xf32>) -> tensor<?x128x16384xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#lhs_map, #rhs_map, #scale_lhs, #scale_rhs, #out_map],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%A, %B, %A_scales, %B_scales : tensor<?x128x512x32xf4E2M1FN>, tensor<16384x512x32xf4E2M1FN>, tensor<?x128x512xf8E8M0FNU>, tensor<16384x512xf8E8M0FNU>) outs(%C : tensor<?x128x16384xf32>) {
+  ^bb0(%a: f4E2M1FN, %b: f4E2M1FN, %a_scale: f8E8M0FNU, %b_scale: f8E8M0FNU, %out: f32):
+    %1 = arith.scaling_extf %a, %a_scale : f4E2M1FN, f8E8M0FNU to f32
+    %2 = arith.scaling_extf %b, %b_scale : f4E2M1FN, f8E8M0FNU to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<?x128x16384xf32>
+  return %0 : tensor<?x128x16384xf32>
+}
+
+// CHECK-LABEL: func.func @scaled_matmul_with_dynamic_batch
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
+//  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
+//   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
+//  CHECK-SAME:     reduction = [0, 0, 0, 4, 1]
+//  CHECK-SAME:     subgroup = [0, 2, 4, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 64, 128, 0, 0]
+
+// -----
+
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
 #scale_m = affine_map<(M, N, Ko, Kb) -> (M, Ko)>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -940,9 +940,9 @@ setCooperativeMatrixConfig(IREE::GPU::TargetAttr target, linalg::LinalgOp op,
   SmallVector<int64_t> vectorSizes(kIndex + 1, 0);
   if (isBM)
     vectorSizes[bIndex] = 1;
-  vectorSizes[mIndex] = schedule->mSize;
-  vectorSizes[nIndex] = schedule->nSize;
-  vectorSizes[kIndex] = schedule->kSize;
+  vectorSizes[mIndex] = llvm::product_of(schedule->mSizes);
+  vectorSizes[nIndex] = llvm::product_of(schedule->nSizes);
+  vectorSizes[kIndex] = llvm::product_of(schedule->kSizes);
 
   SmallVector<int64_t> subgroupTileSizes(lastParallelDim + 1, 0);
   if (isBM)
@@ -963,7 +963,8 @@ setCooperativeMatrixConfig(IREE::GPU::TargetAttr target, linalg::LinalgOp op,
   // TODO(#10499): Consolidate tiling configuration across different pipelines.
   SmallVector<int64_t> reductionTileSizes;
   reductionTileSizes.append(kIndex, 0);
-  reductionTileSizes.push_back(schedule->kTileSizes[0] * schedule->kSize);
+  reductionTileSizes.push_back(schedule->kTileSizes[0] *
+                               llvm::product_of(schedule->kSizes));
 
   TileSizesListType tileSizes = {workgroupTileSizes, subgroupTileSizes,
                                  reductionTileSizes, vectorSizes};


### PR DESCRIPTION
## Problem

The current alignment check in `GPUHeuristics.cpp` is incorrect for any intrinsic that has multiple M, N, and K dimensions. The root cause is that the product of intrinsic sizes is passed to `GPUMMASchedule` instead of passing the individual dimension sizes as a vector.

## Example

https://github.com/iree-org/iree/blob/b98c1b92cb630bd696992f47df591bb2f247a8d7/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp#L516-L525

Consider the scaled MFMA where `intrinsic.kSizes = [K, KB] = [4, 32]`. Instead of passing the vector `[4, 32]`, the value `128` (product: 4 × 32) is passed to `GPUMMASchedule`.

https://github.com/iree-org/iree/blob/b98c1b92cb630bd696992f47df591bb2f247a8d7/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp#L98-L108

Assume tile size = `[4, 1]`. The returned schedule sizes become `[4, 128]` instead of the correct `[16, 32]`. As a result, the last dimension `128` always makes the alignment check fail, since the problem size of KB is `32` and `32 % 128 != 0`.

When the alignment check fails, no intrinsic is selected and the operation falls back to complete serialization. This leads to extremely slow execution for workloads like Llama 405B FP4 prefill with direct codegen.

## Solution

This PR passes all intrinsic sizes as vectors to `GPUMMASchedule`.

## Performance

**Llama 405B FP4 prefill direct codegen with shark-ai:**
- Before: 11 minutes
- After: 234 ms

Closes: #22559

ci-extra: test_torch