### PR TITLE
[Encoding] Use struct directive for TestingAttr assembly format

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -642,31 +642,6 @@ Attribute UnsupportedResolverAttr::getLayout(RankedTensorType) const {
 // Encoding attributes that are mainly for testing purpose.
 //===---------------------------------------------------------------------===//
 
-Attribute TestingAttr::parse(AsmParser &p, Type type) {
-  if (failed(p.parseLess())) {
-    return {};
-  }
-  ArrayAttr layouts;
-  OptionalParseResult parseResult = p.parseOptionalAttribute(layouts);
-  if (parseResult.has_value() && parseResult.value().failed()) {
-    p.emitError(p.getNameLoc()) << "expected array attribute";
-    return {};
-  }
-  if (failed(p.parseGreater())) {
-    return {};
-  }
-  return get(p.getContext(), layouts);
-}
-
-void TestingAttr::print(AsmPrinter &p) const {
-  auto &os = p.getStream();
-  os << "<";
-  if (auto layouts = getLayouts()) {
-    p.printAttribute(layouts);
-  }
-  os << ">";
-}
-
 bool TestingAttr::isSerialized() const { return getLayouts() ? true : false; }
 
 Attribute TestingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -340,7 +340,7 @@ def TestingAttr :
     "layouts.">:$layouts
   );
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "`<` struct(params) `>`";
   let genVerifyDecl = 0;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -223,11 +223,11 @@ func.func @testing_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<
 
 // -----
 
-#encoding = #iree_encoding.testing<[#iree_encoding.specialization_resolver<123>]>
+#encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialization_resolver<123>]>
 func.func @testing_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialization_resolver<123>]>
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialization_resolver<123>]>
 //      CHECK: func.func @testing_with_layouts(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -66,9 +66,9 @@ util.func private @tensorClone(%arg0: !stream.resource<*>, %arg1: index, %arg2: 
 // -----
 
 #unserialized_encoding = #iree_encoding.testing<>
-#serialized_encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#serialized_encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-DAG:   #[[$ENC_0:.+]] = #iree_encoding.testing<>
-// CHECK-DAG:   #[[$ENC_1:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK-DAG:   #[[$ENC_1:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: @tensorCloneWithEncoding(
 util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
   // CHECK: = stream.tensor.clone %arg0 : tensor<?x4xf32, #[[$ENC_0]]>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC_1]]>{%arg1} in !stream.resource<*>{%arg2}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_encodings.mlir
@@ -168,10 +168,10 @@ util.func public @decode_source_resource(%resource: !stream.resource<*>, %total_
 
 // -----
 
-// CHECK-DAG:  #[[ENCODING0:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
-// CHECK-DAG:  #[[ENCODING1:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<456>]>
-#encoding0 = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
-#encoding1 = #iree_encoding.testing<[#iree_encoding.specialized<456>]>
+// CHECK-DAG:  #[[ENCODING0:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+// CHECK-DAG:  #[[ENCODING1:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
+#encoding0 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456>]>
 // CHECK:      stream.executable private @[[$EX:.+]] {
 // CHECK:         stream.executable.export public @[[$ENTRY:.+]] workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
 // CHECK-NEXT:      iree_tensor_ext.dispatch.workgroup_count_from_slice(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]])

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -170,7 +170,7 @@ util.func public @create_pad_identity_encoding(%arg0: index, %arg1: index) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK: #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.padding<[0, 0]>]>
+// CHECK: #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.padding<[0, 0]>]>
 // CHECK-LABEL: @create_pad_identity_encoding
 // CHECK: stream.tensor.empty {{.*}} :  tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
 
@@ -192,8 +192,8 @@ util.func public @ops_with_result_encoding_only(%arg0: index, %arg1: index, %sca
   %2 = stream.tensor.splat on(#hal.device.affinity<@device_a>) %scalar_f32 : f32 -> tensor<?x1x10xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x0xf32>>]>
-// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x1x10xf32>>]>
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x0xf32>>]>
+// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x1x10xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @ops_with_result_encoding_only
@@ -216,7 +216,7 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
     -> tensor<?x4xf32, #encoding>{%arg2} in %arg1 as !stream.resource<*>{%arg3}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x4xf32>>]>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x4xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @tensor_fill_op
@@ -237,7 +237,7 @@ util.func public @tensor_encode_op(%arg0: !stream.resource<*>, %arg1: index, %ar
     -> tensor<?x?xf32, #encoding>{%arg2, %arg3} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x?xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @tensor_encode_op
@@ -259,7 +259,7 @@ util.func public @tensor_encode_op_change_encoding(%arg0: !stream.resource<*>, %
     -> tensor<?x?xf32, #encoding1>{%arg2, %arg3} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x?xf32>>]>
 // CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.unknown
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
@@ -289,13 +289,13 @@ module {
 
 // -----
 
-#encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a : !hal.device
 util.func public @tensor_constant_op_with_serialized_encoding(%arg0: index) {
   %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
   util.return
 }
-// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: util.func public @tensor_constant_op_with_serialized_encoding(
 // CHECK:         stream.tensor.constant
 // CHECK-SAME:      tensor<?x5x64xf32, #[[$SERIALIZED_ENCODING]]>
@@ -352,7 +352,7 @@ util.func public @tensor_clone_op_with_unknowns(%arg0: !stream.resource<*>, %arg
 
 // -----
 
-#serialized_encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#serialized_encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a : !hal.device
 util.func public @tensor_clone_op_with_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
   %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
@@ -360,7 +360,7 @@ util.func public @tensor_clone_op_with_serialized_encodings(%arg0: !stream.resou
     -> tensor<?x4xf32, #serialized_encoding>{%arg1} in !stream.resource<*>{%arg2}
   util.return
 }
-// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: util.func public @tensor_clone_op_with_serialized_encodings(
 // CHECK:         stream.tensor.clone
 // CHECK-SAME:      tensor<?x4xf32, #[[$SERIALIZED_ENCODING]]>
@@ -392,7 +392,7 @@ module {
 // -----
 
 #unknown = #iree_encoding.unknown
-#serialized_encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#serialized_encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a : !hal.device
 util.func public @tensor_slice_op_with_unknown_or_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
   %c0 = arith.constant 0 : index
@@ -403,7 +403,7 @@ util.func public @tensor_slice_op_with_unknown_or_serialized_encodings(%arg0: !s
   util.return
 }
 // CHECK:       #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown
-// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: util.func public @tensor_slice_op_with_unknown_or_serialized_encodings(
 // CHECK:         stream.tensor.slice
 // CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
@@ -435,7 +435,7 @@ module {
 // -----
 
 #unknown = #iree_encoding.unknown
-#serialized_encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#serialized_encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a : !hal.device
 util.func public @tensor_update_op_with_unknown_or_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
   %c0 = arith.constant 0 : index
@@ -446,7 +446,7 @@ util.func public @tensor_update_op_with_unknown_or_serialized_encodings(%arg0: !
   util.return
 }
 // CHECK:       #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown
-// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: util.func public @tensor_update_op_with_unknown_or_serialized_encodings(
 // CHECK:         stream.tensor.update
 // CHECK-SAME:      tensor<2x2xf32, #[[$UNKNOWN_ENCODING]]>
@@ -466,7 +466,7 @@ util.func public @drop_encoding(%arg0: index, %arg1: index, %scalar_f32 : f32) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.identity]>
+// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.identity]>
 // CHECK-LABEL: util.func public @drop_encoding
 // CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
 
@@ -483,7 +483,7 @@ util.func public @ignore_encoding_by_identity_resolver(%arg0: index, %arg1: inde
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.identity]>
+// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.identity]>
 // CHECK-LABEL: util.func public @ignore_encoding_by_identity_resolver
 // CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
 
@@ -493,13 +493,13 @@ util.func public @ignore_encoding_by_identity_resolver(%arg0: index, %arg1: inde
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a = #device_target_local_0_
 util.func public @keep_encoding_if_serialized(%arg0: index, %arg1: index, %scalar_f32 : f32) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK-LABEL: util.func public @keep_encoding_if_serialized
 // CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$ENCODING]]>
 
@@ -549,7 +549,7 @@ util.func public @tensor_dispatch_with_tied_operands(%arg0: !stream.resource<ext
   %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable::@dispatch(%0, %arg3) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32, #encoding>{%arg2} in %0{%arg1}
   util.return %1 : !stream.resource<*>
 }
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<4x?xf32>>]>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<4x?xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @tensor_dispatch_with_tied_operands
@@ -589,7 +589,7 @@ util.func public @multi_device_with_same_executable_targets(%arg0: !stream.resou
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<16xf32>>]>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<16xf32>>]>
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
@@ -636,8 +636,8 @@ util.func public @multi_device_with_different_executable_targets(%arg0: !stream.
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<16xf32>>]>
-// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<456, tensor<16xf32>>]>
+// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<16xf32>>]>
+// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456, tensor<16xf32>>]>
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
@@ -694,8 +694,8 @@ util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %
   util.return
 }
 
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x?xf32>>]>
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<456, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456, tensor<?x?xf32>>]>
 // CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.testing<>
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
@@ -768,8 +768,8 @@ util.func public @multi_device_unset_encoding(%arg0: !stream.resource<external>,
   %3 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@unset_encoding(%2, %M, %N) : (tensor<?x?xf32, #encoding>{%M, %N} in !stream.resource<*>{%arg2}, index, index) -> (tensor<?x?xf32>{%M, %N} in !stream.resource<*>{%arg2})
   util.return
 }
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<?x?xf32>>]>
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<456, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<456, tensor<?x?xf32>>]>
 // CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.testing<>
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
@@ -950,7 +950,7 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // the encoding is already serialized.
 
 #unknown = #iree_encoding.unknown
-#serialized_encoding = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+#serialized_encoding = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 util.global private @device_a : !hal.device
 stream.executable private @executable {
   stream.executable.export public @dispatch
@@ -969,7 +969,7 @@ util.func public @tensor_dispatch_with_unknown_and_serialized_encodings(%arg0: !
   util.return %1 : !stream.resource<*>
 }
 // CHECK-DAG:   #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown
-// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123>]>
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123>]>
 // CHECK:       stream.executable
 // CHECK:         func.func
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
@@ -1009,7 +1009,7 @@ util.func public @tensor_dispatch_with_unknown_and_unserialized_encodings(%arg0:
   util.return %1 : !stream.resource<*>
 }
 // CHECK-DAG:   #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown
-// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<[#iree_encoding.specialized<123, tensor<4x?xf32>>]>
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing<layouts = [#iree_encoding.specialized<123, tensor<4x?xf32>>]>
 // CHECK:       stream.executable
 // CHECK:         func.func
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -229,8 +229,8 @@ util.func public @move_dependencies_before_dispatch(%arg0: tensor<?xf32>, %arg1:
 
 // -----
 
-#encoding0 = #iree_encoding.testing<[#iree_encoding.specialized<0>]>
-#encoding1 = #iree_encoding.testing<[#iree_encoding.specialized<1>]>
+#encoding0 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<0>]>
+#encoding1 = #iree_encoding.testing<layouts = [#iree_encoding.specialized<1>]>
 util.func public @encoding_fusion(%arg0: tensor<128xf32, #encoding0>) -> tensor<128xf32, #encoding1> {
   %1 = flow.dispatch.region -> (tensor<128xf32>) {
     %3 = iree_encoding.unset_encoding %arg0 : tensor<128xf32, #encoding0> -> tensor<128xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/propagate_encodings.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-propagate-encodings))" --split-input-file %s | FileCheck %s
 
-#encoding = #iree_encoding.layout<[#iree_encoding.testing<[]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.testing<layouts = []>]>
 util.func @propagate_encoding_through_tensor_cast(%src: tensor<1024x?xf16>) -> tensor<?x512xf16, #encoding> {
   %cast = tensor.cast %src : tensor<1024x?xf16> to tensor<?x512xf16>
   %0 = iree_encoding.set_encoding %cast : tensor<?x512xf16> -> tensor<?x512xf16, #encoding>


### PR DESCRIPTION
The custom assembly format for encoding dialect's TestingAttr allowed specifying an testing attribute without layouts with `#iree_encoding.testing<>` instead of `#iree_encoding.testing<[]>`. By making use of the struct directive we can avoid the need for a custom assembly format while keeping the same behaviour, except for the parameter keys being added. However, these additional keys like `layouts =` are useful as well imo to improve the readability of the attribute.

Note that this also aligns the testing attribute assembly format with other related attributes:
https://github.com/iree-org/iree/blob/68a9309688a6605151d97d369a68cb5b620802bc/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td#L140
https://github.com/iree-org/iree/blob/68a9309688a6605151d97d369a68cb5b620802bc/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td#L629
https://github.com/iree-org/iree/blob/68a9309688a6605151d97d369a68cb5b620802bc/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td#L97