### PR TITLE
build_tools: fix: ensure that iree-flatcc-cli and iree-c-embed-data are build for the target during cross-compilation

### DIFF
--- a/build_tools/cmake/flatbuffer_c_library.cmake
+++ b/build_tools/cmake/flatbuffer_c_library.cmake
@@ -85,11 +85,17 @@ function(flatbuffer_c_library)
   endforeach()
   list(TRANSFORM _OUTS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
 
+  # When cross-compiling execute the binary from the host build.
+  set(IREE_FLATCC_TOOL_BINARY iree-flatcc-cli)
+  if (IREE_HOST_BIN_DIR)
+    set(IREE_FLATCC_TOOL_BINARY "${IREE_HOST_BIN_DIR}/iree-flatcc-cli")
+  endif()
+
   add_custom_command(
     OUTPUT
       ${_OUTS}
     COMMAND
-      iree-flatcc-cli
+      ${IREE_FLATCC_TOOL_BINARY}
           -o "${CMAKE_CURRENT_BINARY_DIR}"
           -I "${IREE_ROOT_DIR}"
           -I "${IREE_ROOT_DIR}/runtime/src"
@@ -100,6 +106,7 @@ function(flatbuffer_c_library)
     MAIN_DEPENDENCY
       ${_RULE_SRCS}
     DEPENDS
+      ${IREE_FLATCC_TOOL_BINARY}
       ${_RULE_SRCS}
     COMMAND_EXPAND_LISTS
   )

--- a/build_tools/cmake/iree_c_embed_data.cmake
+++ b/build_tools/cmake/iree_c_embed_data.cmake
@@ -92,10 +92,16 @@ function(iree_c_embed_data)
     endif()
   endforeach(_SRC)
 
+  # When cross-compiling execute the binary from the host build.
+  set(IREE_C_EMBED_DATA_TOOL_BINARY iree-c-embed-data)
+  if (IREE_HOST_BIN_DIR)
+    set(IREE_C_EMBED_DATA_TOOL_BINARY "${IREE_HOST_BIN_DIR}/iree-c-embed-data")
+  endif()
+
   add_custom_command(
     OUTPUT "${_RULE_H_FILE_OUTPUT}" "${_RULE_C_FILE_OUTPUT}"
-    COMMAND iree-c-embed-data ${_ARGS} ${_RESOLVED_SRCS}
-    DEPENDS iree-c-embed-data ${_RESOLVED_SRCS}
+    COMMAND ${IREE_C_EMBED_DATA_TOOL_BINARY} ${_ARGS} ${_RESOLVED_SRCS}
+    DEPENDS ${IREE_C_EMBED_DATA_TOOL_BINARY} ${_RESOLVED_SRCS}
   )
 
   if(_RULE_TESTONLY)

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -4,16 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Just import if IREE_HOST_BIN_DIR is set (e.g. when cross-compiling).
-if(IREE_HOST_BIN_DIR)
-  iree_import_binary(NAME iree-c-embed-data)
-  install(IMPORTED_RUNTIME_ARTIFACTS iree-c-embed-data
-          COMPONENT iree-c-embed-data
-          RUNTIME DESTINATION bin
-          BUNDLE DESTINATION bin)
-  return()
-endif()
-
 add_executable(iree-c-embed-data)
 target_sources(iree-c-embed-data PRIVATE iree-c-embed-data-main.cc)
 set_target_properties(iree-c-embed-data PROPERTIES

--- a/build_tools/third_party/flatcc/CMakeLists.txt
+++ b/build_tools/third_party/flatcc/CMakeLists.txt
@@ -86,12 +86,6 @@ external_cc_library(
   PUBLIC
 )
 
-if(IREE_HOST_BIN_DIR)
-  # Just import if IREE_HOST_BIN_DIR is set (e.g. when cross-compiling).
-  iree_import_binary(NAME iree-flatcc-cli)
-  return()
-endif()
-
 # Define our own binary target for the CLI.
 # flatcc's `flatcc_cli` target renames itself to `flatcc` or `flatcc_d`
 # depending on the build configuration, so we prefer to just set our own name.


### PR DESCRIPTION
When running a cross-compilation of the runtime I noticed that the install includes binaries from the host binary directory that I specified, specifically: `iree-c-embed-data`. Looking at `third-party/iree/build_tools/embed_data/CMakeLists.txt:8`  you can see that the binary is only imported but never built for the cross-target.

When trying to also cross-compile the python bindings the cmake setup was failing with:
```
CMake Error at third-party/iree/runtime/bindings/python/CMakeLists.txt:334:EVAL:2 (install):
  install TARGETS given target "iree-c-embed-data" which does not exist.
Call Stack (most recent call first):
  third-party/iree/CMakeLists.txt:DEFERRED
```

This happens because the binary is not being build for the cross-target. The same issue happens for the `iree-flatcc-cli` tool.

This PR ensures that the host binaries are correctly used during the cross-compilation, as well as ensuring that the binaries are built for the target and included in the install.