### PR TITLE
[Encoding] Add verifier for iree_encoding.layouts

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -93,6 +93,19 @@ Value LayoutAttr::calculateStorageSizeInBytes(Location loc, OpBuilder &builder,
   return res;
 }
 
+LogicalResult LayoutAttr::verifyEncoding(
+    llvm::ArrayRef<int64_t> shape, mlir::Type elementType,
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
+  for (Attribute attr : getLayouts()) {
+    auto verifiableAttr = dyn_cast<VerifiableTensorEncoding>(attr);
+    if (verifiableAttr &&
+        failed(verifiableAttr.verifyEncoding(shape, elementType, emitError))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
 //===---------------------------------------------------------------------===//
 // iree_encoding.packed_storage
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -51,7 +51,8 @@ def LayoutAttr :
         "isSerialized",
         "isIdentityLayout",
         "calculateStorageSizeInBytes",
-      ]>
+      ]>,
+      DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
     ]> {
   let mnemonic = "layout";
   let assemblyFormat = "`<` $layouts `>`";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -207,3 +207,12 @@ func.func @negative_packed_storage_superbyte(%arg0: tensor<?x4xi12, #iree_encodi
 func.func @negative_packed_storage_non_po2(%arg0: tensor<?x4xi3, #iree_encoding.packed_storage>) -> tensor<?x4xi3, #iree_encoding.packed_storage> {
   return %arg0 : tensor<?x4xi3, #iree_encoding.packed_storage>
 }
+
+// -----
+
+// Test the verification of `#iree_encoding.layout`. `packed_storage` is just used as a utility here to check that the error gets propagated.
+
+// expected-error @+1 {{bit-width of the element type is 32 but packed_storage is currently only supported for sub-byte types}}
+func.func @negative_layout_packed_storage_superbyte(%arg0: tensor<?x4xf32, #iree_encoding.layout<[#iree_encoding.packed_storage]>>) -> tensor<?x4xf32, #iree_encoding.layout<[#iree_encoding.packed_storage]>> {
+  return %arg0 : tensor<?x4xf32, #iree_encoding.layout<[#iree_encoding.packed_storage]>>
+}


### PR DESCRIPTION
Related to https://github.com/iree-org/iree/pull/22838, this PR adds a verifier for `#iree_encoding.layouts`.