### PR TITLE
[DispatchCreation] Fold unit dims with encoding

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -203,7 +203,10 @@ LogicalResult PackedStorageAttr::verifyEncoding(
   return success();
 }
 
-bool PackedStorageAttr::canCollapse() const { return true; }
+Attribute PackedStorageAttr::getCollapsedEncoding(ArrayRef<int64_t>,
+                                                  ArrayRef<int64_t>) const {
+  return *this;
+}
 
 //===---------------------------------------------------------------------===//
 // iree_encoding.encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -203,6 +203,8 @@ LogicalResult PackedStorageAttr::verifyEncoding(
   return success();
 }
 
+bool PackedStorageAttr::canCollapse() const { return true; }
+
 //===---------------------------------------------------------------------===//
 // iree_encoding.encoding
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -91,6 +91,9 @@ def PackedStorageAttr :
           "calculateStorageSizeInBytes",
           "isCompatibleWith",
       ]>,
+      DeclareAttrInterfaceMethods<IREEEncoding_CollapsibleEncodingAttrInterface, [
+          "canCollapse",
+      ]>,
       DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
     ]> {
   let mnemonic = "packed_storage";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -90,9 +90,7 @@ def PackedStorageAttr :
           "isSerialized",
           "calculateStorageSizeInBytes",
           "isCompatibleWith",
-      ]>,
-      DeclareAttrInterfaceMethods<IREEEncoding_CollapsibleEncodingAttrInterface, [
-          "canCollapse",
+          "getCollapsedEncoding",
       ]>,
       DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
     ]> {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -220,6 +220,23 @@ def IREEEncoding_SerializableAttr :
         assert(false && "unimplemented interface method");
         return {};
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the new encoding after collapsing the type from `origShape`
+        to `targetShape`. If the type with this encoding cannot be collapsed,
+        returns `nullptr`.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getCollapsedEncoding",
+      /*args=*/(ins
+        "::llvm::ArrayRef<int64_t>":$origShape,
+        "::llvm::ArrayRef<int64_t>":$targetShape
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return nullptr;
+      }]
     >
   ];
 
@@ -337,32 +354,6 @@ def IREEEncoding_ContractionEncodingAttrInterface :
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return std::nullopt;
-      }]
-    >
-  ];
-}
-
-def IREEEncoding_CollapsibleEncodingAttrInterface :
-  AttrInterface<"CollapsibleEncodingAttrInterface"> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
-  let description = [{
-    Interface used to query whether a tensor with the encoding
-    can be collapsed, e.g., to fold away unit extent dimensions.
-  }];
-
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/[{
-        Returns true if a tensor type with this encoding can be
-        collapsed.
-      }],
-      /*retTy=*/"bool",
-      /*methodName=*/"canCollapse",
-      /*args=*/(ins
-      ),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return false;
       }]
     >
   ];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -342,6 +342,32 @@ def IREEEncoding_ContractionEncodingAttrInterface :
   ];
 }
 
+def IREEEncoding_CollapsibleEncodingAttrInterface :
+  AttrInterface<"CollapsibleEncodingAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
+  let description = [{
+    Interface used to query whether a tensor with the encoding
+    can be collapsed, e.g., to fold away unit extent dimensions.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if a tensor type with this encoding can be
+        collapsed.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"canCollapse",
+      /*args=*/(ins
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return false;
+      }]
+    >
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Type Interfaces
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -279,29 +279,51 @@ static linalg::ControlDropUnitDims getControlDropUnitDimsOptions() {
     return defaultFn(op);
   };
 
+  auto getCollapsedEncoding =
+      [](Attribute encoding, ArrayRef<int64_t> origShape,
+         ArrayRef<int64_t> targetShape) -> FailureOr<Attribute> {
+    if (!encoding) {
+      return encoding;
+    }
+    auto serializableEncoding =
+        dyn_cast<IREE::Encoding::SerializableAttr>(encoding);
+    if (!serializableEncoding) {
+      // If the encoding doesn't implement the interface, it can't be collapsed.
+      return failure();
+    }
+    Attribute collapsedEncoding =
+        serializableEncoding.getCollapsedEncoding(origShape, targetShape);
+    if (!collapsedEncoding) {
+      // If the interface function returns nullptr, the encoding can't be
+      // collapsed.
+      return failure();
+    }
+    return collapsedEncoding;
+  };
+
   options.collapseFn =
-      [](RewriterBase &rewriter, Location loc, Value operand,
-         ArrayRef<int64_t> targetShape,
-         ArrayRef<ReassociationIndices> reassociation,
-         const linalg::ControlDropUnitDims &control) -> FailureOr<Value> {
+      [=](RewriterBase &rewriter, Location loc, Value operand,
+          ArrayRef<int64_t> targetShape,
+          ArrayRef<ReassociationIndices> reassociation,
+          const linalg::ControlDropUnitDims &control) -> FailureOr<Value> {
     auto tensorType = cast<RankedTensorType>(operand.getType());
     assert(control.rankReductionStrategy ==
                linalg::ControlDropUnitDims::RankReductionStrategy::
                    ReassociativeReshape &&
            "unexpected rank reduction strategy");
-    auto encoding = tensorType.getEncoding();
-    if (encoding &&
-        (!isa_and_present<IREE::Encoding::CollapsibleEncodingAttrInterface>(
-             encoding) ||
-         !cast<IREE::Encoding::CollapsibleEncodingAttrInterface>(encoding)
-              .canCollapse())) {
+    ArrayRef<int64_t> origShape = tensorType.getShape();
+    Attribute encoding = tensorType.getEncoding();
+    FailureOr<Attribute> maybeCollapsedEncoding =
+        getCollapsedEncoding(encoding, origShape, targetShape);
+    if (failed(maybeCollapsedEncoding)) {
       // If the tensor has an encoding and that encoding does not implement the
       // interface or cannot be collapsed, return failure to abort the
       // transformation.
       return failure();
     }
-    auto targetType = RankedTensorType::get(
-        targetShape, tensorType.getElementType(), encoding);
+    auto targetType =
+        RankedTensorType::get(targetShape, tensorType.getElementType(),
+                              maybeCollapsedEncoding.value());
     return tensor::CollapseShapeOp::create(rewriter, loc, targetType, operand,
                                            reassociation)
         .getResult();
@@ -312,20 +334,22 @@ static linalg::ControlDropUnitDims getControlDropUnitDimsOptions() {
           ArrayRef<ReassociationIndices> reassociation,
           const linalg::ControlDropUnitDims &control) -> FailureOr<Value> {
     auto origResultType = cast<RankedTensorType>(origDest.getType());
-    auto origEncoding = origResultType.getEncoding();
-    if (origEncoding &&
-        (!isa_and_present<IREE::Encoding::CollapsibleEncodingAttrInterface>(
-             origEncoding) ||
-         !cast<IREE::Encoding::CollapsibleEncodingAttrInterface>(origEncoding)
-              .canCollapse())) {
-      // If the tensor has an encoding that does not implement the interface or
-      // cannot be collapsed, return failure to abort the transformation.
-      return failure();
-    }
     assert(control.rankReductionStrategy ==
                linalg::ControlDropUnitDims::RankReductionStrategy::
                    ReassociativeReshape &&
            "unknown rank reduction strategy");
+    ArrayRef<int64_t> origShape = origResultType.getShape();
+    Attribute origEncoding = origResultType.getEncoding();
+    auto newResultType = cast<RankedTensorType>(result.getType());
+    ArrayRef<int64_t> targetShape = newResultType.getShape();
+    FailureOr<Attribute> maybeCollapsedEncoding =
+        getCollapsedEncoding(origEncoding, origShape, targetShape);
+    if (failed(maybeCollapsedEncoding)) {
+      // If the tensor has an encoding and that encoding does not implement the
+      // interface or cannot be collapsed, return failure to abort the
+      // transformation.
+      return failure();
+    }
     return tensor::ExpandShapeOp::create(rewriter, loc, origResultType, result,
                                          reassociation)
         .getResult();

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -473,3 +473,43 @@ util.func @fold_unit_dims_from_extract_all_unit(%arg0: tensor<1x1x1xf32>, %idx0:
 //       CHECK:   %[[EXTRACT:.+]] = tensor.extract %[[COLLAPSED]]
 //  CHECK-SAME:     tensor<f32>
 //       CHECK:   util.return %[[EXTRACT]] : f32
+
+// -----
+
+util.func @fold_unit_dims_with_encoding(%arg0: tensor<1x1x4x8xi1, #iree_encoding.packed_storage>, %arg1: tensor<4xi8>) -> tensor<1x1x4x8xi1, #iree_encoding.packed_storage> {
+  %arg1_encoded = flow.tensor.bitcast %arg1 : tensor<4xi8> -> tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+  %0 = tensor.empty() : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+  %result = linalg.generic{
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%arg0, %arg1_encoded : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>, tensor<1x1x4x8xi1, #iree_encoding.packed_storage>)
+    outs(%0 : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>) {
+  ^bb0(%in_0: i1, %in_1: i1, %out: i1):
+    %1 = arith.ori %in_0, %in_1 : i1
+    linalg.yield %1 : i1
+  } -> tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+  util.return %result : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+}
+
+// CHECK-LABEL:   util.func public @fold_unit_dims_with_encoding(
+// CHECK-SAME:      %[[ARG0:.*]]: tensor<1x1x4x8xi1, #iree_encoding.packed_storage>,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xi8>) -> tensor<1x1x4x8xi1, #iree_encoding.packed_storage> {
+// CHECK:           %[[TENSOR_0:.*]] = flow.tensor.bitcast %[[ARG1]] : tensor<4xi8> -> tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[ARG0]] {{\[\[}}0, 1, 2], [3]] : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+// CHECK-SAME:        into tensor<4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           %[[COLLAPSE_SHAPE_1:.*]] = tensor.collapse_shape %[[TENSOR_0]] {{\[\[}}0, 1, 2], [3]] : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+// CHECK-SAME:        into tensor<4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4x8xi1>
+// CHECK:           %[[CAST_0:.*]] = tensor.cast %[[EMPTY_0]] : tensor<4x8xi1> to tensor<4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic
+// CHECK-SAME:        {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:        ins(%[[COLLAPSE_SHAPE_0]], %[[COLLAPSE_SHAPE_1]] : tensor<4x8xi1, #iree_encoding.packed_storage>, tensor<4x8xi1, #iree_encoding.packed_storage>)
+// CHECK-SAME:        outs(%[[CAST_0]] : tensor<4x8xi1, #iree_encoding.packed_storage>) {
+// CHECK:           ^bb0(%[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1):
+// CHECK:             %[[ORI_0:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i1
+// CHECK:             linalg.yield %[[ORI_0]] : i1
+// CHECK:           } -> tensor<4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[GENERIC_0]] {{\[\[}}0, 1, 2], [3]] output_shape [1, 1, 4, 8] : tensor<4x8xi1, #iree_encoding.packed_storage>
+// CHECK-SAME:        into tensor<1x1x4x8xi1, #iree_encoding.packed_storage>
+// CHECK:           util.return %[[EXPAND_SHAPE_0]] : tensor<1x1x4x8xi1, #iree_encoding.packed_storage>


### PR DESCRIPTION
Extend the `FoldUnitExtentDims` pass to handle tensors with encoding attached.

Encodings can opt into folding of unit extent dimensions by adding the `SerializableAttr` interface and implementing the new interface method `getCollapsedEncoding` that is used to query whether a tensor with encoding can be collapsed. If any of the tensor operands or results has an encoding that doesn't implement the interface, no folding happens to avoid issues with 0-entries in the indexing maps and passes that don't handle that case well.

Signed-off-by: Lukas Sommer <lukas.sommer@amd.com>