### PR TITLE
[Encoding] Test i1 mask attention with packed_storage

### DIFF
--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -81,6 +81,7 @@ VMVX_SRCS = enforce_glob(
     exclude = [
         "attention.mlir",
         "attention_i1_mask.mlir",
+        "attention_i1_mask_encoding.mlir",
     ],
 )
 
@@ -107,6 +108,7 @@ LLVM_GPU_SRCS = enforce_glob(
     exclude = [
         "attention.mlir",
         "attention_i1_mask.mlir",
+        "attention_i1_mask_encoding.mlir",
         "map_scatter.mlir",
     ],
 )
@@ -144,6 +146,7 @@ ROCM_HIP_SRCS = enforce_glob(
         "top-k.mlir",
         "attention.mlir",
         "attention_i1_mask.mlir",
+        "attention_i1_mask_encoding.mlir",
     ],
 )
 
@@ -171,6 +174,7 @@ iree_check_single_backend_test_suite(
         exclude = [
             "attention.mlir",
             "attention_i1_mask.mlir",
+            "attention_i1_mask_encoding.mlir",
             "map_scatter.mlir",
             "top-k.mlir",
         ],
@@ -196,6 +200,7 @@ iree_check_single_backend_test_suite(
         exclude = [
             "attention.mlir",
             "attention_i1_mask.mlir",
+            "attention_i1_mask_encoding.mlir",
             "map_scatter.mlir",
             "top-k.mlir",
         ],

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -17,6 +17,7 @@ ALL_SRCS = enforce_glob(
     [
         "arg_compare.mlir",
         "attention.mlir",
+        "attention_i1_mask_encoding.mlir",
         "gather.mlir",
         "map_scatter.mlir",
         "scan.mlir",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "arg_compare.mlir"
     "attention.mlir"
+    "attention_i1_mask_encoding.mlir"
     "gather.mlir"
     "map_scatter.mlir"
     "scan.mlir"

--- a/tests/e2e/linalg_ext_ops/attention_i1_mask_encoding.mlir
+++ b/tests/e2e/linalg_ext_ops/attention_i1_mask_encoding.mlir
@@ -1,0 +1,122 @@
+func.func @attention4x4_i1_mask() {
+  %init = tensor.empty() : tensor<4x4xf32>
+  %query = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %key = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                          [0.5, 0.6, 0.7, 0.8],
+                                          [0.9, 1.0, 1.1, 1.2],
+                                          [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+  %value = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %i8mask = util.unfoldable_constant dense<[165, 165]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<4x4xi1, #iree_encoding.packed_storage>
+
+  %scale = arith.constant 0.5 : f32
+  %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> ()>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d3)>]}
+                     ins(%query, %key, %value, %scale, %mask : tensor<4x4xf32>,
+        tensor<4x4xf32>, tensor<4x4xf32>, f32, tensor<4x4xi1, #iree_encoding.packed_storage>) outs(%init : tensor<4x4xf32>) {
+          ^bb0(%arg0: f32):
+          iree_linalg_ext.yield %arg0 : f32
+        } -> tensor<4x4xf32>
+  check.expect_almost_eq_const(
+      %1,
+      dense<[[0.57895, 0.67895, 0.77895, 0.87895],
+              [1.09108, 1.19108, 1.29108, 1.39108],
+              [0.774324, 0.874324, 0.974324, 1.07432],
+              [1.22842, 1.32842, 1.42842, 1.52842]]> : tensor<4x4xf32>
+  ) : tensor<4x4xf32>
+  return
+}
+
+func.func @attention4x4_i1_mask_all_ones() {
+  %init = tensor.empty() : tensor<4x4xf32>
+  %query = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %key = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                          [0.5, 0.6, 0.7, 0.8],
+                                          [0.9, 1.0, 1.1, 1.2],
+                                          [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+  %value = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %i8mask = util.unfoldable_constant dense<[255, 255]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<4x4xi1, #iree_encoding.packed_storage>
+
+  %scale = arith.constant 0.5 : f32
+  %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> ()>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d3)>]}
+                     ins(%query, %key, %value, %scale, %mask : tensor<4x4xf32>,
+        tensor<4x4xf32>, tensor<4x4xf32>, f32, tensor<4x4xi1, #iree_encoding.packed_storage>) outs(%init : tensor<4x4xf32>) {
+          ^bb0(%arg0: f32):
+          iree_linalg_ext.yield %arg0 : f32
+        } -> tensor<4x4xf32>
+  check.expect_almost_eq_const(
+      %1,
+      dense<[[0.798884, 0.898884, 0.998884, 1.09888],
+              [0.941939, 1.04194, 1.14194, 1.24194],
+              [1.05371, 1.15371, 1.25371, 1.35371],
+              [1.13295, 1.23295, 1.33295, 1.43295]]> : tensor<4x4xf32>
+  ) : tensor<4x4xf32>
+  return
+}
+
+func.func @attention4x4_i1_mask_tril() {
+  %init = tensor.empty() : tensor<4x4xf32>
+  %query = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %key = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                          [0.5, 0.6, 0.7, 0.8],
+                                          [0.9, 1.0, 1.1, 1.2],
+                                          [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+  %value = util.unfoldable_constant dense<[[0.1, 0.2, 0.3, 0.4],
+                                            [0.5, 0.6, 0.7, 0.8],
+                                            [0.9, 1.0, 1.1, 1.2],
+                                            [1.3, 1.4, 1.5, 1.6]]> : tensor<4x4xf32>
+
+  %i8mask = util.unfoldable_constant dense<[140, 239]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<4x4xi1, #iree_encoding.packed_storage>
+
+  %scale = arith.constant 0.5 : f32
+  %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> ()>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d3)>]}
+                     ins(%query, %key, %value, %scale, %mask : tensor<4x4xf32>,
+        tensor<4x4xf32>, tensor<4x4xf32>, f32, tensor<4x4xi1, #iree_encoding.packed_storage>) outs(%init : tensor<4x4xf32>) {
+          ^bb0(%arg0: f32):
+          iree_linalg_ext.yield %arg0 : f32
+        } -> tensor<4x4xf32>
+  check.expect_almost_eq_const(
+      %1,
+      dense<[[1.11993, 1.21993, 1.31993, 1.41993],
+              [1.3, 1.4, 1.5, 1.6],
+              [1.05371, 1.15371, 1.25371, 1.35371],
+              [1.15549, 1.25549, 1.35549, 1.45549]]> : tensor<4x4xf32>
+  ) : tensor<4x4xf32>
+  return
+}


### PR DESCRIPTION
Test attention with an `i1` mask using the `packed_storage` encoding attribute instead of the experimental flag to avoid extending `i1` to `i8` during compilation.

Currently the test needs to drop the unit extent dimension compared to the other attention tests due to problems with FoldUnitExtentDims.

Signed-off-by: Lukas Sommer <lukas.sommer@amd.com>