### PR TITLE
[Codegen][GPU] Preserve loop domain when collapsing dims in Conv to Matmul conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
@@ -61,6 +61,7 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
     return;
   AffineMap inputMap = indexingMaps[0];
   AffineMap filterMap = indexingMaps[1];
+  AffineMap outputMap = indexingMaps[2];
 
   // Check that all filter loop dimensions are unit and then make them zero.
   DenseMap<AffineExpr, AffineExpr> dimMap;
@@ -76,11 +77,13 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
     dimMap[rewriter.getAffineDimExpr(filterLoop)] =
         getAffineConstantExpr(0, filterMap.getContext());
   }
-  SmallVector<AffineMap> newIndexingMaps;
-  newIndexingMaps.push_back(inputMap.replace(dimMap));
+  ArrayRef<AffineExpr> newResults = inputMap.replace(dimMap).getResults();
+  AffineMap newInputMap = AffineMap::get(inputMap.getNumDims(), 0, newResults,
+                                         inputMap.getContext());
+
   // No changes to the filter and output map.
-  newIndexingMaps.push_back(filterMap);
-  newIndexingMaps.push_back(indexingMaps[2]);
+  SmallVector<AffineMap> newIndexingMaps = {newInputMap, filterMap, outputMap};
+
   // Create the new contraction op and replace the old convolution op.
   auto newOp = linalg::GenericOp::create(
       rewriter, linalgOp.getLoc(), linalgOp.getDpsInits().getType(),

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileAndConvertConvToMatmul.cpp
@@ -78,11 +78,11 @@ void static removeUnitExtentDimsfromMaps(linalg::LinalgOp linalgOp,
         getAffineConstantExpr(0, filterMap.getContext());
   }
   ArrayRef<AffineExpr> newResults = inputMap.replace(dimMap).getResults();
-  AffineMap newInputMap = AffineMap::get(inputMap.getNumDims(), 0, newResults,
-                                         inputMap.getContext());
+  auto newInputMap = AffineMap::get(inputMap.getNumDims(), 0, newResults,
+                                    inputMap.getContext());
 
   // No changes to the filter and output map.
-  SmallVector<AffineMap> newIndexingMaps = {newInputMap, filterMap, outputMap};
+  AffineMap newIndexingMaps[] = {newInputMap, filterMap, outputMap};
 
   // Create the new contraction op and replace the old convolution op.
   auto newOp = linalg::GenericOp::create(


### PR DESCRIPTION
This PR fixes an issue where `AffineMap::replace` dropped unused dims, leading to the loop-domain mismatch. For example, the following affine map

`affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>`

will become

`affine_map<(d0, d1, d2, d3, d4) -> (d4, d1, d2, d3)`

This PR rewrites the affected expressions manually while preserving the original loop domain.