### PR TITLE
Add CDNA3 test filtering to CI

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi325.yml
+++ b/.github/workflows/pkgci_test_amd_mi325.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           CTEST_PARALLEL_LEVEL: 2
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
+          IREE_AMD_CDNA3_TESTS_DISABLE: 0
           IREE_AMD_RDNA3_TESTS_DISABLE: 1
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -40,6 +40,8 @@ export IREE_VULKAN_F16_DISABLE="${IREE_VULKAN_F16_DISABLE:-1}"
 export IREE_NVIDIA_GPU_TESTS_DISABLE="${IREE_NVIDIA_GPU_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require SM80 Nvidia GPU.
 export IREE_NVIDIA_SM80_TESTS_DISABLE="${IREE_NVIDIA_SM80_TESTS_DISABLE:-1}"
+# Respect the user setting, but default to skipping tests that require CDNA3 AMD GPU.
+export IREE_AMD_CDNA3_TESTS_DISABLE="${IREE_AMD_CDNA3_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require RDNA3 AMD GPU.
 export IREE_AMD_RDNA3_TESTS_DISABLE="${IREE_AMD_RDNA3_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require RDNA4 AMD GPU.
@@ -95,6 +97,9 @@ if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
 fi
 if (( IREE_NVIDIA_SM80_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-sm80$")
+fi
+if (( IREE_AMD_CDNA3_TESTS_DISABLE == 1 )); then
+  label_exclude_args+=("^requires-gpu-cdna3$")
 fi
 if (( IREE_AMD_RDNA3_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-rdna3$")


### PR DESCRIPTION
Tests with `requires-gpu-cdna3` label lacked the filtering mechanism in `ctest_all.sh`. It could leak to run on non-cdna3 machines.

This adds `IREE_AMD_CDNA3_TESTS_DISABLE`: disabled by default, excludes labeled tests when set.

It should also enables CDNA3 tests in MI325 workflow.