### PR TITLE
[TensorExt] Add flags and direction attrs to compute barriers

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
@@ -152,6 +152,20 @@ iree_gentbl_cc_library(
         ),
         (
             [
+                "--gen-enum-decls",
+                "--dialect=iree_tensor_ext",
+            ],
+            "TensorExtEnums.h.inc",
+        ),
+        (
+            [
+                "--gen-enum-defs",
+                "--dialect=iree_tensor_ext",
+            ],
+            "TensorExtEnums.cpp.inc",
+        ),
+        (
+            [
                 "--dialect=iree_tensor_ext",
                 "--gen-dialect-decls",
             ],

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
@@ -94,6 +94,8 @@ iree_tablegen_library(
   OUTS
     --gen-op-decls TensorExtOps.h.inc
     --gen-op-defs TensorExtOps.cpp.inc
+    --gen-enum-decls --dialect=iree_tensor_ext TensorExtEnums.h.inc
+    --gen-enum-defs --dialect=iree_tensor_ext TensorExtEnums.cpp.inc
     --dialect=iree_tensor_ext --gen-dialect-decls TensorExtDialect.h.inc
     --dialect=iree_tensor_ext --gen-dialect-defs TensorExtDialect.cpp.inc
 )

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.cpp
@@ -7,11 +7,15 @@
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtEnums.cpp.inc"
 
 // clang-format off
 #define GET_ATTRDEF_CLASSES

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h
@@ -9,6 +9,9 @@
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrInterfaces.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtEnums.h.inc"
 
 // clang-format off
 #define GET_ATTRDEF_CLASSES

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td
@@ -4,11 +4,45 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_DIALECT_TENSOR_EXT_ATTRS
-#define IREE_DIALECT_TENSOR_EXT_ATTRS
+#ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXT_ATTRS
+#define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXT_ATTRS
 
 include "iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td"
 include "iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+//===----------------------------------------------------------------------===//
+// Barrier Enums and Attributes
+//===----------------------------------------------------------------------===//
+
+// Transformation flags that control which operations can move through barriers
+def IREETensorExt_TransformationFlag_None : I32BitEnumAttrCase<"None", 0x0000>;
+def IREETensorExt_TransformationFlag_AllowExpand : I32BitEnumAttrCase<"AllowExpand", 0x0001>;
+def IREETensorExt_TransformationFlag_AllowCollapse : I32BitEnumAttrCase<"AllowCollapse", 0x0002>;
+def IREETensorExt_TransformationFlagBitfieldAttr :
+    I32BitEnumAttr<"TransformationFlagBitfield", "valid TransformationFlag", [
+      IREETensorExt_TransformationFlag_None,
+      IREETensorExt_TransformationFlag_AllowExpand,
+      IREETensorExt_TransformationFlag_AllowCollapse,
+    ]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::TensorExt";
+}
+
+// Direction that operations can move through the barrier
+def IREETensorExt_BarrierDirection_Up : I32EnumAttrCase<"Up", 0, "up">;
+def IREETensorExt_BarrierDirection_Down : I32EnumAttrCase<"Down", 1, "down">;
+def IREETensorExt_BarrierDirectionAttr :
+    I32EnumAttr<"BarrierDirection", "valid BarrierDirection", [
+      IREETensorExt_BarrierDirection_Up,
+      IREETensorExt_BarrierDirection_Down,
+    ]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::TensorExt";
+}
+
+//===----------------------------------------------------------------------===//
+// RaggedShape Attribute
+//===----------------------------------------------------------------------===//
 
 def RaggedShapeAttr :
   AttrDef<IREETensorExt_Dialect, "RaggedShape", [
@@ -46,4 +80,4 @@ def RaggedShapeAttr :
   }];
 }
 
-#endif // IREE_DIALECT_TENSOR_EXT_ATTRS
+#endif  // IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXT_ATTRS

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -64,4 +64,4 @@ Operation *IREETensorExtDialect::materializeConstant(OpBuilder &builder,
 
 } // namespace mlir::iree_compiler::IREE::TensorExt
 
-#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp.inc"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp.inc" // IWYU pragma: keep

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_H_
 #define IREE_COMPILER_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_H_
 
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/TypeID.h"

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -452,27 +452,18 @@ void DispatchWorkloadOrdinalOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
-// iree_tensor_ext.compute_barrier.start
+// iree_tensor_ext.compute_barrier
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ComputeBarrierStartOp::fold(FoldAdaptor adaptor) {
-  // Fold duplicate barriers in a chain:
-  // compute_barrier.start(compute_barrier.start(x)) -> compute_barrier.start(x)
-  if (auto producer = getValue().getDefiningOp<ComputeBarrierStartOp>()) {
-    return producer.getResult();
-  }
-  return {};
-}
-
-//===----------------------------------------------------------------------===//
-// iree_tensor_ext.compute_barrier.end
-//===----------------------------------------------------------------------===//
-
-OpFoldResult ComputeBarrierEndOp::fold(FoldAdaptor adaptor) {
-  // Fold duplicate barriers in a chain:
-  // compute_barrier.end(compute_barrier.end(x)) -> compute_barrier.end(x)
-  if (auto producer = getValue().getDefiningOp<ComputeBarrierEndOp>()) {
-    return producer.getResult();
+OpFoldResult ComputeBarrierOp::fold(FoldAdaptor adaptor) {
+  // Fold duplicate barriers in a chain with matching direction and flags:
+  // compute_barrier<dir, flags>(compute_barrier<dir, flags>(x)) ->
+  // compute_barrier<dir, flags>(x)
+  if (auto producer = getValue().getDefiningOp<ComputeBarrierOp>()) {
+    if (producer.getDirection() == getDirection() &&
+        producer.getFlags() == getFlags()) {
+      return producer.getResult();
+    }
   }
   return {};
 }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -383,27 +383,11 @@ void DispatchWorkloadOrdinalOp::inferResultRanges(
 }
 
 //===----------------------------------------------------------------------===//
-// iree_tensor_ext.compute_barrier.start
+// iree_tensor_ext.compute_barrier
 //===----------------------------------------------------------------------===//
 
-LogicalResult ComputeBarrierStartOp::verify() {
-  ComputeBarrierStartOp op = *this;
-  if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
-    return failure();
-  }
-
-  if (op.getValue().getType() != op.getResult().getType()) {
-    return op.emitOpError("value and result types must match");
-  }
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// iree_tensor_ext.compute_barrier.end
-//===----------------------------------------------------------------------===//
-
-LogicalResult ComputeBarrierEndOp::verify() {
-  ComputeBarrierEndOp op = *this;
+LogicalResult ComputeBarrierOp::verify() {
+  ComputeBarrierOp op = *this;
   if (failed(verifyOpDynamicDims(op, {op.getValue()}, op.getValueDims()))) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -7,6 +7,7 @@
 #ifndef IREE_DIALECT_TENSOR_EXT_OPS
 #define IREE_DIALECT_TENSOR_EXT_OPS
 
+include "iree/compiler/Dialect/TensorExt/IR/TensorExtAttrs.td"
 include "iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td"
 include "iree/compiler/Dialect/TensorExt/IR/TensorExtInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
@@ -448,74 +449,48 @@ def IREETensorExt_DispatchWorkloadOrdinalOp :
 // Barrier Ops
 //===---------------------------------------------------------------------===//
 
-def IREETensorExt_ComputeBarrierStartOp : IREETensorExt_PureOp<"compute_barrier.start", [
+def IREETensorExt_ComputeBarrierOp : IREETensorExt_PureOp<"compute_barrier", [
   Util_ShapeAwareOp,
 ]> {
-  let summary = "Tensor compute barrier start operation";
+  let summary = "Tensor compute barrier operation";
   let description = [{
-    This barrier prevents certain transformations (like reshape propagation)
-    from moving operations down across this boundary.
+    This barrier controls which transformations (like reshape propagation)
+    can move across this boundary and in which direction.
+
+    The direction attribute specifies which way operations can move:
+    - "up": allows operations to move above the barrier
+    - "down": allows operations to move below the barrier
+
+    The flags attribute specifies which types of transformations are allowed:
+    - AllowExpand: allows tensor.expand_shape operations
+    - AllowCollapse: allows tensor.collapse_shape operations
+
     The operand is returned as the result with identical type.
   }];
 
   let arguments = (ins
     AnyRankedTensor:$value,
-    IREETensorExt_ShapeDynamicDims:$value_dims
+    IREETensorExt_ShapeDynamicDims:$value_dims,
+    IREETensorExt_BarrierDirectionAttr:$direction,
+    IREETensorExt_TransformationFlagBitfieldAttr:$flags
   );
   let results = (outs
     AnyRankedTensor:$result
   );
 
   let assemblyFormat = [{
+    `<` $direction `,` $flags `>`
     $value `:` type($value) (`{` $value_dims^ `}`)? `->`
     type($result)
     attr-dict-with-keyword
   }];
 
   let builders = [
-    OpBuilder<(ins "Value":$value), [{
+    OpBuilder<(ins "Value":$value, "IREE::TensorExt::BarrierDirection":$direction, "IREE::TensorExt::TransformationFlagBitfield":$flags), [{
       build($_builder, $_state, value.getType(), value,
-            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
-    }]>,
-  ];
-
-  let extraClassDeclaration = [{
-    ValueRange getOperandDynamicDims(unsigned idx) { return getValueDims(); }
-    ValueRange getResultDynamicDims(unsigned idx) { return getValueDims(); }
-  }];
-
-  let hasFolder = 1;
-  let hasVerifier = 1;
-}
-
-def IREETensorExt_ComputeBarrierEndOp : IREETensorExt_PureOp<"compute_barrier.end", [
-  Util_ShapeAwareOp,
-]> {
-  let summary = "Tensor compute barrier end operation";
-  let description = [{
-    This barrier prevents certain transformations (like reshape propagation)
-    from moving operations up across this boundary.
-    The operand is returned as the result with identical type.
-  }];
-
-  let arguments = (ins
-    AnyRankedTensor:$value,
-    IREETensorExt_ShapeDynamicDims:$value_dims
-  );
-  let results = (outs
-    AnyRankedTensor:$result
-  );
-
-  let assemblyFormat = [{
-    $value `:` type($value) (`{` $value_dims^ `}`)? `->`
-    type($result)
-    attr-dict-with-keyword
-  }];
-
-  let builders = [
-    OpBuilder<(ins "Value":$value), [{
-      build($_builder, $_state, value.getType(), value,
-            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder));
+            IREE::Util::buildDynamicDimsForValue($_state.location, value, $_builder),
+            direction,
+            flags);
     }]>,
   ];
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -1,48 +1,24 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
-util.func public @barrier_start_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value and result types must match}}
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
+util.func public @barrier_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier' op value and result types must match}}
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
   util.return %0 : tensor<8x4xf32>
 }
 
 // -----
 
-util.func public @barrier_start_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
+util.func public @barrier_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 
 // -----
 
-util.func public @barrier_start_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.start' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
-  util.return %0 : tensor<4x8xf32>
-}
-
-// -----
-
-util.func public @barrier_end_shape_mismatch(%arg0: tensor<4x8xf32>) -> tensor<8x4xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value and result types must match}}
-  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32> -> tensor<8x4xf32>
-  util.return %0 : tensor<8x4xf32>
-}
-
-// -----
-
-util.func public @barrier_end_missing_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index) -> tensor<?x?xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value set has 2 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<?x?xf32>{%dim0} -> tensor<?x?xf32>
-  util.return %0 : tensor<?x?xf32>
-}
-
-// -----
-
-util.func public @barrier_end_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
-  // expected-error@+1 {{'iree_tensor_ext.compute_barrier.end' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
-  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
+util.func public @barrier_static_with_dims(%arg0: tensor<4x8xf32>, %dim0: index) -> tensor<4x8xf32> {
+  // expected-error@+1 {{'iree_tensor_ext.compute_barrier' op value set has 0 dynamic dimensions but only 1 dimension values are attached}}
+  %0 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32>{%dim0} -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/roundtrip.mlir
@@ -51,39 +51,39 @@ util.func public @tensorBitCastDynamic(%arg0: tensor<?x16xi32>, %arg1: index, %a
 
 // -----
 
-// CHECK-LABEL: @barrier_start_static
-util.func public @barrier_start_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  // CHECK: iree_tensor_ext.compute_barrier.start
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+// CHECK-LABEL: @barrier_up_static
+util.func public @barrier_up_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK: iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse">
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 
 // -----
 
-// CHECK-LABEL: @barrier_start_dynamic
+// CHECK-LABEL: @barrier_up_dynamic
 // CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
-util.func public @barrier_start_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  // CHECK: iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+util.func public @barrier_up_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
+  // CHECK: iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 
 // -----
 
-// CHECK-LABEL: @barrier_end_static
-util.func public @barrier_end_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  // CHECK: iree_tensor_ext.compute_barrier.end
-  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+// CHECK-LABEL: @barrier_down_static
+util.func public @barrier_down_static(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // CHECK: iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse">
+  %0 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %0 : tensor<4x8xf32>
 }
 
 // -----
 
-// CHECK-LABEL: @barrier_end_dynamic
+// CHECK-LABEL: @barrier_down_dynamic
 // CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index
-util.func public @barrier_end_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  // CHECK: iree_tensor_ext.compute_barrier.end %[[ARG0]] : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
-  %0 = iree_tensor_ext.compute_barrier.end %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
+util.func public @barrier_down_dynamic(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
+  // CHECK: iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[ARG0]] : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %arg0 : tensor<?x?xf32>{%dim0, %dim1} -> tensor<?x?xf32>
   util.return %0 : tensor<?x?xf32>
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -51,13 +51,16 @@ def InsertTensorBarriersPass :
                   "mlir::FunctionOpInterface"> {
   let summary = "Insert tensor barrier markers around computation regions.";
   let description = [{
-    Walks from function boundaries and inserts iree_tensor_ext.compute_barrier.start
-    and iree_tensor_ext.compute_barrier.end operations at the boundaries of
-    computation regions (tensor/linalg/linalgext ops). These barriers allow
-    controlling where certain transformations like reshape propagation can occur.
+    Walks from function boundaries and inserts iree_tensor_ext.compute_barrier
+    operations at the boundaries of computation regions (tensor/linalg/linalgext ops).
 
-    The pass identifies compute operations and wraps tensor values flowing
-    into and out of the compute region with the barrier operations.
+    These barriers allow controlling where certain transformations like reshape
+    propagation can occur. Barriers with direction "up" are inserted for values
+    flowing into compute regions, while barriers with direction "down" are inserted
+    for values flowing out of compute regions.
+
+    By default, barriers are configured to allow both expand_shape and collapse_shape
+    operations to move through them.
   }];
   let dependentDialects = [
     "IREE::TensorExt::IREETensorExtDialect",
@@ -69,10 +72,10 @@ def RemoveTensorBarriersPass :
                   "mlir::FunctionOpInterface"> {
   let summary = "Remove tensor barrier markers from the program.";
   let description = [{
-    Removes iree_tensor_ext.compute_barrier.start and iree_tensor_ext.compute_barrier.end
-    operations from the program. These are identity operations that simply
-    pass through their operands, so they can be safely removed by replacing
-    all uses of their results with their operands.
+    Removes iree_tensor_ext.compute_barrier operations from the program.
+    These are identity operations that simply pass through their operands,
+    so they can be safely removed by replacing all uses of their results
+    with their operands.
   }];
   let dependentDialects = [
     "IREE::TensorExt::IREETensorExtDialect",
@@ -105,8 +108,15 @@ def FoldReshapesIntoTensorBarriersPass :
   let summary = "Fold reshape operations into tensor barriers.";
   let description = [{
     Moves tensor.expand_shape and tensor.collapse_shape operations through
-    iree_tensor_ext.compute_barrier.start and iree_tensor_ext.compute_barrier.end operations.
-    This blocks reshapes on the edge of the program from being propagated.
+    iree_tensor_ext.compute_barrier operations based on the barrier's direction
+    and transformation flags.
+
+    - For barriers with direction "up", reshapes can move above the barrier
+    - For barriers with direction "down", reshapes can move below the barrier
+    - Only reshapes matching the barrier's flags (AllowExpand, AllowCollapse) are moved
+
+    This allows precise control over where reshapes can propagate, blocking them
+    from moving across program boundaries while allowing controlled movement elsewhere.
   }];
   let dependentDialects = [
     "IREE::TensorExt::IREETensorExtDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/RemoveTensorBarriers.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/RemoveTensorBarriers.cpp
@@ -23,10 +23,7 @@ struct RemoveTensorBarriersPass final
     auto funcOp = getOperation();
     IRRewriter rewriter(funcOp.getContext());
 
-    funcOp.walk([&](IREE::TensorExt::ComputeBarrierStartOp op) {
-      rewriter.replaceOp(op, op.getValue());
-    });
-    funcOp.walk([&](IREE::TensorExt::ComputeBarrierEndOp op) {
+    funcOp.walk([&](IREE::TensorExt::ComputeBarrierOp op) {
       rewriter.replaceOp(op, op.getValue());
     });
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_reshapes_into_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_reshapes_into_tensor_barriers.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fold-reshapes-into-tensor-barriers))" %s | FileCheck %s
 
 util.func public @move_expand_shape_above_barrier_start(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
-  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<32xf32> -> tensor<32xf32>
+  %start = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<32xf32> -> tensor<32xf32>
   %expanded = tensor.expand_shape %start [[0, 1]] output_shape [4, 8] : tensor<32xf32> into tensor<4x8xf32>
   util.return %expanded : tensor<4x8xf32>
 }
@@ -9,14 +9,14 @@ util.func public @move_expand_shape_above_barrier_start(%arg0: tensor<32xf32>) -
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<32xf32> into tensor<4x8xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[EXPAND]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[EXPAND]]
 //  CHECK-SAME:     tensor<4x8xf32> -> tensor<4x8xf32>
 //       CHECK:   util.return %[[START]]
 
 // -----
 
 util.func public @move_collapse_shape_above_barrier_start(%arg0: tensor<4x8xf32>) -> tensor<32xf32> {
-  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %start = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   %collapsed = tensor.collapse_shape %start [[0, 1]] : tensor<4x8xf32> into tensor<32xf32>
   util.return %collapsed : tensor<32xf32>
 }
@@ -24,7 +24,7 @@ util.func public @move_collapse_shape_above_barrier_start(%arg0: tensor<4x8xf32>
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<4x8xf32> into tensor<32xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[COLLAPSE]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[COLLAPSE]]
 //  CHECK-SAME:     tensor<32xf32> -> tensor<32xf32>
 //       CHECK:   util.return %[[START]]
 
@@ -32,12 +32,12 @@ util.func public @move_collapse_shape_above_barrier_start(%arg0: tensor<4x8xf32>
 
 util.func public @move_expand_shape_below_barrier_end(%arg0: tensor<32xf32>) -> tensor<4x8xf32> {
   %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : tensor<32xf32> into tensor<4x8xf32>
-  %end = iree_tensor_ext.compute_barrier.end %expanded : tensor<4x8xf32> -> tensor<4x8xf32>
+  %end = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %expanded : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %end : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @move_expand_shape_below_barrier_end
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[ARG0]]
 //  CHECK-SAME:     tensor<32xf32> -> tensor<32xf32>
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[END]]
 //  CHECK-SAME:     tensor<32xf32> into tensor<4x8xf32>
@@ -47,12 +47,12 @@ util.func public @move_expand_shape_below_barrier_end(%arg0: tensor<32xf32>) -> 
 
 util.func public @move_collapse_shape_below_barrier_end(%arg0: tensor<4x8xf32>) -> tensor<32xf32> {
   %collapsed = tensor.collapse_shape %arg0 [[0, 1]] : tensor<4x8xf32> into tensor<32xf32>
-  %end = iree_tensor_ext.compute_barrier.end %collapsed : tensor<32xf32> -> tensor<32xf32>
+  %end = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %collapsed : tensor<32xf32> -> tensor<32xf32>
   util.return %end : tensor<32xf32>
 }
 // CHECK-LABEL: util.func public @move_collapse_shape_below_barrier_end
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[ARG0]]
 //  CHECK-SAME:     tensor<4x8xf32> -> tensor<4x8xf32>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[END]]
 //  CHECK-SAME:     tensor<4x8xf32> into tensor<32xf32>
@@ -65,7 +65,7 @@ util.func public @move_expand_shape_above_barrier_start_dynamic(%arg0: tensor<?x
   %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
   %c8 = arith.constant 8 : index
   %div = arith.divsi %dim, %c8 : index
-  %start = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?xf32>{%dim} -> tensor<?xf32>
+  %start = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<?xf32>{%dim} -> tensor<?xf32>
   %expanded = tensor.expand_shape %start [[0, 1]] output_shape [%div, 8] : tensor<?xf32> into tensor<?x8xf32>
   util.return %expanded : tensor<?x8xf32>
 }
@@ -73,7 +73,7 @@ util.func public @move_expand_shape_above_barrier_start_dynamic(%arg0: tensor<?x
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<?xf32> into tensor<?x8xf32>
-//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier.start %[[EXPAND]]
+//       CHECK:   %[[START:.+]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[EXPAND]]
 //  CHECK-SAME:     tensor<?x8xf32>{{.*}} -> tensor<?x8xf32>
 //       CHECK:   util.return %[[START]]
 
@@ -85,12 +85,12 @@ util.func public @move_expand_shape_below_barrier_end_dynamic(%arg0: tensor<?xf3
   %c8 = arith.constant 8 : index
   %div = arith.divsi %dim, %c8 : index
   %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [%div, 8] : tensor<?xf32> into tensor<?x8xf32>
-  %end = iree_tensor_ext.compute_barrier.end %expanded : tensor<?x8xf32>{%dim} -> tensor<?x8xf32>
+  %end = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %expanded : tensor<?x8xf32>{%dim} -> tensor<?x8xf32>
   util.return %end : tensor<?x8xf32>
 }
 // CHECK-LABEL: util.func public @move_expand_shape_below_barrier_end_dynamic
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[ARG0]]
 //  CHECK-SAME:     tensor<?xf32>{{.*}} -> tensor<?xf32>
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[END]]
 //  CHECK-SAME:     tensor<?xf32> into tensor<?x8xf32>
@@ -104,12 +104,12 @@ util.func public @move_collapse_shape_below_barrier_end_dynamic(%arg0: tensor<?x
   %c8 = arith.constant 8 : index
   %size = arith.muli %dim, %c8 : index
   %collapsed = tensor.collapse_shape %arg0 [[0, 1]] : tensor<?x8xf32> into tensor<?xf32>
-  %end = iree_tensor_ext.compute_barrier.end %collapsed : tensor<?xf32>{%size} -> tensor<?xf32>
+  %end = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %collapsed : tensor<?xf32>{%size} -> tensor<?xf32>
   util.return %end : tensor<?xf32>
 }
 // CHECK-LABEL: util.func public @move_collapse_shape_below_barrier_end_dynamic
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[ARG0]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[ARG0]]
 //  CHECK-SAME:     tensor<?x8xf32>{{.*}} -> tensor<?x8xf32>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[END]]
 //  CHECK-SAME:     tensor<?x8xf32> into tensor<?xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests_aggressive.mlir
@@ -169,7 +169,7 @@ util.func public @transpose_barrier_matmul(%arg0: tensor<128x64xf32>, %arg1: ten
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
   } -> tensor<64x128xf32>
-  %barrier = iree_tensor_ext.compute_barrier.start %transpose : tensor<64x128xf32> -> tensor<64x128xf32>
+  %barrier = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %transpose : tensor<64x128xf32> -> tensor<64x128xf32>
   %empty_matmul = tensor.empty() : tensor<128x128xf32>
   %init = linalg.fill ins(%c0 : f32) outs(%empty_matmul : tensor<128x128xf32>) -> tensor<128x128xf32>
   %matmul = linalg.matmul ins(%arg1, %barrier : tensor<128x64xf32>, tensor<64x128xf32>) outs(%init : tensor<128x128xf32>) -> tensor<128x128xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/remove_tensor_barriers.mlir
@@ -1,20 +1,19 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-remove-tensor-barriers))" %s | FileCheck %s
 
 util.func public @simple_barrier(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
-  %1 = iree_tensor_ext.compute_barrier.end %0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %1 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %0 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %1 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @simple_barrier
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
-//   CHECK-NOT:   compute_barrier.start
-//   CHECK-NOT:   compute_barrier.end
+//   CHECK-NOT:   compute_barrier
 //       CHECK:   util.return %[[ARG0]]
 
 // -----
 
 util.func public @barrier_with_compute(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4x8xf32> -> tensor<4x8xf32>
   %empty = tensor.empty() : tensor<4x8xf32>
   %1 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
@@ -24,43 +23,41 @@ util.func public @barrier_with_compute(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
   } -> tensor<4x8xf32>
-  %2 = iree_tensor_ext.compute_barrier.end %1 : tensor<4x8xf32> -> tensor<4x8xf32>
+  %2 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %1 : tensor<4x8xf32> -> tensor<4x8xf32>
   util.return %2 : tensor<4x8xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_compute
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
-//   CHECK-NOT:   compute_barrier.start
+//   CHECK-NOT:   compute_barrier
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[ARG0]] :
-//   CHECK-NOT:   compute_barrier.end
+//   CHECK-NOT:   compute_barrier
 //       CHECK:   util.return %[[GENERIC]]
 
 // -----
 
 util.func public @multiple_barriers(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<4xf32> -> tensor<4xf32>
-  %1 = iree_tensor_ext.compute_barrier.start %arg1 : tensor<4xf32> -> tensor<4xf32>
-  %2 = iree_tensor_ext.compute_barrier.end %0 : tensor<4xf32> -> tensor<4xf32>
-  %3 = iree_tensor_ext.compute_barrier.end %1 : tensor<4xf32> -> tensor<4xf32>
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<4xf32> -> tensor<4xf32>
+  %1 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg1 : tensor<4xf32> -> tensor<4xf32>
+  %2 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %0 : tensor<4xf32> -> tensor<4xf32>
+  %3 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %1 : tensor<4xf32> -> tensor<4xf32>
   util.return %2, %3 : tensor<4xf32>, tensor<4xf32>
 }
 // CHECK-LABEL: util.func public @multiple_barriers
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]
-//   CHECK-NOT:   compute_barrier.start
-//   CHECK-NOT:   compute_barrier.end
+//   CHECK-NOT:   compute_barrier
 //       CHECK:   util.return %[[ARG0]], %[[ARG1]]
 
 // -----
 
 util.func public @barrier_with_dynamic_dims(%arg0: tensor<?x?xf32>, %dim0: index, %dim1: index) -> tensor<?x?xf32> {
-  %0 = iree_tensor_ext.compute_barrier.start %arg0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
-  %1 = iree_tensor_ext.compute_barrier.end %0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
+  %0 = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %arg0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
+  %1 = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %0 : tensor<?x?xf32> {%dim0, %dim1} -> tensor<?x?xf32>
   util.return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: util.func public @barrier_with_dynamic_dims
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
-//   CHECK-NOT:   compute_barrier.start
-//   CHECK-NOT:   compute_barrier.end
+//   CHECK-NOT:   compute_barrier
 //       CHECK:   util.return %[[ARG0]]

--- a/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/transformation_pipeline.mlir
@@ -49,8 +49,8 @@ util.func public @transpose_with_strided_conv(%arg0: tensor<40x1x1x32xbf16>, %ar
 // CHECK-LABEL: util.func public @transpose_with_strided_conv
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<40x1x1x32xbf16>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x192x128x32xbf16>
-//       CHECK:   %[[START0:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG1]]
-//       CHECK:   %[[START1:.+]] = iree_tensor_ext.compute_barrier.start %[[ARG0]]
+//       CHECK:   %[[START0:.+]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[ARG1]]
+//       CHECK:   %[[START1:.+]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[ARG0]]
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[START1]]
 //       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[START0]][0, 0, 0, 0] [16, 96, 64, 32] [1, 2, 2, 1]
 //  CHECK-SAME:     tensor<16x192x128x32xbf16> to tensor<16x96x64x32xbf16>
@@ -59,5 +59,5 @@ util.func public @transpose_with_strided_conv(%arg0: tensor<40x1x1x32xbf16>, %ar
 //  CHECK-SAME:     ins(%[[SLICE]], %[[COLLAPSED]] : tensor<16x96x64x32xbf16>, tensor<40x32xbf16>)
 //       CHECK:   %[[TRUNC:.+]] = linalg.generic
 //  CHECK-SAME:     ins(%[[CONTRACT]] : tensor<16x96x64x40xf32>)
-//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier.end %[[TRUNC]]
+//       CHECK:   %[[END:.+]] = iree_tensor_ext.compute_barrier<down, "AllowExpand|AllowCollapse"> %[[TRUNC]]
 //       CHECK:   util.return %[[END]]

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -93,7 +93,7 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xf32>
 // CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [3, 1, 2, 0]
-// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
 // CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
@@ -120,7 +120,7 @@ util.func public @conv_2d_nhwgc_gchwf(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xf32>
 // CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x3x3x16xf32>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xf32>)
 // CHECK-FHWC-SAME:   permutation = [0, 4, 2, 3, 1]
-// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier<up, "AllowExpand|AllowCollapse"> %[[TRANSPOSE]]
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
 // CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)


### PR DESCRIPTION
This change refactors the tensor compute barrier operations to provide more fine-grained control over allowed transformations. Replaced the separate compute_barrier.start and compute_barrier.end operations with a single compute_barrier op that accepts direction and transformation flags.