### PR TITLE
Adding AsyncUpdateOp elision support to ElideAsyncCopiesPass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -108,6 +108,11 @@ bool AsyncAccessRange::mayOverlap(const AsyncAccessRange &lhs,
     return false;
   }
 
+  // TODO(benvanik): use integer range analysis (Presburger) to prove when
+  // constant or affine ranges like [100,200) and [500,600) don't overlap.
+  // This would enable more aggressive optimization in ElideAsyncCopies and
+  // other passes that use overlap checking.
+
   // _May_ overlap. More analysis required.
   return true;
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.h
@@ -60,6 +60,8 @@ struct AsyncAccessRange {
 
   // Returns true if the access is read-only.
   bool isReadOnly() const { return access == ResourceAccessBitfield::Read; }
+  // Returns true if the access is write-only.
+  bool isWriteOnly() const { return access == ResourceAccessBitfield::Write; }
 
   // Prints a textual representation of the range.
   void print(llvm::raw_ostream &os, AsmState &asmState);


### PR DESCRIPTION
Adds support for eliding stream.async.update operations when the mutation has no observable effect. An update is safe to elide if:
- The target is not a by-reference function argument (mutation observable to caller)
- No subsequent operation reads from the mutated region

This enables optimizations where staging buffers can be bypassed when the update is immediately overwritten by another operation.

(most of this was authored with claude)