### PR TITLE
[Codegen][GPU] Allow channel first layouts to lower through direct convolution path

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_and_convert_conv_to_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_tile_and_convert_conv_to_matmul.mlir
@@ -1,23 +1,21 @@
 // RUN: iree-opt %s --mlir-print-local-scope --pass-pipeline='builtin.module(func.func(iree-codegen-gpu-tile-and-convert-conv-to-matmul, canonicalize, cse))' --split-input-file | FileCheck %s
 
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>}>
-module {
-  func.func @conv_nhwc_generic(%a: tensor<1x3x66x8xf32>, %b: tensor<32x3x3x8xf32>, %c: tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32> {
-    %conv = linalg.generic {
-      indexing_maps =
-        [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]}
-      ins(%a, %b : tensor<1x3x66x8xf32>, tensor<32x3x3x8xf32>) outs(%c : tensor<1x1x64x32xf32>)
-      attrs = {lowering_config = #config} {
-      ^bb0(%in: f32, %in_2: f32, %out: f32):
-        %14 = arith.mulf %in, %in_2 : f32
-        %15 = arith.addf %out, %14 : f32
-        linalg.yield %15 : f32
-      } -> tensor<1x1x64x32xf32>
-    return %conv : tensor<1x1x64x32xf32>
-  }
+func.func @conv_nhwc_generic(%a: tensor<1x3x66x8xf32>, %b: tensor<32x3x3x8xf32>, %c: tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32> {
+  %conv = linalg.generic {
+    indexing_maps =
+      [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>,
+      affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>,
+      affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]}
+    ins(%a, %b : tensor<1x3x66x8xf32>, tensor<32x3x3x8xf32>) outs(%c : tensor<1x1x64x32xf32>)
+    attrs = {lowering_config = #config} {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %14 = arith.mulf %in, %in_2 : f32
+      %15 = arith.addf %out, %14 : f32
+      linalg.yield %15 : f32
+    } -> tensor<1x1x64x32xf32>
+  return %conv : tensor<1x1x64x32xf32>
 }
 
 // CHECK-LABEL: func.func @conv_nhwc_generic
@@ -29,16 +27,14 @@ module {
 // -----
 
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>}>
-module {
-  func.func @conv_named_dilated(%a: tensor<1x5x68x8xf32>, %b: tensor<32x3x3x8xf32>, %c: tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32> {
-    %conv = linalg.conv_2d_nhwc_fhwc
-      {dilations = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config}
-      ins(%a, %b : tensor<1x5x68x8xf32>, tensor<32x3x3x8xf32>) outs(%c : tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32>
-    return %conv : tensor<1x1x64x32xf32>
-  }
+func.func @conv_nhwc_named_dilated(%a: tensor<1x5x68x8xf32>, %b: tensor<32x3x3x8xf32>, %c: tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32> {
+  %conv = linalg.conv_2d_nhwc_fhwc
+    {dilations = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config}
+    ins(%a, %b : tensor<1x5x68x8xf32>, tensor<32x3x3x8xf32>) outs(%c : tensor<1x1x64x32xf32>) -> tensor<1x1x64x32xf32>
+  return %conv : tensor<1x1x64x32xf32>
 }
 
-// CHECK-LABEL: func.func @conv_named_dilated
+// CHECK-LABEL: func.func @conv_nhwc_named_dilated
 //       CHECK:  scf.for %{{.*}} = %c0 to %c3 step %c1
 //       CHECK:    scf.for %{{.*}} = %c0 to %c3 step %c1
 //       CHECK:      linalg.generic
@@ -47,23 +43,37 @@ module {
 // -----
 
 #config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>}>
-module {
-  func.func @conv_chwn_generic(%a: tensor<16x24x16x16xf32>, %b: tensor<16x24x16x16xf32>, %c: tensor<16x1x1x16xf32>) -> tensor<16x1x1x16xf32> {
-    %conv = linalg.generic {
-      indexing_maps =
-        [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]}
-      ins(%a, %b : tensor<16x24x16x16xf32>, tensor<16x24x16x16xf32>) outs(%c : tensor<16x1x1x16xf32>)
-      attrs = {lowering_config = #config} {
-      ^bb0(%in: f32, %in_2: f32, %out: f32):
-        %14 = arith.mulf %in, %in_2 : f32
-        %15 = arith.addf %out, %14 : f32
-        linalg.yield %15 : f32
-      } -> tensor<16x1x1x16xf32>
-    return %conv : tensor<16x1x1x16xf32>
-  }
+func.func @conv_nchw_named(%arg0: tensor<2x16x130x130xf32>, %arg1: tensor<32x16x3x3xf32>, %arg2: tensor<2x32x128x128xf32>) -> tensor<2x32x128x128xf32> {
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, lowering_config = #config}
+    ins(%arg0, %arg1 : tensor<2x16x130x130xf32>, tensor<32x16x3x3xf32>) outs(%arg2 : tensor<2x32x128x128xf32>) -> tensor<2x32x128x128xf32>
+  return %0 : tensor<2x32x128x128xf32>
+}
+
+// CHECK-LABEL: func.func @conv_nchw_named
+//       CHECK:  scf.for %{{.*}} = %c0 to %c3 step %c1
+//       CHECK:    scf.for %{{.*}} = %c0 to %c3 step %c1
+//       CHECK:      linalg.generic
+//  CHECK-SAME:        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2, d3)>
+
+// -----
+
+#config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>}>
+func.func @conv_chwn_generic(%a: tensor<16x24x16x16xf32>, %b: tensor<16x24x16x16xf32>, %c: tensor<16x1x1x16xf32>) -> tensor<16x1x1x16xf32> {
+  %conv = linalg.generic {
+    indexing_maps =
+      [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>,
+      affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>,
+      affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]}
+    ins(%a, %b : tensor<16x24x16x16xf32>, tensor<16x24x16x16xf32>) outs(%c : tensor<16x1x1x16xf32>)
+    attrs = {lowering_config = #config} {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %14 = arith.mulf %in, %in_2 : f32
+      %15 = arith.addf %out, %14 : f32
+      linalg.yield %15 : f32
+    } -> tensor<16x1x1x16xf32>
+  return %conv : tensor<16x1x1x16xf32>
 }
 
 // CHECK-LABEL: func.func @conv_chwn_generic

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -1671,8 +1671,8 @@ setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
     return failure();
   }
 
-  // This strategy turns non-strided/dilated convolution problems into matmul
-  // problems by tiling certain dimensions to 1:
+  // This strategy turns non-strided convolution problems into matmul problems
+  // by tiling certain dimensions to 1:
   //  - Filter dimensions (reduction on the filter, and convolved on the image).
   //  - All parallel dimensions except the innermost output channel dimension
   //    and output image/batch dimension.
@@ -1695,17 +1695,8 @@ setDirectConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
     return llvm::all_of(list, [](int64_t i) { return i == 1; });
   };
 
-  // TODO: Support non-unit strides/dilations.
-  if (!isAllOnesList(convolutionDims->strides) ||
-      !isAllOnesList(convolutionDims->dilations)) {
-    return failure();
-  }
-
-  // TODO: Support NCHW convolutions. This is just a matmul_transpose_a, however
-  // the distribution patterns currently do not support that variant.
-  bool isOutputChannelFirst = convolutionDims->outputChannel.back() <
-                              convolutionDims->outputImage.front();
-  if (isOutputChannelFirst) {
+  // TODO: Support non-unit strides.
+  if (!isAllOnesList(convolutionDims->strides)) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_direct_conv_tile_and_fuse.mlir
@@ -119,3 +119,56 @@ func.func @conv_nhwc_fhc_two_batch_dims(%arg0: tensor<16x50x32x576xf16>, %arg1: 
 //  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 4]
 //  CHECK-SAME:     subgroup = [0, 0, 1, 1, 0, 0]
 //  CHECK-SAME:     workgroup = [1, 1, 32, 64, 0, 0]
+
+// -----
+
+func.func @conv_nchw_named(%3: tensor<2x128x34x34xf32>, %4: tensor<64x128x3x3xf32>) -> tensor<2x64x32x32xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %5 = tensor.empty() : tensor<2x64x32x32xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x64x32x32xf32>) -> tensor<2x64x32x32xf32>
+  %7 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%3, %4 : tensor<2x128x34x34xf32>, tensor<64x128x3x3xf32>) outs(%6 : tensor<2x64x32x32xf32>) -> tensor<2x64x32x32xf32>
+  return %7 : tensor<2x64x32x32xf32>
+}
+
+// CHECK-LABEL: func.func @conv_nchw_named
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
+//  CHECK-SAME:   use_igemm_convolution = false
+
+//       CHECK:   linalg.conv_2d_nchw_fchw {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+
+//  CHECK-SAME:     promote_operands = [0, 1]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 16, 1, 1]
+//  CHECK-SAME:     subgroup = [0, 1, 0, 1, 0, 0, 0]
+//  CHECK-SAME:     workgroup = [1, 64, 1, 32, 0, 0, 0]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+func.func @conv_chwn_fhwn(%arg0: tensor<16x26x18x144xf16>, %arg1: tensor<16x24x16x144xf16>, %arg2: tensor<144x3x3x144xf32>) -> tensor<144x3x3x144xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x18x144xf16>, tensor<16x24x16x144xf16>) outs(%arg2 : tensor<144x3x3x144xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f32):
+    %1 = arith.extf %in : f16 to f32
+    %2 = arith.extf %in_0 : f16 to f32
+    %3 = arith.mulf %1, %2 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<144x3x3x144xf32>
+  return %0 : tensor<144x3x3x144xf32>
+}
+
+// CHECK-LABEL: func.func @conv_chwn_fhwn
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = false
+//  CHECK-SAME:   use_igemm_convolution = false
+
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
+
+//  CHECK-SAME:     promote_operands = [0, 1]
+//  CHECK-SAME:     reduction = [0, 0, 0, 0, 1, 1, 1]
+//  CHECK-SAME:     subgroup = [1, 0, 0, 1, 0, 0, 0]
+//  CHECK-SAME:     workgroup = [16, 1, 1, 16, 0, 0, 0]


### PR DESCRIPTION
This PR removes some constraints for lowering through direct convolution pipeline, and closes the issue [#22032](https://github.com/iree-org/iree/issues/22032).

- With fix https://github.com/iree-org/iree/pull/22821, now channel first conv layouts, e.g., `nchw` or `chwn` can lower through direct convolution. Adding more tests to validate that.
- As non-unit dilation is natively supported in `GPUTileAndConvertConvToMatmul`, removing the constraint for that as well. 