### PR TITLE
[Codegen] Do not swap extract_slice and collapse_shape for a special case

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -672,7 +672,7 @@ func.func @no_swap_collapse_shape_with_extract_slice_3(%arg0: tensor<8x1x4x16x16
   return %1 : tensor<512x48x48xf32>
 }
 
-// No swap would happen when the user of extract_slice is a tensor.parallel_insert_slice.
+// No swap would happen when extract_slice and collapse_shape ops are within the same block.
 // NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice_3
 //       NORM-REDUCTION:   scf.forall
 //       NORM-REDUCTION:     linalg.copy

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -639,7 +639,7 @@ func.func @no_swap_collapse_shape_with_extract_slice_2(%arg0: tensor<32x2x2x16xf
 // -----
 
 #config = #iree_gpu.lowering_config<{reduction = [0, 30]}>
-func.func @no_swap_collapse_shape_with_extract_slice(%arg0: tensor<288x3x3x32xf32>) -> tensor<2592x32xf32> {
+func.func @no_swap_collapse_shape_with_extract_slice_dynamic(%arg0: tensor<288x3x3x32xf32>) -> tensor<2592x32xf32> {
   %collapsed = tensor.collapse_shape %arg0 [[0, 1, 2], [3]] : tensor<288x3x3x32xf32> into tensor<2592x32xf32>
   %empty = tensor.empty() : tensor<2592x32xf32>
   %0 = linalg.copy {lowering_config = #config} ins(%collapsed : tensor<2592x32xf32>) outs(%empty : tensor<2592x32xf32>) -> tensor<2592x32xf32>
@@ -647,12 +647,37 @@ func.func @no_swap_collapse_shape_with_extract_slice(%arg0: tensor<288x3x3x32xf3
 }
 
 // No swap would happen when both the collapsed size and offset are dynamic after tiling.
-// NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice
+// NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice_dynamic
 //       NORM-REDUCTION:   tensor.collapse_shape
 //       NORM-REDUCTION:   scf.for
 //       NORM-REDUCTION:     tensor.extract_slice {{.*}} tensor<2592x32xf32> to tensor<2592x?xf32>
 //   NORM-REDUCTION-NOT:     tensor.collapse_shape
 //       NORM-REDUCTION:     linalg.copy
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 0, 1]}>
+func.func @no_swap_collapse_shape_with_extract_slice_3(%arg0: tensor<8x1x4x16x16xf32>) -> tensor<512x48x48xf32> {
+  %0 = tensor.empty() : tensor<512x48x48xf32>
+  %1 = scf.forall (%arg1, %arg2, %arg3) in (4, 48, 1) shared_outs(%arg4 = %0) -> (tensor<512x48x48xf32>) {
+    %2 = tensor.empty() : tensor<8x16x1x4x16xf32>
+    %transposed = linalg.transpose ins(%arg0 : tensor<8x1x4x16x16xf32>) outs(%2 : tensor<8x16x1x4x16xf32>) permutation = [0, 3, 1, 2, 4]
+    %3 = linalg.copy {lowering_config = #config} ins(%transposed : tensor<8x16x1x4x16xf32>) outs(%2 : tensor<8x16x1x4x16xf32>) -> tensor<8x16x1x4x16xf32>
+    %collapsed = tensor.collapse_shape %3 [[0, 1], [2], [3, 4]] : tensor<8x16x1x4x16xf32> into tensor<128x1x64xf32>
+    %extracted_slice = tensor.extract_slice %collapsed[0, 0, 0] [128, 1, 48] [1, 1, 1] : tensor<128x1x64xf32> to tensor<128x1x48xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %extracted_slice into %arg4[0, 0, 0] [128, 1, 48] [1, 1, 1] : tensor<128x1x48xf32> into tensor<512x48x48xf32>
+    }
+  } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+  return %1 : tensor<512x48x48xf32>
+}
+
+// No swap would happen when the user of extract_slice is a tensor.parallel_insert_slice.
+// NORM-REDUCTION-LABEL: func.func @no_swap_collapse_shape_with_extract_slice_3
+//       NORM-REDUCTION:   scf.forall
+//       NORM-REDUCTION:     linalg.copy
+//       NORM-REDUCTION:     tensor.collapse_shape
+//       NORM-REDUCTION:     tensor.extract_slice
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -445,6 +445,15 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
     }
   });
 
+  // TODO(vivian): remove this check once we have a better solution on fusion of
+  // extract_slice with scf.forall loop.
+  for (Operation *user : sliceOp->getUsers()) {
+    if (isa<tensor::ParallelInsertSliceOp>(user)) {
+      return rewriter.notifyMatchFailure(
+          sliceOp, "unsupported: user is tensor.parallel_insert_slice");
+    }
+  }
+
   // The tensor.extract_slice before applying the pattern works on the result
   // of the tensor.collapse_shape, so variables (i.e. inputs for
   // ExtractSliceOp) referring to the state before applying the pattern are

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -445,13 +445,14 @@ swapCollapseShapeWithSlice(RewriterBase &rewriter,
     }
   });
 
-  // TODO(vivian): remove this check once we have a better solution on fusion of
+  // Limit the pattern to work with extract_slice and collapse_shape ops in
+  // different blocks.
+  // TODO(vivian): remove this check once we have a better handle on fusion of
   // extract_slice with scf.forall loop.
-  for (Operation *user : sliceOp->getUsers()) {
-    if (isa<tensor::ParallelInsertSliceOp>(user)) {
-      return rewriter.notifyMatchFailure(
-          sliceOp, "unsupported: user is tensor.parallel_insert_slice");
-    }
+  if (sliceOp->getBlock() == collapseShapeOp->getBlock()) {
+    return rewriter.notifyMatchFailure(
+        sliceOp, "unsupported: extract_slice and collapse_shape ops are within "
+                 "the same block");
   }
 
   // The tensor.extract_slice before applying the pattern works on the result


### PR DESCRIPTION
This is a stop gap fix for https://github.com/iree-org/iree/issues/22833.

In this special case, the `collapse_shape` is from `unpack` op decomposition and there is no benefit to swap it with `extract_slice`. `collapse_shape` is then used as a blocker to avoid fusing `extract_slice` into `scf.forall`. Otherwise, an extra private allocation may be created. Some attempts were made to remove the extra `tensor.empty`, however, some other tests would fail as shown in https://github.com/iree-org/iree/pull/22861.