### PR TITLE
[Encoding] Implement compatibility check for packed_storage

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -99,6 +99,17 @@ Value LayoutAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
 
 bool PackedStorageAttr::isSerialized() const { return true; }
 
+bool PackedStorageAttr::isCompatibleWith(
+    IREE::Encoding::SerializableAttr other) const {
+  // The packed_storage encodings is compatible with empty encodings, because it
+  // doesn't impact tensor shape.
+  if (!other) {
+    return true;
+  }
+  // Otherwise, packed_storage is only compatible with itself.
+  return isa<IREE::Encoding::PackedStorageAttr>(other);
+}
+
 /// Returns the bit-width of the scalar type. If the type is complex, it
 /// returns the type of individual elements * 2 (1 for real and 1 for
 /// complex).

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -88,6 +88,7 @@ def PackedStorageAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableAttr, [
           "isSerialized",
           "calculateStorageSizeInBytes",
+          "isCompatibleWith",
       ]>,
       DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
     ]> {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -164,7 +164,7 @@ def IREEEncoding_SerializableAttr :
       /*defaultImplementation=*/[{
         auto attr =
           dyn_cast_if_present<SerializableAttr>($_attr);
-        if (!attr) {
+        if (!attr || !other) {
           return false;
         }
         if (attr.isSerialized() && other.isSerialized()) {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -23,11 +23,9 @@ bool SerializableAttr::areCompatible(Attribute lhs, Attribute rhs) {
   }
   auto lhsEncoding = dyn_cast_if_present<SerializableAttr>(lhs);
   auto rhsEncoding = dyn_cast_if_present<SerializableAttr>(rhs);
-  if (!lhsEncoding || !rhsEncoding) {
-    return false;
-  }
-  return lhsEncoding.isCompatibleWith(rhsEncoding) &&
-         rhsEncoding.isCompatibleWith(lhsEncoding);
+
+  return (!lhsEncoding || lhsEncoding.isCompatibleWith(rhsEncoding)) &&
+         (!rhsEncoding || rhsEncoding.isCompatibleWith(lhsEncoding));
 }
 
 std::string stringifyOperandIndex(IntegerAttr valueAttr) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -100,6 +100,30 @@ util.func public @tensorBitCastWithSingleUse(%input: tensor<5x24x48xi8>) -> tens
 
 // -----
 
+// CHECK-LABEL: @tensorBitCastToEncoding
+//  CHECK-SAME: (%[[INPUT:.*]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index)
+util.func public @tensorBitCastToEncoding(%input: tensor<4x16x8xi1>) -> tensor<4x16x8xi1, #iree_encoding.packed_storage> {
+  // CHECK: %[[RESULT_SIZE:.*]] = stream.tensor.sizeof tensor<4x16x8xi1, #iree_encoding.packed_storage> : index
+  // CHECK: %[[BITCAST:.*]] = stream.tensor.clone %[[INPUT]] : tensor<4x16x8xi1> in !stream.resource<*>{%[[INPUT_SIZE]]} -> tensor<4x16x8xi1, #iree_encoding.packed_storage> in !stream.resource<*>{%[[RESULT_SIZE]]}
+  %0 = flow.tensor.bitcast %input : tensor<4x16x8xi1> -> tensor<4x16x8xi1, #iree_encoding.packed_storage>
+  // CHECK: util.return %[[BITCAST]], %[[RESULT_SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4x16x8xi1, #iree_encoding.packed_storage>
+}
+
+// -----
+
+// CHECK-LABEL: @tensorBitCastFromEncoding
+//  CHECK-SAME: (%[[INPUT:.*]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index)
+util.func public @tensorBitCastFromEncoding(%input: tensor<4x16x8xi1, #iree_encoding.packed_storage>) -> tensor<4x16x8xi1> {
+  // CHECK: %[[RESULT_SIZE:.*]] = stream.tensor.sizeof tensor<4x16x8xi1> : index
+  // CHECK: %[[BITCAST:.*]] = stream.tensor.clone %[[INPUT]] : tensor<4x16x8xi1, #iree_encoding.packed_storage> in !stream.resource<*>{%[[INPUT_SIZE]]} -> tensor<4x16x8xi1> in !stream.resource<*>{%[[RESULT_SIZE]]}
+  %0 = flow.tensor.bitcast %input : tensor<4x16x8xi1, #iree_encoding.packed_storage> -> tensor<4x16x8xi1>
+  // CHECK: util.return %[[BITCAST]], %[[RESULT_SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4x16x8xi1>
+}
+
+// -----
+
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<>
 // CHECK-LABEL: @tensorEncodeStatic
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]


### PR DESCRIPTION
Implement the `SerializableAttr` interface method to check compatibility with other encodings for the `packed_storage` encoding.

In particular, `packed_storage` does not affect the shape of the tensor, so it's compatible with no encoding at all and `flow.tensor.bitcast` can be used to attach the encoding to a tensor.