### PR TITLE
Remove the accumulator-aliasing workaround now that #16168 is fixed

### DIFF
--- a/tests/e2e/matmul/common.py
+++ b/tests/e2e/matmul/common.py
@@ -243,11 +243,10 @@ random_matrix_seed = 0
 
 # Generate a matrix function argument of the given size as `%name`.
 def generate_random_matrix(
-    name: str, matrix_shape: list, element_type: MatrixElemTypeId, increment_seed=True
+    name: str, matrix_shape: list, element_type: MatrixElemTypeId
 ):
     global random_matrix_seed
-    if increment_seed:
-        random_matrix_seed += 1
+    random_matrix_seed += 1
     return (
         f"  %{name}_dim0 = arith.constant {matrix_shape[0]} : i64\n"
         f"  %{name}_dim1 = arith.constant {matrix_shape[1]} : i64\n"

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -218,14 +218,7 @@ def generate_call(
 
     for arg_name, arg_shape, arg_elemtype in matmul_args:
         op = op + generate_random_matrix(arg_name, arg_shape, arg_elemtype)
-        # TODO(#16168): there's a bug with in-place input->output aliasing and
-        # we work around it here by passing in a unique copy.
-        if arg_name == "acc":
-            # TODO(#16168): there's a bug with in-place input->output aliasing and
-            # we work around it here by passing in a unique copy.
-            op = op + generate_random_matrix(
-                "acc_copy", arg_shape, arg_elemtype, increment_seed=False
-            )
+
     gen_names_and_types = lambda args_list: (
         ", ".join(["%" + name for name, shape, ty in args_list]),
         ", ".join(["!hal.buffer_view" for a in args_list]),
@@ -238,7 +231,7 @@ def generate_call(
         f"  %k = arith.constant {shape.k} : i64\n"
         f"  %n = arith.constant {shape.n} : i64\n"
         f"  %transpose_rhs = arith.constant {transpose_rhs} : i32\n"
-        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, {check_argnames}, {'%acc_copy' if shape.accumulate else '%acc'}, %result) : (!hal.device, i64, i64, i64, i32,  {check_argtypes}, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, {check_argnames}, %acc, %result) : (!hal.device, i64, i64, i64, i32,  {check_argtypes}, !hal.buffer_view, !hal.buffer_view) -> ()\n"
         f"  util.return\n"
         f"}}\n"
     )

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -295,14 +295,7 @@ def generate_call(
 
     for arg_name, arg_shape, arg_elemtype in matmul_args:
         op = op + generate_random_matrix(arg_name, arg_shape, arg_elemtype)
-        # TODO(#16168): there's a bug with in-place input->output aliasing and
-        # we work around it here by passing in a unique copy.
-        if arg_name == "acc":
-            # TODO(#16168): there's a bug with in-place input->output aliasing and
-            # we work around it here by passing in a unique copy.
-            op = op + generate_random_matrix(
-                "acc_copy", arg_shape, arg_elemtype, increment_seed=False
-            )
+
     gen_names_and_types = lambda args_list: (
         ", ".join(["%" + name for name, shape, ty in args_list]),
         ", ".join(["!hal.buffer_view" for a in args_list]),
@@ -315,7 +308,7 @@ def generate_call(
         f"  %k = arith.constant {shape.k} : i64\n"
         f"  %n = arith.constant {shape.n} : i64\n"
         f"  %transpose_rhs = arith.constant {transpose_rhs} : i32\n"
-        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, {check_argnames}, {'%acc_copy' if shape.accumulate else '%acc'}, %result) : (!hal.device, i64, i64, i64, i32,  {check_argtypes}, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, {check_argnames}, %acc, %result) : (!hal.device, i64, i64, i64, i32,  {check_argtypes}, !hal.buffer_view, !hal.buffer_view) -> ()\n"
         f"  util.return\n"
         f"}}\n"
     )

--- a/tests/e2e/matmul/generate_code_mx.py
+++ b/tests/e2e/matmul/generate_code_mx.py
@@ -244,14 +244,7 @@ def generate_call_mx(
 
     for arg_name, arg_shape, arg_elemtype in matmul_args:
         op = op + generate_random_matrix(arg_name, arg_shape, arg_elemtype)
-        # TODO(#16168): there's a bug with in-place input->output aliasing and
-        # we work around it here by passing in a unique copy.
-        if arg_name == "acc":
-            # TODO(#16168): there's a bug with in-place input->output aliasing and
-            # we work around it here by passing in a unique copy.
-            op = op + generate_random_matrix(
-                "acc_copy", arg_shape, arg_elemtype, increment_seed=False
-            )
+
     gen_names_and_types = lambda args_list: (
         ", ".join(["%" + name for name, shape, ty in args_list]),
         ", ".join(["!hal.buffer_view" for a in args_list]),
@@ -331,7 +324,7 @@ def generate_call_mx(
         f"  %scaled_rhs_tensor = tensor.collapse_shape %scaled_rhs_expanded_tensor [[0], [1, 2]] : {scaled_rhs_expanded_tensor_type} into {scaled_rhs_tensor_type}\n"
         f"  %scaled_lhs = hal.tensor.export %scaled_lhs_tensor : {scaled_lhs_tensor_type} -> !hal.buffer_view\n"
         f"  %scaled_rhs = hal.tensor.export %scaled_rhs_tensor : {scaled_rhs_tensor_type} -> !hal.buffer_view\n"
-        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %scaled_lhs, %scaled_rhs, {'%acc_copy' if shape.accumulate else '%acc'}, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %scaled_lhs, %scaled_rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
         f"  util.return\n"
         f"}}\n"
     )

--- a/tests/e2e/matmul/generate_code_mx.py
+++ b/tests/e2e/matmul/generate_code_mx.py
@@ -248,14 +248,7 @@ def generate_call_mx(
 
     for arg_name, arg_shape, arg_elemtype in matmul_args:
         op = op + generate_random_matrix(arg_name, arg_shape, arg_elemtype)
-        # TODO(#16168): there's a bug with in-place input->output aliasing and
-        # we work around it here by passing in a unique copy.
-        if arg_name == "acc":
-            # TODO(#16168): there's a bug with in-place input->output aliasing and
-            # we work around it here by passing in a unique copy.
-            op = op + generate_random_matrix(
-                "acc_copy", arg_shape, arg_elemtype, increment_seed=False
-            )
+
     gen_names_and_types = lambda args_list: (
         ", ".join(["%" + name for name, shape, ty in args_list]),
         ", ".join(["!hal.buffer_view" for a in args_list]),
@@ -335,7 +328,7 @@ def generate_call_mx(
         f"  %scaled_rhs_tensor = tensor.collapse_shape %scaled_rhs_expanded_tensor [[0], [1, 2]] : {scaled_rhs_expanded_tensor_type} into {scaled_rhs_tensor_type}\n"
         f"  %scaled_lhs = hal.tensor.export %scaled_lhs_tensor : {scaled_lhs_tensor_type} -> !hal.buffer_view\n"
         f"  %scaled_rhs = hal.tensor.export %scaled_rhs_tensor : {scaled_rhs_tensor_type} -> !hal.buffer_view\n"
-        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %scaled_lhs, %scaled_rhs, {'%acc_copy' if shape.accumulate else '%acc'}, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
+        f"  util.call @matmul_test.check_matmul_results(%device, %m, %k, %n, %transpose_rhs, %scaled_lhs, %scaled_rhs, %acc, %result) : (!hal.device, i64, i64, i64, i32, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.buffer_view) -> ()\n"
         f"  util.return\n"
         f"}}\n"
     )


### PR DESCRIPTION
Now that  #16168 is fixed by #22739, we should be able to drop this work-around.

Problem: at the moment this runs into this new issue flagged by UBSan (to reproduce, compile with `-DIREE_ENABLE_UBSAN=ON`, `ninja iree-test-deps` and run the ctest command pasted below), seen on every single CPU matmul test, e.g.:

```
$ ctest -R iree/tests/e2e/matmul/e2e_matmul_cpu_dt_i8_i32_llvm-cpu_local-task_generic --output-on-failure
Test project /tmp/xx/iree-build
    Start 1355: iree/tests/e2e/matmul/e2e_matmul_cpu_dt_i8_i32_llvm-cpu_local-task_generic
1/1 Test #1355: iree/tests/e2e/matmul/e2e_matmul_cpu_dt_i8_i32_llvm-cpu_local-task_generic ...***Failed    0.11 sec
--- TEST[matmul_accumulate_DYNxDYNxi8_times_DYNxDYNxi8_into_DYNxDYNxi32_1_1_1_acc_0] ---
Matmul shape (MxKxN): 1x1x1
/tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:399:18: runtime error: member access within misaligned address 0x7ffdbaf4719c for type 'iree_vm_ref_t', which requires 8 byte alignment
0x7ffdbaf4719c: note: pointer points here
  00 00 00 00 60 c2 c3 aa  f8 55 00 00 e8 c8 1c a8  f8 55 00 00 b0 c3 c3 aa  f8 55 00 00 e8 c8 1c a8
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:399:18 
/tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:399:18: runtime error: load of misaligned address 0x7ffdbaf471a4 for type 'iree_vm_ref_type_t' (aka 'unsigned long'), which requires 8 byte alignment
0x7ffdbaf471a4: note: pointer points here
  f8 55 00 00 e8 c8 1c a8  f8 55 00 00 b0 c3 c3 aa  f8 55 00 00 e8 c8 1c a8  f8 55 00 00 00 c5 c3 aa
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:399:18 
/tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:400:64: runtime error: member access within misaligned address 0x7ffdbaf4719c for type 'iree_vm_ref_t', which requires 8 byte alignment
0x7ffdbaf4719c: note: pointer points here
  00 00 00 00 60 c2 c3 aa  f8 55 00 00 e8 c8 1c a8  f8 55 00 00 b0 c3 c3 aa  f8 55 00 00 e8 c8 1c a8
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:400:64 
/tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:400:64: runtime error: load of misaligned address 0x7ffdbaf4719c for type 'void *', which requires 8 byte alignment
0x7ffdbaf4719c: note: pointer points here
  00 00 00 00 60 c2 c3 aa  f8 55 00 00 e8 c8 1c a8  f8 55 00 00 b0 c3 c3 aa  f8 55 00 00 e8 c8 1c a8
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/xx/iree/runtime/src/iree/vm/native_module_packing.h:400:64 
--- TEST[matmul_accumulate_1x1xi8_times_1x1xi8_into_1x1xi32_1_1_1_acc_1] ---
Matmul shape (MxKxN): 1x1x1


error: the actual and expected result matrices disagree at row 0, column 0.

actual value: 2
expected value: -2

left-hand side (rows 0..0 out of 0..0, columns 0..0 out of 0..0)
2   

right-hand side (rows 0..0 out of 0..0, columns 0..0 out of 0..0)
-2   

input accumulator (rows 0..0 out of 0..0, columns 0..0 out of 0..0)
2   

expected result (rows 0..0 out of 0..0, columns 0..0 out of 0..0)
-2🦄 

actual result (rows 0..0 out of 0..0, columns 0..0 out of 0..0)
 2🎃 
```