### PR TITLE
[GlobalOpt] Fix rank-reduced permutation in SinkTransposeThroughExtractSlice

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -494,10 +494,10 @@ public:
     llvm::SmallDenseMap<int64_t, int64_t> rankReducedMap;
     // Since `dim` is in the pre-transposed domain, and is incrementing each
     // iteration, `idx` must also be in the pre-transposed domain.
-    for (int64_t idx = 0, e = perm.size(); idx < e; ++idx) {
+    for (int64_t idx = 0, e = invPerm.size(); idx < e; ++idx) {
       // Get index in the transposed domain, since `rankReducingMask` is in
       // the transposed domain.
-      if (!rankReducingMask.contains(perm[idx])) {
+      if (!rankReducingMask.contains(invPerm[idx])) {
         // Domain of `rankReducedMap` is in pre-transposed domain.
         rankReducedMap[idx] = dim++;
       }
@@ -506,7 +506,7 @@ public:
     // Compute the new permutation by dropping all rank-reduced dimensions.
     SmallVector<int64_t> rankReducedPerm;
     for (int64_t i : perm) {
-      if (!rankReducingMask.contains(i)) {
+      if (rankReducedMap.contains(i)) {
         rankReducedPerm.push_back(rankReducedMap[i]);
       }
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/propagate_linalg_transpose.mlir
@@ -94,6 +94,22 @@ util.func public @propagate_through_rank_reduced_extract_slice(%arg0 : tensor<1x
 
 // -----
 
+util.func public @propagate_through_rank_reduced_extract_slice_2(%arg0: tensor<80x80x1x1x1203xf16>) -> tensor<1203x5x80xf16> {
+  %empty = tensor.empty() : tensor<1x1203x80x80x1xf16>
+  %transposed = linalg.transpose ins(%arg0 : tensor<80x80x1x1x1203xf16>) outs(%empty : tensor<1x1203x80x80x1xf16>) permutation = [3, 4, 0, 1, 2]
+  %extracted_slice = tensor.extract_slice %transposed[0, 0, 0, 0, 0] [1, 1203, 5, 80, 1] [1, 1, 1, 1, 1] : tensor<1x1203x80x80x1xf16> to tensor<1203x5x80xf16>
+  util.return %extracted_slice : tensor<1203x5x80xf16>
+}
+// CHECK-LABEL:   util.func public @propagate_through_rank_reduced_extract_slice_2(
+//  CHECK-SAME:     %[[ARG0:.*]]: tensor<80x80x1x1x1203xf16>) -> tensor<1203x5x80xf16> {
+//       CHECK:     %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[ARG0]][0, 0, 0, 0, 0] [5, 80, 1, 1, 1203] [1, 1, 1, 1, 1] : tensor<80x80x1x1x1203xf16> to tensor<5x80x1203xf16>
+//       CHECK:     %[[EMPTY_0:.*]] = tensor.empty() : tensor<1203x5x80xf16>
+//       CHECK:     %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[EXTRACT_SLICE_0]] : tensor<5x80x1203xf16>) outs(%[[EMPTY_0]] : tensor<1203x5x80xf16>) permutation = [2, 0, 1]
+//       CHECK:     util.return %[[TRANSPOSE_0]] : tensor<1203x5x80xf16>
+//       CHECK:   }
+
+// -----
+
 util.func public @rank_reduced_extract_transposed_unit_dim(%arg0: tensor<256x1x32x128xf32>, %arg1: tensor<1x32x256x128xf32>) -> tensor<32x64x128xf32> {
   %transposed = linalg.transpose ins(%arg0 : tensor<256x1x32x128xf32>) outs(%arg1 : tensor<1x32x256x128xf32>) permutation = [1, 2, 0, 3]
   %extracted_slice = tensor.extract_slice %transposed[0, 0, 0, 0] [1, 32, 64, 128] [1, 1, 1, 1] : tensor<1x32x256x128xf32> to tensor<32x64x128xf32>


### PR DESCRIPTION
Fixes #22687

Fixed incorrect computation of rank-reduced permutation when sinking transpose through rank-reducing extract_slice operations.

Added test case propagate_through_rank_reduced_extract_slice_2 to verify the fix with a 5D tensor using permutation [3,4,0,1,2] and rank reduction from 5D to 3D.