### PR TITLE
Fix tests: `noubsan` was not being honored, and MXFP4 matmul tests are static-shape-only

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -10,6 +10,7 @@ function(iree_is_bytecode_module_test_excluded_by_labels _DST_IS_EXCLUDED_VAR _S
      (EMSCRIPTEN AND ("nowasm" IN_LIST _SRC_LABELS)) OR
      (IREE_ENABLE_ASAN AND ("noasan" IN_LIST _SRC_LABELS)) OR
      (IREE_ENABLE_TSAN AND ("notsan" IN_LIST _SRC_LABELS)) OR
+     (IREE_ENABLE_UBSAN AND ("noubsan" IN_LIST _SRC_LABELS)) OR
      (CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS) OR
      ((_LOWERCASE_BUILD_TYPE STREQUAL "debug") AND ( "optonly" IN_LIST _RULE_LABELS)))
     set("${_DST_IS_EXCLUDED_VAR}" TRUE PARENT_SCOPE)

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -2011,6 +2011,7 @@ iree_generated_e2e_runner_test(
     "--mx_block_size=32"
     "--shapes=custom_mnk"
     "--mnk=10000,16384,16384"
+    "--mnk_dynamicities=static,static,static"
     "--transpose_rhs"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test


### PR DESCRIPTION
This gfx950-only test failed to generate due to the static-shape limitation. Fixing that resulted in a [compilation failure](https://gist.github.com/bjacob/5a3015daaa027721337192de99311f8a) due to a stack frame exceeding the max size by ~2x when UBSan is enabled, which is not surprising due to the combination of a very large static shape and a sanitizer. The problem was that the existing `noubsan` test tag was not being honored.