### PR TITLE
Add some nvidia tensor core support to TileAndFuse and VectorDistribute pipelines

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -152,3 +152,15 @@ func.func @pad_if_below_limit() {
   %0 = memref.alloc() : memref<4x32x126xf32, #gpu.address_space<workgroup>>
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @pad_alloc_with_alignment
+// CHECK:         %[[A:.*]] = memref.alloc() {alignment = 16 : i64} : memref<32x40xf16, #gpu.address_space<workgroup>>
+// CHECK:         memref.subview %[[A]][0, 0] [32, 32] [1, 1] :
+// CHECK-SAME:      memref<32x40xf16, #gpu.address_space<workgroup>> to
+// CHECK-SAME:      memref<32x32xf16, strided<[40, 1]>, #gpu.address_space<workgroup>>
+func.func @pad_alloc_with_alignment() {
+  %0 = memref.alloc() {alignment = 16 : i64} : memref<32x32xf16, #gpu.address_space<workgroup>>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -114,13 +116,15 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
   case MMAIntrinsic::MFMA_F32_32x32x16_F16:
   case MMAIntrinsic::WMMAR3_F32_16x16x16_F16:
   case MMAIntrinsic::WMMAR4_F32_16x16x16_F16:
+  case MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16:
   case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16:
   case MMAIntrinsic::WMMA_F32_16x16x32_F16:
     return {f16, f16, f32};
   case MMAIntrinsic::WMMAR3_F16_16x16x16_F16:
   case MMAIntrinsic::WMMAR4_F16_16x16x16_F16:
-  case MMAIntrinsic::WMMA_F16_16x16x32_F16:
   case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
+  case MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16:
+  case MMAIntrinsic::WMMA_F16_16x16x32_F16:
     return {f16, f16, f16};
   case MMAIntrinsic::MFMA_F32_16x16x8_BF16:
   case MMAIntrinsic::MFMA_F32_32x32x4_BF16:
@@ -204,21 +208,6 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
     return {i8, i8, i32};
   }
   assert(false && "unexpected enum value");
-  return {};
-}
-
-/// Returns the MNK shape for an intrinsic without an implemented concrete
-/// layout.
-static std::tuple<int64_t, int64_t, int64_t>
-getUnsupportedMNKShape(MMAIntrinsic intrinsic) {
-  switch (intrinsic) {
-  case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16:
-  case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
-    return {16, 16, 16};
-  default:
-    assert(false && "unexpected enum value");
-    return {};
-  }
   return {};
 }
 
@@ -511,6 +500,20 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
     case kMMAOperandAcc:
       return gfx12WmmaAcc16x16;
     }
+  case MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16:
+  case MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16:
+    switch (operandIndex) {
+    case kMMAOperandLhs:
+      return {/*outer=*/{2, 2}, /*thread=*/{8, 4}, /*strides=*/{4, 1},
+              /*element=*/{1, 2}};
+    case kMMAOperandRhs:
+      return {/*outer=*/{2, 1}, /*thread=*/{4, 8}, /*strides=*/{1, 4},
+              /*element=*/{2, 1}};
+    case kMMAOperandAcc:
+      return {/*outer=*/{2, 1}, /*thread=*/{8, 4}, /*strides=*/{4, 1},
+              /*element=*/{1, 2}};
+    }
+    return {};
   case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16:
   case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
     return {};
@@ -559,16 +562,31 @@ struct OpaqueMmaLayout {
   Type cType;
 };
 
+/// Returns the MNK shape for an intrinsic without an implemented concrete
+/// layout.
+static std::tuple<int64_t, int64_t, int64_t>
+getUnsupportedMNKShape(MMAIntrinsic intrinsic) {
+  switch (intrinsic) {
+  case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16:
+  case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
+    return {16, 16, 16};
+  default:
+    assert(false && "unexpected enum value");
+    return {};
+  }
+}
+
 static std::tuple<int64_t, int64_t, int64_t>
 getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {
-  if (is_AMD(intrinsic)) {
-    auto lhs = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
-    auto rhs = getSingleSubgroupLayout(intrinsic, kMMAOperandRhs);
-    return {lhs.outer[0] * lhs.thread[0] * lhs.element[0],
-            rhs.outer[1] * rhs.thread[1] * rhs.element[1],
-            lhs.outer[1] * lhs.thread[1] * lhs.element[1]};
+  if (intrinsic == MMAIntrinsic::NV_WMMA_F32_16x16x16_F16 ||
+      intrinsic == MMAIntrinsic::NV_WMMA_F16_16x16x16_F16) {
+    return getUnsupportedMNKShape(intrinsic);
   }
-  return getUnsupportedMNKShape(intrinsic);
+  auto lhs = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
+  auto rhs = getSingleSubgroupLayout(intrinsic, kMMAOperandRhs);
+  return {lhs.outer[0] * lhs.thread[0] * lhs.element[0],
+          rhs.outer[1] * rhs.thread[1] * rhs.element[1],
+          lhs.outer[1] * lhs.thread[1] * lhs.element[1]};
 }
 
 int64_t getMSize(MMAIntrinsic intrinsic) {
@@ -652,6 +670,20 @@ static VectorType getThreadVectorType(MLIRContext *context,
   Type elemType = isIntrinsicLhs<MMAIntrinsicType>(operandIndex)   ? o.aType
                   : isIntrinsicRhs<MMAIntrinsicType>(operandIndex) ? o.bType
                                                                    : o.cType;
+  if constexpr (std::is_same_v<MMAIntrinsicType, MMAIntrinsic>) {
+    if (intrinsic == MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16 ||
+        intrinsic == MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16) {
+      if (operandIndex == kMMAOperandLhs) {
+        return VectorType::get({4, 2}, elemType);
+      }
+      if (operandIndex == kMMAOperandRhs) {
+        return VectorType::get({2, 2}, elemType);
+      }
+      if (operandIndex == kMMAOperandAcc) {
+        return VectorType::get({2, 2}, elemType);
+      }
+    }
+  }
   return VectorType::get(
       {s.element[0] * s.element[1] * s.outer[0] * s.outer[1]}, elemType);
 }
@@ -688,7 +720,7 @@ int64_t MMAAttr::getSubgroupSize() const {
 }
 
 Attribute MMAAttr::getDistributionMappingKind() const {
-  // Explicit distribution currently unsupported for NV intrinsics.
+  // Explicit distribution currently unsupported for NV WMMA intrinsics.
   MMAIntrinsic intrinsic = getIntrinsic();
   if (intrinsic == MMAIntrinsic::NV_WMMA_F16_16x16x16_F16 ||
       intrinsic == MMAIntrinsic::NV_WMMA_F32_16x16x16_F16) {
@@ -747,6 +779,27 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
   if (is_AMD_WMMA(intrinsic)) {
     return amdgpu::WMMAOp::create(builder, loc, resultType, layout.mSize,
                                   layout.nSize, layout.kSize, lhs, rhs, acc)
+        .getResult();
+  }
+  if (intrinsic == MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16 ||
+      intrinsic == MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16) {
+    // Transpose the two outer dimensions to model the column-major register
+    // ordering expected by mma.sync. The input shape differs between pipelines:
+    // VectorDistribute produces 2x2x1x2, TileAndFuse produces 2x1x2x2.
+    // Remove the unit dimension to simplify the transpose.
+    auto nonUnitVecType = VectorType::get({2, 2, 2}, builder.getF16Type());
+    auto reshaped =
+        vector::ShapeCastOp::create(builder, loc, nonUnitVecType, lhs);
+    auto permAttr = builder.getDenseI64ArrayAttr({1, 0, 2});
+    auto transposed = vector::TransposeOp::create(builder, loc, nonUnitVecType,
+                                                  reshaped, permAttr);
+    lhs = vector::ShapeCastOp::create(builder, loc, lhs.getType(), transposed);
+    SmallVector<Attribute> mmaShape{builder.getI64IntegerAttr(layout.mSize),
+                                    builder.getI64IntegerAttr(layout.nSize),
+                                    builder.getI64IntegerAttr(layout.kSize)};
+    ArrayAttr mmShapeAttr = builder.getArrayAttr(mmaShape);
+
+    return nvgpu::MmaSyncOp::create(builder, loc, lhs, rhs, acc, mmShapeAttr)
         .getResult();
   }
   return {};

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -255,9 +255,13 @@ def WMMA_F16_16x16x128_F8E5M2_F8E4M3FN : I32EnumAttrCase<"WMMA_F16_16x16x128_F8E
 def WMMA_F16_16x16x128_F8E4M3FN : I32EnumAttrCase<"WMMA_F16_16x16x128_F8E4M3FN", 0x1A3E>;
 def WMMA_F16_16x16x128_F8E4M3FN_F8E5M2 : I32EnumAttrCase<"WMMA_F16_16x16x128_F8E4M3FN_F8E5M2", 0x1A3F>;
 
-// NV intrinsics.
-def NV_WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F32_16x16x16_F16", 0x2020>;
-def NV_WMMA_F16_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F16_16x16x16_F16", 0x2021>;
+// NV intrinsics for CUDA (mma.sync)
+def NV_MMA_SYNC_F32_16x8x16_F16 : I32EnumAttrCase<"NV_MMA_SYNC_F32_16x8x16_F16", 0x2020>;
+def NV_MMA_SYNC_F16_16x8x16_F16 : I32EnumAttrCase<"NV_MMA_SYNC_F16_16x8x16_F16", 0x2023>;
+
+// NV intrinsics for Vulkan/SPIRV (cooperative matrix)
+def NV_WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F32_16x16x16_F16", 0x2021>;
+def NV_WMMA_F16_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F16_16x16x16_F16", 0x2022>;
 
 def IREEGPU_MMAIntrinsic : IREEGPU_I32EnumAttr<"MMAIntrinsic",
     "Descriptor for different MMA intrinsics", [
@@ -357,7 +361,11 @@ def IREEGPU_MMAIntrinsic : IREEGPU_I32EnumAttr<"MMAIntrinsic",
       WMMA_F16_16x16x128_F8E4M3FN,
       WMMA_F16_16x16x128_F8E4M3FN_F8E5M2,
 
-      // NV intrinsics
+      // NV intrinsics (CUDA mma.sync)
+      NV_MMA_SYNC_F32_16x8x16_F16,
+      NV_MMA_SYNC_F16_16x8x16_F16,
+
+      // NV intrinsics (Vulkan/SPIRV cooperative matrix)
       NV_WMMA_F32_16x16x16_F16,
       NV_WMMA_F16_16x16x16_F16,
     ]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -839,6 +839,8 @@ StringRef normalizeARMGPUTarget(StringRef target) {
 
 const WgpDetails *getAmpereWgpDetails() {
   static const MMAIntrinsic mmaOps[] = {
+      MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16,
+      MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16,
       MMAIntrinsic::NV_WMMA_F32_16x16x16_F16,
       MMAIntrinsic::NV_WMMA_F16_16x16x16_F16,
   };
@@ -860,6 +862,8 @@ const WgpDetails *getAmpereWgpDetails() {
 
 const WgpDetails *getTuringWgpDetails() {
   static const MMAIntrinsic mmaOps[] = {
+      MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16,
+      MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16,
       MMAIntrinsic::NV_WMMA_F32_16x16x16_F16,
       MMAIntrinsic::NV_WMMA_F16_16x16x16_F16,
   };
@@ -881,6 +885,8 @@ const WgpDetails *getTuringWgpDetails() {
 
 const WgpDetails *getVoltaWgpDetails() {
   static const MMAIntrinsic mmaOps[] = {
+      MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16,
+      MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16,
       MMAIntrinsic::NV_WMMA_F32_16x16x16_F16,
       MMAIntrinsic::NV_WMMA_F16_16x16x16_F16,
   };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -104,6 +104,7 @@ struct ConvertToNVVMPass final
       vector::populateVectorGatherLoweringPatterns(patterns);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       vector::populateVectorFromElementsUnrollPatterns(patterns);
+      vector::populateVectorToElementsUnrollPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
       vector::populateVectorMaskMaterializationPatterns(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -94,18 +94,6 @@ llvm::cl::opt<bool> clGPUUseTileAndFuseConvolution(
         "enable the tile and fuse pipeline for supported convolutions"),
     llvm::cl::init(true));
 
-/// Flag to force using WMMA tensorcore operations.
-llvm::cl::opt<bool>
-    clGPUUseWMMA("iree-codegen-llvmgpu-use-wmma",
-                 llvm::cl::desc("force use of wmma operations for tensorcore"),
-                 llvm::cl::init(false));
-
-/// Flag used to toggle using mma.sync vs wmma when targeting tensorcore.
-llvm::cl::opt<bool>
-    clGPUUseMMASync("iree-codegen-llvmgpu-use-mma-sync",
-                    llvm::cl::desc("force use mma sync instead of wmma ops"),
-                    llvm::cl::init(false));
-
 llvm::cl::opt<int> clGPUMatmulCThreshold(
     "iree-codegen-llvmgpu-matmul-c-matrix-threshold",
     llvm::cl::desc("matmul c matrix element count threshold to be considered "
@@ -304,6 +292,9 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   MLIRContext *context = op.getContext();
   for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
     if (mma.getSubgroupSize() != targetSubgroupSize)
+      continue;
+    // Intrinsics without distribution mapping cannot be distributed.
+    if (!mma.getDistributionMappingKind())
       continue;
     storeMmaInfo(mma, intrinsics);
     // Skip adding any virtual intrinsics since they are not tested for
@@ -530,6 +521,9 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   MLIRContext *context = op.getContext();
   for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
     if (mma.getSubgroupSize() != targetSubgroupSize)
+      continue;
+    // Intrinsics without distribution mapping cannot be distributed.
+    if (!mma.getDistributionMappingKind())
       continue;
     storeMmaInfo(mma, intrinsics);
     // Skip adding any virtual intrinsics since they are not tested for matmuls.
@@ -776,6 +770,9 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   MLIRContext *context = op.getContext();
   for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
     if (mma.getSubgroupSize() != targetSubgroupSize)
+      continue;
+    // Intrinsics without distribution mapping cannot be distributed.
+    if (!mma.getDistributionMappingKind())
       continue;
     storeMmaInfo(mma, intrinsics);
     // Store info on virtual intrinsics based on current mma if any
@@ -1331,11 +1328,6 @@ static LogicalResult
 setVectorDistributionConfig(IREE::GPU::TargetAttr target,
                             mlir::FunctionOpInterface entryPoint,
                             Operation *computeOp) {
-  // We haven't properly plumbed through MMA op layouts and conversions for CUDA
-  // to target NVIDIA GPUs. So disable the vector distribution pass for it.
-  if (!isROCmBackend(target))
-    return failure();
-
   if (!clGPUEnableVectorDistribution) {
     LDBG() << "Vector Distribution not enabled, skipping...";
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -60,6 +61,7 @@ struct LLVMGPUVectorDistributePass final
     registry.insert<affine::AffineDialect>();
     registry.insert<amdgpu::AMDGPUDialect>();
     registry.insert<gpu::GPUDialect>();
+    registry.insert<nvgpu::NVGPUDialect>();
     registry.insert<scf::SCFDialect>();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -121,6 +121,7 @@ def LLVMGPUTileAndDistributePass :
 def LLVMGPUVectorDistributePass :
     InterfacePass<"iree-llvmgpu-vector-distribute", "mlir::FunctionOpInterface"> {
   let summary = "Pass to distribute vectorized functions.";
+  let dependentDialects = ["::mlir::nvgpu::NVGPUDialect"];
 }
 
 def LLVMGPUVectorLoweringPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" -iree-codegen-llvmgpu-use-wmma %s | FileCheck %s --check-prefix=SM80
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_60 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-nvvm-pipeline)))" %s | FileCheck %s --check-prefix=SM80
 
 // Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_fusion.mlir
@@ -67,8 +67,8 @@ func.func @matmul_i4_quant_weight() {
 }
 
 //     CHECK-LABEL: func.func @matmul_i4_quant_weight()
-//           CHECK:   %[[A_ALLOC:.+]] = memref.alloc() : memref<32x1x36xf32, #gpu.address_space<workgroup>>
-//           CHECK:   %[[B_ALLOC:.+]] = memref.alloc() : memref<1x32x132xf32, #gpu.address_space<workgroup>>
+//           CHECK:   %[[A_ALLOC:.+]] = memref.alloc() {{.*}}: memref<32x1x48xf32, #gpu.address_space<workgroup>>
+//           CHECK:   %[[B_ALLOC:.+]] = memref.alloc() {{.*}}: memref<1x32x144xf32, #gpu.address_space<workgroup>>
 //           CHECK:   %[[WEIGHT_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //           CHECK:   %[[WEIGHT_ALIGNED:.+]] = memref.assume_alignment %[[WEIGHT_BINDING]]
 //           CHECK:   %[[SCALE_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -55,33 +55,33 @@ hal.executable @matmul_f32_128x256x64 {
 //     CHECK-LABEL: func.func @matmul_f32_128x256x64()
 //      CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //           CHECK:   %[[PV:.+]] = ub.poison : f32
-//           CHECK:   memref.alloc() : memref<2x64x20xf32, #gpu.address_space<workgroup>>
-//           CHECK:   memref.alloc() : memref<2x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   memref.alloc() {{.*}}: memref<2x64x32xf32, #gpu.address_space<workgroup>>
+//           CHECK:   memref.alloc() {{.*}}: memref<2x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   scf.for
 //           CHECK:     gpu.barrier
 //           CHECK:     affine.apply #[[$MAP]]
-//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, #gpu.address_space<workgroup>>
-//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x32xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:     gpu.barrier
-//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:     scf.yield
 //           CHECK:   gpu.barrier
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, #gpu.address_space<workgroup>>
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x32xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   gpu.barrier
-//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //           CHECK:   gpu.barrier
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, #gpu.address_space<workgroup>>
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x32xf32, #gpu.address_space<workgroup>>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   gpu.barrier
-//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<2x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
@@ -140,46 +140,46 @@ hal.executable @matmul_f32_128x256x64 {
 //     CHECK-LABEL: func.func @matmul_f32_128x256x64()
 //      CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //           CHECK:   %[[PV:.+]] = ub.poison : f32
-//           CHECK:   memref.alloc() : memref<3x64x20xf32, #gpu.address_space<workgroup>>
-//           CHECK:   memref.alloc() : memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   memref.alloc() {{.*}}: memref<3x64x32xf32, #gpu.address_space<workgroup>>
+//           CHECK:   memref.alloc() {{.*}}: memref<3x16x80xf32, #gpu.address_space<workgroup>>
 // TODO: transfer_writes should be forwarded to the following transfer_reads
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:   gpu.barrier {__pipelining_first_stage__}
 //           CHECK:   scf.for
-//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //       CHECK-DAG:     %[[APPLY:.+]] = affine.apply #[[$MAP]]
 //       CHECK-DAG:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, #gpu.address_space<workgroup>>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x32xf32, #gpu.address_space<workgroup>>
 //           CHECK:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:     vector.transfer_read %{{.+}}, %[[PV]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, #gpu.address_space<workgroup>>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}}[%[[APPLY]], {{.+}}] {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x80xf32, #gpu.address_space<workgroup>>
 //           CHECK:     gpu.barrier {__pipelining_first_stage__}
 //           CHECK:     scf.yield
-//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
-//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x20xf32, #gpu.address_space<workgroup>>, vector<4xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x68xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x64x32xf32, #gpu.address_space<workgroup>>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<3x16x80xf32, #gpu.address_space<workgroup>>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[PV]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
@@ -237,8 +237,8 @@ hal.executable @matmul_f16_4096x512x512 {
 
 //     CHECK-LABEL: func.func @matmul_f16_4096x512x512()
 //       CHECK-NOT:   memref.alloc()
-//           CHECK:   %{{.+}} = memref.alloc() : memref<32x264xf16, #gpu.address_space<workgroup>>
-//           CHECK:   %{{.+}} = memref.alloc() : memref<64x40xf16, #gpu.address_space<workgroup>>
+//           CHECK:   %{{.+}} = memref.alloc() {{.*}}: memref<32x288xf16, #gpu.address_space<workgroup>>
+//           CHECK:   %{{.+}} = memref.alloc() {{.*}}: memref<64x64xf16, #gpu.address_space<workgroup>>
 //       CHECK-NOT:   memref.alloc()
 //           CHECK:   scf.for %{{.+}} = %c0 to %c480 step %c32
 // CHECK-COUNT-512:     vector.fma

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -42,9 +42,9 @@ hal.executable @matmul_f32_128x256x64 {
 }
 
 // Default promotion requires 1024 x vector<4xf32>, however padding to avoid bank conflicts
-// produces an array of size 1056. Similarly 256 gets padded to 288 x vector<4xf32>.
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1056 x vector<4xf32>>)>, Workgroup>
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<288 x vector<4xf32>>)>, Workgroup>
+// produces an array of size 1152. Similarly 256 gets padded to 384 x vector<4xf32>.
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1152 x vector<4xf32>>)>, Workgroup>
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<384 x vector<4xf32>>)>, Workgroup>
 
 // CHECK-LABEL: spirv.func @matmul_f32_128x256x64
 
@@ -114,10 +114,10 @@ hal.executable @matmul_f16_128x256x64 {
 }
 
 // Ditto on the above.
-//    1024 x vector<4xf32> -> 1056 x vector<4xf32>
-//    256 x vector<4xf32> -> 320 x vector<4xf32>
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1056 x vector<4xf32>>)>, Workgroup>
-// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<320 x vector<4xf32>>)>, Workgroup>
+//    1024 x vector<4xf32> -> 1152 x vector<4xf32>
+//    256 x vector<4xf32> -> 512 x vector<4xf32>
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1152 x vector<4xf32>>)>, Workgroup>
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<512 x vector<4xf32>>)>, Workgroup>
 
 // CHECK-LABEL: spirv.func @matmul_f16_128x256x64
 
@@ -183,8 +183,8 @@ hal.executable @matmul_f16_32x1280x1280 {
   }
 }
 
-//   CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<2176 x f16>)>, Workgroup>
-//   CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<384 x f16>)>, Workgroup>
+//   CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<2560 x f16>)>, Workgroup>
+//   CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<512 x f16>)>, Workgroup>
 
 // CHECK-LABEL: spirv.func @matmul_f16_32x1280x1280
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -419,4 +419,102 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("f32", "f32"),
 ]]
 
+###########################################################################
+##
+## CUDA backend - VectorDistribute and TileAndFuse pipelines
+##
+###########################################################################
+
+# CUDA VectorDistribute pipeline with mma.sync (sm_80+, F16 only)
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cuda_vecdist_f16",
+    compiler_flags = [
+        "--iree-cuda-target=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--acc_type=f32",
+        "--shapes=easy_large_static",
+        "--compilation_info=LLVMGPUVectorDistributeCUDA",
+    ],
+    tags = [
+        "requires-gpu-sm80",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
+# CUDA TileAndFuse pipeline with mma.sync (sm_80+, F16 only)
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cuda_tileandfuse_f16",
+    compiler_flags = [
+        "--iree-cuda-target=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--acc_type=f32",
+        "--shapes=easy_large_static",
+        "--compilation_info=LLVMGPUTileAndFuseCUDA",
+    ],
+    tags = [
+        "requires-gpu-sm80",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
+# CUDA VectorDistribute pipeline with mma.sync F16 accumulator (sm_80+)
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cuda_vecdist_f16_f16",
+    compiler_flags = [
+        "--iree-cuda-target=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--acc_type=f16",
+        "--shapes=easy_large_static",
+        "--compilation_info=LLVMGPUVectorDistributeCUDA",
+    ],
+    tags = [
+        "requires-gpu-sm80",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
+# CUDA TileAndFuse pipeline with mma.sync F16 accumulator (sm_80+)
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cuda_tileandfuse_f16_f16",
+    compiler_flags = [
+        "--iree-cuda-target=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--acc_type=f16",
+        "--shapes=easy_large_static",
+        "--compilation_info=LLVMGPUTileAndFuseCUDA",
+    ],
+    tags = [
+        "requires-gpu-sm80",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
 # TODO(#19465): add large matmul tests for rdna3 and rdna4.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1142,6 +1142,102 @@ iree_generated_e2e_runner_test(
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cuda_vecdist_f16
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=easy_large_static"
+    "--compilation_info=LLVMGPUVectorDistributeCUDA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-target=sm_80"
+  LABELS
+    "requires-gpu-sm80"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cuda_tileandfuse_f16
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--shapes=easy_large_static"
+    "--compilation_info=LLVMGPUTileAndFuseCUDA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-target=sm_80"
+  LABELS
+    "requires-gpu-sm80"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cuda_vecdist_f16_f16
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=easy_large_static"
+    "--compilation_info=LLVMGPUVectorDistributeCUDA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-target=sm_80"
+  LABELS
+    "requires-gpu-sm80"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cuda_tileandfuse_f16_f16
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f16"
+    "--shapes=easy_large_static"
+    "--compilation_info=LLVMGPUTileAndFuseCUDA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-target=sm_80"
+  LABELS
+    "requires-gpu-sm80"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
 # To distinguish between CDNA(gfx9), RDNA3(gfx11), and RDNA4(gfx12)

--- a/tests/e2e/matmul/compilation_info.py
+++ b/tests/e2e/matmul/compilation_info.py
@@ -27,17 +27,21 @@ class MMASchedule:
     def get_subgroup_basis(self) -> str:
         return f"[[{self.m_count}, {self.n_count}, 1], [0, 1, 2]]"
 
+    def get_subgroup_tile(self) -> str:
+        """Returns subgroup tile sizes for TileAndFuse pipeline."""
+        return f"[{self.m_count}, {self.n_count}, 0]"
+
 
 # Enumerates of the collections of compilation info that we can generate tests
 # for. The values are the accepted values for the --compilation_info= flag.
 @enum.unique
 class CompilationInfoId(enum.Enum):
     NONE = ""
-    LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
-    LLVMGPUMatmulTensorCoreMmaSync = "LLVMGPUMatmulTensorCoreMmaSync"
     LLVMGPUVectorDistributeMFMA = "LLVMGPUVectorDistributeMFMA"
     LLVMGPUVectorDistributeWMMAR3 = "LLVMGPUVectorDistributeWMMAR3"
     LLVMGPUVectorDistributeWMMAR4 = "LLVMGPUVectorDistributeWMMAR4"
+    LLVMGPUVectorDistributeCUDA = "LLVMGPUVectorDistributeCUDA"
+    LLVMGPUTileAndFuseCUDA = "LLVMGPUTileAndFuseCUDA"
     SPIRVCooperativeMatrixVectorize = "SPIRVCooperativeMatrixVectorize"
     SPIRVVectorizeMali = "SPIRVVectorizeMali"
     SPIRVVectorizeNVIDIA = "SPIRVVectorizeNVIDIA"
@@ -76,13 +80,27 @@ class IREEGPUCompilationInfo(CompilationInfo):
         if self.subgroup_size is not None:
             subgroup_size_str = f"subgroup_size = {self.subgroup_size}"
 
+        if compiler_pipeline == "LLVMGPUTileAndFuse":
+            lowering_config = (
+                f"  lowering_config = #iree_gpu.lowering_config<{{"
+                f"  mma_kind = #iree_gpu.mma_layout<{self.mma_schedule.intrinsic}>, "
+                f"  subgroup = {self.mma_schedule.get_subgroup_tile()}, "
+                f"  promote_operands = [0, 1], "
+                f"  workgroup = {self.workgroup_tile}, "
+                f"  reduction = {self.reduction_tile} }}>,\n"
+            )
+        else:
+            lowering_config = (
+                f"  lowering_config = #iree_gpu.lowering_config<{{"
+                f"  mma_kind = #iree_gpu.mma_layout<{self.mma_schedule.intrinsic}>, "
+                f"  subgroup_basis = {self.mma_schedule.get_subgroup_basis()}, "
+                f"  workgroup = {self.workgroup_tile}, "
+                f"  reduction = {self.reduction_tile} }}>,\n"
+            )
+
         return (
             "#iree_codegen.compilation_info<\n"
-            f"  lowering_config = #iree_gpu.lowering_config<{{"
-            f"  mma_kind = #iree_gpu.mma_layout<{self.mma_schedule.intrinsic}>, "
-            f"  subgroup_basis = {self.mma_schedule.get_subgroup_basis()}, "
-            f"  workgroup = {self.workgroup_tile}, "
-            f"  reduction = {self.reduction_tile} }}>,\n"
+            f"{lowering_config}"
             f"  translation_info = #iree_codegen.translation_info<pipeline = {compiler_pipeline} {self.workgroup_size_str()}\n"
             f"  {subgroup_size_str}>>\n"
         )
@@ -347,9 +365,73 @@ def get_rocm_test_compilation_infos(
     return infos
 
 
+def get_cuda_test_compilation_infos(
+    compilation_info_id: CompilationInfoId,
+    lhs_rhs_type: MatrixElemTypeId,
+    acc_type: Optional[MatrixElemTypeId] = None,
+):
+    """Generate compilation infos for CUDA/NVIDIA GPU tests."""
+    # Only F16 input is supported for NV_MMA_SYNC intrinsics
+    if lhs_rhs_type != MatrixElemTypeId.F16:
+        return []
+
+    # Determine the pipeline based on compilation_info_id
+    if compilation_info_id == CompilationInfoId.LLVMGPUVectorDistributeCUDA:
+        pipeline = "LLVMGPUVectorDistribute"
+    elif compilation_info_id == CompilationInfoId.LLVMGPUTileAndFuseCUDA:
+        pipeline = "LLVMGPUTileAndFuse"
+    else:
+        raise ValueError("Unknown pipeline for CUDA")
+
+    if acc_type == MatrixElemTypeId.F16:
+        intrinsic = "NV_MMA_SYNC_F16_16x8x16_F16"
+    else:
+        # Default to F32 accumulator
+        intrinsic = "NV_MMA_SYNC_F32_16x8x16_F16"
+
+    schedules = [
+        # Basic single subgroup configurations
+        MMASchedule(intrinsic, 1, 1, 1, 1, 1),
+        MMASchedule(intrinsic, 1, 1, 1, 1, 2),
+        MMASchedule(intrinsic, 1, 1, 1, 2, 1),
+        MMASchedule(intrinsic, 1, 1, 2, 1, 1),
+        # Multiple subgroups
+        MMASchedule(intrinsic, 2, 2, 1, 1, 1),
+        MMASchedule(intrinsic, 2, 2, 2, 2, 2),
+        MMASchedule(intrinsic, 2, 4, 2, 1, 2),
+        MMASchedule(intrinsic, 4, 2, 4, 2, 2),
+    ]
+
+    subgroup_size = 32
+
+    infos = []
+    for schedule in schedules:
+        # NV_MMA_SYNC intrinsics: M=16, N=8, K=16
+        wg_tile_m = schedule.m_count * schedule.m_tile_count * 16
+        wg_tile_n = schedule.n_count * schedule.n_tile_count * 8
+        wg_tile_k = schedule.k_tile_count * 16
+
+        workgroup_tile = [wg_tile_m, wg_tile_n, 0]
+        reduction_tile = [0, 0, wg_tile_k]
+        workgroup_size = [schedule.n_count * subgroup_size, schedule.m_count, 1]
+        infos.append(
+            IREEGPUCompilationInfo(
+                workgroup_tile=workgroup_tile,
+                reduction_tile=reduction_tile,
+                dispatch_lowering_pass_pipeline=pipeline,
+                workgroup_size=workgroup_size,
+                mma_schedule=schedule,
+                subgroup_size=subgroup_size,
+            )
+        )
+    return infos
+
+
 # Returns the list of CompilationInfo's to use for the CompilationInfoId.
 def get_test_compilation_infos(
-    compilation_info_id: CompilationInfoId, lhs_rhs_type: MatrixElemTypeId
+    compilation_info_id: CompilationInfoId,
+    lhs_rhs_type: MatrixElemTypeId,
+    acc_type: Optional[MatrixElemTypeId] = None,
 ) -> typing.List[typing.Optional[CompilationInfo]]:
     if compilation_info_id == CompilationInfoId.NONE:
         return [None]
@@ -360,6 +442,14 @@ def get_test_compilation_infos(
         CompilationInfoId.LLVMGPUVectorDistributeWMMAR4,
     ]:
         return get_rocm_test_compilation_infos(compilation_info_id, lhs_rhs_type)
+
+    if compilation_info_id in [
+        CompilationInfoId.LLVMGPUVectorDistributeCUDA,
+        CompilationInfoId.LLVMGPUTileAndFuseCUDA,
+    ]:
+        return get_cuda_test_compilation_infos(
+            compilation_info_id, lhs_rhs_type, acc_type
+        )
 
     software_pipeline_depth = 0
     tile_workgroup_size_pairs = []
@@ -373,34 +463,6 @@ def get_test_compilation_infos(
         tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(32)
     elif compilation_info_id == CompilationInfoId.SPIRVVectorizeMali:
         tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(4)
-    elif (
-        compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore
-        or compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCoreMmaSync
-    ):
-        tile_workgroup_size_pairs = []
-        ## WarpShape = 2x2
-        tile_workgroup_size_pairs.append(
-            TileWorkgroupSizePair([[32, 32, 16]], [64, 2, 1])
-        )
-        tile_workgroup_size_pairs.append(
-            TileWorkgroupSizePair([[64, 64, 64]], [64, 2, 1])
-        )
-
-        ## WarpShape = 4x1
-        tile_workgroup_size_pairs.append(
-            TileWorkgroupSizePair([[32, 32, 32]], [64, 1, 1])
-        )
-
-        ## WarpShape = 2x2 with large tiles using larger Shared Memory capacity.
-        if lhs_rhs_type == MatrixElemTypeId.F16:
-            tile_workgroup_size_pairs.append(
-                TileWorkgroupSizePair([[128, 128, 64]], [64, 2, 1])
-            )
-        elif lhs_rhs_type == MatrixElemTypeId.F32:
-            tile_workgroup_size_pairs.append(
-                TileWorkgroupSizePair([[128, 128, 16]], [64, 2, 1])
-            )
-        software_pipeline_depth = 3
 
     compilation_infos = []
     for tile_workgroup_size_pair in tile_workgroup_size_pairs:

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -114,7 +114,7 @@ def generate(
     calls = []
 
     for compilation_info in get_test_compilation_infos(
-        compilation_info_id, lhs_rhs_type
+        compilation_info_id, lhs_rhs_type, acc_type
     ):
         for shape in get_test_shapes(shapes_id):
             for dynamicities in get_dynamicities(shapes_id):


### PR DESCRIPTION
Adds some nvidia tensor core support  to the newer LLVMGPU pipelines. This PR is a draft to collect some feedback :) I asked a long time ago about this on discord maybe @Groverkss can remember and i finally had some time and motivation to work on this :) 

At its core i added the layouts to support the[ `mma.sync.aligned.m16n8k16` ](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=ldmatrix#warp-level-matrix-fragment-mma-16816-float)instruction with fp32 and fp16 accumulators.
In addition to this there are also the following changes on this branch:

- remove some old reference to nvidia tensor core pipelines that no longer exist
- add support for lowering loads from shmem to the matrix fragments with [ldmatrix](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=ldmatrix#warp-level-matrix-instructions-ldmatrix) in the VectorDistribute pipeline
- makes the ReduceBankConflicts pass always pad atleast as many elements as the shmem allocation has alignment (ldmatrix loads always need to be aligned to 16 bytes)

if you guys wan't this in some form, i would definitely split this as this mixes a couple of changes together.

Most changes here are actually to support ldmatrix loads (adding only the mma.sync ops requires barely any changes), however from what im seeing so far it seems that this gives basically no performance in the current state and its also the part thats the most "hacky" in the current implementation. 

Would be nice if there is some way to implemented it so both pipelines could use it, but i couldn't really 
think of something that would work without putting too much effort, so i only implemented it for VectorDistribute as it seemed easiest to add there. 


I didn't do much benchmarking yet but at its current state this gives up to ~7-8x improvements for larger matmul shapes on my pc with a RTX 3070 (sm_86).

### Benchmark results on latest main (Contract Config)
```
====================================================================================================
Size                    Time (us)       Stddev     CV (%)       TFLOPS   Iterations
====================================================================================================
512x512x512                 98.50         0.64       0.65         2.73            5
1024x1024x1024             482.00         0.48       0.10         4.46            5
2048x2048x2048            3448.00        13.80       0.40         4.98            5
4096x4096x4096           25053.00        33.70       0.13         5.49            5
8192x8192x8192          196089.00       230.00       0.12         5.61            5
====================================================================================================
```
### Benchmark results for mma.sync with TileAndFuse (ldmatrix not implemented)
```
====================================================================================================
Size                    Time (us)       Stddev     CV (%)       TFLOPS   Iterations
====================================================================================================
512x512x512                 49.80         1.13       2.27         5.39            5
1024x1024x1024             102.00         0.19       0.18        21.05            5
2048x2048x2048             479.00         0.47       0.10        35.87            5
4096x4096x4096            3578.00        39.80       1.11        38.41            5
8192x8192x8192           26413.00        44.40       0.17        41.63            5
====================================================================================================
```
### Benchmark results for mma.sync with VectorDistribute (without ldmatrix)
```
====================================================================================================
Size                    Time (us)       Stddev     CV (%)       TFLOPS   Iterations
====================================================================================================
512x512x512                 50.60         1.00       1.97         5.31            5
1024x1024x1024              97.30         5.58       5.73        22.07            5
2048x2048x2048             503.00         3.23       0.64        34.15            5
4096x4096x4096            4825.00        28.80       0.60        28.48            5
8192x8192x8192           43237.00        54.90       0.13        25.43            5
====================================================================================================
```
### Benchmark results for mma.sync with VectorDistribute (with ldmatrix)
```
====================================================================================================
Size                    Time (us)       Stddev     CV (%)       TFLOPS   Iterations
====================================================================================================
512x512x512                 45.60         1.16       2.55         5.89            5
1024x1024x1024              90.90         0.43       0.47        23.62            5
2048x2048x2048             535.00         0.43       0.08        32.11            5
4096x4096x4096            4232.00        32.60       0.77        32.48            5
8192x8192x8192           42684.00        26.10       0.06        25.76            5
====================================================================================================
```