### PR TITLE
[python] use pytest for tests

### DIFF
--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -105,7 +105,7 @@ function(iree_local_py_test)
   add_test(
     NAME ${_NAME_PATH}
     COMMAND
-      "${Python3_EXECUTABLE}"
+      "${Python3_EXECUTABLE}" -m pytest
       "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}"
       ${_RULE_ARGS}
   )

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -10,3 +10,4 @@ requests>=2.28.0
 wheel>=0.36.2
 sympy==1.12.1
 ml_dtypes>=0.5.1
+pytest


### PR DESCRIPTION
Existing Python tests like `dialects_test.py` use raw assert statements. 

This PR aims to transition them to pytest.

ci-extra: test_torch, windows_x64_msvc