### PR TITLE
(Do not review) Play with transparent huge pages

### DIFF
--- a/runtime/src/iree/io/file_contents.c
+++ b/runtime/src/iree/io/file_contents.c
@@ -303,11 +303,12 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_map(
       host_allocator, sizeof(*contents), (void**)&contents);
 
   if (iree_status_is_ok(status)) {
-    status =
-        iree_io_file_map_view(handle, access, 0, IREE_HOST_SIZE_MAX,
-                              IREE_IO_FILE_MAPPING_FLAG_PRIVATE |
-                                  IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
-                              host_allocator, &contents->mapping);
+    status = iree_io_file_map_view(
+        handle, access, 0, IREE_HOST_SIZE_MAX,
+        IREE_IO_FILE_MAPPING_FLAG_PRIVATE |
+            IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES |
+            IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
+        host_allocator, &contents->mapping);
   }
 
   iree_io_file_handle_release(handle);

--- a/runtime/src/iree/io/file_handle.c
+++ b/runtime/src/iree/io/file_handle.c
@@ -724,6 +724,13 @@ static iree_status_t iree_io_platform_map_file_view(
     advice |= MADV_DONTDUMP;
   }
 #endif  // MADV_DONTDUMP
+#if defined(MADV_HUGEPAGE)
+  if (iree_all_bits_set(flags,
+                        IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES)) {
+    advice |= MADV_HUGEPAGE;
+  }
+#endif  // MADV_HUGEPAGE
+
   if (advice) {
     madvise(ptr, adjusted_length, advice);
   }

--- a/runtime/src/iree/io/file_handle.h
+++ b/runtime/src/iree/io/file_handle.h
@@ -277,6 +277,12 @@ enum iree_io_file_mapping_flag_bits_t {
   //
   // Implemented by MAP_PRIVATE, where available.
   IREE_IO_FILE_MAPPING_FLAG_PRIVATE = 1ull << 3,
+
+  // Hint the OS to use large pages, but do not require it like
+  // IREE_IO_FILE_MAPPING_FLAG_LARGE_PAGES does. On linux, this is implemented
+  // by the "transparent huge pages" feature, madvise(MADV_HUGEPAGE), and is
+  // more widely enabled than MAP_HUGETLB.
+  IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES = 1ull << 4,
 };
 
 // A mapped file view into host memory.

--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -736,10 +736,12 @@ IREE_API_EXPORT iree_status_t iree_io_parse_gguf_index(
   // in the index.
   iree_io_file_mapping_t* file_mapping = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_io_file_map_view(file_handle, IREE_IO_FILE_ACCESS_READ, 0,
-                                IREE_HOST_SIZE_MAX,
-                                IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
-                                host_allocator, &file_mapping));
+      z0, iree_io_file_map_view(
+              file_handle, IREE_IO_FILE_ACCESS_READ, 0, IREE_HOST_SIZE_MAX,
+              IREE_IO_FILE_MAPPING_FLAG_PRIVATE |
+                  IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES |
+                  IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
+              host_allocator, &file_mapping));
 
   iree_status_t status = iree_io_parse_gguf_index_from_memory(
       file_handle, iree_io_file_mapping_contents_ro(file_mapping), index);

--- a/runtime/src/iree/io/formats/irpa/irpa_parser.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser.c
@@ -331,10 +331,12 @@ IREE_API_EXPORT iree_status_t iree_io_parse_irpa_index(
   // in the index.
   iree_io_file_mapping_t* file_mapping = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_io_file_map_view(file_handle, IREE_IO_FILE_ACCESS_READ, 0,
-                                IREE_HOST_SIZE_MAX,
-                                IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
-                                host_allocator, &file_mapping));
+      z0, iree_io_file_map_view(
+              file_handle, IREE_IO_FILE_ACCESS_READ, 0, IREE_HOST_SIZE_MAX,
+              IREE_IO_FILE_MAPPING_FLAG_PRIVATE |
+                  IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES |
+                  IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
+              host_allocator, &file_mapping));
 
   iree_status_t status = iree_io_parse_irpa_index_from_memory(
       file_handle, iree_io_file_mapping_contents_ro(file_mapping),

--- a/runtime/src/iree/io/formats/safetensors/safetensors_parser.c
+++ b/runtime/src/iree/io/formats/safetensors/safetensors_parser.c
@@ -514,10 +514,12 @@ IREE_API_EXPORT iree_status_t iree_io_parse_safetensors_index(
   // implementations.
   iree_io_file_mapping_t* file_mapping = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_io_file_map_view(file_handle, IREE_IO_FILE_ACCESS_READ, 0,
-                                IREE_HOST_SIZE_MAX,
-                                IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
-                                host_allocator, &file_mapping));
+      z0, iree_io_file_map_view(
+              file_handle, IREE_IO_FILE_ACCESS_READ, 0, IREE_HOST_SIZE_MAX,
+              IREE_IO_FILE_MAPPING_FLAG_PRIVATE |
+                  IREE_IO_FILE_MAPPING_FLAG_TRANSPARENT_LARGE_PAGES |
+                  IREE_IO_FILE_MAPPING_FLAG_EXCLUDE_FROM_DUMPS,
+              host_allocator, &file_mapping));
 
   iree_status_t status = iree_io_parse_safetensors_index_from_memory(
       file_handle, iree_io_file_mapping_contents_ro(file_mapping), index);


### PR DESCRIPTION
This fails at the moment with `madvise` returning `EINVAL`, but this could change in the future with filesystems gaining support for huge pages. This is potentially a large performance improvement, so it's worth monitoring. https://discord.com/channels/689900678990135345/760577505840463893/1448036330591490293