### PR TITLE
[CI] Adding MI355x runner test

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -64,6 +64,12 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
     uses: ./.github/workflows/pkgci_test_amd_w7900.yml
 
+  test_amd_mi355x:
+    name: Test AMD MI355x
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi355x')
+    uses: ./.github/workflows/pkgci_test_amd_mi355x.yml
+
   # TODO(#18238): migrate to new runner cluster
   # test_nvidia_t4:
   #   name: Test NVIDIA T4
@@ -135,6 +141,7 @@ jobs:
       - test_amd_mi250
       - test_amd_mi325
       - test_amd_w7900
+      - test_amd_mi355x
       # - test_nvidia_t4
       - test_android
       - test_riscv64

--- a/.github/workflows/pkgci_test_amd_mi355x.yml
+++ b/.github/workflows/pkgci_test_amd_mi355x.yml
@@ -1,0 +1,69 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: PkgCI Test AMD MI355x
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+
+jobs:
+  test_mi355x:
+    runs-on: linux-mi35x-1gpu-ossci-iree-org
+    env:
+      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+      BUILD_DIR: build-tests
+      VENV_DIR: ${{ github.workspace }}/.venv
+      GH_TOKEN: ${{ github.token }}
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 1
+      IREE_CUDA_ENABLE: 0
+      IREE_HIP_ENABLE: 1
+      IREE_HIP_TEST_TARGET_CHIP: "gfx950"
+    steps:
+      - name: Run rocminfo
+        run: rocminfo
+      - name: Check out repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          submodules: false
+      - name: Check out runtime submodules
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          # Must match the subset of versions built in pkgci_build_packages.
+          python-version: "3.11"
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        if: ${{ inputs.artifact_run_id == '' }}
+        with:
+          name: linux_x86_64_release_packages
+          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Setup base venv
+        run: |
+          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build tests
+        run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin
+      - name: Run GPU tests
+        env:
+          CTEST_PARALLEL_LEVEL: 2
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
+          IREE_AMD_RDNA3_TESTS_DISABLE: 1
+          IREE_NVIDIA_GPU_TESTS_DISABLE: 0
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+        run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}


### PR DESCRIPTION
We have self-hosted runners that can run mxfp4 e2e tests so we should use them.