### PR TITLE
[Encoding] Remove unneeded command line option

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/AnnotateDataTilingHints.cpp
@@ -23,15 +23,6 @@ namespace mlir::iree_compiler::DispatchCreation {
 #define GEN_PASS_DEF_ANNOTATEDATATILINGHINTSPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
 
-/// Command line options used purely for development purposes. Not to be relied
-/// on in any way.
-/// TODO(Max191): Remove this once materialization for scaled matmul encodings
-/// is implemented.
-static llvm::cl::opt<bool> clTestSetScaledMatmulEncodings(
-    "iree-dispatch-creation-test-set-scaled-matmul-encodings",
-    llvm::cl::desc("Set encodings on scaled matmul ops"), llvm::cl::init(false),
-    llvm::cl::Hidden);
-
 namespace {
 struct AnnotateDataTilingHintsPass final
     : impl::AnnotateDataTilingHintsPassBase<AnnotateDataTilingHintsPass> {
@@ -159,9 +150,6 @@ static bool isSupportedContractionOp(linalg::LinalgOp linalgOp) {
 /// TODO(Max191): Loosen restrictions on scaled contraction ops once data tiling
 /// can support more cases.
 static bool isSupportedScaledContractionOp(linalg::LinalgOp linalgOp) {
-  if (!clTestSetScaledMatmulEncodings) {
-    return false;
-  }
   if (!dataTilablePreCondition(linalgOp)) {
     return false;
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-dispatch-creation-test-set-scaled-matmul-encodings \
+// RUN: iree-opt --split-input-file \
 // RUN:   --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-annotate-data-tiling-hints,iree-dispatch-creation-set-encoding))" %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK
 // Test with `iree-dispatch-creation-annotate-data-tiling-hints` that adds the
 // data-tiling hint to all the available gemm ops. Otherwise, we have to add the


### PR DESCRIPTION
Previously, scaled GEMMs were unsupported in the data tiling pipeline and so a CL option was introduced to not generate scaled GEMM encodings by default. Now that we have support for data tiled scaled GEMMs, these encodings properly materialize, and this CL option can be removed.