### PR TITLE
[Stream] Preserve borrowed imports during copy elision

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -662,13 +662,15 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
           exportOp.getArgAttrOfType<TypeAttr>(argIndex, "iree.abi.encoding");
       auto consumeAttr =
           exportOp.getArgAttrOfType<UnitAttr>(argIndex, "iree.abi.consume");
+      auto outputAttr =
+          exportOp.getArgAttrOfType<IntegerAttr>(argIndex, "iree.abi.output");
       auto affinityAttr = exportOp.getArgAttr(argIndex, "iree.abi.affinity");
       auto argName = inferArgumentName(entryBuilder.getContext(), argIndex,
                                        exportOp.getArgAttrDict(argIndex));
       auto tensorImportOp = IREE::HAL::TensorImportOp::create(
           entryBuilder, arg.getLoc(), oldType, arg,
           fallback(encodingAttr, TypeAttr::get(oldType)),
-          /*consume=*/consumeAttr ? true : false, waitFence, argName,
+          /*consume=*/consumeAttr || outputAttr, waitFence, argName,
           fallback(affinityAttr, defaultAffinityAttr));
       arguments.push_back(tensorImportOp.getTarget());
     } else {

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
@@ -127,6 +127,29 @@ util.func public @outputStorage(%arg0: tensor<?x8x8x3xf32>, %ret1: !hal.buffer {
 
 // -----
 
+// Tests that tensor-typed output storage arguments are imported as consumed.
+// The caller is explicitly providing storage to overwrite and return, so the
+// stream program may update that storage in-place.
+
+// CHECK-LABEL: util.func public @outputTensorStorage
+//  CHECK-SAME: (%[[ARG0:[a-z0-9]+]]: !hal.buffer_view, %[[STORAGE:[a-z0-9]+]]: !hal.buffer_view) -> !hal.buffer_view
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] "input0" : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[STORAGE_TENSOR:.+]] = hal.tensor.import consume %[[STORAGE]] "input1" : !hal.buffer_view -> tensor<4xf32>
+//  CHECK-NEXT:   %[[RET_TENSOR:.+]] = util.call @_outputTensorStorage(%[[ARG0_TENSOR]], %[[STORAGE_TENSOR]])
+//  CHECK-NEXT:   %[[RET_ALIAS:.+]] = hal.tensor.alias %[[RET_TENSOR]] : tensor<4xf32> to %[[STORAGE]] : !hal.buffer_view
+//  CHECK-NEXT:   %[[RET_VIEW:.+]] = hal.tensor.export %[[RET_ALIAS]] "output0" : tensor<4xf32> -> !hal.buffer_view
+//  CHECK-NEXT:   util.return %[[RET_VIEW]]
+//  CHECK-NEXT: }
+
+// CHECK-LABEL: util.func private @_outputTensorStorage(
+// CHECK-SAME: hal.abi.convention = #hal.abi.convention<synchronous>
+util.func public @outputTensorStorage(%arg0: tensor<4xf32>, %storage: tensor<4xf32> {iree.abi.output = 0 : index}) -> tensor<4xf32> {
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
 // Tests that functions already wrapped (iree.abi.stub present) are ignored.
 
 // CHECK-LABEL: util.func public @wrappedAlready

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -246,7 +246,8 @@ struct ConvertTensorAliasOp
     auto importOp = IREE::Stream::TensorImportOp::create(
         rewriter, op.getLoc(), externalType, adaptor.getStorage().front(),
         TypeAttr::get(sourceType), convertedSourceDims, storageSize,
-        /*consume=*/UnitAttr{}, executionAffinityAttr);
+        /*consume=*/UnitAttr::get(rewriter.getContext()),
+        executionAffinityAttr);
 
     // Await the fence, if needed. When not specified the storage is assumed to
     // be immediately available.

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -114,7 +114,7 @@ util.func public @exportBufferView(%tensor: tensor<?x?x4xf32>, %dim0: index, %di
 // CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[DIM0:.+]]: index, %[[STORAGE:.+]]: !hal.buffer)
 util.func public @aliasStorage(%tensor: tensor<?x4xf32>, %dim0: index, %storage: !hal.buffer) -> tensor<?x4xf32> {
   // CHECK: %[[MIN_STORAGE_SIZE:.+]] = stream.tensor.sizeof tensor<?x4xf32>{%[[DIM0]]}
-  // CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import %[[STORAGE]] : !hal.buffer -> tensor<?x4xf32>{%[[DIM0]]} in !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
+  // CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import consume %[[STORAGE]] : !hal.buffer -> tensor<?x4xf32>{%[[DIM0]]} in !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[STORAGE_RESOURCE]][%c0 to %[[SIZE]]] : !stream.resource<*>{%[[SIZE]]} -> %[[STORAGE_RESOURCE]] as !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[SLICE:.+]] = stream.async.slice %[[UPDATE]][%c0 to %[[SIZE]]] : !stream.resource<external>{%[[MIN_STORAGE_SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
   // CHECK: %[[RESULT:.+]] = stream.async.clone %[[SLICE]] : !stream.resource<external>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
@@ -129,7 +129,7 @@ util.func public @aliasStorage(%tensor: tensor<?x4xf32>, %dim0: index, %storage:
 // CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[DIM0:.+]]: index, %[[STORAGE:.+]]: !hal.buffer, %[[FENCE:.+]]: !hal.fence)
 util.func public @aliasStorageAsync(%tensor: tensor<?x4xf32>, %dim0: index, %storage: !hal.buffer, %fence: !hal.fence) -> tensor<?x4xf32> {
   // CHECK-DAG: %[[MIN_STORAGE_SIZE:.+]] = stream.tensor.sizeof tensor<?x4xf32>{%[[DIM0]]}
-  // CHECK-DAG: %[[UNREADY_STORAGE:.+]] = stream.tensor.import %[[STORAGE]] : !hal.buffer -> tensor<?x4xf32>{%[[DIM0]]} in !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
+  // CHECK-DAG: %[[UNREADY_STORAGE:.+]] = stream.tensor.import consume %[[STORAGE]] : !hal.buffer -> tensor<?x4xf32>{%[[DIM0]]} in !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK-DAG: %[[TIMEPOINT:.+]] = stream.timepoint.import %[[FENCE]]
   // CHECK-DAG: %[[READY_STORAGE:.+]] = stream.timepoint.await %[[TIMEPOINT]] => %[[UNREADY_STORAGE]] : !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
   // CHECK: %[[UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[READY_STORAGE]][%c0 to %[[SIZE]]] : !stream.resource<*>{%[[SIZE]]} -> %[[READY_STORAGE]] as !stream.resource<external>{%[[MIN_STORAGE_SIZE]]}
@@ -209,7 +209,7 @@ util.func public @aliasStorageCrossDevice(%tensor: tensor<4xf32>, %storage: !hal
   //      CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[TENSOR]] : !stream.resource<*>{%[[SIZE]]}
   // CHECK-SAME:     -> to(#hal.device.promise<@dev_b>) !stream.resource<*>{%[[SIZE]]}
   //  CHECK-DAG: %[[STORAGE_SIZE:.+]] = stream.tensor.sizeof on(#hal.device.promise<@dev_b>) tensor<4xf32>
-  //      CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import on(#hal.device.promise<@dev_b>) %[[STORAGE]] :
+  //      CHECK: %[[STORAGE_RESOURCE:.+]] = stream.tensor.import on(#hal.device.promise<@dev_b>) consume %[[STORAGE]] :
   // CHECK-SAME:     !hal.buffer -> tensor<4xf32> in !stream.resource<external>{%[[STORAGE_SIZE]]}
   //      CHECK: %[[UPDATE:.+]] = stream.async.update on(#hal.device.promise<@dev_b>) %[[TRANSFER]], %[[STORAGE_RESOURCE]][%c0 to %[[SIZE]]] :
   // CHECK-SAME:     !stream.resource<*>{%[[SIZE]]} -> %[[STORAGE_RESOURCE]] as !stream.resource<external>{%[[STORAGE_SIZE]]}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -714,6 +714,15 @@ public:
     return mutationSemantics.isAssumedNotMutated();
   }
 
+  // Returns true if |value| may alias storage imported without consuming it.
+  // Such storage is caller-owned even when this SSA value is its last local
+  // use, so eliding a protective copy is only valid when the copy result is
+  // read-only.
+  bool containsBorrowedStorage(Value value) {
+    llvm::SmallPtrSet<Value, 8> visited;
+    return containsBorrowedStorage(value, visited);
+  }
+
   // Attempts to infer the affinity of |value| by walking up its defining ops
   // and checking for explicit affinity annotations or default affinities.
   // Returns nullptr if no affinity can be determined.
@@ -770,6 +779,55 @@ public:
   }
 
 private:
+  bool containsBorrowedStorage(Value value,
+                               llvm::SmallPtrSetImpl<Value> &visited) {
+    if (!visited.insert(value).second) {
+      return true;
+    }
+
+    bool foundBorrowedStorage = false;
+    auto traversalResult = explorer.walkDefiningOps(
+        value,
+        [&](OpResult result) {
+          Operation *op = result.getOwner();
+
+          // A non-consuming import borrows externally-owned storage. A
+          // consuming import transfers ownership to the stream program.
+          if (auto importOp = dyn_cast<IREE::Stream::TensorImportOp>(op)) {
+            foundBorrowedStorage = !importOp.getConsume();
+            return WalkResult::interrupt();
+          }
+
+          // Same-lifetime transfers are usage/affinity refinements and may be
+          // elided later, so preserve the source storage ownership. A
+          // lifetime-changing transfer materializes storage with distinct
+          // ownership semantics and stops the borrowed-storage chain.
+          if (auto transferOp = dyn_cast<IREE::Stream::AsyncTransferOp>(op)) {
+            auto sourceType = cast<IREE::Stream::ResourceType>(
+                transferOp.getSource().getType());
+            auto resultType =
+                cast<IREE::Stream::ResourceType>(result.getType());
+            if (sourceType.getLifetime() == resultType.getLifetime()) {
+              foundBorrowedStorage =
+                  containsBorrowedStorage(transferOp.getSource(), visited);
+            }
+            return foundBorrowedStorage ? WalkResult::interrupt()
+                                        : WalkResult::skip();
+          }
+
+          // Clones produce independent storage. If this clone remains, uses of
+          // its result do not mutate the original borrowed storage.
+          if (isa<IREE::Stream::AsyncCloneOp>(op)) {
+            return WalkResult::skip();
+          }
+
+          return WalkResult::advance();
+        },
+        TraversalBehavior::DEFAULT);
+    return foundBorrowedStorage ||
+           traversalResult == TraversalResult::INCOMPLETE;
+  }
+
   Explorer explorer;
   llvm::BumpPtrAllocator allocator;
   DFX::Solver solver;
@@ -866,12 +924,23 @@ static bool isSafeToElideCloneOp(IREE::Stream::AsyncCloneOp cloneOp,
                << "  ? clone source is a by-value arg; may elide\n");
   }
 
+  // A non-consuming import borrows caller-owned storage. If a clone of that
+  // storage is later mutated then the clone is semantically required even when
+  // the imported SSA value has no remaining local uses: without the clone, the
+  // mutation would be performed in-place on the caller's buffer.
+  bool resultSafe = analysis.isNeverMutated(cloneOp.getResult());
+  if (analysis.containsBorrowedStorage(cloneOp.getSource()) && !resultSafe) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "  - clone protects borrowed storage from mutation; cannot "
+                  "elide\n");
+    return false;
+  }
+
   // If neither source nor result is ever mutated anywhere in the program,
   // we can safely elide the clone because sharing the underlying buffer has no
   // observable effect. This extends the constant-to-constant analysis above to
   // all lifetime types - if no writes occur, reads can safely share buffers.
   bool sourceSafe = analysis.isNeverMutated(cloneOp.getSource());
-  bool resultSafe = analysis.isNeverMutated(cloneOp.getResult());
   if (sourceSafe && resultSafe) {
     LLVM_DEBUG(llvm::dbgs()
                << "  + source and result never mutated; can elide\n");

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_copies_tensor_import_consume.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_copies_tensor_import_consume.mlir
@@ -266,3 +266,119 @@ util.func public @mixed_consume_no_consume(%arg0: !util.buffer, %arg1: !util.buf
   // CHECK: util.return %[[FILL0]], %[[FILL1]], %[[IMPORT1]]
   util.return %fill0, %fill1, %import1 : !stream.resource<external>, !stream.resource<external>, !stream.resource<external>
 }
+
+// -----
+
+// Tests that a non-consuming import remains borrowed even when the imported SSA
+// value has no uses after the clone. The clone protects caller-owned storage
+// from the tied fill mutation and must not be elided by one-use reasoning.
+
+// CHECK-LABEL: @borrowed_import_single_use_preserves_mutating_clone
+// CHECK-SAME: (%[[BUFFER:[^:]+]]: !util.buffer)
+util.func public @borrowed_import_single_use_preserves_mutating_clone(%arg0: !util.buffer) -> !stream.resource<external> {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[IMPORT:.+]] = stream.tensor.import %[[BUFFER]]
+  %import = stream.tensor.import %arg0 : !util.buffer -> tensor<f32> in !stream.resource<external>{%c100}
+  // CHECK: %[[CLONE:.+]] = stream.async.clone %[[IMPORT]]
+  %clone = stream.async.clone %import : !stream.resource<external>{%c100} -> !stream.resource<external>{%c100}
+  // CHECK: %[[FILL:.+]] = stream.async.fill %c123_i32, %[[CLONE]]
+  %fill = stream.async.fill %c123_i32, %clone[%c0 to %c100 for %c100] : i32 -> %clone as !stream.resource<external>{%c100}
+  // CHECK: util.return %[[FILL]]
+  util.return %fill : !stream.resource<external>
+}
+
+// -----
+
+// Tests that borrowed storage is preserved across call boundaries. Even though
+// the imported SSA value is a last-use call operand, the callee argument still
+// aliases non-consuming imported storage and needs its protective clone.
+
+// CHECK-LABEL: util.func private @borrowed_import_last_use_callee
+// CHECK-SAME: (%[[ARG:.+]]: !stream.resource<external>)
+util.func private @borrowed_import_last_use_callee(%arg: !stream.resource<external>) -> !stream.resource<external> {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[CLONE:.+]] = stream.async.clone %[[ARG]]
+  %clone = stream.async.clone %arg : !stream.resource<external>{%c100} -> !stream.resource<external>{%c100}
+  // CHECK: %[[FILL:.+]] = stream.async.fill %c123_i32, %[[CLONE]]
+  %fill = stream.async.fill %c123_i32, %clone[%c0 to %c100 for %c100] : i32 -> %clone as !stream.resource<external>{%c100}
+  // CHECK: util.return %[[FILL]]
+  util.return %fill : !stream.resource<external>
+}
+
+// CHECK-LABEL: @borrowed_import_last_use_caller
+// CHECK-SAME: (%[[BUFFER:[^:]+]]: !util.buffer)
+util.func public @borrowed_import_last_use_caller(%arg0: !util.buffer) -> !stream.resource<external> {
+  %c100 = arith.constant 100 : index
+  // CHECK: %[[IMPORT:.+]] = stream.tensor.import %[[BUFFER]]
+  %import = stream.tensor.import %arg0 : !util.buffer -> tensor<f32> in !stream.resource<external>{%c100}
+  // CHECK: %[[RESULT:.+]] = util.call @borrowed_import_last_use_callee(%[[IMPORT]])
+  %result = util.call @borrowed_import_last_use_callee(%import) : (!stream.resource<external>) -> !stream.resource<external>
+  // CHECK: util.return %[[RESULT]]
+  util.return %result : !stream.resource<external>
+}
+
+// -----
+
+// Tests that borrowed imports still permit clone elision when the clone result
+// is read-only. Non-consuming imports only require protective clones when the
+// clone would otherwise shield caller-owned storage from mutation.
+
+stream.executable private @ex_borrowed_readonly {
+  stream.executable.export public @read_only workgroups() -> (index, index, index) {
+    %c1 = arith.constant 1 : index
+    stream.return %c1, %c1, %c1 : index, index, index
+  }
+}
+
+// CHECK-LABEL: @borrowed_import_readonly_elides_clone
+// CHECK-SAME: (%[[BUFFER:[^:]+]]: !util.buffer)
+util.func public @borrowed_import_readonly_elides_clone(%arg0: !util.buffer) -> !stream.resource<external> {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  // CHECK: %[[IMPORT:.+]] = stream.tensor.import %[[BUFFER]]
+  %import = stream.tensor.import %arg0 : !util.buffer -> tensor<f32> in !stream.resource<external>{%c100}
+  // CHECK-NOT: stream.async.clone
+  %clone = stream.async.clone %import : !stream.resource<external>{%c100} -> !stream.resource<external>{%c100}
+  // CHECK: %[[RESULT:.+]] = stream.async.dispatch @ex_borrowed_readonly::@read_only(%[[IMPORT]]
+  %result = stream.async.dispatch @ex_borrowed_readonly::@read_only(%clone[%c0 to %c100 for %c100]) : (!stream.resource<external>{%c100}) -> !stream.resource<external>{%c100}
+  // CHECK: util.return %[[RESULT]]
+  util.return %result : !stream.resource<external>
+}
+
+// -----
+
+// Tests that borrowed storage remains borrowed through a same-lifetime transfer
+// that topology analysis cannot remove. The transfer may move the storage
+// between devices, but it does not create an owned copy with a new lifetime.
+
+module @test attributes {
+  stream.topology = #hal.device.topology<links = [
+    (@dev_a -> @dev_c = {})
+  ]>
+} {
+
+// CHECK-LABEL: @borrowed_import_transfer_preserves_mutating_clone
+// CHECK-SAME: (%[[BUFFER:[^:]+]]: !util.buffer)
+util.func public @borrowed_import_transfer_preserves_mutating_clone(%arg0: !util.buffer) -> !stream.resource<external> {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[IMPORT:.+]] = stream.tensor.import on(#hal.device.promise<@dev_a>) %[[BUFFER]]
+  %import = stream.tensor.import on(#hal.device.promise<@dev_a>) %arg0 : !util.buffer -> tensor<f32> in !stream.resource<external>{%c100}
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[IMPORT]]
+  // CHECK-SAME: from(#hal.device.promise<@dev_a>) -> to(#hal.device.promise<@dev_c>)
+  %transfer = stream.async.transfer %import : !stream.resource<external>{%c100}
+      from(#hal.device.promise<@dev_a>) -> to(#hal.device.promise<@dev_c>) !stream.resource<external>{%c100}
+  // CHECK: %[[CLONE:.+]] = stream.async.clone %[[TRANSFER]]
+  %clone = stream.async.clone %transfer : !stream.resource<external>{%c100} -> !stream.resource<external>{%c100}
+  // CHECK: %[[FILL:.+]] = stream.async.fill %c123_i32, %[[CLONE]]
+  %fill = stream.async.fill %c123_i32, %clone[%c0 to %c100 for %c100] : i32 -> %clone as !stream.resource<external>{%c100}
+  // CHECK: util.return %[[FILL]]
+  util.return %fill : !stream.resource<external>
+}
+
+} // module


### PR DESCRIPTION
Fixes #16168.

This is a follow-up/root-cause fix after #22739. That PR taught copy elision about the positive ownership case: `stream.tensor.import consume` transfers ownership into the program, so later tied mutations may legally reuse imported storage. The remaining bug is the inverse ownership case: a non-consuming `stream.tensor.import` borrows caller-owned storage, and local SSA last-use or one-use information does not prove that mutating the underlying storage is legal.

`ElideAsyncCopies` now tracks whether a clone source may contain non-consuming imported storage, including through call boundaries, tied pass-through ops, and same-lifetime transfers. Clones protecting borrowed storage are kept when the clone result is mutated; clones from consuming imports and read-only clone results remain elidable.

This is a correctness fix with a conservative safety shape. For well-formed IR, the new check only vetoes clone elision when the source may contain borrowed imported storage and the clone result is mutated. If analysis is incomplete or cyclic, it keeps the clone instead of guessing. That can miss an optimization, but should not introduce new aliasing wrong-code.

The main contract to preserve is on producers of `consume`: they must only mark imports as consumed when ownership transfer is actually valid. Paths that want zero-copy in-place mutation of imported storage now need to say so explicitly with `consume`; otherwise the compiler preserves the protective copy.

The materialized-copy tests that intentionally model in-place mutation of imported storage now mark that ownership transfer explicitly with `consume`.
