### PR TITLE
Fix deadlock in `ROCMDialect::getMlirUKernels` by disabling `verifyAfterParse`

### DIFF
--- a/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMBuiltinManager.cpp
+++ b/compiler/plugins/target/ROCM/Dialect/ROCM/IR/ROCMBuiltinManager.cpp
@@ -31,9 +31,10 @@ FailureOr<ModuleOp> ROCMDialect::getOrLoadBuiltinModule(StringRef path) {
   // We update the storage for the library regardless of whether parsing
   // succeeds so that other threads don't have to retry.
   OwningOpRef<ModuleOp> &parsedLibrary = builtinModules[path];
-
-  parsedLibrary = parseSourceString<mlir::ModuleOp>(maybeBuiltin.value(), ctx,
-                                                    /*sourceName=*/path);
+  ParserConfig config(ctx, /*verifyAfterParse=*/false);
+  parsedLibrary =
+      parseSourceString<mlir::ModuleOp>(maybeBuiltin.value(), config,
+                                        /*sourceName=*/path);
   if (!parsedLibrary) {
     return failure();
   }


### PR DESCRIPTION
This is another take on https://github.com/iree-org/iree/pull/22843, see the discussion there and the closing https://github.com/iree-org/iree/pull/22843#issuecomment-3621564372.

As suggested by Krzysztof, we can simply opt out of `verifyAfterParse`. The downside is that we're crossing fingers that nothing else than verifier will yield; in particular, we're relying on the parsing itself not having the same flavor of threading.

But at this point, we are pretty desperate for a fix, and the alternative described in the comment linked above adds substantial complexity.

Fixes https://github.com/iree-org/iree/issues/22842.