### PR TITLE
[LLVMGPU] Fix lowering strategy for direct convolution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -89,3 +89,33 @@ func.func @group_conv_hwgc_gfhwc_unaligned(%arg0: tensor<61x93x16x56xbf16>, %arg
 //  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
 //  CHECK-SAME:     subgroup = [0, 1, 0, 1, 0, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 32, 1, 64, 0, 0, 0]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1 + d4, d2, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+func.func @conv_nhwc_fhc_two_batch_dims(%arg0: tensor<16x50x32x576xf16>, %arg1: tensor<576x3x576xf16>, %arg2: tensor<16x48x32x576xf32>) -> tensor<16x48x32x576xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x50x32x576xf16>, tensor<576x3x576xf16>) outs(%arg2 : tensor<16x48x32x576xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<16x48x32x576xf32>
+  return %0 : tensor<16x48x32x576xf32>
+}
+
+// CHECK-LABEL: func.func @conv_nhwc_fhc_two_batch_dims
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = false
+//  CHECK-SAME:   use_igemm_convolution = false
+
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+
+//  CHECK-SAME:     promote_operands = [0, 1]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 4]
+//  CHECK-SAME:     subgroup = [0, 0, 1, 1, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 1, 32, 64, 0, 0]


### PR DESCRIPTION
This fixes issue https://github.com/iree-org/iree/issues/22795.

When the convolution filter size is 3x1, the unit filter dimension is folded and the original innermost output image dimension now becomes a batch dimension.  Without this change, it tiles the innermost output image dimension to 1 while keeping the outermost dimension as non-unit, and caused bad code after PackToIntrinsics.