### PR TITLE
Fix incompatible pointer types for macOS build.

### DIFF
--- a/samples/external_transients/main.c
+++ b/samples/external_transients/main.c
@@ -48,7 +48,8 @@ static iree_status_t query_transient_size(
       main_function, IREE_SV("iree.abi.transients.size.constant"));
   if (!iree_string_view_is_empty(size_constant_attr)) {
     // Constant size is specified - parse it directly.
-    if (!iree_string_view_atoi_uint64(size_constant_attr, out_size)) {
+    if (!iree_string_view_atoi_uint64(size_constant_attr,
+                                      (uint64_t*)(out_size))) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "failed to parse integer attribute");
     }


### PR DESCRIPTION
- `unsigned long` is a fundamental C type whose size is platform-dependent. On 64-bit macOS, unsigned long is typically 64 bits.
- `uint64_t` is a fixed-width integer type defined in <stdint.h>. It is guaranteed to be exactly 64 bits wide, regardless of the platform. On 64-bit macOS, uint64_t is often a typedef for unsigned long long.

The revision explicitly cast the pointer to the expected type to fix the failure.

Note: it produces below error without the fix.

```
iree/samples/external_transients/main.c:51:59: error: incompatible pointer types passing 'iree_host_size_t *' (aka 'unsigned long *') to parameter of type 'uint64_t *' (aka 'unsigned long long *') [-Werror,-Wincompatible-pointer-types]
    if (!iree_string_view_atoi_uint64(size_constant_attr, out_size)) {
                                                          ^~~~~~~~
runtime/src/iree/base/string_view.h:254:61: note: passing argument to parameter 'out_value' here
                                                  uint64_t* out_value);
```