### PR TITLE
[Dispatch Creation] Ignore unfusable consumer

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -780,8 +780,6 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
         if (isFusableWithConsumer(*fusableUse, tracker, options)) {
           tracker.appendToFusionGroup(consumerOp, fusionGroup);
           workList.push_back(consumerOp);
-        } else {
-          break;
         }
       }
     }


### PR DESCRIPTION
This constraint was added back when we needed to fuse in dominance-order. It was possible to generate illegal IR if we skipped a consumer. This is now handled and the "break" can be removed after we now form multi-use dispatches https://github.com/iree-org/iree/issues/22462.


Results in 2 dispatches instead of 3 for https://github.com/iree-org/iree/issues/22528

ci-extra: test_torch