### PR TITLE
[Codegen][GPU] Apply FoldTensorEmptyPatterns with single use only

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -511,7 +511,8 @@ combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
                             CombineRelayoutOpsControlFnRef controlFn) {
   // Sink relayout operations to the end of the funcOp.
   RewritePatternSet propagationPatterns(ctx);
-  tensor::populateFoldTensorEmptyPatterns(propagationPatterns);
+  tensor::populateFoldTensorEmptyPatterns(propagationPatterns,
+                                          /*foldSingleUseOnly=*/true);
   tensor::ExpandShapeOp::getCanonicalizationPatterns(propagationPatterns, ctx);
   tensor::CollapseShapeOp::getCanonicalizationPatterns(propagationPatterns,
                                                        ctx);
@@ -697,7 +698,8 @@ struct CombineLayoutTransformationPass final
       RewritePatternSet patterns(context);
       populateFuseTilableForallConsumersPattern(patterns);
       scf::ForallOp::getCanonicalizationPatterns(patterns, context);
-      tensor::populateFoldTensorEmptyPatterns(patterns);
+      tensor::populateFoldTensorEmptyPatterns(patterns,
+                                              /*foldSingleUseOnly=*/true);
       if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -377,7 +377,8 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     patterns.add<FuseCollapseShapeConsumers>(context);
     patterns.add<FuseExtractSliceConsumers>(context);
     populateSwapExtractWithExpandPattern(patterns);
-    tensor::populateFoldTensorEmptyPatterns(patterns);
+    tensor::populateFoldTensorEmptyPatterns(patterns,
+                                            /*foldSingleUseOnly=*/true);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp->emitOpError("failed to apply fusion + hoisting patterns (set 2)");
@@ -392,7 +393,8 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     RewritePatternSet patterns(context);
     patterns.add<FuseTilableDestinationProducers>(context);
     patterns.add<FuseTilableSliceProducers>(context);
-    tensor::populateFoldTensorEmptyPatterns(patterns);
+    tensor::populateFoldTensorEmptyPatterns(patterns,
+                                            /*foldSingleUseOnly=*/true);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp->emitOpError("failed to apply fusion + hoisting patterns (set 3)");


### PR DESCRIPTION
This PR is to fix https://github.com/iree-org/iree/issues/22833.

Without this fix, the `extract_slice` was fused into the scf.forall loop while generating an extra empty tensor inside the loop. As a result, it lowered to an unnecessary allocation after bufferization.