### PR TITLE
[Encoding] Add resolver swizzle verification

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.cpp
@@ -7,9 +7,41 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/DialectImplementation.h"
 
 // clang-format off
 #define GET_TYPEDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.cpp.inc" // IWYU pragma: export
 // clang-format on
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+int64_t TileSwizzle::getExpandedSize() const {
+  int64_t totalExpandedDims = 0;
+  for (const ExpandShapeDimVectorType &expandDims : expandShape) {
+    totalExpandedDims += static_cast<int64_t>(expandDims.size());
+  }
+  return totalExpandedDims;
+}
+
+LogicalResult
+TileSwizzle::verify(function_ref<InFlightDiagnostic()> emitError) const {
+  int64_t totalExpandedDims = getExpandedSize();
+
+  // The permutation size must match the total expanded dimensions.
+  if (static_cast<int64_t>(permutation.size()) != totalExpandedDims) {
+    return emitError() << "swizzle permutation size (" << permutation.size()
+                       << ") does not match total expanded dimensions ("
+                       << totalExpandedDims << ")";
+  }
+
+  // Check that permutation is valid.
+  if (!isPermutationVector(permutation)) {
+    return emitError() << "swizzle permutation is not a valid permutation";
+  }
+
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/Support/LLVM.h"
 
 // clang-format off
@@ -48,7 +49,7 @@ struct TileSwizzle {
       // "unrolled" across subgroups. Such dimensions are cross-subgroup, so in
       // particular they are cross-thread.
       CrossThread,
-      // This dimensions is across intrinsics, as in, actual instructions in the
+      // This dimension is across intrinsics, as in, actual instructions in the
       // generated code. In other words, it is an actual unrolling factor,
       // resulting in this many more instructions being generated and executed
       // on each thread/subgroup.
@@ -82,8 +83,8 @@ struct TileSwizzle {
         : kind(kind), size(size), distributionSize(distributionSize) {}
   };
 
-  using ExpandShapeDimVectorType = llvm::SmallVector<Dim, 4>;
-  using ExpandShapeType = llvm::SmallVector<ExpandShapeDimVectorType>;
+  using ExpandShapeDimVectorType = SmallVector<Dim, 4>;
+  using ExpandShapeType = SmallVector<ExpandShapeDimVectorType>;
 
   // This vector-of-vectors contains all the information needed to generate
   // a `tensor.expand_shape` creating additional internal dimensions into the
@@ -96,7 +97,15 @@ struct TileSwizzle {
   // to generate a `linalg.transpose` changing the layout of the tile. For
   // example, permutation[0] dictates which of the expanded dimensions becomes
   // the leading dimension of the layout.
-  llvm::SmallVector<int64_t> permutation;
+  SmallVector<int64_t> permutation;
+
+  // Returns the total number of expanded dimensions.
+  int64_t getExpandedSize() const;
+
+  // Verifies consistency of the tile swizzle:
+  // - The permutation size must match the total number of expanded dimensions.
+  // - The permutation indices must be valid (within bounds and unique).
+  LogicalResult verify(function_ref<InFlightDiagnostic()> emitError) const;
 };
 
 using ScalableTileFlags = SmallVector<bool>;


### PR DESCRIPTION
Add swizzle verification as a follow up on the encoding verification added in https://github.com/iree-org/iree/pull/22838