### PR TITLE
[tests][e2e] Add more llama related shapes

### DIFF
--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2013,7 +2013,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,1024,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--remove_accumulator"
+    "--no-accumulate"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2046,7 +2046,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,16384,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--remove_accumulator"
+    "--no-accumulate"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2079,7 +2079,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--remove_accumulator"
+    "--no-accumulate"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2112,7 +2112,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,53248"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--remove_accumulator"
+    "--no-accumulate"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2013,7 +2013,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,1024,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--no_accumulator_arg"
+    "--remove_accumulator"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2046,7 +2046,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,16384,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--no_accumulator_arg"
+    "--remove_accumulator"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2079,7 +2079,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--no_accumulator_arg"
+    "--remove_accumulator"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2112,7 +2112,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,53248"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
-    "--no_accumulator_arg"
+    "--remove_accumulator"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1999,7 +1999,39 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_cdna4_mxfp4_llama
+    e2e_matmul_cdna4_mxfp4_llama_0
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=custom_mnk"
+    "--mnk=10000,1024,16384"
+    "--mnk_dynamicities=static,static,static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna4_mxfp4_llama_1
   TEST_TYPE
     matmul
   GENERATOR
@@ -2011,6 +2043,71 @@ iree_generated_e2e_runner_test(
     "--mx_block_size=32"
     "--shapes=custom_mnk"
     "--mnk=10000,16384,16384"
+    "--mnk_dynamicities=static,static,static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna4_mxfp4_llama_2
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=custom_mnk"
+    "--mnk=10000,53248,16384"
+    "--mnk_dynamicities=static,static,static"
+    "--transpose_rhs"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna4_mxfp4_llama_3
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f4E2M1FN"
+    "--acc_type=f32"
+    "--mx_scale_type=f8E8M0FNU"
+    "--mx_block_size=32"
+    "--shapes=custom_mnk"
+    "--mnk=10000,53248,53248"
+    "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2013,6 +2013,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,1024,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
+    "--no_accumulator_arg"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2045,6 +2046,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,16384,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
+    "--no_accumulator_arg"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2077,6 +2079,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,16384"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
+    "--no_accumulator_arg"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -2109,6 +2112,7 @@ iree_generated_e2e_runner_test(
     "--mnk=10000,53248,53248"
     "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
+    "--no_accumulator_arg"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test
   TARGET_BACKENDS

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -95,11 +95,9 @@ def get_test_shapes(shapes_id: ShapesId, accumulate=True):
         m, n, k = ShapesId.custom_mnk_values
         test_shapes = [TestShape(m=m, k=k, n=n, accumulate=False)]
         if accumulate:
-            test_shapes.extend(
-                [
-                    TestShape(m=m, k=k, n=n, accumulate=True),
-                ]
-            )
+            test_shapes += [
+                TestShape(m=m, k=k, n=n, accumulate=True),
+            ]
         return test_shapes
 
     raise ValueError(shapes_id)


### PR DESCRIPTION
This patch adds other llama related shapes that were left out of [a previous PR](https://github.com/iree-org/iree/pull/22775). 

| N | K | 
|-------|-------|
| 1024 | 16384 |
| 16384 | 16384 |
| 53248 | 16384 |
| 53248 | 53248 |

Also, when running these tests locally, it was found that due to the extremely large size of the generated shapes, allocating space for accumulator arguments of type f32 was infeasible. So, a new argument is introduced `--no-accumulator` which allows you to generate tests which omit the accumulator as a function argument and instead use a constant set to zero in the IR.