### PR TITLE
[CI] Bump golden value to 165*1.1=181.5 for prefill benchmark on mi325

### DIFF
--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/prefill_benchmark_seq2048_mi325.json
@@ -36,5 +36,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 169.6
+    "golden_time_ms": 181.5
 }


### PR DESCRIPTION
I only bumped it to 165+5 in https://github.com/iree-org/iree/pull/22595, because I thought it's good enough. However, we're experiencing "flaky" tests recently. Bumping it to `val*1.1` as 10% is the usual max delta across chips from the same SKU.

ci-extra: test_torch