### PR TITLE
[LLVMGPU] Update seeds for scaled gemm

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -55,7 +55,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     case GemmSize::SmallGemm: return os << "SmallGemm";
     case GemmSize::MediumGemm: return os << "MediumGemm";
     case GemmSize::LargeGemm: return os << "LargeGemm";
-    default: return os << "NotSet";
+    default: 
+      assert(false && "Unhandled gemm size");
+      return os << "NotSet";
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -49,6 +49,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os;
 }
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const GemmSize &gemmSize) {
+  switch (gemmSize) {
+    case GemmSize::SmallGemm: return os << "SmallGemm";
+    case GemmSize::MediumGemm: return os << "MediumGemm";
+    case GemmSize::LargeGemm: return os << "LargeGemm";
+    default: return os << "NotSet";
+  }
+}
+
 static int64_t calculateOperandsSharedMemoryUsedInBytes(
     const GPUMMASchedule &schedule, int64_t lhsBitwidth, int64_t rhsBitwidth,
     int64_t numRhs = 1) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -49,15 +49,17 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os;
 }
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const GemmSize &gemmSize) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize) {
   switch (gemmSize) {
-    case GemmSize::SmallGemm: return os << "SmallGemm";
-    case GemmSize::MediumGemm: return os << "MediumGemm";
-    case GemmSize::LargeGemm: return os << "LargeGemm";
-    default: 
-      assert(false && "Unhandled gemm size");
-      return os << "NotSet";
+  case GemmSize::SmallGemm:
+    return os << "SmallGemm";
+  case GemmSize::MediumGemm:
+    return os << "MediumGemm";
+  case GemmSize::LargeGemm:
+    return os << "LargeGemm";
+  default:
+    assert(false && "Unhandled gemm size");
+    return os << "NotSet";
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -12,8 +12,7 @@ namespace mlir::iree_compiler {
 
 enum class GemmSize { NotSet, SmallGemm, MediumGemm, LargeGemm };
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-  const GemmSize &gemmSize);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const GemmSize &gemmSize);
 
 /// Struct containing information about a matmul's shape and type.
 struct GPUMatmulShapeType {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -12,6 +12,9 @@ namespace mlir::iree_compiler {
 
 enum class GemmSize { NotSet, SmallGemm, MediumGemm, LargeGemm };
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+  const GemmSize &gemmSize);
+
 /// Struct containing information about a matmul's shape and type.
 struct GPUMatmulShapeType {
   SmallVector<int64_t, 2> mSizes;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -258,7 +258,8 @@ getGemmHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth, bool scaled) {
           {/*bestSubgroupCountPerWorkgroup=*/8,
            /*bestMNTileCountPerSubgroup=*/32,
            /*bestKTileCountPerSubgroup=*/4,
-           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
+           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 /
+               inBitWidth});
     }
     return GPUMMAHeuristicSeeds(
         {/*bestSubgroupCountPerWorkgroup=*/4,
@@ -271,7 +272,8 @@ getGemmHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth, bool scaled) {
           {/*bestSubgroupCountPerWorkgroup=*/8,
            /*bestMNTileCountPerSubgroup=*/32,
            /*bestKTileCountPerSubgroup=*/2,
-           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
+           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 /
+               inBitWidth});
     }
     return GPUMMAHeuristicSeeds(
         {/*bestSubgroupCountPerWorkgroup=*/4,
@@ -296,15 +298,17 @@ getConvolutionHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth) {
   case GemmSize::MediumGemm:
     return GPUMMAHeuristicSeeds(
         {/*bestSubgroupCountPerWorkgroup=*/8,
-         /*bestMNTileCountPerSubgroup=*/8,
-         /*bestKTileCountPerSubgroup=*/2,
-         /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
-  case GemmSize::LargeGemm:
-    return GPUMMAHeuristicSeeds(
-        {/*bestSubgroupCountPerWorkgroup=*/8,
          /*bestMNTileCountPerSubgroup=*/4,
          /*bestKTileCountPerSubgroup=*/4,
          /*bestKElementCountPerSubgroup=*/2 * kCacheLineSizeBits / inBitWidth});
+  case GemmSize::LargeGemm:
+    // Favor more subgroups for convolution to help latency hiding from global
+    // loads.
+    return GPUMMAHeuristicSeeds(
+        {/*bestSubgroupCountPerWorkgroup=*/8,
+         /*bestMNTileCountPerSubgroup=*/8,
+         /*bestKTileCountPerSubgroup=*/2,
+         /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
   default:
     assert(false && "Unhandled convolution gemm size");
     return std::nullopt;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -405,7 +405,6 @@ static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
     problem.gemmSize = GemmSize::MediumGemm;
   }
   LDBG() << "This config is " << problem.gemmSize;
-  llvm::errs() << "problem.gemmSize: " << problem.gemmSize << "\n";
   std::optional<GPUMMAHeuristicSeeds> maybeSeeds =
       getContractionHeuristicSeeds(problem, isGemm, scaled);
   assert(maybeSeeds.has_value() && "expected seeds to be found");
@@ -1987,8 +1986,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     }
   }
 
-  return os << "{"
-            << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", prefetchNumStages = " << options.prefetchNumStages
             << ", useIgemmConvolution = " << options.useIgemmConvolution

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -179,7 +179,7 @@ static GemmCutoff computeGemmCutoffsForAI(IREE::GPU::TargetAttr target,
   // left to do before any analysis done on tuning data is actionable.
   // See https://github.com/iree-org/iree/issues/22785 for details.
   if (scaled) {
-    return {smallGemmCutoff, 2 * largeGemmCutoff};
+    return {100.0f, 10000.0f};
   }
   if (!target.getChip()) {
     LDBG() << "Target chip is not specified, using default gemm cutoffs: "
@@ -255,11 +255,10 @@ getGemmHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth, bool scaled) {
   case GemmSize::MediumGemm:
     if (scaled) {
       return GPUMMAHeuristicSeeds(
-          {/*bestSubgroupCountPerWorkgroup=*/4,
-           /*bestMNTileCountPerSubgroup=*/16,
-           /*bestKTileCountPerSubgroup=*/2,
-           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 /
-               inBitWidth});
+          {/*bestSubgroupCountPerWorkgroup=*/8,
+           /*bestMNTileCountPerSubgroup=*/32,
+           /*bestKTileCountPerSubgroup=*/4,
+           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
     }
     return GPUMMAHeuristicSeeds(
         {/*bestSubgroupCountPerWorkgroup=*/4,
@@ -269,10 +268,10 @@ getGemmHeuristicSeeds(GemmSize gemmSize, int64_t inBitWidth, bool scaled) {
   case GemmSize::LargeGemm:
     if (scaled) {
       return GPUMMAHeuristicSeeds(
-          {/*bestSubgroupCountPerWorkgroup=*/4,
-           /*bestMNTileCountPerSubgroup=*/64,
+          {/*bestSubgroupCountPerWorkgroup=*/8,
+           /*bestMNTileCountPerSubgroup=*/32,
            /*bestKTileCountPerSubgroup=*/2,
-           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / inBitWidth});
+           /*bestKElementCountPerSubgroup=*/kCacheLineSizeBits / 2 / inBitWidth});
     }
     return GPUMMAHeuristicSeeds(
         {/*bestSubgroupCountPerWorkgroup=*/4,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -25,15 +25,15 @@ func.func @scaled_matmul(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
 //   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
-//  CHECK-SAME:     reduction = [0, 0, 4, 1]
-//  CHECK-SAME:     subgroup = [2, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [64, 128, 0, 0]
+//  CHECK-SAME:     reduction = [0, 0, 1, 1]
+//  CHECK-SAME:     subgroup = [4, 8, 0, 0]
+//  CHECK-SAME:     workgroup = [256, 256, 0, 0]
 
 // -----
 
@@ -59,16 +59,16 @@ func.func @scaled_matmul_with_batch(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //   CHECK-NOT:   promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
 //   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
-//  CHECK-SAME:     reduction = [0, 0, 0, 4, 1]
-//  CHECK-SAME:     subgroup = [0, 2, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [1, 64, 128, 0, 0]
+//  CHECK-SAME:     reduction = [0, 0, 0, 1, 1]
+//  CHECK-SAME:     subgroup = [0, 4, 8, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 256, 256, 0, 0]
 
 // -----
 
@@ -122,15 +122,15 @@ func.func @scaled_matmul_with_dynamic_batch(
 }
 
 // CHECK-LABEL: func.func @scaled_matmul_with_dynamic_batch
-//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32>
 //  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
 //   CHECK-NOT:     promotion_types = [{{.*}}#iree_gpu.use_global_load_dma{{.*}}
-//  CHECK-SAME:     reduction = [0, 0, 0, 4, 1]
-//  CHECK-SAME:     subgroup = [0, 2, 4, 0, 0]
-//  CHECK-SAME:     workgroup = [1, 64, 128, 0, 0]
+//  CHECK-SAME:     reduction = [0, 0, 0, 1, 1]
+//  CHECK-SAME:     subgroup = [0, 4, 4, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 128, 256, 0, 0]
 
 // -----
 
@@ -191,5 +191,6 @@ module {
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
 //  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     promote_operands = [0, 1]
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 0, 0]


### PR DESCRIPTION
Change the seed heuristics to align more closely with the asm kernel. The changes are made to the large and medium GEMM seeds:
- increase subgroup count to 8.
- increase MN Tile count to 32.
- increase K tile count to 2/4 (large/medium).

Based on preliminary testing we find that this patch achieves a ~26% geomean improvement across shapes tested.

The cutoff points used are temporarily arbitrary while other performance improvements are implemented. Prior to these other efforts being completed the value gained from performing extensive tuning to pick cutoff points risks becoming immediately outdated as soon as a performance improvement is completed.