### PR TITLE
[bindings] Add `iree_tensor_ext` to python bindings

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -118,6 +118,16 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME iree_gpu
 )
 
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT IREEPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
+  TD_FILE dialects/TensorExtBinding.td
+  GEN_ENUM_BINDINGS
+  SOURCES dialects/iree_tensor_ext.py
+  DIALECT_NAME iree_tensor_ext
+)
+
+
 declare_mlir_dialect_extension_python_bindings(
   ADD_TO_PARENT IREEPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"

--- a/compiler/bindings/python/iree/compiler/dialects/TensorExtBinding.td
+++ b/compiler/bindings/python/iree/compiler/dialects/TensorExtBinding.td
@@ -1,0 +1,12 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TENSOR_EXT_OPS
+#define PYTHON_BINDINGS_TENSOR_EXT_OPS
+
+include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td"
+
+#endif // PYTHON_BINDINGS_TENSOR_EXT_OPS

--- a/compiler/bindings/python/iree/compiler/dialects/iree_tensor_ext.py
+++ b/compiler/bindings/python/iree/compiler/dialects/iree_tensor_ext.py
@@ -1,0 +1,8 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._iree_tensor_ext_ops_gen import *
+from ._iree_tensor_ext_enum_gen import *

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -58,6 +58,7 @@ from iree.compiler.dialects import (
     util,
     iree_codegen,
     iree_gpu,
+    iree_tensor_ext,
     preprocessing_transform,
 )
 
@@ -688,6 +689,17 @@ def gpu_target_info_constructor_error_cases():
         assert False, "Expected TypeError for wrong MMA intrinsic object type"
     except TypeError:
         pass
+
+
+# ======================================================================
+# IREE TensorExt Dialect
+# ======================================================================
+
+
+@run
+def iree_tensor_ext_smoke_test():
+    # Make sure that generated op bindings are accessible.
+    assert issubclass(iree_tensor_ext.ComputeBarrierStartOp, ir.OpView)
 
 
 # ======================================================================


### PR DESCRIPTION
This is for use downstream in iree-turbine.