### PR TITLE
[Torch Models] Fix SDXL golden dispatch counts

### DIFF
--- a/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/clip_compstat_gfx942.json
@@ -5,6 +5,6 @@
     "gfx942"
   ],
   "module": "sdxl/modules/clip_gfx942",
-  "golden_dispatch_count": 790,
+  "golden_dispatch_count": 792,
   "golden_binary_size": 460000
 }

--- a/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942_v2.json
+++ b/tests/external/iree-test-suites/torch_models/sdxl/punet_compstat_gfx942_v2.json
@@ -6,6 +6,6 @@
     "punet"
   ],
   "module": "sdxl/modules/punet_gfx942_v2",
-  "golden_dispatch_count" : 1530,
+  "golden_dispatch_count" : 1531,
   "golden_binary_size" : 2000000
 }


### PR DESCRIPTION
Fixes golden dispatch counts that were not updated in https://github.com/iree-org/iree/pull/22819 because the PR wasn't run with  `ci-extra: test_torch`.





ci-extra: test_torch