### PR TITLE
[tests][e2e] Add custom mxfp4 gemm tests to verify shape of interest.

### DIFF
--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1997,6 +1997,37 @@ iree_generated_e2e_runner_test(
     "requires-gpu-cdna4"
 )
 
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna4_mxfp4_llama
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=custom_mnk"
+    "--mnk=10000,16384,16384"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
 endif()
 
 


### PR DESCRIPTION
This patch adds a e2e matmul test for the shape `10000,16384,16384` which appears in models we care about. There was a choice between adding a singular custom test vs creating a new class of tests specifically for VERY_LARGE shapes which would be very problematic space wise for any other data type but mxfp4. But given that we want to test a very specific shape I didn't feel the need to go through with more changes than necessary. Open to discussion.