### PR TITLE
[GPU] Add M dimension constraints for pingpong ukernel

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
+++ b/compiler/plugins/target/ROCM/builtins/mlir_ukernel/iree_uk_amdgpu_dt_matmul_f8E4M3FNUZ.mlir
@@ -30,6 +30,10 @@ util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs
       types = [f8E4M3FNUZ, f8E4M3FNUZ, f32],
       iteration_sizes_constraints = [
         #rocm.ukernel_interation_size_constraint<
+          index = 0,
+          size_min = 64
+        >,
+        #rocm.ukernel_interation_size_constraint<
           index = 1,
           size_min = 2048,
           size_max = 8192
@@ -298,7 +302,13 @@ util.func @pingpong_dt_large_f8E4M3FNUZ(%lhs_base: !lhs_base_ty, %rhs_base: !rhs
 util.func private @pingpong_dt_medium_f8E4M3FNUZ(%lhs_base: !m_lhs_base_ty, %rhs_base: !m_rhs_base_ty, %unused_acc: !m_acc_base_ty) -> !m_acc_base_ty attributes {
   ukernel_info = #rocm.ukernel_info<
     match = {
-      types = [f8E4M3FNUZ, f8E4M3FNUZ, f32]
+      types = [f8E4M3FNUZ, f8E4M3FNUZ, f32],
+      iteration_sizes_constraints = [
+        #rocm.ukernel_interation_size_constraint<
+          index = 0,
+          size_min = 32
+        >
+      ]
     },
     mma = #iree_gpu.data_tiled_mma_layout<
       intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ,

--- a/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
@@ -170,3 +170,124 @@ func.func @matmul_f8_f8_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf8
 // CHECK:      iree_codegen.inner_tiled
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ,  intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, operands_interleaving_intrinsics_k = [0, 1]>
+
+// -----
+
+// Test that with M=4, no ukernel matches due to the M dimension constraint,
+// so it falls back to the default heuristic which should produce much smaller
+// tile sizes to avoid excessive padding.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
+  abi = "hip",
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
+  iree_codegen.target_info = #iree_gpu.target<
+    arch = "gfx942",
+    features = "",
+    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+    storage =  b64|b32|b16|b8,
+    subgroup =  shuffle|arithmetic,
+    dot =  dp4xi8toi32,
+    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
+           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
+           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
+           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
+           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
+           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
+           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
+          ],
+    subgroup_size_choices = [64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128,
+    simds_per_wgp = 4,
+    vgpr_space_bits = 16384>
+  >,
+  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
+  ukernels = "none"
+}>
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
+#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
+#pipeline_layout_3 = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<4x4096xf32, #encoding_result>) -> tensor<4x4096xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<4x4096xf8E4M3FNUZ, #encoding_lhs>, tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs>)
+      outs(%arg2 : tensor<4x4096xf32, #encoding_result>)
+      -> tensor<4x4096xf32, #encoding_result>
+  return %0 : tensor<4x4096xf32, #encoding_result>
+}
+// CHECK-LABEL: matmul_f8_f8_f32_small_m_no_ukernel_match
+// CHECK:      iree_codegen.inner_tiled
+// CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK-NOT:     intrinsics_m = 8, subgroups_m = 2
+// CHECK-NOT:     intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8
+
+// -----
+
+// Test that with M=32 (just at the boundary), the medium ukernel matches.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
+  abi = "hip",
+  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
+  iree_codegen.target_info = #iree_gpu.target<
+    arch = "gfx942",
+    features = "",
+    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+    storage =  b64|b32|b16|b8,
+    subgroup =  shuffle|arithmetic,
+    dot =  dp4xi8toi32,
+    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
+           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
+           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
+           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
+           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
+           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
+           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
+          ],
+    subgroup_size_choices = [64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128,
+    simds_per_wgp = 4,
+    vgpr_space_bits = 16384>
+  >,
+  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
+  ukernels = "none"
+}>
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
+#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
+#pipeline_layout_3 = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @matmul_f8_f8_f32_m32_medium_ukernel_match(%arg0: tensor<32x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<32x1024xf32, #encoding_result>) -> tensor<32x1024xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1 : tensor<32x4096xf8E4M3FNUZ, #encoding_lhs>, tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs>)
+      outs(%arg2 : tensor<32x1024xf32, #encoding_result>)
+      -> tensor<32x1024xf32, #encoding_result>
+  return %0 : tensor<32x1024xf32, #encoding_result>
+}
+// CHECK-LABEL: matmul_f8_f8_f32_m32_medium_ukernel_match
+// CHECK:      iree_codegen.inner_tiled
+// CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>

--- a/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
@@ -1,4 +1,8 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding))" %s | FileCheck %s
+
+// ===----------------------------------------------------------------------===//
+// Shared Attributes
+// ===----------------------------------------------------------------------===//
 
 // Note the ukernel provider being specified in the executable target. This should be used to determine the data tiling.
 
@@ -36,176 +40,73 @@
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 
-func.func @matmul_f16_f16_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf16, #encoding_lhs>, %arg1: tensor<?x?xf16, #encoding_rhs>, %arg2: tensor<?x?xf32, #encoding_result>) -> tensor<?x?xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+// ===----------------------------------------------------------------------===//
+// Tests
+// ===----------------------------------------------------------------------===//
+
+#encoding_lhs_f16 = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_rhs_f16 = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_result_f16 = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+
+func.func @matmul_f16_f16_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf16, #encoding_lhs_f16>, %arg1: tensor<?x?xf16, #encoding_rhs_f16>, %arg2: tensor<?x?xf32, #encoding_result_f16>) -> tensor<?x?xf32, #encoding_result_f16> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
-      ins(%arg0, %arg1 : tensor<?x?xf16, #encoding_lhs>, tensor<?x?xf16, #encoding_rhs>)
-      outs(%arg2 : tensor<?x?xf32, #encoding_result>)
-      -> tensor<?x?xf32, #encoding_result>
-  return %0 : tensor<?x?xf32, #encoding_result>
+      ins(%arg0, %arg1 : tensor<?x?xf16, #encoding_lhs_f16>, tensor<?x?xf16, #encoding_rhs_f16>)
+      outs(%arg2 : tensor<?x?xf32, #encoding_result_f16>)
+      -> tensor<?x?xf32, #encoding_result_f16>
+  return %0 : tensor<?x?xf32, #encoding_result_f16>
 }
 // CHECK-LABEL: matmul_f16_f16_f32_large_lowering_ukernel_provider
 // CHECK:      iree_codegen.inner_tiled
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_F16, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4>
 
-// -----
+#encoding_lhs_f8_medium = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_rhs_f8_medium = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_result_f8_medium = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
-  iree_codegen.target_info = #iree_gpu.target<
-    arch = "gfx942",
-    features = "",
-    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
-    storage =  b64|b32|b16|b8,
-    subgroup =  shuffle|arithmetic,
-    dot =  dp4xi8toi32,
-    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
-           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
-           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
-           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
-           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
-           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
-           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
-          ],
-    subgroup_size_choices = [64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-    max_load_instruction_bits = 128,
-    simds_per_wgp = 4,
-    vgpr_space_bits = 16384>
-  >,
-  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
-  ukernels = "none"
-}>
-
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-
-func.func @matmul_f8_f8_f32_medium_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<?x?xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<?x?xf32, #encoding_result>) -> tensor<?x?xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+func.func @matmul_f8_f8_f32_medium_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs_f8_medium>, %arg1: tensor<?x?xf8E4M3FNUZ, #encoding_rhs_f8_medium>, %arg2: tensor<?x?xf32, #encoding_result_f8_medium>) -> tensor<?x?xf32, #encoding_result_f8_medium> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
-      ins(%arg0, %arg1 : tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, tensor<?x?xf8E4M3FNUZ, #encoding_rhs>)
-      outs(%arg2 : tensor<?x?xf32, #encoding_result>)
-      -> tensor<?x?xf32, #encoding_result>
-  return %0 : tensor<?x?xf32, #encoding_result>
+      ins(%arg0, %arg1 : tensor<?x?xf8E4M3FNUZ, #encoding_lhs_f8_medium>, tensor<?x?xf8E4M3FNUZ, #encoding_rhs_f8_medium>)
+      outs(%arg2 : tensor<?x?xf32, #encoding_result_f8_medium>)
+      -> tensor<?x?xf32, #encoding_result_f8_medium>
+  return %0 : tensor<?x?xf32, #encoding_result_f8_medium>
 }
 // CHECK-LABEL: matmul_f8_f8_f32_medium_lowering_ukernel_provider
 // CHECK:      iree_codegen.inner_tiled
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 
-// -----
+#encoding_lhs_f8_large = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
+#encoding_rhs_f8_large = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
+#encoding_result_f8_large = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
-  iree_codegen.target_info = #iree_gpu.target<
-    arch = "gfx942",
-    features = "",
-    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
-    storage =  b64|b32|b16|b8,
-    subgroup =  shuffle|arithmetic,
-    dot =  dp4xi8toi32,
-    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
-           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
-           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
-           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
-           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
-           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
-           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
-          ],
-    subgroup_size_choices = [64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-    max_load_instruction_bits = 128,
-    simds_per_wgp = 4,
-    vgpr_space_bits = 16384>
-  >,
-  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
-  ukernels = "none"
-}>
-
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
-#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
-
-func.func @matmul_f8_f8_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<?x2048xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<?x2048xf32, #encoding_result>) -> tensor<?x2048xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+func.func @matmul_f8_f8_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs_f8_large>, %arg1: tensor<?x2048xf8E4M3FNUZ, #encoding_rhs_f8_large>, %arg2: tensor<?x2048xf32, #encoding_result_f8_large>) -> tensor<?x2048xf32, #encoding_result_f8_large> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
-      ins(%arg0, %arg1 : tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, tensor<?x2048xf8E4M3FNUZ, #encoding_rhs>)
-      outs(%arg2 : tensor<?x2048xf32, #encoding_result>)
-      -> tensor<?x2048xf32, #encoding_result>
-  return %0 : tensor<?x2048xf32, #encoding_result>
+      ins(%arg0, %arg1 : tensor<?x?xf8E4M3FNUZ, #encoding_lhs_f8_large>, tensor<?x2048xf8E4M3FNUZ, #encoding_rhs_f8_large>)
+      outs(%arg2 : tensor<?x2048xf32, #encoding_result_f8_large>)
+      -> tensor<?x2048xf32, #encoding_result_f8_large>
+  return %0 : tensor<?x2048xf32, #encoding_result_f8_large>
 }
 // CHECK-LABEL: matmul_f8_f8_f32_large_lowering_ukernel_provider
 // CHECK:      iree_codegen.inner_tiled
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
 // CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ,  intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, operands_interleaving_intrinsics_k = [0, 1]>
 
-// -----
-
 // Test that with M=4, no ukernel matches due to the M dimension constraint,
 // so it falls back to the default heuristic which should produce much smaller
 // tile sizes to avoid excessive padding.
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
-  iree_codegen.target_info = #iree_gpu.target<
-    arch = "gfx942",
-    features = "",
-    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
-    storage =  b64|b32|b16|b8,
-    subgroup =  shuffle|arithmetic,
-    dot =  dp4xi8toi32,
-    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
-           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
-           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
-           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
-           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
-           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
-           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
-          ],
-    subgroup_size_choices = [64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-    max_load_instruction_bits = 128,
-    simds_per_wgp = 4,
-    vgpr_space_bits = 16384>
-  >,
-  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
-  ukernels = "none"
-}>
+#encoding_lhs_f8_small_m = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
+#encoding_rhs_f8_small_m = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
+#encoding_result_f8_small_m = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
 
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
-#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
-
-func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<4x4096xf32, #encoding_result>) -> tensor<4x4096xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3FNUZ, #encoding_lhs_f8_small_m>, %arg1: tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs_f8_small_m>, %arg2: tensor<4x4096xf32, #encoding_result_f8_small_m>) -> tensor<4x4096xf32, #encoding_result_f8_small_m> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
-      ins(%arg0, %arg1 : tensor<4x4096xf8E4M3FNUZ, #encoding_lhs>, tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs>)
-      outs(%arg2 : tensor<4x4096xf32, #encoding_result>)
-      -> tensor<4x4096xf32, #encoding_result>
-  return %0 : tensor<4x4096xf32, #encoding_result>
+      ins(%arg0, %arg1 : tensor<4x4096xf8E4M3FNUZ, #encoding_lhs_f8_small_m>, tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs_f8_small_m>)
+      outs(%arg2 : tensor<4x4096xf32, #encoding_result_f8_small_m>)
+      -> tensor<4x4096xf32, #encoding_result_f8_small_m>
+  return %0 : tensor<4x4096xf32, #encoding_result_f8_small_m>
 }
 // CHECK-LABEL: matmul_f8_f8_f32_small_m_no_ukernel_match
 // CHECK:      iree_codegen.inner_tiled
@@ -213,54 +114,18 @@ func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3
 // CHECK-NOT:     intrinsics_m = 8, subgroups_m = 2
 // CHECK-NOT:     intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8
 
-// -----
-
 // Test that with M=32 (just at the boundary), the medium ukernel matches.
 
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {
-  abi = "hip",
-  iree.encoding.resolver = #iree_gpu.gpu_encoding_resolver<>,
-  iree_codegen.target_info = #iree_gpu.target<
-    arch = "gfx942",
-    features = "",
-    wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
-    storage =  b64|b32|b16|b8,
-    subgroup =  shuffle|arithmetic,
-    dot =  dp4xi8toi32,
-    mma = [<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>,
-           <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
-           <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>,
-           <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>,
-           <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>,
-           <MFMA_I32_32x32x16_I8>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x4_F32>,
-           <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>
-          ],
-    subgroup_size_choices = [64],
-    max_workgroup_sizes = [1024, 1024, 1024],
-    max_thread_count_per_workgroup = 1024,
-    max_workgroup_memory_bytes = 65536,
-    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
-    max_load_instruction_bits = 128,
-    simds_per_wgp = 4,
-    vgpr_space_bits = 16384>
-  >,
-  iree_codegen.ukernel_provider = #rocm.tensor_ukernel_provider,
-  ukernels = "none"
-}>
+#encoding_lhs_f8_m32 = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
+#encoding_rhs_f8_m32 = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
+#encoding_result_f8_m32 = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
 
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
-#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
-#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
-
-func.func @matmul_f8_f8_f32_m32_medium_ukernel_match(%arg0: tensor<32x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<32x1024xf32, #encoding_result>) -> tensor<32x1024xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
+func.func @matmul_f8_f8_f32_m32_medium_ukernel_match(%arg0: tensor<32x4096xf8E4M3FNUZ, #encoding_lhs_f8_m32>, %arg1: tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs_f8_m32>, %arg2: tensor<32x1024xf32, #encoding_result_f8_m32>) -> tensor<32x1024xf32, #encoding_result_f8_m32> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
-      ins(%arg0, %arg1 : tensor<32x4096xf8E4M3FNUZ, #encoding_lhs>, tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs>)
-      outs(%arg2 : tensor<32x1024xf32, #encoding_result>)
-      -> tensor<32x1024xf32, #encoding_result>
-  return %0 : tensor<32x1024xf32, #encoding_result>
+      ins(%arg0, %arg1 : tensor<32x4096xf8E4M3FNUZ, #encoding_lhs_f8_m32>, tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs_f8_m32>)
+      outs(%arg2 : tensor<32x1024xf32, #encoding_result_f8_m32>)
+      -> tensor<32x1024xf32, #encoding_result_f8_m32>
+  return %0 : tensor<32x1024xf32, #encoding_result_f8_m32>
 }
 // CHECK-LABEL: matmul_f8_f8_f32_m32_medium_ukernel_match
 // CHECK:      iree_codegen.inner_tiled

--- a/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/test/materialize_encoding_ukernel_gfx942.mlir
@@ -39,11 +39,6 @@
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 
 func.func @matmul_f16_f16_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf16, #encoding_lhs>, %arg1: tensor<?x?xf16, #encoding_rhs>, %arg2: tensor<?x?xf32, #encoding_result>) -> tensor<?x?xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
@@ -96,11 +91,6 @@ func.func @matmul_f16_f16_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?x
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 3, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 
 func.func @matmul_f8_f8_f32_medium_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<?x?xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<?x?xf32, #encoding_result>) -> tensor<?x?xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
@@ -153,11 +143,6 @@ func.func @matmul_f8_f8_f32_medium_lowering_ukernel_provider(%arg0: tensor<?x?xf
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, 2048, ?]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 
 func.func @matmul_f8_f8_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<?x2048xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<?x2048xf32, #encoding_result>) -> tensor<?x2048xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
@@ -214,11 +199,6 @@ func.func @matmul_f8_f8_f32_large_lowering_ukernel_provider(%arg0: tensor<?x?xf8
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [4, 4096, 4096]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 
 func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x4096xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<4x4096xf32, #encoding_result>) -> tensor<4x4096xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul
@@ -274,11 +254,6 @@ func.func @matmul_f8_f8_f32_small_m_no_ukernel_match(%arg0: tensor<4x4096xf8E4M3
 #encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
 #encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
 #encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [32, 1024, 4096]>
-#pipeline_layout_3 = #hal.pipeline.layout<constants = 2, bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
 
 func.func @matmul_f8_f8_f32_m32_medium_ukernel_match(%arg0: tensor<32x4096xf8E4M3FNUZ, #encoding_lhs>, %arg1: tensor<4096x1024xf8E4M3FNUZ, #encoding_rhs>, %arg2: tensor<32x1024xf32, #encoding_result>) -> tensor<32x1024xf32, #encoding_result> attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %0 = linalg.matmul

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/compstat_gfx942_data_tiling.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "llama_8b_fp8/modules/llama_gfx942_data_tiling",
-  "golden_dispatch_count": 1711,
+  "golden_dispatch_count": 1935,
   "golden_binary_size": 3300000
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq128_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 58.3
+    "golden_time_ms": 17.0
 }

--- a/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
+++ b/tests/external/iree-test-suites/torch_models/llama_8b_fp8/decode_benchmark_seq2048_mi325_data_tiling.json
@@ -39,5 +39,5 @@
         "value": "34x2097152xf8E4M3FNUZ"
       }
     ],
-    "golden_time_ms": 60.5
+    "golden_time_ms": 20.0
 }


### PR DESCRIPTION
The pingpong_dt_large_f8E4M3FNUZ and pingpong_dt_medium_f8E4M3FNUZ ukernels had no constraints on the M dimension, causing them to match matmuls with very small M sizes. This resulted in extreme padding overhead for small M sizes. This change adds constraints for the "large" and "medium" ukernels:

- pingpong_dt_large_f8E4M3FNUZ: Added M_min = 64 (≥25% utilization for M_tile=256)
- pingpong_dt_medium_f8E4M3FNUZ: Added M_min = 32 (≥25% utilization for M_tile=128)

This roughly thirds the runtime for data tiled llama decode and I have decreased the golden times accordingly. I also confirmed that the increase in dispatches is only from initializers.






closes https://github.com/iree-org/iree/issues/22799

ci-extra: test_torch